### PR TITLE
Allow WS connections to the app and not only extensions

### DIFF
--- a/.changeset/light-apples-jump.md
+++ b/.changeset/light-apples-jump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Allow websocket connections to support vite HMR

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -77,8 +77,7 @@ ${output.token.json(JSON.stringify(rules))}
   // Capture websocket requests and forward them to the proxy
   server.on('upgrade', function (req, socket, head) {
     const target = match(rules, req)
-    if (target && req.url?.includes('/extensions')) return proxy.ws(req, socket, head, {target})
-    socket.destroy()
+    return proxy.ws(req, socket, head, {target})
   })
 
   await Promise.all([

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -77,7 +77,8 @@ ${output.token.json(JSON.stringify(rules))}
   // Capture websocket requests and forward them to the proxy
   server.on('upgrade', function (req, socket, head) {
     const target = match(rules, req)
-    return proxy.ws(req, socket, head, {target})
+    if (target) return proxy.ws(req, socket, head, {target})
+    socket.destroy()
   })
 
   await Promise.all([


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Initially we only supported 1 websocket through our reverse proxy (because of how it worked), this was the extensions websocket needed for updates and dev-console.

With the proxy refactor we can now easily support multiple websockets, basically 1 per route. So one for `/` and one for `/extensions`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Allow websockets in `/`, fixing the vite HMR issue
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
