### PR TITLE
Revert "Change dashes to underscores for metafields in Checkout UI Extension config scaffolding"

### DIFF
--- a/fixtures/app/extensions/checkout-ui/shopify.ui.extension.toml
+++ b/fixtures/app/extensions/checkout-ui/shopify.ui.extension.toml
@@ -7,9 +7,9 @@ extension_points = [
 ]
 
 # [[metafields]]
-# namespace = "my_namespace"
-# key = "my_key"
+# namespace = "my-namespace"
+# key = "my-key"
 
 # [[metafields]]
-# namespace = "my_namespace"
-# key = "my_key_2"
+# namespace = "my-namespace"
+# key = "my-key-2"


### PR DESCRIPTION
Reverts Shopify/cli#198

Upon further review, this isn't the correct spot to change how the `shopify.ui.extension.toml` file is generated for Checkout UI Extensions.  Reverting as this is now an unnecessary change.