### PR TITLE
Upload built assets to DMS

### DIFF
--- a/packages/cli-hydrogen/src/cli/services/deploy.ts
+++ b/packages/cli-hydrogen/src/cli/services/deploy.ts
@@ -1,6 +1,6 @@
 import {DeployConfig} from './deploy/types.js'
 import {getDeployConfig} from './deploy/config.js'
-import {createDeploymentStep, runBuildCommandStep} from './deploy/deployer.js'
+import {createDeploymentStep, runBuildCommandStep, uploadDeploymentStep} from './deploy/deployer.js'
 import {output} from '@shopify/cli-kit'
 
 export async function deployToOxygen(_config: DeployConfig) {
@@ -14,7 +14,11 @@ export async function deployToOxygen(_config: DeployConfig) {
   output.info(`Base Asset URL: ${assetBaseURL}`)
   output.info(`Error Message: ${error?.debugInfo}`)
 
-  await runBuildCommandStep(config, assetBaseURL)
+  // note: need to handle this error
+  const buildResponse = await runBuildCommandStep(config, assetBaseURL)
+  const deployResponse = await uploadDeploymentStep(config, deploymentID)
 
-  output.success('Deployment created!')
+  output.success('Deployed and healthy!')
+  output.info(`• Preview URL: ${deployResponse}`)
+  // note: should try output URL after the "success" message for scripting purposes like oxygenctl does right now
 }

--- a/packages/cli-hydrogen/src/cli/services/deploy/types.ts
+++ b/packages/cli-hydrogen/src/cli/services/deploy/types.ts
@@ -16,3 +16,13 @@ export interface DMSError {
   unrecoverable: boolean
   debugInfo: string
 }
+
+export interface UploadDeploymentResponse {
+  data: {
+    uploadDeployment: {
+      deployment: {
+        previewURL: string
+      }
+    }
+  }
+}

--- a/packages/cli-kit/src/constants.ts
+++ b/packages/cli-kit/src/constants.ts
@@ -17,6 +17,7 @@ const constants = {
     partnersEnv: 'SHOPIFY_PARTNERS_ENV',
     shopifyEnv: 'SHOPIFY_SHOPIFY_ENV',
     identityEnv: 'SHOPIFY_IDENTITY_ENV',
+    dmsEnv: 'SHOPIFY_DMS_ENV',
     spin: 'SPIN',
     spinInstance: 'SPIN_INSTANCE',
     spinWorkspace: 'SPIN_WORKSPACE',

--- a/packages/cli-kit/src/environment/service.ts
+++ b/packages/cli-kit/src/environment/service.ts
@@ -2,6 +2,7 @@ import {
   partners as partnersEnvironment,
   shopify as shopifyEnvironment,
   identity as identityEnvironment,
+  dms as dmsEnvironment,
 } from './service.js'
 import {Environment, Service} from '../network/service.js'
 import constants from '../constants.js'
@@ -17,6 +18,9 @@ export async function environmentForService(service: Service): Promise<Environme
       break
     case 'shopify':
       environment = await shopifyEnvironment()
+      break
+    case 'dms':
+      environment = await dmsEnvironment()
       break
   }
   return environment
@@ -60,4 +64,12 @@ export function shopify(env = process.env): Environment {
  */
 export function identity(env = process.env): Environment {
   return service(env[constants.environmentVariables.identityEnv])
+}
+
+/**
+ * Returns the environment to be used for the interactions with dms.
+ * @param env The environment variables from the environment of the current process.
+ */
+export function dms(env = process.env): Environment {
+  return service(env[constants.environmentVariables.dmsEnv])
 }

--- a/packages/cli-kit/src/network/service.ts
+++ b/packages/cli-kit/src/network/service.ts
@@ -3,7 +3,7 @@
  * @readonly
  * @enum {number}
  */
-export type Service = 'shopify' | 'partners' | 'identity'
+export type Service = 'shopify' | 'partners' | 'identity' | 'dms'
 
 /**
  * Enum that represents the environment to use for a given service.


### PR DESCRIPTION
### WHY are these changes introduced?

Add support for uploading built assets to DMS and closes pretty much closes https://github.com/Shopify/oxygen-platform/issues/464

### WHAT is this pull request doing?

I am using the [graphql mutlipart-request-spec](https://github.com/jaydenseric/graphql-multipart-request-spec) that DMS is expecting to upload a zip of `worker` and `client` folders that are built by Vite when doing a production build.