### PR TITLE
Make Nx the interface to interact with the repository projects

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,6 +8,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: './tsconfig.json',
+    EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
     extraFileExtensions: ['.cjs'],
   },
   plugins: ['no-catch-all', 'jest', '@nrwl/nx', 'unused-imports', 'rulesdir'],

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -131,6 +131,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         node: ["18.7.0"]
+        target: ['build', 'tsc', 'lint']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -168,12 +169,8 @@ jobs:
         run: yarn config set network-timeout 300000
       - name: Install dependencies
         run: yarn install --ignore-engines
-      - name: Build
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build
-      - name: Type-check
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=tsc
-      - name: Lint
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint
+      - name: ${{ matrix.target }}
+        run: yarn nx ${{ github.event.inputs.nxLevel || '--all --skip-nx-cache' }} --target=${{ matrix.target }}
 
   pr-platform-dependent:
     name: Testing with Node ${{ matrix.node }} in ${{ matrix.os }}
@@ -224,7 +221,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Unit tests
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features
+        run: yarn nx ${{ github.event.inputs.nxLevel || '--all --skip-nx-cache' }} --target=test --exclude=features
       - name: Acceptance tests
         if: ${{ matrix.node == '18.7.0' }}
         run: yarn nx run features:test

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -144,13 +144,6 @@ jobs:
           git config --global user.name "Development Lifecycle"
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v2
-      - name: Set Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-          bundler-cache: true
-      - name: Install Bundler
-        run: gem install bundler -v ${{ env.BUNDLER_VERSION }}
       - name: Setup build toolchain
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: ${{ matrix.target }}
-        run: yarn nx ${{ github.event.inputs.nxLevel || '--all --skip-nx-cache' }} --target=${{ matrix.target }}
+        run: yarn nx ${{ github.event.inputs.nxLevel || 'run-many --all --skip-nx-cache' }} --target=${{ matrix.target }}
 
   pr-platform-dependent:
     name: Testing with Node ${{ matrix.node }} in ${{ matrix.os }}
@@ -221,7 +221,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Unit tests
-        run: yarn nx ${{ github.event.inputs.nxLevel || '--all --skip-nx-cache' }} --target=test --exclude=features
+        run: yarn nx ${{ github.event.inputs.nxLevel || 'run-many --all --skip-nx-cache' }} --target=test --exclude=features
       - name: Acceptance tests
         if: ${{ matrix.node == '18.7.0' }}
         run: yarn nx run features:test

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -123,7 +123,7 @@ jobs:
         run: yarn nx run features:test
 
   pr-platform-agnostic:
-    name: Building, linting, and type-checking with Node ${{ matrix.node }} in ${{ matrix.os }}
+    name: ${{ matrix.target }} with Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name == 'pull_request' }}
     timeout-minutes: 30

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -114,7 +114,7 @@ jobs:
         run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
       - name: Type-check
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=tsc
+        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=type-check
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
       - name: Unit tests
         run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features
@@ -131,7 +131,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         node: ["18.7.0"]
-        target: ['build', 'tsc', 'lint']
+        target: ['build', 'type-check', 'lint']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.nxignore
+++ b/.nxignore
@@ -1,10 +1,2 @@
 **/templates/**
 docs/**
-**/dist/**
-.build/
-packages/features/steps/**
-packages/features/lib/**
-packages/features/features/**
-packages/features/world/**
-packages/cli-hydrogen/src/cli/commands/hydrogen/init.ts
-packages/cli-kit/src/constants.ts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "javascript.validate.enable": false,
   "css.validate": false,
   "scss.validate": false,
-  "typescript.tsdk": "./node_modules/typescript/lib",
+  "typescript.tsdk": "node_modules/typescript/lib",
   "files.exclude": {
     ".dev": true,
     ".history/**": true,

--- a/configurations/tsconfig.json
+++ b/configurations/tsconfig.json
@@ -24,7 +24,7 @@
         "@shopify/cli-kit/common/*": ["../packages/cli-kit/src/common/*.ts"],
         "@shopify/cli-kit/typing/*": ["../packages/cli-kit/src/typing/*.ts"],
         "@shopify/cli-kit/plugins/*": ["../packages/cli-kit/src/plugins/*.ts"],
-      }
+      },
     },
     "exclude": ["**/dist/**"]
 }

--- a/dev.yml
+++ b/dev.yml
@@ -55,9 +55,9 @@ commands:
   lint:fix:
     desc: 'Fix the lint issues in the project'
     run: yarn run lint:fix:affected
-  tsc:
+  type-check:
     desc: 'Type-check the project'
-    run: yarn run tsc:affected
+    run: yarn run type-check:affected
   fixture:
     desc: 'Commands to interact with the fixture project'
     subcommands:

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,10 +18,11 @@ our biggest decisions.
 * [FAQ](./faq.md)
 
 ## Decision Record
-* [January 2022 - TypeScript rewrite](./decision-record/2022_01-TypeScript-rewrite.md)
-* [January 2022 - Unified dependency graph](./decision-record/2022_01-unified-dependency-graph.md)
-* [February 2022 - ESM, Rollup, and Vitest](./decision-record/2022_02-ESM,-Rollup,-and-Vitest.md)
-* [February 2022 - Incremental builds with Nx](./decision-record/2022_02-Incremental-builds-with-Nx.md)
-* [March 2022 - Configuration source of truth](./decision-record/2022_03-Configuration-source-of-truth.md)
-* [March 2022 - Lazy downloading a fixed version of the extension binary](./decision-record/2022_03-Lazy-downloading-a-fixed-version-of-the-extension-binary.md)
+* [August 2022 - Automating via Nx](./decision-record/2022_08-automation-via-nx.md)
 * [May 2022 - IDs' persistence](./decision-record/2022_05-IDs'-persistence.md)
+* [March 2022 - Lazy downloading a fixed version of the extension binary](./decision-record/2022_03-Lazy-downloading-a-fixed-version-of-the-extension-binary.md)
+* [March 2022 - Configuration source of truth](./decision-record/2022_03-Configuration-source-of-truth.md)
+* [February 2022 - Incremental builds with Nx](./decision-record/2022_02-Incremental-builds-with-Nx.md)
+* [February 2022 - ESM, Rollup, and Vitest](./decision-record/2022_02-ESM,-Rollup,-and-Vitest.md)
+* [January 2022 - Unified dependency graph](./decision-record/2022_01-unified-dependency-graph.md)
+* [January 2022 - TypeScript rewrite](./decision-record/2022_01-TypeScript-rewrite.md)

--- a/docs/decision-record/2022_08-automation-via-nx.md
+++ b/docs/decision-record/2022_08-automation-via-nx.md
@@ -11,4 +11,4 @@
 }
 ```
 
-This implicitness is undesirable for Nx because some of its capabilities rely on the graph information being very explicit. Because of it, we decided to move away from Nx's default mode to codify actions explicitly in projects' `project.json` files. Developers will run tasks using `yarn nx` as opposed to `yarn run` and Nx will ensure dependent tasks are executed in the right order and only if needed based on the file changes.
+This implicitness is undesirable for Nx because some of its capabilities rely on the graph information being very explicit. Because of it, we decided to move away from Nx's default mode to codify actions explicitly in projects' `project.json` files.

--- a/docs/decision-record/2022_08-automation-via-nx.md
+++ b/docs/decision-record/2022_08-automation-via-nx.md
@@ -1,0 +1,14 @@
+# Automating via Nx
+
+[Nx](https://nx.dev/) is a Node-based build tool. We've been using it since the inception of the repository to have incremental builds locally and selective builds on CI. Nx's default behavior infers the dependency graph and build tasks from the projects' `package.json` files. This is how we've been using it, but we started diverging from this model when we [merged the UI extensions' projects](https://github.com/Shopify/cli/pull/237), some of which are not NPM packages but Go projects. This effort made us realize how scripts in `package.json`'s declared build task dependencies implicitly in `scripts`. The example below shows how the `build` script depends on `clean` being executed first:
+
+```json
+{
+  "scripts": {
+    "build": "yarn clean && tsc",
+    "clean": "rm -rf dist/"
+  }
+}
+```
+
+This implicitness is undesirable for Nx because some of its capabilities rely on the graph information being very explicit. Because of it, we decided to move away from Nx's default mode to codify actions explicitly in projects' `project.json` files. Developers will run tasks using `yarn nx` as opposed to `yarn run` and Nx will ensure dependent tasks are executed in the right order and only if needed based on the file changes.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -49,7 +49,7 @@ Besides the scripts for building and running the CLIs, there are others that mig
 - `yarn test`: Runs the tests of all the packages.
 - `yarn lint`: Runs ESLint and Prettier checks for all the packages.
 - `yarn lint:fix`: Runs ESLint and Prettier checks for all the packages and fixes the fixable issues.
-- `yarn tsc`: Type-checks all the packagesusing the Typescript `tsc` tool.
+- `yarn type-check`: Type-checks all the packagesusing the Typescript `tsc` tool.
 - `yarn clean`: Removes the `dist` directory from all the packages.
 
 All the packages in the repository contain the above scripts so they can be executed too for an individual package.

--- a/nx.json
+++ b/nx.json
@@ -28,7 +28,7 @@
       "dependsOn": ["build"]
     },
     "tsc": {
-      "dependsOn": ["^tsc"]
+      "dependsOn": ["^build"]
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -6,15 +6,29 @@
       "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
         "cacheableOperations": [
-          "build",
-          "test",
-          "lint",
-          "tsc"
+          "build"
         ]
       }
     }
   },
   "affected": {
     "defaultBase": "main"
+  },
+  "targetDefaults": {
+    "clean": {
+      "dependsOn": ["^clean"]
+    },
+    "build": {
+      "dependsOn": ["clean", "^build"]
+    },
+    "lint": {
+      "dependsOn": ["build"]
+    },
+    "lint:fix": {
+      "dependsOn": ["build"]
+    },
+    "tsc": {
+      "dependsOn": ["^tsc"]
+    }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -19,7 +19,7 @@
       "dependsOn": ["^clean"]
     },
     "build": {
-      "dependsOn": ["clean", "^build"]
+      "dependsOn": ["^build"]
     },
     "lint": {
       "dependsOn": ["build"]

--- a/nx.json
+++ b/nx.json
@@ -26,7 +26,7 @@
     "lint:fix": {
       "dependsOn": ["build"]
     },
-    "tsc": {
+    "type-check": {
       "dependsOn": ["^build"]
     }
   }

--- a/nx.json
+++ b/nx.json
@@ -21,7 +21,6 @@
       "dependsOn": ["^build"]
     },
     "lint": {
-      "dependsOn": ["build"]
     },
     "lint:fix": {
       "dependsOn": ["build"]

--- a/nx.json
+++ b/nx.json
@@ -6,7 +6,6 @@
       "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
         "cacheableOperations": [
-          "build"
         ]
       }
     }

--- a/nx.json
+++ b/nx.json
@@ -6,7 +6,9 @@
       "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
         "cacheableOperations": [
-        ]
+          "build"
+        ],
+        "runtimeCacheInputs": ["node -v", "yarn tsc --version", "go version"]
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "lint:fix:affected": "nx affected --target=lint:fix --all",
     "test": "nx run-many --target=test --all --skip-nx-cache",
     "test:affected": "nx affected --target=test --all",
-    "tsc": "nx run-many --target=tsc --all --skip-nx-cache",
-    "tsc:affected": "nx affected --target=tsc --all",
+    "type-check": "nx run-many --target=type-check --all --skip-nx-cache",
+    "type-check:affected": "nx affected --target=type-check --all",
     "build": "nx run-many --target=build --all --skip-nx-cache",
     "build:affected": "nx affected --target=build --all",
     "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "graphql-tag": "^2.12.4",
     "liquidjs": "^9.36.0",
     "node-fetch": "^3.2.4",
-    "nx": "^14.0.5",
+    "nx": "^14.5.10",
     "octokit-plugin-create-pull-request": "^3.12.2",
     "patch-package": "^6.4.7",
     "pathe": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nrwl/eslint-plugin-nx": "^14.0.5",
     "@nrwl/js": "^14.0.5",
     "@nrwl/tao": "^14.0.1",
-    "@nrwl/workspace": "^14.0.1",
+    "@nrwl/workspace": "^14.5.10",
     "@octokit/core": "^4.0.5",
     "@octokit/rest": "^19.0.4",
     "@shopify/admin-ui-extensions": "1.0.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,15 +16,13 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "clean": "rimraf dist/",
-    "build": "tsc -b ./tsconfig.build.json",
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
-    "test": "yarn --cwd ../.. nx run app:test",
-    "test:nx": "vitest run",
-    "test:watch": "vitest watch",
-    "tsc": "tsc --noEmit"
+    "build": "yarn nx build",
+    "clean": "yarn nx clean",
+    "lint": "yarn nx lint",
+    "lint:fix": "yarn nx lint:fix",
+    "test": "yarn nx test",
+    "tsc": "yarn nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,12 +17,12 @@
   },
   "scripts": {
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
-    "build": "yarn nx build",
-    "clean": "yarn nx clean",
-    "lint": "yarn nx lint",
-    "lint:fix": "yarn nx lint:fix",
-    "test": "yarn nx test",
-    "tsc": "yarn nx tsc"
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "test": "nx test",
+    "tsc": "nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,7 +22,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
-    "tsc": "nx tsc"
+    "type-check": "nx type-check"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,6 +22,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
+    "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "clean": "rimraf dist/",
     "build": "tsc -b ./tsconfig.build.json",
-    "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md",
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint 'src/**/*.ts' --fix",
     "test": "yarn --cwd ../.. nx run app:test",

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -9,28 +9,28 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/",
+          "command": "yarn rimraf dist/",
           "cwd": "packages/app"
         }
       },
       "build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/app"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/app"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "command": "yarn eslint 'src/**/*.ts' --fix",
           "cwd": "packages/app"
         }
       },
