### PR TITLE
hydrogen dev open flag

### DIFF
--- a/.changeset/healthy-books-remain.md
+++ b/.changeset/healthy-books-remain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': minor
+---
+
+New `open` flag for the `hydrogen dev` command. When `--open` is passed to this command, the app will automatically open in a browser window. The default value is false.

--- a/packages/cli-hydrogen/src/cli/commands/hydrogen/dev.ts
+++ b/packages/cli-hydrogen/src/cli/commands/hydrogen/dev.ts
@@ -17,6 +17,10 @@ export default class Dev extends Command {
       description: 'listen on all addresses, including LAN and public addresses.',
       env: 'SHOPIFY_FLAG_DEV_HOST',
     }),
+    open: Flags.boolean({
+      description: 'automatically open the app in the browser',
+      env: 'SHOPIFY_FLAG_DEV_OPEN',
+    }),
   }
 
   async run(): Promise<void> {

--- a/packages/cli-hydrogen/src/cli/commands/hydrogen/dev.ts
+++ b/packages/cli-hydrogen/src/cli/commands/hydrogen/dev.ts
@@ -20,6 +20,7 @@ export default class Dev extends Command {
     open: Flags.boolean({
       description: 'automatically open the app in the browser',
       env: 'SHOPIFY_FLAG_DEV_OPEN',
+      default: false,
     }),
   }
 

--- a/packages/cli-hydrogen/src/cli/services/dev.ts
+++ b/packages/cli-hydrogen/src/cli/services/dev.ts
@@ -3,18 +3,19 @@ import {analytics, error as kitError} from '@shopify/cli-kit'
 import {Config} from '@oclif/core'
 
 interface DevOptions {
+  commandConfig: Config
   directory: string
   force: boolean
   host: boolean
-  commandConfig: Config
+  open: boolean
 }
 
-async function dev({directory, force, host, commandConfig}: DevOptions) {
+async function dev({commandConfig, directory, force, host, open}: DevOptions) {
   try {
     const server = await createServer({
       root: directory,
       server: {
-        open: true,
+        open,
         force,
         host,
       },


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/226

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

New `open` flag for the `hydrogen dev` command. When `--open` is passed to this command, the app will automatically open in a browser window. The default value is false.

### How to test your changes?

- Pull this branch
- Run `dev shopify hydrogen dev --path ../hydrogen/templates/hello-world`, note the app does not open in a browser window
- Run `dev shopify hydrogen dev --path ../hydrogen/templates/hello-world --open`, note the app opens in a browser window

@Shopify/hydrogen 