### PR TITLE
Stop following semantic versioning in `@shopify/cli-kit` and pin the version from the dependent packages

### DIFF
--- a/.changeset/tasty-feet-wave.md
+++ b/.changeset/tasty-feet-wave.md
@@ -1,0 +1,10 @@
+---
+'@shopify/app': minor
+'@shopify/cli-hydrogen': minor
+'@shopify/cli': minor
+'@shopify/create-app': minor
+'@shopify/create-hydrogen': minor
+'@shopify/theme': minor
+---
+
+Stop using semantic versioning for @shopify/cli-kit and pin the version from all the dependent packages

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -49,7 +49,7 @@
     "@fastify/reply-from": "^8.0.0",
     "@oclif/core": "^1.0",
     "@shopify/shopify-cli-extensions": "^0.2.1",
-    "@shopify/cli-kit": "^3.1.0",
+    "@shopify/cli-kit": "3.1.0",
     "ws": "^8.7.0",
     "@fastify/http-proxy": "^8.0.1"
   }

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -43,7 +43,7 @@
     "@types/prettier": "^2.6.3",
     "prettier": "^2.6.1",
     "vite": "^2.9.9",
-    "@shopify/cli-kit": "^3.1.0",
+    "@shopify/cli-kit": "3.1.0",
     "fast-glob": "^3.2.11",
     "fs-extra": "^10.0.0",
     "typescript": "^4.7.4",

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -55,7 +55,7 @@
     "@oclif/plugin-help": "^5.1.12",
     "@oclif/plugin-plugins": "^2.1.0",
     "@shopify/plugin-ngrok": "^0.2.9",
-    "@shopify/cli-kit": "^3.1.0"
+    "@shopify/cli-kit": "3.1.0"
   },
   "devDependencies": {
     "vitest": "^0.17.1"

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@oclif/core": "^1.0",
-    "@shopify/cli-kit": "^3.1.0"
+    "@shopify/cli-kit": "3.1.0"
   },
   "devDependencies": {
     "vitest": "^0.17.1"

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@oclif/core": "^1.0",
-    "@shopify/cli-kit": "^3.1.0",
+    "@shopify/cli-kit": "3.1.0",
     "@types/download": "^8.0.1",
     "download": "^8.0.0"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@oclif/core": "^1.0",
-    "@shopify/cli-kit": "^3.0.26"
+    "@shopify/cli-kit": "3.1.0"
   },
   "devDependencies": {
     "vitest": "^0.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9661,11 +9661,6 @@ tiny-lru@^8.0.1, tiny-lru@^8.0.2:
   resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-8.0.2.tgz#812fccbe6e622ded552e3ff8a4c3b5ff34a85e4c"
   integrity sha512-ApGvZ6vVvTNdsmt676grvCkUCGwzG9IqXma5Z07xJgiC5L7akUMof5U8G2JTI9Rz/ovtVhJBlY6mNhEvtjzOIg==
 
-tinypool@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.1.3.tgz#b5570b364a1775fd403de5e7660b325308fee26b"
-  integrity sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==
-
 tinypool@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.2.2.tgz#9b1da3a4f0c8c44c04e8af8783d9f27f1795bda2"
@@ -10171,18 +10166,6 @@ vite-plugin-inspect@^0.3.6:
     sirv "^2.0.2"
     ufo "^0.7.10"
 
-vite@^2.9.12:
-  version "2.9.12"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.12.tgz#b1d636b0a8ac636afe9d83e3792d4895509a941b"
-  integrity sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==
-  dependencies:
-    esbuild "^0.14.27"
-    postcss "^8.4.13"
-    resolve "^1.22.0"
-    rollup "^2.59.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
 "vite@^2.9.12 || ^3.0.0-0":
   version "2.9.13"
   resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.13.tgz#859cb5d4c316c0d8c6ec9866045c0f7858ca6abc"
@@ -10206,21 +10189,6 @@ vite@^2.9.9:
     rollup "^2.59.0"
   optionalDependencies:
     fsevents "~2.3.2"
-
-vitest@^0.15.1:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.15.2.tgz#3931c390685ff03331298c7719d27d691f79e782"
-  integrity sha512-cMabuUqu+nNHafkdN7H8Z20+UZTrrUfqjGwAoLwUwrqFGWBz3gXwxndjbLf6mgSFs9lF/JWjKeNM1CXKwtk26w==
-  dependencies:
-    "@types/chai" "^4.3.1"
-    "@types/chai-subset" "^1.3.3"
-    "@types/node" "*"
-    chai "^4.3.6"
-    debug "^4.3.4"
-    local-pkg "^0.4.1"
-    tinypool "^0.1.3"
-    tinyspy "^0.3.3"
-    vite "^2.9.12"
 
 vitest@^0.17.1:
   version "0.17.1"


### PR DESCRIPTION
### WHY are these changes introduced?
Until now we used a loose version requirement between all the packages and `@shopify/cli-kit`. This helps eliminate potential duplicates under `node_modules`, but requires following semver in `@shopify/cli-kit` and do major bumps when breaking changes are introduced. Unfortunately, detecting breaking changes is a human task in PR reviews and therefore very error-prone that might lead to runtime errors on the user side. The alternative model is to not follow semver, pin the version, and accept that some duplication might happen when developers add plugins.
Considering the size of the package and putting users' first, we've leaned towards accepting potential duplications but less risk of breaking users' setup.

### WHAT is this pull request doing?

I'm pinning the `@shopify/cli-kit` version from all the other packages.
