### PR TITLE
Create AppClass as implementation of App interface

### DIFF
--- a/packages/app/src/cli/commands/app/build.ts
+++ b/packages/app/src/cli/commands/app/build.ts
@@ -1,5 +1,5 @@
 import {appFlags} from '../../flags.js'
-import {App, load as loadApp} from '../../models/app/app.js'
+import {AppInterface, load as loadApp} from '../../models/app/app.js'
 import build from '../../services/build.js'
 import {Command, Flags} from '@oclif/core'
 import {path, cli} from '@shopify/cli-kit'
@@ -28,7 +28,7 @@ export default class Build extends Command {
   async run(): Promise<void> {
     const {flags} = await this.parse(Build)
     const directory = flags.path ? path.resolve(flags.path) : process.cwd()
-    const app: App = await loadApp(directory)
+    const app: AppInterface = await loadApp(directory)
     await build({app, skipDependenciesInstallation: flags['skip-dependencies-installation'], apiKey: flags['api-key']})
   }
 }

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -1,6 +1,6 @@
 import {appFlags} from '../../flags.js'
 import {deploy} from '../../services/deploy.js'
-import {App, load as loadApp} from '../../models/app/app.js'
+import {AppInterface, load as loadApp} from '../../models/app/app.js'
 import {Command, Flags} from '@oclif/core'
 import {path, cli} from '@shopify/cli-kit'
 
@@ -21,7 +21,7 @@ export default class Deploy extends Command {
   async run(): Promise<void> {
     const {args, flags} = await this.parse(Deploy)
     const directory = flags.path ? path.resolve(flags.path) : process.cwd()
-    const app: App = await loadApp(directory)
+    const app: AppInterface = await loadApp(directory)
     await deploy({app, reset: flags.reset})
   }
 }

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -1,5 +1,5 @@
 import {appFlags} from '../../flags.js'
-import {load as loadApp, App} from '../../models/app/app.js'
+import {load as loadApp, AppInterface} from '../../models/app/app.js'
 import dev from '../../services/dev.js'
 import {Command, Flags} from '@oclif/core'
 import {path, string, cli, error} from '@shopify/cli-kit'
