### PR TITLE
Pass env var to CLI2 to hide upgrade warning

### DIFF
--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -9,7 +9,7 @@ import {AdminSession} from '../session.js'
 import {content, token} from '../output.js'
 import {Writable} from 'node:stream'
 
-const RubyCLIVersion = '2.20.1'
+const RubyCLIVersion = '2.23.0'
 const ThemeCheckVersion = '1.10.3'
 const MinBundlerVersion = '2.3.8'
 const MinRubyVersion = '2.3.0'

--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -38,6 +38,7 @@ export async function execCLI2(args: string[], {adminSession, storefrontToken, d
     SHOPIFY_CLI_STOREFRONT_RENDERER_AUTH_TOKEN: storefrontToken,
     SHOPIFY_CLI_ADMIN_AUTH_TOKEN: adminSession?.token,
     SHOPIFY_CLI_STORE: adminSession?.storeFqdn,
+    SHOPIFY_CLI_RUN_AS_SUBPROCESS: 'true',
     // Bundler uses this Gemfile to understand which gems are available in the
     // environment. We use this to specify our own Gemfile for CLI2, which exists
     // outside the user's project directory.


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/343

We need to tell CLI2 that upgrade messages can be ingnored when we execute it from CLI3

### WHAT is this pull request doing?

Pass an env var to CLI2 which it will use to hide the message.
