### PR TITLE
upgrade to go 1.19 to avoid windows issue with mimetypes when serving…

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -24,7 +24,7 @@ env:
   RUBY_VERSION: "3.1.2"
   BUNDLER_VERSION: "2.3.18"
   PNPM_VERSION: "7.9.4"
-  GO_VERSION: "1.17"
+  GO_VERSION: "1.19"
 
 jobs:
   fixture:

--- a/.github/workflows/ui-extensions-go-cli-release.yml
+++ b/.github/workflows/ui-extensions-go-cli-release.yml
@@ -5,7 +5,7 @@ on:
     types: [created, edited]
 
 env:
-  GO_VERSION: "1.17"
+  GO_VERSION: "1.19"
   YARN_VERSION: "1.22.19"
 
 jobs:

--- a/dev.yml
+++ b/dev.yml
@@ -7,7 +7,7 @@ up:
       packages:
         - ./
   - go:
-      version: 1.17.6
+      version: 1.19
       modules: true
   - ruby:
       version: 3.1.2

--- a/packages/ui-extensions-go-cli/.github/workflows/release.yml
+++ b/packages/ui-extensions-go-cli/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup build toolchain
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
       - name: Setup ruby
         uses: actions/setup-ruby@v1
       - name: Build node packages

--- a/packages/ui-extensions-go-cli/.github/workflows/testing.yml
+++ b/packages/ui-extensions-go-cli/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
       - name: Test
         run: make test
 
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
           cache: true
       - run: go mod vendor
       - uses: actions/setup-node@v2

--- a/packages/ui-extensions-go-cli/README.md
+++ b/packages/ui-extensions-go-cli/README.md
@@ -8,7 +8,7 @@ The information below is mainly targeting contributors rather than users. If you
 
 Prerequisites:
 
-- [Go](https://go.dev/), version 1.17 or higher
+- [Go](https://go.dev/), version 1.19 or higher
 - The current [LTS version](https://nodejs.org/en/about/releases/) of [Node.JS](https://nodejs.org/en/)
 
 Install Go by running

--- a/packages/ui-extensions-go-cli/go.mod
+++ b/packages/ui-extensions-go-cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/shopify-cli-extensions
 
-go 1.17
+go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.2.0


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #355

Go <1.19 mime type function fails on windows if the registry is overwritten (see more info [here](https://github.com/golang/go/issues/32350)). This results on setting the contentype for main.js to plain/text therefore the extension fails to load the script.

### WHAT is this pull request doing?

- upgrade go version to 1.19

### How to test your changes?