@@ -38,14 +38,14 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "node_modules/.bin/vitest run",
+          "command": "yarn vitest run",
           "cwd": "packages/app"
         }
       },
       "tsc": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc --noEmit",
+          "command": "yarn tsc --noEmit",
           "cwd": "packages/app"
         }
       }

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -6,11 +6,48 @@
     "implicitDependencies": ["ui-extensions-go-cli"],
     "tags": ["scope:feature"],
     "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run rimraf dist/",
+          "cwd": "packages/app"
+        }
+      },
+      "build": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["clean"],
+        "options": {
+          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "cwd": "packages/app"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint \"src/**/*.ts\"",
+          "cwd": "packages/app"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "cwd": "packages/app"
+        }
+      },
       "test": {
-        "executor": "nx:run-script",
+        "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "script": "test:nx"
+          "command": "./node_modules/.bin/vitest run",
+          "cwd": "packages/app"
+        }
+      },
+      "tsc": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/tsc --noEmit",
+          "cwd": "packages/app"
         }
       }
     }

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -42,7 +42,7 @@
           "cwd": "packages/app"
         }
       },
-      "tsc": {
+      "type-check": {
         "executor": "nx:run-commands",
         "options": {
           "command": "yarn tsc --noEmit",

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -39,7 +39,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "./node_modules/.bin/vitest run",
+          "command": "node_modules/.bin/vitest run",
           "cwd": "packages/app"
         }
       },

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -42,6 +42,14 @@
           "cwd": "packages/app"
         }
       },
+      "test:watch": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "yarn vitest watch",
+          "cwd": "packages/app"
+        }
+      },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -9,13 +9,12 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run rimraf dist/",
+          "command": "../../node_modules/.bin/rimraf dist/",
           "cwd": "packages/app"
         }
       },
       "build": {
         "executor": "nx:run-commands",
-        "dependsOn": ["clean"],
         "options": {
           "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
           "cwd": "packages/app"
@@ -24,14 +23,14 @@
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint \"src/**/*.ts\"",
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
           "cwd": "packages/app"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
           "cwd": "packages/app"
         }
       },

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -15,6 +15,8 @@
       },
       "build": {
         "executor": "nx:run-commands",
+        "outputs": ["dist"],
+        "inputs": ["{projectRoot}/src"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/app"

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -22,7 +22,13 @@
     }
   },
   "scripts": {
-    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
+    "build": "yarn nx build",
+    "clean": "yarn nx clean",
+    "lint": "yarn nx lint",
+    "lint:fix": "yarn nx lint:fix",
+    "test": "yarn nx test",
+    "tsc": "yarn nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -23,12 +23,12 @@
   },
   "scripts": {
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
-    "build": "yarn nx build",
-    "clean": "yarn nx clean",
-    "lint": "yarn nx lint",
-    "lint:fix": "yarn nx lint:fix",
-    "test": "yarn nx test",
-    "tsc": "yarn nx tsc"
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "test": "nx test",
+    "tsc": "nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -22,7 +22,7 @@
     }
   },
   "scripts": {
-    "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -28,6 +28,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
+    "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -22,14 +22,7 @@
     }
   },
   "scripts": {
-    "clean": "rimraf dist/",
-    "build": "tsc -b ./tsconfig.build.json",
-    "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
-    "tsc": "tsc --noEmit"
+    "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -28,7 +28,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
-    "tsc": "nx tsc"
+    "type-check": "nx type-check"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -37,7 +37,7 @@
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "./node_modules/.bin/vitest run",
+          "command": "node_modules/.bin/vitest run",
           "cwd": "packages/cli-hydrogen"
         }
       },

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -3,5 +3,50 @@
     "sourceRoot": "packages/cli-hydrogen/src",
     "projectType": "library",
     "implicitDependencies": [],
