### PR TITLE
Fix error when exchanging identity tokens

### DIFF
--- a/.changeset/bright-rocks-yawn.md
+++ b/.changeset/bright-rocks-yawn.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/features': patch
+---
+
+Fix issue when exchanging an identity token fails

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -9,7 +9,7 @@ import {
 } from '../utilities/app/http-reverse-proxy'
 import {App, AppConfiguration, UIExtension, Web, WebType} from '../models/app/app'
 import {fetchProductVariant} from '../utilities/extensions/fetch-product-variant'
-import {error, analytics, output, port, system} from '@shopify/cli-kit'
+import {error, analytics, output, port, system, session} from '@shopify/cli-kit'
 import {Config} from '@oclif/core'
 import {Writable} from 'node:stream'
 
@@ -42,11 +42,12 @@ async function dev(options: DevOptions) {
       app: await installAppDependencies(options.app),
     }
   }
+  const token = await session.ensureAuthenticatedPartners()
   const {
     identifiers,
     storeFqdn,
     app: {apiSecret},
-  } = await ensureDevEnvironment(options)
+  } = await ensureDevEnvironment(options, token)
 
   let proxyPort: number
   let url: string
@@ -69,7 +70,7 @@ async function dev(options: DevOptions) {
 
   /** If the app doesn't have web/ the link message is not necessary */
   if (frontendConfig || backendConfig) {
-    if (options.update) await updateURLs(identifiers.app, url)
+    if (options.update) await updateURLs(identifiers.app, url, token)
     outputAppURL(options.update, storeFqdn, url)
   }
 

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -75,7 +75,7 @@ describe('updateURLs', () => {
     }
 
     // When
-    await updateURLs('apiKey', 'http://localhost:3456')
+    await updateURLs('apiKey', 'http://localhost:3456', 'token')
 
     // Then
     expect(api.partners.request).toHaveBeenCalledWith(api.graphql.UpdateURLsQuery, 'token', expectedVariables)
@@ -86,7 +86,7 @@ describe('updateURLs', () => {
     vi.mocked(api.partners.request).mockResolvedValueOnce({appUpdate: {userErrors: [{message: 'Boom!'}]}})
 
     // When
-    const got = updateURLs('apiKey', 'http://localhost:3456')
+    const got = updateURLs('apiKey', 'http://localhost:3456', 'token')
 
     // Then
     expect(got).rejects.toThrow(new error.Abort(`Boom!`))

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -1,4 +1,4 @@
-import {api, error, output, plugins, session} from '@shopify/cli-kit'
+import {api, error, output, plugins} from '@shopify/cli-kit'
 import {Plugin} from '@oclif/core/lib/interfaces'
 
 export async function generateURL(pluginList: Plugin[], frontendPort: number): Promise<string> {
@@ -9,9 +9,7 @@ export async function generateURL(pluginList: Plugin[], frontendPort: number): P
   return url
 }
 
-export async function updateURLs(apiKey: string, url: string): Promise<void> {
-  const token = await session.ensureAuthenticatedPartners()
-
+export async function updateURLs(apiKey: string, url: string, token: string): Promise<void> {
   const variables: api.graphql.UpdateURLsQueryVariables = {
     apiKey,
     appUrl: url,

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -152,7 +152,7 @@ describe('ensureDevEnvironment', () => {
     vi.mocked(updateAppIdentifiers).mockResolvedValue(LOCAL_APP)
 
     // When
-    const got = await ensureDevEnvironment(INPUT)
+    const got = await ensureDevEnvironment(INPUT, 'token')
 
     // Then
     expect(got).toEqual({
@@ -195,7 +195,7 @@ describe('ensureDevEnvironment', () => {
     vi.mocked(updateAppIdentifiers).mockResolvedValue(LOCAL_APP)
 
     // When
-    const got = await ensureDevEnvironment(INPUT)
+    const got = await ensureDevEnvironment(INPUT, 'token')
 
     // Then
     expect(got).toEqual({
@@ -239,7 +239,7 @@ describe('ensureDevEnvironment', () => {
     vi.mocked(updateAppIdentifiers).mockResolvedValue(LOCAL_APP)
 
     // When
-    const got = await ensureDevEnvironment(INPUT)
+    const got = await ensureDevEnvironment(INPUT, 'token')
 
     // Then
     expect(got).toEqual({
@@ -261,7 +261,7 @@ describe('ensureDevEnvironment', () => {
     vi.mocked(updateAppIdentifiers).mockResolvedValue(LOCAL_APP)
 
     // When
-    const got = await ensureDevEnvironment(INPUT)
+    const got = await ensureDevEnvironment(INPUT, 'token')
 
     // Then
     expect(got).toEqual({
@@ -282,7 +282,7 @@ describe('ensureDevEnvironment', () => {
     vi.mocked(updateAppIdentifiers).mockResolvedValue(LOCAL_APP)
 
     // When
-    const got = await ensureDevEnvironment(INPUT_WITH_DATA)
+    const got = await ensureDevEnvironment(INPUT_WITH_DATA, 'token')
 
     // Then
     expect(got).toEqual({
@@ -321,7 +321,7 @@ describe('ensureDevEnvironment', () => {
       directory: LOCAL_APP.directory,
     })
     vi.mocked(updateAppIdentifiers).mockResolvedValue(LOCAL_APP)
-    await ensureDevEnvironment({...INPUT, reset: true})
+    await ensureDevEnvironment({...INPUT, reset: true}, 'token')
 
     // Then
     expect(conf.clearAppInfo).toHaveBeenCalledWith(LOCAL_APP.directory)

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -63,9 +63,10 @@ interface DevEnvironmentOutput {
  * @param options {DevEnvironmentInput} Current dev environment options
  * @returns {Promise<DevEnvironmentOutput>} The selected org, app and dev store
  */
-export async function ensureDevEnvironment(options: DevEnvironmentOptions): Promise<DevEnvironmentOutput> {
-  const token = await session.ensureAuthenticatedPartners()
-
+export async function ensureDevEnvironment(
+  options: DevEnvironmentOptions,
+  token: string,
+): Promise<DevEnvironmentOutput> {
   // We retrieve the production identifiers to know if the user has selected the prod app for `dev`
   const prodEnvIdentifiers = await getAppIdentifiers({app: options.app})
   const envExtensionsIds = prodEnvIdentifiers.extensions || {}

--- a/packages/cli-kit/src/api.ts
+++ b/packages/cli-kit/src/api.ts
@@ -1,5 +1,6 @@
 import * as admin from './api/admin'
 import * as partners from './api/partners'
 import * as graphql from './api/graphql'
+import * as identity from './api/identity'
 
-export {admin, partners, graphql}
+export {admin, partners, graphql, identity}

--- a/packages/cli-kit/src/api/identity.ts
+++ b/packages/cli-kit/src/api/identity.ts
@@ -20,7 +20,7 @@ export async function validateIdentityToken(token: string) {
 }
 
 async function getInstrospectionEndpoint(): Promise<string> {
-  const response = await fetch(`https://${identity()}/.well-known/openid-configuration.json`)
+  const response = await fetch(`https://${await identity()}/.well-known/openid-configuration.json`)
   const json = await response.json()
   return json.introspection_endpoint
 }

--- a/packages/cli-kit/src/api/identity.ts
+++ b/packages/cli-kit/src/api/identity.ts
@@ -10,17 +10,11 @@ export async function validateIdentityToken(token: string) {
       headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
       body: JSON.stringify({token}),
     }
-    debug(`
-Sending Identity Introspection request:
-URL: ${instrospectionURL}
-
-With options:
-${JSON.stringify(options, null, 2)}
-}
-`)
+    debug(`Sending Identity Introspection request to URL: ${instrospectionURL}`)
 
     const response = await fetch(instrospectionURL, options)
     const json = await response.json()
+
     debug(`The identity token is valid: ${json.valid}`)
     return json.valid
     // eslint-disable-next-line no-catch-all/no-catch-all

--- a/packages/cli-kit/src/api/identity.ts
+++ b/packages/cli-kit/src/api/identity.ts
@@ -1,4 +1,5 @@
 import {identity} from '../environment/fqdn'
+import {debug} from '../output'
 
 export async function validateIdentityToken(token: string) {
   try {
@@ -9,12 +10,22 @@ export async function validateIdentityToken(token: string) {
       headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
       body: JSON.stringify({token}),
     }
+    debug(`
+Sending Identity Introspection request:
+URL: ${instrospectionURL}
+
+With options:
+${JSON.stringify(options, null, 2)}
+}
+`)
 
     const response = await fetch(instrospectionURL, options)
     const json = await response.json()
+    debug(`The identity token is valid: ${json.valid}`)
     return json.valid
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
+    debug(`The identity token is invalid: ${error}`)
     return false
   }
 }

--- a/packages/cli-kit/src/api/identity.ts
+++ b/packages/cli-kit/src/api/identity.ts
@@ -1,3 +1,5 @@
+import {identity} from '../environment/fqdn'
+
 export async function validateIdentityToken(token: string) {
   try {
     const instrospectionURL = await getInstrospectionEndpoint()
@@ -9,7 +11,6 @@ export async function validateIdentityToken(token: string) {
     }
 
     const response = await fetch(instrospectionURL, options)
-
     const json = await response.json()
     return json.valid
     // eslint-disable-next-line no-catch-all/no-catch-all
@@ -19,7 +20,7 @@ export async function validateIdentityToken(token: string) {
 }
 
 async function getInstrospectionEndpoint(): Promise<string> {
-  const response = await fetch('https://accounts.shopify.com/.well-known/openid-configuration.json')
+  const response = await fetch(`https://${identity()}/.well-known/openid-configuration.json`)
   const json = await response.json()
   return json.introspection_endpoint
 }

--- a/packages/cli-kit/src/api/identity.ts
+++ b/packages/cli-kit/src/api/identity.ts
@@ -1,0 +1,25 @@
+export async function validateIdentityToken(token: string) {
+  try {
+    const instrospectionURL = await getInstrospectionEndpoint()
+    const options = {
+      method: 'POST',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
+      body: JSON.stringify({token}),
+    }
+
+    const response = await fetch(instrospectionURL, options)
+
+    const json = await response.json()
+    return json.valid
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (error) {
+    return false
+  }
+}
+
+async function getInstrospectionEndpoint(): Promise<string> {
+  const response = await fetch('https://accounts.shopify.com/.well-known/openid-configuration.json')
+  const json = await response.json()
+  return json.introspection_endpoint
+}

--- a/packages/cli-kit/src/session/exchange.ts
+++ b/packages/cli-kit/src/session/exchange.ts
@@ -11,7 +11,7 @@ export class InvalidGrantError extends Error {}
 
 const InvalidIdentityError = new Abort(
   '\nError validating auth session',
-  "We've cleared the current session, Please try again",
+  "We've cleared the current session, please try again",
 )
 
 export interface ExchangeScopes {
@@ -119,7 +119,7 @@ async function requestAppToken(
     client_id: clientId,
     audience: appId,
     scope: scopes.join(' '),
-    subject_token: 'token',
+    subject_token: token,
     ...(api === 'admin' && {destination: `https://${store}/admin`}),
   }
   /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/cli-kit/src/session/exchange.ts
+++ b/packages/cli-kit/src/session/exchange.ts
@@ -146,6 +146,8 @@ async function tokenRequest(params: {[key: string]: string}): Promise<any> {
       // using a valid refresh token. When that happens, we take the user through the authentication flow.
       throw new InvalidGrantError(payload.error_description)
     } else if (payload.error_description === "Invalid 'subject_token' value: invalid") {
+      // There's an scenario when Identity returns "invalid_requests" when exchanging an identity token.
+      // This means the token is invalid. We clear the session and throw an error to let the caller know.
       secureStore.remove()
       throw InvalidIdentityError
     } else {

--- a/packages/cli-kit/src/session/exchange.ts
+++ b/packages/cli-kit/src/session/exchange.ts
@@ -1,13 +1,18 @@
 import {ApplicationToken, IdentityToken} from './schema'
 import {applicationId, clientId as getIdentityClientId} from './identity'
 import {CodeAuthResult} from './authorize'
+import * as secureStore from './store'
 import {Abort} from '../error'
 import {API} from '../network/api'
 import {fetch} from '../http'
 import {identity as identityFqdn} from '../environment/fqdn'
-import {identity} from '../api'
 
 export class InvalidGrantError extends Error {}
+
+const InvalidIdentityError = new Abort(
+  '\nError validating auth session',
+  "We've cleared the current session, Please try again",
+)
 
 export interface ExchangeScopes {
   admin: string[]
@@ -106,12 +111,6 @@ async function requestAppToken(
   const appId = applicationId(api)
   const clientId = await getIdentityClientId()
 
-  const isValid = await identity.validateIdentityToken(token)
-
-  if (!isValid) {
-    throw new InvalidGrantError('Invalid identity token')
-  }
-
   /* eslint-disable @typescript-eslint/naming-convention */
   const params = {
     grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
@@ -146,6 +145,9 @@ async function tokenRequest(params: {[key: string]: string}): Promise<any> {
       // There's an scenario when Identity returns "invalid_grant" when trying to refresh the token
       // using a valid refresh token. When that happens, we take the user through the authentication flow.
       throw new InvalidGrantError(payload.error_description)
+    } else if (payload.error_description === "Invalid 'subject_token' value: invalid") {
+      secureStore.remove()
+      throw InvalidIdentityError
     } else {
       throw new Abort(payload.error_description)
     }

--- a/packages/cli-kit/src/session/exchange.ts
+++ b/packages/cli-kit/src/session/exchange.ts
@@ -5,6 +5,7 @@ import {Abort} from '../error'
 import {API} from '../network/api'
 import {fetch} from '../http'
 import {identity as identityFqdn} from '../environment/fqdn'
+import {identity} from '../api'
 
 export class InvalidGrantError extends Error {}
 
@@ -105,6 +106,12 @@ async function requestAppToken(
   const appId = applicationId(api)
   const clientId = await getIdentityClientId()
 
+  const isValid = await identity.validateIdentityToken(token)
+
+  if (!isValid) {
+    throw new InvalidGrantError('Invalid identity token')
+  }
+
   /* eslint-disable @typescript-eslint/naming-convention */
   const params = {
     grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
@@ -113,7 +120,7 @@ async function requestAppToken(
     client_id: clientId,
     audience: appId,
     scope: scopes.join(' '),
-    subject_token: token,
+    subject_token: 'token',
     ...(api === 'admin' && {destination: `https://${store}/admin`}),
   }
   /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/cli-kit/src/session/exchange.ts
+++ b/packages/cli-kit/src/session/exchange.ts
@@ -145,8 +145,8 @@ async function tokenRequest(params: {[key: string]: string}): Promise<any> {
       // There's an scenario when Identity returns "invalid_grant" when trying to refresh the token
       // using a valid refresh token. When that happens, we take the user through the authentication flow.
       throw new InvalidGrantError(payload.error_description)
-    } else if (payload.error_description === "Invalid 'subject_token' value: invalid") {
-      // There's an scenario when Identity returns "invalid_requests" when exchanging an identity token.
+    } else if (payload.error === 'invalid_request') {
+      // There's an scenario when Identity returns "invalid_request" when exchanging an identity token.
       // This means the token is invalid. We clear the session and throw an error to let the caller know.
       secureStore.remove()
       throw InvalidIdentityError

--- a/packages/cli-kit/src/session/validate.test.ts
+++ b/packages/cli-kit/src/session/validate.test.ts
@@ -2,7 +2,7 @@ import {applicationId} from './identity'
 import {IdentityToken} from './schema'
 import {validateSession} from './validate'
 import {OAuthApplications} from '../session'
-import {partners} from '../api'
+import {identity, partners} from '../api'
 import {expect, describe, it, vi, afterAll, beforeEach} from 'vitest'
 
 const pastDate = new Date(2022, 1, 1, 9)
@@ -75,6 +75,7 @@ beforeEach(() => {
   vi.setSystemTime(currentDate)
   vi.mock('../api')
   vi.mocked(partners.checkIfTokenIsRevoked).mockResolvedValue(false)
+  vi.mocked(identity.validateIdentityToken).mockResolvedValue(true)
 })
 
 afterAll(() => {
@@ -100,6 +101,21 @@ describe('validateSession', () => {
   it('returns needs_full_auth if there is no session', async () => {
     // Given
     const session: any = undefined
+
+    // When
+    const got = await validateSession(requestedScopes, defaultApps, session)
+
+    // Then
+    expect(got).toBe('needs_full_auth')
+  })
+
+  it('returns needs_full_auth if identity token is invalid', async () => {
+    // Given
+    const session = {
+      identity: validIdentity,
+      applications: validApplications,
+    }
+    vi.mocked(identity.validateIdentityToken).mockResolvedValueOnce(false)
 
     // When
     const got = await validateSession(requestedScopes, defaultApps, session)

--- a/packages/cli-kit/src/session/validate.ts
+++ b/packages/cli-kit/src/session/validate.ts
@@ -61,10 +61,12 @@ export async function validateSession(
   }
 
   debug(`
-tokensAreExpired: ${tokensAreExpired}
-tokensAreRevoked: ${tokensAreRevoked}
-identityIsValid: ${identityIsValid}
+The validation of the token for application/identity completed with the following results:
+- It's expired: ${tokensAreExpired}
+- It's been revoked: ${tokensAreRevoked}
+- It's invalid in identity: ${!identityIsValid}
   `)
+
   if (tokensAreRevoked) return 'needs_full_auth'
   if (tokensAreExpired) return 'needs_refresh'
   if (!identityIsValid) return 'needs_full_auth'

--- a/packages/cli-kit/src/session/validate.ts
+++ b/packages/cli-kit/src/session/validate.ts
@@ -2,7 +2,7 @@ import {applicationId} from './identity'
 import {ApplicationToken, IdentityToken} from './schema'
 import constants from '../constants'
 import {OAuthApplications} from '../session'
-import {partners} from '../api'
+import {identity, partners} from '../api'
 
 type ValidationResult = 'needs_refresh' | 'needs_full_auth' | 'ok'
 
@@ -34,7 +34,8 @@ export async function validateSession(
 ): Promise<ValidationResult> {
   if (!session) return 'needs_full_auth'
   const scopesAreValid = validateScopes(scopes, session.identity)
-  if (!scopesAreValid) return 'needs_full_auth'
+  const identityIsValid = await identity.validateIdentityToken(session.identity.accessToken)
+  if (!scopesAreValid || !identityIsValid) return 'needs_full_auth'
   let tokensAreExpired = isTokenExpired(session.identity)
   let tokensAreRevoked = false
 

--- a/packages/features/features/hydrogen.feature
+++ b/packages/features/features/hydrogen.feature
@@ -3,3 +3,4 @@ Feature: App development
 Scenario: I initialize a project in an empty directory
   Given I have a working directory
    Then I see Hydrogen's help menu
+


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
There is a weird case where an Identity token would become invalid and any attempt to exchange it for app tokens will fail.
We need to check if the identity token is valid before using the session and handle better any possible error.

Fixes https://github.com/Shopify/cli/issues/67
Fixes https://github.com/Shopify/shopify-cli-planning/issues/269

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- When calling `ensureAuthenticated...` validate that the identity token is still valid using the new introspection query
- If not, force a full auth.
- If for some reason this validation is passed but after trying to exchange the token we still receive the error: show a better error message.

<img width="533" alt="Captura de Pantalla 2022-06-28 a las 14 50 38" src="https://user-images.githubusercontent.com/3757193/176185810-14b1600e-09ed-4ebe-8def-823613595d03.png">


<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Unfortunately there is no way (at least that I know of) to reproduce this issue in a real case scenario, but you can invalidate your identity tokens manually by editing the keychain.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
