### PR TITLE
Run the extensions Node CLI executable through Node

### DIFF
--- a/packages/ui-extensions-go-cli/bin/build.js
+++ b/packages/ui-extensions-go-cli/bin/build.js
@@ -17,4 +17,6 @@ if (process.env.GOOS === "windows" || platform() === "win32") {
 
 const executableName = `shopify-extensions${fileExtension}`
 
-await execa("go", ["build", "-o", executableName], {cwd: rootDirectory, stdio: 'inherit'})
+await execa("go", ["build", "-o", executableName], {cwd: rootDirectory, stdio: 'inherit'}).catch((_) => {
+  process.exit(1)
+})

--- a/packages/ui-extensions-go-cli/bin/test.js
+++ b/packages/ui-extensions-go-cli/bin/test.js
@@ -23,4 +23,6 @@ const execa = require('execa')
 const binDirectory = dirname(fileURLToPath(import.meta.url))
 const rootDirectory = dirname(binDirectory)
 
-await execa("go", ["test", "./..."], {cwd: rootDirectory, stdio: 'inherit'})
+await execa("go", ["test", "./..."], {cwd: rootDirectory, stdio: 'inherit'}).catch((_) => {
+  process.exit(1)
+})

--- a/packages/ui-extensions-go-cli/build/script.go
+++ b/packages/ui-extensions-go-cli/build/script.go
@@ -11,7 +11,7 @@ var (
 )
 
 func nodeExecutableScript(dir, nodeExecutable string, script string, args ...string) *exec.Cmd {
-	cmd := Command(nodeExecutable, append([]string{script}, args...)...)
+	cmd := Command("node", append([]string{nodeExecutable, script}, args...)...)
 	cmd.Dir = dir
 	return cmd
 }

--- a/packages/ui-extensions-go-cli/build/script_test.go
+++ b/packages/ui-extensions-go-cli/build/script_test.go
@@ -10,7 +10,7 @@ import (
 func TestNodeExecutableCommandStructure(t *testing.T) {
 	cmd := nodeExecutableScript("root/dir", "/path/to/executable", "build", "some-arg")
 
-	if !reflect.DeepEqual(cmd.Args, []string{"/path/to/executable", "build", "some-arg"}) {
+	if !reflect.DeepEqual(cmd.Args, []string{"node", "/path/to/executable", "build", "some-arg"}) {
 		t.Errorf("Unexpected program arguments: %s", strings.Join(cmd.Args, " "))
 	}
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Acceptance tests [continue to fail](https://github.com/Shopify/cli/runs/7862796532?check_suite_focus=true) on Windows because the Go CLI runs directly the Node CLI and Windows doesn't use the [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)#:~:text=In%20computing%2C%20a%20shebang%20is,bang%2C%20or%20hash%2Dpling.) to execute it via Node.

### WHAT is this pull request doing?
I'm adjusting the execution logic in the Go binary to invoke the `node` process instead passing the path to the executable script.

### How to test your changes?
You should be able to run `yarn test` on the features project and get the tests passing on a Windows environment.
