### PR TITLE
Only execute acceptance tests on Linux

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Unit tests
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features --skip-nx-cache
       - name: Acceptance tests
-        run: npx nx ${{ github.event.inputs.nxLevel || 'run' }} features:test --skip-nx-cache
+        run: npx nx run features:test --skip-nx-cache
   pr:
     name: Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -137,4 +137,4 @@ jobs:
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features --skip-nx-cache
       - name: Acceptance tests
         if: matrix.os == 'ubuntu-latest'
-        run: npx nx ${{ github.event.inputs.nxLevel || 'run' }} features:test --skip-nx-cache
+        run: npx nx run features:test --skip-nx-cache

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -131,5 +131,8 @@ jobs:
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=tsc --skip-nx-cache
       - name: Lint
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint --skip-nx-cache
-      - name: Test
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --skip-nx-cache
+      - name: Unit tests
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features --skip-nx-cache
+      - name: Acceptance tests
+        if: matrix.os == 'ubuntu-latest'
+        run: npx nx ${{ github.event.inputs.nxLevel || 'run' }} features:test --skip-nx-cache

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -85,12 +85,14 @@ jobs:
         run: yarn install --ignore-engines
       - name: Build
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build --skip-nx-cache
-      - name: Test
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --skip-nx-cache
       - name: Lint
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint --skip-nx-cache
       - name: Type-check
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=tsc --skip-nx-cache
+      - name: Unit tests
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features --skip-nx-cache
+      - name: Acceptance tests
+        run: npx nx ${{ github.event.inputs.nxLevel || 'run' }} features:test --skip-nx-cache
   pr:
     name: Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### WHY are these changes introduced?
Acceptance tests are slow by nature and they are currently taking a lot of time from our CI quota because we run them in all the OSs that we support. GitHub prices Windows and macOS builds more expensive than Linux ones.

### WHAT is this pull request doing?
I'm adjusting the CI workflow to run acceptance tests:
- Only in Linux for PRs and branches.
- In all the OSs for commits in `main`.

### How to test your changes?
CI should pass.
