### PR TITLE
Define new hooks for tunnel plugins

### DIFF
--- a/configurations/tsconfig.json
+++ b/configurations/tsconfig.json
@@ -22,6 +22,7 @@
         "@shopify/cli-kit/node/*": ["../packages/cli-kit/src/node/*.ts"],
         "@shopify/cli-kit/common/*": ["../packages/cli-kit/src/common/*.ts"],
         "@shopify/cli-kit/typing/*": ["../packages/cli-kit/src/typing/*.ts"],
+        "@shopify/cli-kit/plugins/*": ["../packages/cli-kit/src/plugins/*.ts"],
       }
     },
     "exclude": ["**/dist/**"]

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -21,6 +21,10 @@
       "node": "./dist/node/*.js",
       "types": "./dist/node/*.d.ts"
     },
+    "./plugins/*": {
+      "node": "./dist/plugins/*.js",
+      "types": "./dist/plugins/*.d.ts"
+    },
     "./common/*": {
       "node": "./dist/common/*.js",
       "types": "./dist/common/*.d.ts"

--- a/packages/cli-kit/src/plugins.ts
+++ b/packages/cli-kit/src/plugins.ts
@@ -59,7 +59,7 @@ interface HookReturnsPerPlugin {
   tunnel_provider: {
     options: {[key: string]: never}
     pluginReturns: {
-      [pluginName: string]: Required<TunnelProvider>
+      [pluginName: string]: {name: string}
     }
   }
   public_command_metadata: {
@@ -89,3 +89,5 @@ export type FanoutHookFunction<
   this: Interfaces.Hook.Context,
   options: TPluginMap[TEvent]['options'] & {config: Interfaces.Config},
 ) => Promise<PluginReturnsForHook<TEvent, TPluginName, TPluginMap>>
+
+export const defineProvider = (input: {name: string}) => input

--- a/packages/cli-kit/src/plugins.ts
+++ b/packages/cli-kit/src/plugins.ts
@@ -53,7 +53,7 @@ interface HookReturnsPerPlugin {
   [key: TunnelHook]: {
     options: {port: number}
     pluginReturns: {
-      [pluginName: string]: {url: string; error: string}
+      [pluginName: string]: {url: string}
     }
   }
   tunnel_provider: {

--- a/packages/cli-kit/src/plugins.ts
+++ b/packages/cli-kit/src/plugins.ts
@@ -50,8 +50,8 @@ type AppSpecificMonorailFields = PickByPrefix<MonorailEventPublic, 'app_', 'proj
   PickByPrefix<MonorailEventPublic, 'cmd_scaffold_'>
 
 interface HookReturnsPerPlugin {
-  [key: TunnelHook]: {
-    options: {port: number}
+  tunnel_start: {
+    options: {port: number; provider: string}
     pluginReturns: {
       [pluginName: string]: {url: string}
     }
@@ -90,4 +90,12 @@ export type FanoutHookFunction<
   options: TPluginMap[TEvent]['options'] & {config: Interfaces.Config},
 ) => Promise<PluginReturnsForHook<TEvent, TPluginName, TPluginMap>>
 
-export const defineProvider = (input: {name: string}) => input
+export const tunnel = {
+  defineProvider: (input: {name: string}) => () => input,
+  startTunnel: (options: {provider: string; action: (port: number) => Promise<string | undefined>}) => {
+    return (inputs: {port: number; provider: string}) => {
+      if (inputs.provider !== options.provider) return undefined
+      return options.action(inputs.port)
+    }
+  },
+}

--- a/packages/cli-kit/src/plugins.ts
+++ b/packages/cli-kit/src/plugins.ts
@@ -3,7 +3,7 @@ import {debug, content} from './output.js'
 import {JsonMap} from './json.js'
 import {PickByPrefix} from './typing/pick-by-prefix.js'
 import {MonorailEventPublic} from './monorail.js'
-import {Interfaces, Config} from '@oclif/core'
+import {Interfaces} from '@oclif/core'
 
 const TUNNEL_PLUGINS = ['@shopify/plugin-ngrok']
 

--- a/packages/cli-kit/src/plugins.ts
+++ b/packages/cli-kit/src/plugins.ts
@@ -5,10 +5,16 @@ import {PickByPrefix} from './typing/pick-by-prefix.js'
 import {MonorailEventPublic} from './monorail.js'
 import {Interfaces} from '@oclif/core'
 
+export type TunnelHook = `tunnel_start_${string}`
 const TUNNEL_PLUGINS = ['@shopify/plugin-ngrok']
 
 interface TunnelPlugin {
   start: (options: TunnelStartOptions) => Promise<string>
+}
+
+export interface TunnelProvider {
+  provider: string
+  hook: TunnelHook
 }
 
 interface TunnelStartOptions {
@@ -44,6 +50,18 @@ type AppSpecificMonorailFields = PickByPrefix<MonorailEventPublic, 'app_', 'proj
   PickByPrefix<MonorailEventPublic, 'cmd_scaffold_'>
 
 interface HookReturnsPerPlugin {
+  [key: TunnelHook]: {
+    options: {port: number}
+    pluginReturns: {
+      [pluginName: string]: {url: string; error: string}
+    }
+  }
+  tunnel_provider: {
+    options: {[key: string]: never}
+    pluginReturns: {
+      [pluginName: string]: Required<TunnelProvider>
+    }
+  }
   public_command_metadata: {
     options: {[key: string]: never}
     pluginReturns: {
@@ -70,4 +88,4 @@ export type FanoutHookFunction<
 > = (
   this: Interfaces.Hook.Context,
   options: TPluginMap[TEvent]['options'] & {config: Interfaces.Config},
-) => Promise<Partial<PluginReturnsForHook<TEvent, TPluginName, TPluginMap>>>
+) => Promise<PluginReturnsForHook<TEvent, TPluginName, TPluginMap>>

--- a/packages/cli-kit/src/plugins/tunnel.ts
+++ b/packages/cli-kit/src/plugins/tunnel.ts
@@ -1,0 +1,36 @@
+import {FanoutHookFunction, PluginReturnsForHook} from '../plugins.js'
+
+/**
+ * Tunnel Plugins types
+ *
+ * Any plugin that provides tunnel functionality should implement `defineProvider`and `startTunnel`
+ */
+export interface HookReturnPerTunnelPlugin {
+  tunnel_start: {
+    options: {port: number; provider: string}
+    pluginReturns: {
+      [pluginName: string]: {url: string | undefined}
+    }
+  }
+  tunnel_provider: {
+    options: {[key: string]: never}
+    pluginReturns: {
+      [pluginName: string]: {name: string}
+    }
+  }
+}
+
+export type TunnelProviderFunction = FanoutHookFunction<'tunnel_provider', ''>
+export type TunnelStartFunction = FanoutHookFunction<'tunnel_start', ''>
+export type TunnelStartReturn = PluginReturnsForHook<'tunnel_start', ''>
+export type TunnelStartAction = (port: number) => Promise<TunnelStartReturn>
+
+export const defineProvider = (input: {name: string}): TunnelProviderFunction => {
+  return async () => input
+}
+export const startTunnel = (options: {provider: string; action: TunnelStartAction}): TunnelStartFunction => {
+  return async (inputs: {provider: string; port: number}): Promise<TunnelStartReturn> => {
+    if (inputs.provider !== options.provider) return {url: undefined}
+    return options.action(inputs.port)
+  }
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
In the process of migrating the ngrok tunnel to use hooks, we first need to define those hooks in cli-kit so that they can be the imported in any tunnel plugin.

Contributes to https://github.com/Shopify/shopify-cli-planning/issues/305

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Add two new typed hooks:
- `tunnel_provider` for discoverability. Any plugin implementing this hooks means it can handle tunnels.
- `tunnel_start_${provider}` for execution. After discovering the plugins, each one will report what hook to use to start a tunnel, this hook is unique per plugin.

This approach allow us to have multiple tunnel plugins installed and decide at runtime which one we want to use for tunnelling depending on user input/selection without having incompatibilities.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Nothing to test yet
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
