### PR TITLE
Reenable nx cache to avoid double-building

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -86,17 +86,17 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Build
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build
       - name: Lint
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '14' }}
       - name: Type-check
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=tsc --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=tsc
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '14' }}
       - name: Unit tests
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features
       - name: Acceptance tests
-        run: npx nx run features:test --skip-nx-cache
+        run: npx nx run features:test
         env:
           SKIP_BUILD_BEFORE_ACCEPTANCE_TESTS: 1
   pr-ubuntu:
@@ -136,18 +136,18 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Build
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build
       - name: Type-check
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=tsc --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=tsc
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '14' }}
       - name: Lint
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '14' }}
       - name: Unit tests
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features
       - name: Acceptance tests
         if: ${{ matrix.os == 'ubuntu-latest' && (matrix.node == '14' || matrix.node == '18') }}
-        run: npx nx run features:test --skip-nx-cache
+        run: npx nx run features:test
         env:
           SKIP_BUILD_BEFORE_ACCEPTANCE_TESTS: 1
   pr-windows-and-mac:
@@ -193,6 +193,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Build
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build
       - name: Unit tests
-        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features --skip-nx-cache
+        run: npx nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Faster CI

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Since we already build explicitly at the beginning of the build, may as well not rebuild each time we run unit/acceptance tests. No code is faster than no code...

I think we saw some issues earlier when enabling this, hopefully we don't see them again.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
CI