### PR TITLE
Fix post merge debug flows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,20 +7,42 @@
       {
         "type": "node",
         "request": "launch",
+        "name": "shopify app build",
+        "cwd": "${workspaceFolder}",
+        "runtimeExecutable": "pnpm",
+        "runtimeArgs": [
+          "shopify",
+          "app",
+          "build",
+          "--path=${input:appDir}",
+        ],
+        "env": {
+          "DEBUG": "\"*\"",
+          "SHOPIFY_DEBUG_GO_BINARY": "1",       // Switch to 1 to pause execution of the Go binary until the debgger is attached.
+        },
+        "skipFiles": [
+          "<node_internals>/**",
+        ],
+      },
+      {
+        "type": "node",
+        "request": "launch",
         "name": "shopify app dev",
-        "runtimeExecutable": "yarn",
+        "cwd": "${workspaceFolder}",
+        "runtimeExecutable": "pnpm",
         "runtimeArgs": [
           "shopify",
           "app",
           "dev",
-          "--path=${input:appDir}"
+          "--no-update",
+          "--path=${input:appDir}",
         ],
         "env": {
           "DEBUG": "\"*\"",
-          "SHOPIFY_DEBUG_GO_BINARY": "0",       // Switch to 1 to pause execution of the Go binary until the debgger is attached.
+          "SHOPIFY_DEBUG_GO_BINARY": "1",       // Switch to 1 to pause execution of the Go binary until the debgger is attached.
         },
         "skipFiles": [
-          "<node_internals>/**"
+          "<node_internals>/**",
         ],
       },
       {
@@ -40,44 +62,11 @@
         ],
         "env": {
           "DEBUG": "\"*\"",
-          "SHOPIFY_DEBUG_GO_BINARY": "0",       // Switch to 1 to pause execution of the Go binary until the debgger is attached.
+          "SHOPIFY_DEBUG_GO_BINARY": "1",       // Switch to 1 to pause execution of the Go binary until the debgger is attached.
         },
         "skipFiles": [
           "<node_internals>/**"
         ],
-      },
-      {
-        "name": "Extension server: create",
-        "type": "go",
-        "request": "launch",
-        "mode": "auto",
-        "program": ".",
-        "args": ["create", "${input:extensionConfigPath}"]
-      },
-      {
-        "name": "Extension server: serve",
-        "type": "go",
-        "request": "launch",
-        "mode": "auto",
-        "program": ".",
-        "args": ["serve", "${input:extensionConfigPath}"]
-      },
-      {
-      "name": "Extension server: build",
-      "type": "go",
-      "request": "launch",
-      "mode": "auto",
-      "program": ".",
-      "args": ["build", "${input:extensionConfigPath}"]
-      },
-      {
-        "name": "Extension server: Attach to Debug Session",
-        "type": "go",
-        "debugAdapter": "dlv-dap",
-        "request": "attach",
-        "mode": "remote",
-        "host": "${input:remoteIpAddress}",
-        "port": "${input:remotePort}",
       },
     ],
     "inputs": [
@@ -85,6 +74,7 @@
         "id": "appDir",
         "type": "promptString",
         "description": "App Directory: ",
+        "default": ".",
       },
       {
         "id": "extensionName",
@@ -106,7 +96,7 @@
           "order_discounts",
           "shipping_discounts",
           "payment_customization",
-          "shipping_rate_presenter"
+          "shipping_rate_presenter",
         ],
         "default": "checkout_ui_extension",
     },
@@ -120,27 +110,9 @@
         "typescript",
         "typescript-react",
         "wasm",
-        "rust"
+        "rust",
       ],
       "default": "react",
     },
