### PR TITLE
Add a simple test scenario to test the app creation with pnpm

### DIFF
--- a/.changeset/curvy-adults-wash.md
+++ b/.changeset/curvy-adults-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': minor
+---
+
+Fix the creation of apps using pnpm

--- a/.changeset/shy-dryers-mate.md
+++ b/.changeset/shy-dryers-mate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Fix a bug that caused pnpm not to work with Shopify app projects.

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -23,6 +23,7 @@ env:
   YARN_VERSION: "1.22.18"
   RUBY_VERSION: "3.1.2"
   BUNDLER_VERSION: "2.3.18"
+  PNPM_VERSION: "7.9.3"
   GO_VERSION: "1.17"
 
 jobs:
@@ -92,6 +93,9 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version:  ${{ env.PNPM_VERSION }}
       - name: Set Node.js
         uses: actions/setup-node@master
         with:

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -156,6 +156,9 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version:  ${{ env.PNPM_VERSION }}
       - name: Set Node.js on ubuntu environments
         uses: actions/setup-node@master
         with:

--- a/dev.yml
+++ b/dev.yml
@@ -14,6 +14,8 @@ up:
   - homebrew:
     - jq
     - delve
+    - pnpm:
+        version: 7.9.3
 
 env:
   SHOPIFY_ENV: development

