### PR TITLE
Fix error messages to show up when running hydrogen preview

### DIFF
--- a/.changeset/lovely-adults-fix.md
+++ b/.changeset/lovely-adults-fix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix error messages to show up when running hydrogen preview

--- a/packages/cli-hydrogen/src/cli/services/preview.ts
+++ b/packages/cli-hydrogen/src/cli/services/preview.ts
@@ -21,6 +21,7 @@ export async function previewInNode({directory, port}: PreviewOptions) {
     await system.exec('yarn', ['shopify', 'hydrogen', 'build', '--target=node'], {
       cwd: directory,
       stdout: process.stdout,
+      stderr: process.stderr,
     })
   }
 
@@ -28,6 +29,7 @@ export async function previewInNode({directory, port}: PreviewOptions) {
     env: {PORT: `${port}`},
     cwd: directory,
     stdout: process.stdout,
+    stderr: process.stderr,
   })
 }
 
@@ -59,6 +61,7 @@ export async function previewInWorker({directory, port}: PreviewOptions) {
     env: {NODE_OPTIONS: '--experimental-vm-modules'},
     cwd: directory,
     stdout: process.stdout,
+    stderr: process.stderr,
   })
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

When running `shopify hydrogen preview`, all console error and warning messages are hidden.
Reproduce by creating a hydrogen app, and adding to App.server.tsx:

```ts
  console.error('error');
  console.warn('warn');
  console.info('info');
  console.log('log');
```

Run `shopify hydrogen preview`. Note that info and log show up, but warn and error do not.

### WHAT is this pull request doing?

Propagating stderr.

### How to test your changes?

Create a project that uses `console.error`. Make sure that it shows up.
