### PR TITLE
Add verbose flag to hydrogen build

### DIFF
--- a/.changeset/strong-comics-exist.md
+++ b/.changeset/strong-comics-exist.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': minor
+---
+
+Adds a "verbose" flag to the `shopify hydrogen build` command to outout a list of built files, among other logs from vite. These were previously displayed by default, but are now hidden when this flag is not present.

--- a/packages/cli-hydrogen/src/cli/services/build.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/build.test.ts
@@ -1,0 +1,41 @@
+import build from './build.js'
+import {describe, it, expect, vi} from 'vitest'
+import {build as viteBuild} from 'vite'
+import {file} from '@shopify/cli-kit'
+
+vi.mock('vite')
+
+describe('build', () => {
+  it('runs vite build with logLevel as "silent" by default', async () => {
+    await file.inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const options = {
+        directory: tmpDir,
+        targets: {client: false, worker: 'path/to/target', node: false},
+      }
+
+      // When
+      await build(options)
+
+      // Then
+      await expect(viteBuild).toHaveBeenCalledWith(expect.objectContaining({logLevel: 'silent'}))
+    })
+  })
+
+  it('runs vite build with logLevel as "info" when verbose flag is passed', async () => {
+    await file.inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const options = {
+        verbose: true,
+        directory: tmpDir,
+        targets: {client: false, worker: 'path/to/target', node: false},
+      }
+
+      // When
+      await build(options)
+
+      // Then
+      await expect(viteBuild).toHaveBeenCalledWith(expect.objectContaining({logLevel: 'info'}))
+    })
+  })
+})

--- a/packages/cli-hydrogen/src/cli/services/build.ts
+++ b/packages/cli-hydrogen/src/cli/services/build.ts
@@ -3,13 +3,14 @@ import {ui, environment, error as kitError} from '@shopify/cli-kit'
 
 type Target = 'node' | 'client' | 'worker'
 
-interface DevOptions {
+interface BuildOptions {
   directory: string
   targets: {[key in Target]: boolean | string}
   base?: string
+  verbose?: boolean
 }
 
-async function build({directory, targets, base}: DevOptions) {
+async function build({directory, targets, base, verbose}: BuildOptions) {
   const commonConfig = {base, root: directory}
 
   const tasks: ui.ListrTask[] = Object.entries(targets)
@@ -29,6 +30,7 @@ async function build({directory, targets, base}: DevOptions) {
                 ssr: typeof value === 'string' ? value : undefined,
                 manifest: key === 'client',
               },
+              logLevel: verbose ? 'info' : 'silent',
             })
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } catch (error: any) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Added upon request from @lynchv.

In general, I think we begin to polish some of what we output in the terminal. This is one step toward that effort and this PR may help address this issue as well https://github.com/Shopify/cli/issues/318.

### WHAT is this pull request doing?

This PR uses the global `verbose` flag in the build command to determine if we should output the list of build files or not. 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### How to test your changes?

1. run ` dev shopify hydrogen build --path ../hydrogen/templates/hello-world --verbose` and you should see something like this:

<img width="600" alt="Screenshot 2022-08-25 at 13 18 04" src="https://user-images.githubusercontent.com/462077/186650867-d99f1cee-4653-4912-a0a9-61a2d14a314f.png">

2. run `dev shopify hydrogen build --path ../hydrogen/templates/hello-world` and you should see something like this:

<img width="223" alt="Screenshot 2022-08-25 at 13 18 16" src="https://user-images.githubusercontent.com/462077/186650884-0f3c54f5-b40e-4f05-9a4f-6c1dc49d7227.png">

