### PR TITLE
`hydrogen add eslint` TypeScript support

### DIFF
--- a/.changeset/fair-buckets-beam.md
+++ b/.changeset/fair-buckets-beam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix TypeScript support in `hydrogen add eslint`. This command will now add the TypeScript eslint configuration in addition to the recommended configuration for TypeScript projects.

--- a/packages/cli-hydrogen/src/cli/services/eslint.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/eslint.test.ts
@@ -1,18 +1,151 @@
-import {describe, it, expect} from 'vitest'
-import {file, path} from '@shopify/cli-kit'
+import {addESLint} from './eslint'
+import {genericConfigurationFileNames} from '../constants'
+import {HydrogenApp} from '../models/hydrogen'
+import {describe, vi, it, expect} from 'vitest'
+import {file, dependency, vscode, path} from '@shopify/cli-kit'
 import {temporary} from '@shopify/cli-testing'
 
+vi.mock('@shopify/cli-kit', async () => {
+  const cliKit: any = await vi.importActual('@shopify/cli-kit')
+  return {
+    ...cliKit,
+    dependency: {
+      addNPMDependenciesWithoutVersionIfNeeded: vi.fn(),
+    },
+    vscode: {
+      isVSCode: vi.fn(),
+      addRecommendedExtensions: vi.fn(),
+    },
+  }
+})
+
 describe('addEslint', () => {
-  it("throws an error if the configuration file doesn't exist", async () => {
+  it('adds a eslintrc file with recommended config if none exists', async () => {
     await temporary.directory(async (tmpDir) => {
-      const app = {
+      // Given
+      const app = await createMockApp({
         directory: tmpDir,
-      }
+      })
+
       // When
-      await addESLint({app})
+      await addESLint({app, force: false, install: true})
 
       // Then
-      await expect(file.read(path.join(tmpDir, '.eslintrc'))).resolves.toBe(true)
+      await expect(file.read(path.join(tmpDir, genericConfigurationFileNames.eslint))).resolves.toMatchInlineSnapshot(
+        `
+        "module.exports = {
+          extends: ['plugin:hydrogen/recommended'],
+        };
+        "
+      `,
+      )
+    })
+  })
+
+  it('adds a eslintrc file with typescript config for typescript projects', async () => {
+    await temporary.directory(async (tmpDir) => {
+      // Given
+      const app = await createMockApp({
+        directory: tmpDir,
+        language: 'TypeScript',
+      })
+
+      // When
+      await addESLint({app, force: false, install: true})
+
+      // Then
+      await expect(file.read(path.join(tmpDir, genericConfigurationFileNames.eslint))).resolves.toMatchInlineSnapshot(
+        `
+        "module.exports = {
+          extends: ['plugin:hydrogen/recommended', 'plugin:hydrogen/typescript'],
+        };
+        "
+      `,
+      )
+    })
+  })
+
+  it('adds eslint and prettier dependencies when install is true', async () => {
+    await temporary.directory(async (tmpDir) => {
+      // Given
+      const app = await createMockApp({
+        directory: tmpDir,
+      })
+
+      // When
+      await addESLint({app, force: false, install: true})
+
+      // Then
+      await expect(dependency.addNPMDependenciesWithoutVersionIfNeeded).toHaveBeenCalledWith(
+        ['eslint', 'eslint-plugin-hydrogen', 'prettier', '@shopify/prettier-config'],
+        expect.objectContaining({}),
+      )
+    })
+  })
+
+  it('does not add eslint and prettier dependencies when install is false', async () => {
+    await temporary.directory(async (tmpDir) => {
+      // Given
+      const app = await createMockApp({
+        directory: tmpDir,
+      })
+
+      // When
+      await addESLint({app, force: false, install: false})
+
+      // Then
+      await expect(dependency.addNPMDependenciesWithoutVersionIfNeeded).not.toHaveBeenCalled()
+    })
+  })
+
+  it('adds vscode recommendations', async () => {
+    await temporary.directory(async (tmpDir) => {
+      // Given
+      vi.mocked(vscode.isVSCode).mockResolvedValue(true)
+      const app = await createMockApp({
+        directory: tmpDir,
+      })
+
+      // When
+      await addESLint({app, force: false, install: true})
+
+      // Then
+      await expect(vscode.addRecommendedExtensions).toHaveBeenCalledWith(tmpDir, ['dbaeumer.vscode-eslint'])
+    })
+  })
+
+  it('throws error when eslint config already exists', async () => {
+    await temporary.directory(async (tmpDir) => {
+      // Given
+      await file.write(path.join(tmpDir, genericConfigurationFileNames.eslint), '')
+      const app = await createMockApp({
+        directory: tmpDir,
+      })
+
+      // When/Then
+      await expect(addESLint({app, force: false, install: true})).rejects.toThrowError('ESLint config already exists.')
     })
   })
 })
+
+async function createMockApp(mockHydrogenApp: Partial<HydrogenApp> = {}) {
+  const app = {
+    name: 'snow-devil',
+    configuration: {
+      shopify: {
+        ...mockHydrogenApp.configuration?.shopify,
+      },
+    },
+    dependencyManager: 'npm',
+    language: 'JavaScript',
+    nodeDependencies: {
+      ...mockHydrogenApp.configuration?.nodeDependencies,
+    },
+    directory: './some/path',
+    ...mockHydrogenApp,
+  } as const
+
+  await file.write(path.join(app.directory, 'package.json'), JSON.stringify({scripts: {}}, null, 2))
+
+  return app
+}

--- a/packages/cli-hydrogen/src/cli/services/eslint.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/eslint.test.ts
@@ -20,6 +20,11 @@ vi.mock('@shopify/cli-kit', async () => {
 })
 
 describe('addEslint', () => {
+  const defaultOptions = {
+    install: true,
+    force: false,
+  }
+
   it('adds a eslintrc file with recommended config if none exists', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
@@ -28,7 +33,7 @@ describe('addEslint', () => {
       })
 
       // When
-      await addESLint({app, force: false, install: true})
+      await addESLint({app, ...defaultOptions})
 
       // Then
       await expect(file.read(path.join(tmpDir, genericConfigurationFileNames.eslint))).resolves.toMatchInlineSnapshot(
@@ -51,7 +56,7 @@ describe('addEslint', () => {
       })
 
       // When
-      await addESLint({app, force: false, install: true})
+      await addESLint({app, ...defaultOptions})
 
       // Then
       await expect(file.read(path.join(tmpDir, genericConfigurationFileNames.eslint))).resolves.toMatchInlineSnapshot(
@@ -73,7 +78,7 @@ describe('addEslint', () => {
       })
 
       // When
-      await addESLint({app, force: false, install: true})
+      await addESLint({app, ...defaultOptions, install: true})
 
       // Then
       await expect(dependency.addNPMDependenciesWithoutVersionIfNeeded).toHaveBeenCalledWith(
@@ -91,7 +96,7 @@ describe('addEslint', () => {
       })
 
       // When
-      await addESLint({app, force: false, install: false})
+      await addESLint({app, ...defaultOptions, install: false})
 
       // Then
       await expect(dependency.addNPMDependenciesWithoutVersionIfNeeded).not.toHaveBeenCalled()
@@ -107,14 +112,14 @@ describe('addEslint', () => {
       })
 
       // When
-      await addESLint({app, force: false, install: true})
+      await addESLint({app, ...defaultOptions})
 
       // Then
       await expect(vscode.addRecommendedExtensions).toHaveBeenCalledWith(tmpDir, ['dbaeumer.vscode-eslint'])
     })
   })
 
-  it('throws error when eslint config already exists', async () => {
+  it('throws error when eslintrc already exists', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
       await file.write(path.join(tmpDir, genericConfigurationFileNames.eslint), '')
@@ -123,7 +128,7 @@ describe('addEslint', () => {
       })
 
       // When/Then
-      await expect(addESLint({app, force: false, install: true})).rejects.toThrowError('ESLint config already exists.')
+      await expect(addESLint({app, ...defaultOptions})).rejects.toThrowError('ESLint config already exists.')
     })
   })
 })

--- a/packages/cli-hydrogen/src/cli/services/eslint.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/eslint.test.ts
@@ -1,0 +1,18 @@
+import {describe, it, expect} from 'vitest'
+import {file, path} from '@shopify/cli-kit'
+import {temporary} from '@shopify/cli-testing'
+
+describe('addEslint', () => {
+  it("throws an error if the configuration file doesn't exist", async () => {
+    await temporary.directory(async (tmpDir) => {
+      const app = {
+        directory: tmpDir,
+      }
+      // When
+      await addESLint({app})
+
+      // Then
+      await expect(file.read(path.join(tmpDir, '.eslintrc'))).resolves.toBe(true)
+    })
+  })
+})

--- a/packages/cli-hydrogen/src/cli/services/eslint.ts
+++ b/packages/cli-hydrogen/src/cli/services/eslint.ts
@@ -50,8 +50,14 @@ export async function addESLint({app, force, install}: AddESlintOptions) {
           }
         }
 
