### PR TITLE
Remind to check the README after creation

### DIFF
--- a/.changeset/happy-pigs-bow.md
+++ b/.changeset/happy-pigs-bow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': patch
+---
+
+Remind to check the README after creation

--- a/packages/create-app/src/services/init.ts
+++ b/packages/create-app/src/services/init.ts
@@ -152,6 +152,7 @@ async function init(options: InitOptions) {
 
   output.info(output.content`
   ${hyphenizedName} is ready for you to build! Remember to ${output.token.genericShellCommand(`cd ${hyphenizedName}`)}
+  Check the setup instructions in your README file
   To preview your project, run ${output.token.packagejsonScript(packageManager, 'dev')}
   To add extensions, run ${output.token.packagejsonScript(packageManager, 'scaffold extension')}
   For more details on all that you can build, see the docs: ${output.token.link(


### PR DESCRIPTION
### WHY are these changes introduced?

Ruby or PHP templates require additional setup before running `dev` and it was [confusing for the users](https://github.com/Shopify/cli/issues/110#issuecomment-1180025043).

### WHAT is this pull request doing?

Before:
![before](https://user-images.githubusercontent.com/14979109/178420055-6a90ac36-74d5-44e3-b121-49e924cd17c1.png)

After:
![after](https://user-images.githubusercontent.com/14979109/178420247-92a7961d-4aec-4321-88e7-6f3a442f5383.png)

### How to test your changes?

`yarn create-app`
