### PR TITLE
Add flags for theme check

### DIFF
--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -29,11 +29,12 @@ export async function execCLI2(args: string[], adminSession?: AdminSession) {
     ...process.env,
     SHOPIFY_CLI_ADMIN_AUTH_TOKEN: adminSession?.token,
     SHOPIFY_CLI_STORE: adminSession?.storeFqdn,
+    BUNDLE_GEMFILE: join(shopifyCLIDirectory(), 'Gemfile'),
   }
 
   await system.exec('bundle', ['exec', 'shopify'].concat(args), {
     stdio: 'inherit',
-    cwd: shopifyCLIDirectory(),
+    cwd: process.cwd(),
     env,
   })
 }

--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -15,15 +15,21 @@ const MinBundlerVersion = '2.3.8'
 const MinRubyVersion = '2.3.0'
 const MinRubyGemVersion = '2.5.0'
 
+interface ExecCLI2Options {
+  // Contains token and store to pass to CLI 2.0, which will be set as environment variables
+  adminSession?: AdminSession
+  // Directory in which to execute the command. Otherwise the current directory will be used.
+  directory?: string
+}
 /**
  * Execute CLI 2.0 commands.
  * Installs a version of RubyCLI as a vendor dependency in a hidden folder in the system.
  * User must have a valid ruby+bundler environment to run any command.
  *
  * @param args {string[]} List of argumets to execute. (ex: ['theme', 'pull'])
- * @param adminSession {AdminSession} Contains token and store to pass to CLI 2.0, which will be set as environment variables
+ * @param options {ExecCLI2Options}
  */
-export async function execCLI2(args: string[], adminSession?: AdminSession) {
+export async function execCLI2(args: string[], {adminSession, directory}: ExecCLI2Options = {}) {
   await installCLIDependencies()
   const env = {
     ...process.env,
@@ -34,7 +40,7 @@ export async function execCLI2(args: string[], adminSession?: AdminSession) {
 
   await system.exec('bundle', ['exec', 'shopify'].concat(args), {
     stdio: 'inherit',
-    cwd: process.cwd(),
+    cwd: directory || process.cwd(),
     env,
   })
 }

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -81,7 +81,7 @@ Excludes checks matching any category when specified more than once`,
     const {flags} = await this.parse(Check)
     const passThroughFlags: string[] = []
     for (const [label, value] of Object.entries(flags)) {
-      if (label === 'path') {
+      if (['path', 'verbose'].includes(label)) {
         continue
       } else if (typeof value === 'boolean') {
         passThroughFlags.push(`--${label}`)

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -79,7 +79,6 @@ Excludes checks matching any category when specified more than once`,
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Check)
-    if (flags.path) process.chdir(path.resolve(flags.path))
     const passThroughFlags: string[] = []
     for (const [label, value] of Object.entries(flags)) {
       if (label === 'path') {
@@ -90,6 +89,6 @@ Excludes checks matching any category when specified more than once`,
         passThroughFlags.push(`--${label}=${value}`)
       }
     }
-    await execCLI2(['theme', 'check', ...passThroughFlags])
+    await execCLI2(['theme', 'check', ...passThroughFlags], {directory: flags.path})
   }
 }

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -1,15 +1,90 @@
 import Command from '@shopify/cli-kit/node/base-command'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {cli} from '@shopify/cli-kit'
+import {Flags} from '@oclif/core'
 
 export default class Check extends Command {
   static description = 'Validate the theme'
 
   static flags = {
     ...cli.globalFlags,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'auto-correct': Flags.boolean({
+      char: 'a',
+      required: false,
+      description: 'Automatically fix offenses',
+      env: 'SHOPIFY_FLAG_AUTO_CORRECT',
+    }),
+    category: Flags.string({
+      char: 'c',
+      required: false,
+      description: `Only run this category of checks
+Runs checks matching all categories when specified more than once`,
+      env: 'SHOPIFY_FLAG_CATEGORY',
+    }),
+    config: Flags.string({
+      char: 'C',
+      required: false,
+      description: `Use the config provided, overriding .theme-check.yml if present
+Use :theme_app_extension to use default checks for theme app extensions`,
+      env: 'SHOPIFY_FLAG_CONFIG',
+    }),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'exclude-category': Flags.string({
+      char: 'x',
+      required: false,
+      description: `Exclude this category of checks
+Excludes checks matching any category when specified more than once`,
+      env: 'SHOPIFY_FLAG_EXCLUDE_CATEGORY',
+    }),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'fail-level': Flags.string({
+      required: false,
+      description: 'Minimum severity for exit with error code',
+      env: 'SHOPIFY_FLAG_FAIL_LEVEL',
+      options: ['error', 'suggestion', 'style'],
+    }),
+    init: Flags.boolean({
+      required: false,
+      description: 'Generate a .theme-check.yml file',
+      env: 'SHOPIFY_FLAG_INIT',
+    }),
+    list: Flags.boolean({
+      required: false,
+      description: 'List enabled checks',
+      env: 'SHOPIFY_FLAG_LIST',
+    }),
+    output: Flags.string({
+      char: 'o',
+      required: false,
+      description: 'The output format to use',
+      env: 'SHOPIFY_FLAG_OUTPUT',
+      options: ['text', 'json'],
+      default: 'text',
+    }),
+    print: Flags.boolean({
+      required: false,
+      description: 'Output active config to STDOUT',
+      env: 'SHOPIFY_FLAG_PRINT',
+    }),
+    version: Flags.boolean({
+      char: 'v',
+      required: false,
+      description: 'Print Theme Check version',
+      env: 'SHOPIFY_FLAG_VERSION',
+    }),
   }
 
   async run(): Promise<void> {
-    await execCLI2(['theme', 'check'])
+    const {flags} = await this.parse(Check)
+    const passThroughFlags: string[] = []
+    for (const [label, value] of Object.entries(flags)) {
+      if (typeof value === 'boolean') {
+        passThroughFlags.push(`--${label}`)
+      } else {
+        passThroughFlags.push(`--${label}=${value}`)
+      }
+    }
+    await execCLI2(['theme', 'check', ...passThroughFlags])
   }
 }

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -1,6 +1,7 @@
+import {themeFlags} from '../../flags.js'
 import Command from '@shopify/cli-kit/node/base-command'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
-import {cli} from '@shopify/cli-kit'
+import {cli, path} from '@shopify/cli-kit'
 import {Flags} from '@oclif/core'
 
 export default class Check extends Command {
@@ -8,6 +9,7 @@ export default class Check extends Command {
 
   static flags = {
     ...cli.globalFlags,
+    ...themeFlags,
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'auto-correct': Flags.boolean({
       char: 'a',
@@ -77,9 +79,12 @@ Excludes checks matching any category when specified more than once`,
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Check)
+    if (flags.path) process.chdir(path.resolve(flags.path))
     const passThroughFlags: string[] = []
     for (const [label, value] of Object.entries(flags)) {
-      if (typeof value === 'boolean') {
+      if (label === 'path') {
+        continue
+      } else if (typeof value === 'boolean') {
         passThroughFlags.push(`--${label}`)
       } else {
         passThroughFlags.push(`--${label}=${value}`)

--- a/packages/theme/src/cli/commands/theme/delete.ts
+++ b/packages/theme/src/cli/commands/theme/delete.ts
@@ -55,6 +55,6 @@ export default class Delete extends Command {
     }
 
     const adminSession = await session.ensureAuthenticatedAdmin(store)
-    await execCLI2(command, adminSession)
+    await execCLI2(command, {adminSession})
   }
 }

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -78,6 +78,6 @@ export default class Dev extends Command {
     }
 
     const adminSession = await session.ensureAuthenticatedAdmin(store)
-    await execCLI2(command, adminSession)
+    await execCLI2(command, {adminSession})
   }
 }

--- a/packages/theme/src/cli/commands/theme/list.ts
+++ b/packages/theme/src/cli/commands/theme/list.ts
@@ -21,6 +21,6 @@ export default class List extends Command {
     const {flags} = await this.parse(List)
     const store = getTheme(flags)
     const adminSession = await session.ensureAuthenticatedAdmin(store)
-    await execCLI2(['theme', 'list'], adminSession)
+    await execCLI2(['theme', 'list'], {adminSession})
   }
 }

--- a/packages/theme/src/cli/commands/theme/open.ts
+++ b/packages/theme/src/cli/commands/theme/open.ts
@@ -49,6 +49,6 @@ export default class Open extends Command {
     }
 
     const adminSession = await session.ensureAuthenticatedAdmin(store)
-    await execCLI2(command, adminSession)
+    await execCLI2(command, {adminSession})
   }
 }

