### PR TITLE
Add total time to analytics reports

### DIFF
--- a/.changeset/six-laws-vanish.md
+++ b/.changeset/six-laws-vanish.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/cli': patch
+---
+
+Add total time to analytics reports

--- a/packages/cli-kit/src/analytics.test.ts
+++ b/packages/cli-kit/src/analytics.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {reportEvent} from './analytics'
+import {reportEvent, startTimer} from './analytics'
 import * as environment from './environment'
 import * as http from './http'
 import * as os from './os'
@@ -35,6 +35,7 @@ beforeEach(() => {
   vi.mocked(http.fetch).mockResolvedValue({status: 200} as any)
   vi.mocked(version.cliVersion).mockReturnValue('3.0.0')
   vi.mocked(dependency.getProjectType).mockResolvedValue('node')
+  startTimer(currentDate.getTime() - 100)
 })
 
 afterEach(() => {
@@ -56,9 +57,9 @@ it('makes an API call to Monorail with the expected payload and headers', async 
       project_type: 'node',
       command,
       args: '',
-      time_start: 1643709600000,
+      time_start: 1643709599900,
       time_end: 1643709600000,
-      total_time: 0,
+      total_time: 100,
       success: true,
       uname: 'darwin arm64',
       cli_version: '3.0.0',
@@ -69,6 +70,7 @@ it('makes an API call to Monorail with the expected payload and headers', async 
       partner_id: undefined,
     },
   }
+  expect(http.fetch).toHaveBeenCalled()
   expect(http.fetch).toHaveBeenCalledWith(expectedURL, {
     method: 'POST',
     body: JSON.stringify(expectedBody),
@@ -97,9 +99,9 @@ it('makes an API call to Monorail with the expected payload with cached app info
       project_type: 'node',
       command,
       args: '--path fixtures/app',
-      time_start: currentDate.getTime(),
-      time_end: currentDate.getTime(),
-      total_time: 0,
+      time_start: 1643709599900,
+      time_end: 1643709600000,
+      total_time: 100,
       success: true,
       uname: 'darwin arm64',
       cli_version: '3.0.0',

--- a/packages/cli-kit/src/analytics.test.ts
+++ b/packages/cli-kit/src/analytics.test.ts
@@ -119,19 +119,6 @@ it('makes an API call to Monorail with the expected payload with cached app info
   })
 })
 
-it('does nothing in Debug mode', async () => {
-  // Given
-  vi.mocked(environment.local.isDebug).mockReturnValue(true)
-  const command = 'app dev'
-  const args: string[] = []
-
-  // When
-  await reportEvent(command, args)
-
-  // Then
-  expect(http.fetch).not.toHaveBeenCalled()
-})
-
 it('does nothing when analytics are disabled', async () => {
   // Given
   vi.mocked(environment.local.analyticsDisabled).mockReturnValueOnce(true)

--- a/packages/cli-kit/src/analytics.ts
+++ b/packages/cli-kit/src/analytics.ts
@@ -12,9 +12,8 @@ import {getProjectType} from './dependency'
 export const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 
 export const reportEvent = async (command: string, args: string[]) => {
-  if (environment.local.isDebug() || environment.local.analyticsDisabled()) {
-    return
-  }
+  if (noTracking()) return
+
   try {
     const currentTime = new Date().getTime()
     const payload = await buildPayload(command, args, currentTime)
@@ -35,6 +34,21 @@ export const reportEvent = async (command: string, args: string[]) => {
     }
     debug(message)
   }
+}
+
+const noTracking = (): boolean => {
+  return environment.local.isDebug() || environment.local.analyticsDisabled()
+}
+
+let startTime: number | undefined
+
+export const startTimer = (currentTime: number = new Date().getTime()) => {
+  startTime = currentTime
+}
+
+const totalTime = (currentTime: number): number | undefined => {
+  if (startTime === undefined) return undefined
+  return currentTime - startTime
 }
 
 const buildHeaders = (currentTime: number) => {
@@ -69,9 +83,9 @@ const buildPayload = async (command: string, args: string[] = [], currentTime: n
       project_type: await getProjectType(join(directory, 'web')),
       command,
       args: args.join(' '),
-      time_start: currentTime,
+      time_start: startTime,
       time_end: currentTime,
-      total_time: 0,
+      total_time: totalTime(currentTime),
       success: true,
       uname: `${platform} ${arch}`,
       cli_version: cliVersion(),

--- a/packages/cli-kit/src/analytics.ts
+++ b/packages/cli-kit/src/analytics.ts
@@ -12,7 +12,7 @@ import {getProjectType} from './dependency'
 export const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 
 export const reportEvent = async (command: string, args: string[]) => {
-  if (noTracking()) return
+  if (environment.local.analyticsDisabled()) return
 
   try {
     const currentTime = new Date().getTime()
@@ -34,10 +34,6 @@ export const reportEvent = async (command: string, args: string[]) => {
     }
     debug(message)
   }
-}
-
-const noTracking = (): boolean => {
-  return environment.local.isDebug() || environment.local.analyticsDisabled()
 }
 
 let startTime: number | undefined

--- a/packages/cli-kit/src/environment/local.test.ts
+++ b/packages/cli-kit/src/environment/local.test.ts
@@ -1,5 +1,5 @@
 import {isSpin} from './spin'
-import {hasGit, isDebug, isShopify, isUnitTest} from './local'
+import {hasGit, isDebug, isShopify, isUnitTest, analyticsDisabled} from './local'
 import {exists as fileExists} from '../file'
 import {exec} from '../system'
 import {expect, it, describe, vi, test} from 'vitest'
@@ -91,5 +91,40 @@ describe('hasGit', () => {
 
     // Then
     expect(got).toBeTruthy()
+  })
+})
+
+describe('analitycsDisabled', () => {
+  it('returns true when SHOPIFY_CLI_NO_ANALYTICS is truthy', () => {
+    // Given
+    const env = {SHOPIFY_CLI_NO_ANALYTICS: '1'}
+
+    // When
+    const got = analyticsDisabled(env)
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  it('returns true when debug mode is enbled', () => {
+    // Given
+    const env = {SHOPIFY_CONFIG: 'debug'}
+
+    // When
+    const got = analyticsDisabled(env)
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  it('returns false without env variables', () => {
+    // Given
+    const env = {}
+
+    // When
+    const got = analyticsDisabled(env)
+
+    // Then
+    expect(got).toBe(false)
   })
 })

--- a/packages/cli-kit/src/environment/local.ts
+++ b/packages/cli-kit/src/environment/local.ts
@@ -67,10 +67,10 @@ export function isUnitTest(env = process.env): boolean {
 /**
  * Returns true if reporting analytics is enabled.
  * @param env The environment variables from the environment of the current process.
- * @returns true unless SHOPIFY_CLI_NO_ANALYTICS is truthy.
+ * @returns true unless SHOPIFY_CLI_NO_ANALYTICS is truthy or debug mode is enabled.
  */
 export function analyticsDisabled(env = process.env): boolean {
-  return isTruthy(env[constants.environmentVariables.noAnalytics])
+  return isTruthy(env[constants.environmentVariables.noAnalytics]) || isDebug(env)
 }
 
 /**

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -100,6 +100,7 @@
       "-h"
     ],
     "hooks": {
+      "prerun": "dist/hooks/prerun",
       "postrun": "dist/hooks/postrun"
     }
   }

--- a/packages/cli-main/src/hooks/prerun.ts
+++ b/packages/cli-main/src/hooks/prerun.ts
@@ -1,0 +1,7 @@
+import {analytics} from '@shopify/cli-kit'
+import {Hook} from '@oclif/core'
+
+// This hook is called before each command run. More info: https://oclif.io/docs/hooks
+export const hook: Hook.Prerun = async (_options) => {
+  analytics.startTimer()
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/272

### WHAT is this pull request doing?

- Adds a prerun hook to start a timer before running a command
- Calculate the total time when the command finishes and send the right start time and total time

### How to test your changes?

- Comment out [this line](https://github.com/Shopify/shopify-cli-next/blob/8d24d8311e8c4a07161f932ffef1e5762b589363/packages/cli-main/bin/dev.js#L5) to disable debug mode
- `yarn shopify app info --path fixtures/app`