### PR TITLE
Bump extensions cli binary to 0.20.6

### DIFF
--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -22,7 +22,7 @@ export const environmentVariables = {
 } as const
 
 export const versions = {
-  extensionsBinary: 'v0.20.5',
+  extensionsBinary: 'v0.20.6',
   react: '^17.0.0',
 } as const
 


### PR DESCRIPTION
### WHY are these changes introduced?

So that the CLI downloads the extensions CLI version that contains the scaffolds for `customer_accounts_ui_extensions`
