### PR TITLE
Release v3.1.0

### DIFF
--- a/.changeset/lazy-teachers-battle.md
+++ b/.changeset/lazy-teachers-battle.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Added a retrying implementation to the method that obtains a random local port. Occasionally that third party logic failed in the middle of the execution of a command and abort the process. Running the command for a second time solved that temporary problem

--- a/.changeset/many-meals-fly.md
+++ b/.changeset/many-meals-fly.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': minor
----
-
-Massage error stacktraces to be properly formatted on Bugsnag

--- a/.changeset/quick-pandas-boil.md
+++ b/.changeset/quick-pandas-boil.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': minor
----
-
-Not report unhandled errors that go straight to the Node runtime

--- a/.changeset/soft-students-refuse.md
+++ b/.changeset/soft-students-refuse.md
@@ -1,6 +1,0 @@
----
-'@shopify/app': patch
-'@shopify/cli-kit': patch
----
-
-[FEATURE] Add query to fetch shop by domain

--- a/.changeset/stale-cobras-boil.md
+++ b/.changeset/stale-cobras-boil.md
@@ -1,6 +1,0 @@
----
-'@shopify/app': patch
-'@shopify/cli-kit': patch
----
-
-Bump theme-check version

--- a/.changeset/weak-humans-mix.md
+++ b/.changeset/weak-humans-mix.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli': patch
----
-
-Replaces btoa() with Buffer.from()

--- a/fixtures/app/CHANGELOG.md
+++ b/fixtures/app/CHANGELOG.md
@@ -1,5 +1,14 @@
 # app
 
+## 3.1.0
+
+### Patch Changes
+
+- Updated dependencies [de8ee02d]
+- Updated dependencies [45f0f0b9]
+  - @shopify/app@3.1.0
+  - @shopify/cli@3.1.0
+
 ## 3.0.27
 
 ### Patch Changes

--- a/fixtures/app/package.json
+++ b/fixtures/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/fixtures-app",
-  "version": "3.0.27",
+  "version": "3.1.0",
   "main": "web/backend/index.js",
   "license": "UNLICENSED",
   "private": true,
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@shopify/admin-ui-extensions-react": "^1.0.1",
-    "@shopify/app": "3.0.27",
+    "@shopify/app": "3.1.0",
     "@shopify/checkout-ui-extensions-react": "^0.15.2",
-    "@shopify/cli": "3.0.27",
+    "@shopify/cli": "3.1.0",
     "@shopify/post-purchase-ui-extensions-react": "^0.13.3",
     "@shopify/web-pixels-extension": "^0.1.1",
     "react": "^18.1.0"

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @shopify/app
 
+## 3.1.0
+
+### Patch Changes
+
+- de8ee02d: [FEATURE] Add query to fetch shop by domain
+- 45f0f0b9: Bump theme-check version
+- Updated dependencies [740f73ac]
+- Updated dependencies [d17770e8]
+- Updated dependencies [d17770e8]
+- Updated dependencies [de8ee02d]
+- Updated dependencies [45f0f0b9]
+  - @shopify/cli-kit@3.1.0
+
 ## 3.0.27
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/app",
-  "version": "3.0.27",
+  "version": "3.1.0",
   "description": "Utilities for loading, building, and publishing apps.",
   "homepage": "https://github.com/shopify/cli#readme",
   "bugs": {
@@ -49,7 +49,7 @@
     "@fastify/reply-from": "^8.0.0",
     "@oclif/core": "^1.0",
     "@shopify/shopify-cli-extensions": "^0.2.1",
-    "@shopify/cli-kit": "^3.0.27",
+    "@shopify/cli-kit": "^3.1.0",
     "ws": "^8.7.0",
     "@fastify/http-proxy": "^8.0.1"
   }

--- a/packages/cli-hydrogen/CHANGELOG.md
+++ b/packages/cli-hydrogen/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @shopify/cli-hydrogen
 
