### PR TITLE
Remove rack inclusion from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,5 @@
 Copyright 2019-present, Shopify Inc.
 
-Contains code from rack, Copyright (C) 2007-2019 Leah Neukirchen <http://leahneukirchen.org/infopage.html>
-Contains code from rack-proxy, Copyright (c) 2013 Jacek Becela jacek.becela@gmail.com
 ​​
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 ​


### PR DESCRIPTION
This was originally needed for the theme dev server in the old CLI (ref: https://github.com/Shopify/shopify-cli/commit/39950c19dfee6ec0126fb54ae90a1769169f9854) which doesn't apply to this codebase anymore.