### PR TITLE
Fix the installation of dependencies on app creation in Windows environments

### DIFF
--- a/.changeset/red-seas-impress.md
+++ b/.changeset/red-seas-impress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': minor
+---
+
+Limit the concurrency installing dependencies with Yarn on Windows to prevent race conditions from happening

--- a/packages/cli-kit/src/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/node/node-package-manager.test.ts
@@ -70,7 +70,11 @@ describe('install', () => {
     const directory = '/path/to/project'
 
     // When
-    await installNodeModules(directory, packageManager)
+    await installNodeModules({
+      directory,
+      packageManager,
+      args: [],
+    })
 
     // Then
     expect(mockedExec).toHaveBeenCalledWith(packageManager, ['install'], {

--- a/packages/cli-kit/src/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/node/node-package-manager.test.ts
@@ -73,11 +73,11 @@ describe('install', () => {
     await installNodeModules({
       directory,
       packageManager,
-      args: [],
+      args: ['arg1'],
     })
 
     // Then
-    expect(mockedExec).toHaveBeenCalledWith(packageManager, ['install'], {
+    expect(mockedExec).toHaveBeenCalledWith(packageManager, ['install', 'arg1'], {
       cwd: directory,
     })
   })

--- a/packages/create-app/src/utils/template/npm.test.ts
+++ b/packages/create-app/src/utils/template/npm.test.ts
@@ -216,7 +216,7 @@ describe('getDeepInstallNPMTasks', () => {
       const install = vi.mocked(installNodeModules)
 
       install.mock.calls.forEach((args, i) => {
-        const stdout = args[2]
+        const stdout = args[0].stdout
 
         stdout!.write(`stdout ${i}`)
       })
@@ -237,7 +237,7 @@ describe('getDeepInstallNPMTasks', () => {
       const install = vi.mocked(installNodeModules)
 
       install.mock.calls.forEach((args, i) => {
-        const stderr = args[3]
+        const stderr = args[0].stderr
 
         stderr!.write(`stderr ${i}`)
       })

--- a/packages/create-app/src/utils/template/npm.test.ts
+++ b/packages/create-app/src/utils/template/npm.test.ts
@@ -3,11 +3,13 @@ import {file, npm, path, ui} from '@shopify/cli-kit'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {installNodeModules, PackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {Writable} from 'stream'
+import {platform} from 'node:os'
 
 let cliVersion: undefined | string
 let appVersion: undefined | string
 
 beforeEach(async () => {
+  vi.mock('node:os')
   vi.mock('@shopify/cli-kit/node/node-package-manager')
   vi.mock('@shopify/cli-kit', async () => {
     const module: any = await vi.importActual('@shopify/cli-kit')
@@ -151,28 +153,33 @@ describe('getDeepInstallNPMTasks', () => {
 
   it('each task.task installs dependencies', async () => {
     await mockAppFolder(async (tmpDir) => {
+      vi.mocked(platform).mockReturnValue('darwin')
+
       const tasks = await getDeepInstallNPMTasks({...defaultArgs, from: tmpDir})
 
       await Promise.all(tasks.map(({task}) => task(null, {} as ui.ListrTaskWrapper<any, any>)))
 
-      expect(installNodeModules).toHaveBeenCalledWith(
-        `${path.normalize(tmpDir)}/`,
-        defaultArgs.packageManager,
-        expect.any(Writable),
-        expect.any(Writable),
-      )
-      expect(installNodeModules).toHaveBeenCalledWith(
-        `${path.join(tmpDir, 'web')}/`,
-        defaultArgs.packageManager,
-        expect.any(Writable),
-        expect.any(Writable),
-      )
-      expect(installNodeModules).toHaveBeenCalledWith(
-        `${path.join(tmpDir, 'web', 'frontend')}/`,
-        defaultArgs.packageManager,
-        expect.any(Writable),
-        expect.any(Writable),
-      )
+      expect(installNodeModules).toHaveBeenCalledWith({
+        directory: `${path.normalize(tmpDir)}/`,
+        packageManager: defaultArgs.packageManager,
+        stdout: expect.any(Writable),
+        stderr: expect.any(Writable),
+        args: [],
+      })
+      expect(installNodeModules).toHaveBeenCalledWith({
+        directory: `${path.join(tmpDir, 'web')}/`,
+        packageManager: defaultArgs.packageManager,
+        stdout: expect.any(Writable),
+        stderr: expect.any(Writable),
+        args: [],
+      })
+      expect(installNodeModules).toHaveBeenCalledWith({
+        directory: `${path.join(tmpDir, 'web', 'frontend')}/`,
+        packageManager: defaultArgs.packageManager,
+        stdout: expect.any(Writable),
+        stderr: expect.any(Writable),
+        args: [],
+      })
     })
   })
 

--- a/packages/create-app/src/utils/template/npm.ts
+++ b/packages/create-app/src/utils/template/npm.ts
@@ -75,7 +75,7 @@ export async function getDeepInstallNPMTasks({
          * Failing scenario: https://github.com/Shopify/cli/runs/7913938724
          * Reported issue: https://github.com/yarnpkg/yarn/issues/7212
          */
-        let args = platform() === 'win32' && packageManager === 'yarn' ? ['--network-concurrency', '1'] : []
+        const args = platform() === 'win32' && packageManager === 'yarn' ? ['--network-concurrency', '1'] : []
         await installNodeModules({directory: folderPath, packageManager, stdout: output, stderr: output, args})
 
         task.title = `Installed dependencies in ${titlePath}`

--- a/packages/create-app/src/utils/template/npm.ts
+++ b/packages/create-app/src/utils/template/npm.ts
@@ -1,6 +1,7 @@
 import {path, ui, npm, constants} from '@shopify/cli-kit'
 import {PackageManager, installNodeModules} from '@shopify/cli-kit/node/node-package-manager'
 import {Writable} from 'stream'
+import {platform} from 'node:os'
 
 export async function updateCLIDependencies(packageJSON: npm.PackageJSON, local: boolean): Promise<npm.PackageJSON> {
   const cliKitVersion = await constants.versions.cliKit()
@@ -65,8 +66,17 @@ export async function getDeepInstallNPMTasks({
             next()
           },
         })
-
-        await installNodeModules(folderPath, packageManager, output, output)
+        /**
+         * Installation of dependencies using Yarn on Windows might lead
+         * to "EPERM: operation not permitted, unlink" errors when Yarn tries
+         * to access the cache. By limiting the network concurrency we mitigate the
+         * error:
+         *
+         * Failing scenario: https://github.com/Shopify/cli/runs/7913938724
+         * Reported issue: https://github.com/yarnpkg/yarn/issues/7212
+         */
+        let args = platform() === 'win32' && packageManager === 'yarn' ? ['--network-concurrency', '1'] : []
+        await installNodeModules({directory: folderPath, packageManager, stdout: output, stderr: output, args})
 
         task.title = `Installed dependencies in ${titlePath}`
 

--- a/packages/create-hydrogen/src/services/init.ts
+++ b/packages/create-hydrogen/src/services/init.ts
@@ -254,7 +254,7 @@ async function installDependencies(directory: string, packageManager: PackageMan
   if (packageManager === 'pnpm') {
     await writeToNpmrc(directory, 'auto-install-peers = true')
   }
-  await installNodeModules(directory, packageManager, stdout)
+  await installNodeModules({directory, packageManager, stdout, args: []})
 }
 
 async function writeToNpmrc(directory: string, content: string) {


### PR DESCRIPTION
Related: https://github.com/Shopify/cli/pull/320

### WHY are these changes introduced?

Acceptance tests [uncovered](https://github.com/Shopify/cli/runs/7913938724?check_suite_focus=true) Yarn installation errors in Windows environments when it tries to concurrently access the global cache. 

### WHAT is this pull request doing?
I'm adjusting the app creation logic to limit the concurrency to one as recommended [here](https://github.com/yarnpkg/yarn/issues/7212) by other Yarn users. Some are experiencing it with newer versions of Yarn too so it seems that the issue is rooted in some core business logic of Yarn.
 
### How to test your changes?

Acceptance tests should pass on Windows