### PR TITLE
Remove trailing period that appears in the extension scaffolding success message

### DIFF
--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -33,7 +33,7 @@ export async function selectAppPrompt(apps: OrganizationApp[]): Promise<Organiza
 export async function selectStorePrompt(stores: OrganizationStore[]): Promise<OrganizationStore | undefined> {
   if (stores.length === 0) return undefined
   if (stores.length === 1) {
-    output.completed(`Using your default dev store (${stores[0].shopName}) to preview your project`)
+    output.completed(`Using your default dev store (${stores[0].shopName}) to preview your project.`)
     return stores[0]
   }
   const storeList = stores.map((store) => ({name: store.shopName, value: store.shopId}))

--- a/packages/app/src/cli/services/environment/identifiers.ts
+++ b/packages/app/src/cli/services/environment/identifiers.ts
@@ -119,7 +119,7 @@ async function createExtensions(extensions: Extension[], appId: string) {
   for (const extension of extensions) {
     // eslint-disable-next-line no-await-in-loop
     const registration = await createExtension(appId, extension.type, extension.localIdentifier, token)
-    output.completed(`Created extension ${extension.localIdentifier}`)
+    output.completed(`Created extension ${extension.localIdentifier}.`)
     result[extension.localIdentifier] = registration
   }
   return result

--- a/packages/cli-kit/src/output.ts
+++ b/packages/cli-kit/src/output.ts
@@ -308,7 +308,7 @@ export const success = (content: Message) => {
  * @param content {string} The content to be output to the user.
  */
 export const completed = (content: Message) => {
-  const message = `${colors.green('✔')} ${stringifyMessage(content)}.`
+  const message = `${colors.green('✔')} ${stringifyMessage(content)}`
   outputWhereAppropriate('info', consoleLog, message)
 }
 

--- a/packages/cli-kit/src/session.ts
+++ b/packages/cli-kit/src/session.ts
@@ -276,7 +276,7 @@ async function executeCompleteFlow(applications: OAuthApplications, identityFqdn
     },
   }
 
-  output.completed('Logged in')
+  output.completed('Logged in.')
 
   return session
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The success message after scaffolding an extension has an extra period after the exclamation mark ([screenshot](https://screenshot.click/16-31-mnk2n-97o8c.png))

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

It removes the trailing period that appears in the extension scaffolding success message.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

- scaffold an extension to see the success message

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
