### PR TITLE
Fix identity validation

### DIFF
--- a/.changeset/strange-pots-jump.md
+++ b/.changeset/strange-pots-jump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix identity token validation which is requiring a new login every time

--- a/packages/cli-kit/src/api/identity.ts
+++ b/packages/cli-kit/src/api/identity.ts
@@ -1,5 +1,6 @@
 import {identity} from '../environment/fqdn.js'
 import {debug} from '../output.js'
+import {fetch} from '../http.js'
 
 export async function validateIdentityToken(token: string) {
   try {
@@ -13,7 +14,8 @@ export async function validateIdentityToken(token: string) {
     debug(`Sending Identity Introspection request to URL: ${instrospectionURL}`)
 
     const response = await fetch(instrospectionURL, options)
-    const json = await response.json()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const json: any = await response.json()
 
     debug(`The identity token is valid: ${json.valid}`)
     return json.valid
@@ -26,6 +28,7 @@ export async function validateIdentityToken(token: string) {
 
 async function getInstrospectionEndpoint(): Promise<string> {
   const response = await fetch(`https://${await identity()}/.well-known/openid-configuration.json`)
-  const json = await response.json()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const json: any = await response.json()
   return json.introspection_endpoint
 }


### PR DESCRIPTION
### WHY are these changes introduced?

After releasing https://github.com/Shopify/cli/pull/70, we are now trying to validate the Identity token, but we are using Node's fetch, [which is only available after Node 18](https://nodejs.org/en/blog/announcements/v18-release-announce/#fetch-experimental), so it's failing for older versions:

`The identity token is invalid: ReferenceError: fetch is not defined`

And this is requiring a new login on every command.

### WHAT is this pull request doing?

Use the right fetch function from the cli-kit to support all the Node versions

### How to test your changes?

`yarn dev` 2 times