--- a/packages/app/src/cli/utilities/extensions/cli.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.ts
@@ -57,7 +57,11 @@ export async function nodeExtensionsCLIPath(): Promise<string> {
       cwd,
     })) as string
   } else {
-    const executablePath = await path.findUp('node_modules/.bin/shopify-cli-extensions', {type: 'file', cwd})
+    const executablePath = await path.findUp('node_modules/.bin/shopify-cli-extensions', {
+      type: 'file',
+      cwd,
+      allowSymlinks: true,
+    })
     if (!executablePath) {
       throw NodeExtensionsCLINotFoundError()
     }

--- a/packages/cli-hydrogen/src/cli/services/preview.ts
+++ b/packages/cli-hydrogen/src/cli/services/preview.ts
@@ -71,7 +71,7 @@ export const OxygenPreviewExecutableNotFound = new error.Bug(
 
 async function oxygenPreviewExecutable(): Promise<string> {
   const cwd = path.dirname(fileURLToPath(import.meta.url))
-  const executablePath = await path.findUp('node_modules/.bin/oxygen-preview', {type: 'file', cwd})
+  const executablePath = await path.findUp('node_modules/.bin/oxygen-preview', {type: 'file', cwd, allowSymlinks: true})
   if (!executablePath) {
     throw OxygenPreviewExecutableNotFound
   }

--- a/packages/cli-kit/src/file.ts
+++ b/packages/cli-kit/src/file.ts
@@ -38,6 +38,16 @@ export async function read(path: string, options: object = {encoding: 'utf-8'}):
   return content
 }
 
+/**
+ * Given a path, it determines the actual path. This is useful when working
+ * with paths that represent symlinks.
+ * @param path {string} Path whose real path will be returned.
+ * @returns
+ */
+export async function realpath(path: string): Promise<string> {
+  return fs.promises.realpath(path)
+}
+
 export function readSync(path: string, options: object = {encoding: 'utf-8'}): string {
   debug(outputContent`Sync-reading the content of file at ${token.path(path)}...`)
   const content = fs.readFileSync(path, options)

--- a/packages/create-app/src/services/init.ts
+++ b/packages/create-app/src/services/init.ts
@@ -76,6 +76,12 @@ async function init(options: InitOptions) {
 
                 await npm.writePackageJSON(templateScaffoldDir, packageJSON)
 
+                // Ensure that the installation of dependencies doesn't fail when using
+                // pnpm due to missing peerDependencies.
+                if (packageManager === 'pnpm') {
+                  await file.append(path.join(templateScaffoldDir, '.npmrc'), `auto-install-peers=true\n`)
+                }
+
                 task.title = 'Updated package.json'
                 parentTask.title = 'App initialized'
               },

--- a/packages/create-app/src/utils/versions.ts
+++ b/packages/create-app/src/utils/versions.ts
@@ -6,6 +6,7 @@ export async function cliVersion(): Promise<string> {
     (await path.findUp('@shopify/cli/package.json', {
       cwd: path.dirname(fileURLToPath(import.meta.url)),
       type: 'file',
+      allowSymlinks: true,
     })) ??
     (await path.findUp('packages/cli-main/package.json', {
       cwd: path.dirname(fileURLToPath(import.meta.url)),

--- a/packages/features/features/app.feature
+++ b/packages/features/features/app.feature
@@ -1,11 +1,10 @@
-Feature: Extension creation
+Feature: Apps
 
 Background:
   Given I have a working directory
-  And I create an app named MyExtendedApp with yarn as dependency manager
 
 Scenario: I scaffold theme, ui, and function extensions
-
+  And I create an app named MyExtendedApp with yarn as dependency manager
   When I create an extension named TestPurchaseExtensionReact of type post_purchase_ui and flavor react
   Then I have a ui extension named TestPurchaseExtensionReact of type checkout_post_purchase and flavor react
   When I create an extension named TestThemeExtension of type theme_app_extension
@@ -18,6 +17,7 @@ Scenario: I scaffold theme, ui, and function extensions
   Then I can build the app
 
 Scenario: I scaffold ui extensions with different templates
+  And I create an app named MyExtendedApp with yarn as dependency manager
   When I create an extension named TestPurchaseExtensionJavaScript of type checkout_ui and flavor vanilla-js
   Then I have a ui extension named TestPurchaseExtensionJavaScript of type checkout_ui_extension and flavor vanilla-js
   When I create an extension named TestPurchaseExtensionReact of type checkout_ui and flavor react
@@ -26,3 +26,8 @@ Scenario: I scaffold ui extensions with different templates
   Then I have a ui extension named TestPurchaseExtensionTypeScript of type checkout_ui_extension and flavor typescript
   When I create an extension named TestPurchaseExtensionTypeScriptReact of type checkout_ui and flavor typescript-react
   Then I have a ui extension named TestPurchaseExtensionTypeScriptReact of type checkout_ui_extension and flavor typescript-react
+
+Scenario: I create an app with a extension using pnpm
+  And I create an app named MyExtendedApp with pnpm as dependency manager
+  When I create an extension named TestPurchaseExtensionReact of type post_purchase_ui and flavor react
+  Then I can build the app

--- a/packages/features/steps/create-app.steps.ts
+++ b/packages/features/steps/create-app.steps.ts
@@ -41,7 +41,7 @@ Then(
   },
 )
 
-Then(/I can build the app/, {timeout: 2 * 60 * 1000}, async function () {
+Then(/I can build the app/, {timeout: 2 * 60 * 1000 * 1000}, async function () {
   await exec('node', [executables.cli, 'app', 'build', '--path', this.appDirectory], {
     env: {...process.env, ...this.temporaryEnv},
   })


### PR DESCRIPTION
### WHY are these changes introduced?
[Working on replacing Yarn with PNPM](https://github.com/Shopify/cli/pull/320) that the creation of apps with `pnpm` fails. PNPM fails the installation of peer dependencies are not declared as `dependencies` or `devDependencies` upstream in the graph. In our case, the UI extensions CLI depends on `@luckycatfactory/esbuild-graphql-loader`, which has `graphql` as a `peerDependency`.

### WHAT is this pull request doing?

I'm adjusting the creation logic to change PNPM's behaviour in the created project such that peer dependencies are installed by default. To prevent bugs like this to happen, I'm adding a short acceptance test that creates an app with an extension and tries to build it.

### How to test your changes?
Acceptance tests should pass.