+        const extended = [`'plugin:hydrogen/recommended'`]
+
+        if (app.language === 'TypeScript') {
+          extended.push(`'plugin:hydrogen/typescript'`)
+        }
+
         const eslintConfig = await file.format(
-          ['module.exports = {', 'extends: [', `'plugin:hydrogen/recommended'`, ' ],', ' };'].join('\n'),
+          ['module.exports = {', 'extends: [', `${extended.join(',')}`, ' ],', ' };'].join('\n'),
           {path: genericConfigurationFileNames.eslint},
         )
 

--- a/packages/cli-hydrogen/src/cli/services/info.ts
+++ b/packages/cli-hydrogen/src/cli/services/info.ts
@@ -132,8 +132,6 @@ class AppInfo {
   systemInfoSection(): [string, string] {
     const title = 'Tooling and System'
     const {platform, arch} = os.platformAndArch()
-    const dependencyResults = this.dependencyCheck(['eslint', 'eslint-plugin-hydrogen'])
-
     const lines: string[][] = [
       ...this.dependencyCheck(['@shopify/hydrogen', '@shopify/cli-hydrogen', '@shopify/cli']),
       ['Package manager', this.app.dependencyManager],


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Adds TypeScript support in `hydrogen add eslint` command, meaning that if we detect a project with TypeScript is running this command, we will automatically configure the eslintrc to extent the `plugin:hydrogen/typescript` config.

### WHAT is this pull request doing?

- Adds a condition on the `app.language` key, pushing the `plugin:hydrogen/typescript` into the `extends` of the projects eslintrc file.
- Adds tests for this feature as well as back-fills tests for this command.

### How to test your changes?

```
dev shopify hydrogen add eslint --path PATH
```
Run the above command, where `PATH` is the path to a typescript hydrogen project. (for example `../hydrogen/templates/hello-world`)

And then check the eslintrc file in that project and make sure it has:

```
module.exports = {
  extends: ['plugin:hydrogen/recommended', 'plugin:hydrogen/typescript'],
};
```

@Shopify/hydrogen 
