### PR TITLE
Send analytics metadata for scaffold extension

### DIFF
--- a/packages/app/src/cli/commands/app/scaffold/extension.ts
+++ b/packages/app/src/cli/commands/app/scaffold/extension.ts
@@ -12,7 +12,7 @@ import scaffoldExtensionPrompt from '../../../prompts/scaffold/extension.js'
 import {load as loadApp, App} from '../../../models/app/app.js'
 import scaffoldExtensionService from '../../../services/scaffold/extension.js'
 import {getUIExtensionTemplates} from '../../../utilities/extensions/template-configuration.js'
-import {output, path, cli, error, environment} from '@shopify/cli-kit'
+import {output, path, cli, error, environment, analytics} from '@shopify/cli-kit'
 import {Command, Flags} from '@oclif/core'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
 
@@ -83,6 +83,13 @@ export default class AppScaffoldExtension extends Command {
       app.packageManager,
     )
     output.info(formattedSuccessfulMessage)
+
+    analytics.addMetadata({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      extension_type: promptAnswers.extensionType,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      extension_template: promptAnswers.extensionFlavor,
+    })
   }
 
   async validateExtensionType(type: string | undefined) {

--- a/packages/cli-kit/src/analytics.ts
+++ b/packages/cli-kit/src/analytics.ts
@@ -13,6 +13,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 let startTime: number | undefined
 let startCommand: string
 let startArgs: string[]
+let metadata: object
 
 interface startOptions {
   command: string
@@ -24,6 +25,10 @@ export const start = ({command, args, currentTime = new Date().getTime()}: start
   startCommand = command
   startArgs = args
   startTime = currentTime
+}
+
+export const addMetadata = (newMetadata: object) => {
+  metadata = {...metadata, ...newMetadata}
 }
 
 interface ReportEventOptions {
@@ -105,6 +110,7 @@ const buildPayload = async (errorMessage: string | undefined, currentTime: numbe
       is_employee: await environment.local.isShopify(),
       api_key: appInfo?.appId,
       partner_id: partnerIdAsInt,
+      metadata: JSON.stringify(metadata),
     },
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/shopify-cli-planning/issues/274

### WHAT is this pull request doing?

Sends extension type and flavor to Monorail when scaffolding a new extension

### How to test your changes?

`yarn scaffold extension`