-    "tags": ["scope:feature"]
+    "tags": ["scope:feature"],
+    "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run rimraf dist/",
+          "cwd": "packages/cli-hydrogen"
+        }
+      },
+      "build": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["clean"],
+        "options": {
+          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "cwd": "packages/cli-hydrogen"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint \"src/**/*.ts\"",
+          "cwd": "packages/cli-hydrogen"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "cwd": "packages/cli-hydrogen"
+        }
+      },
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "./node_modules/.bin/vitest run",
+          "cwd": "packages/cli-hydrogen"
+        }
+      },
+      "tsc": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/tsc --noEmit",
+          "cwd": "packages/cli-hydrogen"
+        }
+      }
+    }
 }

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -14,6 +14,8 @@
       },
       "build": {
         "executor": "nx:run-commands",
+        "outputs": ["dist"],
+        "inputs": ["{projectRoot}/src"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-hydrogen"

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -8,13 +8,12 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run rimraf dist/",
+          "command": "../../node_modules/.bin/rimraf dist/",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "build": {
         "executor": "nx:run-commands",
-        "dependsOn": ["clean"],
         "options": {
           "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-hydrogen"
@@ -23,14 +22,14 @@
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint \"src/**/*.ts\"",
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
           "cwd": "packages/cli-hydrogen"
         }
       },

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -8,42 +8,42 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/",
+          "command": "yarn rimraf dist/",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "command": "yarn eslint 'src/**/*.ts' --fix",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "node_modules/.bin/vitest run",
+          "command": "yarn vitest run",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "tsc": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc --noEmit",
+          "command": "yarn tsc --noEmit",
           "cwd": "packages/cli-hydrogen"
         }
       }

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -40,7 +40,7 @@
           "cwd": "packages/cli-hydrogen"
         }
       },
-      "tsc": {
+      "type-check": {
         "executor": "nx:run-commands",
         "options": {
           "command": "yarn tsc --noEmit",

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -40,6 +40,14 @@
           "cwd": "packages/cli-hydrogen"
         }
       },
+      "test:watch": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "yarn vitest watch",
+          "cwd": "packages/cli-hydrogen"
+        }
+      },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -53,6 +53,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
+    "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -47,14 +47,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "clean": "rimraf dist/",
-    "build": "tsc -b ./tsconfig.build.json",
-    "prepack": "cross-env NODE_ENV=production yarn run build",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
-    "tsc": "tsc --noEmit"
+    "prepack": "cross-env NODE_ENV=production yarn nx build"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -48,12 +48,12 @@
   },
   "scripts": {
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
-    "build": "yarn nx build",
-    "clean": "yarn nx clean",
-    "lint": "yarn nx lint",
-    "lint:fix": "yarn nx lint:fix",
-    "test": "yarn nx test",
-    "tsc": "yarn nx tsc"
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "test": "nx test",
+    "tsc": "nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -53,7 +53,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
-    "tsc": "nx tsc"
+    "type-check": "nx type-check"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -47,7 +47,13 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "prepack": "cross-env NODE_ENV=production yarn nx build"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
+    "build": "yarn nx build",
+    "clean": "yarn nx clean",
+    "lint": "yarn nx lint",
+    "lint:fix": "yarn nx lint:fix",
+    "test": "yarn nx test",
+    "tsc": "yarn nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -37,7 +37,7 @@
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "./node_modules/.bin/vitest run",
+          "command": "node_modules/.bin/vitest run",
           "cwd": "packages/cli-kit"
         }
       },

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -8,42 +8,42 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/",
+          "command": "yarn rimraf dist/",
           "cwd": "packages/cli-kit"
         }
       },
       "build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-kit"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/cli-kit"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "command": "yarn eslint 'src/**/*.ts' --fix",
           "cwd": "packages/cli-kit"
         }
       },
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "node_modules/.bin/vitest run",
+          "command": "yarn vitest run",
           "cwd": "packages/cli-kit"
         }
       },
       "tsc": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc --noEmit",
+          "command": "yarn tsc --noEmit",
           "cwd": "packages/cli-kit"
         }
       }

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -3,5 +3,50 @@
     "root": "packages/cli-kit",
     "sourceRoot": "packages/cli-kit/src",
     "projectType": "library",
-    "tags": ["scope:foundation"]
+    "tags": ["scope:foundation"],
+    "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run rimraf dist/",
+          "cwd": "packages/cli-kit"
+        }
+      },
+      "build": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["clean"],
+        "options": {
+          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "cwd": "packages/cli-kit"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint \"src/**/*.ts\"",
+          "cwd": "packages/cli-kit"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "cwd": "packages/cli-kit"
+        }
+      },
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "./node_modules/.bin/vitest run",
+          "cwd": "packages/cli-kit"
+        }
+      },
+      "tsc": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/tsc --noEmit",
+          "cwd": "packages/cli-kit"
+        }
+      }
+    }
 }

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -40,7 +40,7 @@
           "cwd": "packages/cli-kit"
         }
       },
-      "tsc": {
+      "type-check": {
         "executor": "nx:run-commands",
         "options": {
           "command": "yarn tsc --noEmit",

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -8,13 +8,12 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run rimraf dist/",
+          "command": "../../node_modules/.bin/rimraf dist/",
           "cwd": "packages/cli-kit"
         }
       },
       "build": {
         "executor": "nx:run-commands",
-        "dependsOn": ["clean"],
         "options": {
           "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-kit"
@@ -23,14 +22,14 @@
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint \"src/**/*.ts\"",
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
           "cwd": "packages/cli-kit"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
           "cwd": "packages/cli-kit"
         }
       },

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -40,6 +40,14 @@
           "cwd": "packages/cli-kit"
         }
       },
+      "test:watch": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "yarn vitest watch",
+          "cwd": "packages/cli-kit"
+        }
+      },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -14,6 +14,8 @@
       },
       "build": {
         "executor": "nx:run-commands",
+        "outputs": ["dist"],
+        "inputs": ["{projectRoot}/src"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-kit"

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -42,6 +42,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
+    "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -37,12 +37,12 @@
   },
   "scripts": {
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
-    "build": "yarn nx build",
-    "clean": "yarn nx clean",
-    "lint": "yarn nx lint",
-    "lint:fix": "yarn nx lint:fix",
-    "test": "yarn nx test",
-    "tsc": "yarn nx tsc"
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "test": "nx test",
+    "tsc": "nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -36,14 +36,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "clean": "rimraf dist/",
-    "build": "tsc -b ./tsconfig.build.json",
-    "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
-    "tsc": "tsc --noEmit"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -42,7 +42,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
-    "tsc": "nx tsc"
+    "type-check": "nx type-check"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -36,7 +36,13 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
+    "build": "yarn nx build",
+    "clean": "yarn nx clean",
+    "lint": "yarn nx lint",
+    "lint:fix": "yarn nx lint:fix",
+    "test": "yarn nx test",
+    "tsc": "yarn nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -8,7 +8,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run rimraf dist/",
+          "command": "../../node_modules/.bin/rimraf dist/",
           "cwd": "packages/cli-main"
         }
       },
@@ -22,14 +22,14 @@
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint \"src/**/*.ts\"",
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
           "cwd": "packages/cli-main"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
           "cwd": "packages/cli-main"
         }
       },

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -3,5 +3,50 @@
     "sourceRoot": "packages/cli-main/src",
     "projectType": "library",
     "implicitDependencies": ["app", "theme", "cli-hydrogen"],
-    "tags": ["scope:cli"]
+    "tags": ["scope:cli"],
+    "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run rimraf dist/",
+          "cwd": "packages/cli-main"
+        }
+      },
+      "build": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["clean"],
+        "options": {
+          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "cwd": "packages/cli-main"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint \"src/**/*.ts\"",
+          "cwd": "packages/cli-main"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "cwd": "packages/cli-main"
+        }
+      },
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "./node_modules/.bin/vitest run",
+          "cwd": "packages/cli-main"
+        }
+      },
+      "tsc": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/tsc --noEmit",
+          "cwd": "packages/cli-main"
+        }
+      }
+    }
 }

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -14,7 +14,6 @@
       },
       "build": {
         "executor": "nx:run-commands",
-        "dependsOn": ["clean", "^build"],
         "options": {
           "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-main"

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -40,7 +40,7 @@
           "cwd": "packages/cli-main"
         }
       },
-      "tsc": {
+      "type-check": {
         "executor": "nx:run-commands",
         "options": {
           "command": "yarn tsc --noEmit",

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -40,6 +40,14 @@
           "cwd": "packages/cli-main"
         }
       },
+      "test:watch": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "yarn vitest watch",
+          "cwd": "packages/cli-main"
+        }
+      },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -8,42 +8,42 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/",
+          "command": "yarn rimraf dist/",
           "cwd": "packages/cli-main"
         }
       },
       "build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-main"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/cli-main"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "command": "yarn eslint 'src/**/*.ts' --fix",
           "cwd": "packages/cli-main"
         }
       },
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "node_modules/.bin/vitest run",
+          "command": "yarn vitest run",
           "cwd": "packages/cli-main"
         }
       },
       "tsc": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc --noEmit",
