### PR TITLE
Clean Up Theme Lightweight Commands

### DIFF
--- a/.changeset/eighty-cameras-nail.md
+++ b/.changeset/eighty-cameras-nail.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme': minor
+---
+
+- Clean up theme share
+- Clean up theme package
+- Clean up theme publish
+- Clean up theme delete

--- a/.changeset/eighty-cameras-nail.md
+++ b/.changeset/eighty-cameras-nail.md
@@ -6,3 +6,4 @@
 - Clean up theme package
 - Clean up theme publish
 - Clean up theme delete
+- Clean up theme open

--- a/packages/theme/src/cli/commands/theme/delete.ts
+++ b/packages/theme/src/cli/commands/theme/delete.ts
@@ -14,18 +14,18 @@ export default class Delete extends ThemeCommand {
     development: Flags.boolean({
       char: 'd',
       description: 'Delete your development theme.',
-      env: 'SHOPIFY_FLAG_THEME_DEVELOPMENT',
+      env: 'SHOPIFY_FLAG_DEVELOPMENT',
     }),
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'show-all': Flags.boolean({
       char: 'a',
       description: 'Include others development themes in theme list.',
-      env: 'SHOPIFY_FLAG_THEME_SHOW_ALL',
+      env: 'SHOPIFY_FLAG_SHOW_ALL',
     }),
     force: Flags.boolean({
       char: 'f',
       description: 'Skip confirmation.',
-      env: 'SHOPIFY_FLAG_THEME_FORCE',
+      env: 'SHOPIFY_FLAG_FORCE',
     }),
     store: Flags.string({
       char: 's',

--- a/packages/theme/src/cli/commands/theme/delete.ts
+++ b/packages/theme/src/cli/commands/theme/delete.ts
@@ -1,10 +1,10 @@
 import {getTheme} from '../../utilities/theme-store.js'
+import ThemeCommand from '../theme-command.js'
 import {Flags} from '@oclif/core'
 import {cli, session, string} from '@shopify/cli-kit'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
-import Command from '@shopify/cli-kit/node/base-command'
 
-export default class Delete extends Command {
+export default class Delete extends ThemeCommand {
   static description = "Delete remote themes from the connected store. This command can't be undone"
 
   static args = [{name: 'themeId', description: 'The ID of the theme to delete', required: false}]
@@ -44,15 +44,8 @@ export default class Delete extends Command {
     if (args.themeId) {
       command.push(args.themeId)
     }
-    if (flags.development) {
-      command.push('-d')
-    }
-    if (flags.force) {
-      command.push('-f')
-    }
-    if (flags['show-all']) {
-      command.push('-a')
-    }
+    const flagsToPass = this.passThroughFlags(flags, {exclude: ['store', 'verbose']})
+    command.push(...flagsToPass)
 
     const adminSession = await session.ensureAuthenticatedAdmin(store)
     await execCLI2(command, {adminSession})

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -28,7 +28,7 @@ export default class Dev extends ThemeCommand {
     }),
     poll: Flags.boolean({
       description: 'Force polling to detect file changes.',
-      env: 'SHOPIFY_FLAG_THEME_POLL',
+      env: 'SHOPIFY_FLAG_POLL',
     }),
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'theme-editor-sync': Flags.boolean({

--- a/packages/theme/src/cli/commands/theme/help-old.ts
+++ b/packages/theme/src/cli/commands/theme/help-old.ts
@@ -17,8 +17,9 @@ export default class HelpOld extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(HelpOld)
-    const cli2Args: string[] = ['help', 'theme']
+    const cli2Args: string[] = ['theme']
     if (flags.command) cli2Args.push(flags.command)
+    cli2Args.push('-h')
     await execCLI2(cli2Args)
   }
 }

--- a/packages/theme/src/cli/commands/theme/open.ts
+++ b/packages/theme/src/cli/commands/theme/open.ts
@@ -1,10 +1,10 @@
 import {getTheme} from '../../utilities/theme-store.js'
+import ThemeCommand from '../theme-command.js'
 import {Flags} from '@oclif/core'
 import {cli, session, string} from '@shopify/cli-kit'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
-import Command from '@shopify/cli-kit/node/base-command'
 
-export default class Open extends Command {
+export default class Open extends ThemeCommand {
   static description = 'Opens the preview of your remote theme.'
 
   static flags = {
@@ -12,12 +12,17 @@ export default class Open extends Command {
     development: Flags.boolean({
       char: 'd',
       description: 'Delete your development theme.',
-      env: 'SHOPIFY_FLAG_THEME_DEVELOPMENT',
+      env: 'SHOPIFY_FLAG_DEVELOPMENT',
+    }),
+    editor: Flags.boolean({
+      char: 'e',
+      description: 'Open the theme editor for the specified theme in the browser.',
+      env: 'SHOPIFY_FLAG_EDITOR',
     }),
     live: Flags.boolean({
       char: 'l',
       description: 'Pull theme files from your remote live theme.',
-      env: 'SHOPIFY_FLAG_THEME_LIVE',
+      env: 'SHOPIFY_FLAG_LIVE',
     }),
     theme: Flags.string({
       char: 't',
@@ -34,20 +39,10 @@ export default class Open extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Open)
+    const flagsToPass = this.passThroughFlags(flags, {exclude: ['store', 'verbose']})
+    const command = ['theme', 'open', ...flagsToPass]
+
     const store = getTheme(flags)
-
-    const command = ['theme', 'open']
-    if (flags.theme) {
-      command.push('-t')
-      command.push(flags.theme)
-    }
-    if (flags.development) {
-      command.push('-d')
-    }
-    if (flags.live) {
-      command.push('-l')
-    }
-
     const adminSession = await session.ensureAuthenticatedAdmin(store)
     await execCLI2(command, {adminSession})
   }

--- a/packages/theme/src/cli/commands/theme/package.ts
+++ b/packages/theme/src/cli/commands/theme/package.ts
@@ -1,19 +1,14 @@
-import {Flags} from '@oclif/core'
-import {cli, path} from '@shopify/cli-kit'
+import {themeFlags} from '../../flags.js'
+import ThemeCommand from '../theme-command.js'
+import {cli} from '@shopify/cli-kit'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
-import Command from '@shopify/cli-kit/node/base-command'
 
-export default class Package extends Command {
+export default class Package extends ThemeCommand {
   static description = 'Package your theme into a .zip file, ready to upload to the Online Store.'
 
   static flags = {
     ...cli.globalFlags,
-    path: Flags.string({
-      description: 'The path to your theme',
-      default: '.',
-      env: 'SHOPIFY_FLAG_PATH',
-      parse: (input, _) => Promise.resolve(path.resolve(input)),
-    }),
+    ...themeFlags,
   }
 
   async run(): Promise<void> {

--- a/packages/theme/src/cli/commands/theme/publish.ts
+++ b/packages/theme/src/cli/commands/theme/publish.ts
@@ -1,10 +1,10 @@
 import {getTheme} from '../../utilities/theme-store.js'
+import ThemeCommand from '../theme-command.js'
 import {Flags} from '@oclif/core'
 import {cli, session, string} from '@shopify/cli-kit'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
-import Command from '@shopify/cli-kit/node/base-command'
 
-export default class Publish extends Command {
+export default class Publish extends ThemeCommand {
   static description = 'Set a remote theme as the live theme.'
 
   static args = [{name: 'themeId', description: 'The ID of the theme', required: false}]
@@ -28,14 +28,12 @@ export default class Publish extends Command {
     const {flags, args} = await this.parse(Publish)
 
     const store = getTheme(flags)
-
+    const flagsToPass = this.passThroughFlags(flags, {exclude: ['path', 'store', 'verbose']})
     const command = ['theme', 'publish']
     if (args.themeId) {
       command.push(args.themeId)
     }
-    if (flags.force) {
-      command.push('-f')
-    }
+    command.push(...flagsToPass)
 
     const adminSession = await session.ensureAuthenticatedAdmin(store)
     await execCLI2(command, {adminSession})

--- a/packages/theme/src/cli/commands/theme/publish.ts
+++ b/packages/theme/src/cli/commands/theme/publish.ts
@@ -14,7 +14,7 @@ export default class Publish extends ThemeCommand {
     force: Flags.boolean({
       char: 'f',
       description: 'Skip confirmation.',
-      env: 'SHOPIFY_FLAG_THEME_FORCE',
+      env: 'SHOPIFY_FLAG_FORCE',
     }),
     store: Flags.string({
       char: 's',

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -19,29 +19,29 @@ export default class Pull extends ThemeCommand {
     development: Flags.boolean({
       char: 'd',
       description: 'Pull theme files from your remote development theme.',
-      env: 'SHOPIFY_FLAG_THEME_DEVELOPMENT',
+      env: 'SHOPIFY_FLAG_DEVELOPMENT',
     }),
     live: Flags.boolean({
       char: 'l',
       description: 'Pull theme files from your remote live theme.',
-      env: 'SHOPIFY_FLAG_THEME_LIVE',
+      env: 'SHOPIFY_FLAG_LIVE',
     }),
     nodelete: Flags.boolean({
       char: 'n',
       description: 'Runs the pull command without deleting local files.',
-      env: 'SHOPIFY_FLAG_THEME_NODELETE',
+      env: 'SHOPIFY_FLAG_NODELETE',
     }),
     only: Flags.string({
       char: 'o',
       multiple: true,
       description: 'Download only the specified files (Multiple flags allowed).',
-      env: 'SHOPIFY_FLAG_THEME_ONLY',
+      env: 'SHOPIFY_FLAG_ONLY',
     }),
     ignore: Flags.string({
       char: 'x',
       multiple: true,
       description: 'Skip downloading the specified files (Multiple flags allowed).',
-      env: 'SHOPIFY_FLAG_THEME_IGNORE',
+      env: 'SHOPIFY_FLAG_IGNORE',
     }),
     store: Flags.string({
       char: 's',

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -20,34 +20,34 @@ export default class Push extends ThemeCommand {
     development: Flags.boolean({
       char: 'd',
       description: 'Pull theme files from your remote development theme.',
-      env: 'SHOPIFY_FLAG_THEME_DEVELOPMENT',
+      env: 'SHOPIFY_FLAG_DEVELOPMENT',
     }),
     live: Flags.boolean({
       char: 'l',
       description: 'Pull theme files from your remote live theme.',
-      env: 'SHOPIFY_FLAG_THEME_LIVE',
+      env: 'SHOPIFY_FLAG_LIVE',
     }),
     unpublished: Flags.boolean({
       char: 'u',
       description: 'Create a new unpublished theme and push to it.',
-      env: 'SHOPIFY_FLAG_THEME_UNPUBLISHED',
+      env: 'SHOPIFY_FLAG_UNPUBLISHED',
     }),
     nodelete: Flags.boolean({
       char: 'n',
       description: 'Runs the pull command without deleting local files.',
-      env: 'SHOPIFY_FLAG_THEME_NODELETE',
+      env: 'SHOPIFY_FLAG_NODELETE',
     }),
     only: Flags.string({
       char: 'o',
       description: 'Download only the specified files (Multiple flags allowed).',
       multiple: true,
-      env: 'SHOPIFY_FLAG_THEME_ONLY',
+      env: 'SHOPIFY_FLAG_ONLY',
     }),
     ignore: Flags.string({
       char: 'x',
       description: 'Skip downloading the specified files (Multiple flags allowed).',
       multiple: true,
-      env: 'SHOPIFY_FLAG_THEME_IGNORE',
+      env: 'SHOPIFY_FLAG_IGNORE',
     }),
     json: Flags.boolean({
       char: 'j',
@@ -58,12 +58,12 @@ export default class Push extends ThemeCommand {
     'allow-live': Flags.boolean({
       char: 'a',
       description: 'Allow push to a live theme.',
-      env: 'SHOPIFY_FLAG_THEME_ALLOW_LIVE',
+      env: 'SHOPIFY_FLAG_ALLOW_LIVE',
     }),
     publish: Flags.boolean({
       char: 'p',
       description: 'Publish as the live theme after uploading.',
-      env: 'SHOPIFY_FLAG_THEME_PUBLISH',
+      env: 'SHOPIFY_FLAG_PUBLISH',
     }),
     store: Flags.string({
       char: 's',

--- a/packages/theme/src/cli/commands/theme/share.ts
+++ b/packages/theme/src/cli/commands/theme/share.ts
@@ -1,21 +1,17 @@
+import {themeFlags} from '../../flags.js'
 import {getTheme} from '../../utilities/theme-store.js'
+import ThemeCommand from '../theme-command.js'
 import {Flags} from '@oclif/core'
-import {cli, path, session, string} from '@shopify/cli-kit'
+import {cli, session, string} from '@shopify/cli-kit'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
-import Command from '@shopify/cli-kit/node/base-command'
 
-export default class Share extends Command {
+export default class Share extends ThemeCommand {
   static description =
     'Creates a shareable, unpublished, and new theme on your theme library with a randomized name. Works like an alias to {{command:theme push -u -t=RANDOMIZED_NAME}}'
 
   static flags = {
     ...cli.globalFlags,
-    path: Flags.string({
-      description: 'The path to your theme',
-      default: '.',
-      env: 'SHOPIFY_FLAG_PATH',
-      parse: (input, _) => Promise.resolve(path.resolve(input)),
-    }),
+    ...themeFlags,
     store: Flags.string({
       char: 's',
       description: 'Store URL',


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Aligns 5 more theme commands with the new conventions.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Edits 5 simple commands to make them consistent with how we're making theme commands work:

1. `shopify theme share`
2. `shopify theme package`
3. `shopify theme publish`
4. `shopify theme delete`
5. `shopify theme open`

Also removes `_THEME` from the env variable names associated with theme commands. We don't do this in other areas of the CLI, so this brings themes into alignment with everything else.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run the commands!