### PR TITLE
Themes: add multiple IDs to theme delete, don't show duplicated errors

### DIFF
--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -51,6 +51,7 @@ export async function execCLI2(args: string[], {adminSession, storefrontToken, d
       env,
     })
   } catch (error) {
+    // CLI2 will show it's own errors, we don't need to show an additional CLI3 error
     throw new AbortSilent()
   }
 }

--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -1,7 +1,7 @@
 import * as file from '../file.js'
 import * as ui from '../ui.js'
 import * as system from '../system.js'
-import {Abort} from '../error.js'
+import {Abort, AbortSilent} from '../error.js'
 import {glob, join} from '../path.js'
 import constants from '../constants.js'
 import {coerce} from '../semver.js'
@@ -44,11 +44,15 @@ export async function execCLI2(args: string[], {adminSession, storefrontToken, d
     BUNDLE_GEMFILE: join(shopifyCLIDirectory(), 'Gemfile'),
   }
 
-  await system.exec('bundle', ['exec', 'shopify'].concat(args), {
-    stdio: 'inherit',
-    cwd: directory ?? process.cwd(),
-    env,
-  })
+  try {
+    await system.exec('bundle', ['exec', 'shopify'].concat(args), {
+      stdio: 'inherit',
+      cwd: directory ?? process.cwd(),
+      env,
+    })
+  } catch (error) {
+    throw new AbortSilent()
+  }
 }
 
 interface ExecThemeCheckCLIOptions {

--- a/packages/theme/src/cli/commands/theme/delete.ts
+++ b/packages/theme/src/cli/commands/theme/delete.ts
@@ -7,7 +7,8 @@ import {execCLI2} from '@shopify/cli-kit/node/ruby'
 export default class Delete extends ThemeCommand {
   static description = "Delete remote themes from the connected store. This command can't be undone"
 
-  static args = [{name: 'themeId', description: 'The ID of the theme to delete', required: false}]
+  // Accept any number of args without naming them
+  static strict = false
 
   static flags = {
     ...cli.globalFlags,
@@ -36,14 +37,17 @@ export default class Delete extends ThemeCommand {
   }
 
   async run(): Promise<void> {
-    const {flags, args} = await this.parse(Delete)
+    const {flags, argv} = await this.parse(Delete)
 
     const store = getTheme(flags)
 
     const command = ['theme', 'delete']
-    if (args.themeId) {
-      command.push(args.themeId)
+
+    // Pass all args without validation
+    if (argv.length > 0) {
+      command.push(...argv)
     }
+
     const flagsToPass = this.passThroughFlags(flags, {exclude: ['store', 'verbose']})
     command.push(...flagsToPass)
 

--- a/packages/theme/src/cli/commands/theme/delete.ts
+++ b/packages/theme/src/cli/commands/theme/delete.ts
@@ -43,7 +43,6 @@ export default class Delete extends ThemeCommand {
 
     const command = ['theme', 'delete']
 
-    // Pass all args without validation
     if (argv.length > 0) {
       command.push(...argv)
     }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Improving how theme commands are executed from CLI3.0, this PR fixes some bugs reported by @karreiro 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Don't show an additional CLI3 error on terminal when CLI2 crashes. CLI2 has it's own errors and showing an extra CLI3 error doesn't add any value
- Add support for multiple IDs in the `delete` command

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
`yarn shopify theme pull -t 123` should only show a CLI2 error
`yarn shopify theme delete 123 234 345` will pass al IDs to be deleted (and tell you that they don't exists)

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
