### PR TITLE
[Feature] adding blockProgress capability for checkout ui extensions

### DIFF
--- a/packages/ui-extensions-go-cli/api/api_test.go
+++ b/packages/ui-extensions-go-cli/api/api_test.go
@@ -806,7 +806,8 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 			"localization": null,
 			"surface": "checkout",
 			"capabilities": {
-				"networkAccess": false
+				"networkAccess": false,
+				"blockProgress": false
 			}
 		}
 		]`, extensionAssetUrl, extensionRootUrl, dispatchExtensionUUID)

--- a/packages/ui-extensions-go-cli/core/core.go
+++ b/packages/ui-extensions-go-cli/core/core.go
@@ -83,6 +83,10 @@ func normalizeConfig(config *Config) {
 			config.Extensions[index].Capabilities.NetworkAccess = NewBoolPointer(false)
 		}
 
+		if config.Extensions[index].Capabilities.BlockProgress == nil {
+			config.Extensions[index].Capabilities.BlockProgress = NewBoolPointer(false)
+		}
+
 		if config.Extensions[index].Development.Hidden == nil {
 			config.Extensions[index].Development.Hidden = NewBoolPointer(false)
 		}
@@ -133,6 +137,7 @@ type Localization struct {
 
 type Capabilities struct {
 	NetworkAccess *bool `json:"networkAccess" yaml:"network_access"`
+	BlockProgress *bool `json:"blockProgress" yaml:"block_progress"`
 }
 
 type Extension struct {

--- a/packages/ui-extensions-go-cli/core/core_test.go
+++ b/packages/ui-extensions-go-cli/core/core_test.go
@@ -17,6 +17,7 @@ extensions:
 		name: Alternate Name
 		capabilities:
 			network_access: true
+			block_progress: true
 `)
 
 	config, err := core.LoadConfig(strings.NewReader(serializedConfig))
@@ -53,6 +54,10 @@ extensions:
 
 	if *extension.Capabilities.NetworkAccess != true {
 		t.Errorf("invalid value for Capabilities - expected network_access got %t", *extension.Capabilities.NetworkAccess)
+	}
+
+	if *extension.Capabilities.BlockProgress != true {
+		t.Errorf("invalid value for Capabilities - expected block_progress got %t", *extension.Capabilities.BlockProgress)
 	}
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves https://github.com/Shopify/checkout-web/issues/12795, we've added a new [`block_progress`](https://vault.shopify.io/gsd/projects/29745/decisions/484) flag to our checkout ui extension configuration, this allows developers to state that their extension can block checkout progress and will allow merchants to grant or deny this capability from within the checkout editor.

Like `network_access`, when running an extension locally, this capability needs to be detected from the TOML file and passed as part of the extension data.

This capability is documented in this [PR](https://github.com/Shopify/shopify-dev/pull/25455).

<!--
  Context about the problem that’s being addressed.
-->

### How to test your changes?

* create a new Checkout UI Extension or use an existing one
* add a `block_progress` flag under `capabilities` within the configuration TOML file
* booleans should persist to the JSON being served
