### PR TITLE
Change Partners Dashboard wording

### DIFF
--- a/.changeset/honest-rules-compete.md
+++ b/.changeset/honest-rules-compete.md
@@ -2,4 +2,4 @@
 '@shopify/app': patch
 ---
 
-Changed how we refer to the Partners Dashboard
+Be more consistent in how we refer to the Partners Dashboard

--- a/.changeset/honest-rules-compete.md
+++ b/.changeset/honest-rules-compete.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Changed how we refer to the Partners Dashboard

--- a/fixtures/app/README.md
+++ b/fixtures/app/README.md
@@ -12,7 +12,7 @@ This is the repository used when you create a new Node app with the [Shopify CLI
 
 - If you don’t have one, [create a Shopify partner account](https://partners.shopify.com/signup).
 - If you don’t have one, [create a Development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) where you can install and test your app.
-- **If you are not using the Shopify CLI**, in the Partner dashboard, [create a new app](https://help.shopify.com/en/api/tools/partner-dashboard/your-apps#create-a-new-app). You’ll need this app’s API credentials during the setup process.
+- **If you are not using the Shopify CLI**, in the Partners Dashboard, [create a new app](https://help.shopify.com/en/api/tools/partner-dashboard/your-apps#create-a-new-app). You’ll need this app’s API credentials during the setup process.
 
 ## Installation
 

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -38,7 +38,7 @@ export default class Dev extends Command {
     }),
     'no-update': Flags.boolean({
       hidden: false,
-      description: 'Skips the dashboard URL update step.',
+      description: 'Skips the Partners Dashboard URL update step.',
       env: 'SHOPIFY_FLAG_NO_UPDATE',
       default: false,
     }),

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -137,7 +137,7 @@ function getHumanKey(type: ExtensionTypes) {
 
 function partnersURL(organizationId: string, appId: string): string {
   return output.content`${output.token.link(
-    `Shopify Partners dashboard`,
+    `Partners Dashboard`,
     `https://partners.shopify.com/${organizationId}/apps/${appId}/edit`,
   )}`.value
 }

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -21,7 +21,7 @@ import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
 export const InvalidApiKeyError = (apiKey: string) => {
   return new kitError.Abort(
     output.content`Invalid API key: ${apiKey}`,
-    output.content`You can find the API key in the app settings in the Partner Dashboard.`,
+    output.content`You can find the API key in the app settings in the Partners Dashboard.`,
   )
 }
 

--- a/packages/cli-kit/src/api/graphql/update_draft.ts
+++ b/packages/cli-kit/src/api/graphql/update_draft.ts
@@ -74,7 +74,7 @@ export interface ExtensionVersion {
   lastUserInteractionAt: string
 
   // """
-  // The URL to view the app extension version in the partners dashboard
+  // The URL to view the app extension version in the Partners Dashboard
   // """
   // location: Url
   location: string


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/318

### WHAT is this pull request doing?

This PR changes how we refer to the Partners Dashboard. We were using the term "Shopify Partners" when referring to it.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact