### PR TITLE
Report 5xx responses from the Partners' API as Aborts

### DIFF
--- a/.changeset/smart-dodos-battle.md
+++ b/.changeset/smart-dodos-battle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Report 5xx reponses coming from the Partners' API as aborts

--- a/packages/cli-kit/src/api/admin.test.ts
+++ b/packages/cli-kit/src/api/admin.test.ts
@@ -12,7 +12,13 @@ vi.mock('graphql-request', async () => {
   }
 })
 
-vi.mock('./common')
+vi.mock('./common.js', async () => {
+  const common: any = await vi.importActual('./common.js')
+  return {
+    ...common,
+    buildHeaders: vi.fn(),
+  }
+})
 
 const mockedResult = {
   publicApiVersions: [

--- a/packages/cli-kit/src/api/admin.ts
+++ b/packages/cli-kit/src/api/admin.ts
@@ -1,8 +1,8 @@
-import {buildHeaders, sanitizedHeadersOutput} from './common.js'
+import {buildHeaders, debugLogRequest, handlingErrors} from './common.js'
 import {AdminSession} from '../session.js'
 import {debug, content, token as outputToken} from '../output.js'
 import {Bug, Abort} from '../error.js'
-import {request as graphqlRequest, gql, RequestDocument, Variables, ClientError} from 'graphql-request'
+import {request as graphqlRequest, gql, RequestDocument, Variables} from 'graphql-request'
 
 const UnauthorizedAccessError = (store: string) => {
   const adminLink = outputToken.link(`URL`, `https://${store}/admin`)
@@ -20,36 +20,15 @@ const UnknownError = () => {
 }
 
 export async function request<T>(query: RequestDocument, session: AdminSession, variables?: Variables): Promise<T> {
-  const version = await fetchApiVersion(session)
-  const url = adminUrl(session.storeFqdn, version)
-  const headers = await buildHeaders(session.token)
-  debug(`
-Sending Admin GraphQL request:
-${query}
-
-With variables:
-${variables ? JSON.stringify(variables, null, 2) : ''}
-
-And headers:
-${sanitizedHeadersOutput(headers)}
-`)
-  try {
+  const api = 'Admin'
+  return handlingErrors(api, async () => {
+    const version = await fetchApiVersion(session)
+    const url = adminUrl(session.storeFqdn, version)
+    const headers = await buildHeaders(session.token)
+    debugLogRequest(api, query, variables, headers)
     const response = await graphqlRequest<T>(url, query, variables, headers)
     return response
-  } catch (error) {
-    if (error instanceof ClientError) {
-      const errorMessage = content`
-The Admin GraphQL API responded unsuccessfully with the HTTP status ${`${error.response.status}`} and errors:
-
-${outputToken.json(error.response.errors)}
-      `
-      const abortError = new Abort(errorMessage.value)
-      abortError.stack = error.stack
-      throw abortError
-    } else {
-      throw error
-    }
-  }
+  })
 }
 
 async function fetchApiVersion(session: AdminSession): Promise<string> {

--- a/packages/cli-kit/src/api/common.ts
+++ b/packages/cli-kit/src/api/common.ts
@@ -1,6 +1,17 @@
 import {isShopify} from '../environment/local.js'
 import constants from '../constants.js'
+import {stringifyMessage, content, token as outputToken, token, debug} from '../output.js'
+import {Abort, ExtendableError} from '../error.js'
+import {ClientError, RequestDocument, Variables} from 'graphql-request'
 import {randomUUID} from 'crypto'
+
+export class RequestClientError extends ExtendableError {
+  statusCode: number
+  public constructor(message: string, statusCode: number) {
+    super(message)
+    this.statusCode = statusCode
+  }
+}
 
 export async function buildHeaders(token: string): Promise<{[key: string]: string}> {
   const userAgent = `Shopify CLI; v=${await constants.versions.cliKit()}`
@@ -23,7 +34,7 @@ export async function buildHeaders(token: string): Promise<{[key: string]: strin
 }
 
 /**
- * Remvoes the sensitive data from the headers and outputs them as a string.
+ * Removes the sensitive data from the headers and outputs them as a string.
  * @param headers {{[key: string]: string}} HTTP headers.
  * @returns {string} A sanitized version of the headers as a string.
  */
@@ -40,4 +51,48 @@ export function sanitizedHeadersOutput(headers: {[key: string]: string}): string
       return ` - ${header}: ${sanitized[header]}`
     })
     .join('\n')
+}
+
+export async function debugLogRequest<T>(
+  api: string,
+  query: RequestDocument,
+  variables?: Variables,
+  headers: {[key: string]: string} = {},
+) {
+  debug(`
+Sending ${token.raw(api)} GraphQL request:
+${query}
+
+With variables:
+${variables ? JSON.stringify(variables, null, 2) : ''}
+
+And headers:
+${sanitizedHeadersOutput(headers)}
+`)
+}
+
+export async function handlingErrors<T>(api: string, action: () => Promise<T>): Promise<T> {
+  try {
+    return await action()
+  } catch (error) {
+    if (error instanceof ClientError) {
+      const errorMessage = stringifyMessage(content`
+  The ${token.raw(
+    api,
+  )} GraphQL API responded unsuccessfully with the HTTP status ${`${error.response.status}`} and errors:
+
+  ${outputToken.json(error.response.errors)}
+      `)
+      let mappedError: Error
+      if (error.response.status < 500) {
+        mappedError = new RequestClientError(errorMessage, error.response.status)
+      } else {
+        mappedError = new Abort(errorMessage)
+      }
+      mappedError.stack = error.stack
+      throw mappedError
+    } else {
+      throw error
+    }
+  }
 }

--- a/packages/cli-kit/src/api/partners.test.ts
+++ b/packages/cli-kit/src/api/partners.test.ts
@@ -13,7 +13,13 @@ vi.mock('graphql-request', async () => {
   }
 })
 
-vi.mock('./common')
+vi.mock('./common.js', async () => {
+  const common: any = await vi.importActual('./common.js')
+  return {
+    ...common,
+    buildHeaders: vi.fn(),
+  }
+})
 vi.mock('../environment/fqdn')
 
 const mockedResult = 'OK'

--- a/packages/cli-kit/src/api/partners.ts
+++ b/packages/cli-kit/src/api/partners.ts
@@ -1,55 +1,18 @@
-import {buildHeaders, sanitizedHeadersOutput} from './common.js'
+import {buildHeaders, debugLogRequest, handlingErrors} from './common.js'
 import {ScriptServiceProxyQuery} from './graphql/index.js'
 import {partners as partnersFqdn} from '../environment/fqdn.js'
-import {debug, stringifyMessage, content, token as outputToken} from '../output.js'
-import {ExtendableError, Abort} from '../error.js'
 import {request as graphqlRequest, Variables, RequestDocument, ClientError, gql} from 'graphql-request'
 
-export class RequestClientError extends ExtendableError {
-  statusCode: number
-  public constructor(message: string, statusCode: number) {
-    super(message)
-    this.statusCode = statusCode
-  }
-}
-
 export async function request<T>(query: RequestDocument, token: string, variables?: Variables): Promise<T> {
-  const fqdn = await partnersFqdn()
-  const url = `https://${fqdn}/api/cli/graphql`
-  const headers = await buildHeaders(token)
-  debug(`
-Sending Partners GraphQL request:
-${query}
-
-With variables:
-${variables ? JSON.stringify(variables, null, 2) : ''}
-
-And headers:
-${sanitizedHeadersOutput(headers)}
-  `)
-
-  try {
+  const api = 'Partners'
+  return handlingErrors(api, async () => {
+    const fqdn = await partnersFqdn()
+    const url = `https://${fqdn}/api/cli/graphql`
+    const headers = await buildHeaders(token)
+    debugLogRequest(api, query, variables, headers)
     const response = await graphqlRequest<T>(url, query, variables, headers)
     return response
-  } catch (error) {
-    if (error instanceof ClientError) {
-      const errorMessage = stringifyMessage(content`
-The Partners GraphQL API responded unsuccessfully with the HTTP status ${`${error.response.status}`} and errors:
-
-${outputToken.json(error.response.errors)}
-      `)
-      let mappedError: Error
-      if (error.response.status < 500) {
-        mappedError = new RequestClientError(errorMessage, error.response.status)
-      } else {
-        mappedError = new Abort(errorMessage)
-      }
-      mappedError.stack = error.stack
-      throw mappedError
-    } else {
-      throw error
-    }
-  }
+  })
 }
 
 /**

--- a/packages/cli-kit/src/session.ts
+++ b/packages/cli-kit/src/session.ts
@@ -23,6 +23,7 @@ import constants from './constants.js'
 import {normalizeStoreName} from './string.js'
 import * as output from './output.js'
 import {partners} from './api.js'
+import {RequestClientError} from './api/common.js'
 import {gql} from 'graphql-request'
 
 const NoSessionError = new Bug('No session found after ensuring authenticated')
@@ -222,7 +223,7 @@ export async function hasPartnerAccount(partnersToken: string): Promise<boolean>
     return true
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
-    if (error instanceof partners.RequestClientError && error.statusCode === 404) {
+    if (error instanceof RequestClientError && error.statusCode === 404) {
       return false
     } else {
       return true


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed that we [are reporting](https://app.bugsnag.com/shopify/cli/errors/62ac4e8ed3273c0008d0b78a?filters[event.since]=30d&filters[error.status]=open&filters[release.seen_in]=3.3.2) 5xx responses from the Partners' API as bugs to Bugsnag. That's not necessary because 5xx errors coming from the API are already tracked server-side.

### WHAT is this pull request doing?
I adjusted the logic to use an `Abort` error when the response status code is `5xx`.