### PR TITLE
Fix link to theme app extensions docs

### DIFF
--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -87,7 +87,7 @@ function outputThemeExtensionsMessage(extensions: ThemeExtension[]) {
   const heading = output.token.heading(`${extensions[0].configuration.name} (${getHumanKey(extensions[0].type)})`)
   const link = output.token.link(
     'dev doc instructions',
-    'https://shopify.dev/apps/online-store/theme-app-extensions/getting-started#step-4-test-your-changes',
+    'https://shopify.dev/apps/online-store/theme-app-extensions/getting-started#step-3-test-your-changes',
   )
   const message = output.content`Follow the ${link} by deploying your work as a draft`.value
   output.info(output.content`${heading}\n${message}\n`)


### PR DESCRIPTION
### WHY are these changes introduced?

The anchor tag to the theme app extensions page in the cli output is outdated, and doesn't take app devs to the correct location on the page.

### WHAT is this pull request doing?

Fixes the link.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
