### PR TITLE
Configure VSCode to add the `.js` extension automatically when auto-importing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,4 +37,6 @@
   "eslint.workingDirectories": [{ "pattern": "packages/*/package.json" }],
   "vitest.enable": true,
   "testing.automaticallyOpenPeekView": "never",
+  "javascript.preferences.importModuleSpecifierEnding": "js",
+  "typescript.preferences.importModuleSpecifierEnding": "js",
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Before removing Rollup, when module identifiers didn't require to include the extensions, VSCode's auto-import behaviour aligned with what Rollup expected (i.e. module ids were added without extension). However, with the replacement for `tsc`, which requires the `.js` extension in the module identifiers, VSCode's auto-import behaviour broke.

### WHAT is this pull request doing?
I'm setting the necessary VSCode configuration to align with `tsc`.

### How to test your changes?
Try to use the auto-import functionality.
