### PR TITLE
Add payment_customization support

### DIFF
--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -60,7 +60,7 @@ export const publicFunctionExtensions = {
   types: ['product_discounts', 'order_discounts', 'shipping_discounts'],
 } as const
 export const functionExtensions = {
-  types: [...publicFunctionExtensions.types, 'payment_methods', 'shipping_rate_presenter'],
+  types: [...publicFunctionExtensions.types, 'payment_methods', 'shipping_rate_presenter', 'payment_customization'],
 } as const
 
 export const functionExtensionTemplates = [
@@ -140,6 +140,8 @@ export const getFunctionExtensionPointName = (type: FunctionExtensionTypes) => {
       return 'SHIPPING_DISCOUNTS'
     case 'payment_methods':
       return 'PAYMENT_METHODS'
+    case 'payment_customization':
+      return 'PAYMENT_CUSTOMIZATION'
     case 'shipping_rate_presenter':
       return 'SHIPPING_METHODS'
   }
@@ -266,6 +268,7 @@ export const extensionGraphqlId = (type: ExtensionTypes) => {
     case 'order_discounts':
     case 'shipping_discounts':
     case 'payment_methods':
+    case 'payment_customization':
     case 'shipping_rate_presenter':
       // As we add new extensions, this bug will force us to add a new case here.
       return type


### PR DESCRIPTION
### WHY are these changes introduced?

This allows us to push payment_customization functions as we are building it out.
