### PR TITLE
Cache node_modules pre-install in CI for faster builds

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -91,7 +91,7 @@ jobs:
           path: |
             ./**/*
             ./**/.*
-          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('./**/*') }}-${{ hashFiles('./**/.*') }}
+          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('yarn.lock', 'packages/**/*') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout
@@ -138,7 +138,7 @@ jobs:
           path: |
             ./**/*
             ./**/.*
-          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('./**/*') }}-${{ hashFiles('./**/.*') }}
+          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('yarn.lock', 'packages/**/*') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout
@@ -197,7 +197,7 @@ jobs:
           path: |
             ./**/*
             ./**/.*
-          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('./**/*') }}-${{ hashFiles('./**/.*') }}
+          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('yarn.lock', 'packages/**/*') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -116,8 +116,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         node: ['14', '16', '18']
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
       max-parallel: 6
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -91,7 +91,7 @@ jobs:
           path: |
             ./**/*
             ./**/.*
-          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
+          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('./**/*') }}-${{ hashFiles('./**/.*') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout
@@ -138,7 +138,7 @@ jobs:
           path: |
             ./**/*
             ./**/.*
-          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
+          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('./**/*') }}-${{ hashFiles('./**/.*') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout
@@ -197,7 +197,7 @@ jobs:
           path: |
             ./**/*
             ./**/.*
-          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
+          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('./**/*') }}-${{ hashFiles('./**/.*') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
+      - name: Cache node_modules pre-install
+        id: cache_node_modules
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Install dependencies
@@ -79,6 +85,12 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
+      - name: Cache node_modules pre-install
+        id: cache_node_modules
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout
@@ -128,6 +140,12 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
+      - name: Cache node_modules pre-install
+        id: cache_node_modules
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -48,7 +48,9 @@ jobs:
         id: cache_node_modules
         uses: actions/cache@v2
         with:
-          path: '**/node_modules/**'
+          path: |
+            **/node_modules
+            **/node_modules/.yarn-integrity
           key: cache-node-modules-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
@@ -89,7 +91,9 @@ jobs:
         id: cache_node_modules
         uses: actions/cache@v2
         with:
-          path: '**/node_modules/**'
+          path: |
+            **/node_modules
+            **/node_modules/.yarn-integrity
           key: cache-node-modules-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
@@ -144,7 +148,9 @@ jobs:
         id: cache_node_modules
         uses: actions/cache@v2
         with:
-          path: '**/node_modules/**'
+          path: |
+            **/node_modules
+            **/node_modules/.yarn-integrity
           key: cache-node-modules-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -48,7 +48,7 @@ jobs:
         id: cache_node_modules
         uses: actions/cache@v2
         with:
-          path: '**/node_modules'
+          path: '**/node_modules/**'
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
@@ -89,7 +89,7 @@ jobs:
         id: cache_node_modules
         uses: actions/cache@v2
         with:
-          path: '**/node_modules'
+          path: '**/node_modules/**'
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
@@ -144,7 +144,7 @@ jobs:
         id: cache_node_modules
         uses: actions/cache@v2
         with:
-          path: '**/node_modules'
+          path: '**/node_modules/**'
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '**/node_modules/**'
-          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
+          key: cache-node-modules-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Install dependencies
@@ -90,7 +90,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '**/node_modules/**'
-          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
+          key: cache-node-modules-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout
@@ -145,7 +145,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '**/node_modules/**'
-          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
+          key: cache-node-modules-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -84,7 +84,6 @@ jobs:
         uses: actions/setup-node@master
         with:
           node-version: 18
-          cache: 'yarn'
       - name: Cache built app
         id: cache_built_app
         uses: actions/cache@v2
@@ -132,7 +131,6 @@ jobs:
         uses: actions/setup-node@master
         with:
           node-version: ${{ matrix.node }}
-          cache: 'yarn'
       - name: Cache built app
         id: cache_built_app
         uses: actions/cache@v2
@@ -192,7 +190,6 @@ jobs:
         uses: actions/setup-node@master
         with:
           node-version: ${{ matrix.node }}
-          cache: 'yarn'
       - name: Cache built app
         id: cache_built_app
         uses: actions/cache@v2

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -118,7 +118,7 @@ jobs:
       matrix:
         node: ['14', '16', '18']
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-      max-parallel: 6
+      max-parallel: 3
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -58,10 +58,56 @@ jobs:
         run: yarn install --ignore-engines
       - name: Build the fixture app
         run: yarn shopify app build --path ./fixtures/app
+  warm-cache:
+    name: Warm Cache
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout [main]
+        with:
+          fetch-depth: 0
+      - name: Set Git configuration
+        run: |
+          git config --global user.email "development-lifecycle@shopify.com"
+          git config --global user.name "Development Lifecycle"
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v2
+      - name: Set Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Set Node.js
+        uses: actions/setup-node@master
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - name: Cache built app
+        id: cache_built_app
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./**/*
+            ./**/.*
+          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Install yarn
+        run: npm install --global yarn@${{ env.YARN_VERSION }}
+      - name: Increase yarn timeout
+        run: yarn config set network-timeout 300000
+      - name: Install dependencies
+        if: steps.cache_built_app.outputs.cache-hit != 'true'
+        run: yarn install --ignore-engines
+      - name: Build
+        if: steps.cache_built_app.outputs.cache-hit != 'true'
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build --skip-nx-cache
   main:
     name: Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'pull_request' }}
+    needs: warm-cache
     timeout-minutes: 30
     strategy:
       matrix:
@@ -87,21 +133,23 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
-      - name: Cache node_modules pre-install
-        id: cache_node_modules
+      - name: Cache built app
+        id: cache_built_app
         uses: actions/cache@v2
         with:
           path: |
-            **/node_modules
-            **/node_modules/.yarn-integrity
-          key: cache-node-modules-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
+            ./**/*
+            ./**/.*
+          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout
         run: yarn config set network-timeout 300000
       - name: Install dependencies
+        if: steps.cache_built_app.outputs.cache-hit != 'true'
         run: yarn install --ignore-engines
       - name: Build
+        if: steps.cache_built_app.outputs.cache-hit != 'true'
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build --skip-nx-cache
       - name: Lint
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint --skip-nx-cache
@@ -117,6 +165,7 @@ jobs:
     name: Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name == 'pull_request' }}
+    needs: warm-cache
     timeout-minutes: 30
     strategy:
       matrix:
@@ -144,21 +193,23 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
-      - name: Cache node_modules pre-install
-        id: cache_node_modules
+      - name: Cache built app
+        id: cache_built_app
         uses: actions/cache@v2
         with:
           path: |
-            **/node_modules
-            **/node_modules/.yarn-integrity
-          key: cache-node-modules-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
+            ./**/*
+            ./**/.*
+          key: cache-built-app-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install yarn
         run: npm install --global yarn@${{ env.YARN_VERSION }}
       - name: Increase yarn timeout
         run: yarn config set network-timeout 300000
       - name: Install dependencies
+        if: steps.cache_built_app.outputs.cache-hit != 'true'
         run: yarn install --ignore-engines
       - name: Build
+        if: steps.cache_built_app.outputs.cache-hit != 'true'
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build --skip-nx-cache
       - name: Type-check
         run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=tsc --skip-nx-cache


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Make CI faster! Cache allthethings!

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Caches node_modules, as it's faster to reconstitute from a cache than to install via yarn, which involves lengthy resolution, linking, and build steps. We then run `yarn install anyway` because:

1. Maybe it's the first time
2. `yarn install` should be just a second or two when it's not the first time, as it'll find that everything is already there and built!

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
CI