### PR TITLE
Exclude tests when building for distribution

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "clean": "shx rm -rf dist",
-    "build": "rimraf dist/ && tsc -b",
+    "build": "rimraf dist/ && tsc -b ./tsconfig.build.json",
     "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md",
     "lint": "prettier -c src/** && eslint \"src/**/*.ts\"",
     "lint:fix": "prettier -w src/** && eslint 'src/**/*.ts' --fix",

--- a/packages/app/tsconfig.build.json
+++ b/packages/app/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.test.ts"],
+    "references": [
+      {"path": "../cli-kit"}
+    ]
+}

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "clean": "shx rm -rf dist",
-    "build": "rimraf dist/ && tsc -b",
+    "build": "rimraf dist/ && tsc -b ./tsconfig.build.json",
     "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md",
     "lint": "prettier -c src/** && eslint \"src/**/*.ts\"",
     "lint:fix": "prettier src/** -w && eslint 'src/**/*.ts' --fix",

--- a/packages/cli-hydrogen/tsconfig.build.json
+++ b/packages/cli-hydrogen/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts"],
+  "references": [
+    {"path": "../cli-kit"}
+  ]
+}

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "clean": "shx rm -rf dist",
-    "build": "rimraf dist/ && tsc -b",
+    "build": "rimraf dist/ && tsc -b ./tsconfig.build.json",
     "prepack": "cross-env NODE_ENV=production yarn run build",
     "lint": "prettier -c src/** && eslint \"src/**/*.ts\"",
     "lint:fix": "eslint 'src/**/*.ts' --fix",

--- a/packages/cli-kit/tsconfig.build.json
+++ b/packages/cli-kit/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.test.ts"],
+  }

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "clean": "shx rm -rf dist",
-    "build": "rimraf dist/ && tsc -b",
+    "build": "rimraf dist/ && tsc -b ./tsconfig.build.json",
     "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md",
     "lint": "prettier -c src/** && eslint \"src/**/*.ts\"",
     "lint:fix": "prettier -w src/** && eslint 'src/**/*.ts' --fix",

--- a/packages/cli-main/tsconfig.build.json
+++ b/packages/cli-main/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts"],
+  "references": [
+    {"path": "../cli-kit"}
+  ]
+}

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "clean": "shx rm -rf dist",
-    "build": "rimraf dist/ && tsc -b",
+    "build": "rimraf dist/ && tsc -b ./tsconfig.build.json",
     "prepack": "cross-env NODE_ENV=production yarn run build",
     "lint": "prettier -c src/** && eslint \"src/**/*.ts\"",
     "lint:fix": "prettier -w src/** && eslint 'src/**/*.ts' --fix",

--- a/packages/create-app/tsconfig.build.json
+++ b/packages/create-app/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts"],
+  "references": [
+    {"path": "../cli-kit"}
+  ]
+}

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "clean": "shx rm -rf dist",
-    "build": "rimraf dist/ && tsc -b",
+    "build": "rimraf dist/ && tsc -b ./tsconfig.build.json",
     "prepack": "cross-env NODE_ENV=production yarn run build",
     "lint": "prettier -c src/** && eslint \"src/**/*.ts\"",
     "lint:fix": "prettier -w src/** && eslint 'src/**/*.ts' --fix",

--- a/packages/create-hydrogen/tsconfig.build.json
+++ b/packages/create-hydrogen/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts"],
+  "references": [
+    {"path": "../cli-kit"}
+  ]
+}

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "clean": "shx rm -rf dist",
-    "build": "rimraf dist/ && tsc -b",
+    "build": "rimraf dist/ && tsc -b ./tsconfig.build.json",
     "lint": "prettier -c src/** && eslint \"src/**/*.ts\"",
     "lint:fix": "prettier -w src/** && eslint 'src/**/*.ts' --fix",
     "test": "vitest run",

--- a/packages/theme/tsconfig.build.json
+++ b/packages/theme/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts"],
+  "references": [
+    {"path": "../cli-kit"}
+  ]
+}


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed with the recent replacement of Rollup with `tsc`, `build` also outputs the `.test.ts` files into the `dist` directory.

### WHAT is this pull request doing?
Since excluding the `test.ts` files from the `tsconfig.json` would yield to the IDE not assisting with types in test files, I created a separate `tsconfig.build.json` file in each package and adjusted the `build` script to use that configuration file instead.
My first approach to solve this was to use a flag, for example `--exclude`, but the `tsc` CLI doesn't support excluding via flags.

### How to test your changes?
Run `yarn build `and check that there are no `.test.js` files in the `dist/` directory.
