### PR TITLE
Report Vite build errors as aborts

### DIFF
--- a/.changeset/perfect-rats-retire.md
+++ b/.changeset/perfect-rats-retire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Not report Vite build errors as bugs

--- a/packages/cli-hydrogen/src/cli/services/dev.ts
+++ b/packages/cli-hydrogen/src/cli/services/dev.ts
@@ -8,16 +8,15 @@ interface DevOptions {
 }
 
 async function dev({directory, force, host}: DevOptions) {
-  const server = await createServer({
-    root: directory,
-    server: {
-      open: true,
-      force,
-      host,
-    },
-  })
-
   try {
+    const server = await createServer({
+      root: directory,
+      server: {
+        open: true,
+        force,
+        host,
+      },
+    })
     await server.listen()
     server.printUrls()
     server.config.logger.info('')


### PR DESCRIPTION
### WHY are these changes introduced?
There are many errors thrown by Vite that are reported as bugs to Bugsnag.

### WHAT is this pull request doing?
I'm wrapping the Vite build promise in a `try/catch` to map the errors to aborts.

### How to test your changes?
Try to build a Hydrogen storefront project that doesn't compile, for example due to a broken import.
