### PR TITLE
Change dashes to underscores for metafields in Checkout UI Extension config scaffolding

### DIFF
--- a/fixtures/app/extensions/checkout-ui/shopify.ui.extension.toml
+++ b/fixtures/app/extensions/checkout-ui/shopify.ui.extension.toml
@@ -7,9 +7,9 @@ extension_points = [
 ]
 
 # [[metafields]]
-# namespace = "my-namespace"
-# key = "my-key"
+# namespace = "my_namespace"
+# key = "my_key"
 
 # [[metafields]]
-# namespace = "my-namespace"
-# key = "my-key-2"
+# namespace = "my_namespace"
+# key = "my_key_2"


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

When defining Metafields in the Admin, the app will auto-convert spaces in the metafield name to underscores in the proposed metafield key.  For example, a metafield named "My test metafield" will have a proposed namespace and key of `custom.my_test_metafield`.

This PR is just changing our default metafield config scaffolding for Checkout UI Extensions from dashes to underscores to better align with the "smart defaults" proposed by the Admin.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Changing dashes `-` to underscores `_` in the TOML config scaffolding for Checkout UI extensions.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
