### PR TITLE
Increase yarn timeout to handle slower CI installs on Windows/Mac

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -81,6 +81,8 @@ jobs:
           cache: 'yarn'
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
+      - name: Increase yarn timeout
+        run: yarn config set network-timeout 300000
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Build
@@ -125,6 +127,8 @@ jobs:
           cache: 'yarn'
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
+      - name: Increase yarn timeout
+        run: yarn config set network-timeout 300000
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Build


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We've had many CI builds failing due to yarn install taking too long.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Extends the timeout from the 30-second default to 5 minutes. According to [this](https://github.com/yarnpkg/yarn/issues/8242#issuecomment-661881292) it should be a good enough workaround, as the problems are likely caused by the filesystem of Windows/Mac being significantly slower than Linux, so it needs some extra time.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
CI