### PR TITLE
Add acceptence test code to check build command builds extensions

### DIFF
--- a/packages/features/features/app.feature
+++ b/packages/features/features/app.feature
@@ -16,7 +16,8 @@ Scenario: I scaffold theme, ui, and function extensions
   Then I do not have a theme extension named TestThemeExtension2 of type theme
   When I create an extension named TestOrderDiscounts of type order_discounts and flavor wasm
   Then I have a function extension named TestOrderDiscounts of type order_discounts
-  Then I build the app and its extensions
+  Then I build the app
+  Then The UI extensions are built
 
 Scenario: I scaffold ui extensions with different templates
   And I create an app named MyExtendedApp with npm as package manager

--- a/packages/features/features/app.feature
+++ b/packages/features/features/app.feature
@@ -16,7 +16,7 @@ Scenario: I scaffold theme, ui, and function extensions
   Then I do not have a theme extension named TestThemeExtension2 of type theme
   When I create an extension named TestOrderDiscounts of type order_discounts and flavor wasm
   Then I have a function extension named TestOrderDiscounts of type order_discounts
-  Then I can build the app
+  Then I build the app and its extensions
 
 Scenario: I scaffold ui extensions with different templates
   And I create an app named MyExtendedApp with npm as package manager
@@ -35,4 +35,4 @@ Scenario: I scaffold ui extensions with different templates
 # Scenario: I create an app with a extension using pnpm
 #   And I create an app named MyExtendedApp with pnpm as package manager
 #   When I create an extension named TestPurchaseExtensionReact of type post_purchase_ui and flavor react
-#   Then I can build the app
+#   Then I build the app and its extensions

--- a/packages/features/steps/create-app.steps.ts
+++ b/packages/features/steps/create-app.steps.ts
@@ -49,11 +49,13 @@ Then(
   },
 )
 
-Then(/I build the app and its extensions/, {timeout: 2 * 60 * 1000 * 1000}, async function () {
+Then(/I build the app/, {timeout: 2 * 60 * 1000 * 1000}, async function () {
   await exec('node', [executables.cli, 'app', 'build', '--path', this.appDirectory], {
     env: {...process.env, ...this.temporaryEnv},
   })
+})
 
+Then(/The UI extensions are built/, {timeout: 2 * 60 * 1000 * 1000}, async function () {
   const appInfo = await this.appInfo()
   const extensionsMissingBuildFile = appInfo.extensions.ui.filter((extension: ExtensionConfiguration) => {
     const buildFilePath = path.join(extension.buildDirectory, 'main.js')


### PR DESCRIPTION
### WHY are these changes introduced?
Our acceptance tests did not test that we were building extensions.  Now they do.

Issue: https://github.com/Shopify/shopify-cli-extensions/issues/373

### WHAT is this pull request doing?
Update the acceptance test for building an app.  Previously this test simply checked that the build command didn't throw an error.  Now it checks that the UI extensions are built.  We thought it was better to add this to the existing test because we didn't see a way to test the extension functionality without duplicating the existing test.

We do this by checking that there is a main.js file for each UI extension, in the location we expect.

We did not add any tests for the dev command.  The dev command has interactive prompts, which don't work with the current tests setup.  We will chat with Pedro to see what we can do here and understand what the scope might be.

### How to test your changes?
Does CI pass?