+          "command": "yarn tsc --noEmit",
           "cwd": "packages/cli-main"
         }
       }

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -14,6 +14,8 @@
       },
       "build": {
         "executor": "nx:run-commands",
+        "outputs": ["dist"],
+        "inputs": ["{projectRoot}/src"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-main"

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -36,7 +36,7 @@
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "./node_modules/.bin/vitest run",
+          "command": "node_modules/.bin/vitest run",
           "cwd": "packages/cli-main"
         }
       },

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -14,7 +14,7 @@
       },
       "build": {
         "executor": "nx:run-commands",
-        "dependsOn": ["clean"],
+        "dependsOn": ["clean", "^build"],
         "options": {
           "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-main"

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -32,12 +32,12 @@
   },
   "scripts": {
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
-    "build": "yarn nx build",
-    "clean": "yarn nx clean",
-    "lint": "yarn nx lint",
-    "lint:fix": "yarn nx lint:fix",
-    "test": "yarn nx test",
-    "tsc": "yarn nx tsc"
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "test": "nx test",
+    "tsc": "nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -37,7 +37,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
-    "tsc": "nx tsc"
+    "type-check": "nx type-check"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -31,14 +31,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "clean": "rimraf dist/",
-    "build": "tsc -b ./tsconfig.build.json",
-    "prepack": "cross-env NODE_ENV=production yarn run build",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
-    "tsc": "tsc --noEmit"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -31,7 +31,13 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
+    "build": "yarn nx build",
+    "clean": "yarn nx clean",
+    "lint": "yarn nx lint",
+    "lint:fix": "yarn nx lint:fix",
+    "test": "yarn nx test",
+    "tsc": "yarn nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -37,6 +37,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
+    "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -14,6 +14,8 @@
       },
       "build": {
         "executor": "nx:run-commands",
+        "outputs": ["dist"],
+        "inputs": ["{projectRoot}/src"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/create-app"

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -8,7 +8,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run rimraf dist/",
+          "command": "../../node_modules/.bin/rimraf dist/",
           "cwd": "packages/create-app"
         }
       },
@@ -22,14 +22,14 @@
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint \"src/**/*.ts\"",
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
           "cwd": "packages/create-app"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
           "cwd": "packages/create-app"
         }
       },

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -8,42 +8,42 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/",
+          "command": "yarn rimraf dist/",
           "cwd": "packages/create-app"
         }
       },
       "build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/create-app"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/create-app"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "command": "yarn eslint 'src/**/*.ts' --fix",
           "cwd": "packages/create-app"
         }
       },
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "node_modules/.bin/vitest run",
+          "command": "yarn vitest run",
           "cwd": "packages/create-app"
         }
       },
       "tsc": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc --noEmit",
+          "command": "yarn tsc --noEmit",
           "cwd": "packages/create-app"
         }
       }

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -40,7 +40,7 @@
           "cwd": "packages/create-app"
         }
       },
-      "tsc": {
+      "type-check": {
         "executor": "nx:run-commands",
         "options": {
           "command": "yarn tsc --noEmit",

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -40,6 +40,14 @@
           "cwd": "packages/create-app"
         }
       },
+      "test:watch": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "yarn vitest watch",
+          "cwd": "packages/create-app"
+        }
+      },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -3,5 +3,50 @@
     "root": "packages/create-app",
     "sourceRoot": "packages/create-app/src",
     "projectType": "library",
-    "tags": ["scope:create-cli"]
+    "tags": ["scope:create-cli"],
+    "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run rimraf dist/",
+          "cwd": "packages/create-app"
+        }
+      },
+      "build": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["clean", "^build"],
+        "options": {
+          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "cwd": "packages/create-app"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint \"src/**/*.ts\"",
+          "cwd": "packages/create-app"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "cwd": "packages/create-app"
+        }
+      },
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "./node_modules/.bin/vitest run",
+          "cwd": "packages/create-app"
+        }
+      },
+      "tsc": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/tsc --noEmit",
+          "cwd": "packages/create-app"
+        }
+      }
+    }
 }

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -36,7 +36,7 @@
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "./node_modules/.bin/vitest run",
+          "command": "node_modules/.bin/vitest run",
           "cwd": "packages/create-app"
         }
       },

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -14,7 +14,6 @@
       },
       "build": {
         "executor": "nx:run-commands",
-        "dependsOn": ["clean", "^build"],
         "options": {
           "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
           "cwd": "packages/create-app"

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -38,6 +38,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
+    "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -33,12 +33,12 @@
   },
   "scripts": {
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
-    "build": "yarn nx build",
-    "clean": "yarn nx clean",
-    "lint": "yarn nx lint",
-    "lint:fix": "yarn nx lint:fix",
-    "test": "yarn nx test",
-    "tsc": "yarn nx tsc"
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "test": "nx test",
+    "tsc": "nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -38,7 +38,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
-    "tsc": "nx tsc"
+    "type-check": "nx type-check"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -32,14 +32,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "clean": "rimraf dist/",
-    "build": "tsc -b ./tsconfig.build.json",
-    "prepack": "cross-env NODE_ENV=production yarn run build",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
-    "tsc": "tsc --noEmit"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -32,7 +32,13 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
+    "build": "yarn nx build",
+    "clean": "yarn nx clean",
+    "lint": "yarn nx lint",
+    "lint:fix": "yarn nx lint:fix",
+    "test": "yarn nx test",
+    "tsc": "yarn nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/create-hydrogen/project.json
+++ b/packages/create-hydrogen/project.json
@@ -1,7 +1,51 @@
 {
-    "name": "create-hydrogen",
-    "root": "packages/create-hydrogen",
-    "sourceRoot": "packages/create-hydrogen/src",
-    "projectType": "library",
-    "tags": ["scope:create-cli"]
+  "name": "create-hydrogen",
+  "root": "packages/create-hydrogen",
+  "sourceRoot": "packages/create-hydrogen/src",
+  "projectType": "library",
+  "tags": ["scope:create-cli"],
+  "targets": {
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "yarn run rimraf dist/",
+        "cwd": "packages/create-hydrogen"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+        "cwd": "packages/create-hydrogen"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "yarn run eslint \"src/**/*.ts\"",
+        "cwd": "packages/create-hydrogen"
+      }
+    },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "yarn run eslint 'src/**/*.ts' --fix",
+        "cwd": "packages/create-hydrogen"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./node_modules/.bin/vitest run",
+        "cwd": "packages/create-hydrogen"
+      }
+    },
+    "tsc": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "../../node_modules/.bin/tsc --noEmit",
+        "cwd": "packages/create-hydrogen"
+      }
+    }
+  }
 }

--- a/packages/create-hydrogen/project.json
+++ b/packages/create-hydrogen/project.json
@@ -40,6 +40,14 @@
         "cwd": "packages/create-hydrogen"
       }
     },
+    "test:watch": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
+      "options": {
+        "command": "yarn vitest watch",
+        "cwd": "packages/create-hydrogen"
+      }
+    },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/create-hydrogen/project.json
+++ b/packages/create-hydrogen/project.json
@@ -40,7 +40,7 @@
         "cwd": "packages/create-hydrogen"
       }
     },
-    "tsc": {
+    "type-check": {
       "executor": "nx:run-commands",
       "options": {
         "command": "yarn tsc --noEmit",

--- a/packages/create-hydrogen/project.json
+++ b/packages/create-hydrogen/project.json
@@ -8,42 +8,42 @@
     "clean": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "../../node_modules/.bin/rimraf dist/",
+        "command": "yarn rimraf dist/",
         "cwd": "packages/create-hydrogen"
       }
     },
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+        "command": "yarn tsc -b ./tsconfig.build.json",
         "cwd": "packages/create-hydrogen"
       }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+        "command": "yarn eslint \"src/**/*.ts\"",
         "cwd": "packages/create-hydrogen"
       }
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+        "command": "yarn eslint 'src/**/*.ts' --fix",
         "cwd": "packages/create-hydrogen"
       }
     },
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "node_modules/.bin/vitest run",
+        "command": "yarn vitest run",
         "cwd": "packages/create-hydrogen"
       }
     },
     "tsc": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "../../node_modules/.bin/tsc --noEmit",
+        "command": "yarn tsc --noEmit",
         "cwd": "packages/create-hydrogen"
       }
     }

--- a/packages/create-hydrogen/project.json
+++ b/packages/create-hydrogen/project.json
@@ -8,7 +8,7 @@
     "clean": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "yarn run rimraf dist/",
+        "command": "../../node_modules/.bin/rimraf dist/",
         "cwd": "packages/create-hydrogen"
       }
     },
