### PR TITLE
New Result type for handling errors

### DIFF
--- a/.changeset/rich-islands-beg.md
+++ b/.changeset/rich-islands-beg.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': minor
+'@shopify/cli-kit': minor
+---
+
+New Result type for handling errors

--- a/packages/app/src/cli/services/environment/id-matching.test.ts
+++ b/packages/app/src/cli/services/environment/id-matching.test.ts
@@ -192,7 +192,7 @@ describe('automaticMatchmaking: case 6 remote extensions have types not present 
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [REGISTRATION_C, REGISTRATION_D], {})
 
     // Then
-    expect(got).toEqual(err(new Error('Unknown error')))
+    expect(got).toEqual(err(new Error('invalid-environment')))
   })
 })
 
@@ -202,7 +202,7 @@ describe('automaticMatchmaking: case 7 some extensions match, but other are miss
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [REGISTRATION_A, REGISTRATION_C], {})
 
     // Then
-    expect(got).toEqual(err(new Error('Unknown error')))
+    expect(got).toEqual(err(new Error('invalid-environment')))
   })
 })
 
@@ -248,7 +248,7 @@ describe('automaticMatchmaking: case 10 there are more remote than local extensi
     const got = await automaticMatchmaking([EXTENSION_A], [REGISTRATION_A, REGISTRATION_A_2], {})
 
     // Then
-    expect(got).toEqual(err(new Error('Unknown error')))
+    expect(got).toEqual(err(new Error('invalid-environment')))
   })
 })
 
@@ -359,6 +359,6 @@ describe('automaticMatchmaking: case 16 more remote than local extensions', () =
     const got = await automaticMatchmaking([EXTENSION_A], [REGISTRATION_A, REGISTRATION_B], {})
 
     // Then
-    expect(got).toEqual(err(new Error('Unknown error')))
+    expect(got).toEqual(err(new Error('invalid-environment')))
   })
 })

--- a/packages/app/src/cli/services/environment/id-matching.test.ts
+++ b/packages/app/src/cli/services/environment/id-matching.test.ts
@@ -330,25 +330,35 @@ describe('automaticMatchmaking: case 14 a bit of everything', () => {
     })
     expect(got).toEqual(expected)
   })
+})
 
-  describe('automaticMatchmaking: case 15 automatic matches with different names', () => {
-    it('suceeds returning matches pending confirmation', async () => {
-      // When
-      const registrationNewA = {...REGISTRATION_A, title: 'A_NEW'}
-      const registrationNewB = {...REGISTRATION_B, title: 'B_NEW'}
-      const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [registrationNewA, registrationNewB], {})
+describe('automaticMatchmaking: case 15 automatic matches with different names', () => {
+  it('suceeds returning matches pending confirmation', async () => {
+    // When
+    const registrationNewA = {...REGISTRATION_A, title: 'A_NEW'}
+    const registrationNewB = {...REGISTRATION_B, title: 'B_NEW'}
+    const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [registrationNewA, registrationNewB], {})
 
-      // Then
-      const expected = ok({
-        identifiers: {},
-        pendingConfirmation: [
-          {extension: EXTENSION_A, registration: registrationNewA},
-          {extension: EXTENSION_B, registration: registrationNewB},
-        ],
-        toCreate: [],
-        toManualMatch: {local: [], remote: []},
-      })
-      expect(got).toEqual(expected)
+    // Then
+    const expected = ok({
+      identifiers: {},
+      pendingConfirmation: [
+        {extension: EXTENSION_A, registration: registrationNewA},
+        {extension: EXTENSION_B, registration: registrationNewB},
+      ],
+      toCreate: [],
+      toManualMatch: {local: [], remote: []},
     })
+    expect(got).toEqual(expected)
+  })
+})
+
+describe('automaticMatchmaking: case 16 more remote than local extensions', () => {
+  it('throw error, invalid local environment', async () => {
+    // When
+    const got = await automaticMatchmaking([EXTENSION_A], [REGISTRATION_A, REGISTRATION_B], {})
+
+    // Then
+    expect(got).toEqual(err(new Error('invalid-environment')))
   })
 })

--- a/packages/app/src/cli/services/environment/id-matching.test.ts
+++ b/packages/app/src/cli/services/environment/id-matching.test.ts
@@ -192,7 +192,7 @@ describe('automaticMatchmaking: case 6 remote extensions have types not present 
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [REGISTRATION_C, REGISTRATION_D], {})
 
     // Then
-    expect(got).toEqual(err(new Error('invalid-environment')))
+    expect(got).toEqual(err(new Error('Unknown error')))
   })
 })
 
@@ -202,7 +202,7 @@ describe('automaticMatchmaking: case 7 some extensions match, but other are miss
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [REGISTRATION_A, REGISTRATION_C], {})
 
     // Then
-    expect(got).toEqual(err(new Error('invalid-environment')))
+    expect(got).toEqual(err(new Error('Unknown error')))
   })
 })
 
@@ -248,7 +248,7 @@ describe('automaticMatchmaking: case 10 there are more remote than local extensi
     const got = await automaticMatchmaking([EXTENSION_A], [REGISTRATION_A, REGISTRATION_A_2], {})
 
     // Then
-    expect(got).toEqual(err(new Error('invalid-environment')))
+    expect(got).toEqual(err(new Error('Unknown error')))
   })
 })
 
@@ -359,6 +359,6 @@ describe('automaticMatchmaking: case 16 more remote than local extensions', () =
     const got = await automaticMatchmaking([EXTENSION_A], [REGISTRATION_A, REGISTRATION_B], {})
 
     // Then
-    expect(got).toEqual(err(new Error('invalid-environment')))
+    expect(got).toEqual(err(new Error('Unknown error')))
   })
 })