+## 3.1.0
+
+### Patch Changes
+
+- Updated dependencies [740f73ac]
+- Updated dependencies [d17770e8]
+- Updated dependencies [d17770e8]
+- Updated dependencies [de8ee02d]
+- Updated dependencies [45f0f0b9]
+  - @shopify/cli-kit@3.1.0
+
 ## 3.0.27
 
 ### Patch Changes

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/cli-hydrogen",
-  "version": "3.0.27",
+  "version": "3.1.0",
   "private": false,
   "description": "Commands for building Hydrogen storefronts",
   "bugs": {
@@ -43,7 +43,7 @@
     "@types/prettier": "^2.6.3",
     "prettier": "^2.6.1",
     "vite": "^2.9.9",
-    "@shopify/cli-kit": "^3.0.27",
+    "@shopify/cli-kit": "^3.1.0",
     "fast-glob": "^3.2.11",
     "fs-extra": "^10.0.0",
     "typescript": "^4.7.4",

--- a/packages/cli-kit/CHANGELOG.md
+++ b/packages/cli-kit/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @shopify/cli-kit
 
+## 3.1.0
+
+### Minor Changes
+
+- d17770e8: Massage error stacktraces to be properly formatted on Bugsnag
+- d17770e8: Not report unhandled errors that go straight to the Node runtime
+
+### Patch Changes
+
+- 740f73ac: Added a retrying implementation to the method that obtains a random local port. Occasionally that third party logic failed in the middle of the execution of a command and abort the process. Running the command for a second time solved that temporary problem
+- de8ee02d: [FEATURE] Add query to fetch shop by domain
+- 45f0f0b9: Bump theme-check version
+
 ## 3.0.27
 
 ### Patch Changes

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/cli-kit",
-  "version": "3.0.27",
+  "version": "3.1.0",
   "private": false,
   "description": "A set of utilities, interfaces, and models that are common across all the platform features",
   "keywords": [

--- a/packages/cli-main/CHANGELOG.md
+++ b/packages/cli-main/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @shopify/cli
 
+## 3.1.0
+
+### Patch Changes
+
+- Updated dependencies [740f73ac]
+- Updated dependencies [d17770e8]
+- Updated dependencies [d17770e8]
+- Updated dependencies [de8ee02d]
+- Updated dependencies [45f0f0b9]
+  - @shopify/cli-kit@3.1.0
+
 ## 3.0.27
 
 ### Patch Changes

--- a/packages/cli-main/CHANGELOG.md
+++ b/packages/cli-main/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated dependencies [d17770e8]
 - Updated dependencies [de8ee02d]
 - Updated dependencies [45f0f0b9]
+- 53c46773: Replaces btoa() with Buffer.from()
   - @shopify/cli-kit@3.1.0
 
 ## 3.0.27

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/cli",
-  "version": "3.0.27",
+  "version": "3.1.0",
   "private": false,
   "description": "A CLI tool to build for the Shopify platform",
   "homepage": "https://github.com/shopify/cli#readme",
@@ -55,7 +55,7 @@
     "@oclif/plugin-help": "^5.1.12",
     "@oclif/plugin-plugins": "^2.1.0",
     "@shopify/plugin-ngrok": "^0.2.9",
-    "@shopify/cli-kit": "^3.0.27"
+    "@shopify/cli-kit": "^3.1.0"
   },
   "devDependencies": {
     "vitest": "^0.17.1"

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @shopify/create-app
 
+## 3.1.0
+
+### Patch Changes
+
+- Updated dependencies [740f73ac]
+- Updated dependencies [d17770e8]
+- Updated dependencies [d17770e8]
+- Updated dependencies [de8ee02d]
+- Updated dependencies [45f0f0b9]
+  - @shopify/cli-kit@3.1.0
+
 ## 3.0.27
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/create-app",
-  "version": "3.0.27",
+  "version": "3.1.0",
   "private": false,
   "description": "A CLI tool to create a new Shopify app.",
   "type": "module",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@oclif/core": "^1.0",
-    "@shopify/cli-kit": "^3.0.27"
+    "@shopify/cli-kit": "^3.1.0"
   },
   "devDependencies": {
     "vitest": "^0.17.1"

--- a/packages/create-hydrogen/CHANGELOG.md
+++ b/packages/create-hydrogen/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @shopify/create-hydrogen
 
+## 3.1.0
+
+### Patch Changes
+
+- Updated dependencies [740f73ac]
+- Updated dependencies [d17770e8]
+- Updated dependencies [d17770e8]
+- Updated dependencies [de8ee02d]
+- Updated dependencies [45f0f0b9]
+  - @shopify/cli-kit@3.1.0
+
 ## 3.0.27
 
 ### Patch Changes

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/create-hydrogen",
-  "version": "3.0.27",
+  "version": "3.1.0",
   "private": false,
   "description": "A CLI tool to create a new Shopify hydrogen app.",
   "type": "module",
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@oclif/core": "^1.0",
-    "@shopify/cli-kit": "^3.0.27",
+    "@shopify/cli-kit": "^3.1.0",
     "@types/download": "^8.0.1",
     "download": "^8.0.0"
   },


### PR DESCRIPTION
- [Retry system to obtain a random port](https://github.com/Shopify/cli/pull/117)
- [Improve performance when fetching shops](https://github.com/Shopify/cli/pull/103)
- [Upgrade theme check to 1.10.3](https://github.com/Shopify/cli/pull/113)
- [Improve error reporting to Bugsnag](https://github.com/Shopify/cli/pull/129)
- [Fix btoa issue for old Node versions](https://github.com/Shopify/cli/pull/116)