### PR TITLE
[POC] Tunnel plugins & hooks

### DIFF
--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -57,11 +57,10 @@ export default class Dev extends Command {
       description: 'Override the ngrok tunnel URL. Format: "https://my-tunnel-url:port"',
       env: 'SHOPIFY_FLAG_TUNNEL_URL',
     }),
-    'no-tunnel': Flags.boolean({
+    tunnel: Flags.string({
       hidden: true,
       description: 'Automatic creation of a tunnel is disabled. Service entry point will listen to localhost instead',
       env: 'SHOPIFY_FLAG_NO_TUNNEL',
-      default: false,
     }),
   }
 
@@ -82,7 +81,8 @@ export default class Dev extends Command {
       subscriptionProductUrl: flags['subscription-product-url'],
       checkoutCartUrl: flags['checkout-cart-url'],
       tunnelUrl: flags['tunnel-url'],
-      noTunnel: flags['no-tunnel'],
+      noTunnel: false,
+      tunnel: flags.tunnel,
     })
   }
 }

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -55,20 +55,6 @@ async function dev(options: DevOptions) {
   let frontendPort: number
   let frontendUrl: string
 
-  // if (options.tunnel) {
-  //   const matches = options.tunnel.match(/(https:\/\/[^:]+):([0-9]+)/)
-  //   if (matches) {
-  //     frontendPort = Number(matches[2])
-  //     frontendUrl = matches[1]
-  //   } else {
-  //     frontendPort = await port.getRandomPort()
-  //     frontendUrl = await generateURL(options.commandConfig, frontendPort, options.tunnel)
-  //   }
-  // } else {
-  //   frontendPort = await port.getRandomPort()
-  //   frontendUrl = 'http://localhost'
-  // }
-
   if (options.noTunnel === true) {
     frontendPort = await port.getRandomPort()
     frontendUrl = 'http://localhost'

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -26,6 +26,7 @@ export interface DevOptions {
   checkoutCartUrl?: string
   tunnelUrl?: string
   noTunnel: boolean
+  tunnel?: string
 }
 
 interface DevWebOptions {
@@ -54,19 +55,33 @@ async function dev(options: DevOptions) {
   let frontendPort: number
   let frontendUrl: string
 
+  // if (options.tunnel) {
+  //   const matches = options.tunnel.match(/(https:\/\/[^:]+):([0-9]+)/)
+  //   if (matches) {
+  //     frontendPort = Number(matches[2])
+  //     frontendUrl = matches[1]
+  //   } else {
+  //     frontendPort = await port.getRandomPort()
+  //     frontendUrl = await generateURL(options.commandConfig, frontendPort, options.tunnel)
+  //   }
+  // } else {
+  //   frontendPort = await port.getRandomPort()
+  //   frontendUrl = 'http://localhost'
+  // }
+
   if (options.noTunnel === true) {
     frontendPort = await port.getRandomPort()
     frontendUrl = 'http://localhost'
-  } else if (options.tunnelUrl) {
-    const matches = options.tunnelUrl.match(/(https:\/\/[^:]+):([0-9]+)/)
-    if (!matches) {
-      throw new error.Abort(`Invalid tunnel URL: ${options.tunnelUrl}`, 'Valid format: "https://my-tunnel-url:port"')
-    }
-    frontendPort = Number(matches[2])
-    frontendUrl = matches[1]
+    // } else if (options.tunnel) {
+    //   const matches = options.tunnel.match(/(https:\/\/[^:]+):([0-9]+)/)
+    //   if (!matches) {
+    //     throw new error.Abort(`Invalid tunnel URL: ${options.tunnelUrl}`, 'Valid format: "https://my-tunnel-url:port"')
+    //   }
+    //   frontendPort = Number(matches[2])
+    //   frontendUrl = matches[1]
   } else {
     frontendPort = await port.getRandomPort()
-    frontendUrl = await generateURL(options.commandConfig.plugins, frontendPort)
+    frontendUrl = await generateURL(options.commandConfig, frontendPort, options.tunnel)
   }
 
   const backendPort = await port.getRandomPort()

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -58,13 +58,13 @@ async function dev(options: DevOptions) {
   if (options.noTunnel === true) {
     frontendPort = await port.getRandomPort()
     frontendUrl = 'http://localhost'
-    // } else if (options.tunnel) {
-    //   const matches = options.tunnel.match(/(https:\/\/[^:]+):([0-9]+)/)
-    //   if (!matches) {
-    //     throw new error.Abort(`Invalid tunnel URL: ${options.tunnelUrl}`, 'Valid format: "https://my-tunnel-url:port"')
-    //   }
-    //   frontendPort = Number(matches[2])
-    //   frontendUrl = matches[1]
+  } else if (options.tunnelUrl) {
+    const matches = options.tunnelUrl.match(/(https:\/\/[^:]+):([0-9]+)/)
+    if (!matches) {
+      throw new error.Abort(`Invalid tunnel URL: ${options.tunnelUrl}`, 'Valid format: "https://my-tunnel-url:port"')
+    }
+    frontendPort = Number(matches[2])
+    frontendUrl = matches[1]
   } else {
     frontendPort = await port.getRandomPort()
     frontendUrl = await generateURL(options.commandConfig, frontendPort, options.tunnel)

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -1,12 +1,42 @@
-import {api, error, output, plugins} from '@shopify/cli-kit'
-import {Plugin} from '@oclif/core/lib/interfaces'
+import {api, error, output, plugins, ui} from '@shopify/cli-kit'
+import {Config} from '@oclif/core'
+import {TunnelHook} from '@shopify/cli-kit/src/plugins.js'
 
-export async function generateURL(pluginList: Plugin[], frontendPort: number): Promise<string> {
-  const tunnelPlugin = await plugins.lookupTunnelPlugin(pluginList)
-  if (!tunnelPlugin) throw new error.Bug('The tunnel could not be found')
-  const url = await tunnelPlugin?.start({port: frontendPort})
+export async function generateURL(config: Config, frontendPort: number, tunnelFlag?: string): Promise<string> {
+  // List of plugins that support tunneling
+  const hookResult = await plugins.fanoutHooks(config, 'tunnel_provider', {})
+  const tunnelPlugins = Object.values(hookResult).flatMap((plugin) => (plugin ? [plugin] : []))
+
+  if (tunnelPlugins.length === 0) throw new error.Bug('No tunnel plugins detected')
+
+  let selectedHook = tunnelPlugins[0].hookName
+
+  if (tunnelFlag) {
+    const hookFromFlag = tunnelPlugins.find((plugin) => plugin.name === tunnelFlag)?.hookName
+    if (!hookFromFlag) throw new error.Abort(`Tunnel plugin "${tunnelFlag}" not found`)
+    selectedHook = hookFromFlag
+  } else if (tunnelPlugins.length > 1) {
+    selectedHook = await promptTunnelOptions(tunnelPlugins)
+  }
+
+  const pluginName = tunnelPlugins.find((plugin) => plugin.hookName === selectedHook)?.name
+
+  // const selectedPlugin = Object.keys(tunnelPlugins)[0]
+  // const tunnelProvider = tunnelPlugins[selectedPlugin]
+
+  // Hook of the selected tunnel plugin that will generate a URL
+  // const hookName = tunnelProvider.hookName
+
+  // Generated tunnel URLs, should only be one but hooks will always return an map
+  const tunnelURLs = await plugins.fanoutHooks(config, selectedHook, {port: frontendPort})
+
+  const tunnelURL = tunnelURLs[Object.keys(tunnelURLs)[0]]?.url
+
+  // Should we show this error or let the plugins handle the output and fail silently here?
+  if (!tunnelURL) throw new error.Bug(`Error obtaining tunnel URL from plugin: ${pluginName}`)
+
   output.success('The tunnel is running and you can now view your app')
-  return url
+  return tunnelURL
 }
 
 export async function updateURLs(apiKey: string, url: string, token: string): Promise<void> {
@@ -22,4 +52,17 @@ export async function updateURLs(apiKey: string, url: string, token: string): Pr
     const errors = result.appUpdate.userErrors.map((error) => error.message).join(', ')
     throw new error.Abort(errors)
   }
+}
+
+async function promptTunnelOptions(options: {hookName: TunnelHook; name: string}[]): Promise<TunnelHook> {
+  const hookList = options.map((option) => ({name: option.name, value: option.hookName}))
+  const choice = await ui.prompt([
+    {
+      type: 'select',
+      name: 'value',
+      message: 'We detected multiple tunnel plugins, which one do you want to use?',
+      choices: hookList,
+    },
+  ])
+  return choice.value as TunnelHook
 }

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -10,7 +10,6 @@ export async function generateURL(config: Config, frontendPort: number, tunnelFl
   if (tunnelPlugins.length === 0) throw new error.Bug('No tunnel plugins detected')
 
   let selectedHook = tunnelPlugins[0].hookName
-
   if (tunnelFlag) {
     const hookFromFlag = tunnelPlugins.find((plugin) => plugin.name === tunnelFlag)?.hookName
     if (!hookFromFlag) throw new error.Abort(`Tunnel plugin "${tunnelFlag}" not found`)
@@ -20,12 +19,6 @@ export async function generateURL(config: Config, frontendPort: number, tunnelFl
   }
 
   const pluginName = tunnelPlugins.find((plugin) => plugin.hookName === selectedHook)?.name
-
-  // const selectedPlugin = Object.keys(tunnelPlugins)[0]
-  // const tunnelProvider = tunnelPlugins[selectedPlugin]
-
-  // Hook of the selected tunnel plugin that will generate a URL
-  // const hookName = tunnelProvider.hookName
 
   // Generated tunnel URLs, should only be one but hooks will always return an map
   const tunnelURLs = await plugins.fanoutHooks(config, selectedHook, {port: frontendPort})

--- a/packages/cli-kit/src/plugins.ts
+++ b/packages/cli-kit/src/plugins.ts
@@ -34,11 +34,26 @@ export async function fanoutHooks<TPluginMap extends HookReturnsPerPlugin, TEven
   timeout?: number,
 ): Promise<Partial<TPluginMap[typeof event]['pluginReturns']>> {
   const res = await config.runHook(event, options, timeout)
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return Object.fromEntries(res.successes.map(({result, plugin}) => [plugin.name, result])) as any
 }
 
+export type TunnelHook = `tunnel_start_${string}`
+
 interface HookReturnsPerPlugin {
+  [key: TunnelHook]: {
+    options: {port: number}
+    pluginReturns: {
+      [pluginName: string]: {url: string; error: string}
+    }
+  }
+  tunnel_provider: {
+    options: {[key: string]: unknown}
+    pluginReturns: {
+      [pluginName: string]: {hookName: TunnelHook; name: string}
+    }
+  }
   public_command_metadata: {
     options: {[key: string]: never}
     pluginReturns: {

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -77,6 +77,7 @@
       "@shopify/theme",
       "@shopify/cli-hydrogen",
       "@oclif/plugin-help",
+      "@oclif/plugin-plugins",
       "@shopify/plugin-ngrok"
     ],
     "scope": "shopify",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Investigation around how to use Hooks to communicate between plugins and the CLI and how to handle multiple plugins with the same functionality.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add two new hooks for tunnel discoverability and execution: `tunnel_provider` and `tunnel_start_{providerName}`
- Modify `tunnel` flag to accept any string, if the value provided is an existing plugin provider, we will load that plugin. 
- If there are multiple plugins registered as tunnel plugins and no flag is provided, prompt the user to select.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- You'd need the changes in `https://github.com/Shopify/awesome-shopify-cli-plugins/pull/31`
- If you want to test with multiple plugins you'd need to create a new plugin that supports the tunnel hooks (or I can provide you with one)
- You'd also need to register your plugins for development like: `dev shopify plugins link {plugin_local_path}`

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->


https://user-images.githubusercontent.com/3757193/183978448-d39cc236-4d19-441a-b790-441c1ea39f56.mov



