### PR TITLE
Add an additional step to the release docs for merging the formula PR

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -20,4 +20,4 @@ The steps are:
        * The release is not created: Retry again from _step 3_
        * Some of the binaries are not correctly uploaded to the release: The release should be deleted manually from Github and then retry again from _step 3_
     2. Publishing of the CLI packages to the [NPM registry](https://www.npmjs.com/package/@shopify/cli). In case an error is produced the extension binary release should be deleted manually from Github and retry again from _step 3_
-
+5. Once the deployment completes, [find the PR](https://github.com/Shopify/homebrew-shopify/pulls) in the homebrew-shopify repository and merge the changes in the formula.


### PR DESCRIPTION
### WHY are these changes introduced?
We extended the release process recently to open a PR in the Shopify Homebrew Formulas repository but forgot to update release documentation.

### WHAT is this pull request doing?
I'm updating the documentation to mention that the PR opened by the deployment should be merged.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact
