### PR TITLE
Introduce theme app extensions support in the `app dev` command

### DIFF
--- a/.changeset/twelve-fireants-deliver.md
+++ b/.changeset/twelve-fireants-deliver.md
@@ -1,0 +1,7 @@
+---
+'@shopify/app': minor
+'@shopify/cli-kit': minor
+---
+
+- `@shopify/cli-kit` - Add support to partners tokens in the `execCLI2` function
+- `@shopify/app` - Add support to theme app extensions in the `app dev` command

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -78,11 +78,10 @@ export default class Dev extends Command {
       description: 'Theme ID or name of the theme app extension host theme.',
       env: 'SHOPIFY_FLAG_THEME',
     }),
-    port: Flags.integer({
+    'theme-app-extension-port': Flags.integer({
       hidden: false,
-      char: 'p',
       description: 'Local port of the theme app extension development server.',
-      env: 'SHOPIFY_FLAG_PORT',
+      env: 'SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT',
     }),
   }
 
@@ -106,7 +105,7 @@ export default class Dev extends Command {
       tunnel: flags.tunnel,
       noTunnel: flags['no-tunnel'],
       theme: flags.theme,
-      port: flags.port,
+      themeExtensionPort: flags['theme-app-extension-port'],
     })
   }
 }

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -72,6 +72,18 @@ export default class Dev extends Command {
       default: false,
       exclusive: ['tunnel-url', 'no-tunnel'],
     }),
+    theme: Flags.string({
+      hidden: false,
+      char: 't',
+      description: 'Theme ID or name of the theme app extension host theme.',
+      env: 'SHOPIFY_FLAG_THEME',
+    }),
+    port: Flags.integer({
+      hidden: false,
+      char: 'p',
+      description: 'Local port of the theme app extension development server.',
+      env: 'SHOPIFY_FLAG_PORT',
+    }),
   }
 
   public async run(): Promise<void> {
@@ -93,6 +105,8 @@ export default class Dev extends Command {
       tunnelUrl: flags['tunnel-url'],
       tunnel: flags.tunnel,
       noTunnel: flags['no-tunnel'],
+      theme: flags.theme,
+      port: flags.port,
     })
   }
 }

--- a/packages/app/src/cli/commands/app/generate/extension.test.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-irregular-whitespace */
 import AppScaffoldExtension from './extension.js'
-import {ExternalExtensionTypeNames, getExtensionOutputConfig} from '../../../constants.js'
+import {ExternalExtensionTypeNames, isThemeExtensionType, getExtensionOutputConfig} from '../../../constants.js'
 import {load as loadApp} from '../../../models/app/loader.js'
 import generateExtensionPrompt from '../../../prompts/generate/extension.js'
 import generateExtensionService from '../../../services/generate/extension.js'
@@ -34,7 +34,7 @@ describe('after extension command finishes correctly', () => {
     expect(outputInfo.info()).toMatchInlineSnapshot('"\n  To find your extension, remember to cd extensions/name\n"')
   })
 
