### PR TITLE
Fix using the wrong package manager when installing dependencies

### DIFF
--- a/.changeset/fast-dolls-march.md
+++ b/.changeset/fast-dolls-march.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-go-cli': minor
+---
+
+Don't install dependencies when creating a new extension

--- a/.changeset/fluffy-ladybugs-explain.md
+++ b/.changeset/fluffy-ladybugs-explain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Fix using the wrong package manager when installing dependencies in dev

--- a/packages/ui-extensions-go-cli/create/create.go
+++ b/packages/ui-extensions-go-cli/create/create.go
@@ -15,7 +15,6 @@ func NewExtensionProject(extension core.Extension) error {
 	setup := NewProcess(
 		MakeDir(extension.Development.RootDir),
 		CreateProject(extension),
-		InstallDependencies(extension.Development.RootDir),
 	)
 
 	return setup.Run()

--- a/packages/ui-extensions-go-cli/create/create_test.go
+++ b/packages/ui-extensions-go-cli/create/create_test.go
@@ -156,40 +156,6 @@ func TestCreateAdditionalSourceFiles(t *testing.T) {
 	})
 }
 
-func TestInstallDependencies(t *testing.T) {
-	runnerWasCalled := false
-	Command = func(path, executable string, args ...string) Runner {
-		runnerWasCalled = true
-		return dummyRunner{}
-	}
-	LookPath = func(file string) (string, error) {
-		return file, nil
-	}
-	rootDir := "tmp/TestInstallDependencies"
-	extension := core.Extension{
-		Type: "integration_test",
-		Development: core.Development{
-			Template: "typescript-react",
-			RootDir:  rootDir,
-			Renderer: core.Renderer{Name: "@shopify/post-purchase-ui-extension"},
-		},
-	}
-
-	err := NewExtensionProject(extension)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if runnerWasCalled == false {
-		t.Fatal("Expected runner to be called")
-	}
-
-	t.Cleanup(func() {
-		os.RemoveAll(rootDir)
-	})
-}
-
 func TestCreateLocaleFiles(t *testing.T) {
 	Command = makeDummyRunner
 	LookPath = func(file string) (string, error) {

--- a/packages/ui-extensions-go-cli/create/tasks.go
+++ b/packages/ui-extensions-go-cli/create/tasks.go
@@ -2,13 +2,10 @@ package create
 
 import (
 	"embed"
-	"errors"
-	"fmt"
 	"html/template"
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path"
 
 	"github.com/Shopify/shopify-cli-extensions/core"
@@ -41,36 +38,6 @@ func (path MakeDir) Run() error {
 
 func (path MakeDir) Undo() error {
 	return os.Remove(string(path))
-}
-
-// InstallDependencies is a process.Task for installing the JavaScript packages required
-// by an extension. It's automatically choose which package manager to use.
-type InstallDependencies string
-
-func (path InstallDependencies) Run() error {
-	var package_manager string
-	if yarn, err := LookPath("yarn"); err == nil {
-		package_manager = yarn
-	} else if npm, err := LookPath("npm"); err == nil {
-		package_manager = npm
-	} else {
-		return errors.New("package manager not found")
-	}
-
-	cmd := Command(string(path), package_manager)
-	output, err := cmd.CombinedOutput()
-
-	if err != nil {
-		return fmt.Errorf("failed to install dependencies: %s", output)
-	}
-	return nil
-}
-
-func (path InstallDependencies) Undo() error {
-	// TODO: Skip if directory doesn't exist
-	cmd := exec.Command("rm", "-rf", "node_modules")
-	cmd.Dir = string(path)
-	return cmd.Run()
 }
 
 type RenderTask struct {


### PR DESCRIPTION
### WHY are these changes introduced?
The Go binary is still installing dependencies when creating new extensions even though that's a responsibility that the CLI has already. This led to dependency creation using a package manager other than the one used by the app.

### WHAT is this pull request doing?
I'm removing the installation of dependencies from the Go binary because it's not needed.

### How to test your changes?
Try to scaffold a new extension in the fixture app. 
