### PR TITLE
Fix ui-extensions-related tests on Windows

### DIFF
--- a/packages/app/src/cli/services/scaffold/extension.test.ts
+++ b/packages/app/src/cli/services/scaffold/extension.test.ts
@@ -12,9 +12,6 @@ import {load as loadApp} from '../../models/app/loader.js'
 import {describe, it, expect, vi, test, beforeEach} from 'vitest'
 import {file, output, path} from '@shopify/cli-kit'
 import {addNPMDependenciesIfNeeded} from '@shopify/cli-kit/node/node-package-manager'
-import {platform} from 'node:os'
-
-const isWindows = platform() === 'win32'
 
 beforeEach(() => {
   vi.mock('@shopify/cli-kit/node/node-package-manager')
@@ -24,11 +21,6 @@ describe('initialize a extension', () => {
   it(
     'successfully scaffolds the extension when no other extensions exist',
     async () => {
-      // eslint-disable-next-line no-warning-comments
-      // FIXME
-      if (isWindows) {
-        return
-      }
       await withTemporaryApp(async (tmpDir) => {
         vi.spyOn(output, 'info').mockImplementation(() => {})
         const name = 'my-ext-1'
@@ -45,11 +37,6 @@ describe('initialize a extension', () => {
   it(
     'successfully scaffolds the extension when another extension exists',
     async () => {
-      // eslint-disable-next-line no-warning-comments
-      // FIXME
-      if (isWindows) {
-        return
-      }
       await withTemporaryApp(async (tmpDir) => {
         const name1 = 'my-ext-1'
         const name2 = 'my-ext-2'
@@ -89,11 +76,6 @@ describe('initialize a extension', () => {
   it(
     'errors when trying to re-scaffold an existing extension',
     async () => {
-      // eslint-disable-next-line no-warning-comments
-      // FIXME
-      if (isWindows) {
-        return
-      }
       await withTemporaryApp(async (tmpDir: string) => {
         const name = 'my-ext-1'
         const extensionType = 'checkout_post_purchase'

--- a/packages/app/src/cli/utilities/extensions/cli.test.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.test.ts
@@ -71,7 +71,7 @@ describe('runGoExtensionsCLI', () => {
     expect(system.exec).toHaveBeenNthCalledWith(
       1,
       'sh',
-      [path.join(extensionsGoCliDirectory, `shopify-extensions-debug${extensionsBinaryExtension}`), 'build'],
+      [path.join(extensionsGoCliDirectory, `shopify-extensions-debug`), 'build'],
       {
         stdout,
       },

--- a/packages/app/src/cli/utilities/extensions/cli.test.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.test.ts
@@ -1,7 +1,8 @@
 import {runGoExtensionsCLI, nodeExtensionsCLIPath} from './cli.js'
 import {getBinaryPathOrDownload} from './binary.js'
-import {describe, test, expect, vi} from 'vitest'
+import {describe, test, expect, vi, beforeAll} from 'vitest'
 import {system, environment, path} from '@shopify/cli-kit'
+import {platform} from 'node:os'
 
 vi.mock('../../environment')
 vi.mock('./binary')
@@ -26,6 +27,12 @@ vi.mock('@shopify/cli-kit', async () => {
   }
 })
 
+let extensionsBinaryExtension: string | undefined
+
+beforeAll(() => {
+  extensionsBinaryExtension = platform() === 'win32' ? '.exe' : ''
+})
+
 describe('runGoExtensionsCLI', () => {
   test('runs the CLI through local sources without debug when running it locally', async () => {
     // Given
@@ -41,7 +48,7 @@ describe('runGoExtensionsCLI', () => {
     // Then
     expect(system.exec).toHaveBeenNthCalledWith(
       1,
-      path.join(extensionsGoCliDirectory, 'shopify-extensions'),
+      path.join(extensionsGoCliDirectory, `shopify-extensions${extensionsBinaryExtension}`),
       ['build'],
       {
         stdout,
@@ -64,7 +71,7 @@ describe('runGoExtensionsCLI', () => {
     expect(system.exec).toHaveBeenNthCalledWith(
       1,
       'sh',
-      [path.join(extensionsGoCliDirectory, 'shopify-extensions-debug'), 'build'],
+      [path.join(extensionsGoCliDirectory, `shopify-extensions-debug${extensionsBinaryExtension}`), 'build'],
       {
         stdout,
       },

--- a/packages/app/src/cli/utilities/extensions/cli.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.ts
@@ -17,7 +17,6 @@ const NodeExtensionsCLINotFoundError = () => {
  */
 export async function runGoExtensionsCLI(args: string[], options: system.WritableExecOptions = {}) {
   const stdout = options.stdout || {write: () => {}}
-  const isWindows = platform() === 'win32'
   if (environment.local.isDevelopment()) {
     await metadata.addPublic(() => ({cmd_extensions_binary_from_source: true}))
     const extensionsGoCliDirectory = (await path.findUp('packages/ui-extensions-go-cli/', {
@@ -27,14 +26,11 @@ export async function runGoExtensionsCLI(args: string[], options: system.Writabl
 
     stdout.write(`Using extensions CLI from ${extensionsGoCliDirectory}`)
     try {
-      const extension = isWindows ? '.exe' : ''
       if (environment.local.isDebugGoBinary()) {
-        await system.exec(
-          'sh',
-          [path.join(extensionsGoCliDirectory, `shopify-extensions-debug${extension}`)].concat(args),
-          options,
-        )
+        await system.exec('sh', [path.join(extensionsGoCliDirectory, `shopify-extensions-debug`)].concat(args), options)
       } else {
+        const isWindows = platform() === 'win32'
+        const extension = isWindows ? '.exe' : ''
         await system.exec(path.join(extensionsGoCliDirectory, `shopify-extensions${extension}`), args, options)
       }
     } catch {

--- a/packages/ui-extensions-go-cli/bin/build.js
+++ b/packages/ui-extensions-go-cli/bin/build.js
@@ -2,7 +2,7 @@
 
 import {fileURLToPath} from 'url'
 import {dirname, join} from 'pathe'
-
+import { platform } from "node:os"
 import {createRequire} from 'module'
 const require = createRequire(import.meta.url)
 const execa = require('execa')
@@ -10,8 +10,11 @@ const execa = require('execa')
 const binDirectory = dirname(fileURLToPath(import.meta.url))
 const rootDirectory = dirname(binDirectory)
 
-const os = process.env.GOOS
+let fileExtension = ""
+if (process.env.GOOS === "windows" || platform() === "win32") {
+  fileExtension = ".exe"
+}
 
-const executableName = (os === "windows") ? "shopify-extensions.exe" : "shopify-extensions"
+const executableName = `shopify-extensions${fileExtension}`
 
 await execa("go", ["build", "-o", executableName], {cwd: rootDirectory, stdio: 'inherit'})

--- a/packages/ui-extensions-go-cli/shopify-extensions-debug
+++ b/packages/ui-extensions-go-cli/shopify-extensions-debug
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+# Usage: shopify-extensions-debug [-h host] [-p port] [build|create|extend] <extension-config>
+#
+#     e.g., shopify-extensions-debug -h 127.0.0.1 -p 12345 create -
+
+if ! command -v dlv &> /dev/null; then
+    if [ 'Darwin' = $(uname) ] && [ command -v brew ]; then
+        echo "The Delve (Go) debugger is not installed. Please run `dev up`."
+    else
+        echo "The Delve (Go) debugger is not installed. Please install it first."
+    fi
+    exit 1
+fi
+
+echo "Executing $(basename $0)..."
+
+HOST="127.0.0.1"
+PORT="12345"
+
+while getopts h:p: TIMED 2>/dev/null; do
+    case $TIMED in
+       h) HOST=$OPTARG
+          ;;
+       p) PORT=$OPTARG
+          ;;
+    esac
+done
+
+# NOTE: The $@ is used to pass all the arguments to the script
+dlv exec $HOME/src/github.com/shopify/shopify-cli-extensions/shopify-extensions --headless --listen="$HOST:$PORT" --api-version=2 -- $@


### PR DESCRIPTION
### WHY are these changes introduced?

Acceptance tests [are failing](https://github.com/Shopify/cli/runs/7857264246?check_suite_focus=true) on Windows because the logic that runs the Go CLI from within the repository doesn't account for the fact that the output binary in Windows is suffixed with the `.exe` extension. The acceptance tests are failing with the error:

```
node: [DATA] 'D:\a\cli\cli\packages\ui-extensions-go-cli\shopify-extensions' is not recognized as an internal or external command,
[DATA] operable program or batch file.
```

### WHAT is this pull request doing?
I'm extending the logic to add the right extension based on the platform.

### How to test your changes?
Try to run the `app` package unit tests or the acceptance tests from a Windows environment.