### PR TITLE
Downgrade pnpm version used in the dev.yml

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -15,7 +15,7 @@ up:
     - jq
     - delve
     - pnpm:
-        version: 7.9.4
+        version: 7.9.3
 
 env:
   SHOPIFY_ENV: development


### PR DESCRIPTION
### WHY are these changes introduced?
A Homebrew formula for installing pnpm 7.9.4 is not yet available and it causes `dev up` to fail.

### WHAT is this pull request doing?
I'm reverting the version to `7.9.3`. As soon as the formula is available we can revert this change.
