### PR TITLE
Grouping extension types in scaffold select type prompt

### DIFF
--- a/.changeset/nine-candles-think.md
+++ b/.changeset/nine-candles-think.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': minor
+'@shopify/cli-kit': minor
+---
+
+Grouping extension types in scaffold select type prompt

--- a/packages/app/src/cli/commands/app/scaffold/extension.test.ts
+++ b/packages/app/src/cli/commands/app/scaffold/extension.test.ts
@@ -23,21 +23,21 @@ describe('after extension command finishes correctly', () => {
   it('displays a confirmation message with only the human-facing name', async () => {
     // Given
     const outputInfo = mockSuccessfulCommandExecution({
-      humanKey: 'checkout UI',
+      humanKey: 'Checkout UI',
     })
 
     // When
     await AppScaffoldExtension.run()
 
     // Then
-    expect(outputInfo.completed()).toMatchInlineSnapshot('"Your checkout UI extension was added to your project!"')
+    expect(outputInfo.completed()).toMatchInlineSnapshot('"Your Checkout UI extension was added to your project!"')
     expect(outputInfo.info()).toMatchInlineSnapshot('"\n  To find your extension, remember to cd extensions/name\n"')
   })
 
   it('displays a confirmation message with human-facing name and help url', async () => {
     // Given
     const outputInfo = mockSuccessfulCommandExecution({
-      humanKey: 'checkout UI',
+      humanKey: 'Checkout UI',
       helpURL: 'http://help.com',
     })
 
@@ -46,7 +46,7 @@ describe('after extension command finishes correctly', () => {
 
     // Then
 
-    expect(outputInfo.completed()).toMatchInlineSnapshot('"Your checkout UI extension was added to your project!"')
+    expect(outputInfo.completed()).toMatchInlineSnapshot('"Your Checkout UI extension was added to your project!"')
     expect(outputInfo.info()).toMatchInlineSnapshot(
       `"\n  To find your extension, remember to cd extensions/name\n  For more details, see the docs (​http://help.com​) ✨\n"`,
     )
@@ -55,7 +55,7 @@ describe('after extension command finishes correctly', () => {
   it('displays a confirmation message with human-facing name and additional help', async () => {
     // Given
     const outputInfo = mockSuccessfulCommandExecution({
-      humanKey: 'checkout UI',
+      humanKey: 'Checkout UI',
       additionalHelp: 'Additional help',
     })
 
@@ -63,7 +63,7 @@ describe('after extension command finishes correctly', () => {
     await AppScaffoldExtension.run()
 
     // Then
-    expect(outputInfo.completed()).toMatchInlineSnapshot('"Your checkout UI extension was added to your project!"')
+    expect(outputInfo.completed()).toMatchInlineSnapshot('"Your Checkout UI extension was added to your project!"')
     expect(outputInfo.info()).toMatchInlineSnapshot(
       `"\n  To find your extension, remember to cd extensions/name\n  Additional help\n"`,
     )
@@ -72,7 +72,7 @@ describe('after extension command finishes correctly', () => {
   it('displays a confirmation message with human-facing name , help url and additional help', async () => {
     // Given
     const outputInfo = mockSuccessfulCommandExecution({
-      humanKey: 'checkout UI',
+      humanKey: 'Checkout UI',
       helpURL: 'http://help.com',
       additionalHelp: 'Additional help',
     })
@@ -81,7 +81,7 @@ describe('after extension command finishes correctly', () => {
     await AppScaffoldExtension.run()
 
     // Then
-    expect(outputInfo.completed()).toMatchInlineSnapshot('"Your checkout UI extension was added to your project!"')
+    expect(outputInfo.completed()).toMatchInlineSnapshot('"Your Checkout UI extension was added to your project!"')
     expect(outputInfo.info()).toMatchInlineSnapshot(
       `"\n  To find your extension, remember to cd extensions/name\n  Additional help\n  For more details, see the docs (​http://help.com​) ✨\n"`,
     )

--- a/packages/app/src/cli/constants.test.ts
+++ b/packages/app/src/cli/constants.test.ts
@@ -11,7 +11,7 @@ describe('get extension type output configuration', () => {
 
     // Then
     expect(extensionOutputConfig).toEqual({
-      humanKey: 'web pixel',
+      humanKey: 'Web pixel',
     })
   })
 
@@ -38,7 +38,7 @@ describe('get extension type output configuration', () => {
 
     // Then
     expect(extensionOutputConfig).toEqual({
-      humanKey: 'theme app extension',
+      humanKey: 'Theme app extension',
     })
   })
 
@@ -51,7 +51,7 @@ describe('get extension type output configuration', () => {
 
     // Then
     expect(extensionOutputConfig).toEqual({
-      humanKey: 'checkout UI',
+      humanKey: 'Checkout UI',
     })
   })
 
@@ -64,7 +64,7 @@ describe('get extension type output configuration', () => {
 
     // Then
     expect(extensionOutputConfig).toEqual({
-      humanKey: 'subscription UI',
+      humanKey: 'Subscription UI',
     })
   })
 
@@ -77,7 +77,7 @@ describe('get extension type output configuration', () => {
 
     // Then
     expect(extensionOutputConfig).toEqual({
-      humanKey: 'product discount',
+      humanKey: 'Function - Product discount',
       helpURL: 'https://shopify.dev/apps/subscriptions/discounts',
     })
   })
@@ -91,7 +91,7 @@ describe('get extension type output configuration', () => {
 
     // Then
     expect(extensionOutputConfig).toEqual({
-      humanKey: 'order discount',
+      humanKey: 'Function - Order discount',
       helpURL: 'https://shopify.dev/apps/subscriptions/discounts',
     })
   })
@@ -105,7 +105,7 @@ describe('get extension type output configuration', () => {
 
     // Then
     expect(extensionOutputConfig).toEqual({
-      humanKey: 'shipping discount',
+      humanKey: 'Function - Shipping discount',
       helpURL: 'https://shopify.dev/apps/subscriptions/discounts',
     })
   })

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -187,18 +187,29 @@ export const externalExtensionTypes = {
 
 export type ExternalExtensionTypes = typeof externalExtensionTypes.types[number]
 
+// The order of the groups in extensionTypesGroups will be the same displayed in the select prompt
+export const extensionTypesGroups: {name: string; extensions: ExtensionTypes[]}[] = [
+  {name: 'Online store', extensions: ['theme']},
+  {
+    name: 'Discounts and checkout',
+    extensions: ['product_discounts', 'order_discounts', 'shipping_discounts', 'checkout_ui_extension'],
+  },
+  {name: 'Analytics', extensions: ['web_pixel_extension']},
+  {name: 'Merchant admin', extensions: ['product_subscription']},
+]
+
 export const externalExtensionTypeNames = {
   types: [
-    'web pixel',
+    'Web pixel',
     'post-purchase UI',
-    'theme app extension',
-    'checkout UI',
+    'Theme app extension',
+    'Checkout UI',
     'POS UI',
     'customer accounts UI',
-    'subscription UI',
-    'product discount',
-    'order discount',
-    'shipping discount',
+    'Subscription UI',
+    'Function - Product discount',
+    'Function - Order discount',
+    'Function - Shipping discount',
     'payment customization',
     'delivery option presenter',
     'customer accounts UI',
@@ -215,25 +226,31 @@ export interface ExtensionOutputConfig {
 export function getExtensionOutputConfig(extensionType: ExtensionTypes): ExtensionOutputConfig {
   switch (extensionType) {
     case 'web_pixel_extension':
-      return buildExtensionOutputConfig('web pixel')
+      return buildExtensionOutputConfig('Web pixel')
     case 'checkout_post_purchase':
       return buildExtensionOutputConfig('post-purchase UI', 'https://shopify.dev/apps/checkout/post-purchase')
     case 'theme':
-      return buildExtensionOutputConfig('theme app extension')
+      return buildExtensionOutputConfig('Theme app extension')
     case 'checkout_ui_extension':
-      return buildExtensionOutputConfig('checkout UI')
+      return buildExtensionOutputConfig('Checkout UI')
     case 'customer_accounts_ui_extension':
       return buildExtensionOutputConfig('customer accounts UI')
     case 'product_subscription':
-      return buildExtensionOutputConfig('subscription UI')
+      return buildExtensionOutputConfig('Subscription UI')
     case 'pos_ui_extension':
       return buildExtensionOutputConfig('POS UI')
     case 'product_discounts':
-      return buildExtensionOutputConfig('product discount', 'https://shopify.dev/apps/subscriptions/discounts')
+      return buildExtensionOutputConfig(
+        'Function - Product discount',
+        'https://shopify.dev/apps/subscriptions/discounts',
+      )
     case 'order_discounts':
-      return buildExtensionOutputConfig('order discount', 'https://shopify.dev/apps/subscriptions/discounts')
+      return buildExtensionOutputConfig('Function - Order discount', 'https://shopify.dev/apps/subscriptions/discounts')
     case 'shipping_discounts':
-      return buildExtensionOutputConfig('shipping discount', 'https://shopify.dev/apps/subscriptions/discounts')
+      return buildExtensionOutputConfig(
+        'Function - Shipping discount',
+        'https://shopify.dev/apps/subscriptions/discounts',
+      )
     case 'payment_customization':
       return buildExtensionOutputConfig('payment customization')
     case 'shipping_rate_presenter':

--- a/packages/app/src/cli/prompts/scaffold/extension.test.ts
+++ b/packages/app/src/cli/prompts/scaffold/extension.test.ts
@@ -1,5 +1,5 @@
-import scaffoldExtensionPrompt, {extensionTypeChoiceSorterByGroupAndName, extensionFlavorQuestion} from './extension.js'
-import {extensions, getExtensionOutputConfig} from '../../constants.js'
+import scaffoldExtensionPrompt, {extensionFlavorQuestion} from './extension.js'
+import {extensions, extensionTypesGroups, getExtensionOutputConfig} from '../../constants.js'
 import {describe, it, expect, vi, beforeEach} from 'vitest'
 import {environment} from '@shopify/cli-kit'
 
@@ -82,7 +82,7 @@ describe('extension prompt', async () => {
         type: 'select',
         name: 'extensionType',
         message: 'Type of extension?',
-        choices: (await buildChoices()).filter((choice) => choice.name !== 'theme app extension'),
+        choices: (await buildChoices()).filter((choice) => choice.name !== 'Theme app extension'),
       },
     ])
     expect(got).toEqual({...options, ...answers})
@@ -162,10 +162,25 @@ const buildChoices = async (): Promise<
     value: string
   }[]
 > => {
-  return extensions.types
-    .map((type) => ({
+  return extensions.types.map((type) => {
+    const choiceWithoutGroup = {
       name: getExtensionOutputConfig(type).humanKey,
       value: type,
-    }))
-    .sort(extensionTypeChoiceSorterByGroupAndName)
+    }
+    const group = extensionTypesGroups.find((group) => includes(group.extensions, type))
+    if (group) {
+      return {
+        ...choiceWithoutGroup,
+        group: {
+          name: group.name,
+          order: extensionTypesGroups.indexOf(group),
+        },
+      }
+    }
+    return choiceWithoutGroup
+  })
+}
+
+function includes<TNarrow extends TWide, TWide>(coll: ReadonlyArray<TNarrow>, el: TWide): el is TNarrow {
+  return coll.includes(el as TNarrow)
 }

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -46,7 +46,7 @@ export interface ThemeExtensionBuildOptions extends ExtensionBuildOptions {
  */
 export async function buildThemeExtensions(options: ThemeExtensionBuildOptions): Promise<void> {
   if (options.extensions.length === 0) return
-  options.stdout.write(`Running theme check on your theme app extension...`)
+  options.stdout.write(`Running theme check on your Theme app extension...`)
   const themeDirectories = options.extensions.map((extension) => extension.directory)
   await execThemeCheckCLI({
     directories: themeDirectories,

--- a/packages/cli-kit/src/ui.ts
+++ b/packages/cli-kit/src/ui.ts
@@ -45,7 +45,7 @@ export interface Question<TName extends string = string> {
   default?: string
   result?: (value: string) => string | boolean
   type: 'input' | 'select' | 'autocomplete' | 'password'
-  choices?: {name: string; value: string}[]
+  choices?: {name: string; value: string; group?: {name: string; order: number}}[]
 }
 
 const started = (content: Message, logger: Logger) => {

--- a/packages/cli-kit/src/ui/executor.test.ts
+++ b/packages/cli-kit/src/ui/executor.test.ts
@@ -1,0 +1,81 @@
+import {groupAndMapChoices} from './executor.js'
+import {it, describe, expect} from 'vitest'
+
+describe('groupAndMapChoices', () => {
+  it('return choices ordered by name and without separator when group information is absent', async () => {
+    const choice1 = {
+      name: 'choice2',
+      value: 'value2',
+    }
+    const choice2 = {
+      name: 'choice1',
+      value: 'value1',
+    }
+
+    const result = groupAndMapChoices([choice1, choice2])
+    expect(result).toHaveLength(2)
+    expect((result[0] as {name: string; value: string}).name).toEqual('choice1')
+    expect((result[1] as {name: string; value: string}).name).toEqual('choice2')
+  })
+
+  it('return choices ordered by name and with separator when at least one of them has group information', async () => {
+    const choice1 = {
+      name: 'choice2',
+      value: 'value2',
+      group: {
+        name: 'group1',
+        order: 0,
+      },
+    }
+    const choice2 = {
+      name: 'choice1',
+      value: 'value1',
+    }
+
+    const result = groupAndMapChoices([choice1, choice2])
+    expect(result).toHaveLength(6)
+    expect((result[0] as {type: 'separator'; line: string}).line).toEqual('')
+    expect((result[1] as {type: 'separator'; line: string}).line).toEqual('group1')
+    expect((result[2] as {name: string; value: string}).name).toEqual('choice2')
+    expect((result[3] as {type: 'separator'; line: string}).line).toEqual('')
+    expect((result[4] as {type: 'separator'; line: string}).line).toEqual('Other')
+    expect((result[5] as {name: string; value: string}).name).toEqual('choice1')
+  })
+
+  it('return groups and choices ordered by name and wicth separator when all of them has group information', async () => {
+    const choice1 = {
+      name: 'name2',
+      value: 'value2',
+      group: {
+        name: 'group2',
+        order: 1,
+      },
+    }
+    const choice2 = {
+      name: 'name3',
+      value: 'value3',
+      group: {
+        name: 'group1',
+        order: 0,
+      },
+    }
+    const choice3 = {
+      name: 'name1',
+      value: 'value1',
+      group: {
+        name: 'group1',
+        order: 0,
+      },
+    }
+
+    const result = groupAndMapChoices([choice1, choice2, choice3])
+    expect(result).toHaveLength(7)
+    expect((result[0] as {type: 'separator'; line: string}).line).toEqual('')
+    expect((result[1] as {type: 'separator'; line: string}).line).toEqual('group1')
+    expect((result[2] as {name: string; value: string}).name).toEqual('name1')
+    expect((result[3] as {name: string; value: string}).name).toEqual('name3')
+    expect((result[4] as {type: 'separator'; line: string}).line).toEqual('')
+    expect((result[5] as {type: 'separator'; line: string}).line).toEqual('group2')
+    expect((result[6] as {name: string; value: string}).name).toEqual('name2')
+  })
+})

--- a/packages/cli-kit/src/ui/inquirer/autocomplete.ts
+++ b/packages/cli-kit/src/ui/inquirer/autocomplete.ts
@@ -2,6 +2,8 @@ import {colors} from '../../node/colors.js'
 import AutocompletePrompt from 'inquirer-autocomplete-prompt'
 import DistinctChoice from 'inquirer/lib/objects/choices'
 import inquirer from 'inquirer'
+// eslint-disable-next-line import/extensions
+import Paginator from 'inquirer/lib/utils/paginator.js'
 import {Interface} from 'readline'
 
 export class CustomAutocomplete extends AutocompletePrompt {
@@ -10,6 +12,9 @@ export class CustomAutocomplete extends AutocompletePrompt {
   constructor(questions: inquirer.Question<inquirer.Answers>, rl: Interface, answers: inquirer.Answers) {
     super(questions, rl, answers)
     this.isAutocomplete = true
+    this.paginator = new Paginator(this.screen, {
+      isInfinite: false,
+    })
   }
 
   protected render(error?: string) {
@@ -45,7 +50,7 @@ export class CustomAutocomplete extends AutocompletePrompt {
         realIndexPosition += name ? name.split('\n').length : 0
         return true
       })
-      bottomContent += this.paginator.paginate(choicesStr, realIndexPosition, 10)
+      bottomContent += this.paginator.paginate(choicesStr, realIndexPosition, this.isAutocomplete ? 10 : 500)
     } else {
       content += this.rl.line
       bottomContent += `  ${colors.magenta('No matching choices')}`
@@ -77,7 +82,11 @@ function listRender(choices: DistinctChoice, pointer: number, searchToken?: stri
   choices.forEach((choice, i: number) => {
     if (choice.type === 'separator') {
       separatorOffset++
-      output += `  ${choice}\n`
+      if (choice.line.includes('──────────────')) {
+        output += `\n`
+      } else {
+        output += `  ${colors.dim.underline(choice)}\n`
+      }
       return
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/shopify-cli-planning/issues/323

![image](https://user-images.githubusercontent.com/105213827/186362185-a93670e8-8b6d-408e-b24d-965d64cbe942.png)

### WHAT is this pull request doing?
- Added public extensions group information. The order used to define the groups is used to the order the extension group types are displayed in the prompt
- Add optional `group` attribute to CLI `Question->choice` model.
- Map new choice group information to `inquirer separator` component so the extension types are showed with the group name as the separator
- Reimplement the default `inquirer separator` component style

### How to test your changes?
- Run the command `yarn shopify app scaffold extension`
