### PR TITLE
Report MODULE_NOT_FOUND errors coming from @oclif

### DIFF
--- a/.changeset/short-pumpkins-rest.md
+++ b/.changeset/short-pumpkins-rest.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Report errors coming from @oclif

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -1,6 +1,6 @@
 // CLI
 import {findUpAndReadPackageJson} from './node-package-manager.js'
-import {errorHandler} from './error-handler.js'
+import {errorHandler, subscribeToProcessEmittedErrors} from './error-handler.js'
 import {initializeCliKitStore} from '../store.js'
 import {initiateLogging} from '../output.js'
 import {isDebug} from '../environment/local.js'
@@ -36,7 +36,7 @@ export async function runCLI(options: RunCLIOptions) {
       autoDetectErrors: false,
     })
   }
-
+  await subscribeToProcessEmittedErrors()
   run(undefined, options.moduleURL).then(flush).catch(errorHandler)
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?
@oclif eager-loads all plugins and swallows module loading errors to present a more user-friendly error, `command not found`. This is not great because some module loading errors might be actual bugs in our code, like it was the case with `@shopify/cli-kit` introducing breaking changes in a minor version, so we need to report those too.

### WHAT is this pull request doing?
Since `@oclif/core` [sends those errors](https://github.com/oclif/core/blob/main/src/config/config.ts#L244) through the `process.emitWarning` API, we can subscribe to those events and make sure we report the ones that might indicate that there's a bug in the CLI. Note that it'll take some iterations until we find the right level of granularity in the error handling logic. For instance, once we have the notion of 3P plugins, we need to filter out module-loading errors that don't come from Shopify's plugins or CLI.

### How to test your changes?

Add an invalid import to the info command and invoke it:

```ts
import { invalid } from "non-existing-module"

invalid()
```