### PR TITLE
Don't register the hook if the ClI is running in debug

### DIFF
--- a/packages/cli-kit/src/node/base-command.ts
+++ b/packages/cli-kit/src/node/base-command.ts
@@ -1,4 +1,5 @@
 import {errorHandler, registerCleanBugsnagErrorsFromWithinPlugins} from './error-handler.js'
+import {isDebug} from '../environment/local.js'
 import {Command} from '@oclif/core'
 
 // eslint-disable-next-line import/no-anonymous-default-export
@@ -9,8 +10,10 @@ export default abstract class extends Command {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async init(): Promise<any> {
-    // This function runs just prior to `run`
-    registerCleanBugsnagErrorsFromWithinPlugins(this.config.plugins)
+    if (!isDebug()) {
+      // This function runs just prior to `run`
+      registerCleanBugsnagErrorsFromWithinPlugins(this.config.plugins)
+    }
     return super.init()
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
This [recent work](https://github.com/Shopify/cli/pull/192) led to warnings when using the CLL in development because we try to register a Bugsnag hook without having initialized `Bugsnag`.

### WHAT is this pull request doing?
Since we don't initialize `Bugsnag` when in development, we need to take that into account when registering the hooks.
