### PR TITLE
Fix app URL output

### DIFF
--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -34,9 +34,7 @@ export function outputUpdatedURLFirstTime(url: string, dashboardURL: string) {
 export function outputAppURL(storeFqdn: string, url: string) {
   const heading = output.token.heading('Shareable app URL')
   const appURL = buildAppURL(storeFqdn, url)
-  const formattedAppURL = output.token.link(appURL, appURL)
-  const notes = '' // one note per line, start notes with \n
-  output.info(output.content`\n\n${heading}\n\n  ${formattedAppURL}\n${notes}`)
+  output.info(output.content`\n\n${heading}\n\n  ${appURL}\n`)
 }
 
 export function outputExtensionsMessages(app: AppInterface, storeFqdn: string, url: string) {


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/334 it was changed the way we print the app URL, but it's not showing it properly when hyperlinks are not supported (like Terminal).

More info: https://github.com/Shopify/cli/pull/334#discussion_r953458305

### WHAT is this pull request doing?

Before:
![before](https://user-images.githubusercontent.com/14979109/186659855-ed2a95dd-f7c1-44f5-af93-d30072f80627.png)

After:
![after](https://user-images.githubusercontent.com/14979109/186659866-1a2697b2-6a61-4701-89b3-851bc4a21f2e.png)


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### How to test your changes?

`dev fixture dev` from different terminals.