### PR TITLE
Enhance Debug Capabilities w/ Go Binary

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,46 +5,46 @@
     "version": "0.2.0",
     "configurations": [
       {
-          "type": "node",
-          "request": "launch",
-          "name": "shopify app dev",
-          "runtimeExecutable": "yarn",
-          "runtimeArgs": [
-              "shopify",
-              "app",
-              "dev",
-              "--path=${input:appDir}"
-          ],
-          "env": {
-            "DEBUG": "\"*\"",
-            "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1"
-          },
-          "skipFiles": [
-              "<node_internals>/**"
-          ],
+        "type": "node",
+        "request": "launch",
+        "name": "shopify app dev",
+        "runtimeExecutable": "yarn",
+        "runtimeArgs": [
+          "shopify",
+          "app",
+          "dev",
+          "--path=${input:appDir}"
+        ],
+        "env": {
+          "DEBUG": "\"*\"",
+          "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1"
+        },
+        "skipFiles": [
+          "<node_internals>/**"
+        ],
       },
       {
-          "type": "node",
-          "request": "launch",
-          "name": "shopify app scaffold extension",
-          "runtimeExecutable": "yarn",
-          "runtimeArgs": [
-              "shopify",
-              "app",
-              "scaffold",
-              "extension",
-              "--path=${input:appDir}",
-              "--name=${input:extensionName}",
-              "--type=${input:extensionType}",
-              "--template=${input:extensionTemplate}",
-          ],
-          "env": {
-            "DEBUG": "\"*\"",
-            "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1"
-          },
-          "skipFiles": [
-              "<node_internals>/**"
-          ],
+        "type": "node",
+        "request": "launch",
+        "name": "shopify app scaffold extension",
+        "runtimeExecutable": "yarn",
+        "runtimeArgs": [
+          "shopify",
+          "app",
+          "scaffold",
+          "extension",
+          "--path=${input:appDir}",
+          "--name=${input:extensionName}",
+          "--type=${input:extensionType}",
+          "--template=${input:extensionTemplate}",
+        ],
+        "env": {
+          "DEBUG": "\"*\"",
+          "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1"
+        },
+        "skipFiles": [
+          "<node_internals>/**"
+        ],
       },
     ],
     "inputs": [
@@ -76,18 +76,18 @@
           "shipping_rate_presenter"
         ],
         "default": "checkout_ui_extension",
-      },
-      {
-        "id": "extensionTemplate",
-        "type": "pickString",
-        "description": "Extension Template: ",
-        "options": [
-          "vanilla-js",
-          "react",
-          "wasm",
-          "rust"
-        ],
-        "default": "react",
-      }
-    ]
+    },
+    {
+      "id": "extensionTemplate",
+      "type": "pickString",
+      "description": "Extension Template: ",
+      "options": [
+        "vanilla-js",
+        "react",
+        "wasm",
+        "rust"
+      ],
+      "default": "react",
+    }
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,49 @@
 {
-  "name": "Shopify",
-  "type": "node",
-  "request": "launch",
-  "cwd": "${workspaceFolder}",
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+          "type": "node",
+          "request": "launch",
+          "name": "shopify app dev",
+          "runtimeExecutable": "yarn",
+          "runtimeArgs": [
+              "shopify",
+              "app",
+              "dev",
+              "--path=${input:appDir}"
+          ],
+          "env": {
+            "DEBUG": "\"*\"",
+            "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1"
+          },
+          "skipFiles": [
+              "<node_internals>/**"
+          ],
+      },
+    ],
+    "inputs": [
+      {
+        "id": "appDir",
+        "type": "promptString",
+        "description": "App Directory: ",
+      },
+      {
+        "id": "extensionName",
+        "type": "promptString",
+        "description": "Extension Name: ",
+      },
+      {
+        "id": "extensionType",
+        "type": "promptString",
+        "default": "checkout_ui_extension",
+      },
+      {
+        "id": "extensionTemplate",
+        "type": "promptString",
+        "default": "react",
+      }
+    ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,29 @@
               "<node_internals>/**"
           ],
       },
