### PR TITLE
Rename SHOPIFY_CONFIG to SHOPIFY_ENV

### DIFF
--- a/.changeset/neat-schools-warn.md
+++ b/.changeset/neat-schools-warn.md
@@ -1,0 +1,8 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/cli': minor
+'@shopify/create-app': minor
+'@shopify/create-hydrogen': minor
+---
+
+Rename the environment variable SHOPIFY_CONFIG to SHOPIFY_ENV because it's more representative of its usage

--- a/dev.yml
+++ b/dev.yml
@@ -13,7 +13,7 @@ up:
     - delve
 
 env:
-  SHOPIFY_CONFIG: debug
+  SHOPIFY_ENV: development
   SHOPIFY_PARTNERS_API_ENV: production
   SHOPIFY_ADMIN_API_ENV: production
   SHOPIFY_STOREFRONT_RENDERER_API_ENV: production

--- a/packages/cli-kit/src/analytics.test.ts
+++ b/packages/cli-kit/src/analytics.test.ts
@@ -25,7 +25,7 @@ describe('event tracking', () => {
     vi.mock('./version.js')
     vi.mock('./monorail.js')
     vi.mocked(environment.local.isShopify).mockResolvedValue(false)
-    vi.mocked(environment.local.isDebug).mockReturnValue(false)
+    vi.mocked(environment.local.isDevelopment).mockReturnValue(false)
     vi.mocked(environment.local.analyticsDisabled).mockReturnValue(false)
     vi.mocked(environment.local.ciPlatform).mockReturnValue({isCI: true, name: 'vitest'})
     vi.mocked(environment.local.webIDEPlatform).mockReturnValue(undefined)

--- a/packages/cli-kit/src/constants.ts
+++ b/packages/cli-kit/src/constants.ts
@@ -12,7 +12,7 @@ const cacheFolder = () => {
 const constants = {
   environmentVariables: {
     unitTest: 'SHOPIFY_UNIT_TEST',
-    shopifyConfig: 'SHOPIFY_CONFIG',
+    shopifyEnv: 'SHOPIFY_ENV',
     runAsUser: 'SHOPIFY_RUN_AS_USER',
     partnersEnv: 'SHOPIFY_PARTNERS_ENV',
     shopifyEnv: 'SHOPIFY_SHOPIFY_ENV',

--- a/packages/cli-kit/src/constants.ts
+++ b/packages/cli-kit/src/constants.ts
@@ -12,7 +12,7 @@ const cacheFolder = () => {
 const constants = {
   environmentVariables: {
     unitTest: 'SHOPIFY_UNIT_TEST',
-    shopifyEnv: 'SHOPIFY_ENV',
+    env: 'SHOPIFY_ENV',
     runAsUser: 'SHOPIFY_RUN_AS_USER',
     partnersEnv: 'SHOPIFY_PARTNERS_ENV',
     shopifyEnv: 'SHOPIFY_SHOPIFY_ENV',

--- a/packages/cli-kit/src/environment/local.test.ts
+++ b/packages/cli-kit/src/environment/local.test.ts
@@ -1,5 +1,5 @@
 import {isSpin} from './spin.js'
-import {hasGit, isDebug, isShopify, isUnitTest, analyticsDisabled} from './local.js'
+import {hasGit, isDevelopment, isShopify, isUnitTest, analyticsDisabled} from './local.js'
 import {exists as fileExists} from '../file.js'
 import {exec} from '../system.js'
 import {expect, it, describe, vi, test} from 'vitest'
@@ -23,13 +23,13 @@ describe('isUnitTest', () => {
   })
 })
 
-describe('isDebug', () => {
-  it('returns true when SHOPIFY_CONFIG is debug', () => {
+describe('isDevelopment', () => {
+  it('returns true when SHOPIFY_ENV is debug', () => {
     // Given
-    const env = {SHOPIFY_CONFIG: 'debug'}
+    const env = {SHOPIFY_ENV: 'debug'}
 
     // When
-    const got = isDebug(env)
+    const got = isDevelopment(env)
 
     // Then
     expect(got).toBe(true)
@@ -106,9 +106,9 @@ describe('analitycsDisabled', () => {
     expect(got).toBe(true)
   })
 
-  it('returns true when debug mode is enbled', () => {
+  it('returns true when in development', () => {
     // Given
-    const env = {SHOPIFY_CONFIG: 'debug'}
+    const env = {SHOPIFY_ENV: 'development'}
 
     // When
     const got = analyticsDisabled(env)

--- a/packages/cli-kit/src/environment/local.test.ts
+++ b/packages/cli-kit/src/environment/local.test.ts
@@ -26,7 +26,7 @@ describe('isUnitTest', () => {
 describe('isDevelopment', () => {
   it('returns true when SHOPIFY_ENV is debug', () => {
     // Given
-    const env = {SHOPIFY_ENV: 'debug'}
+    const env = {SHOPIFY_ENV: 'development'}
 
     // When
     const got = isDevelopment(env)

--- a/packages/cli-kit/src/environment/local.ts
+++ b/packages/cli-kit/src/environment/local.ts
@@ -28,7 +28,7 @@ export function homeDirectory(): string {
  * @returns true if SHOPIFY_ENV is development
  */
 export function isDevelopment(env = process.env): boolean {
-  return env[constants.environmentVariables.shopifyEnv] === 'development'
+  return env[constants.environmentVariables.env] === 'development'
 }
 
 /**

--- a/packages/cli-kit/src/environment/local.ts
+++ b/packages/cli-kit/src/environment/local.ts
@@ -25,10 +25,10 @@ export function homeDirectory(): string {
 /**
  * Returns true if the CLI is running in debug mode.
  * @param env The environment variables from the environment of the current process.
- * @returns true if SHOPIFY_CONFIG is debug
+ * @returns true if SHOPIFY_ENV is development
  */
-export function isDebug(env = process.env): boolean {
-  return env[constants.environmentVariables.shopifyConfig] === 'debug'
+export function isDevelopment(env = process.env): boolean {
+  return env[constants.environmentVariables.shopifyEnv] === 'development'
 }
 
 /**
@@ -70,7 +70,7 @@ export function isUnitTest(env = process.env): boolean {
  * @returns true unless SHOPIFY_CLI_NO_ANALYTICS is truthy or debug mode is enabled.
  */
 export function analyticsDisabled(env = process.env): boolean {
-  return isTruthy(env[constants.environmentVariables.noAnalytics]) || isDebug(env)
+  return isTruthy(env[constants.environmentVariables.noAnalytics]) || isDevelopment(env)
 }
 
 /** Returns true if reporting analytics should always happen, regardless of DEBUG mode etc. */

--- a/packages/cli-kit/src/node/base-command.ts
+++ b/packages/cli-kit/src/node/base-command.ts
@@ -1,5 +1,5 @@
 import {errorHandler, registerCleanBugsnagErrorsFromWithinPlugins} from './error-handler.js'
-import {isDebug} from '../environment/local.js'
+import {isDevelopment} from '../environment/local.js'
 import {addPublic} from '../metadata.js'
 import {hashString} from '../string.js'
 import {Command, Interfaces} from '@oclif/core'
@@ -12,7 +12,7 @@ export default abstract class extends Command {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async init(): Promise<any> {
-    if (!isDebug()) {
+    if (!isDevelopment()) {
       // This function runs just prior to `run`
       await registerCleanBugsnagErrorsFromWithinPlugins(this.config.plugins)
     }

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -1,7 +1,7 @@
 // CLI
 import {findUpAndReadPackageJson} from './node-package-manager.js'
 import {errorHandler} from './error-handler.js'
-import {isDebug} from '../environment/local.js'
+import {isDevelopment} from '../environment/local.js'
 import constants, {bugsnagApiKey} from '../constants.js'
 import {moduleDirectory} from '../path.js'
 import {run, settings, flush} from '@oclif/core'
@@ -18,7 +18,7 @@ interface RunCLIOptions {
  * @param module {RunCLIOptions} Options.
  */
 export async function runCLI(options: RunCLIOptions) {
-  if (isDebug()) {
+  if (isDevelopment()) {
     settings.debug = true
   } else {
     Bugsnag.start({

--- a/packages/cli-main/bin/dev.js
+++ b/packages/cli-main/bin/dev.js
@@ -2,7 +2,7 @@
 
 process.removeAllListeners('warning');
 
-process.env.SHOPIFY_CONFIG = "debug"
+process.env.SHOPIFY_ENV = process.env.SHOPIFY_ENV ?? "development"
 
 import runCLI from "../dist/index.js";
 

--- a/packages/create-app/bin/dev.js
+++ b/packages/create-app/bin/dev.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 process.removeAllListeners('warning');
 
-process.env.SHOPIFY_CONFIG = "debug"
+process.env.SHOPIFY_ENV = process.env.SHOPIFY_ENV ?? "development"
 
 import runCreateApp from "../dist/index.js";
 

--- a/packages/create-hydrogen/bin/dev.js
+++ b/packages/create-hydrogen/bin/dev.js
@@ -2,7 +2,7 @@
 
 process.removeAllListeners('warning');
 
-process.env.SHOPIFY_CONFIG = "debug"
+process.env.SHOPIFY_ENV = process.env.SHOPIFY_ENV ?? "development"
 
 import runCreateHydrogen from "../dist/index.js";
 


### PR DESCRIPTION
### WHY are these changes introduced?
While working with @alvaro-shopify on merging the `shopify-cli-extensions` projects we realized that the `SHOPIFY_CONFIG=debug` environment variable is misleading to represent a development environment. 

### WHAT is this pull request doing?

I'm renaming the variable to `SHOPIFY_ENV=development`, which aligns with the convention many projects follow.

### How to test your changes?
Tests should pass on CI and you should be able to interact with the fixture project.
