### PR TITLE
Use the same package manager throughout all the CLI workflows

### DIFF
--- a/.changeset/tough-jokes-dream.md
+++ b/.changeset/tough-jokes-dream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Use the same package manager consistently througout all the CLI workflows

--- a/packages/app/src/cli/services/scaffold/extension.ts
+++ b/packages/app/src/cli/services/scaffold/extension.ts
@@ -113,6 +113,8 @@ async function uiExtensionInit({
                   // eslint-disable-next-line @typescript-eslint/naming-convention
                   root_dir: '.',
                   template: extensionFlavor,
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  install_dependencies: false,
                 },
               },
             ],


### PR DESCRIPTION
Related https://github.com/Shopify/shopify-cli-extensions/pull/376
Fixes https://github.com/Shopify/shopify-cli-planning/issues/280

### WHY are these changes introduced?
@ani-shopify [noticed](https://github.com/Shopify/shopify-cli-planning/issues/280) inconsistencies in the package manager being used. It turns out that the [extensions' binary](https://github.com/Shopify/shopify-cli-extensions/pull/376) is doing dependency installation on extension generation, and that's causing the inconsistencies. Since that's a responsibility of the CLI, I added an [interface](https://github.com/Shopify/shopify-cli-extensions/pull/376) to opt out from that behaviour, and the changes in this PR consume that interface to disable the behavior.

### WHAT is this pull request doing?
Fixing the inconsistent usage of package managers.

### How to test your changes?
Once [this PR](https://github.com/Shopify/shopify-cli-extensions/pull/376) is merged, create an app with `npm`, and try to scaffold a new extension with the changes in this PR. You should not get any `yarn.lock` file generated in the app's directory.