### PR TITLE
Handle missing template branch and subdirectory

### DIFF
--- a/packages/create-hydrogen/src/services/init.ts
+++ b/packages/create-hydrogen/src/services/init.ts
@@ -66,7 +66,7 @@ async function init(options: InitOptions) {
         title: 'Downloading template',
 
         task: async (_, task) => {
-          const url = `${templateInfo.http}#${templateInfo.ref}`
+          const url = templateInfo.ref ? `${templateInfo.http}#${templateInfo.ref}` : templateInfo.http
           await git.downloadRepository({
             repoUrl: url,
             destination: templateDownloadDir,
@@ -77,8 +77,17 @@ async function init(options: InitOptions) {
             },
           })
 
-          if (!(await file.exists(path.join(templateDownloadDir, templateInfo.subDirectory, 'package.json')))) {
-            throw new error.Abort(`The template ${templateInfo.subDirectory} was not found.`, suggestHydrogenSupport())
+          if (
+            !(await file.exists(
+              templateInfo.subDirectory
+                ? path.join(templateDownloadDir, templateInfo.subDirectory, 'package.json')
+                : path.join(templateDownloadDir, 'package.json'),
+            ))
+          ) {
+            throw new error.Abort(
+              `The template ${templateInfo.subDirectory || templateInfo.name} was not found.`,
+              suggestHydrogenSupport(),
+            )
           }
           task.title = 'Template downloaded'
         },
@@ -103,7 +112,7 @@ async function init(options: InitOptions) {
                     dependency_manager: options.dependencyManager,
                   }
                   await template.recursiveDirectoryCopy(
-                    `${templateDownloadDir}/${templateInfo.subDirectory}`,
+                    `${templateDownloadDir}/${templateInfo.subDirectory || ''}`,
                     templateScaffoldDir,
                     templateData,
                   )


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Currently, passing a git template name to `create-hydrogen` fails if no branch or subdirectory is included. This PR handles those cases

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR does two things:

- If no branch is specified, use the default. Currently it tries to use the string `undefined`
- If no subdirectory is specified, use the template repo root

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
 Run `yarn create-hydrogen -t netlify/hydrogen-netlify-starter` and confirm that it creates a site correctly