### PR TITLE
Add `-t/--theme` flag in the `theme dev` command

### DIFF
--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -45,10 +45,15 @@ export default class Dev extends ThemeCommand {
       env: 'SHOPIFY_FLAG_STORE',
       parse: (input, _) => Promise.resolve(string.normalizeStoreName(input)),
     }),
+    theme: Flags.string({
+      char: 't',
+      description: 'Theme ID or name of the remote theme.',
+      env: 'SHOPIFY_FLAG_THEME_ID',
+    }),
   }
 
   async run(): Promise<void> {
-    const {flags, args} = await this.parse(Dev)
+    const {flags} = await this.parse(Dev)
 
     const flagsToPass = this.passThroughFlags(flags, {exclude: ['path', 'store', 'verbose']})
     const command = ['theme', 'serve', flags.path, ...flagsToPass]


### PR DESCRIPTION
### WHY are these changes introduced?

The `theme dev` command must support the `-t/--theme` flag.

I've recently fixed the help message [here](https://github.com/Shopify/shopify-cli/pull/2512), and now this PR adds support in the `shopify/cli` side.

### WHAT is this pull request doing?

This PR adds the new `-t/--theme` and also I've removed the unused `args` variable from the `theme/dev.ts` file.

### How to test your changes?

- Run `shopify theme dev -t <THEME_ID>`
- Run `shopify theme dev --theme <THEME_ID>`

<img width="1415" alt="image" src="https://user-images.githubusercontent.com/1079279/182786583-4c906325-bf23-4999-9569-415dd83e549b.png">


