### PR TITLE
Move devDependencies to dependencies

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -30,12 +30,6 @@
       "../../.eslintrc.cjs"
     ]
   },
-  "dependencies": {
-    "@fastify/reply-from": "^8.0.0",
-    "@oclif/core": "^1.0",
-    "@shopify/shopify-cli-extensions": "^0.2.1",
-    "@shopify/cli-kit": "^3.0.25"
-  },
   "engine-strict": true,
   "engines": {
     "node": "^14.13.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
@@ -49,7 +43,13 @@
     "commands": "dist/cli/commands"
   },
   "devDependencies": {
-    "vitest": "^0.15.1",
+    "vitest": "^0.15.1"
+  },
+  "dependencies": {
+    "@fastify/reply-from": "^8.0.0",
+    "@oclif/core": "^1.0",
+    "@shopify/shopify-cli-extensions": "^0.2.1",
+    "@shopify/cli-kit": "^3.0.25",
     "ws": "^8.7.0",
     "@fastify/http-proxy": "^8.0.1"
   }

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -43,15 +43,14 @@
     "@types/prettier": "^2.6.3",
     "prettier": "^2.6.1",
     "vite": "^2.9.9",
-    "@shopify/cli-kit": "^3.0.25"
-  },
-  "devDependencies": {
-    "@shopify/prettier-config": "^1.1.2",
-    "@types/fs-extra": "^9.0.12",
+    "@shopify/cli-kit": "^3.0.25",
     "fast-glob": "^3.2.11",
     "fs-extra": "^10.0.0",
     "typescript": "^4.6.4",
-    "vite": "^2.9.9",
+    "@shopify/prettier-config": "^1.1.2"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^9.0.12",
     "vitest": "^0.15.1"
   },
   "engine-strict": true,

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -101,17 +101,17 @@
     "tempy": "^2.0.0",
     "term-size": "^3.0.1",
     "terminal-link": "^3.0.0",
-    "zod": "^3.17.3"
+    "zod": "^3.17.3",
+    "semver": "^7.3.6",
+    "ansi-colors": "^4.1.1",
+    "unique-string": "^3.0.0",
+    "strip-ansi": "^7.0.1"
   },
   "devDependencies": {
     "@types/cross-zip": "^4.0.0",
     "@types/inquirer": "^8.2.1",
     "@types/js-yaml": "^4.0.5",
     "@types/semver": "^7.3.9",
-    "vitest": "^0.15.1",
-    "semver": "^7.3.6",
-    "ansi-colors": "^4.1.1",
-    "unique-string": "^3.0.0",
-    "strip-ansi": "^7.0.1"
+    "vitest": "^0.15.1"
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
With the move from `rollup` to `tsc` we forgot to move `devDependencies` to `dependencies` to make sure they get installed on the user-side. Without this change, development and tests pass, but the CLI will fail at runtime when users install it.

### WHAT is this pull request doing?
Move the production dependencies to `dependencies`.