+      {
+          "type": "node",
+          "request": "launch",
+          "name": "shopify app scaffold extension",
+          "runtimeExecutable": "yarn",
+          "runtimeArgs": [
+              "shopify",
+              "app",
+              "scaffold",
+              "extension",
+              "--path=${input:appDir}",
+              "--name=${input:extensionName}",
+              "--type=${input:extensionType}",
+              "--template=${input:extensionTemplate}",
+          ],
+          "env": {
+            "DEBUG": "\"*\"",
+            "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1"
+          },
+          "skipFiles": [
+              "<node_internals>/**"
+          ],
+      },
     ],
     "inputs": [
       {
@@ -37,12 +60,33 @@
       },
       {
         "id": "extensionType",
-        "type": "promptString",
+        "type": "pickString",
+        "description": "Extension Type: ",
+        "options": [
+          "theme",
+          "product_subscription",
+          "checkout_ui_extension",
+          "checkout_post_purchase",
+          "web_pixel_extension",
+          "pos_ui_extension",
+          "product_discounts",
+          "order_discounts",
+          "shipping_discounts",
+          "payment_methods",
+          "shipping_rate_presenter"
+        ],
         "default": "checkout_ui_extension",
       },
       {
         "id": "extensionTemplate",
-        "type": "promptString",
+        "type": "pickString",
+        "description": "Extension Template: ",
+        "options": [
+          "vanilla-js",
+          "react",
+          "wasm",
+          "rust"
+        ],
         "default": "react",
       }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,8 @@
         ],
         "env": {
           "DEBUG": "\"*\"",
-          "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1"
+          "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1",
+          // "DEBUG_GO_BINARY": "1",       // Pause execution of the Go binary until the debgger is attached.
         },
         "skipFiles": [
           "<node_internals>/**"
@@ -40,7 +41,8 @@
         ],
         "env": {
           "DEBUG": "\"*\"",
-          "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1"
+          "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1",
+          // "DEBUG_GO_BINARY": "1",       // Pause execution of the Go binary until the debgger is attached.
         },
         "skipFiles": [
           "<node_internals>/**"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
         ],
         "env": {
           "DEBUG": "\"*\"",
-          "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1",
+          // "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1",
           // "DEBUG_GO_BINARY": "1",       // Pause execution of the Go binary until the debgger is attached.
         },
         "skipFiles": [
@@ -41,7 +41,7 @@
         ],
         "env": {
           "DEBUG": "\"*\"",
-          "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1",
+          // "SHOPIFY_USE_EXTENSIONS_CLI_SOURCES": "1",
           // "DEBUG_GO_BINARY": "1",       // Pause execution of the Go binary until the debgger is attached.
         },
         "skipFiles": [

--- a/dev.yml
+++ b/dev.yml
@@ -10,6 +10,7 @@ up:
       version: 3.1.2
   - homebrew:
     - jq
+    - delve
 
 env:
   SHOPIFY_CONFIG: debug

--- a/packages/app/src/cli/utilities/extensions/cli.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.ts
@@ -45,7 +45,7 @@ export async function runGoExtensionsCLI(args: string[], options: system.Writabl
         built = true
         stdout.write('Built extensions CLI successfully!')
       }
-      await system.exec('sh', [path.join(projectDirectory, 'shopify-extensions-debug.sh')].concat(args), options)
+      await system.exec('sh', [path.join(projectDirectory, 'shopify-extensions-debug')].concat(args), options)
       // await system.exec(path.join(projectDirectory, 'shopify-extensions'), args, options)
     } catch {
       throw new error.AbortSilent()

--- a/packages/app/src/cli/utilities/extensions/cli.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.ts
@@ -35,12 +35,13 @@ export async function runGoExtensionsCLI(args: string[], options: system.Writabl
       } else {
         building = true
         stdout.write('Building extensions CLI...')
-        await system.exec('make', ['build'], {
-          ...options,
-          stdout: undefined,
-          stderr: undefined,
-          cwd: projectDirectory,
-        })
+        // TODO: Uncomment
+        // await system.exec('make', ['build'], {
+        //   ...options,
+        //   stdout: undefined,
+        //   stderr: undefined,
+        //   cwd: projectDirectory,
+        // })
         built = true
         stdout.write('Built extensions CLI successfully!')
       }

--- a/packages/app/src/cli/utilities/extensions/cli.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.ts
@@ -45,7 +45,8 @@ export async function runGoExtensionsCLI(args: string[], options: system.Writabl
         built = true
         stdout.write('Built extensions CLI successfully!')
       }
-      await system.exec(path.join(projectDirectory, 'shopify-extensions'), args, options)
+      await system.exec('sh', [path.join(projectDirectory, 'shopify-extensions-debug.sh')].concat(args), options)
+      // await system.exec(path.join(projectDirectory, 'shopify-extensions'), args, options)
     } catch {
       throw new error.AbortSilent()
     }

--- a/packages/app/src/cli/utilities/extensions/cli.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.ts
@@ -2,7 +2,6 @@ import {getBinaryPathOrDownload} from './binary.js'
 import {useExtensionsCLISources} from '../../environment.js'
 import {environment, error, path, system} from '@shopify/cli-kit'
 import {fileURLToPath} from 'url'