--- a/packages/theme/src/cli/commands/theme/publish.ts
+++ b/packages/theme/src/cli/commands/theme/publish.ts
@@ -38,6 +38,6 @@ export default class Publish extends Command {
     }
 
     const adminSession = await session.ensureAuthenticatedAdmin(store)
-    await execCLI2(command, adminSession)
+    await execCLI2(command, {adminSession})
   }
 }

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -83,6 +83,6 @@ export default class Pull extends Command {
 
     const store = getTheme(flags)
     const adminSession = await session.ensureAuthenticatedAdmin(store)
-    await execCLI2(command, adminSession)
+    await execCLI2(command, {adminSession})
   }
 }

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -112,6 +112,6 @@ export default class Push extends Command {
 
     const store = getTheme(flags)
     const adminSession = await session.ensureAuthenticatedAdmin(store)
-    await execCLI2(command, adminSession)
+    await execCLI2(command, {adminSession})
   }
 }

--- a/packages/theme/src/cli/commands/theme/share.ts
+++ b/packages/theme/src/cli/commands/theme/share.ts
@@ -28,6 +28,6 @@ export default class Share extends Command {
     const {flags} = await this.parse(Share)
     const store = getTheme(flags)
     const adminSession = await session.ensureAuthenticatedAdmin(store)
-    await execCLI2(['theme', 'share', flags.path], adminSession)
+    await execCLI2(['theme', 'share', flags.path], {adminSession})
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

`theme-check` run via Node doesn't currently support params. We need to allow that.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
1. Adds the relevant params, parses and passes through to the Ruby CLI.
2. Adds a `--path` param allowing you to specify where the command should be run. This was non-trivial as we were previously relying on the command's cwd to be in the same place as the Ruby CLI2 executable. We're now using `BUNDLE_GEMFILE` to tell bundler where it can find the Ruby dependencies, then running the command in a specified directory or defaulting to the current working directory.

Change 2 will be very big in improving our development workflow, as we can run `dev shopify theme check --path=/path/to/theme/project in development, or we can write feature tests depending on this behavior, as we've done for `app`.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
```sh
$ dev shopify theme init --path=/path/to/some/writable/directory --name=my-theme-for-testing
$ dev shopify theme check --path=/path/to/some/writable/directory/my-theme-for-testing
```