### PR TITLE
Display App URL more clearly  in console output for easier copy & paste

### DIFF
--- a/.changeset/small-dots-try.md
+++ b/.changeset/small-dots-try.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Displayed app URL more clearly in console output

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -32,11 +32,11 @@ export function outputUpdatedURLFirstTime(url: string, dashboardURL: string) {
 }
 
 export function outputAppURL(storeFqdn: string, url: string) {
+  const heading = output.token.heading('Shareable app URL')
   const appURL = buildAppURL(storeFqdn, url)
-  const heading = output.token.heading('App URL (shareable link)')
-  const notes = '\n - this URL will be accessible once everything builds'
-  const message = `\n  ${appURL}\n${notes}`
-  output.info(output.content`\n\n${heading}\n${message}\n`)
+  const formattedAppURL = output.token.link(appURL, appURL)
+  const notes = '' // one note per line, start notes with \n
+  output.info(output.content`\n\n${heading}\n\n  ${formattedAppURL}\n${notes}`)
 }
 
 export function outputExtensionsMessages(app: AppInterface, storeFqdn: string, url: string) {

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -33,8 +33,9 @@ export function outputUpdatedURLFirstTime(url: string, dashboardURL: string) {
 
 export function outputAppURL(storeFqdn: string, url: string) {
   const appURL = buildAppURL(storeFqdn, url)
-  const heading = output.token.heading('App URL')
-  const message = `Once everything's built, your app's shareable link will be:\n${appURL}`
+  const heading = output.token.heading('App URL (shareable link)')
+  const notes = '\n - this URL will be accessible once everything builds'
+  const message = `\n  ${appURL}\n${notes}`
   output.info(output.content`\n\n${heading}\n${message}\n`)
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

- I'm part of a team (Core > Promote) working on 1P apps in a Discounts context
- we're starting to write docs and I'm on the lookout for 'small wins' and friction points
- this PR slightly reworks the display of App URLs to make them easier to see, and easier to copy and paste from console output

### WHAT is this pull request doing?
- adds keyword to header title ('shareable link')
- sets off most important information (app URL) with blank lines before and after
- moves less-important context to below the app URL

#### Before
<img width="745" alt="before" src="https://user-images.githubusercontent.com/4842862/185989262-ad3ebf08-4ca0-4b97-9160-ba8370ee5b42.png">

#### After
<img width="801" alt="after" src="https://user-images.githubusercontent.com/4842862/185989300-830280cd-5338-46cc-beef-ca9eff937f7f.png">

### How to test your changes?

- run `yarn dev` in a CLI 3.0 app 
