### PR TITLE
Fix normalizing stores when it's a spin URL

### DIFF
--- a/packages/cli-kit/src/string.test.ts
+++ b/packages/cli-kit/src/string.test.ts
@@ -18,6 +18,14 @@ describe('normalizeStore', () => {
     expect(got).toEqual('example.myshopify.com')
   })
 
+  it('parses store name with https when spin URL', () => {
+    // When
+    const got = normalizeStoreName('https://devstore001.shopify.partners-6xat.test.us.spin.dev')
+
+    // Then
+    expect(got).toEqual('devstore001.shopify.partners-6xat.test.us.spin.dev')
+  })
+
   it('parses store name without domain', () => {
     // When
     const got = normalizeStoreName('example')

--- a/packages/cli-kit/src/string.ts
+++ b/packages/cli-kit/src/string.ts
@@ -40,5 +40,7 @@ export function capitalize(string: string) {
  */
 export function normalizeStoreName(store: string) {
   const storeFqdn = store.replace(/^https?:\/\//, '').replace(/\/$/, '')
-  return storeFqdn.includes('.myshopify.com') ? storeFqdn : `${storeFqdn}.myshopify.com`
+  return storeFqdn.includes('.myshopify.com') || storeFqdn.includes('spin.dev')
+    ? storeFqdn
+    : `${storeFqdn}.myshopify.com`
 }


### PR DESCRIPTION
### WHY are these changes introduced?
The utility function that normalizes the store name doesn't account for spin URLs and that causes [authentication](https://shopify.slack.com/archives/C030LHFCA5T/p1658268059844849) not to work.

### WHAT is this pull request doing?
I'm adjusting the logic to account for stores that have a Spin URL.

### How to test your changes?
Testing the changes e2e is a bit tedious. You'd need to  `spin up` a constellation that includes partners, spin, and shopify, create a store, and run `dev` against that store.