### PR TITLE
Replaces btoa to Buffer.from

### DIFF
--- a/.changeset/weak-humans-mix.md
+++ b/.changeset/weak-humans-mix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Replaces btoa() with Buffer.from()

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -66,7 +66,7 @@ function outputThemeExtensionsMessage(extensions: ThemeExtension[]) {
 
 function buildAppURL(storeFqdn: string, publicURL: string) {
   const hostUrl = `${storeFqdn}/admin`
-  const hostParam = btoa(hostUrl).replace(/[=]/g, '')
+  const hostParam = Buffer.from(hostUrl, 'binary').toString('base64').replace(/[=]/g, '')
   return `${publicURL}?shop=${storeFqdn}&host=${hostParam}`
 }
 

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -66,7 +66,7 @@ function outputThemeExtensionsMessage(extensions: ThemeExtension[]) {
 
 function buildAppURL(storeFqdn: string, publicURL: string) {
   const hostUrl = `${storeFqdn}/admin`
-  const hostParam = Buffer.from(hostUrl, 'binary').toString('base64').replace(/[=]/g, '')
+  const hostParam = Buffer.from(hostUrl).toString('base64').replace(/[=]/g, '')
   return `${publicURL}?shop=${storeFqdn}&host=${hostParam}`
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-app-template-php/issues/237 

A line of code uses `btoa` which only works in the browser and is undefined in nodejs. 
This PR replaces that with a working code.

### WHAT is this pull request doing?

Removes `btoa` which is only available in the browser and replaces with `Buffer.from` which is the common approach to convert into a base64 string in node js

https://nodejs.org/api/buffer.html#bufferbtoadata

<img width="817" alt="image" src="https://user-images.githubusercontent.com/29296982/177477815-76e1c55d-e910-4160-b95f-589553a8be18.png">
