### PR TITLE
Add option to choose typescript templates for ui extensions

### DIFF
--- a/.changeset/mighty-crabs-raise.md
+++ b/.changeset/mighty-crabs-raise.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli': minor
+'@shopify/create-hydrogen': patch
+---
+
+Add the option to choose typescript templates for ui extensions

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -116,7 +116,9 @@
       "description": "Extension Template: ",
       "options": [
         "vanilla-js",
-        "react",
+        "vanilla-js-react",
+        "typescript",
+        "typescript-react",
         "wasm",
         "rust"
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -116,7 +116,7 @@
       "description": "Extension Template: ",
       "options": [
         "vanilla-js",
-        "vanilla-js-react",
+        "react",
         "typescript",
         "typescript-react",
         "wasm",

--- a/packages/app/src/cli/commands/app/scaffold/extension.ts
+++ b/packages/app/src/cli/commands/app/scaffold/extension.ts
@@ -58,7 +58,7 @@ export default class AppScaffoldExtension extends Command {
     template: Flags.string({
       hidden: false,
       description: 'Choose a starting template for your extension, where applicable',
-      options: ['vanilla-js', 'vanilla-js-react', 'typescript', 'typescript-react', 'wasm', 'rust'],
+      options: ['vanilla-js', 'react', 'typescript', 'typescript-react', 'wasm', 'rust'],
       env: 'SHOPIFY_FLAG_TEMPLATE',
     }),
   }

--- a/packages/app/src/cli/commands/app/scaffold/extension.ts
+++ b/packages/app/src/cli/commands/app/scaffold/extension.ts
@@ -58,7 +58,7 @@ export default class AppScaffoldExtension extends Command {
     template: Flags.string({
       hidden: false,
       description: 'Choose a starting template for your extension, where applicable',
-      options: ['vanilla-js', 'react', 'wasm', 'rust'],
+      options: ['vanilla-js', 'vanilla-js-react', 'typescript', 'typescript-react', 'wasm', 'rust'],
       env: 'SHOPIFY_FLAG_TEMPLATE',
     }),
   }

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -89,8 +89,8 @@ export type UIExtensionTypes = typeof uiExtensions.types[number]
 export const uiExtensionTemplates = [
   {name: 'TypeScript', value: 'typescript'},
   {name: 'Vanilla JavaScript', value: 'vanilla-js'},
+  {name: 'JavaScript React', value: 'react'},
   {name: 'TypeScript React', value: 'typescript-react'},
-  {name: 'Vanilla JavaScript React', value: 'vanilla-js-react'},
 ]
 
 export function isUiExtensionType(extensionType: string) {

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -87,9 +87,9 @@ export const activeUIExtensions = {
 export type UIExtensionTypes = typeof uiExtensions.types[number]
 
 export const uiExtensionTemplates = [
-  {name: 'Typescript', value: 'typescript'},
+  {name: 'TypeScript', value: 'typescript'},
   {name: 'Vanilla JavaScript', value: 'vanilla-js'},
-  {name: 'Typescript React', value: 'typescript-react'},
+  {name: 'TypeScript React', value: 'typescript-react'},
   {name: 'Vanilla JavaScript React', value: 'vanilla-js-react'},
 ]
 

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -88,9 +88,9 @@ export type UIExtensionTypes = typeof uiExtensions.types[number]
 
 export const uiExtensionTemplates = [
   {name: 'TypeScript', value: 'typescript'},
-  {name: 'Vanilla JavaScript', value: 'vanilla-js'},
-  {name: 'JavaScript React', value: 'react'},
+  {name: 'JavaScript', value: 'vanilla-js'},
   {name: 'TypeScript React', value: 'typescript-react'},
+  {name: 'JavaScript React', value: 'react'},
 ]
 
 export function isUiExtensionType(extensionType: string) {

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -87,8 +87,10 @@ export const activeUIExtensions = {
 export type UIExtensionTypes = typeof uiExtensions.types[number]
 
 export const uiExtensionTemplates = [
-  {name: 'React', value: 'react'},
-  {name: 'vanilla JavaScript', value: 'vanilla-js'},
+  {name: 'Typescript', value: 'typescript'},
+  {name: 'Vanilla JavaScript', value: 'vanilla-js'},
+  {name: 'Typescript React', value: 'typescript-react'},
+  {name: 'Vanilla JavaScript React', value: 'vanilla-js-react'},
 ]
 
 export function isUiExtensionType(extensionType: string) {

--- a/packages/app/src/cli/prompts/scaffold/extension.test.ts
+++ b/packages/app/src/cli/prompts/scaffold/extension.test.ts
@@ -90,7 +90,7 @@ describe('extension prompt', async () => {
 
   it('when scaffolding a UI extension type prompts for language/framework preference', async () => {
     const prompt = vi.fn()
-    const answers = {extensionFlavor: 'react'}
+    const answers = {extensionFlavor: 'vanilla-js-react'}
     const options = {
       name: 'my-special-extension',
       extensionTypesAlreadyAtQuota: [],

--- a/packages/app/src/cli/prompts/scaffold/extension.test.ts
+++ b/packages/app/src/cli/prompts/scaffold/extension.test.ts
@@ -90,7 +90,7 @@ describe('extension prompt', async () => {
 
   it('when scaffolding a UI extension type prompts for language/framework preference', async () => {
     const prompt = vi.fn()
-    const answers = {extensionFlavor: 'vanilla-js-react'}
+    const answers = {extensionFlavor: 'react'}
     const options = {
       name: 'my-special-extension',
       extensionTypesAlreadyAtQuota: [],

--- a/packages/app/src/cli/prompts/scaffold/extension.ts
+++ b/packages/app/src/cli/prompts/scaffold/extension.ts
@@ -37,7 +37,7 @@ export const extensionFlavorQuestion = (extensionType: string): ui.Question => {
   return {
     type: 'select',
     name: 'extensionFlavor',
-    message: 'Choose a starting template for your extension',
+    message: 'What would you like to work in?',
     choices,
     default: 'react',
   }

--- a/packages/app/src/cli/prompts/scaffold/extension.ts
+++ b/packages/app/src/cli/prompts/scaffold/extension.ts
@@ -39,7 +39,7 @@ export const extensionFlavorQuestion = (extensionType: string): ui.Question => {
     name: 'extensionFlavor',
     message: 'Choose a starting template for your extension',
     choices,
-    default: 'vanilla-js-react',
+    default: 'react',
   }
 }
 

--- a/packages/app/src/cli/prompts/scaffold/extension.ts
+++ b/packages/app/src/cli/prompts/scaffold/extension.ts
@@ -39,7 +39,7 @@ export const extensionFlavorQuestion = (extensionType: string): ui.Question => {
     name: 'extensionFlavor',
     message: 'Choose a starting template for your extension',
     choices,
-    default: 'react',
+    default: 'vanilla-js-react',
   }
 }
 

--- a/packages/app/src/cli/services/scaffold/extension.test.ts
+++ b/packages/app/src/cli/services/scaffold/extension.test.ts
@@ -120,7 +120,7 @@ describe('initialize a extension', () => {
 
       await withTemporaryApp(async (tmpDir: string) => {
         const name = 'my-ext-2'
-        const extensionFlavor = 'vanilla-js-react'
+        const extensionFlavor = 'react'
         await createFromTemplate({name, extensionType, externalExtensionType, extensionFlavor, appDirectory: tmpDir})
         const extensionIndexFile = path.join(tmpDir, 'extensions', name, 'src', 'index.jsx')
         expect(file.exists(extensionIndexFile)).resolves.toBe(true)

--- a/packages/app/src/cli/utilities/extensions/template-configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/template-configuration.test.ts
@@ -21,7 +21,7 @@ describe('get ui extension template types', () => {
 
       // Then
       expect(result).toEqual([
-        {name: 'Typescript', value: 'typescript'},
+        {name: 'TypeScript', value: 'typescript'},
         {name: 'Vanilla JavaScript', value: 'vanilla-js'},
       ])
     },

--- a/packages/app/src/cli/utilities/extensions/template-configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/template-configuration.test.ts
@@ -22,7 +22,7 @@ describe('get ui extension template types', () => {
       // Then
       expect(result).toEqual([
         {name: 'TypeScript', value: 'typescript'},
-        {name: 'Vanilla JavaScript', value: 'vanilla-js'},
+        {name: 'JavaScript', value: 'vanilla-js'},
       ])
     },
   )

--- a/packages/app/src/cli/utilities/extensions/template-configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/template-configuration.test.ts
@@ -20,7 +20,10 @@ describe('get ui extension template types', () => {
       const result = getUIExtensionTemplates(extension)
 
       // Then
-      expect(result).toEqual([{name: 'vanilla JavaScript', value: 'vanilla-js'}])
+      expect(result).toEqual([
+        {name: 'Typescript', value: 'typescript'},
+        {name: 'Vanilla JavaScript', value: 'vanilla-js'},
+      ])
     },
   )
 })
@@ -28,21 +31,21 @@ describe('get ui extension template types', () => {
 describe('is valid ui extension template', () => {
   it('is invalid when no ui extension type', () => {
     // When
-    const result = isValidUIExtensionTemplate('product_discounts', 'react')
+    const result = isValidUIExtensionTemplate('product_discounts', 'vanilla-js-react')
 
     // Then
     expect(result).toEqual(false)
   })
   it('is invalid when template not supported', () => {
     // When
-    const result = isValidUIExtensionTemplate('web_pixel_extension', 'react')
+    const result = isValidUIExtensionTemplate('web_pixel_extension', 'vanilla-js-react')
 
     // Then
     expect(result).toEqual(false)
   })
   it('is invalid when template is supported', () => {
     // When
-    const result = isValidUIExtensionTemplate('checkout_ui_extension', 'react')
+    const result = isValidUIExtensionTemplate('checkout_ui_extension', 'vanilla-js-react')
 
     // Then
     expect(result).toEqual(true)

--- a/packages/app/src/cli/utilities/extensions/template-configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/template-configuration.test.ts
@@ -31,21 +31,21 @@ describe('get ui extension template types', () => {
 describe('is valid ui extension template', () => {
   it('is invalid when no ui extension type', () => {
     // When
-    const result = isValidUIExtensionTemplate('product_discounts', 'vanilla-js-react')
+    const result = isValidUIExtensionTemplate('product_discounts', 'react')
 
     // Then
     expect(result).toEqual(false)
   })
   it('is invalid when template not supported', () => {
     // When
-    const result = isValidUIExtensionTemplate('web_pixel_extension', 'vanilla-js-react')
+    const result = isValidUIExtensionTemplate('web_pixel_extension', 'react')
 
     // Then
     expect(result).toEqual(false)
   })
   it('is invalid when template is supported', () => {
     // When
-    const result = isValidUIExtensionTemplate('checkout_ui_extension', 'vanilla-js-react')
+    const result = isValidUIExtensionTemplate('checkout_ui_extension', 'react')
 
     // Then
     expect(result).toEqual(true)

--- a/packages/app/src/cli/utilities/extensions/template-configuration.ts
+++ b/packages/app/src/cli/utilities/extensions/template-configuration.ts
@@ -3,7 +3,7 @@ import {isUiExtensionType, uiExtensionTemplates} from '../../constants.js'
 export function getUIExtensionTemplates(extensionType: string): {name: string; value: string}[] {
   let filteredFlavors: string[] = []
   if (extensionType === 'web_pixel_extension') {
-    filteredFlavors = [...filteredFlavors, 'vanilla-js-react', 'typescript-react']
+    filteredFlavors = [...filteredFlavors, 'react', 'typescript-react']
   }
   return uiExtensionTemplates.filter((template) => !filteredFlavors.includes(template.value))
 }

--- a/packages/app/src/cli/utilities/extensions/template-configuration.ts
+++ b/packages/app/src/cli/utilities/extensions/template-configuration.ts
@@ -1,9 +1,9 @@
 import {isUiExtensionType, uiExtensionTemplates} from '../../constants.js'
 
 export function getUIExtensionTemplates(extensionType: string): {name: string; value: string}[] {
-  const filteredFlavors: string[] = []
+  let filteredFlavors: string[] = []
   if (extensionType === 'web_pixel_extension') {
-    filteredFlavors.push('react')
+    filteredFlavors = [...filteredFlavors, 'vanilla-js-react', 'typescript-react']
   }
   return uiExtensionTemplates.filter((template) => !filteredFlavors.includes(template.value))
 }

--- a/packages/create-hydrogen/src/commands/init.ts
+++ b/packages/create-hydrogen/src/commands/init.ts
@@ -23,7 +23,7 @@ export default class Init extends Command {
       hidden: false,
     }),
     ts: Flags.boolean({
-      description: 'Set the language of the template to Typescript instead of Javascript.',
+      description: 'Set the language of the template to TypeScript instead of JavaScript.',
       env: 'SHOPIFY_FLAG_LANGUAGE',
       hidden: false,
     }),

--- a/packages/features/features/app.feature
+++ b/packages/features/features/app.feature
@@ -3,7 +3,7 @@ Feature: Extension creation
 Scenario: I scaffold theme, ui, and function extensions
   Given I have a working directory
   And I create an app named MyExtendedApp with yarn as dependency manager
-  When I create an extension named TestPurchaseExtension of type post_purchase_ui and flavor vanilla-js-react
+  When I create an extension named TestPurchaseExtension of type post_purchase_ui and flavor react
   Then I have a ui extension named TestPurchaseExtension of type checkout_post_purchase
   When I create an extension named TestThemeExtension of type theme_app_extension
   Then I have a theme extension named TestThemeExtension of type theme

--- a/packages/features/features/app.feature
+++ b/packages/features/features/app.feature
@@ -1,10 +1,13 @@
 Feature: Extension creation
 
-Scenario: I scaffold theme, ui, and function extensions
+Background:
   Given I have a working directory
   And I create an app named MyExtendedApp with yarn as dependency manager
-  When I create an extension named TestPurchaseExtension of type post_purchase_ui and flavor react
-  Then I have a ui extension named TestPurchaseExtension of type checkout_post_purchase
+
+Scenario: I scaffold theme, ui, and function extensions
+
+  When I create an extension named TestPurchaseExtensionReact of type post_purchase_ui and flavor react
+  Then I have a ui extension named TestPurchaseExtensionReact of type checkout_post_purchase and flavor react
   When I create an extension named TestThemeExtension of type theme_app_extension
   Then I have a theme extension named TestThemeExtension of type theme
   Then The extension named TestThemeExtension contains the theme extension directories
@@ -13,3 +16,13 @@ Scenario: I scaffold theme, ui, and function extensions
   When I create an extension named TestOrderDiscounts of type order_discounts and flavor wasm
   Then I have a function extension named TestOrderDiscounts of type order_discounts
   Then I can build the app
+
+Scenario: I scaffold ui extensions with different templates
+  When I create an extension named TestPurchaseExtensionJavaScript of type checkout_ui and flavor vanilla-js
+  Then I have a ui extension named TestPurchaseExtensionJavaScript of type checkout_ui_extension and flavor vanilla-js
+  When I create an extension named TestPurchaseExtensionReact of type checkout_ui and flavor react
+  Then I have a ui extension named TestPurchaseExtensionReact of type checkout_ui_extension and flavor react
+  When I create an extension named TestPurchaseExtensionTypeScript of type checkout_ui and flavor typescript
+  Then I have a ui extension named TestPurchaseExtensionTypeScript of type checkout_ui_extension and flavor typescript
+  When I create an extension named TestPurchaseExtensionTypeScriptReact of type checkout_ui and flavor typescript-react
+  Then I have a ui extension named TestPurchaseExtensionTypeScriptReact of type checkout_ui_extension and flavor typescript-react

--- a/packages/features/features/app.feature
+++ b/packages/features/features/app.feature
@@ -3,7 +3,7 @@ Feature: Extension creation
 Scenario: I scaffold theme, ui, and function extensions
   Given I have a working directory
   And I create an app named MyExtendedApp with yarn as dependency manager
-  When I create an extension named TestPurchaseExtension of type post_purchase_ui and flavor react
+  When I create an extension named TestPurchaseExtension of type post_purchase_ui and flavor vanilla-js-react
   Then I have a ui extension named TestPurchaseExtension of type checkout_post_purchase
   When I create an extension named TestThemeExtension of type theme_app_extension
   Then I have a theme extension named TestThemeExtension of type theme

--- a/packages/features/steps/app.steps.ts
+++ b/packages/features/steps/app.steps.ts
@@ -39,7 +39,41 @@ When(
 )
 
 Then(
-  /I have a (.+) extension named (.+) of type (.+)/,
+  /I have a (.+) extension named (.+) of type ([^\s]+) and flavor (.+)$/,
+  {},
+  async function (category: string, appName: string, extensionType: string, flavor: string) {
+    const appInfo = await this.appInfo()
+    const extension = appInfo.extensions[category].find((extension: {configuration: ExtensionConfiguration}) => {
+      return extension.configuration.name === appName
+    })
+    if (!extension) assert.fail(`Extension not created! Config:\n${JSON.stringify(appInfo, null, 2)}`)
+    assert.equal(extension.configuration.type, extensionType)
+
+    let fileExtension
+
+    switch (flavor) {
+      case 'react':
+        fileExtension = 'jsx'
+        break
+      case 'typescript-react':
+        fileExtension = 'tsx'
+        break
+      case 'typescript':
+        fileExtension = 'ts'
+        break
+      case 'javascript':
+        fileExtension = 'js'
+        break
+      default:
+        fileExtension = 'js'
+    }
+
+    assert.equal(extension.entrySourceFilePath.split('/').pop(), `index.${fileExtension}`)
+  },
+)
+
+Then(
+  /I have a (.+) extension named (.+) of type ([^\s]+)$/,
   {},
   async function (category: string, appName: string, extensionType: string) {
     const appInfo = await this.appInfo()
@@ -52,7 +86,7 @@ Then(
 )
 
 Then(
-  /I do not have a (.+) extension named (.+) of type (.+)/,
+  /I do not have a (.+) extension named (.+) of type ([^\s]+)/,
   {},
   async function (category: string, appName: string, extensionType: string) {
     const appInfo = await this.appInfo()

--- a/packages/features/steps/app.steps.ts
+++ b/packages/features/steps/app.steps.ts
@@ -61,7 +61,7 @@ Then(
       case 'typescript':
         fileExtension = 'ts'
         break
-      case 'javascript':
+      case 'vanilla-js':
         fileExtension = 'js'
         break
       default:


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/329

The go binary already supported passing an extension flavor that includes the word `typescript`, so we want to leverage that option to allow users to select typescript for ui extension templates.

### WHAT is this pull request doing?

I've added two new options to the extension flavor question:
- `Typescript React`
- `Typescript`

### How to test your changes?

Run `dev fixture scaffold extension` and choose any of the new options. The file names will be either `ts` or `tsx`.
