### PR TITLE
Turn `@shopify/cli-kit` into a `dependency` of `@shopify/app`

### DIFF
--- a/.changeset/loud-carrots-flow.md
+++ b/.changeset/loud-carrots-flow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Make @shopify/cli-kit a dependency instead of a peerDependency

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -33,9 +33,7 @@
   "dependencies": {
     "@fastify/reply-from": "^8.0.0",
     "@oclif/core": "^1.0",
-    "@shopify/shopify-cli-extensions": "^0.2.1"
-  },
-  "peerDependencies": {
+    "@shopify/shopify-cli-extensions": "^0.2.1",
     "@shopify/cli-kit": "^3.0.15"
   },
   "engine-strict": true,


### PR DESCRIPTION
### WHY are these changes introduced?
As part of [this effort](https://github.com/Shopify/shopify-cli-next/pull/543) to loose version requirements and stop using peer dependencies, I forgot to move the `@shopify/cli-kit` dependency of `@shopify/app` to the `dependencies` group in the `package.json`.

### WHAT is this pull request doing?
I'm making `@shopify/cli-kit` a `dependency` of `@shopify/app`. This should mitigate the issues trying to create an app with `pnpm`.