@@ -22,14 +22,14 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "yarn run eslint \"src/**/*.ts\"",
+        "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
         "cwd": "packages/create-hydrogen"
       }
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "yarn run eslint 'src/**/*.ts' --fix",
+        "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
         "cwd": "packages/create-hydrogen"
       }
     },

--- a/packages/create-hydrogen/project.json
+++ b/packages/create-hydrogen/project.json
@@ -14,6 +14,8 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "outputs": ["dist"],
+      "inputs": ["{projectRoot}/src"],
       "options": {
         "command": "yarn tsc -b ./tsconfig.build.json",
         "cwd": "packages/create-hydrogen"

--- a/packages/create-hydrogen/project.json
+++ b/packages/create-hydrogen/project.json
@@ -36,7 +36,7 @@
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "./node_modules/.bin/vitest run",
+        "command": "node_modules/.bin/vitest run",
         "cwd": "packages/create-hydrogen"
       }
     },

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -3,10 +3,10 @@
   "version": "0.4.0",
   "private": true,
   "scripts": {
-    "lint": "yarn nx lint",
-    "lint:fix": "yarn nx lint:fix",
-    "test": "yarn nx test",
-    "tsc": "yarn nx tsc"
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "test": "nx test",
+    "tsc": "nx tsc"
   },
   "devDependencies": {
     "fs-extra": "^10.0.0",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -2,6 +2,12 @@
   "name": "@shopify/features",
   "version": "0.4.0",
   "private": true,
+  "scripts": {
+    "lint": "yarn nx lint",
+    "lint:fix": "yarn nx lint:fix",
+    "test": "yarn nx test",
+    "tsc": "yarn nx tsc"
+  },
   "devDependencies": {
     "fs-extra": "^10.0.0",
     "@types/cucumber": "^7.0.0",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -2,15 +2,6 @@
   "name": "@shopify/features",
   "version": "0.4.0",
   "private": true,
-  "scripts": {
-    "clean": "cd .",
-    "build": "cd .",
-    "lint": "eslint **/*.ts",
-    "lint:fix": "eslint **/*.ts --fix",
-    "test": "yarn --cwd ../.. nx run features:test",
-    "test:acceptance": "cucumber-js -p default -c ./cucumber.js",
-    "tsc": "tsc --noEmit"
-  },
   "devDependencies": {
     "fs-extra": "^10.0.0",
     "@types/cucumber": "^7.0.0",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -6,7 +6,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
-    "tsc": "nx tsc"
+    "type-check": "nx type-check"
   },
   "devDependencies": {
     "fs-extra": "^10.0.0",

--- a/packages/features/project.json
+++ b/packages/features/project.json
@@ -7,10 +7,32 @@
   "tags": ["scope:e2e"],
   "targets": {
     "test": {
-      "executor": "nx:run-script",
+      "executor": "nx:run-commands",
       "dependsOn": ["^build"],
       "options": {
-        "script": "test:acceptance"
+        "command": "node_modules/.bin/cucumber-js -p default -c cucumber.js",
+        "cwd": "packages/features"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "yarn run eslint \"**/*.ts\"",
+        "cwd": "packages/features"
+      }
+    },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "yarn run eslint '**/*.ts' --fix",
+        "cwd": "packages/features"
+      }
+    },
+    "tsc": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "../../node_modules/.bin/tsc --noEmit",
+        "cwd": "packages/features"
       }
     }
   }

--- a/packages/features/project.json
+++ b/packages/features/project.json
@@ -10,28 +10,28 @@
       "executor": "nx:run-commands",
       "dependsOn": ["^build"],
       "options": {
-        "command": "node_modules/.bin/cucumber-js -p default -c cucumber.js",
+        "command": "yarn cucumber-js -p default -c cucumber.js",
         "cwd": "packages/features"
       }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "../../node_modules/.bin/eslint \"**/*.ts\"",
+        "command": "yarn eslint \"**/*.ts\"",
         "cwd": "packages/features"
       }
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "../../node_modules/.bin/eslint '**/*.ts' --fix",
+        "command": "yarn eslint '**/*.ts' --fix",
         "cwd": "packages/features"
       }
     },
     "tsc": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "../../node_modules/.bin/tsc --noEmit",
+        "command": "yarn tsc --noEmit",
         "cwd": "packages/features"
       }
     }

--- a/packages/features/project.json
+++ b/packages/features/project.json
@@ -28,7 +28,7 @@
         "cwd": "packages/features"
       }
     },
-    "tsc": {
+    "type-check": {
       "executor": "nx:run-commands",
       "options": {
         "command": "yarn tsc --noEmit",

--- a/packages/features/project.json
+++ b/packages/features/project.json
@@ -17,14 +17,14 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "yarn run eslint \"**/*.ts\"",
+        "command": "../../node_modules/.bin/eslint \"**/*.ts\"",
         "cwd": "packages/features"
       }
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "yarn run eslint '**/*.ts' --fix",
+        "command": "../../node_modules/.bin/eslint '**/*.ts' --fix",
         "cwd": "packages/features"
       }
     },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,14 +17,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "clean": "rimraf dist/",
-    "build": "tsc -b ./tsconfig.build.json",
-    "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
-    "tsc": "tsc --noEmit"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -18,12 +18,12 @@
   },
   "scripts": {
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
-    "build": "yarn nx build",
-    "clean": "yarn nx clean",
-    "lint": "yarn nx lint",
-    "lint:fix": "yarn nx lint:fix",
-    "test": "yarn nx test",
-    "tsc": "yarn nx tsc"
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "test": "nx test",
+    "tsc": "nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -23,7 +23,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
-    "tsc": "nx tsc"
+    "type-check": "nx type-check"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -23,6 +23,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "test": "nx test",
+    "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,7 +17,13 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
+    "build": "yarn nx build",
+    "clean": "yarn nx clean",
+    "lint": "yarn nx lint",
+    "lint:fix": "yarn nx lint:fix",
+    "test": "yarn nx test",
+    "tsc": "yarn nx tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -8,28 +8,28 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/",
+          "command": "yarn rimraf dist/",
           "cwd": "packages/theme"
         }
       },
       "build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/theme"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/theme"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "command": "yarn eslint 'src/**/*.ts' --fix",
           "cwd": "packages/theme"
         }
       },
@@ -37,14 +37,14 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "node_modules/.bin/vitest run",
+          "command": "yarn vitest run",
           "cwd": "packages/theme"
         }
       },
       "tsc": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc --noEmit",
+          "command": "yarn tsc --noEmit",
           "cwd": "packages/theme"
         }
       }

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -3,5 +3,51 @@
     "root": "packages/theme",
     "sourceRoot": "packages/theme/src",
     "projectType": "library",
-    "tags": ["scope:feature"]
+    "tags": ["scope:feature"],
+    "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run rimraf dist/",
+          "cwd": "packages/theme"
+        }
+      },
+      "build": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["clean"],
+        "options": {
+          "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
+          "cwd": "packages/theme"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint \"src/**/*.ts\"",
+          "cwd": "packages/theme"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "cwd": "packages/theme"
+        }
+      },
+      "test": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "node_modules/.bin/vitest run",
+          "cwd": "packages/theme"
+        }
+      },
+      "tsc": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/tsc --noEmit",
+          "cwd": "packages/theme"
+        }
+      }
+    }
 }

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -41,7 +41,7 @@
           "cwd": "packages/theme"
         }
       },
-      "tsc": {
+      "type-check": {
         "executor": "nx:run-commands",
         "options": {
           "command": "yarn tsc --noEmit",

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -14,6 +14,8 @@
       },
       "build": {
         "executor": "nx:run-commands",
+        "outputs": ["dist"],
+        "inputs": ["{projectRoot}/src"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/theme"

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -8,13 +8,12 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run rimraf dist/",
+          "command": "../../node_modules/.bin/rimraf dist/",
           "cwd": "packages/theme"
         }
       },
       "build": {
         "executor": "nx:run-commands",
-        "dependsOn": ["clean"],
         "options": {
           "command": "../../node_modules/.bin/tsc -b ./tsconfig.build.json",
           "cwd": "packages/theme"
@@ -23,14 +22,14 @@
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint \"src/**/*.ts\"",
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
           "cwd": "packages/theme"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn run eslint 'src/**/*.ts' --fix",
+          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
           "cwd": "packages/theme"
         }
       },

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -41,6 +41,14 @@
           "cwd": "packages/theme"
         }
       },
+      "test:watch": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "yarn vitest watch",
+          "cwd": "packages/theme"
+        }
+      },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {

--- a/packages/ui-extensions-cli/package.json
+++ b/packages/ui-extensions-cli/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
     "clean": "nx clean",
-    "build": "nx type-check",
+    "build": "nx build",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix"
   },

--- a/packages/ui-extensions-cli/package.json
+++ b/packages/ui-extensions-cli/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
     "clean": "nx clean",
