### PR TITLE
Fix go build in Linux

### DIFF
--- a/packages/ui-extensions-go-cli/bin/build.js
+++ b/packages/ui-extensions-go-cli/bin/build.js
@@ -14,7 +14,7 @@ let fileExtension = ""
 if (process.env.GOOS === "windows" || platform() === "win32") {
   fileExtension = ".exe"
 } else {
-  await execa("go", ["build","-gcflags='all=-N -l'" ,"-o", "shopify-extensions-debug"], {cwd: rootDirectory, stdio: 'inherit'}).catch((_) => {
+  await execa("go", ["build","-gcflags=all=-N -l" ,"-o", "shopify-extensions-debug"], {cwd: rootDirectory, stdio: 'inherit'}).catch((_) => {
     process.exit(1)
   })
 


### PR DESCRIPTION
### WHY are these changes introduced?

The extensions build is failing in Linux because single quotes are not allowed for `go build` flags.

```
✖ nx run ui-extensions-go-cli:build
$ node bin/build.js
      invalid value "'all=-N -l'" for flag -gcflags: parameter may not start with quote character '
      usage: go build [-o output] [build flags] [packages]
      Run 'go help build' for details.
```

### WHAT is this pull request doing?

Just remove the quotes, which are not needed.

### How to test your changes?

`yarn build` on Linux/Mac/Windows.
