### PR TITLE
Add a link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you encounter issues using the CLI or have feedback you'd like to share with 
 
 - [Open a GitHub issue](https://github.com/Shopify/cli/issues) - To report bugs or request new features, open an issue in the Shopify CLI repository.
 - [Shopify Community Forums](https://community.shopify.com/) - Visit our forums to connect with the community and learn more about Shopify CLI development.
+- [CLI Documentation](https://shopify.dev/apps/tools/cli) - To view our complete API documentation
 
 <p>&nbsp;</p>
 


### PR DESCRIPTION
This was a hassle when I first landed on this readme that there wasn't a docs page- I wanted information about a specific command and had to find it by trawling shopify.dev.

Thoughts on adding a link to that overview within the repository somewhere?

I have no opinion on where to include it or the copy, I just would like a link to be somewhere.

There's a link to how to create an app, but that only answers one specific query. Another link to the root of the docs page would be helpful.
