### PR TITLE
Auto install peer dependencies when using pnpm in Hydrogen projects

### DIFF
--- a/packages/cli-kit/src/file.test.ts
+++ b/packages/cli-kit/src/file.test.ts
@@ -12,9 +12,11 @@ import {
   remove,
   stripUp,
   format,
+  touch,
+  appendFile,
 } from './file.js'
 import {join} from './path.js'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, test} from 'vitest'
 
 describe('inTemporaryDirectory', () => {
   it('ties the lifecycle of the temporary directory to the lifecycle of the callback', async () => {
@@ -239,5 +241,17 @@ describe('format', () => {
 
     // Then
     await expect(formattedContent).toEqual('<div>much extra space</div>\n')
+  })
+})
+
+describe('appendFile', () => {
+  test('it appends content to an existing file', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const filePath = join(tmpDir, 'test-file')
+      const content = 'test-content'
+      await touch(filePath)
+      await appendFile(filePath, content)
+      await expect(read(filePath)).resolves.toContain(content)
+    })
   })
 })

--- a/packages/cli-kit/src/file.ts
+++ b/packages/cli-kit/src/file.ts
@@ -59,6 +59,16 @@ export async function touch(path: string): Promise<void> {
   await fs.ensureFile(path)
 }
 
+export async function appendFile(path: string, content: string): Promise<void> {
+  debug(outputContent`Appending the following content to ${token.path(path)}:
+    ${content
+      .split('\n')
+      .map((line) => `  ${line}`)
+      .join('\n')}
+  `)
+  await fs.appendFile(path, content)
+}
+
 export async function touchSync(path: string): Promise<void> {
   debug(outputContent`Creating an empty file at ${token.path(path)}...`)
   await fs.ensureFileSync(path)

--- a/packages/create-hydrogen/src/services/init.ts
+++ b/packages/create-hydrogen/src/services/init.ts
@@ -149,9 +149,7 @@ async function init(options: InitOptions) {
       tasks.push({
         title: "[Shopifolks-only] Configuring the project's NPM registry",
         task: async (_, task) => {
-          const npmrcPath = path.join(templateScaffoldDir, '.npmrc')
-          const npmrcContent = `@shopify:registry=https://registry.npmjs.org`
-          await file.write(npmrcPath, npmrcContent)
+          await writeToNpmrc(templateScaffoldDir, `@shopify:registry=https://registry.npmjs.org`)
           task.title = "[Shopifolks-only] Project's NPM registry configured."
         },
       })
@@ -266,7 +264,19 @@ async function updateCLIDependencies(
 }
 
 async function installDependencies(directory: string, packageManager: PackageManager, stdout: Writable): Promise<void> {
+  if (packageManager === 'pnpm') {
+    writeToNpmrc(directory, 'auto-install-peers = true')
+  }
   await installNodeModules(directory, packageManager, stdout)
+}
+
+async function writeToNpmrc(directory: string, content: string) {
+  const npmrcPath = path.join(directory, '.npmrc')
+  const npmrcContent = `${content}\n`
+  if (!(await file.exists(npmrcPath))) {
+    await file.touch(npmrcPath)
+  }
+  await file.appendFile(npmrcPath, npmrcContent)
 }
 
 async function cleanup(webOutputDirectory: string) {


### PR DESCRIPTION
### WHY are these changes introduced?
The creation of Hydrogen storefronts [fails](https://github.com/Shopify/cli/issues/159) when using pnpm because transitive dependencies have peer dependencies that are not automatically installed by pnpm by default.
 
### WHAT is this pull request doing?
I'm extending the initialization logic to add `auto-install-peers = true` to the `.npmrc` file in the root of the project to instruct pnpm to install unresolved peer dependencies.

### How to test your changes?
Run `dev create-hydrogen --package-manager pnpm`