--- a/packages/app/src/cli/services/environment/id-matching.test.ts
+++ b/packages/app/src/cli/services/environment/id-matching.test.ts
@@ -1,7 +1,8 @@
-import {automaticMatchmaking, MatchResult} from './id-matching.js'
+import {automaticMatchmaking} from './id-matching.js'
 import {ExtensionRegistration} from '../dev/create-extension.js'
 import {UIExtension} from '../../models/app/extensions.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {err, ok} from '@shopify/cli-kit/common/result'
 
 beforeEach(() => {
   vi.mock('@shopify/cli-kit', async () => {
@@ -123,13 +124,12 @@ describe('automaticMatchmaking: case 3 some local extensions, no remote ones', (
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [], {})
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {},
       pendingConfirmation: [],
       toCreate: [EXTENSION_A, EXTENSION_B],
       toManualMatch: {local: [], remote: []},
-    }
+    })
     expect(got).toEqual(expected)
   })
 })
@@ -140,13 +140,12 @@ describe('automaticMatchmaking: case 3b some local extensions of the same type, 
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_A_2], [], {})
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {},
       pendingConfirmation: [],
       toCreate: [EXTENSION_A, EXTENSION_A_2],
       toManualMatch: {local: [], remote: []},
-    }
+    })
     expect(got).toEqual(expected)
   })
 })
@@ -157,13 +156,12 @@ describe('automaticMatchmaking: case 4 same number of extensions local and remot
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [REGISTRATION_A, REGISTRATION_B], {})
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {EXTENSION_A: 'UUID_A', EXTENSION_B: 'UUID_B'},
       pendingConfirmation: [],
       toCreate: [],
       toManualMatch: {local: [], remote: []},
-    }
+    })
     expect(got).toEqual(expected)
   })
 })
@@ -178,13 +176,12 @@ describe('automaticMatchmaking: case 5 more extensions local than remote, all re
     )
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {EXTENSION_A: 'UUID_A', EXTENSION_B: 'UUID_B'},
       pendingConfirmation: [],
       toCreate: [EXTENSION_C, EXTENSION_D],
       toManualMatch: {local: [], remote: []},
-    }
+    })
     expect(got).toEqual(expected)
   })
 })
@@ -195,7 +192,7 @@ describe('automaticMatchmaking: case 6 remote extensions have types not present 
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [REGISTRATION_C, REGISTRATION_D], {})
 
     // Then
-    expect(got).toEqual({result: 'invalid-environment'})
+    expect(got).toEqual(err(new Error('invalid-environment')))
   })
 })
 
@@ -205,7 +202,7 @@ describe('automaticMatchmaking: case 7 some extensions match, but other are miss
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [REGISTRATION_A, REGISTRATION_C], {})
 
     // Then
-    expect(got).toEqual({result: 'invalid-environment'})
+    expect(got).toEqual(err(new Error('invalid-environment')))
   })
 })
 
@@ -215,13 +212,12 @@ describe('automaticMatchmaking: case 8 multiple extensions of the same type loca
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_A_2], [REGISTRATION_A, REGISTRATION_A_2], {})
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {},
       pendingConfirmation: [],
       toCreate: [],
       toManualMatch: {local: [EXTENSION_A, EXTENSION_A_2], remote: [REGISTRATION_A, REGISTRATION_A_2]},
-    }
+    })
     expect(got).toEqual(expected)
   })
 })
@@ -236,13 +232,12 @@ describe('automaticMatchmaking: case 9 multiple extensions of the same type loca
     )
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {},
       pendingConfirmation: [],
       toCreate: [EXTENSION_B],
       toManualMatch: {local: [EXTENSION_A, EXTENSION_A_2], remote: [REGISTRATION_A, REGISTRATION_A_2]},
-    }
+    })
     expect(got).toEqual(expected)
   })
 })
@@ -253,7 +248,7 @@ describe('automaticMatchmaking: case 10 there are more remote than local extensi
     const got = await automaticMatchmaking([EXTENSION_A], [REGISTRATION_A, REGISTRATION_A_2], {})
 
     // Then
-    expect(got).toEqual({result: 'invalid-environment'})
+    expect(got).toEqual(err(new Error('invalid-environment')))
   })
 })
 
@@ -265,13 +260,12 @@ describe('automaticMatchmaking: case 11 some extension have uuid, others can be 
     })
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {EXTENSION_A: 'UUID_A', EXTENSION_B: 'UUID_B'},
       pendingConfirmation: [],
       toCreate: [],
       toManualMatch: {local: [], remote: []},
-    }
+    })
     expect(got).toEqual(expected)
   })
 })
@@ -284,13 +278,12 @@ describe("automaticMatchmaking: case 12 some extension have uuid, but doesn't ma
     })
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {EXTENSION_A: 'UUID_A', EXTENSION_B: 'UUID_B'},
       pendingConfirmation: [],
       toCreate: [],
       toManualMatch: {local: [], remote: []},
-    }
+    })
     expect(got).toEqual(expected)
   })
 })
@@ -307,13 +300,12 @@ describe('automaticMatchmaking: case 13 duplicated extension types but some of t
     )
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {EXTENSION_A: 'UUID_A', EXTENSION_A_2: 'UUID_A_2', EXTENSION_B: 'UUID_B'},
       pendingConfirmation: [],
       toCreate: [],
       toManualMatch: {local: [], remote: []},
-    }
+    })
     expect(got).toEqual(expected)
   })
 })
