### PR TITLE
Allow running `shopify` instead of `npm/yarn/pnpm shopify`

### DIFF
--- a/.changeset/giant-bikes-dream.md
+++ b/.changeset/giant-bikes-dream.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/cli': minor
+---
+
+Allow running shopify installed globally instead of npm/yarn/pnpm shopify

--- a/packages/cli-kit/src/constants.ts
+++ b/packages/cli-kit/src/constants.ts
@@ -31,6 +31,8 @@ const constants = {
     codespaces: 'CODESPACES',
     codespaceName: 'CODESPACE_NAME',
     gitpod: 'GITPOD_WORKSPACE_URL',
+    enableCliRedirect: 'SHOPIFY_ENABLE_CLI_REDIRECT',
+    skipCliRedirect: 'SHOPIFY_SKIP_CLI_REDIRECT',
   },
   paths: {
     executables: {

--- a/packages/cli-kit/src/constants.ts
+++ b/packages/cli-kit/src/constants.ts
@@ -24,6 +24,8 @@ const constants = {
     noAnalytics: 'SHOPIFY_CLI_NO_ANALYTICS',
     alwaysLogAnalytics: 'SHOPIFY_CLI_ALWAYS_LOG_ANALYTICS',
     firstPartyDev: 'SHOPIFY_CLI_1P_DEV',
+    enableCliRedirect: 'SHOPIFY_CLI_ENABLE_CLI_REDIRECT',
+    skipCliRedirect: 'SHOPIFY_CLI_SKIP_CLI_REDIRECT',
     debugGoBinary: 'SHOPIFY_DEBUG_GO_BINARY',
     deviceAuth: 'SHOPIFY_CLI_DEVICE_AUTH',
     // Variables to detect if the CLI is running in a cloud environment
@@ -31,8 +33,6 @@ const constants = {
     codespaces: 'CODESPACES',
     codespaceName: 'CODESPACE_NAME',
     gitpod: 'GITPOD_WORKSPACE_URL',
-    enableCliRedirect: 'SHOPIFY_ENABLE_CLI_REDIRECT',
-    skipCliRedirect: 'SHOPIFY_SKIP_CLI_REDIRECT',
   },
   paths: {
     executables: {

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -43,6 +43,7 @@ export async function runCreateCLI(options: RunCLIOptions) {
 }
 
 export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boolean> {
+  if (process.env.SHOPIFY_SKIP_CLI_REDIRECT) return false
   if (process.env.npm_config_user_agent) return false
 
   const cliPackage = await localCliPackage()
@@ -51,7 +52,10 @@ export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boole
   const correctExecutablePath = join(cliPackage.path, cliPackage.bin.shopify)
   if (correctExecutablePath === filepath) return false
   try {
-    await exec(correctExecutablePath, process.argv.slice(2, process.argv.length), {stdio: 'inherit'})
+    await exec(correctExecutablePath, process.argv.slice(2, process.argv.length), {
+      stdio: 'inherit',
+      env: {SHOPIFY_SKIP_CLI_REDIRECT: '1'},
+    })
     // eslint-disable-next-line no-catch-all/no-catch-all, @typescript-eslint/no-explicit-any
   } catch (processError: any) {
     process.exit(processError.exitCode)

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -48,7 +48,12 @@ export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boole
 
   const correctExecutablePath = join(cliPackage.path, cliPackage.bin.shopify)
   if (correctExecutablePath === filepath) return false
-  await exec(correctExecutablePath, process.argv.slice(2, process.argv.length), {stdio: 'inherit'})
+  try {
+    await exec(correctExecutablePath, process.argv.slice(2, process.argv.length), {stdio: 'inherit'})
+    // eslint-disable-next-line no-catch-all/no-catch-all, @typescript-eslint/no-explicit-any
+  } catch (processError: any) {
+    process.exit(processError.exitCode)
+  }
   return true
 }
 

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -76,15 +76,22 @@ interface CliPackageInfo {
   bin: {shopify: string}
 }
 
+interface PackageJSON {
+  dependencies?: {[packageName: string]: CliPackageInfo}
+  devDependencies?: {[packageName: string]: CliPackageInfo}
+  peerDependencies?: {[packageName: string]: CliPackageInfo}
+}
+
 async function localCliPackage(): Promise<CliPackageInfo | undefined> {
   let npmListOutput = ''
+  let localShopifyCLI: PackageJSON = {}
   try {
     npmListOutput = await captureOutput('npm', ['list', '@shopify/cli', '--json', '-l'])
+    localShopifyCLI = JSON.parse(npmListOutput)
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (err) {
     return
   }
-  const localShopifyCLI = JSON.parse(npmListOutput)
   const dependenciesList = {
     ...localShopifyCLI.peerDependencies,
     ...localShopifyCLI.devDependencies,

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -43,6 +43,8 @@ export async function runCreateCLI(options: RunCLIOptions) {
 }
 
 export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boolean> {
+  if (process.env.npm_config_user_agent) return false
+
   const cliPackage = await localCliPackage()
   if (!cliPackage) return false
 

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -2,6 +2,7 @@
 import {findUpAndReadPackageJson} from './node-package-manager.js'
 import {errorHandler} from './error-handler.js'
 import {isDevelopment} from '../environment/local.js'
+import {isTruthy} from '../environment/utilities.js'
 import {join, moduleDirectory} from '../path.js'
 import {captureOutput, exec} from '../system.js'
 import {run, settings, flush} from '@oclif/core'
@@ -14,7 +15,7 @@ interface RunCLIOptions {
 /**
  * A function that abstracts away setting up the environment and running
  * a CLI
- * @param module {RunCLIOptions} Options.
+ * @param options {RunCLIOptions} Options.
  */
 export async function runCLI(options: RunCLIOptions) {
   if (isDevelopment()) {
@@ -44,8 +45,8 @@ export async function runCreateCLI(options: RunCLIOptions) {
 
 export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boolean> {
   // Temporary flag while we test out this feature and ensure it won't break anything!
-  if (!process.env.SHOPIFY_ENABLE_CLI_REDIRECT) return false
-  if (process.env.SHOPIFY_SKIP_CLI_REDIRECT) return false
+  if (!isTruthy(process.env.SHOPIFY_ENABLE_CLI_REDIRECT)) return false
+  if (isTruthy(process.env.SHOPIFY_SKIP_CLI_REDIRECT)) return false
   if (process.env.npm_config_user_agent) return false
 
   const cliPackage = await localCliPackage()

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -56,7 +56,6 @@ export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boole
   const correctExecutablePath = join(cliPackage.path, cliPackage.bin.shopify)
   if (correctExecutablePath === filepath) return false
   try {
-    const env = {}
     await exec(correctExecutablePath, process.argv.slice(2, process.argv.length), {
       stdio: 'inherit',
       env: {[constants.environmentVariables.skipCliRedirect]: '1'},

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -44,7 +44,7 @@ export async function runCreateCLI(options: RunCLIOptions) {
   await runCLI(options)
 }
 
-export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boolean> {
+export async function useLocalCLIIfDetected(filepath: string): Promise<boolean> {
   // Temporary flag while we test out this feature and ensure it won't break anything!
   if (!isTruthy(process.env[constants.environmentVariables.enableCliRedirect])) return false
 

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -47,7 +47,11 @@ export async function runCreateCLI(options: RunCLIOptions) {
 export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boolean> {
   // Temporary flag while we test out this feature and ensure it won't break anything!
   if (!isTruthy(process.env[constants.environmentVariables.enableCliRedirect])) return false
+
+  // Setting an env variable in the child process prevents accidental recursion.
   if (isTruthy(process.env[constants.environmentVariables.skipCliRedirect])) return false
+
+  // If already running via package manager, we can assume it's running correctly already.
   if (process.env.npm_config_user_agent) return false
 
   const cliPackage = await localCliPackage()

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -82,9 +82,12 @@ async function localCliPackage(): Promise<CliPackageInfo | undefined> {
     return
   }
   const localShopifyCLI = JSON.parse(npmListOutput)
-  const dependenciesList =
-    localShopifyCLI.dependencies ?? localShopifyCLI.devDependencies ?? localShopifyCLI.peerDependencies
-  return dependenciesList && dependenciesList['@shopify/cli']
+  const dependenciesList = {
+    ...localShopifyCLI.peerDependencies,
+    ...localShopifyCLI.devDependencies,
+    ...localShopifyCLI.dependencies,
+  }
+  return dependenciesList['@shopify/cli']
 }
 
 export default runCLI

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -43,6 +43,8 @@ export async function runCreateCLI(options: RunCLIOptions) {
 }
 
 export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boolean> {
+  // Temporary flag while we test out this feature and ensure it won't break anything!
+  if (!process.env.SHOPIFY_ENABLE_CLI_REDIRECT) return false
   if (process.env.SHOPIFY_SKIP_CLI_REDIRECT) return false
   if (process.env.npm_config_user_agent) return false
 

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -71,7 +71,9 @@ async function localCliPackage(): Promise<CliPackageInfo | undefined> {
     return
   }
   const localShopifyCLI = JSON.parse(npmListOutput)
-  return localShopifyCLI.dependencies && localShopifyCLI.dependencies['@shopify/cli']
+  const dependenciesList =
+    localShopifyCLI.dependencies ?? localShopifyCLI.devDependencies ?? localShopifyCLI.peerDependencies
+  return dependenciesList && dependenciesList['@shopify/cli']
 }
 
 export default runCLI

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -3,6 +3,7 @@ import {findUpAndReadPackageJson} from './node-package-manager.js'
 import {errorHandler} from './error-handler.js'
 import {isDevelopment} from '../environment/local.js'
 import {isTruthy} from '../environment/utilities.js'
+import constants from '../constants.js'
 import {join, moduleDirectory} from '../path.js'
 import {captureOutput, exec} from '../system.js'
 import {run, settings, flush} from '@oclif/core'
@@ -45,8 +46,8 @@ export async function runCreateCLI(options: RunCLIOptions) {
 
 export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boolean> {
   // Temporary flag while we test out this feature and ensure it won't break anything!
-  if (!isTruthy(process.env.SHOPIFY_ENABLE_CLI_REDIRECT)) return false
-  if (isTruthy(process.env.SHOPIFY_SKIP_CLI_REDIRECT)) return false
+  if (!isTruthy(process.env[constants.environmentVariables.enableCliRedirect])) return false
+  if (isTruthy(process.env[constants.environmentVariables.skipCliRedirect])) return false
   if (process.env.npm_config_user_agent) return false
 
   const cliPackage = await localCliPackage()
@@ -55,9 +56,10 @@ export async function replaceGlobalCLIWithLocal(filepath: string): Promise<boole
   const correctExecutablePath = join(cliPackage.path, cliPackage.bin.shopify)
   if (correctExecutablePath === filepath) return false
   try {
+    const env = {}
     await exec(correctExecutablePath, process.argv.slice(2, process.argv.length), {
       stdio: 'inherit',
-      env: {SHOPIFY_SKIP_CLI_REDIRECT: '1'},
+      env: {[constants.environmentVariables.skipCliRedirect]: '1'},
     })
     // eslint-disable-next-line no-catch-all/no-catch-all, @typescript-eslint/no-explicit-any
   } catch (processError: any) {

--- a/packages/cli-main/bin/run.js
+++ b/packages/cli-main/bin/run.js
@@ -2,6 +2,8 @@
 
 process.removeAllListeners('warning');
 
-import runCLI from "@shopify/cli";
+import runCLI, {replaceGlobalCLIWithLocal} from "@shopify/cli";
 
-runCLI();
+// If we run a local CLI instead, don't run the global one again after!
+const ranLocalInstead = await replaceGlobalCLIWithLocal(import.meta.url);
+if (!ranLocalInstead) runCLI();

--- a/packages/cli-main/bin/run.js
+++ b/packages/cli-main/bin/run.js
@@ -2,8 +2,8 @@
 
 process.removeAllListeners('warning');
 
-import runCLI, {replaceGlobalCLIWithLocal} from "@shopify/cli";
+import runCLI, {useLocalCLIIfDetected} from "@shopify/cli";
 
 // If we run a local CLI instead, don't run the global one again after!
-const ranLocalInstead = await replaceGlobalCLIWithLocal(import.meta.url);
+const ranLocalInstead = await useLocalCLIIfDetected(import.meta.url);
 if (!ranLocalInstead) runCLI();

--- a/packages/cli-main/src/index.ts
+++ b/packages/cli-main/src/index.ts
@@ -1,5 +1,7 @@
 import {runCLI} from '@shopify/cli-kit/node/cli'
 
+export {replaceGlobalCLIWithLocal} from '@shopify/cli-kit/node/cli'
+
 async function runShopifyCLI() {
   await runCLI({
     moduleURL: import.meta.url,

--- a/packages/cli-main/src/index.ts
+++ b/packages/cli-main/src/index.ts
@@ -1,6 +1,6 @@
 import {runCLI} from '@shopify/cli-kit/node/cli'
 
-export {replaceGlobalCLIWithLocal} from '@shopify/cli-kit/node/cli'
+export {useLocalCLIIfDetected} from '@shopify/cli-kit/node/cli'
 
 async function runShopifyCLI() {
   await runCLI({


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Allows someone who's installed the shopify CLI package globally to run `shopify` instead of `npm/yarn/pnpm shopify`. This should help avoid users getting confused as we will shortly be supporting a globally installed CLI for certain use cases.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Since `run.js` is the entrypoint to the CLI, we hook in there and check if the running script is the same we'd expect based on `npm list` in the current working directory.

If it's the same script, we can just move on as usual.

If `npm list` fails, it's likely because you're not inside a directory with a `package.json` or [your dependencies are messed up](https://github.com/npm/npm/issues/17624#issuecomment-313294516), and we just go on using the current CLI.

If you're running a different script, we run the correct `run.js`, handing over `argv` as is (excluding the first 2, which based on my testing should be `node` and the current script).

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
```bash
$ npm install -g /path/to/your/local/repo/copy
$ cd ~
$ shopify version # should be the same as your development version
$ cd /path/to/some/app
$ shopify version # should be the same as your app's installed @shopify/cli version
$ shopify app info --verbose # tests that flags are passed correctly, and also shows the correct version