### PR TITLE
Add ENV var to allow to login 

### DIFF
--- a/packages/cli-kit/src/api/common.ts
+++ b/packages/cli-kit/src/api/common.ts
@@ -1,4 +1,4 @@
-import {isShopify} from '../environment/local.js'
+import {isShopifyEmployee} from '../environment/local.js'
 import constants from '../constants.js'
 import {stringifyMessage, content, token as outputToken, token, debug} from '../output.js'
 import {Abort, ExtendableError} from '../error.js'
@@ -15,7 +15,7 @@ export class RequestClientError extends ExtendableError {
 
 export async function buildHeaders(token: string): Promise<{[key: string]: string}> {
   const userAgent = `Shopify CLI; v=${await constants.versions.cliKit()}`
-  const isEmployee = await isShopify()
+  const isEmployee = isShopifyEmployee()
 
   const headers = {
     /* eslint-disable @typescript-eslint/naming-convention */
@@ -26,7 +26,7 @@ export async function buildHeaders(token: string): Promise<{[key: string]: strin
     authorization: `Bearer ${token}`,
     'X-Shopify-Access-Token': `Bearer ${token}`,
     'Content-Type': 'application/json',
-    // ...(isEmployee && {'X-Shopify-Cli-Employee': '1'}),
+    ...(isEmployee && {'X-Shopify-Cli-Employee': '1'}),
     /* eslint-enable @typescript-eslint/naming-convention */
   }
 

--- a/packages/cli-kit/src/constants.ts
+++ b/packages/cli-kit/src/constants.ts
@@ -27,6 +27,7 @@ const constants = {
     partnersToken: 'SHOPIFY_CLI_PARTNERS_TOKEN',
     verbose: 'SHOPIFY_FLAG_VERBOSE',
     noAnalytics: 'SHOPIFY_CLI_NO_ANALYTICS',
+    employee: 'SHOPIFY_CLI_EMPLOYEE',
   },
   paths: {
     executables: {

--- a/packages/cli-kit/src/environment/local.ts
+++ b/packages/cli-kit/src/environment/local.ts
@@ -73,6 +73,10 @@ export function analyticsDisabled(env = process.env): boolean {
   return isTruthy(env[constants.environmentVariables.noAnalytics]) || isDebug(env)
 }
 
+export function isShopifyEmployee(env = process.env): boolean {
+  return isTruthy(env[constants.environmentVariables.employee])
+}
+
 /**
  * Returns whether the environment has Git available.
  * @returns {Promise<boolean>} A promise that resolves with the value.

--- a/packages/cli-kit/src/session.ts
+++ b/packages/cli-kit/src/session.ts
@@ -24,6 +24,7 @@ import {normalizeStoreName} from './string.js'
 import * as output from './output.js'
 import {partners} from './api.js'
 import {RequestClientError} from './api/common.js'
+import {isShopifyEmployee} from './environment/local.js'
 import {gql} from 'graphql-request'
 
 const NoSessionError = new Bug('No session found after ensuring authenticated')
@@ -257,6 +258,10 @@ async function executeCompleteFlow(applications: OAuthApplications, identityFqdn
   const scopes = getFlattenScopes(applications)
   const exchangeScopes = getExchangeScopes(applications)
   const store = applications.adminApi?.storeFqdn
+  if (isShopifyEmployee()) {
+    debug(content`Authenticating as Shopify Employee...`)
+    scopes.push('employee')
+  }
 
   // Authorize user via browser
   debug(content`Authorizing through Identity's website...`)

--- a/packages/cli-kit/src/session/validate.ts
+++ b/packages/cli-kit/src/session/validate.ts
@@ -4,6 +4,7 @@ import constants from '../constants.js'
 import {OAuthApplications} from '../session.js'
 import {identity, partners} from '../api.js'
 import {debug} from '../output.js'
+import {isShopifyEmployee} from '../environment/local.js'
 
 type ValidationResult = 'needs_refresh' | 'needs_full_auth' | 'ok'
 
@@ -15,6 +16,7 @@ type ValidationResult = 'needs_refresh' | 'needs_full_auth' | 'ok'
  */
 function validateScopes(requestedScopes: string[], identity: IdentityToken) {
   const currentScopes = identity.scopes
+  if (isShopifyEmployee() !== currentScopes.includes('employee')) return false
   return requestedScopes.every((scope) => currentScopes.includes(scope))
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We need a way to allow employees to identify as such

Fixes https://github.com/Shopify/shopify-cli-planning/issues/331

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
if the `SHOPIFY_CLI_EMPLOYEE` env var is present, we will perform the login with the `employee` scope.
This will only work for Shopify Employees.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
