### PR TITLE
Fix the VSConfiguration of the ESLint plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "eslint.workingDirectories": [{ "pattern": "packages/*/package.json" }],
+  "eslint.workingDirectories": [{ "pattern": "packages/*" }],
   "vitest.enable": true,
   "testing.automaticallyOpenPeekView": "never",
   "javascript.preferences.importModuleSpecifierEnding": "js",


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed that the configuration of the VSCode ESLint plugin was wrong and that was causing misbehaviours while editing source code.

### WHAT is this pull request doing?
The `eslint.workingDirectories` attribute has to be a glob pointing to the directories containing ESLint projects.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### How to test your changes?
Pull the changes, edit a file and add a line of code that makes ESLint's validation fail. For example:

```
const name: any = "xxx"
```
ESLint should flag it and if you save the file, it should auto-fix it.