### PR TITLE
Retrying implementation for obtaining a random port

### DIFF
--- a/.changeset/lazy-teachers-battle.md
+++ b/.changeset/lazy-teachers-battle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Added a retrying implementation to the method that obtains a random local port. Occasionally that third party logic failed in the middle of the execution of a command and abort the process. Running the command for a second time solved that temporary problem

--- a/packages/cli-kit/src/port.test.ts
+++ b/packages/cli-kit/src/port.test.ts
@@ -37,4 +37,3 @@ describe('getRandomPort', () => {
     await expect(getRandomPort()).rejects.toThrowError(new Abort(errorMessage))
   })
 })
-∫

--- a/packages/cli-kit/src/port.test.ts
+++ b/packages/cli-kit/src/port.test.ts
@@ -1,0 +1,39 @@
+import {getRandomPort} from './port'
+import * as System from './system'
+import {Abort} from './error'
+import * as port from 'get-port-please'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+beforeEach(() => {
+  vi.mock('get-port-please')
+})
+
+const errorMessage = 'Unable to generate random port'
+
+describe('getRandomPort', () => {
+  it('returns random port if the number retries is not exceeded', async () => {
+    // Given
+    vi.mocked(port.getRandomPort).mockRejectedValueOnce(new Error(errorMessage))
+    vi.mocked(port.getRandomPort).mockResolvedValue(5)
+    const debugError = vi.spyOn(System, 'sleep')
+
+    // When
+    const got = await getRandomPort()
+
+    // Then
+    expect(got).toBe(5)
+    expect(debugError).toHaveBeenCalledOnce()
+  })
+
+  it('returns random port if the number retries is not exceeded', async () => {
+    // Given
+    const maxTries = 5
+    for (let i = 0; i < maxTries; i++) {
+      vi.mocked(port.getRandomPort).mockRejectedValueOnce(new Error(errorMessage))
+    }
+    const debugError = vi.spyOn(System, 'sleep')
+
+    // When/Then
+    await expect(getRandomPort()).rejects.toThrowError(new Abort(errorMessage))
+  })
+})

--- a/packages/cli-kit/src/port.test.ts
+++ b/packages/cli-kit/src/port.test.ts
@@ -31,7 +31,6 @@ describe('getRandomPort', () => {
     for (let i = 0; i < maxTries; i++) {
       vi.mocked(port.getRandomPort).mockRejectedValueOnce(new Error(errorMessage))
     }
-    const debugError = vi.spyOn(System, 'sleep')
 
     // When/Then
     await expect(getRandomPort()).rejects.toThrowError(new Abort(errorMessage))

--- a/packages/cli-kit/src/port.test.ts
+++ b/packages/cli-kit/src/port.test.ts
@@ -25,7 +25,7 @@ describe('getRandomPort', () => {
     expect(debugError).toHaveBeenCalledOnce()
   })
 
-  it('thwrows an abort expection with same error message if the number retries is not exceeded', async () => {
+  it('throws an abort exception with same error message received from third party getRandomPort if the number retries is exceeded', async () => {
     // Given
     const maxTries = 5
     for (let i = 0; i < maxTries; i++) {
@@ -37,3 +37,4 @@ describe('getRandomPort', () => {
     await expect(getRandomPort()).rejects.toThrowError(new Abort(errorMessage))
   })
 })
+∫

--- a/packages/cli-kit/src/port.test.ts
+++ b/packages/cli-kit/src/port.test.ts
@@ -25,7 +25,7 @@ describe('getRandomPort', () => {
     expect(debugError).toHaveBeenCalledOnce()
   })
 
-  it('returns random port if the number retries is not exceeded', async () => {
+  it('thwrows an abort expection with same error message if the number retries is not exceeded', async () => {
     // Given
     const maxTries = 5
     for (let i = 0; i < maxTries; i++) {

--- a/packages/cli-kit/src/port.ts
+++ b/packages/cli-kit/src/port.ts
@@ -1,4 +1,6 @@
 import {debug, content, token} from './output.js'
+import {Abort} from './error.js'
+import {sleep} from './system.js'
 import * as port from 'get-port-please'
 
 /**
@@ -7,7 +9,24 @@ import * as port from 'get-port-please'
  */
 export async function getRandomPort(): Promise<number> {
   debug(content`Getting a random port...`)
-  const randomPort = await port.getRandomPort()
-  debug(content`Random port obtained: ${token.raw(`${randomPort}`)}`)
-  return randomPort
+  const maxTries = 5
+  const waitTimeInSeconds = 1
+  let retryCount = 1
+  while (true) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const randomPort = await port.getRandomPort()
+      debug(content`Random port obtained: ${token.raw(`${randomPort}`)}`)
+      return randomPort
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      if (retryCount++ < maxTries) {
+        debug(content`Unknown problem getting a random port: ${error.message}`)
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(waitTimeInSeconds)
+      } else {
+        throw new Abort(error.message)
+      }
+    }
+  }
 }

--- a/packages/cli-kit/src/port.ts
+++ b/packages/cli-kit/src/port.ts
@@ -9,15 +9,17 @@ import * as port from 'get-port-please'
  */
 export async function getRandomPort(): Promise<number> {
   debug(content`Getting a random port...`)
-  const maxTries = 5
-  const waitTimeInSeconds = 1
+  const randomPort = retryOnError(() => port.getRandomPort())
+  debug(content`Random port obtained: ${token.raw(`${randomPort}`)}`)
+  return randomPort
+}
+
+async function retryOnError<T>(execute: () => T, maxTries = 5, waitTimeInSeconds = 1) {
   let retryCount = 1
   while (true) {
     try {
       // eslint-disable-next-line no-await-in-loop
-      const randomPort = await port.getRandomPort()
-      debug(content`Random port obtained: ${token.raw(`${randomPort}`)}`)
-      return randomPort
+      return await execute()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       if (retryCount++ < maxTries) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #109

### WHAT is this pull request doing?
* Added a retrying implementation over the third party method that obtains a random port. Ocassionally that method seems to fail and raises an exception unhandled, so the execution of the command fails. The problem was solved executing the command again

### How to test your changes?
I can't replicate the problem in my local environment, so unit tests were added to verify the implementation. Executing `shopify app dev` should never fails now due to the local port problem
