### PR TITLE
Bumping theme-check version to 1.10.3

### DIFF
--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -12,7 +12,7 @@ import {spawn} from 'child_process'
 import {Writable} from 'node:stream'
 
 const RubyCLIVersion = '2.16.0'
-const ThemeCheckVersion = '1.10.2'
+const ThemeCheckVersion = '1.10.3'
 const MinBundlerVersion = '2.3.8'
 const MinRubyVersion = '2.3.0'
 const MinRubyGemVersion = '2.5.0'


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/cli/issues/112

Bumping `theme-check` version to unblock `yarn deploy` (needed for checkout-ui-extension development)

### WHAT is this pull request doing?
This PR bumps the version of `theme-check` to the latest version, which does not fail when checking `theme-app-extensions` using `app` liquid drops.
