### PR TITLE
Fix flaky checksum hash validation test

### DIFF
--- a/packages/cli-kit/src/node/checksum.test.ts
+++ b/packages/cli-kit/src/node/checksum.test.ts
@@ -41,7 +41,7 @@ describe('validate', () => {
       }
       vi.mocked(fetch).mockResolvedValue(response)
 
-      const got = validateMD5({file, md5FileURL: 'https://test.shopify.com/md5-file'})
+      const got = () => validateMD5({file, md5FileURL: 'https://test.shopify.com/md5-file'})
 
       // When
       await expect(got).rejects.toThrowError(InvalidChecksumError({file, expected: remoteHash, got: hash}))


### PR DESCRIPTION
### WHY are these changes introduced?

The test was calling an async function (without waiting for it) and setting up an expectation on it, but that meant that sometimes the function would throw before having the chance being caught by vitest.

### WHAT is this pull request doing?

Instead of calling the function before passing it to `expect` we wrap it into another function and then pass it to `expect`.