@@ -66,7 +66,7 @@ export default class Dev extends Command {
   public async run(): Promise<void> {
     const {flags} = await this.parse(Dev)
     const directory = flags.path ? path.resolve(flags.path) : process.cwd()
-    const app: App = await loadApp(directory)
+    const app: AppInterface = await loadApp(directory)
     const commandConfig = this.config
 
     try {

--- a/packages/app/src/cli/commands/app/info.ts
+++ b/packages/app/src/cli/commands/app/info.ts
@@ -1,5 +1,5 @@
 import {appFlags} from '../../flags.js'
-import {load as loadApp, App} from '../../models/app/app.js'
+import {load as loadApp, AppInterface} from '../../models/app/app.js'
 import {Format, info} from '../../services/info.js'
 import {Command, Flags} from '@oclif/core'
 import {output, path, cli} from '@shopify/cli-kit'
@@ -27,7 +27,7 @@ export default class AppInfo extends Command {
   public async run(): Promise<void> {
     const {flags} = await this.parse(AppInfo)
     const directory = flags.path ? path.resolve(flags.path) : process.cwd()
-    const app: App = await loadApp(directory, 'report')
+    const app: AppInterface = await loadApp(directory, 'report')
     output.info(await info(app, {format: (flags.json ? 'json' : 'text') as Format, webEnv: flags['web-env']}))
     if (app.errors) process.exit(2)
   }

--- a/packages/app/src/cli/commands/app/scaffold/extension.test.ts
+++ b/packages/app/src/cli/commands/app/scaffold/extension.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-irregular-whitespace */
 import AppScaffoldExtension from './extension.js'
 import {ExtensionTypesHumanKeys, getExtensionOutputConfig} from '../../../constants.js'
-import {App, load as loadApp} from '../../../models/app/app.js'
+import {AppInterface, load as loadApp} from '../../../models/app/app.js'
 import scaffoldExtensionPrompt from '../../../prompts/scaffold/extension.js'
 import scaffoldExtensionService from '../../../services/scaffold/extension.js'
 import {describe, expect, it, vi, beforeAll, afterEach} from 'vitest'
@@ -93,7 +93,7 @@ function mockSuccessfulCommandExecution(outputConfig: {
   additionalHelp?: string
 }) {
   const appRoot = '/'
-  const app: App = {
+  const app: AppInterface = {
     name: 'myapp',
     idEnvironmentVariableName: 'SHOPIFY_API_KEY',
     directory: appRoot,

--- a/packages/app/src/cli/commands/app/scaffold/extension.test.ts
+++ b/packages/app/src/cli/commands/app/scaffold/extension.test.ts
@@ -105,6 +105,8 @@ function mockSuccessfulCommandExecution(outputConfig: {
     webs: [],
     nodeDependencies: {},
     extensions: {ui: [], function: [], theme: []},
+    updateDependencies: vi.fn(),
+    hasExtensions: vi.fn(),
   }
 
   vi.mocked(getExtensionOutputConfig).mockReturnValue(outputConfig)

--- a/packages/app/src/cli/commands/app/scaffold/extension.ts
+++ b/packages/app/src/cli/commands/app/scaffold/extension.ts
@@ -9,7 +9,7 @@ import {
   functionExtensionTemplates,
 } from '../../../constants.js'
 import scaffoldExtensionPrompt from '../../../prompts/scaffold/extension.js'
-import {load as loadApp, App} from '../../../models/app/app.js'
+import {load as loadApp, AppInterface} from '../../../models/app/app.js'
 import scaffoldExtensionService from '../../../services/scaffold/extension.js'
 import {getUIExtensionTemplates} from '../../../utilities/extensions/template-configuration.js'
 import {output, path, cli, error, environment} from '@shopify/cli-kit'
@@ -56,7 +56,7 @@ export default class AppScaffoldExtension extends Command {
   public async run(): Promise<void> {
     const {flags} = await this.parse(AppScaffoldExtension)
     const directory = flags.path ? path.resolve(flags.path) : process.cwd()
-    const app: App = await loadApp(directory)
+    const app: AppInterface = await loadApp(directory)
 
     await this.validateExtensionType(flags.type)
     this.validateExtensionTypeLimit(app, flags.type)
@@ -102,10 +102,10 @@ export default class AppScaffoldExtension extends Command {
   /**
    * If the type passed as flag is not valid because it has already been scaffolded
    * and we don't allow multiple extensions of that type, throw an error
-   * @param app {App} current App
+   * @param app {AppInterface} current App
    * @param type {string} extension type
    */
-  validateExtensionTypeLimit(app: App, type: string | undefined) {
+  validateExtensionTypeLimit(app: AppInterface, type: string | undefined) {
     if (type && this.limitedExtensionsAlreadyScaffolded(app).includes(type)) {
       throw new error.Abort('Invalid extension type', `You can only scaffold one extension of type ${type} per app`)
     }
@@ -136,10 +136,10 @@ export default class AppScaffoldExtension extends Command {
    * Some extension types like `theme` and `product_subscription` are limited to one per app
    * Use this method to retrieve a list of the limited types that have already been scaffolded
    *
-   * @param app {App} current App
+   * @param app {AppInterface} current App
    * @returns {string[]} list of extensions that are limited by quantity and are already scaffolded
    */
-  limitedExtensionsAlreadyScaffolded(app: App): string[] {
+  limitedExtensionsAlreadyScaffolded(app: AppInterface): string[] {
     const themeTypes = app.extensions.theme.map((ext) => ext.configuration.type)
     const uiTypes = app.extensions.ui.map((ext) => ext.configuration.type)
 

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -243,7 +243,7 @@ export function getExtensionTypeFromHumanKey(humanKey: ExtensionTypesHumanKeys):
 }
 
 /**
- * Each extension has a different ID in graphQL.
+ * Each extension has a different ID in GraphQL.
  * Sometimes the ID is the same as the type, sometimes it's different.
  * @param type {string} The extension type
  * @returns {string} The extension GraphQL ID

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -242,6 +242,36 @@ export function getExtensionTypeFromHumanKey(humanKey: ExtensionTypesHumanKeys):
   }
 }
 
+/**
+ * Each extension has a different ID in graphQL.
+ * Sometimes the ID is the same as the type, sometimes it's different.
+ * @param type {string} The extension type
+ * @returns {string} The extension GraphQL ID
+ */
+export const extensionGraphqlId = (type: ExtensionTypes) => {
+  switch (type) {
+    case 'product_subscription':
+      return 'SUBSCRIPTION_MANAGEMENT'
+    case 'checkout_ui_extension':
+      return 'CHECKOUT_UI_EXTENSION'
+    case 'checkout_post_purchase':
+      return 'CHECKOUT_POST_PURCHASE'
+    case 'pos_ui_extension':
+      return 'POS_UI_EXTENSION'
+    case 'theme':
+      return 'THEME_APP_EXTENSION'
+    case 'web_pixel_extension':
+      return 'WEB_PIXEL_EXTENSION'
+    case 'product_discounts':
+    case 'order_discounts':
+    case 'shipping_discounts':
+    case 'payment_methods':
+    case 'shipping_rate_presenter':
+      // As we add new extensions, this bug will force us to add a new case here.
+      return type
+  }
+}
+
 function buildExtensionOutputConfig(humanKey: ExtensionTypesHumanKeys, helpURL?: string, additionalHelp?: string) {
   return {
     humanKey,

--- a/packages/app/src/cli/models/app/app-loader.ts
+++ b/packages/app/src/cli/models/app/app-loader.ts
@@ -7,8 +7,8 @@ import {
   FunctionExtensionMetadataSchema,
   ThemeExtensionConfigurationSchema,
 } from './extensions.js'
-import {AppConfigurationSchema, Web, WebConfigurationSchema, extensionGraphqlId, AppClass} from './app.js'
-import {blocks, configurationFileNames, dotEnvFileNames} from '../../constants.js'
+import {AppConfigurationSchema, Web, WebConfigurationSchema, AppClass} from './app.js'
+import {blocks, configurationFileNames, dotEnvFileNames, extensionGraphqlId} from '../../constants.js'
 import {error, file, id, path, schema, string, toml, output} from '@shopify/cli-kit'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {getDependencies, getPackageManager, getPackageName} from '@shopify/cli-kit/node/node-package-manager'

--- a/packages/app/src/cli/models/app/app-loader.ts
+++ b/packages/app/src/cli/models/app/app-loader.ts
@@ -82,8 +82,9 @@ export class AppLoader {
       themeExtensions,
       functions,
       dotenv,
-      this.errors,
     )
+
+    if (!this.errors.isEmpty()) appClass.errors = this.errors
 
     return appClass
   }

--- a/packages/app/src/cli/models/app/app-loader.ts
+++ b/packages/app/src/cli/models/app/app-loader.ts
@@ -7,7 +7,7 @@ import {
   FunctionExtensionMetadataSchema,
   ThemeExtensionConfigurationSchema,
 } from './extensions.js'
-import {AppConfigurationSchema, Web, WebConfigurationSchema, AppClass} from './app.js'
+import {AppConfigurationSchema, Web, WebConfigurationSchema, App} from './app.js'
 import {blocks, configurationFileNames, dotEnvFileNames, extensionGraphqlId} from '../../constants.js'
 import {error, file, id, path, schema, string, toml, output} from '@shopify/cli-kit'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
@@ -69,7 +69,7 @@ export class AppLoader {
     const packageManager = await getPackageManager(this.appDirectory)
     const webs = await this.loadWebs()
 
-    const appClass = new AppClass(
+    const appClass = new App(
       name,
       'SHOPIFY_API_KEY',
       this.appDirectory,

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1,8 +1,8 @@
-import {App, AppClass} from './app.js'
+import {AppInterface, App} from './app.js'
 import {UIExtension} from './extensions.js'
 
-export function testApp(app: Partial<App> = {}): App {
-  return new AppClass(
+export function testApp(app: Partial<AppInterface> = {}): AppInterface {
+  return new App(
     app.name ?? 'App',
     app.idEnvironmentVariableName ?? 'SHOPIFY_API_KEY',
     app.directory ?? '/tmp/project',

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1,25 +1,22 @@
-import {App} from './app.js'
+import {App, AppClass} from './app.js'
 import {UIExtension} from './extensions.js'
 
 export function testApp(app: Partial<App> = {}): App {
-  return {
-    name: app?.name ?? 'App',
-    idEnvironmentVariableName: app.idEnvironmentVariableName ?? 'SHOPIFY_API_KEY',
-    configuration: {
-      scopes: app?.configuration?.scopes ?? '',
-    },
-    packageManager: app.packageManager ?? 'yarn',
-    directory: app.directory ?? '/tmp/project',
-    extensions: {
-      ui: app?.extensions?.ui ?? [],
-      function: app?.extensions?.function ?? [],
-      theme: app?.extensions?.theme ?? [],
-    },
-    webs: app?.webs ?? [],
-    nodeDependencies: app?.nodeDependencies ?? {},
-    dotenv: app.dotenv,
-    configurationPath: app?.configurationPath ?? '/tmp/project/shopify.app.toml',
-  }
+  return new AppClass(
+    app.name ?? 'App',
+    app.idEnvironmentVariableName ?? 'SHOPIFY_API_KEY',
+    app.directory ?? '/tmp/project',
+    app.packageManager ?? 'yarn',
+    app.configuration ?? {scopes: ''},
+    app.configurationPath ?? '/tmp/project/shopify.app.toml',
+    app.nodeDependencies ?? {},
+    app.webs ?? [],
+    app.extensions?.ui ?? [],
+    app.extensions?.theme ?? [],
+    app.extensions?.function ?? [],
+    app.dotenv,
+    app.errors,
+  )
 }
 
 export function testUIExtension(uiExtension: Partial<UIExtension> = {}): UIExtension {

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -2,7 +2,7 @@ import {load, getUIExtensionRendererVersion, App} from './app.js'
 import {updateAppIdentifiers, getAppIdentifiers} from './identifiers.js'
 import {testApp, testUIExtension} from './app.test-data.js'
 import {configurationFileNames, blocks} from '../../constants.js'
-import {describe, it, expect, beforeEach, afterEach, test} from 'vitest'
+import {describe, it, expect, beforeEach, afterEach, test, vi} from 'vitest'
 import {file, path} from '@shopify/cli-kit'
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env'
 import {yarnLockfile, pnpmLockfile} from '@shopify/cli-kit/node/node-package-manager'
@@ -23,6 +23,8 @@ const DEFAULT_APP: App = {
   webs: [],
   nodeDependencies: {},
   configurationPath: '/tmp/project/shopify.app.toml',
+  updateDependencies: vi.fn(),
+  hasExtensions: vi.fn(),
 }
 
 describe('load', () => {

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -1,4 +1,4 @@
-import {load, getUIExtensionRendererVersion, App} from './app.js'
+import {load, getUIExtensionRendererVersion, AppInterface} from './app.js'
 import {updateAppIdentifiers, getAppIdentifiers} from './identifiers.js'
 import {testApp, testUIExtension} from './app.test-data.js'
 import {configurationFileNames, blocks} from '../../constants.js'
@@ -7,7 +7,7 @@ import {file, path} from '@shopify/cli-kit'
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env'
 import {yarnLockfile, pnpmLockfile} from '@shopify/cli-kit/node/node-package-manager'
 
-const DEFAULT_APP: App = {
+const DEFAULT_APP: AppInterface = {
   name: 'App',
   idEnvironmentVariableName: 'SHOPIFY_API_KEY',
   configuration: {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -111,24 +111,6 @@ export class AppClass implements App {
       this.extensions.ui.length !== 0 || this.extensions.function.length !== 0 || this.extensions.theme.length !== 0
     )
   }
-
-  async getUIExtensionRendererVersion(uiExtensionType: UIExtensionTypes): Promise<RendererVersionResult> {
-    // Look for the vanilla JS version of the dependency (the react one depends on it, will always be present)
-    const fullName = getUIExtensionRendererDependency(uiExtensionType)?.name.replace('-react', '')
-    if (!fullName) return undefined
-    // Split the dependency name to avoid using "/" in windows
-    const dependencyName = fullName.split('/')
-
-    // Find the package.json in the project structure
-    const realPath = path.join('node_modules', dependencyName[0], dependencyName[1], 'package.json')
-    const packagePath = await path.findUp(realPath, {type: 'file', cwd: app.directory})
-    if (!packagePath) return 'not_found'
-
-    // Load the package.json and extract the version
-    const packageContent = await readAndParsePackageJson(packagePath)
-    if (!packageContent.version) return 'not_found'
-    return {name: fullName, version: packageContent.version}
-  }
 }
 
 export async function load(directory: string, mode: AppLoaderMode = 'strict'): Promise<App> {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -31,7 +31,7 @@ export interface Web {
   configuration: WebConfiguration
 }
 
-export interface App {
+export interface AppInterface {
   name: string
   idEnvironmentVariableName: string
   directory: string
@@ -51,7 +51,7 @@ export interface App {
   updateDependencies: () => Promise<void>
 }
 
-export class AppClass implements App {
+export class App implements AppInterface {
   name: string
   idEnvironmentVariableName: string
   directory: string
@@ -113,7 +113,7 @@ export class AppClass implements App {
   }
 }
 
-export async function load(directory: string, mode: AppLoaderMode = 'strict'): Promise<App> {
+export async function load(directory: string, mode: AppLoaderMode = 'strict'): Promise<AppInterface> {
   const loader = new AppLoader({directory, mode})
   return loader.loaded()
 }
@@ -124,12 +124,12 @@ type RendererVersionResult = {name: string; version: string} | undefined | 'not_
  * Given a UI extension and the app it belongs to, it returns the version of the renderer package.
  * Looks for `/node_modules/@shopify/{renderer-package-name}/package.json` to find the real version used.
  * @param uiExtensionType {UIExtensionTypes} UI extension whose renderer version will be obtained.
- * @param app {App} App object containing the extension.
+ * @param app {AppInterface} App object containing the extension.
  * @returns {{name: string; version: string} | undefined} The version if the dependency exists.
  */
 export async function getUIExtensionRendererVersion(
   uiExtensionType: UIExtensionTypes,
-  app: App,
+  app: AppInterface,
 ): Promise<RendererVersionResult> {
   // Look for the vanilla JS version of the dependency (the react one depends on it, will always be present)
   const fullName = getUIExtensionRendererDependency(uiExtensionType)?.name.replace('-react', '')

--- a/packages/app/src/cli/models/app/identifiers.ts
+++ b/packages/app/src/cli/models/app/identifiers.ts
@@ -1,5 +1,5 @@
 import {Extension} from './extensions.js'
-import {App} from './app'
+import {AppInterface} from './app'
 import {dotEnvFileNames} from '../../constants.js'
 import {path, string} from '@shopify/cli-kit'
 import {writeDotEnv} from '@shopify/cli-kit/node/dot-env'
@@ -26,20 +26,20 @@ export interface Identifiers {
 export type UuidOnlyIdentifiers = Omit<Identifiers, 'extensionIds'>
 type UpdateAppIdentifiersCommand = 'dev' | 'deploy'
 interface UpdateAppIdentifiersOptions {
-  app: App
+  app: AppInterface
   identifiers: UuidOnlyIdentifiers
   command: UpdateAppIdentifiersCommand
 }
 /**
  * Given an app and a set of identifiers, it persists the identifiers in the .env files.
  * @param options {UpdateAppIdentifiersOptions} Options.
- * @returns {App} An copy of the app with the environment updated to reflect the updated identifiers.
+ * @returns {AppInterface} An copy of the app with the environment updated to reflect the updated identifiers.
  */
 
 export async function updateAppIdentifiers(
   {app, identifiers, command}: UpdateAppIdentifiersOptions,
   systemEnvironment = process.env,
-): Promise<App> {
+): Promise<AppInterface> {
   let dotenvFile = app.dotenv
   if (!dotenvFile) {
     dotenvFile = {
@@ -70,7 +70,7 @@ export async function updateAppIdentifiers(
 }
 
 interface GetAppIdentifiersOptions {
-  app: App
+  app: AppInterface
 }
 /**
  * Given an app and a environment, it fetches the ids from the environment

--- a/packages/app/src/cli/models/app/identifiers.ts
+++ b/packages/app/src/cli/models/app/identifiers.ts
@@ -63,11 +63,12 @@ export async function updateAppIdentifiers(
   if (write) {
     await writeDotEnv(dotenvFile)
   }
-  return {
-    ...app,
-    dotenv: dotenvFile,
-  }
+
+  // eslint-disable-next-line require-atomic-updates
+  app.dotenv = dotenvFile
+  return app
 }
+
 interface GetAppIdentifiersOptions {
   app: App
 }

--- a/packages/app/src/cli/services/build.ts
+++ b/packages/app/src/cli/services/build.ts
@@ -1,12 +1,12 @@
 import {buildThemeExtensions, buildUIExtensions, buildFunctionExtension} from './build/extension.js'
 import buildWeb from './web.js'
 import {installAppDependencies} from './dependencies.js'
-import {App, Web} from '../models/app/app.js'
+import {AppInterface, Web} from '../models/app/app.js'
 import {error, output} from '@shopify/cli-kit'
 import {Writable} from 'node:stream'
 
 interface BuildOptions {
-  app: App
+  app: AppInterface
   skipDependenciesInstallation: boolean
   apiKey?: string
 }

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -1,5 +1,5 @@
 import {runGoExtensionsCLI} from '../../utilities/extensions/cli.js'
-import {App} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {UIExtension, FunctionExtension, ThemeExtension} from '../../models/app/extensions.js'
 import {extensionConfig} from '../../utilities/extensions/configuration.js'
 import {error, system, yaml, output} from '@shopify/cli-kit'
@@ -30,7 +30,7 @@ export interface ExtensionBuildOptions {
   /**
    * The app that contains the extensions.
    */
-  app: App
+  app: AppInterface
 }
 
 export interface ThemeExtensionBuildOptions extends ExtensionBuildOptions {

--- a/packages/app/src/cli/services/dependencies.test.ts
+++ b/packages/app/src/cli/services/dependencies.test.ts
@@ -42,6 +42,7 @@ describe('installAppDependencies', () => {
       nodeDependencies: {},
       configurationPath: '/tmp/project/shopify.app.toml',
       updateDependencies: vi.fn(),
+      hasExtensions: vi.fn(),
     }
     const listRun = vi.fn().mockResolvedValue(undefined)
     const list: any = {run: listRun}

--- a/packages/app/src/cli/services/dependencies.test.ts
+++ b/packages/app/src/cli/services/dependencies.test.ts
@@ -1,5 +1,5 @@
 import {installAppDependencies} from './dependencies.js'
-import {App} from '../models/app/app.js'
+import {AppInterface} from '../models/app/app.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {ui} from '@shopify/cli-kit'
 import {installNPMDependenciesRecursively} from '@shopify/cli-kit/node/node-package-manager'
@@ -25,7 +25,7 @@ beforeEach(() => {
 describe('installAppDependencies', () => {
   test('installs dependencies recursively', async () => {
     // Given
-    const app: App = {
+    const app: AppInterface = {
       name: 'App',
       idEnvironmentVariableName: 'SHOPIFY_API_KEY',
       configuration: {

--- a/packages/app/src/cli/services/dependencies.test.ts
+++ b/packages/app/src/cli/services/dependencies.test.ts
@@ -1,5 +1,5 @@
 import {installAppDependencies} from './dependencies.js'
-import {App, updateDependencies} from '../models/app/app.js'
+import {App} from '../models/app/app.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {ui} from '@shopify/cli-kit'
 import {installNPMDependenciesRecursively} from '@shopify/cli-kit/node/node-package-manager'
@@ -41,11 +41,11 @@ describe('installAppDependencies', () => {
       webs: [],
       nodeDependencies: {},
       configurationPath: '/tmp/project/shopify.app.toml',
+      updateDependencies: vi.fn(),
     }
     const listRun = vi.fn().mockResolvedValue(undefined)
     const list: any = {run: listRun}
     vi.mocked(ui.newListr).mockReturnValue(list)
-    vi.mocked(updateDependencies).mockResolvedValueOnce(app)
 
     // When
     await installAppDependencies(app)

--- a/packages/app/src/cli/services/dependencies.ts
+++ b/packages/app/src/cli/services/dependencies.ts
@@ -1,4 +1,4 @@
-import {App} from '../models/app/app.js'
+import {AppInterface} from '../models/app/app.js'
 import {ui, environment} from '@shopify/cli-kit'
 import {installNPMDependenciesRecursively} from '@shopify/cli-kit/node/node-package-manager'
 
@@ -6,10 +6,10 @@ import {installNPMDependenciesRecursively} from '@shopify/cli-kit/node/node-pack
  * Given an app, it installs its NPM dependencies by traversing
  * the sub-directories and finding the ones that have NPM dependencies
  * defined in package.json files.
- * @param app {App} App whose dependencies will be installed.
- * @returns {Promise<App>} An copy of the app with the Node dependencies updated.
+ * @param app {AppInterface} App whose dependencies will be installed.
+ * @returns {Promise<AppInterface>} An copy of the app with the Node dependencies updated.
  */
-export async function installAppDependencies(app: App) {
+export async function installAppDependencies(app: AppInterface) {
   const list = ui.newListr(
     [
       {

--- a/packages/app/src/cli/services/dependencies.ts
+++ b/packages/app/src/cli/services/dependencies.ts
@@ -1,4 +1,4 @@
-import {App, updateDependencies} from '../models/app/app.js'
+import {App} from '../models/app/app.js'
 import {ui, environment} from '@shopify/cli-kit'
 import {installNPMDependenciesRecursively} from '@shopify/cli-kit/node/node-package-manager'
 
@@ -27,5 +27,6 @@ export async function installAppDependencies(app: App) {
     {rendererSilent: environment.local.isUnitTest()},
   )
   await list.run()
-  return updateDependencies(app)
+  await app.updateDependencies()
+  return app
 }

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -9,7 +9,7 @@ import {
 
 import {ensureDeployEnvironment} from './environment.js'
 import {fetchAppExtensionRegistrations} from './dev/fetch.js'
-import {App, getUIExtensionRendererVersion} from '../models/app/app.js'
+import {AppInterface, getUIExtensionRendererVersion} from '../models/app/app.js'
 import {Identifiers, updateAppIdentifiers} from '../models/app/identifiers.js'
 import {Extension, UIExtension} from '../models/app/extensions.js'
 import {isFunctionExtensionType, isThemeExtensionType, isUiExtensionType, UIExtensionTypes} from '../constants.js'
@@ -28,7 +28,7 @@ const RendererNotFoundBug = (extension: string) => {
 
 interface DeployOptions {
   /** The app to be built and uploaded */
-  app: App
+  app: AppInterface
 
   /** If true, ignore any cached appId or extensionId */
   reset: boolean
@@ -117,7 +117,7 @@ async function outputCompletionMessage({
   registrations,
   validationErrors,
 }: {
-  app: App
+  app: AppInterface
   partnersApp: Omit<OrganizationApp, 'apiSecretKeys' | 'apiKey'>
   partnersOrganizationId: string
   identifiers: Identifiers
@@ -166,7 +166,7 @@ async function outputCompletionMessage({
   }
 }
 
-async function configFor(extension: UIExtension, app: App) {
+async function configFor(extension: UIExtension, app: AppInterface) {
   const type = extension.type as UIExtensionTypes
   switch (extension.type as UIExtensionTypes) {
     case 'checkout_post_purchase':

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -9,7 +9,7 @@ import {
 
 import {ensureDeployEnvironment} from './environment.js'
 import {fetchAppExtensionRegistrations} from './dev/fetch.js'
-import {App, getUIExtensionRendererVersion, hasExtensions} from '../models/app/app.js'
+import {App, getUIExtensionRendererVersion} from '../models/app/app.js'
 import {Identifiers, updateAppIdentifiers} from '../models/app/identifiers.js'
 import {Extension, UIExtension} from '../models/app/extensions.js'
 import {isFunctionExtensionType, isThemeExtensionType, isUiExtensionType, UIExtensionTypes} from '../constants.js'
@@ -35,7 +35,7 @@ interface DeployOptions {
 }
 
 export const deploy = async (options: DeployOptions) => {
-  if (!hasExtensions(options.app)) {
+  if (!options.app.hasExtensions()) {
     output.newline()
     output.info(`No extensions to deploy to Shopify Partners yet.`)
     return

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -1,5 +1,5 @@
 import {buildThemeExtensions, buildFunctionExtension, buildUIExtensions} from '../build/extension.js'
-import {App} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {Identifiers} from '../../models/app/identifiers.js'
 import {path, output, file, error} from '@shopify/cli-kit'
 import {zip} from '@shopify/cli-kit/node/archiver'
@@ -7,7 +7,7 @@ import {zip} from '@shopify/cli-kit/node/archiver'
 import {Writable} from 'node:stream'
 
 interface BundleOptions {
-  app: App
+  app: AppInterface
   bundlePath: string
   identifiers: Identifiers
   bundle: boolean

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -7,7 +7,7 @@ import {
   ReverseHTTPProxyTarget,
   runConcurrentHTTPProcessesAndPathForwardTraffic,
 } from '../utilities/app/http-reverse-proxy.js'
-import {App, AppConfiguration, Web, WebType} from '../models/app/app.js'
+import {AppInterface, AppConfiguration, Web, WebType} from '../models/app/app.js'
 import {UIExtension} from '../models/app/extensions.js'
 import {fetchProductVariant} from '../utilities/extensions/fetch-product-variant.js'
 import {error, analytics, output, port, system, session} from '@shopify/cli-kit'
@@ -15,7 +15,7 @@ import {Config} from '@oclif/core'
 import {Writable} from 'node:stream'
 
 export interface DevOptions {
-  app: App
+  app: AppInterface
   apiKey?: string
   storeFqdn?: string
   reset: boolean
@@ -194,7 +194,7 @@ function devBackendTarget(web: Web, options: DevWebOptions): output.OutputProces
 }
 
 async function devExtensionsTarget(
-  app: App,
+  app: AppInterface,
   apiKey: string,
   url: string,
   storeFqdn: string,

--- a/packages/app/src/cli/services/dev/create-extension.ts
+++ b/packages/app/src/cli/services/dev/create-extension.ts
@@ -1,5 +1,4 @@
-import {extensionGraphqlId} from '../../models/app/app.js'
-import {ExtensionTypes} from '../../constants.js'
+import {extensionGraphqlId, ExtensionTypes} from '../../constants.js'
 import {api, error} from '@shopify/cli-kit'
 
 export interface ExtensionRegistration {

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -1,4 +1,4 @@
-import {App} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {UIExtension} from '../../models/app/extensions.js'
 import {runGoExtensionsCLI} from '../../utilities/extensions/cli.js'
 import {extensionConfig} from '../../utilities/extensions/configuration.js'
@@ -33,7 +33,7 @@ export interface ExtensionDevOptions {
   /**
    * The app that contains the extension.
    */
-  app: App
+  app: AppInterface
 
   /**
    * The app identifier

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -1,4 +1,4 @@
-import {App} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {FunctionExtension, ThemeExtension, UIExtension} from '../../models/app/extensions.js'
 import {ExtensionTypes, getExtensionOutputConfig, UIExtensionTypes} from '../../constants.js'
 import {output, string} from '@shopify/cli-kit'
@@ -14,7 +14,7 @@ export function outputAppURL(updated: boolean, storeFqdn: string, url: string) {
   output.info(output.content`\n\n${heading}\n${message}\n`)
 }
 
-export function outputExtensionsMessages(app: App, storeFqdn: string, url: string) {
+export function outputExtensionsMessages(app: AppInterface, storeFqdn: string, url: string) {
   outputUIExtensionsURLs(app.extensions.ui, storeFqdn, url)
   outputFunctionsMessage(app.extensions.function)
   outputThemeExtensionsMessage(app.extensions.theme)

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -1,11 +1,11 @@
 import {createApp, selectOrCreateApp} from './select-app.js'
-import {App, WebType} from '../../models/app/app.js'
+import {AppInterface, WebType} from '../../models/app/app.js'
 import {Organization, OrganizationApp} from '../../models/organization.js'
 import {appNamePrompt, appTypePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {api} from '@shopify/cli-kit'
 
-const LOCAL_APP: App = {
+const LOCAL_APP: AppInterface = {
   idEnvironmentVariableName: 'SHOPIFY_API_KEY',
   directory: '',
   packageManager: 'yarn',

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -23,6 +23,8 @@ const LOCAL_APP: App = {
   name: 'my-app',
   nodeDependencies: {},
   extensions: {ui: [], theme: [], function: []},
+  updateDependencies: vi.fn(),
+  hasExtensions: vi.fn(),
 }
 
 const ORG1: Organization = {id: '1', businessName: 'org1', appsNext: true}

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -1,6 +1,6 @@
 import {fetchAppFromApiKey} from './fetch.js'
 import {appNamePrompt, appTypePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
-import {App} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {Organization, OrganizationApp} from '../../models/organization.js'
 import {api, error, output} from '@shopify/cli-kit'
 
@@ -9,14 +9,14 @@ import {api, error, output} from '@shopify/cli-kit'
  * If a cachedAppId is provided, we check if it is valid and return it. If it's not valid, ignore it.
  * If there is no valid app yet, prompt the user to select one from the list or create a new one.
  * If no apps exists, we automatically prompt the user to create a new one.
- * @param app {App} Current local app information
+ * @param app {AppInterface} Current local app information
  * @param apps {OrganizationApp[]} List of remote available apps
  * @param orgId {string} Current Organization
  * @param cachedAppId {string} Cached app apikey
  * @returns {Promise<OrganizationApp>} The selected (or created) app
  */
 export async function selectOrCreateApp(
-  localApp: App,
+  localApp: AppInterface,
   apps: OrganizationApp[],
   org: Organization,
   token: string,
@@ -34,7 +34,7 @@ export async function selectOrCreateApp(
   return app
 }
 
-export async function createApp(org: Organization, app: App, token: string): Promise<OrganizationApp> {
+export async function createApp(org: Organization, app: AppInterface, token: string): Promise<OrganizationApp> {
   const name = await appNamePrompt(app.name)
 
   const type = org.appsNext ? 'undecided' : await appTypePrompt()

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -22,6 +22,8 @@ const LOCAL_APP: App = {
   ],
   nodeDependencies: {},
   extensions: {ui: [], theme: [], function: []},
+  updateDependencies: vi.fn(),
+  hasExtensions: vi.fn(),
 }
 
 beforeEach(() => {

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -1,10 +1,10 @@
 import {updateURLs, generateURL} from './urls.js'
-import {App, WebType} from '../../models/app/app.js'
+import {AppInterface, WebType} from '../../models/app/app.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {api, error} from '@shopify/cli-kit'
 import {Plugin} from '@oclif/core/lib/interfaces'
 
-const LOCAL_APP: App = {
+const LOCAL_APP: AppInterface = {
   name: 'my-app',
   idEnvironmentVariableName: 'SHOPIFY_API_KEY',
   directory: '',

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -121,6 +121,8 @@ const LOCAL_APP: App = {
   ],
   nodeDependencies: {},
   extensions: {ui: [EXTENSION_A], theme: [], function: []},
+  updateDependencies: vi.fn(),
+  hasExtensions: vi.fn(),
 }
 
 const INPUT: DevEnvironmentOptions = {

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -4,7 +4,7 @@ import {selectStore, convertToTestStoreIfNeeded} from './dev/select-store.js'
 import {ensureDeploymentIdsPresence} from './environment/identifiers.js'
 import {DevEnvironmentOptions, ensureDevEnvironment, ensureDeployEnvironment, DeployAppNotFound} from './environment.js'
 import {OrganizationApp, OrganizationStore} from '../models/organization.js'
-import {App, WebType} from '../models/app/app.js'
+import {AppInterface, WebType} from '../models/app/app.js'
 import {updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
 import {UIExtension} from '../models/app/extensions.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
@@ -103,7 +103,7 @@ const EXTENSION_A: UIExtension = {
   devUUID: 'devUUID',
 }
 
-const LOCAL_APP: App = {
+const LOCAL_APP: AppInterface = {
   name: 'my-app',
   idEnvironmentVariableName: 'SHOPIFY_API_KEY',
   directory: '/app',

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -11,7 +11,7 @@ import {
 import {convertToTestStoreIfNeeded, selectStore} from './dev/select-store.js'
 import {ensureDeploymentIdsPresence} from './environment/identifiers.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
-import {App} from '../models/app/app.js'
+import {AppInterface} from '../models/app/app.js'
 import {Identifiers, UuidOnlyIdentifiers, updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
 import {error as kitError, output, session, store, ui, environment, error} from '@shopify/cli-kit'
@@ -51,7 +51,7 @@ const StoreNotFoundError = (storeName: string, org: Organization) => {
 }
 
 export interface DevEnvironmentOptions {
-  app: App
+  app: AppInterface
   apiKey?: string
   storeFqdn?: string
   reset: boolean
@@ -178,12 +178,12 @@ async function updateDevOptions(options: DevEnvironmentOptions & {apiKey: string
 }
 
 export interface DeployEnvironmentOptions {
-  app: App
+  app: AppInterface
   reset: boolean
 }
 
 interface DeployEnvironmentOutput {
-  app: App
+  app: AppInterface
   token: string
   partnersOrganizationId: string
   partnersApp: Omit<OrganizationApp, 'apiSecretKeys' | 'apiKey'>
@@ -192,13 +192,13 @@ interface DeployEnvironmentOutput {
 
 /**
  * If there is a cached ApiKey used for dev, retrieve that and ask the user if they want to reuse it
- * @param app {App} The local app object
+ * @param app {AppInterface} The local app object
  * @param token {string} The token to use to access the Partners API
  * @returns {Promise<OrganizationApp | undefined>}
  * OrganizationApp if a cached value is valid.
  * undefined if there is no cached value or the user doesn't want to use it.
  */
-async function fetchDevAppAndPrompt(app: App, token: string): Promise<OrganizationApp | undefined> {
+async function fetchDevAppAndPrompt(app: AppInterface, token: string): Promise<OrganizationApp | undefined> {
   const devAppId = store.cliKitStore().getAppInfo(app.directory)?.appId
   if (!devAppId) return undefined
 
@@ -262,7 +262,7 @@ export async function ensureDeployEnvironment(options: DeployEnvironmentOptions)
 }
 
 export async function fetchOrganizationAndFetchOrCreateApp(
-  app: App,
+  app: AppInterface,
   token: string,
 ): Promise<{partnersApp: OrganizationApp; orgId: string}> {
   const orgId = await selectOrg(token)
@@ -360,7 +360,7 @@ async function selectOrg(token: string): Promise<string> {
  * @param app {string} App name
  * @param store {string} Store domain
  */
-function showReusedValues(org: string, app: App, store: string) {
+function showReusedValues(org: string, app: AppInterface, store: string) {
   output.info('\nUsing your previous dev settings:')
   output.info(`Org:        ${org}`)
   output.info(`App:        ${app.name}`)

--- a/packages/app/src/cli/services/environment/identifiers.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers.test.ts
@@ -3,7 +3,7 @@ import {automaticMatchmaking} from './id-matching.js'
 import {manualMatchIds} from './id-manual-matching.js'
 import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
 import {createExtension, ExtensionRegistration} from '../dev/create-extension.js'
-import {App} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {FunctionExtension, UIExtension} from '../../models/app/extensions.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {ui} from '@shopify/cli-kit'
@@ -100,7 +100,7 @@ const EXTENSION_C: FunctionExtension = {
   inputQueryPath: () => '/function/input.graphql',
 }
 
-const LOCAL_APP = (uiExtensions: UIExtension[], functionExtensions: FunctionExtension[] = []): App => {
+const LOCAL_APP = (uiExtensions: UIExtension[], functionExtensions: FunctionExtension[] = []): AppInterface => {
   return {
     name: 'my-app',
     idEnvironmentVariableName: 'SHOPIFY_API_KEY',

--- a/packages/app/src/cli/services/environment/identifiers.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers.test.ts
@@ -111,6 +111,8 @@ const LOCAL_APP = (uiExtensions: UIExtension[], functionExtensions: FunctionExte
     webs: [],
     nodeDependencies: {},
     extensions: {ui: uiExtensions, theme: [], function: functionExtensions},
+    updateDependencies: vi.fn(),
+    hasExtensions: vi.fn(),
   }
 }
 

--- a/packages/app/src/cli/services/environment/identifiers.ts
+++ b/packages/app/src/cli/services/environment/identifiers.ts
@@ -1,6 +1,6 @@
 import {automaticMatchmaking} from './id-matching.js'
 import {manualMatchIds} from './id-manual-matching.js'
-import {App} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {Identifiers} from '../../models/app/identifiers.js'
 import {Extension} from '../../models/app/extensions.js'
 import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
@@ -21,7 +21,7 @@ const DeployError = (appName: string, packageManager: PackageManager) => {
 }
 
 export interface EnsureDeploymentIdsPresenceOptions {
-  app: App
+  app: AppInterface
   token: string
   appId: string
   appName: string

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -1,7 +1,7 @@
 import {info} from './info.js'
 import {fetchOrgAndApps, fetchOrganizations} from './dev/fetch.js'
 import {selectOrCreateApp} from './dev/select-app.js'
-import {App} from '../models/app/app.js'
+import {AppInterface} from '../models/app/app.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
 import {path, session, output, store} from '@shopify/cli-kit'
 import {describe, it, expect, vi, beforeEach} from 'vitest'
@@ -145,7 +145,7 @@ describe('info', () => {
   })
 })
 
-function mockApp(currentVersion = '2.2.2'): App {
+function mockApp(currentVersion = '2.2.2'): AppInterface {
   const nodeDependencies: {[key: string]: string} = {}
   nodeDependencies['@shopify/cli'] = currentVersion
   return {

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -160,5 +160,7 @@ function mockApp(currentVersion = '2.2.2'): App {
     webs: [],
     nodeDependencies,
     extensions: {ui: [], function: [], theme: []},
+    updateDependencies: vi.fn(),
+    hasExtensions: vi.fn(),
   }
 }

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -1,6 +1,6 @@
 import {fetchOrgAndApps, fetchOrganizations} from './dev/fetch.js'
 import {selectOrCreateApp} from './dev/select-app.js'
-import {App} from '../models/app/app.js'
+import {AppInterface} from '../models/app/app.js'
 import {FunctionExtension, ThemeExtension, UIExtension} from '../models/app/extensions.js'
 import {configurationFileNames, functionExtensions, themeExtensions, uiExtensions} from '../constants.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
@@ -17,7 +17,7 @@ interface Configurable {
   configuration?: {type?: string}
 }
 
-export async function info(app: App, {format, webEnv}: InfoOptions): Promise<output.Message> {
+export async function info(app: AppInterface, {format, webEnv}: InfoOptions): Promise<output.Message> {
   if (webEnv) {
     return infoWeb(app, {format})
   } else {
@@ -25,7 +25,7 @@ export async function info(app: App, {format, webEnv}: InfoOptions): Promise<out
   }
 }
 
-export async function infoWeb(app: App, {format}: Omit<InfoOptions, 'webEnv'>): Promise<output.Message> {
+export async function infoWeb(app: AppInterface, {format}: Omit<InfoOptions, 'webEnv'>): Promise<output.Message> {
   const token = await session.ensureAuthenticatedPartners()
 
   const orgs = await fetchOrganizations(token)
@@ -50,7 +50,7 @@ Use these environment variables to set up your deployment pipeline for this app:
   }
 }
 
-export async function infoApp(app: App, {format}: Omit<InfoOptions, 'webEnv'>): Promise<output.Message> {
+export async function infoApp(app: AppInterface, {format}: Omit<InfoOptions, 'webEnv'>): Promise<output.Message> {
   if (format === 'json') {
     return output.content`${JSON.stringify(app, null, 2)}`
   } else {
@@ -63,10 +63,10 @@ const UNKNOWN_TEXT = output.content`${output.token.italic('unknown')}`.value
 const NOT_CONFIGURED_TEXT = output.content`${output.token.italic('Not yet configured')}`.value
 
 class AppInfo {
-  private app: App
+  private app: AppInterface
   private cachedAppInfo: store.CachedAppInfo | undefined
 
-  constructor(app: App) {
+  constructor(app: AppInterface) {
     this.app = app
     this.cachedAppInfo = store.cliKitStore().getAppInfo(app.directory)
   }

--- a/packages/app/src/cli/services/scaffold/extension.ts
+++ b/packages/app/src/cli/services/scaffold/extension.ts
@@ -10,7 +10,7 @@ import {
   FunctionExtensionTypes,
   versions,
 } from '../../constants.js'
-import {App} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {error, file, git, path, string, template, ui, yaml, environment} from '@shopify/cli-kit'
 import {addNPMDependenciesIfNeeded, DependencyVersion} from '@shopify/cli-kit/node/node-package-manager'
 import {fileURLToPath} from 'url'
@@ -31,7 +31,7 @@ async function getTemplatePath(name: string): Promise<string> {
 interface ExtensionInitOptions<TExtensionTypes extends ExtensionTypes = ExtensionTypes> {
   name: string
   extensionType: TExtensionTypes
-  app: App
+  app: AppInterface
   cloneUrl?: string
   extensionFlavor?: string
 }
@@ -213,7 +213,7 @@ function functionTemplatePath({extensionType, extensionFlavor}: FunctionExtensio
   }
 }
 
-async function ensureExtensionDirectoryExists({name, app}: {name: string; app: App}): Promise<string> {
+async function ensureExtensionDirectoryExists({name, app}: {name: string; app: AppInterface}): Promise<string> {
   const hyphenizedName = string.hyphenize(name)
   const extensionDirectory = path.join(app.directory, blocks.extensions.directoryName, hyphenizedName)
   if (await file.exists(extensionDirectory)) {

--- a/packages/app/src/cli/utilities/extensions/configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/configuration.test.ts
@@ -66,6 +66,8 @@ describe('extensionConfig', () => {
       webs: [],
       nodeDependencies: {},
       extensions: {ui: [extension], function: [], theme: []},
+      updateDependencies: vi.fn(),
+      hasExtensions: vi.fn(),
     }
 
     const options: ExtensionConfigOptions = {

--- a/packages/app/src/cli/utilities/extensions/configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/configuration.test.ts
@@ -1,5 +1,5 @@
 import {extensionConfig, ExtensionConfigOptions} from './configuration.js'
-import {App} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {UIExtension} from '../../models/app/extensions.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {path} from '@shopify/cli-kit'
@@ -54,7 +54,7 @@ describe('extensionConfig', () => {
       entrySourceFilePath: `${extensionRoot}/src/index.js`,
       devUUID: 'devUUID',
     }
-    const app: App = {
+    const app: AppInterface = {
       name: 'myapp',
       idEnvironmentVariableName: 'SHOPIFY_API_KEY',
       directory: appRoot,

--- a/packages/app/src/cli/utilities/extensions/configuration.ts
+++ b/packages/app/src/cli/utilities/extensions/configuration.ts
@@ -1,5 +1,5 @@
 import {nodeExtensionsCLIPath} from './cli.js'
-import {App, getUIExtensionRendererVersion} from '../../models/app/app.js'
+import {AppInterface, getUIExtensionRendererVersion} from '../../models/app/app.js'
 import {UIExtension} from '../../models/app/extensions.js'
 import {UIExtensionTypes} from '../../constants.js'
 import {error, path} from '@shopify/cli-kit'
@@ -11,7 +11,7 @@ const RendererNotFoundBug = (extension: string) => {
   )
 }
 export interface ExtensionConfigOptions {
-  app: App
+  app: AppInterface
   apiKey?: string
   extensions: UIExtension[]
   buildDirectory?: string

--- a/packages/app/src/cli/validators/extensions.ts
+++ b/packages/app/src/cli/validators/extensions.ts
@@ -1,9 +1,9 @@
 import {validateFunctionExtensions} from './extensions/functions.js'
 import {validateUIExtensions} from './extensions/ui.js'
 import {validateThemeExtensions} from './extensions/theme.js'
-import {App} from '../models/app/app.js'
+import {AppInterface} from '../models/app/app.js'
 
-export async function validateExtensions(app: App) {
+export async function validateExtensions(app: AppInterface) {
   await Promise.all([
     validateFunctionExtensions(app.extensions.function),
     validateUIExtensions(app.extensions.ui),


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
More improvements on the `app.ts` file


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Create `AppClass` as an implementation of the `App` interface. Left `App` as the public interface so that it is easier to mock and test evertything, but please let me know what you think of this approach. Maybe you prefer to have just `App` as a class directly?
- Refactored a couple of functions as methods inside of `AppClass`. What other functions could we add to `AppClass`? Maybe `getAppIndentifiers` and `updateAppIdentifiers`?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