-    "build": "nx tsc",
+    "build": "nx type-check",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix"
   },

--- a/packages/ui-extensions-cli/package.json
+++ b/packages/ui-extensions-cli/package.json
@@ -13,11 +13,11 @@
   },
   "main": "./dist/cli.js",
   "scripts": {
-    "prepack": "cross-env NODE_ENV=production yarn run build && cp ../../README.md README.md",
-    "build": "tsc",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
-    "clean": "rimraf dist/"
+    "prepack": "cross-env NODE_ENV=production yarn nx build && cp ../../README.md README.md",
+    "clean": "nx clean",
+    "build": "nx tsc",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/ui-extensions-cli/project.json
+++ b/packages/ui-extensions-cli/project.json
@@ -9,28 +9,28 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/",
+          "command": "yarn rimraf dist/",
           "cwd": "packages/ui-extensions-cli"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/ui-extensions-cli"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "command": "yarn eslint 'src/**/*.ts' --fix",
           "cwd": "packages/ui-extensions-cli"
         }
       },
       "tsc": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc",
+          "command": "yarn tsc",
           "cwd": "packages/ui-extensions-cli"
         }
       }

--- a/packages/ui-extensions-cli/project.json
+++ b/packages/ui-extensions-cli/project.json
@@ -27,8 +27,10 @@
           "cwd": "packages/ui-extensions-cli"
         }
       },
-      "type-check": {
+      "build": {
         "executor": "nx:run-commands",
+        "outputs": ["dist"],
+        "inputs": ["{projectRoot}/src"],
         "options": {
           "command": "yarn tsc",
           "cwd": "packages/ui-extensions-cli"

--- a/packages/ui-extensions-cli/project.json
+++ b/packages/ui-extensions-cli/project.json
@@ -4,5 +4,35 @@
     "sourceRoot": "packages/ui-extensions-cli/src",
     "projectType": "library",
     "implicitDependencies": ["ui-extensions-dev-console"],
-    "tags": ["scope:feature", "scope:ui-extensions"]
+    "tags": ["scope:feature", "scope:ui-extensions"],
+    "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/rimraf dist/",
+          "cwd": "packages/ui-extensions-cli"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "cwd": "packages/ui-extensions-cli"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "cwd": "packages/ui-extensions-cli"
+        }
+      },
+      "tsc": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/tsc",
+          "cwd": "packages/ui-extensions-cli"
+        }
+      }
+    }
 }

--- a/packages/ui-extensions-cli/project.json
+++ b/packages/ui-extensions-cli/project.json
@@ -27,7 +27,7 @@
           "cwd": "packages/ui-extensions-cli"
         }
       },
-      "tsc": {
+      "type-check": {
         "executor": "nx:run-commands",
         "options": {
           "command": "yarn tsc",

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -3,14 +3,13 @@
   "name": "@shopify/ui-extensions-dev-console-app",
   "version": "3.8.0",
   "scripts": {
-    "build": "yarn clean && yarn --cwd ../.. nx run ui-extensions-dev-console:build",
-    "build:nx": "tsc --project tsconfig.build.json --noEmit && vite build",
-    "clean": "rimraf dist/ ../ui-extensions-go-cli/api/dev-console",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
     "serve": "vite preview",
-    "start": "vite",
-    "test": "vitest"
+    "start": "nx start",
+    "test": "nx test"
   },
   "dependencies": {
     "@shopify/polaris": "^6.6.0",

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -9,7 +9,8 @@
     "lint:fix": "nx lint:fix",
     "serve": "vite preview",
     "start": "nx start",
-    "test": "nx test"
+    "test": "nx test",
+    "test:watch": "nx test:watch"
   },
   "dependencies": {
     "@shopify/polaris": "^6.6.0",

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -16,6 +16,7 @@
       "build": {
         "outputs": ["../ui-extensions-go-cli/api/dev-console"],
         "executor": "nx:run-commands",
+        "inputs": ["{projectRoot}/src"],
         "options": {
           "command": "yarn tsc --project tsconfig.build.json --noEmit && yarn vite build",
           "cwd": "packages/ui-extensions-dev-console"

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -17,7 +17,7 @@
         "outputs": ["../ui-extensions-go-cli/api/dev-console"],
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn tsc --project tsconfig.build.json --noEmit && node_modules/.bin/vite build",
+          "command": "yarn tsc --project tsconfig.build.json --noEmit && yarn vite build",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -6,12 +6,48 @@
     "implicitDependencies": ["ui-extensions-server-kit","ui-extensions-test-utils"],
     "tags": ["scope:feature", "scope:ui-extensions"],
     "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/rimraf dist/ ../ui-extensions-go-cli/api/dev-console",
+          "cwd": "packages/ui-extensions-dev-console"
+        }
+      },
       "build": {
         "outputs": ["../ui-extensions-go-cli/api/dev-console"],
-        "executor": "nx:run-script",
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/tsc --project tsconfig.build.json --noEmit && node_modules/.bin/vite build",
+          "cwd": "packages/ui-extensions-dev-console"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "cwd": "packages/ui-extensions-dev-console"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "cwd": "packages/ui-extensions-dev-console"
+        }
+      },
+      "start": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "node_modules/.bin/vite start",
+          "cwd": "packages/ui-extensions-dev-console"
+        }
+      },
+      "test": {
+        "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "script": "build:nx"
+          "command": "node_modules/.bin/vitest run",
+          "cwd": "packages/ui-extensions-dev-console"
         }
       }
     }

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -49,6 +49,14 @@
           "command": "yarn vitest run",
           "cwd": "packages/ui-extensions-dev-console"
         }
+      },
+      "test:watch": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "yarn vitest watch",
+          "cwd": "packages/ui-extensions-dev-console"
+        }
       }
     }
 }

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -9,7 +9,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/ ../ui-extensions-go-cli/api/dev-console",
+          "command": "yarn rimraf dist/ ../ui-extensions-go-cli/api/dev-console",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
@@ -17,28 +17,28 @@
         "outputs": ["../ui-extensions-go-cli/api/dev-console"],
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc --project tsconfig.build.json --noEmit && node_modules/.bin/vite build",
+          "command": "yarn tsc --project tsconfig.build.json --noEmit && node_modules/.bin/vite build",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "command": "yarn eslint 'src/**/*.ts' --fix",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
       "start": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "node_modules/.bin/vite start",
+          "command": "yarn vite start",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
@@ -46,7 +46,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "node_modules/.bin/vitest run",
+          "command": "yarn vitest run",
           "cwd": "packages/ui-extensions-dev-console"
         }
       }

--- a/packages/ui-extensions-go-cli/package.json
+++ b/packages/ui-extensions-go-cli/package.json
@@ -4,16 +4,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "yarn clean && yarn --cwd ../.. nx run ui-extensions-go-cli:build",
-    "build:nx": "node bin/build.js",
-    "clean": "rimraf api/dev-console/",
-    "start": "cd packages/dev-console-app; yarn start",
-    "test": "yarn clean && yarn --cwd ../.. nx run ui-extensions-go-cli:test",
-    "test:nx": "node bin/test.js",
-    "package": "yarn --cwd ../.. nx run ui-extensions-go-cli:package",
-    "package:nx": "node bin/package.js",
-    "lint": "gofmt -s .",
-    "lint:fix": "gofmt -w -s ."
+    "clean": "nx clean",
+    "build": "nx build",
+    "test": "nx test",
+    "package": "nx package",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix"
   },
   "devDependencies": {
     "@shopify/shopify-cli-extensions": "3.8.0"

--- a/packages/ui-extensions-go-cli/project.json
+++ b/packages/ui-extensions-go-cli/project.json
@@ -6,25 +6,48 @@
     "implicitDependencies": ["ui-extensions-cli"],
     "tags": ["scope:feature", "scope:ui-extensions"],
     "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/rimraf api/dev-console/",
+          "cwd": "packages/ui-extensions-go-cli"
+        }
+      },
       "build": {
-        "executor": "nx:run-script",
+        "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "script": "build:nx"
+          "command": "node bin/build.js",
+          "cwd": "packages/ui-extensions-go-cli"
         }
       },
       "test": {
-        "executor": "nx:run-script",
-        "dependsOn": ["^build"],
+        "executor": "nx:run-commands",
         "options": {
-          "script": "test:nx"
+          "command": "node bin/test.js",
+          "cwd": "packages/ui-extensions-go-cli"
         }
       },
       "package": {
-        "executor": "nx:run-script",
+        "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "script": "package:nx"
+          "command": "node bin/package.js",
+          "cwd": "packages/ui-extensions-go-cli"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "gofmt -s .",
+          "cwd": "packages/ui-extensions-go-cli"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "gofmt -w -s .",
+          "cwd": "packages/ui-extensions-go-cli"
         }
       }
     }

