### PR TITLE
Show error when ESLint is not configured correctly

### DIFF
--- a/.changeset/afraid-panthers-invent.md
+++ b/.changeset/afraid-panthers-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add warning for eslint-plugin-hydrogen missing if eslint exists during `hydrogen info` command.

--- a/packages/cli-hydrogen/src/cli/commands/hydrogen/info.test.ts
+++ b/packages/cli-hydrogen/src/cli/commands/hydrogen/info.test.ts
@@ -29,11 +29,11 @@ function mockOutput(mockHydrogenApp: Partial<HydrogenApp> = {}) {
     name: 'snow-devil',
     configuration: {
       shopify: {
-        ...mockHydrogenApp,
+        ...mockHydrogenApp?.configuration?.shopify,
       },
     },
     dependencyManager: 'npm',
-    language: 'javascript',
+    language: 'JavaScript',
     configurationPath: '',
     nodeDependencies: {},
     directory: './some/path',

--- a/packages/cli-hydrogen/src/cli/commands/hydrogen/info.test.ts
+++ b/packages/cli-hydrogen/src/cli/commands/hydrogen/info.test.ts
@@ -1,0 +1,69 @@
+import InfoCommand from './info'
+import {HydrogenApp, load as loadApp} from '../../models/hydrogen'
+import {describe, expect, vi, it, beforeAll} from 'vitest'
+import {outputMocker} from '@shopify/cli-testing'
+
+beforeAll(() => {
+  vi.mock('../../models/hydrogen')
+})
+
+describe('hydrogen info', () => {
+  it('displays the app information', async () => {
+    // Given
+    const name = 'snow-devil'
+    const directory = './some/path'
+    const outputMock = mockOutput({name, directory})
+
+    // When
+    await InfoCommand.run()
+
+    // Then
+    expect(outputMock.output()).toMatchInlineSnapshot(
+      `
+      "YOUR PROJECT                       
+      Name               snow-devil
+      Project location   ./some/path
+
+      STOREFRONT                         
+      storeDomain            Not yet configured
+      storefrontApiVersion   Not yet configured
+      storefrontToken        Not yet configured
+      ! StoreDomain must be a valid shopify domain
+
+      ESLINT                             
+      eslint                   Not found
+      eslint-plugin-hydrogen   Not found
+
+      TOOLING AND SYSTEM                 
+      @shopify/hydrogen       Not found
+      @shopify/cli-hydrogen   Not found
+      @shopify/cli            Not found
+      Package manager         npm
+      OS                      darwin-arm64
+      Shell                   /bin/zsh
+      Node.js version         v18.0.0"
+    `,
+    )
+  })
+})
+
+function mockOutput(mockHydrogenApp: Partial<HydrogenApp> = {}) {
+  const app = {
+    name: 'snow-devil',
+    configuration: {
+      shopify: {
+        ...mockHydrogenApp,
+      },
+    },
+    dependencyManager: 'npm',
+    language: 'javascript',
+    configurationPath: '',
+    nodeDependencies: {},
+    directory: './some/path',
+    ...mockHydrogenApp,
+  } as const
+
+  vi.mocked(loadApp).mockResolvedValue(app)
+
+  return outputMocker.mockAndCapture()
+}

--- a/packages/cli-hydrogen/src/cli/commands/hydrogen/info.test.ts
+++ b/packages/cli-hydrogen/src/cli/commands/hydrogen/info.test.ts
@@ -18,32 +18,9 @@ describe('hydrogen info', () => {
     await InfoCommand.run()
 
     // Then
-    expect(outputMock.output()).toMatchInlineSnapshot(
-      `
-      "YOUR PROJECT                       
-      Name               snow-devil
-      Project location   ./some/path
-
-      STOREFRONT                         
-      storeDomain            Not yet configured
-      storefrontApiVersion   Not yet configured
-      storefrontToken        Not yet configured
-      ! StoreDomain must be a valid shopify domain
-
-      ESLINT                             
-      eslint                   Not found
-      eslint-plugin-hydrogen   Not found
-
-      TOOLING AND SYSTEM                 
-      @shopify/hydrogen       Not found
-      @shopify/cli-hydrogen   Not found
-      @shopify/cli            Not found
-      Package manager         npm
-      OS                      darwin-arm64
-      Shell                   /bin/zsh
-      Node.js version         v18.0.0"
-    `,
-    )
+    expect(outputMock.output()).toMatch(/Name snow-devil/)
+    expect(outputMock.output()).toMatch(/Project location .\/some\/path/)
+    expect(outputMock.output()).toMatch(/Package manager npm/)
   })
 })
 
