### PR TITLE
More error handling fixes

### DIFF
--- a/packages/cli-kit/src/error.ts
+++ b/packages/cli-kit/src/error.ts
@@ -66,8 +66,11 @@ export async function handler(error: Error): Promise<Error> {
   let fatal: Fatal
   if (isFatal(error)) {
     fatal = error as Fatal
+  } else if (typeof error === 'string') {
+    fatal = new Bug(error as string)
   } else {
     fatal = new Bug(error.message)
+    fatal.stack = error.stack
   }
 
   if (fatal.type === FatalErrorType.Bug) {

--- a/packages/cli-kit/src/node/error-handler.ts
+++ b/packages/cli-kit/src/node/error-handler.ts
@@ -61,7 +61,7 @@ const reportError = async (error: Error): Promise<Error> => {
     reportableError = new Error('Unknown error')
   }
 
-  const formattedStacktrace = new StackTracey(reportableError.stack ?? '')
+  const formattedStacktrace = new StackTracey(stacktrace ?? '')
     .clean()
     .items.map((item) => {
       const filePath = normalize(item.file).replace('file:/', '/').replace('C:/', '')

--- a/packages/cli-kit/src/node/error-handler.ts
+++ b/packages/cli-kit/src/node/error-handler.ts
@@ -31,31 +31,55 @@ export function errorHandler(error: Error & {exitCode?: number | undefined}) {
   }
 }
 
-const reportError = async (errorToReport: Error): Promise<Error> => {
-  await reportEvent({errorMessage: errorToReport.message})
-  if (settings.debug || !shouldReportError(errorToReport)) return errorToReport
+const reportError = async (error: Error): Promise<Error> => {
+  await reportEvent({errorMessage: error.message})
+  if (settings.debug || !shouldReportError(error)) return error
 
-  let mappedError: Error
+  let reportableError: Error
+  let stacktrace: string | undefined
+  let report = false
 
   // eslint-disable-next-line no-prototype-builtins
-  if (Error.prototype.isPrototypeOf(errorToReport)) {
-    mappedError = new Error(errorToReport.message)
-    const mappedStacktrace = new StackTracey(errorToReport)
-      .clean()
-      .items.map((item) => {
-        const filePath = normalize(item.file).replace('file:/', '/').replace('C:/', '')
-        return `    at ${item.callee} (${filePath}:${item.line}:${item.column})`
-      })
-      .join('\n')
-    mappedError.stack = `Error: ${errorToReport.message}\n${mappedStacktrace}`
-  } else if (typeof errorToReport === 'string') {
-    mappedError = new Error(errorToReport)
+  if (Error.prototype.isPrototypeOf(error)) {
+    report = true
+    reportableError = new Error(error.message)
+    stacktrace = error.stack
+
+    /**
+     * Some errors that reach this point have an empty string. For example:
+     * https://app.bugsnag.com/shopify/cli/errors/62cd5d31fd5040000814086c?filters[event.since]=30d&filters[error.status]=new&filters[release.seen_in]=3.1.0
+     *
+     * Because at this point we have neither the error message nor a stack trace reporting them
+     * to Bugsnag is pointless and adds noise.
+     */
+  } else if (typeof error === 'string' && (error as string).trim().length !== 0) {
+    report = true
+    reportableError = new Error(error)
+    stacktrace = reportableError.stack
   } else {
-    mappedError = new Error('Unknown error')
+    report = false
+    reportableError = new Error('Unknown error')
   }
 
-  await new Promise((resolve, reject) => {
-    Bugsnag.notify(mappedError, undefined, resolve)
-  })
-  return mappedError
+  const formattedStacktrace = new StackTracey(reportableError.stack ?? '')
+    .clean()
+    .items.map((item) => {
+      const filePath = normalize(item.file).replace('file:/', '/').replace('C:/', '')
+      return `    at ${item.callee} (${filePath}:${item.line}:${item.column})`
+    })
+    .join('\n')
+  reportableError.stack = `Error: ${reportableError.message}\n${formattedStacktrace}`
+
+  if (report) {
+    await new Promise((resolve, reject) => {
+      Bugsnag.notify(reportableError, undefined, (error, event) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(reportableError)
+        }
+      })
+    })
+  }
+  return reportableError
 }

--- a/packages/cli-kit/src/ui.ts
+++ b/packages/cli-kit/src/ui.ts
@@ -1,7 +1,7 @@
 import {AutoComplete} from './ui/autocomplete.js'
 import {Input} from './ui/input.js'
 import {Select} from './ui/select.js'
-import {Bug, CancelExecution} from './error.js'
+import {CancelExecution, Abort} from './error.js'
 import {remove, exists} from './file.js'
 import {info, content, token, logToFile} from './output.js'
 import {relative} from './path.js'
@@ -80,7 +80,7 @@ export const prompt = async <
   debugForceInquirer = false,
 ): Promise<TAnswers> => {
   if (!isTerminalInteractive() && questions.length !== 0) {
-    throw new Bug(content`
+    throw new Abort(content`
 The CLI prompted in a non-interactive terminal with the following questions:
 ${token.json(questions)}
     `)


### PR DESCRIPTION
### WHY are these changes introduced?
There are still some error scenarios that are not handling gracefully and that lead to wrongly-formatted and classified errors.

### WHAT is this pull request doing?
- [x] The function that outputs the error to the user assumed all errors had `Error` as prototype which is not the case because some are strings. Because of that they were not printed. I've extended the formatting logic to account for that.
- [x] I filtered out the errors that are empty strings. We've [received](https://app.bugsnag.com/shopify/cli/errors/62cd5d31fd5040000814086c?filters[event.since]=30d&filters[error.status]=new&filters[release.seen_in]=3.1.0) some of those in Bugsnag
### How to test your changes?
- [x] I also filtered out `unknown errors` that contain no debuggeable information.
- [x] Change error-throwing when the terminal is non-interactive to be an abort. If a developer tries to use an interactive workflow (e.g. scaffold) in a non-interactive terminal that's not a bug.
