### PR TITLE
308 - source maps to plugins

### DIFF
--- a/bin/update-bugsnag.js
+++ b/bin/update-bugsnag.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import fsPromise from 'node:fs/promises'
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { node } from "@bugsnag/source-maps";
 import reportBuild from 'bugsnag-build-reporter';
+import glob from 'fast-glob';
+import tmp from 'tmp';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -13,13 +16,48 @@ const apiKey = '9e1e6889176fd0c795d5c659225e0fae';
 
 (async () => {
   try {
-    await node.uploadMultiple({
-      apiKey,
-      appVersion,
-      overwrite: true,
-      projectRoot: `${__dirname}/../packages`,
-      directory: '.'
-    });
+    const packageFolders = glob.sync(`${__dirname}/../packages/*`, {onlyDirectories: true})
+
+    const packageMap = {
+      'cli-main': 'cli'
+    }
+
+    // Process each package, and upload to Bugsnag as `@shopify/package-name/dist/file.js`
+    for (const sourceDirectory of packageFolders) {
+      const basePackageName = path.basename(sourceDirectory);
+      const packageName = packageMap[basePackageName] ?? basePackageName
+
+      console.log(`Preparing @shopify/${packageName}`);
+
+      await new Promise((resolve, reject) => {
+        tmp.dir({unsafeCleanup: true}, async (err, temporaryDirectory) => {
+          if (err) {
+            reject(err);
+          }
+          try {
+            const temporaryShopifyPackage = await fsPromise.mkdir(path.join(temporaryDirectory, '@shopify'), { recursive: true});
+            const temporaryPackageCopy = await fsPromise.mkdir(path.join(temporaryShopifyPackage, `${packageName}`), { recursive: true });
+
+            console.log('Copying to temporary directory');
+            fs.cpSync(sourceDirectory, temporaryPackageCopy, {recursive: true});
+
+            console.log('Uploading to Bugsnag');
+            process.chdir(temporaryDirectory);
+            await node.uploadMultiple({
+              apiKey,
+              appVersion,
+              overwrite: true,
+              directory: '.',
+            });
+
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+    }
+
     await reportBuild({apiKey, appVersion}, {})
     console.log('Build reported!')
   } catch (err) {

--- a/packages/cli-kit/src/error.test.ts
+++ b/packages/cli-kit/src/error.test.ts
@@ -1,6 +1,6 @@
-import {Abort, Bug, handler} from './error.js'
+import {Abort, Bug, handler, cleanSingleStackTracePath} from './error.js'
 import {error} from './output.js'
-import {describe, expect, test, vi, beforeEach} from 'vitest'
+import {describe, expect, test, vi, beforeEach, it} from 'vitest'
 
 beforeEach(() => {
   vi.mock('./output')
@@ -42,5 +42,16 @@ describe('handler', () => {
     // Then
     expect(error).toHaveBeenCalledWith(expect.objectContaining({type: expect.any(Number)}))
     expect(unknownError).not.contains({type: expect.any(Number)})
+  })
+})
+
+describe('stack file path helpers', () => {
+  it.each([
+    ['simple file:///', 'file:///something/there.js'],
+    ['windows file://', 'file:///D:\\something\\there.js'],
+    ['unix no file', '/something/there.js'],
+    ['windows no file', 'D:\\something\\there.js'],
+  ])('%s', (_, path) => {
+    expect(cleanSingleStackTracePath(path)).toEqual('/something/there.js')
   })
 })

--- a/packages/cli-kit/src/error.ts
+++ b/packages/cli-kit/src/error.ts
@@ -1,14 +1,9 @@
 import {Message, stringifyMessage, error as outputError} from './output.js'
+import {normalize} from './path.js'
 import {Errors} from '@oclif/core'
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import sourceMapSupport from 'source-map-support'
 
 export {ExtendableError} from 'ts-error'
 export {AbortSignal} from 'abort-controller'
-
-sourceMapSupport.install()
 
 enum FatalErrorType {
   Abort,
@@ -103,4 +98,14 @@ export function shouldReport(error: Error): boolean {
     return true
   }
   return false
+}
+
+/**
+ * Stack traces usually have file:// - we strip that and also remove the Windows drive designation
+ *
+ */
+export function cleanSingleStackTracePath(filePath: string): string {
+  return normalize(filePath)
+    .replace('file:/', '/')
+    .replace(/^\/?[A-Z]:/, '')
 }

--- a/packages/cli-kit/src/node/error-handler.ts
+++ b/packages/cli-kit/src/node/error-handler.ts
@@ -4,6 +4,7 @@ import {
   mapper as errorMapper,
   shouldReport as shouldReportError,
   handler,
+  cleanSingleStackTracePath,
 } from '../error.js'
 import {info} from '../output.js'
 import {reportEvent} from '../analytics.js'
@@ -65,7 +66,7 @@ const reportError = async (error: Error): Promise<Error> => {
   const formattedStacktrace = new StackTracey(stacktrace ?? '')
     .clean()
     .items.map((item) => {
-      const filePath = path.normalize(item.file).replace('file:/', '/').replace('C:/', '')
+      const filePath = cleanSingleStackTracePath(item.file)
       return `    at ${item.callee} (${filePath}:${item.line}:${item.column})`
     })
     .join('\n')

--- a/packages/cli-kit/src/output.ts
+++ b/packages/cli-kit/src/output.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import {Fatal, Bug} from './error.js'
+import {Fatal, Bug, cleanSingleStackTracePath} from './error.js'
 import {isUnitTest, isVerbose} from './environment/local.js'
 import constants from './constants.js'
 import {PackageManager} from './node/node-package-manager.js'
@@ -395,7 +395,12 @@ export const error = async (content: Fatal) => {
     }
   }
 
-  let stack = await new StackTracey(content).withSourcesAsync()
+  let stack = new StackTracey(content)
+  stack.items.forEach((item) => {
+    item.file = cleanSingleStackTracePath(item.file)
+  })
+
+  stack = await stack.withSourcesAsync()
   stack = stack
     .filter((entry) => {
       return !entry.file.includes('@oclif/core')


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes Shopify/shopify-cli-planning#308

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

- Updated the Bugsnag source map uploader to tweak package folders to match their underlying name (i.e. `@shopify/cli`, not `packages/cli-main`)
- Don't follow source maps by default for all errors (partial reversion of https://github.com/Shopify/shopify-cli-next/pull/237 )
- And _do_ follow source maps when displaying an error's stack trace

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Same as https://github.com/Shopify/cli/pull/185

Run a command that breaks. I tested by tweaking the info command to have an unexpected null:
![image](https://user-images.githubusercontent.com/234027/180768410-74565541-4764-490f-a967-87f1decb7ab9.png)