### PR TITLE
Fixed bug by logging the shared output (stderr & stdout are combined)

### DIFF
--- a/.changeset/bright-phones-mate.md
+++ b/.changeset/bright-phones-mate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-go-cli': minor
+---
+
+Fixed missing detailed error console output on extension build failure

--- a/packages/ui-extensions-go-cli/build/build.go
+++ b/packages/ui-extensions-go-cli/build/build.go
@@ -33,7 +33,7 @@ func Build(extension core.Extension, report ResultHandler) {
 
 	output, err := command.CombinedOutput()
 	if err != nil {
-		report(Result{false, err.Error(), extension})
+		report(Result{false, string(output), extension})
 		return
 	}
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #365
Build command was not logging detailed error due to a bug.

WHAT is this pull request doing?

- Logs the output of the command.CombinedOutput method which is mixing both the stderr and stdout

### How to test your changes?

- Create a [checkout UI extension](https://shopify.dev/apps/checkout/delivery-instructions/getting-started#step-1-scaffold-a-new-extension) with a syntax error like the following in src/index.js:
- Run yarn dev. This shows the error as expected: src/index.js:8:23: error: Expected ";" but found "error"
- Run yarn build. This shows the error as expected: src/index.js:8:23: error: Expected ";" but found "error"