### PR TITLE
create app - updating placeholder app urls

### DIFF
--- a/.changeset/dirty-zoos-wait.md
+++ b/.changeset/dirty-zoos-wait.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+updated placeholder app urls used during app creation

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -72,8 +72,8 @@ describe('createApp', () => {
     const variables = {
       org: 2,
       title: 'app-name',
-      appUrl: 'https://shopify.github.io/shopify-cli/help/start-app/',
-      redir: ['http://localhost:3456'],
+      appUrl: 'https://example.com',
+      redir: ['https://example.com/api/auth'],
       type: 'custom',
     }
 
@@ -149,8 +149,8 @@ describe('selectOrCreateApp', () => {
     const variables = {
       org: 1,
       title: 'app-name',
-      appUrl: 'https://shopify.github.io/shopify-cli/help/start-app/',
-      redir: ['http://localhost:3456'],
+      appUrl: 'https://example.com',
+      redir: ['https://example.com/api/auth'],
       type: 'undecided',
     }
 

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -41,8 +41,8 @@ export async function createApp(org: Organization, app: AppInterface, token: str
   const variables: api.graphql.CreateAppQueryVariables = {
     org: parseInt(org.id, 10),
     title: `${name}`,
-    appUrl: 'https://shopify.github.io/shopify-cli/help/start-app/',
-    redir: ['http://localhost:3456'],
+    appUrl: 'https://example.com',
+    redir: ['https://example.com/api/auth'],
     type,
   }
 

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -68,16 +68,16 @@ describe('updateURLs', () => {
     vi.mocked(api.partners.request).mockResolvedValueOnce({appUpdate: {userErrors: []}})
     const expectedVariables = {
       apiKey: 'apiKey',
-      appUrl: 'http://localhost:3456',
+      appUrl: 'https://example.com',
       redir: [
-        'http://localhost:3456/auth/callback',
-        'http://localhost:3456/auth/shopify/callback',
-        'http://localhost:3456/api/auth/callback',
+        'https://example.com/auth/callback',
+        'https://example.com/auth/shopify/callback',
+        'https://example.com/api/auth/callback',
       ],
     }
 
     // When
-    await updateURLs('apiKey', 'http://localhost:3456', 'token')
+    await updateURLs('apiKey', 'https://example.com', 'token')
 
     // Then
     expect(api.partners.request).toHaveBeenCalledWith(api.graphql.UpdateURLsQuery, 'token', expectedVariables)
@@ -88,7 +88,7 @@ describe('updateURLs', () => {
     vi.mocked(api.partners.request).mockResolvedValueOnce({appUpdate: {userErrors: [{message: 'Boom!'}]}})
 
     // When
-    const got = updateURLs('apiKey', 'http://localhost:3456', 'token')
+    const got = updateURLs('apiKey', 'https://example.com', 'token')
 
     // Then
     expect(got).rejects.toThrow(new error.Abort(`Boom!`))


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

We are removing the need to provide URLs when creating a new app in the partner dashboard. The aligns the partners experience with the CLI's experience today. We were going to use the same placeholder URLs as the CLI but discovered that one of them points to a 404 page. 

We had a discussion and collected opinions on what a better placeholders could be ([thread 1](https://shopify.slack.com/archives/C036LL9T0NT/p1657554614844549), [thread2](https://shopify.slack.com/archives/C036LL9T0NT/p1657658050659049)) 

We have aligned on:
1. Placeholder app URL is `https:/example.com`
2. Placeholder redirection URLs are `https:/example.com/api/auth` (aligning on the NodeJS app template's OAuth URL conventions)
  
We have taken the initiative to apply them across the Partners Dashboard and CLI code bases.

### WHY are these changes introduced?

To update and align the app URL placeholders across the Partners Dashboard and CLI experiences.

### WHAT is this pull request doing?

Updating the app URL placeholders in the CLI experience.

### How to test your changes?

1. Create a new app through the CLI 3.0 (do _NOT_ run `yarn run dev`, this updates the app URL with the ngrok tunnel URL)
2. Log-in to the Partners Dashboard
3. Find the app you created
4. Navigate to "App setup" and confirm
  a. App URL is `https:/example.com`
  b. Redirection URLs is `https:/example.com/api/auth`