### PR TITLE
Reuse cache when running `info --web-env`

### DIFF
--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -34,12 +34,13 @@ export async function info(app: AppInterface, {format, webEnv}: InfoOptions): Pr
 
 export async function infoWeb(app: AppInterface, {format}: Omit<InfoOptions, 'webEnv'>): Promise<output.Message> {
   const token = await session.ensureAuthenticatedPartners()
+  const cachedInfo = store.cliKitStore().getAppInfo(app.directory)
 
   const orgs = await fetchOrganizations(token)
-  const org = await selectOrganizationPrompt(orgs)
-  const {organization, apps} = await fetchOrgAndApps(org.id, token)
+  const orgId = cachedInfo?.orgId ?? (await selectOrganizationPrompt(orgs)).id
+  const {organization, apps} = await fetchOrgAndApps(orgId, token)
 
-  const selectedApp = await selectOrCreateApp(app, apps, organization, token)
+  const selectedApp = await selectOrCreateApp(app, apps, organization, token, cachedInfo?.appId)
 
   if (format === 'json') {
     return output.content`${output.token.json({


### PR DESCRIPTION
### WHY are these changes introduced?

While working on a task related to `app info --web-env` I noticed that I was asked to select the app every time.

### WHAT is this pull request doing?

I propose that we can reuse the cached information from `dev` if it's present when choosing the app.

### How to test your changes?

- Run `dev fixture dev` to completion
- Run `dev fixture shopify app info --web-env`
- You shouldn't be asked to choose an app
