### PR TITLE
Fix targetPort is always random. Before generating new randomPort ch…

### DIFF
--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -40,7 +40,7 @@ export async function runConcurrentHTTPProcessesAndPathForwardTraffic(
 
   const processes = await Promise.all(
     proxyTargets.map(async (target): Promise<output.OutputProcess> => {
-      const targetPort = await port.getRandomPort()
+      const targetPort = portNumber ?? (await port.getRandomPort())
       rules[target.pathPrefix ?? '/'] = `http://localhost:${targetPort}`
       return {
         prefix: target.logPrefix,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #136 

Possible issue: same port value for each target inside .map()

### WHAT is this pull request doing?

This will try to assign a port from the function parameter.

### How to test your changes?

This should make --tunnel-url parameter work