--- a/packages/ui-extensions-go-cli/project.json
+++ b/packages/ui-extensions-go-cli/project.json
@@ -23,6 +23,7 @@
       },
       "test": {
         "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
         "options": {
           "command": "node bin/test.js",
           "cwd": "packages/ui-extensions-go-cli"

--- a/packages/ui-extensions-go-cli/project.json
+++ b/packages/ui-extensions-go-cli/project.json
@@ -9,7 +9,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf api/dev-console/",
+          "command": "yarn rimraf api/dev-console/",
           "cwd": "packages/ui-extensions-go-cli"
         }
       },

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -22,13 +22,11 @@
     }
   },
   "scripts": {
-    "build": "yarn build:code && yarn build:types",
-    "build:code": "vite build --config vite.config.ts",
-    "build:types": "tsc --emitDeclarationOnly",
-    "clean": "rimraf dist/",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix",
-    "test": "vitest"
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "test": "nx test"
   },
   "peerDependencies": {
     "react": "16.14.0"

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -26,7 +26,8 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test"
+    "test": "nx test",
+    "test:watch": "nx test:watch"
   },
   "peerDependencies": {
     "react": "16.14.0"

--- a/packages/ui-extensions-server-kit/project.json
+++ b/packages/ui-extensions-server-kit/project.json
@@ -4,5 +4,59 @@
     "sourceRoot": "packages/ui-extensions-server-kit/src",
     "projectType": "library",
     "implicitDependencies": ["ui-extensions-test-utils"],
-    "tags": ["scope:feature", "scope:ui-extensions"]
+    "tags": ["scope:feature", "scope:ui-extensions"],
+    "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/rimraf dist/",
+          "cwd": "packages/ui-extensions-server-kit"
+        }
+      },
+      "build:code": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "node_modules/.bin/vite build --config vite.config.ts",
+          "cwd": "packages/ui-extensions-server-kit"
+        }
+      },
+      "build:types": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "../../node_modules/.bin/tsc --emitDeclarationOnly",
+          "cwd": "packages/ui-extensions-server-kit"
+        }
+      },
+      "build": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["build:code", "build:types"],
+        "options": {
+          "command": "cd .",
+          "cwd": "packages/ui-extensions-server-kit"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "cwd": "packages/ui-extensions-server-kit"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "cwd": "packages/ui-extensions-server-kit"
+        }
+      },
+      "test": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "node_modules/.bin/vitest run",
+          "cwd": "packages/ui-extensions-server-kit"
+        }
+      }
+    }
 }

--- a/packages/ui-extensions-server-kit/project.json
+++ b/packages/ui-extensions-server-kit/project.json
@@ -57,6 +57,14 @@
           "command": "yarn vitest run",
           "cwd": "packages/ui-extensions-server-kit"
         }
+      },
+      "test:watch": {
+        "executor": "nx:run-commands",
+        "dependsOn": ["^build"],
+        "options": {
+          "command": "yarn vitest watch",
+          "cwd": "packages/ui-extensions-server-kit"
+        }
       }
     }
 }

--- a/packages/ui-extensions-server-kit/project.json
+++ b/packages/ui-extensions-server-kit/project.json
@@ -31,6 +31,8 @@
       "build": {
         "executor": "nx:run-commands",
         "dependsOn": ["build:code", "build:types"],
+        "outputs": ["dist"],
+        "inputs": ["{projectRoot}/src", "{projectRoot}/testing.*", "{projectRoot}/index.*"],
         "options": {
           "command": "cd .",
           "cwd": "packages/ui-extensions-server-kit"

--- a/packages/ui-extensions-server-kit/project.json
+++ b/packages/ui-extensions-server-kit/project.json
@@ -9,14 +9,14 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/",
+          "command": "yarn rimraf dist/",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
       "build:code": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "node_modules/.bin/vite build --config vite.config.ts",
+          "command": "yarn vite build --config vite.config.ts",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
@@ -24,7 +24,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "../../node_modules/.bin/tsc --emitDeclarationOnly",
+          "command": "yarn tsc --emitDeclarationOnly",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
@@ -39,14 +39,14 @@
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint 'src/**/*.ts' --fix",
+          "command": "yarn eslint 'src/**/*.ts' --fix",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
@@ -54,7 +54,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "node_modules/.bin/vitest run",
+          "command": "yarn vitest run",
           "cwd": "packages/ui-extensions-server-kit"
         }
       }

--- a/packages/ui-extensions-test-utils/package.json
+++ b/packages/ui-extensions-test-utils/package.json
@@ -5,10 +5,10 @@
   "main": "dist/index",
   "types": "dist/index",
   "scripts": {
-    "clean": "rimraf dist/",
-    "build": "tsc",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint 'src/**/*.ts' --fix"
+    "clean": "nx clean",
+    "build": "nx build",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix"
   },
   "peerDependencies": {
     "react": "16.14.0"

--- a/packages/ui-extensions-test-utils/project.json
+++ b/packages/ui-extensions-test-utils/project.json
@@ -3,5 +3,35 @@
     "root": "packages/ui-extensions-test-utils",
     "sourceRoot": "packages/ui-extensions-test-utils/src",
     "projectType": "library",
-    "tags": ["scope:feature", "scope:ui-extensions"]
+    "tags": ["scope:feature", "scope:ui-extensions"],
+    "targets": {
+      "clean": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/rimraf dist/",
+          "cwd": "packages/ui-extensions-test-utils"
+        }
+      },
+      "build": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/tsc",
+          "cwd": "packages/ui-extensions-test-utils"
+        }
+      },
+      "lint": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "cwd": "packages/ui-extensions-test-utils"
+        }
+      },
+      "lint:fix": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\" --fix",
+          "cwd": "packages/ui-extensions-test-utils"
+        }
+      }
+    }
 }

--- a/packages/ui-extensions-test-utils/project.json
+++ b/packages/ui-extensions-test-utils/project.json
@@ -8,28 +8,28 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/rimraf dist/",
+          "command": "yarn rimraf dist/",
           "cwd": "packages/ui-extensions-test-utils"
         }
       },
       "build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/tsc",
+          "command": "yarn tsc",
           "cwd": "packages/ui-extensions-test-utils"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\"",
+          "command": "yarn eslint \"src/**/*.ts\"",
           "cwd": "packages/ui-extensions-test-utils"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "../../node_modules/.bin/eslint \"src/**/*.ts\" --fix",
+          "command": "yarn eslint \"src/**/*.ts\" --fix",
           "cwd": "packages/ui-extensions-test-utils"
         }
       }