@@ -330,13 +322,12 @@ describe('automaticMatchmaking: case 14 a bit of everything', () => {
     )
 
     // Then
-    const expected: MatchResult = {
-      result: 'ok',
+    const expected = ok({
       identifiers: {EXTENSION_D: 'UUID_D', EXTENSION_B: 'UUID_B'},
       pendingConfirmation: [],
       toCreate: [EXTENSION_C],
       toManualMatch: {local: [EXTENSION_A, EXTENSION_A_2], remote: [REGISTRATION_A, REGISTRATION_A_2]},
-    }
+    })
     expect(got).toEqual(expected)
   })
 
@@ -348,8 +339,7 @@ describe('automaticMatchmaking: case 14 a bit of everything', () => {
       const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_B], [registrationNewA, registrationNewB], {})
 
       // Then
-      const expected: MatchResult = {
-        result: 'ok',
+      const expected = ok({
         identifiers: {},
         pendingConfirmation: [
           {extension: EXTENSION_A, registration: registrationNewA},
@@ -357,7 +347,7 @@ describe('automaticMatchmaking: case 14 a bit of everything', () => {
         ],
         toCreate: [],
         toManualMatch: {local: [], remote: []},
-      }
+      })
       expect(got).toEqual(expected)
     })
   })

--- a/packages/app/src/cli/services/environment/id-matching.ts
+++ b/packages/app/src/cli/services/environment/id-matching.ts
@@ -15,10 +15,8 @@ export async function automaticMatchmaking(
   remoteRegistrations: ExtensionRegistration[],
   identifiers: {[localIdentifier: string]: string},
 ): ResultAsync<MatchResult> {
-  const invalidEnvironmentError = err<MatchResult>(new Error('invalid-environment'))
-
   if (remoteRegistrations.length > localExtensions.length) {
-    return invalidEnvironmentError
+    return err()
   }
 
   const validIdentifiers = identifiers
@@ -65,13 +63,13 @@ export async function automaticMatchmaking(
   // The user must solve the issue in their environment or deploy to a different app
   const impossible = newRemotePending.filter((reg) => !newLocalPending.map((ext) => ext.graphQLType).includes(reg.type))
   if (impossible.length > 0 || newRemotePending.length > newLocalPending.length) {
-    return invalidEnvironmentError
+    return err()
   }
 
   // If there are more remote pending than local in total, then we can't automatically match
   // The user must solve the issue in their environment or deploy to a different app
   if (newRemotePending.length > newLocalPending.length) {
-    return invalidEnvironmentError
+    return err()
   }
 
   const extensionsToCreate: Extension[] = []

--- a/packages/app/src/cli/services/environment/id-matching.ts
+++ b/packages/app/src/cli/services/environment/id-matching.ts
@@ -1,7 +1,7 @@
 import {ExtensionRegistration} from '../dev/create-extension.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {Extension} from '../../models/app/extensions.js'
-import {Result, err, ok} from '@shopify/cli-kit/common/result'
+import {err, ok, ResultAsync} from '@shopify/cli-kit/common/result'
 
 export interface MatchResult {
   identifiers: IdentifiersExtensions
@@ -14,7 +14,7 @@ export async function automaticMatchmaking(
   localExtensions: Extension[],
   remoteRegistrations: ExtensionRegistration[],
   identifiers: {[localIdentifier: string]: string},
-): Promise<Result<MatchResult, Error>> {
+): ResultAsync<MatchResult> {
   const invalidEnvironmentError = err<MatchResult>(new Error('invalid-environment'))
 
   if (remoteRegistrations.length > localExtensions.length) {

--- a/packages/app/src/cli/services/environment/id-matching.ts
+++ b/packages/app/src/cli/services/environment/id-matching.ts
@@ -1,7 +1,7 @@
 import {ExtensionRegistration} from '../dev/create-extension.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {Extension} from '../../models/app/extensions.js'
-import {err, ok, ResultAsync} from '@shopify/cli-kit/common/result'
+import {err, ok, Result} from '@shopify/cli-kit/common/result'
 
 export interface MatchResult {
   identifiers: IdentifiersExtensions
@@ -14,8 +14,8 @@ export async function automaticMatchmaking(
   localExtensions: Extension[],
   remoteRegistrations: ExtensionRegistration[],
   identifiers: {[localIdentifier: string]: string},
-): ResultAsync<MatchResult> {
-  const invalidEnvironmentError = err('invalid-environment')
+): Promise<Result<MatchResult, Error>> {
+  const invalidEnvironmentError = err(new Error('invalid-environment'))
 
   if (remoteRegistrations.length > localExtensions.length) {
     return invalidEnvironmentError

--- a/packages/app/src/cli/services/environment/id-matching.ts
+++ b/packages/app/src/cli/services/environment/id-matching.ts
@@ -15,8 +15,10 @@ export async function automaticMatchmaking(
   remoteRegistrations: ExtensionRegistration[],
   identifiers: {[localIdentifier: string]: string},
 ): ResultAsync<MatchResult> {
+  const invalidEnvironmentError = err('invalid-environment')
+
   if (remoteRegistrations.length > localExtensions.length) {
-    return err()
+    return invalidEnvironmentError
   }
 
   const validIdentifiers = identifiers
@@ -63,13 +65,13 @@ export async function automaticMatchmaking(
   // The user must solve the issue in their environment or deploy to a different app
   const impossible = newRemotePending.filter((reg) => !newLocalPending.map((ext) => ext.graphQLType).includes(reg.type))
   if (impossible.length > 0 || newRemotePending.length > newLocalPending.length) {
-    return err()
+    return invalidEnvironmentError
   }
 
   // If there are more remote pending than local in total, then we can't automatically match
   // The user must solve the issue in their environment or deploy to a different app
   if (newRemotePending.length > newLocalPending.length) {
-    return err()
+    return invalidEnvironmentError
   }
 
   const extensionsToCreate: Extension[] = []

--- a/packages/app/src/cli/services/environment/identifiers.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers.test.ts
@@ -137,21 +137,6 @@ beforeEach(() => {
   vi.mock('./id-manual-matching')
 })
 
-describe('ensureDeploymentIdsPresence: more remote than local extensions', () => {
-  it('throw an invalid environment error', async () => {
-    // Given
-    vi.mocked(fetchAppExtensionRegistrations).mockResolvedValueOnce({
-      app: {extensionRegistrations: [REGISTRATION_A, REGISTRATION_B]},
-    })
-
-    // When
-    const got = ensureDeploymentIdsPresence(options([EXTENSION_A], []))
-
-    // Then
-    await expect(got).rejects.toThrow(/Deployment failed because this local project doesn't seem to match the app/)
-  })
-})
-
 describe('ensureDeploymentIdsPresence: matchmaking returns invalid', () => {
   it('throw an invalid environment error', async () => {
     // Given

--- a/packages/app/src/cli/services/environment/identifiers.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers.test.ts
@@ -8,6 +8,7 @@ import {FunctionExtension, UIExtension} from '../../models/app/extensions.js'
 import {testApp} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {ui} from '@shopify/cli-kit'
+import {err, ok} from '@shopify/cli-kit/common/result'
 
 const REGISTRATION_A: ExtensionRegistration = {
   uuid: 'UUID_A',
@@ -154,7 +155,7 @@ describe('ensureDeploymentIdsPresence: more remote than local extensions', () =>
 describe('ensureDeploymentIdsPresence: matchmaking returns invalid', () => {
   it('throw an invalid environment error', async () => {
     // Given
-    vi.mocked(automaticMatchmaking).mockResolvedValueOnce({result: 'invalid-environment'})
+    vi.mocked(automaticMatchmaking).mockResolvedValueOnce(err(new Error('invalid-environment')))
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValueOnce({
       app: {extensionRegistrations: [REGISTRATION_A, REGISTRATION_B]},
     })
@@ -170,16 +171,17 @@ describe('ensureDeploymentIdsPresence: matchmaking returns invalid', () => {
 describe('ensureDeploymentIdsPresence: matchmaking returns ok with pending manual matches', () => {
   it('will call manualMatch and merge automatic and manual matches and create missing extensions', async () => {
     // Given
-    vi.mocked(automaticMatchmaking).mockResolvedValueOnce({
-      result: 'ok',
-      identifiers: {},
-      toCreate: [],
-      pendingConfirmation: [],
-      toManualMatch: {
-        local: [EXTENSION_A, EXTENSION_A_2, EXTENSION_B],
-        remote: [REGISTRATION_A, REGISTRATION_A_2],
-      },
-    })
+    vi.mocked(automaticMatchmaking).mockResolvedValueOnce(
+      ok({
+        identifiers: {},
+        toCreate: [],
+        pendingConfirmation: [],
+        toManualMatch: {
+          local: [EXTENSION_A, EXTENSION_A_2, EXTENSION_B],
+          remote: [REGISTRATION_A, REGISTRATION_A_2],
+        },
+      }),
+    )
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValueOnce({
       app: {extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2]},
     })
@@ -206,16 +208,17 @@ describe('ensureDeploymentIdsPresence: matchmaking returns ok with pending manua
 describe('ensureDeploymentIdsPresence: matchmaking returns ok with pending manual matches and manual match fails', () => {
   it('throws an error for missing remote extension matches', async () => {
     // Given
-    vi.mocked(automaticMatchmaking).mockResolvedValueOnce({
-      result: 'ok',
-      identifiers: {},
-      toCreate: [],
-      pendingConfirmation: [],
-      toManualMatch: {
-        local: [EXTENSION_A],
-        remote: [REGISTRATION_A, REGISTRATION_A_2],
-      },
-    })
+    vi.mocked(automaticMatchmaking).mockResolvedValueOnce(
+      ok({
+        identifiers: {},
+        toCreate: [],
+        pendingConfirmation: [],
+        toManualMatch: {
+          local: [EXTENSION_A],
+          remote: [REGISTRATION_A, REGISTRATION_A_2],
+        },
+      }),
+    )
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValueOnce({
       app: {extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2]},
     })
@@ -233,16 +236,17 @@ describe('ensureDeploymentIdsPresence: matchmaking returns ok with pending manua
 describe('ensureDeploymentIdsPresence: matchmaking returns ok with pending some pending to create', () => {
   it('Create the pending extensions and suceeds', async () => {
     // Given
-    vi.mocked(automaticMatchmaking).mockResolvedValueOnce({
-      result: 'ok',
-      identifiers: {},
-      pendingConfirmation: [],
-      toCreate: [EXTENSION_A, EXTENSION_A_2],
-      toManualMatch: {
-        local: [],
-        remote: [],
-      },
-    })
+    vi.mocked(automaticMatchmaking).mockResolvedValueOnce(
+      ok({
+        identifiers: {},
+        pendingConfirmation: [],
+        toCreate: [EXTENSION_A, EXTENSION_A_2],
+        toManualMatch: {
+          local: [],
+          remote: [],
+        },
+      }),
+    )
     vi.mocked(createExtension).mockResolvedValueOnce(REGISTRATION_A)
     vi.mocked(createExtension).mockResolvedValueOnce(REGISTRATION_A_2)
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValueOnce({
@@ -266,16 +270,17 @@ describe('ensureDeploymentIdsPresence: matchmaking returns ok with some pending 
   it('confirms the pending ones and suceeds', async () => {
     // Given
     vi.mocked(ui.prompt).mockResolvedValueOnce({value: 'yes'})
-    vi.mocked(automaticMatchmaking).mockResolvedValueOnce({
-      result: 'ok',
-      identifiers: {},
-      pendingConfirmation: [{extension: EXTENSION_B, registration: REGISTRATION_B}],
-      toCreate: [],
-      toManualMatch: {
-        local: [],
-        remote: [],
-      },
-    })
+    vi.mocked(automaticMatchmaking).mockResolvedValueOnce(
+      ok({
+        identifiers: {},
+        pendingConfirmation: [{extension: EXTENSION_B, registration: REGISTRATION_B}],
+        toCreate: [],
+        toManualMatch: {
+          local: [],
+          remote: [],
+        },
+      }),
+    )
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValueOnce({app: {extensionRegistrations: [REGISTRATION_B]}})
 
     // When
@@ -295,16 +300,17 @@ describe('ensureDeploymentIdsPresence: matchmaking returns ok with some pending 
   it('do not confirms the pending ones and fails', async () => {
     // Given
     vi.mocked(ui.prompt).mockResolvedValueOnce({value: 'no'})
-    vi.mocked(automaticMatchmaking).mockResolvedValueOnce({
-      result: 'ok',
-      identifiers: {},
-      pendingConfirmation: [{extension: EXTENSION_B, registration: REGISTRATION_B}],
-      toCreate: [],
-      toManualMatch: {
-        local: [],
-        remote: [],
-      },
-    })
+    vi.mocked(automaticMatchmaking).mockResolvedValueOnce(
+      ok({
+        identifiers: {},
+        pendingConfirmation: [{extension: EXTENSION_B, registration: REGISTRATION_B}],
+        toCreate: [],
+        toManualMatch: {
+          local: [],
+          remote: [],
+        },
+      }),
+    )
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValueOnce({app: {extensionRegistrations: [REGISTRATION_B]}})
 
     // When
@@ -318,16 +324,17 @@ describe('ensureDeploymentIdsPresence: matchmaking returns ok with some pending 
 describe('ensureDeploymentIdsPresence: matchmaking returns ok with nothing pending', () => {
   it('suceeds and returns all identifiers', async () => {
     // Given
-    vi.mocked(automaticMatchmaking).mockResolvedValueOnce({
-      result: 'ok',
-      identifiers: {EXTENSION_A: 'UUID_A', EXTENSION_A_2: 'UUID_A_2'},
-      toCreate: [],
-      pendingConfirmation: [],
-      toManualMatch: {
-        local: [],
-        remote: [],
-      },
-    })
+    vi.mocked(automaticMatchmaking).mockResolvedValueOnce(
+      ok({
+        identifiers: {EXTENSION_A: 'UUID_A', EXTENSION_A_2: 'UUID_A_2'},
+        toCreate: [],
+        pendingConfirmation: [],
+        toManualMatch: {
+          local: [],
+          remote: [],
+        },
+      }),
+    )
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValueOnce({
       app: {extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2]},
     })
@@ -363,16 +370,17 @@ describe("ensureDeploymentIdsPresence: doesn't override existing functions' ids"
     // Given
     const envIdentifiers: {[key: string]: string} = {}
     envIdentifiers[EXTENSION_C.localIdentifier] = 'UUID_C'
-    vi.mocked(automaticMatchmaking).mockResolvedValueOnce({
-      result: 'ok',
-      identifiers: {},
-      toCreate: [],
-      pendingConfirmation: [],
-      toManualMatch: {
-        local: [EXTENSION_A, EXTENSION_A_2, EXTENSION_B],
-        remote: [REGISTRATION_A, REGISTRATION_A_2],
-      },
-    })
+    vi.mocked(automaticMatchmaking).mockResolvedValueOnce(
+      ok({
+        identifiers: {},
+        toCreate: [],
+        pendingConfirmation: [],
+        toManualMatch: {
+          local: [EXTENSION_A, EXTENSION_A_2, EXTENSION_B],
+          remote: [REGISTRATION_A, REGISTRATION_A_2],
+        },
+      }),
+    )
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValueOnce({
       app: {extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2]},
     })

--- a/packages/app/src/cli/services/environment/identifiers.ts
+++ b/packages/app/src/cli/services/environment/identifiers.ts
@@ -7,7 +7,7 @@ import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
 import {createExtension} from '../dev/create-extension.js'
 import {error, output, session, ui} from '@shopify/cli-kit'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
-import {mapError, valueOrThrow} from '@shopify/cli-kit/common/result'
+import {} from '@shopify/cli-kit/common/result'
 
 const DeployError = (appName: string, packageManager: PackageManager) => {
   return new error.Abort(
@@ -65,9 +65,9 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     }
   }
 
-  const match = valueOrThrow(
-    mapError(await automaticMatchmaking(localExtensions, remoteRegistrations, validIdentifiers), () => GenericError()),
-  )
+  const match = (await automaticMatchmaking(localExtensions, remoteRegistrations, validIdentifiers))
+    .mapError(() => GenericError())
+    .valueOrThrow()
 
   let validMatches = match.identifiers ?? {}
   const validMatchesById: {[key: string]: string} = {}

--- a/packages/app/src/cli/services/environment/identifiers.ts
+++ b/packages/app/src/cli/services/environment/identifiers.ts
@@ -7,7 +7,7 @@ import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
 import {createExtension} from '../dev/create-extension.js'
 import {error, output, session, ui} from '@shopify/cli-kit'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
-import {valueOrFatal} from '@shopify/cli-kit/common/result'
+import {valueOrThrow} from '@shopify/cli-kit/common/result'
 
 const DeployError = (appName: string, packageManager: PackageManager) => {
   return new error.Abort(
@@ -65,7 +65,7 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     }
   }
 
-  const match = valueOrFatal(
+  const match = valueOrThrow(
     await automaticMatchmaking(localExtensions, remoteRegistrations, validIdentifiers),
     GenericError(),
   )

--- a/packages/app/src/cli/services/environment/identifiers.ts
+++ b/packages/app/src/cli/services/environment/identifiers.ts
@@ -7,6 +7,7 @@ import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
 import {createExtension} from '../dev/create-extension.js'
 import {error, output, session, ui} from '@shopify/cli-kit'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {valueOrFatal} from '@shopify/cli-kit/common/result'
 
 const DeployError = (appName: string, packageManager: PackageManager) => {
   return new error.Abort(
@@ -64,16 +65,11 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     }
   }
 
-  // If there are more remote extensions than local, then something is missing and we can't continue
-  if (remoteRegistrations.length > localExtensions.length) {
-    throw GenericError()
-  }
+  const match = valueOrFatal(
+    await automaticMatchmaking(localExtensions, remoteRegistrations, validIdentifiers),
+    GenericError(),
+  )
 
-  const match = await automaticMatchmaking(localExtensions, remoteRegistrations, validIdentifiers)
-
-  if (match.result === 'invalid-environment') {
-    throw GenericError()
-  }
   let validMatches = match.identifiers ?? {}
   const validMatchesById: {[key: string]: string} = {}
 

--- a/packages/app/src/cli/services/environment/identifiers.ts
+++ b/packages/app/src/cli/services/environment/identifiers.ts
@@ -7,7 +7,6 @@ import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
 import {createExtension} from '../dev/create-extension.js'
 import {error, output, session, ui} from '@shopify/cli-kit'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
-import {} from '@shopify/cli-kit/common/result'
 
 const DeployError = (appName: string, packageManager: PackageManager) => {
   return new error.Abort(

--- a/packages/app/src/cli/services/environment/identifiers.ts
+++ b/packages/app/src/cli/services/environment/identifiers.ts
@@ -7,7 +7,7 @@ import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
 import {createExtension} from '../dev/create-extension.js'
 import {error, output, session, ui} from '@shopify/cli-kit'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
-import {valueOrThrow} from '@shopify/cli-kit/common/result'
+import {mapError, valueOrThrow} from '@shopify/cli-kit/common/result'
 
 const DeployError = (appName: string, packageManager: PackageManager) => {
   return new error.Abort(
@@ -66,8 +66,7 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
   }
 
   const match = valueOrThrow(
-    await automaticMatchmaking(localExtensions, remoteRegistrations, validIdentifiers),
-    GenericError(),
+    mapError(await automaticMatchmaking(localExtensions, remoteRegistrations, validIdentifiers), () => GenericError()),
   )
 
   let validMatches = match.identifiers ?? {}

--- a/packages/app/src/cli/services/environment/identifiers.ts
+++ b/packages/app/src/cli/services/environment/identifiers.ts
@@ -65,7 +65,7 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
   }
 
   const match = (await automaticMatchmaking(localExtensions, remoteRegistrations, validIdentifiers))
-    .mapError(() => GenericError())
+    .mapError(GenericError)
     .valueOrThrow()
 
   let validMatches = match.identifiers ?? {}

--- a/packages/cli-kit/src/common/result.test.ts
+++ b/packages/cli-kit/src/common/result.test.ts
@@ -1,0 +1,76 @@
+import {err, ok, valueOrThrow} from './result.js'
+import {describe, expect, it} from 'vitest'
+
+describe('ok', () => {
+  it('create ok with value', () => {
+    // When
+    const result = ok(123)
+
+    // Then
+    expect(result.ok).toEqual(true)
+    if (result.ok) {
+      expect(result.value).toEqual(123)
+    }
+  })
+})
+
+describe('err', () => {
+  it('create err without error', () => {
+    // When
+    const result = err()
+
+    // Then
+    expect(result.ok).toEqual(false)
+    if (!result.ok) {
+      expect(result.error).toEqual(new Error('Unknown error'))
+    }
+  })
+
+  it('create err with string', () => {
+    // When
+    const result = err('Custom error string')
+
+    // Then
+    expect(result.ok).toEqual(false)
+    if (!result.ok) {
+      expect(result.error).toEqual(new Error('Custom error string'))
+    }
+  })
+
+  it('create err with en Error', () => {
+    // When
+    const result = err(new Error('Custom error object'))
+
+    // Then
+    expect(result.ok).toEqual(false)
+    if (!result.ok) {
+      expect(result.error).toEqual(new Error('Custom error object'))
+    }
+  })
+})
+
+describe('valueOrThrow', () => {
+  it('when ok result should return value', () => {
+    // When
+    const result = valueOrThrow(ok(123))
+
+    // Then
+    expect(result).toEqual(123)
+  })
+
+  it('when err result and no alternative error to throw should throw err result', () => {
+    // When
+    const result = () => valueOrThrow(err('custom error'))
+
+    // Then
+    expect(result).toThrow(new Error('custom error'))
+  })
+
+  it('when err result and an alternative error is used should throw alternative error', () => {
+    // When
+    const result = () => valueOrThrow(err('custom error'), new Error('alternative error'))
+
+    // Then
+    expect(result).toThrow(new Error('alternative error'))
+  })
+})

--- a/packages/cli-kit/src/common/result.test.ts
+++ b/packages/cli-kit/src/common/result.test.ts
@@ -1,4 +1,4 @@
-import {err, ok, valueOrThrow} from './result.js'
+import {err, mapError, ok, valueOrThrow} from './result.js'
 import {describe, expect, it} from 'vitest'
 
 describe('ok', () => {
@@ -65,12 +65,17 @@ describe('valueOrThrow', () => {
     // Then
     expect(result).toThrow(new Error('custom error'))
   })
+})
 
-  it('when err result and an alternative error is used should throw alternative error', () => {
+describe('map', () => {
+  it('when ok result should return value', () => {
     // When
-    const result = () => valueOrThrow(err('custom error'), new Error('alternative error'))
+    const result = mapError(err('Original error'), () => new Error('Mapped error'))
 
     // Then
-    expect(result).toThrow(new Error('alternative error'))
+    expect(result.ok).toEqual(false)
+    if (!result.ok) {
+      expect(result.error).toEqual(new Error('Mapped error'))
+    }
   })
 })

--- a/packages/cli-kit/src/common/result.test.ts
+++ b/packages/cli-kit/src/common/result.test.ts
@@ -1,5 +1,6 @@
 import {err, ok} from './result.js'
 import {describe, expect, it} from 'vitest'
+import {fail} from 'node:assert'
 
 describe('ok', () => {
   it('create ok with value', () => {
@@ -7,8 +8,11 @@ describe('ok', () => {
     const result = ok(123)
 
     // Then
-    expect(result.isOk()).toEqual(true)
-    expect(result.valueOrThrow()).toEqual(123)
+    if (result.isErr()) {
+      fail('Should return an Ok result')
+    } else {
+      expect(result.value).toEqual(123)
+    }
   })
 })
 
@@ -18,8 +22,11 @@ describe('err', () => {
     const result = err(new Error('Custom error object'))
 
     // Then
-    expect(result.isErr()).toEqual(true)
-    expect(() => result.valueOrThrow()).toThrow(new Error('Custom error object'))
+    if (result.isErr()) {
+      expect(result.error).toEqual(new Error('Custom error object'))
+    } else {
+      fail('Should return an Error result')
+    }
   })
 })
 

--- a/packages/cli-kit/src/common/result.test.ts
+++ b/packages/cli-kit/src/common/result.test.ts
@@ -1,4 +1,4 @@
-import {err, mapError, ok, valueOrThrow} from './result.js'
+import {err, ok} from './result.js'
 import {describe, expect, it} from 'vitest'
 
 describe('ok', () => {
@@ -7,75 +7,46 @@ describe('ok', () => {
     const result = ok(123)
 
     // Then
-    expect(result.ok).toEqual(true)
-    if (result.ok) {
-      expect(result.value).toEqual(123)
-    }
+    expect(result.isOk()).toEqual(true)
+    expect(result.valueOrThrow()).toEqual(123)
   })
 })
 
 describe('err', () => {
-  it('create err without error', () => {
-    // When
-    const result = err()
-
-    // Then
-    expect(result.ok).toEqual(false)
-    if (!result.ok) {
-      expect(result.error).toEqual(new Error('Unknown error'))
-    }
-  })
-
-  it('create err with string', () => {
-    // When
-    const result = err('Custom error string')
-
-    // Then
-    expect(result.ok).toEqual(false)
-    if (!result.ok) {
-      expect(result.error).toEqual(new Error('Custom error string'))
-    }
-  })
-
   it('create err with en Error', () => {
     // When
     const result = err(new Error('Custom error object'))
 
     // Then
-    expect(result.ok).toEqual(false)
-    if (!result.ok) {
-      expect(result.error).toEqual(new Error('Custom error object'))
-    }
+    expect(result.isErr()).toEqual(true)
+    expect(() => result.valueOrThrow()).toThrow(new Error('Custom error object'))
   })
 })
 
 describe('valueOrThrow', () => {
   it('when ok result should return value', () => {
     // When
-    const result = valueOrThrow(ok(123))
+    const result = ok(123).valueOrThrow()
 
     // Then
     expect(result).toEqual(123)
   })
 
-  it('when err result and no alternative error to throw should throw err result', () => {
+  it('when err result should throw err result', () => {
     // When
-    const result = () => valueOrThrow(err('custom error'))
+    const result = err(new Error('custom error'))
 
     // Then
-    expect(result).toThrow(new Error('custom error'))
+    expect(() => result.valueOrThrow()).toThrow(new Error('custom error'))
   })
 })
 
 describe('map', () => {
   it('when ok result should return value', () => {
     // When
-    const result = mapError(err('Original error'), () => new Error('Mapped error'))
+    const result = err(new Error('Original error')).mapError(() => new Error('Mapped error'))
 
     // Then
-    expect(result.ok).toEqual(false)
-    if (!result.ok) {
-      expect(result.error).toEqual(new Error('Mapped error'))
-    }
+    expect(() => result.valueOrThrow()).toThrow('Mapped error')
   })
 })

--- a/packages/cli-kit/src/common/result.ts
+++ b/packages/cli-kit/src/common/result.ts
@@ -1,0 +1,17 @@
+import {Fatal} from '../error.js'
+
+export type Result<T, TError = Error> = {ok: true; value: T} | {ok: false; error: TError}
+
+export const ok = <T, TError = Error>(value: T): Result<T, TError> => {
+  return {ok: true, value}
+}
+
+export const err = <T, TError = Error>(error: TError): Result<T, TError> => {
+  return {ok: false, error}
+}
+
+export const valueOrFatal = <T, TError = Error>(result: Result<T, TError>, error: Fatal): T => {
+  if (!result.ok) throw error
+
+  return result.value
+}

--- a/packages/cli-kit/src/common/result.ts
+++ b/packages/cli-kit/src/common/result.ts
@@ -8,8 +8,18 @@ export const ok = <T, TError = Error>(value: T): Result<T, TError> => {
   return {ok: true, value}
 }
 
-export const err = <T, TError = Error>(error: TError): Result<T, TError> => {
-  return {ok: false, error}
+export const err = <T = never>(error?: unknown): Result<T, Error> => {
+  let errorToUse: Error
+  if (!error) {
+    errorToUse = new Error('Unknown error')
+  } else if (error instanceof Error) {
+    errorToUse = error
+  } else if (typeof error === 'string') {
+    errorToUse = new Error(error)
+  } else {
+    errorToUse = new Error('Unknown error')
+  }
+  return {ok: false, error: errorToUse}
 }
 
 export const valueOrFatal = <T, TError = Error>(result: Result<T, TError>, error: Fatal): T => {

--- a/packages/cli-kit/src/common/result.ts
+++ b/packages/cli-kit/src/common/result.ts
@@ -8,11 +8,7 @@ export const err = <T = never, TError = unknown>(err: TError): Err<T, TError> =>
 export class Ok<T, TError> {
   constructor(readonly value: T) {}
 
-  isOk() {
-    return true
-  }
-
-  isErr() {
+  isErr(): this is Err<T, TError> {
     return false
   }
 
@@ -28,11 +24,7 @@ export class Ok<T, TError> {
 export class Err<T, TError> {
   constructor(readonly error: TError) {}
 
-  isOk() {
-    return false
-  }
-
-  isErr() {
+  isErr(): this is Err<T, TError> {
     return true
   }
 

--- a/packages/cli-kit/src/common/result.ts
+++ b/packages/cli-kit/src/common/result.ts
@@ -2,6 +2,8 @@ import {Fatal} from '../error.js'
 
 export type Result<T, TError = Error> = {ok: true; value: T} | {ok: false; error: TError}
 
+export type ResultAsync<T, TError = Error> = Promise<Result<T, TError>>
+
 export const ok = <T, TError = Error>(value: T): Result<T, TError> => {
   return {ok: true, value}
 }

--- a/packages/cli-kit/src/common/result.ts
+++ b/packages/cli-kit/src/common/result.ts
@@ -1,5 +1,3 @@
-import {Fatal} from '../error.js'
-
 export type Result<T, TError = Error> = {ok: true; value: T} | {ok: false; error: TError}
 
 export type ResultAsync<T, TError = Error> = Promise<Result<T, TError>>
@@ -24,7 +22,7 @@ export const err = <T = never>(error?: unknown): Result<T, Error> => {
   return {ok: false, error: errorToUse}
 }
 
-export const valueOrThrow = <T, TError = Error>(result: Result<T, TError>, error?: Fatal): T => {
+export const valueOrThrow = <T, TError = Error>(result: Result<T, TError>, error?: Error): T => {
   if (!result.ok) {
     if (error) {
       throw error

--- a/packages/cli-kit/src/common/result.ts
+++ b/packages/cli-kit/src/common/result.ts
@@ -8,22 +8,32 @@ export const ok = <T, TError = Error>(value: T): Result<T, TError> => {
   return {ok: true, value}
 }
 
+const UnknownError = new Error('Unknown error')
+
 export const err = <T = never>(error?: unknown): Result<T, Error> => {
   let errorToUse: Error
   if (!error) {
-    errorToUse = new Error('Unknown error')
+    errorToUse = UnknownError
   } else if (error instanceof Error) {
     errorToUse = error
   } else if (typeof error === 'string') {
     errorToUse = new Error(error)
   } else {
-    errorToUse = new Error('Unknown error')
+    errorToUse = UnknownError
   }
   return {ok: false, error: errorToUse}
 }
 
-export const valueOrFatal = <T, TError = Error>(result: Result<T, TError>, error: Fatal): T => {
-  if (!result.ok) throw error
+export const valueOrThrow = <T, TError = Error>(result: Result<T, TError>, error?: Fatal): T => {
+  if (!result.ok) {
+    if (error) {
+      throw error
+    } else if (result.error) {
+      throw result.error
+    } else {
+      throw UnknownError
+    }
+  }
 
   return result.value
 }

--- a/packages/cli-kit/src/common/result.ts
+++ b/packages/cli-kit/src/common/result.ts
@@ -22,16 +22,21 @@ export const err = <T = never>(error?: unknown): Result<T, Error> => {
   return {ok: false, error: errorToUse}
 }
 
-export const valueOrThrow = <T, TError = Error>(result: Result<T, TError>, error?: Error): T => {
+export const valueOrThrow = <T, TError = Error>(result: Result<T, TError>): T => {
   if (!result.ok) {
-    if (error) {
-      throw error
-    } else if (result.error) {
-      throw result.error
-    } else {
-      throw UnknownError
-    }
+    throw result.error
   }
 
   return result.value
+}
+
+export const mapError = <T, TError, TMappedError>(
+  result: Result<T, TError>,
+  mapper: (error: TError) => TMappedError,
+): Result<T, Error> => {
+  if (!result.ok) {
+    return err(mapper(result.error))
+  }
+
+  return result
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/shopify-cli-planning/issues/312
Follow-up: https://github.com/Shopify/cli/pull/319

### WHAT is this pull request doing?
- New `Result` type added. Used as a return type to indicate the operation has suceded or should return an error
- Three utility methods for creating an ok and error response, and to get the value of an ok response or throw a fatal exception (Bug, Abort, AbortSilent) otherwise
- Used new type in `automaticMatchmaking`

TBD: It also should be added to `manualMatchIds` in case the new type is approved

### How to test your changes?
- Run `yarn shopify app deploy` with a remote app that matches local extensions and then with another that does not match to see the abort error message