-import {env} from 'process'
 
 let building = false
 let built = false
@@ -45,7 +44,7 @@ export async function runGoExtensionsCLI(args: string[], options: system.Writabl
         built = true
         stdout.write('Built extensions CLI successfully!')
       }
-      if (env.DEBUG_GO_BINARY) {
+      if (process.env.DEBUG_GO_BINARY) {
         await system.exec('sh', [path.join(projectDirectory, 'shopify-extensions-debug')].concat(args), options)
       } else {
         await system.exec(path.join(projectDirectory, 'shopify-extensions'), args, options)

--- a/packages/app/src/cli/utilities/extensions/cli.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.ts
@@ -2,6 +2,7 @@ import {getBinaryPathOrDownload} from './binary.js'
 import {useExtensionsCLISources} from '../../environment.js'
 import {environment, error, path, system} from '@shopify/cli-kit'
 import {fileURLToPath} from 'url'
+import {env} from 'process'
 
 let building = false
 let built = false
@@ -35,18 +36,20 @@ export async function runGoExtensionsCLI(args: string[], options: system.Writabl
       } else {
         building = true
         stdout.write('Building extensions CLI...')
-        // TODO: Uncomment
-        // await system.exec('make', ['build'], {
-        //   ...options,
-        //   stdout: undefined,
-        //   stderr: undefined,
-        //   cwd: projectDirectory,
-        // })
+        await system.exec('make', ['build'], {
+          ...options,
+          stdout: undefined,
+          stderr: undefined,
+          cwd: projectDirectory,
+        })
         built = true
         stdout.write('Built extensions CLI successfully!')
       }
-      await system.exec('sh', [path.join(projectDirectory, 'shopify-extensions-debug')].concat(args), options)
-      // await system.exec(path.join(projectDirectory, 'shopify-extensions'), args, options)
+      if (env.DEBUG_GO_BINARY) {
+        await system.exec('sh', [path.join(projectDirectory, 'shopify-extensions-debug')].concat(args), options)
+      } else {
+        await system.exec(path.join(projectDirectory, 'shopify-extensions'), args, options)
+      }
     } catch {
       throw new error.AbortSilent()
     }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Reduces friction for new developers by adding interactive debug configs and tying debug execution to the Go binary.

<!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Adds debugging configuration for commands that execute the Development Extension Server Go binary. Debug configurations are generalized and will display prompts where appropriate.
- Switches on the introduced `DEBUG_GO_BINARY` environment variable to launch the Delve (Go) debugger. This enables a (mostly) seamless transition from the JS/TS debugger to the Go debugger (requires `brew install delve`)

https://user-images.githubusercontent.com/4490738/180455487-e8c5bc25-8cae-47f2-8c4f-e069ecfb875e.mp4

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

  1. Due to an incompatibility between Node.js v.18 and the node-sass dependency, it is necessary to manually *comment out* the [make build lines from cli.ts](https://github.com/Shopify/cli/blob/feature/vscode_config/packages/app/src/cli/utilities/extensions/cli.ts#L39-L44).
  2. In `.vscode/launch.json` manually *uncomment* the [two environment variable lines](https://github.com/Shopify/cli/blob/feature/vscode_config/.vscode/launch.json#L44-L45) in the `shopify app scaffold extension` debug configuration. They are commented out in this PR to that ensure CI passes due to the dependency problem described above.
  3.  Delve, the VS Code Go debugger, must be installed (`brew install delve`)
  4. `shopify-cli-extensions` must be cloned locally (`dev clone shopify-cli-extensions`)
  5. From the `shopify-cli-extensions` project directory, build the debug binary (`make build-debug`). This is dependent upon [this PR](https://github.com/Shopify/shopify-cli-extensions/pull/368). As of the writing of this PR, it is unmerged, so it is necessary to checkout the corresponding branch, `feature/vscode_config`, in `shopify-cli-extensions` before running this Make command.
  6. Ensure you have an app directory to which extensions can be created; the next step will prompt for the app directory.
  7. From VS Code (in the `cli` project directory), run the `shopify app scaffold extension` debug launch configuration. VS Code will prompt for the app directory and extension name.
  8. Wait for the following output from the VS Code Debug Console: 
  ```
[DATA] Executing shopify-extensions-debug...
[DATA] API server listening at: 127.0.0.1:12345
```
  9. From a second VS Code instance, open the `shopify-cli-extensions` project and set a breakpoint on the first line of the main method of `main.go`.
  10. In this same VS Code instance, run the `Debug Attach` launch configuration. Respond to the prompts using the default values.
  11. Observe the breakpoint stopping execution.