--- a/packages/ui-extensions-test-utils/project.json
+++ b/packages/ui-extensions-test-utils/project.json
@@ -14,6 +14,8 @@
       },
       "build": {
         "executor": "nx:run-commands",
+        "outputs": ["dist"],
+        "inputs": ["{projectRoot}/src"],
         "options": {
           "command": "yarn tsc",
           "cwd": "packages/ui-extensions-test-utils"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,16 @@
 {
     "extends": "./configurations/tsconfig.json",
-    "include": ["./**/*.ts", "./**/*.cjs", "./**/*.js"]
+    "include": [],
+    "references": [
+      {"path": "./packages/cli-main"},
+      {"path": "./packages/cli-hydrogen"},
+      {"path": "./packages/app"},
+      {"path": "./packages/theme"},
+      {"path": "./packages/cli-kit"},
+      {"path": "./packages/create-hydrogen"},
+      {"path": "./packages/create-app"},
+      {"path": "./packages/ui-extensions-cli"},
+      {"path": "./packages/ui-extensions-server-kit"},
+      {"path": "./packages/ui-extensions-test-utils"}
+    ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,6 +1489,13 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@nrwl/cli@14.5.10":
+  version "14.5.10"
+  resolved "https://registry.yarnpkg.com/@nrwl/cli/-/cli-14.5.10.tgz#826c06a9a272523424f0c5690f5d745260ed1ea1"
+  integrity sha512-GpnnKGO3+HwlMmZSStbq1MOyoDJg2I0HN4nBqM3ltaQkfxGZv3erwRMOAT+8mba2MWbJJ2QQgASAYvTscNYjOQ==
+  dependencies:
+    nx "14.5.10"
+
 "@nrwl/cli@14.5.4":
   version "14.5.4"
   resolved "https://registry.yarnpkg.com/@nrwl/cli/-/cli-14.5.4.tgz#86ac4fbcd1bf079b67c420376cf696b68fcc1200"
@@ -1567,6 +1574,13 @@
     nx "14.5.4"
     tmp "~0.2.1"
     tslib "^2.3.0"
+
+"@nrwl/tao@14.5.10":
+  version "14.5.10"
+  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-14.5.10.tgz#69c90f8b6e13f2bb521840a5903f7eb4884285ff"
+  integrity sha512-eWORRba0HlTNmOQFUxHqki0Z5yiRIq1Hl0taprmZpz2lgDXuzPIjGfAi5/ETy5+G5gkEyxFnCq7+SiMilPokwA==
+  dependencies:
+    nx "14.5.10"
 
 "@nrwl/tao@14.5.4", "@nrwl/tao@^14.0.1":
   version "14.5.4"
@@ -9227,7 +9241,43 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.1.tgz#10a9f268fbf4c461249ebcfe38e359aa36e2577c"
   integrity sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==
 
-nx@14.5.4, nx@^14.0.5:
+nx@14.5.10, nx@^14.5.10:
+  version "14.5.10"
+  resolved "https://registry.yarnpkg.com/nx/-/nx-14.5.10.tgz#cc950bcc2d867f0aa4e86a508842a9299650fbb9"
+  integrity sha512-dqiV+zY32k98mfKFTgiQyYd9HYZmB1zoJj6gYniEuqzs6CKp8ZSpeRDaVQRxR6wEMvW9MSTA9kBg8sJ78W/NZg==
+  dependencies:
+    "@nrwl/cli" "14.5.10"
+    "@nrwl/tao" "14.5.10"
+    "@parcel/watcher" "2.0.4"
+    chalk "4.1.0"
+    chokidar "^3.5.1"
+    cli-cursor "3.1.0"
+    cli-spinners "2.6.1"
+    cliui "^7.0.2"
+    dotenv "~10.0.0"
+    enquirer "~2.3.6"
+    fast-glob "3.2.7"
+    figures "3.2.0"
+    flat "^5.0.2"
+    fs-extra "^10.1.0"
+    glob "7.1.4"
+    ignore "^5.0.4"
+    js-yaml "4.1.0"
+    jsonc-parser "3.0.0"
+    minimatch "3.0.5"
+    npm-run-path "^4.0.1"
+    open "^8.4.0"
+    semver "7.3.4"
+    string-width "^4.2.3"
+    tar-stream "~2.2.0"
+    tmp "~0.2.1"
+    tsconfig-paths "^3.9.0"
+    tslib "^2.3.0"
+    v8-compile-cache "2.3.0"
+    yargs "^17.4.0"
+    yargs-parser "21.0.1"
+
+nx@14.5.4:
   version "14.5.4"
   resolved "https://registry.yarnpkg.com/nx/-/nx-14.5.4.tgz#58b6e8ee798733a6ab9aff2a19180c371482fa10"
   integrity sha512-xv1nTaQP6kqVDE4PXcB1tLlgzNAPUHE/2vlqSLgxjNb6colKf0vrEZhVTjhnbqBeJiTb33gUx50bBXkurCkN5w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,6 +1503,17 @@
   dependencies:
     nx "14.5.4"
 
+"@nrwl/devkit@14.5.10":
+  version "14.5.10"
+  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-14.5.10.tgz#b87bc3dad8e6d019c76adf7f65a56af19df70283"
+  integrity sha512-YVT0MRvyXwe0uczUZK4XUi1f2iLAqklFMfAoqwfgcgWToH8xN06NSlyUphD4eLHFgem3Sd0kimAJVsnse/PTlA==
+  dependencies:
+    "@phenomnomnominal/tsquery" "4.1.1"
+    ejs "^3.1.7"
+    ignore "^5.0.4"
+    semver "7.3.4"
+    tslib "^2.3.0"
+
 "@nrwl/devkit@14.5.4":
   version "14.5.4"
   resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-14.5.4.tgz#f6e5d1b9cc998f231a8ea0a149793dd11bd3b9e6"
@@ -1524,6 +1535,25 @@
     chalk "4.1.0"
     confusing-browser-globals "^1.0.9"
     semver "7.3.4"
+
+"@nrwl/jest@14.5.10":
+  version "14.5.10"
+  resolved "https://registry.yarnpkg.com/@nrwl/jest/-/jest-14.5.10.tgz#1e808608665660c59e4b3026ba0eab7f86153163"
+  integrity sha512-gGqghwDcpBhk8TNK2Gfp/5PWqnnAPUjNfSCOz39kk9ZBtsyloozGwjg/VEF3k2p9uCifRfAyZOpDrSdALxBpdA==
+  dependencies:
+    "@jest/reporters" "27.5.1"
+    "@jest/test-result" "27.5.1"
+    "@nrwl/devkit" "14.5.10"
+    "@phenomnomnominal/tsquery" "4.1.1"
+    chalk "4.1.0"
+    dotenv "~10.0.0"
+    identity-obj-proxy "3.0.0"
+    jest-config "27.5.1"
+    jest-resolve "27.5.1"
+    jest-util "27.5.1"
+    resolve.exports "1.1.0"
+    rxjs "^6.5.4"
+    tslib "^2.3.0"
 
 "@nrwl/jest@14.5.4":
   version "14.5.4"
@@ -1563,6 +1593,18 @@
     source-map-support "0.5.19"
     tree-kill "1.2.2"
 
+"@nrwl/linter@14.5.10":
+  version "14.5.10"
+  resolved "https://registry.yarnpkg.com/@nrwl/linter/-/linter-14.5.10.tgz#c9c78c796667f985ebbc4e126dc37ae5b14f0921"
+  integrity sha512-3c6KhSLJmt8wMkYZw+f/KayPHkM+KV/z+QaYQL59XY5o9DdYyq6jHjnvu/CuW2JzU97yHkacYbwkSFQlDKCyIg==
+  dependencies:
+    "@nrwl/devkit" "14.5.10"
+    "@nrwl/jest" "14.5.10"
+    "@phenomnomnominal/tsquery" "4.1.1"
+    nx "14.5.10"
+    tmp "~0.2.1"
+    tslib "^2.3.0"
+
 "@nrwl/linter@14.5.4":
   version "14.5.4"
   resolved "https://registry.yarnpkg.com/@nrwl/linter/-/linter-14.5.4.tgz#ea82669f8f1ff1ac7803dd55d2e33891ffdbef0f"
@@ -1589,7 +1631,7 @@
   dependencies:
     nx "14.5.4"
 
-"@nrwl/workspace@14.5.4", "@nrwl/workspace@^14.0.1":
+"@nrwl/workspace@14.5.4":
   version "14.5.4"
   resolved "https://registry.yarnpkg.com/@nrwl/workspace/-/workspace-14.5.4.tgz#19971a165d0d36b514dd7359d9027cdd9354283d"
   integrity sha512-DNig3zkfwVickTAVyIYE71w1L1v3SCSP5IzhZjfUN/HIaaMWXm5jedDVZQBZzYyDVdPgf4x2gt3rGPVQK/CgWA==
@@ -1612,6 +1654,37 @@
     minimatch "3.0.5"
     npm-run-path "^4.0.1"
     nx "14.5.4"
+    open "^8.4.0"
+    rxjs "^6.5.4"
+    semver "7.3.4"
+    tmp "~0.2.1"
+    tslib "^2.3.0"
+    yargs "^17.4.0"
+    yargs-parser "21.0.1"
+
+"@nrwl/workspace@^14.5.10":
+  version "14.5.10"
+  resolved "https://registry.yarnpkg.com/@nrwl/workspace/-/workspace-14.5.10.tgz#cf224886a983c53eded62fa3d5e55c80863eca64"
+  integrity sha512-bJK2O5NcIYhU7z1mmWoONo2+tOt1VUYyOQUUrAcI00hiBhMJPOTwPPN+W5BbJsue95ndH6mRLo2UhTz20U2tNA==
+  dependencies:
+    "@nrwl/devkit" "14.5.10"
+    "@nrwl/jest" "14.5.10"
+    "@nrwl/linter" "14.5.10"
+    "@parcel/watcher" "2.0.4"
+    chalk "4.1.0"
+    chokidar "^3.5.1"
+    cli-cursor "3.1.0"
+    cli-spinners "2.6.1"
+    dotenv "~10.0.0"
+    enquirer "~2.3.6"
+    figures "3.2.0"
+    flat "^5.0.2"
+    fs-extra "^10.1.0"
+    glob "7.1.4"
+    ignore "^5.0.4"
+    minimatch "3.0.5"
+    npm-run-path "^4.0.1"
+    nx "14.5.10"
     open "^8.4.0"
     rxjs "^6.5.4"
     semver "7.3.4"


### PR DESCRIPTION
### WHY are these changes introduced?
As explained in the decision-record document added in this PR, the implicit dependencies between actions codified in `package.json` `scripts` is undesirable for Nx's incremental build and caching capabilities. Nx provides an interface to declare each project's tasks and the dependencies between them across projects. 

### WHAT is this pull request doing?
I'm removing `scripts` from packages' `scripts` section with the exception of `prepack` which is executed when publishing new packages. Contributors to this repository will interact directly with `nx` by running `yarn nx build/test/lint` instead of `yarn run build/test/lint`. Nx will run the tasks in the right order and skip the ones whose output is already in the cache.

### How to test your changes?
You can try to run `yarn nx build/lint/test/tsc` with every project of the repository or with the entire repository.