### PR TITLE
Bug-fix: Error handler should expect `unknown` -- lots of things can be thrown

### DIFF
--- a/packages/cli-kit/src/node/error-handler.test.ts
+++ b/packages/cli-kit/src/node/error-handler.test.ts
@@ -110,15 +110,19 @@ describe('send to Bugsnag', () => {
     const toThrow = new Error('In test')
     const res = await sendErrorToBugsnag(toThrow)
     expect(res.reported).toEqual(true)
-    expect(res.error.stack).toMatch(/^Error: In test/)
-    expect(res.error.stack).not.toEqual(toThrow.stack)
+
+    const {error} = res as any
+
+    expect(error.stack).toMatch(/^Error: In test/)
+    expect(error.stack).not.toEqual(toThrow.stack)
     expect(onNotify).toHaveBeenCalledWith(res.error)
   })
 
   it('processes string instances', async () => {
     const res = await sendErrorToBugsnag('In test' as any)
     expect(res.reported).toEqual(true)
-    expect(res.error.stack).toMatch(/^Error: In test/)
+    const {error} = res as any
+    expect(error.stack).toMatch(/^Error: In test/)
     expect(onNotify).toHaveBeenCalledWith(res.error)
   })
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/360 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Error handling functions now take `unknown` and so are robust in case of strange things being thrown.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

TSC for this one.