@@ -65,5 +42,15 @@ function mockOutput(mockHydrogenApp: Partial<HydrogenApp> = {}) {
 
   vi.mocked(loadApp).mockResolvedValue(app)
 
-  return outputMocker.mockAndCapture()
+  const mocker = outputMocker.mockAndCapture()
+
+  return {
+    ...mocker,
+    output() {
+      const output = mocker.output()
+      const trimmedOuput = (output as string).replace(/\s+/g, ' ').trim()
+
+      return trimmedOuput
+    },
+  }
 }

--- a/packages/cli-hydrogen/src/cli/models/hydrogen.test.ts
+++ b/packages/cli-hydrogen/src/cli/models/hydrogen.test.ts
@@ -59,11 +59,13 @@ describe('load', () => {
   }
 
   it("throws an error if the directory doesn't exist", async () => {
-    // Given
-    const directory = '/tmp/non-existent-directory'
+    await temporary.directory(async (tmpDir) => {
+      // Given
+      await file.rmdir(tmpDir, {force: true})
 
-    // When/Then
-    await expect(load(directory)).rejects.toThrow(/Couldn't find directory/)
+      // When/Then
+      await expect(load(tmpDir)).rejects.toThrow(/Couldn't find directory/)
+    })
   })
 
   it("throws an error if the configuration file doesn't exist", async () => {

--- a/packages/cli-hydrogen/src/cli/services/info.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/info.test.ts
@@ -17,24 +17,32 @@ describe('Project settings', () => {
   })
 })
 
-describe('Shopify settings', () => {
-  it('shows an error when the Shopify domain is invalid', async () => {
+describe('ESLint settings', () => {
+  it('shows an error when the ESLint exists, but the eslint-plugin-hydrogen does not', async () => {
     // Given
-    const shopify: HydrogenApp['configuration']['shopify'] = {
-      storeDomain: 'snow-devil.myspotify.com',
+    const app = {
+      configuration: {
+        nodeDependencies: {
+          eslint: '^7.1.0',
+        },
+      },
     }
 
     // When
-    const output = await mockInfoWithApp({configuration: {shopify}})
+    const output = await mockInfoWithApp(app)
 
     // Then
-    expect(output).toMatch(`! StoreDomain must be a valid shopify domain`)
+    expect(output).toMatch('! Run `yarn shopify add eslint` to install and configure eslint for hydrogen')
   })
 
-  it('does not show an error when the Shopify domain is valid', async () => {
+  it('does not show an error when both the ESLint and the eslint-plugin-hydrogen exist', async () => {
     // Given
-    const shopify: HydrogenApp['configuration']['shopify'] = {
-      storeDomain: 'snow-devil.myshopify.com',
+    const shopify: HydrogenApp['configuration'] = {
+      nodeDependencies: {
+        eslint: '^7.1.0',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'eslint-plugin-hydrogen': '^1.0.0',
+      },
     }
 
     // When
@@ -54,14 +62,15 @@ async function mockInfoWithApp(mockHydrogenApp: Partial<HydrogenApp> = {}) {
       },
     },
     dependencyManager: 'npm',
-    language: 'javascript',
-    configurationPath: '',
-    nodeDependencies: {},
+    language: 'JavaScript',
+    nodeDependencies: {
+      ...mockHydrogenApp.configuration?.nodeDependencies,
+    },
     directory: './some/path',
     ...mockHydrogenApp,
   } as const
 
-  const output = await info(app, {format: 'text'})
+  const output = await info(app, {showPrivateData: false})
   const trimmedOuput = (output as string).replace(/\s+/g, ' ').trim()
 
   return trimmedOuput

--- a/packages/cli-hydrogen/src/cli/services/info.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/info.test.ts
@@ -1,0 +1,68 @@
+import {info} from './info'
+import {HydrogenApp} from '../models/hydrogen'
+import {describe, expect, it} from 'vitest'
+
+describe('Project settings', () => {
+  it('displays the name and directory of the app', async () => {
+    // Given
+    const name = 'snow-devil'
+    const directory = './some/path'
+
+    // When
+    const output = await mockInfoWithApp({name, directory})
+
+    // Then
+    expect(output).toMatch(`Name ${name}`)
+    expect(output).toMatch(`Project location ${directory}`)
+  })
+})
+
+describe('Shopify settings', () => {
+  it('shows an error when the Shopify domain is invalid', async () => {
+    // Given
+    const shopify: HydrogenApp['configuration']['shopify'] = {
+      storeDomain: 'snow-devil.myspotify.com',
+    }
+
+    // When
+    const output = await mockInfoWithApp({configuration: {shopify}})
+
+    // Then
+    expect(output).toMatch(`! StoreDomain must be a valid shopify domain`)
+  })
+
+  it('does not show an error when the Shopify domain is valid', async () => {
+    // Given
+    const shopify: HydrogenApp['configuration']['shopify'] = {
+      storeDomain: 'snow-devil.myshopify.com',
+    }
+
+    // When
+    const output = await mockInfoWithApp({configuration: {shopify}})
+
+    // Then
+    expect(output).not.toMatch(`! StoreDomain must be a valid shopify domain`)
+  })
+})
+
+async function mockInfoWithApp(mockHydrogenApp: Partial<HydrogenApp> = {}) {
+  const app = {
+    name: 'snow-devil',
+    configuration: {
+      shopify: {
+        ...mockHydrogenApp,
+      },
+    },
+    dependencyManager: 'npm',
+    language: 'javascript',
+    configurationPath: '',
+    nodeDependencies: {},
+    directory: './some/path',
+    ...mockHydrogenApp,
+  } as const
+
+  const output = await info(app, {format: 'text'})
+  const trimmedOuput = (output as string).replace(/\s+/g, ' ').trim()
+
+  return trimmedOuput
+}

--- a/packages/cli-hydrogen/src/cli/services/info.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/info.test.ts
@@ -37,19 +37,21 @@ describe('ESLint settings', () => {
 
   it('does not show an error when both the ESLint and the eslint-plugin-hydrogen exist', async () => {
     // Given
-    const shopify: HydrogenApp['configuration'] = {
-      nodeDependencies: {
-        eslint: '^7.1.0',
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        'eslint-plugin-hydrogen': '^1.0.0',
+    const app = {
+      configuration: {
+        nodeDependencies: {
+          eslint: '^7.1.0',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'eslint-plugin-hydrogen': '^1.0.0',
+        },
       },
     }
 
     // When
-    const output = await mockInfoWithApp({configuration: {shopify}})
+    const output = await mockInfoWithApp(app)
 
     // Then
-    expect(output).not.toMatch(`! StoreDomain must be a valid shopify domain`)
+    expect(output).not.toMatch('! Run `yarn shopify add eslint` to install and configure eslint for hydrogen')
   })
 })
 
@@ -58,7 +60,7 @@ async function mockInfoWithApp(mockHydrogenApp: Partial<HydrogenApp> = {}) {
     name: 'snow-devil',
     configuration: {
       shopify: {
-        ...mockHydrogenApp,
+        ...mockHydrogenApp.configuration?.shopify,
       },
     },
     dependencyManager: 'npm',
@@ -71,6 +73,7 @@ async function mockInfoWithApp(mockHydrogenApp: Partial<HydrogenApp> = {}) {
   } as const
 
   const output = await info(app, {showPrivateData: false})
+
   const trimmedOuput = (output as string).replace(/\s+/g, ' ').trim()
 
   return trimmedOuput

--- a/packages/cli-hydrogen/src/cli/services/info.ts
+++ b/packages/cli-hydrogen/src/cli/services/info.ts
@@ -76,6 +76,10 @@ class AppInfo {
     const title = 'ESLint'
     const dependencyResults = this.dependencyCheck(['eslint', 'eslint-plugin-hydrogen'])
 
+    if (this.app.nodeDependencies.eslint && !this.app.nodeDependencies['eslint-plugin-hydrogen']) {
+      errors.push('Run `yarn shopify add eslint` to install and configure eslint for hydrogen')
+    }
+
     let errorContent = `\n${errors.map(this.formattedError).join('\n')}`
 
     if (errorContent.trim() === '') errorContent = ''


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds validation for the eslint set up of a hydrogen project by asserting that if `eslint` is installed, that `eslint-plugin-hydrogen` is also install. I imagine us expanding greatly on the logic here to do more granular checks, this PR is just setting up the ground work and backfilling tests so we can build on this.

### How to test your changes?

Run `dev shopify hydrogen info` in a project that has `eslint` but not `eslint-plugin-hydrogen` and you should see an error.

@Shopify/hydrogen 