-    {
-      "id": "extensionConfigPath",
-      "type": "promptString",
-      "description": "Extension Config Path: ",
-      "default": "testdata/extension.config.yml",
-      },
-      {
-      "id": "remoteIpAddress",
-      "type": "promptString",
-      "description": "Remote IP Address: ",
-      "default": "127.0.0.1",
-      },
-      {
-      "id": "remotePort",
-      "type": "promptString",
-      "description": "Remote Port: ",
-      "default": "12345",
-      },
-  ]
+  ],
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
         ],
         "env": {
           "DEBUG": "\"*\"",
-          "SHOPIFY_DEBUG_GO_BINARY": "1",       // Switch to 1 to pause execution of the Go binary until the debgger is attached.
+          "SHOPIFY_DEBUG_GO_BINARY": "1",
         },
         "skipFiles": [
           "<node_internals>/**",
@@ -39,7 +39,7 @@
         ],
         "env": {
           "DEBUG": "\"*\"",
-          "SHOPIFY_DEBUG_GO_BINARY": "1",       // Switch to 1 to pause execution of the Go binary until the debgger is attached.
+          "SHOPIFY_DEBUG_GO_BINARY": "1",
         },
         "skipFiles": [
           "<node_internals>/**",
@@ -62,7 +62,7 @@
         ],
         "env": {
           "DEBUG": "\"*\"",
-          "SHOPIFY_DEBUG_GO_BINARY": "1",       // Switch to 1 to pause execution of the Go binary until the debgger is attached.
+          "SHOPIFY_DEBUG_GO_BINARY": "1",
         },
         "skipFiles": [
           "<node_internals>/**"

--- a/packages/ui-extensions-go-cli/.vscode/launch.json
+++ b/packages/ui-extensions-go-cli/.vscode/launch.json
@@ -24,8 +24,8 @@
         {
             "id": "remotePort",
             "type": "promptString",
-            "description": "Port: ",  // From init-debug-session shell script
-            "default": "54321",
+            "description": "Port: ",
+            "default": "54321",       // Default value from: <cli_root>/packages/ui-extensions-go-cli/init-debug-session
         },
     ],
 }

--- a/packages/ui-extensions-go-cli/.vscode/launch.json
+++ b/packages/ui-extensions-go-cli/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Go Binary",
+            "type": "go",
+            "debugAdapter": "dlv-dap",
+            "request": "attach",
+            "mode": "remote",
+            "host": "${input:remoteIpAddress}",
+            "port": "${input:remotePort}",
+        },
+    ],
+    "inputs": [
+        {
+            "id": "remoteIpAddress",
+            "type": "promptString",
+            "description": "Remote IP Address: ",
+            "default": "127.0.0.1",
+        },
+        {
+            "id": "remotePort",
+            "type": "promptString",
+            "description": "Port: ",  // From init-debug-session shell script
+            "default": "54321",
+        },
+    ],
+}

--- a/packages/ui-extensions-go-cli/init-debug-session
+++ b/packages/ui-extensions-go-cli/init-debug-session
@@ -16,7 +16,7 @@ fi
 echo "Executing $(basename $0)..."
 
 HOST="127.0.0.1"
-PORT="12345"
+PORT="54321"
 
 while getopts h:p: TIMED 2>/dev/null; do
     case $TIMED in


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The CLI and Go binary use different tech stacks, and hence, different debuggers. Previously, I set up a debug "pipeline" wherein the CLI Node process would kick off a remote Go debugger via shell script. This needs re-configuring as part of the merge of `shopify-cli-extensions` into `cli`.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Separating out launch configurations for the CLI and Go binaries. This is necessary because a given VS Code instance can only launch one debug config at a time. To debug the entire flow, a CLI config is necessary. The CLI then kicks a Go debugger and then transfers control to the Go binary. A second VS Code instance is then used to attach to the remote debugger. Note that, while this is technically a remote debug scenario, it is all performed on localhost.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

1. Open two VS Code instances: One from the root of the `cli` project and another from the `packages/ui-extensions-go-cli` directory.
2. In the latter instance, set a breakpoint on the first line of `func main()` in `packages/ui-extensions-go-cli/main.go`.
3. Optional: Control is transferred from the CLI to the Go binary in `packages/app/src/cli/utilities/extensions/cli.ts` on the line that invokes the `init-debug-session` shell script. Set a breakpoint here in the `cli` VS Code instance if you would like to inspect the CLI state before transferring control to the Go binary.
4. Using an existing app, launch one of the CLI debug launch configs: `shopify app build`, `shopify app dev`, or `shopify app scaffold extension`, responding to the prompts. If you set a breakpoint in the previous step, wait until the breakpoint is hit and then continue execution when you're satisfied. Note: The next step will not work if you did not set a breakpoint in the Go binary or if debugging is paused in the CLI.
5. From the second (Go binary) VS Code instance, launch the "Debug Go Binary" config. You will see two prompts, but assuming you did not change how the Go binary is launched in `cli.ts` or the `init-debug-session` shell script, you should use the pre-populated default values.
6. Observe the Go binary breakpoint pausing execution in `main.go`.