-  it('displays a confirmation message with human-facing name and help url', async () => {
+  it('displays a confirmation message with human-facing name and help url when app has a checkout UI extension', async () => {
     // Given
     const outputInfo = mockSuccessfulCommandExecution({
       humanKey: 'Checkout UI',
@@ -49,6 +49,28 @@ describe('after extension command finishes correctly', () => {
     expect(outputInfo.completed()).toMatchInlineSnapshot('"Your Checkout UI extension was added to your project!"')
     expect(outputInfo.info()).toMatchInlineSnapshot(
       `"\n  To find your extension, remember to cd extensions/name\n  For more details, see the docs (​http://help.com​) ✨\n"`,
+    )
+  })
+
+  it('displays a confirmation message with human-facing name and help url when app has a theme app extension', async () => {
+    // Given
+    const outputInfo = mockSuccessfulCommandExecution({
+      humanKey: 'Theme app extension',
+      helpURL: 'http://help.com',
+    })
+    vi.mocked(isThemeExtensionType).mockReturnValue(true)
+
+    // When
+    await AppScaffoldExtension.run()
+
+    // Then
+    expect(outputInfo.completed()).toMatchInlineSnapshot(
+      '"Your Theme app extension extension was added to your project!"',
+    )
+    expect(outputInfo.info()).toMatchInlineSnapshot(
+      '"\n  To find your extension, remember to cd extensions/name' +
+        '\n  To preview your project, run yarn dev' +
+        '\n  For more details, see the docs (​http://help.com​) ✨\n"',
     )
   })
 

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -5,6 +5,7 @@ import {
   getExtensionOutputConfig,
   limitedExtensions,
   isUiExtensionType,
+  isThemeExtensionType,
   isFunctionExtensionType,
   functionExtensionTemplates,
   ExternalExtensionTypes,
@@ -204,7 +205,7 @@ export default class AppScaffoldExtension extends Command {
       )}`.value,
     )
 
-    if (isUiExtensionType(extensionType)) {
+    if (isUiExtensionType(extensionType) || isThemeExtensionType(extensionType)) {
       outputTokens.push(
         output.content`  To preview your project, run ${output.token.packagejsonScript(depndencyManager, 'dev')}`.value,
       )

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1,5 +1,5 @@
 import {App, AppInterface} from './app.js'
-import {UIExtension} from './extensions.js'
+import {ThemeExtension, UIExtension} from './extensions.js'
 
 export function testApp(app: Partial<AppInterface> = {}): AppInterface {
   const newApp = new App(
@@ -43,5 +43,20 @@ export function testUIExtension(uiExtension: Partial<UIExtension> = {}): UIExten
     entrySourceFilePath: uiExtension?.entrySourceFilePath ?? '/tmp/project/extensions/test-ui-extension/src/index.js',
     idEnvironmentVariableName: uiExtension?.idEnvironmentVariableName ?? 'SHOPIFY_TET_UI_EXTENSION_ID',
     devUUID: 'devUUID',
+  }
+}
+
+export function testThemeExtensions(): ThemeExtension {
+  return {
+    configuration: {
+      name: 'theme extension name',
+      type: 'theme',
+    },
+    idEnvironmentVariableName: '',
+    localIdentifier: 'extension title',
+    configurationPath: '',
+    directory: './my-extension',
+    type: 'theme',
+    graphQLType: 'THEME_APP_EXTENSION',
   }
 }

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -180,7 +180,7 @@ function devThemeExtensionTarget(
   return {
     logPrefix: 'extensions',
     action: async (_stdout: Writable, _stderr: Writable, _signal: abort.Signal, _port: number) => {
-      const args = await themeExtensionArgs(extension, apiKey, options)
+      const args = await themeExtensionArgs(extension, apiKey, token, options)
 
       await execCLI2(['extension', 'serve', ...args], {adminSession, storefrontToken, token})
     },

--- a/packages/app/src/cli/services/dev/theme-extension-args.test.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.test.ts
@@ -1,0 +1,96 @@
+import {themeExtensionArgs} from './theme-extension-args'
+import {AppInterface} from '../../models/app/app'
+import {ThemeExtension} from '../../models/app/extensions'
+import {ensureDeployEnvironment} from '../environment'
+import {beforeAll, describe, expect, it, vi} from 'vitest'
+
+beforeAll(() => {
+  vi.mock('../../models/app/app.js')
+  vi.mock('../environment.js')
+})
+
+describe('themeExtensionArgs', async () => {
+  it('returns valid theme extension arguments', async () => {
+    const apiKey = 'api_key_0000_1111_2222'
+    const app = testApp()
+    const reset = false
+    const options = {app, reset, port: 8282, theme: 'theme ID'}
+
+    const deployEnvironmentOutput = {
+      app: options.app,
+      token: 'token',
+      partnersOrganizationId: '123',
+      partnersApp: {
+        id: '456',
+        title: 'title',
+        organizationId: 'orgID',
+      },
+      identifiers: {
+        app: options.app.name,
+        extensions: {},
+        extensionIds: {
+          'extension title': 'extension ID',
+        },
+      },
+    }
+
+    vi.mocked(ensureDeployEnvironment).mockReturnValue(Promise.resolve(deployEnvironmentOutput))
+
+    const args = await themeExtensionArgs(apiKey, options)
+
+    expect(args).toEqual([
+      './my-extension',
+      '--api-key',
+      'api_key_0000_1111_2222',
+
+      // Extension properties
+      '--extension-id',
+      'extension ID',
+      '--extension-title',
+      'extension title',
+      '--extension-type',
+      'THEME_APP_EXTENSION',
+
+      // Optional properties
+      '--theme',
+      'theme ID',
+      '--port',
+      '8282',
+    ])
+  })
+})
+
+export function testApp(): AppInterface {
+  return {
+    name: 'App',
+    idEnvironmentVariableName: 'SHOPIFY_API_KEY',
+    directory: '/tmp/project',
+    packageManager: 'yarn',
+    configuration: {scopes: ''},
+    configurationPath: '/tmp/project/shopify.app.toml',
+    nodeDependencies: {},
+    webs: [],
+    extensions: {
+      ui: [],
+      theme: [testThemeExtensions()],
+      function: [],
+    },
+    hasExtensions: () => true,
+    updateDependencies: async () => {},
+  }
+}
+
+export function testThemeExtensions(): ThemeExtension {
+  return {
+    configuration: {
+      name: 'theme extension name',
+      type: 'theme',
+    },
+    idEnvironmentVariableName: '',
+    localIdentifier: 'extension title',
+    configurationPath: '',
+    directory: './my-extension',
+    type: 'theme',
+    graphQLType: 'THEME_APP_EXTENSION',
+  }
+}

--- a/packages/app/src/cli/services/dev/theme-extension-args.test.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.test.ts
@@ -1,7 +1,6 @@
 import {themeExtensionArgs} from './theme-extension-args'
-import {AppInterface} from '../../models/app/app'
-import {ThemeExtension} from '../../models/app/extensions'
 import {ensureDeployEnvironment} from '../environment'
+import {testApp, testThemeExtensions} from '../../models/app/app.test-data'
 import {beforeAll, describe, expect, it, vi} from 'vitest'
 
 beforeAll(() => {
@@ -12,9 +11,9 @@ beforeAll(() => {
 describe('themeExtensionArgs', async () => {
   it('returns valid theme extension arguments', async () => {
     const apiKey = 'api_key_0000_1111_2222'
-    const app = testApp()
     const reset = false
-    const options = {app, reset, port: 8282, theme: 'theme ID'}
+    const options = {app: testApp(), reset, themeExtensionPort: 8282, theme: 'theme ID'}
+    const extension = testThemeExtensions()
 
     const deployEnvironmentOutput = {
       app: options.app,
@@ -36,7 +35,7 @@ describe('themeExtensionArgs', async () => {
 
     vi.mocked(ensureDeployEnvironment).mockReturnValue(Promise.resolve(deployEnvironmentOutput))
 
-    const args = await themeExtensionArgs(apiKey, options)
+    const args = await themeExtensionArgs(extension, apiKey, options)
 
     expect(args).toEqual([
       './my-extension',
@@ -59,38 +58,3 @@ describe('themeExtensionArgs', async () => {
     ])
   })
 })
-
-export function testApp(): AppInterface {
-  return {
-    name: 'App',
-    idEnvironmentVariableName: 'SHOPIFY_API_KEY',
-    directory: '/tmp/project',
-    packageManager: 'yarn',
-    configuration: {scopes: ''},
-    configurationPath: '/tmp/project/shopify.app.toml',
-    nodeDependencies: {},
-    webs: [],
-    extensions: {
-      ui: [],
-      theme: [testThemeExtensions()],
-      function: [],
-    },
-    hasExtensions: () => true,
-    updateDependencies: async () => {},
-  }
-}
-
-export function testThemeExtensions(): ThemeExtension {
-  return {
-    configuration: {
-      name: 'theme extension name',
-      type: 'theme',
-    },
-    idEnvironmentVariableName: '',
-    localIdentifier: 'extension title',
-    configurationPath: '',
-    directory: './my-extension',
-    type: 'theme',
-    graphQLType: 'THEME_APP_EXTENSION',
-  }
-}

--- a/packages/app/src/cli/services/dev/theme-extension-args.test.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.test.ts
@@ -1,5 +1,5 @@
 import {themeExtensionArgs} from './theme-extension-args'
-import {ensureDeployEnvironment} from '../environment'
+import {ensureThemeExtensionDevEnvironment} from '../environment'
 import {testApp, testThemeExtensions} from '../../models/app/app.test-data'
 import {beforeAll, describe, expect, it, vi} from 'vitest'
 
@@ -11,31 +11,21 @@ beforeAll(() => {
 describe('themeExtensionArgs', async () => {
   it('returns valid theme extension arguments', async () => {
     const apiKey = 'api_key_0000_1111_2222'
+    const token = 'token'
     const reset = false
     const options = {app: testApp(), reset, themeExtensionPort: 8282, theme: 'theme ID'}
     const extension = testThemeExtensions()
 
-    const deployEnvironmentOutput = {
-      app: options.app,
-      token: 'token',
-      partnersOrganizationId: '123',
-      partnersApp: {
-        id: '456',
-        title: 'title',
-        organizationId: 'orgID',
-      },
-      identifiers: {
-        app: options.app.name,
-        extensions: {},
-        extensionIds: {
-          'extension title': 'extension ID',
-        },
-      },
+    const registration = {
+      id: 'extension ID',
+      uuid: 'UUID',
+      type: 'THEME_APP_EXTENSION',
+      title: 'theme app extension',
     }
 
-    vi.mocked(ensureDeployEnvironment).mockReturnValue(Promise.resolve(deployEnvironmentOutput))
+    vi.mocked(ensureThemeExtensionDevEnvironment).mockReturnValue(Promise.resolve(registration))
 
-    const args = await themeExtensionArgs(extension, apiKey, options)
+    const args = await themeExtensionArgs(extension, apiKey, token, options)
 
     expect(args).toEqual([
       './my-extension',

--- a/packages/app/src/cli/services/dev/theme-extension-args.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.ts
@@ -1,0 +1,38 @@
+import {AppInterface} from '../../models/app/app.js'
+import {ensureDeployEnvironment} from '../environment.js'
+
+export async function themeExtensionArgs(
+  apiKey: string,
+  options: {app: AppInterface; theme?: string; port?: number; reset: boolean},
+) {
+  const {identifiers} = await ensureDeployEnvironment(options)
+
+  const extension = options.app.extensions.theme[0]!
+
+  const directory = extension.directory
+  const extensionId = identifiers.extensionIds[extension.localIdentifier]!
+  const extensionTitle = extension.localIdentifier
+  const extensionType = extension.graphQLType
+
+  const args: string[] = [
+    directory,
+    '--api-key',
+    apiKey,
+    '--extension-id',
+    extensionId,
+    '--extension-title',
+    extensionTitle,
+    '--extension-type',
+    extensionType,
+  ]
+
+  if (options.theme) {
+    args.push('--theme', options.theme)
+  }
+
+  if (options.port) {
+    args.push('--port', options.port.toString())
+  }
+
+  return args
+}

--- a/packages/app/src/cli/services/dev/theme-extension-args.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.ts
@@ -1,13 +1,13 @@
 import {AppInterface} from '../../models/app/app.js'
+import {ThemeExtension} from '../../models/app/extensions.js'
 import {ensureDeployEnvironment} from '../environment.js'
 
 export async function themeExtensionArgs(
+  extension: ThemeExtension,
   apiKey: string,
-  options: {app: AppInterface; theme?: string; port?: number; reset: boolean},
+  options: {app: AppInterface; theme?: string; themeExtensionPort?: number; reset: boolean},
 ) {
   const {identifiers} = await ensureDeployEnvironment(options)
-
-  const extension = options.app.extensions.theme[0]!
 
   const directory = extension.directory
   const extensionId = identifiers.extensionIds[extension.localIdentifier]!
@@ -30,8 +30,8 @@ export async function themeExtensionArgs(
     args.push('--theme', options.theme)
   }
 
-  if (options.port) {
-    args.push('--port', options.port.toString())
+  if (options.themeExtensionPort) {
+    args.push('--port', options.themeExtensionPort.toString())
   }
 
   return args

--- a/packages/app/src/cli/services/dev/theme-extension-args.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.ts
@@ -1,16 +1,16 @@
 import {AppInterface} from '../../models/app/app.js'
 import {ThemeExtension} from '../../models/app/extensions.js'
-import {ensureDeployEnvironment} from '../environment.js'
+import {ensureThemeExtensionDevEnvironment} from '../environment.js'
 
 export async function themeExtensionArgs(
   extension: ThemeExtension,
   apiKey: string,
+  token: string,
   options: {app: AppInterface; theme?: string; themeExtensionPort?: number; reset: boolean},
 ) {
-  const {identifiers} = await ensureDeployEnvironment(options)
-
+  const extensionRegistration = await ensureThemeExtensionDevEnvironment(options, extension, token)
+  const extensionId = extensionRegistration.id
   const directory = extension.directory
-  const extensionId = identifiers.extensionIds[extension.localIdentifier]!
   const extensionTitle = extension.localIdentifier
   const extensionType = extension.graphQLType
 

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -506,6 +506,12 @@ describe('ensureThemeExtensionDevEnvironment', () => {
       app: {
         extensionRegistrations: [
           {
+            id: 'other ID',
+            uuid: 'other UUID',
+            title: 'other extension',
+            type: 'other',
+          },
+          {
             id: 'existing ID',
             uuid: 'UUID',
             title: 'theme app extension',

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -7,14 +7,17 @@ import {
   fetchOrgFromId,
   fetchStoreByDomain,
   FetchResponse,
+  fetchAppExtensionRegistrations,
 } from './dev/fetch.js'
 import {convertToTestStoreIfNeeded, selectStore} from './dev/select-store.js'
 import {ensureDeploymentIdsPresence} from './environment/identifiers.js'
+import {createExtension, ExtensionRegistration} from './dev/create-extension.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
 import {AppInterface} from '../models/app/app.js'
 import {Identifiers, UuidOnlyIdentifiers, updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
 import metadata from '../metadata.js'
+import {ThemeExtension} from '../models/app/extensions.js'
 import {error as kitError, output, session, store, ui, environment, error, string} from '@shopify/cli-kit'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
 
@@ -211,7 +214,7 @@ interface DeployEnvironmentOutput {
  * OrganizationApp if a cached value is valid.
  * undefined if there is no cached value or the user doesn't want to use it.
  */
-async function fetchDevAppAndPrompt(app: AppInterface, token: string): Promise<OrganizationApp | undefined> {
+export async function fetchDevAppAndPrompt(app: AppInterface, token: string): Promise<OrganizationApp | undefined> {
   const devAppId = (await store.getAppInfo(app.directory))?.appId
   if (!devAppId) return undefined
 
@@ -225,28 +228,31 @@ async function fetchDevAppAndPrompt(app: AppInterface, token: string): Promise<O
   return reuse ? partnersResponse : undefined
 }
 
+export async function ensureThemeExtensionDevEnvironment(
+  options: DevEnvironmentOptions,
+  extension: ThemeExtension,
+  token: string,
+): Promise<ExtensionRegistration> {
+  const [partnersApp, _] = await fetchAppAndIdentifiers(options, token)
+  const apiKey = partnersApp.apiKey
+
+  const remoteSpecifications = await fetchAppExtensionRegistrations({token, apiKey})
+  const remoteRegistrations = remoteSpecifications.app.extensionRegistrations
+
+  if (remoteRegistrations.length > 0) {
+    return remoteRegistrations[0]!
+  }
+
+  const registration = await createExtension(apiKey, extension.type, extension.localIdentifier, token)
+
+  return registration
+}
+
 export async function ensureDeployEnvironment(options: DeployEnvironmentOptions): Promise<DeployEnvironmentOutput> {
   const token = await session.ensureAuthenticatedPartners()
-  let envIdentifiers = await getAppIdentifiers({app: options.app})
-
-  let partnersApp: OrganizationApp | undefined
-
-  if (options.reset) {
-    envIdentifiers = {app: undefined, extensions: {}}
-  } else if (envIdentifiers.app) {
-    const apiKey = options.apiKey ?? envIdentifiers.app
-    partnersApp = await fetchAppFromApiKey(apiKey, token)
-    if (!partnersApp) throw DeployAppNotFound(apiKey, options.app.packageManager)
-  } else {
-    partnersApp = await fetchDevAppAndPrompt(options.app, token)
-  }
+  const [partnersApp, envIdentifiers] = await fetchAppAndIdentifiers(options, token)
 
   let identifiers: Identifiers = envIdentifiers as Identifiers
-
-  if (!partnersApp) {
-    const result = await fetchOrganizationAndFetchOrCreateApp(options.app, token)
-    partnersApp = result.partnersApp
-  }
 
   identifiers = await ensureDeploymentIdsPresence({
     app: options.app,
@@ -279,7 +285,7 @@ export async function ensureDeployEnvironment(options: DeployEnvironmentOptions)
   return result
 }
 
-async function fetchOrganizationAndFetchOrCreateApp(
+export async function fetchOrganizationAndFetchOrCreateApp(
   app: AppInterface,
   token: string,
 ): Promise<{partnersApp: OrganizationApp; orgId: string}> {
@@ -287,6 +293,32 @@ async function fetchOrganizationAndFetchOrCreateApp(
   const {organization, apps} = await fetchOrgsAppsAndStores(orgId, token)
   const partnersApp = await selectOrCreateApp(app, apps, organization, token, undefined)
   return {orgId, partnersApp}
+}
+
+async function fetchAppAndIdentifiers(
+  options: {app: AppInterface; reset: boolean; packageManager?: PackageManager; apiKey?: string},
+  token: string,
+): Promise<[OrganizationApp, Partial<UuidOnlyIdentifiers>]> {
+  let envIdentifiers = await getAppIdentifiers({app: options.app})
+
+  let partnersApp: OrganizationApp | undefined
+
+  if (options.reset) {
+    envIdentifiers = {app: undefined, extensions: {}}
+  } else if (envIdentifiers.app) {
+    const apiKey = options.apiKey ?? envIdentifiers.app
+    partnersApp = await fetchAppFromApiKey(apiKey, token)
+    if (!partnersApp) throw DeployAppNotFound(apiKey, options.app.packageManager)
+  } else {
+    partnersApp = await fetchDevAppAndPrompt(options.app, token)
+  }
+
+  if (!partnersApp) {
+    const result = await fetchOrganizationAndFetchOrCreateApp(options.app, token)
+    partnersApp = result.partnersApp
+  }
+
+  return [partnersApp, envIdentifiers]
 }
 
 async function fetchOrgsAppsAndStores(orgId: string, token: string): Promise<FetchResponse> {

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -237,7 +237,9 @@ export async function ensureThemeExtensionDevEnvironment(
   const apiKey = partnersApp.apiKey
 
   const remoteSpecifications = await fetchAppExtensionRegistrations({token, apiKey})
-  const remoteRegistrations = remoteSpecifications.app.extensionRegistrations
+  const remoteRegistrations = remoteSpecifications.app.extensionRegistrations.filter((extension) => {
+    return extension.type === 'THEME_APP_EXTENSION'
+  })
 
   if (remoteRegistrations.length > 0) {
     return remoteRegistrations[0]!

--- a/packages/cli-kit/src/node/ruby.test.ts
+++ b/packages/cli-kit/src/node/ruby.test.ts
@@ -57,4 +57,42 @@ describe('execCLI', () => {
 
     await expect(() => execCLI2(['args'])).rejects.toThrowError('Error')
   })
+
+  it('passes token to the CLI2', async () => {
+    // Setup
+    const originalEnv = process.env
+
+    // Given
+    const execSpy = vi.spyOn(system, 'exec')
+
+    process.env = {...originalEnv, SHOPIFY_CLI_2_0_DIRECTORY: './CLI2'}
+
+    vi.mocked(file.exists).mockResolvedValue(true)
+    vi.mocked(system.captureOutput).mockResolvedValueOnce('2.7.5')
+    vi.mocked(system.captureOutput).mockResolvedValueOnce('2.4.0')
+
+    // When
+    await execCLI2(['args'], {
+      token: 'token_0000_1111_2222_3333',
+      directory: './directory',
+    })
+
+    // Then
+    expect(execSpy).toHaveBeenLastCalledWith('bundle', ['exec', 'shopify', 'args'], {
+      stdio: 'inherit',
+      cwd: './directory',
+      env: {
+        ...process.env,
+        SHOPIFY_CLI_STOREFRONT_RENDERER_AUTH_TOKEN: undefined,
+        SHOPIFY_CLI_ADMIN_AUTH_TOKEN: undefined,
+        SHOPIFY_CLI_STORE: undefined,
+        SHOPIFY_CLI_AUTH_TOKEN: 'token_0000_1111_2222_3333',
+        SHOPIFY_CLI_RUN_AS_SUBPROCESS: 'true',
+        BUNDLE_GEMFILE: 'CLI2/Gemfile',
+      },
+    })
+
+    // Teardown
+    process.env = originalEnv
+  })
 })

--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -19,6 +19,8 @@ interface ExecCLI2Options {
   adminSession?: AdminSession
   // Contains token for storefront access to pass to CLI 2.0 as environment variable
   storefrontToken?: string
+  // Contains token for partners access to pass to CLI 2.0 as environment variable
+  token?: string
   // Directory in which to execute the command. Otherwise the current directory will be used.
   directory?: string
 }
@@ -30,13 +32,17 @@ interface ExecCLI2Options {
  * @param args {string[]} List of argumets to execute. (ex: ['theme', 'pull'])
  * @param options {ExecCLI2Options}
  */
-export async function execCLI2(args: string[], {adminSession, storefrontToken, directory}: ExecCLI2Options = {}) {
+export async function execCLI2(
+  args: string[],
+  {adminSession, storefrontToken, token, directory}: ExecCLI2Options = {},
+) {
   await installCLIDependencies()
   const env = {
     ...process.env,
     SHOPIFY_CLI_STOREFRONT_RENDERER_AUTH_TOKEN: storefrontToken,
     SHOPIFY_CLI_ADMIN_AUTH_TOKEN: adminSession?.token,
     SHOPIFY_CLI_STORE: adminSession?.storeFqdn,
+    SHOPIFY_CLI_AUTH_TOKEN: token,
     SHOPIFY_CLI_RUN_AS_SUBPROCESS: 'true',
     // Bundler uses this Gemfile to understand which gems are available in the
     // environment. We use this to specify our own Gemfile for CLI2, which exists

--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -9,7 +9,7 @@ import {AdminSession} from '../session.js'
 import {content, token} from '../output.js'
 import {Writable} from 'node:stream'
 
-const RubyCLIVersion = '2.23.0'
+const RubyCLIVersion = '2.25.0'
 const ThemeCheckVersion = '1.10.3'
 const MinBundlerVersion = '2.3.8'
 const MinRubyVersion = '2.7.5'


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2540.

### WHAT is this pull request doing?

This PR introduces the hot reload feature for theme app extension developers. It reuses the same development server that theme developers use, in the context of theme app extension development.

### How to test your changes?

- Create an app
- Generate a theme app extension with `yarn shopify app generate extension --path <app_directory>`
- Run `yarn shopify app dev --path <theme_app_extension_directory>`
- Notice the CLI 3.x is running the `extension serve` command

![demo](https://user-images.githubusercontent.com/1079279/190362178-19addce2-7a09-4037-85e3-383afaf8de02.gif)

### Post-release steps

Merge the documentation PR https://github.com/Shopify/shopify-dev/pull/26125.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).
