### PR TITLE
Run changelog reminder in ubuntu-latest

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -6,7 +6,7 @@ name: Changelog Reminder
 jobs:
   remind:
     name: Changelog Reminder
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### WHY are these changes introduced?
We [configured](https://github.com/Shopify/shopify-cli-next/pull/25) the changelog-checker workflow to run in self-hosted runners because the repository was private, but that's no longer needed with the repository being public.

### WHAT is this pull request doing?
I'm updating the changelog workflow to run on `ubuntu-latest`.

### How to test your changes?
CI should pass
