### PR TITLE
Fix create-x CLIs on Windows

### DIFF
--- a/.changeset/silver-berries-float.md
+++ b/.changeset/silver-berries-float.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix runCreateCLI's detection of the executable index

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -70,7 +70,8 @@ export async function runCreateCLI(options: RunCLIOptions) {
   const name = packageName.replace('@shopify/create-', '')
   const initIndex = process.argv.findIndex((arg) => arg.includes('init'))
   if (initIndex === -1) {
-    const initIndex = process.argv.findIndex((arg) => arg.match(new RegExp(`bin(/|)(create-${name}|dev|run)`))) + 1
+    const initIndex =
+      process.argv.findIndex((arg) => arg.match(new RegExp(`bin(\\/|\\\\)+(create-${name}|dev|run)`))) + 1
     process.argv.splice(initIndex, 0, 'init')
   }
   await runCLI(options)


### PR DESCRIPTION
### WHY are these changes introduced?
My recent work on [extracting duplicated code](https://github.com/Shopify/cli/pull/93) into `@shopify/cli-kit` came with a regression in the logic that detects the position of the executable in `process.argv` that causes `create-hydrogen` and `create-app` not to work on Windows. Because we don't run Windows' acceptance tests in PRs, we couldn't catch the regression before merging the PR.

### WHAT is this pull request doing?
I'm fixing it by adjusting the regular expression to account for backslashes.

### How to test your changes?

Run `create-app` or `create-hydrogen` on Windows