### PR TITLE
Use a glob to define inputs in Nx projects

### DIFF
--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -16,7 +16,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src"],
+        "inputs": ["{projectRoot}/src/**/*"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/app"

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -15,7 +15,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src"],
+        "inputs": ["{projectRoot}/src/**/*"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-hydrogen"

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -15,7 +15,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src"],
+        "inputs": ["{projectRoot}/src/**/*"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-kit"

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -15,7 +15,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src"],
+        "inputs": ["{projectRoot}/src/**/*"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-main"

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -15,7 +15,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src"],
+        "inputs": ["{projectRoot}/src/**/*"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/create-app"

--- a/packages/create-hydrogen/project.json
+++ b/packages/create-hydrogen/project.json
@@ -15,7 +15,7 @@
     "build": {
       "executor": "nx:run-commands",
       "outputs": ["dist"],
-      "inputs": ["{projectRoot}/src"],
+      "inputs": ["{projectRoot}/src/**/*"],
       "options": {
         "command": "yarn tsc -b ./tsconfig.build.json",
         "cwd": "packages/create-hydrogen"

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -15,7 +15,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src"],
+        "inputs": ["{projectRoot}/src/**/*"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/theme"

--- a/packages/ui-extensions-cli/project.json
+++ b/packages/ui-extensions-cli/project.json
@@ -30,7 +30,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src"],
+        "inputs": ["{projectRoot}/src/**/*"],
         "options": {
           "command": "yarn tsc",
           "cwd": "packages/ui-extensions-cli"

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -16,7 +16,7 @@
       "build": {
         "outputs": ["../ui-extensions-go-cli/api/dev-console"],
         "executor": "nx:run-commands",
-        "inputs": ["{projectRoot}/src"],
+        "inputs": ["{projectRoot}/src/**/*"],
         "options": {
           "command": "yarn tsc --project tsconfig.build.json --noEmit && yarn vite build",
           "cwd": "packages/ui-extensions-dev-console"

--- a/packages/ui-extensions-server-kit/project.json
+++ b/packages/ui-extensions-server-kit/project.json
@@ -32,7 +32,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["build:code", "build:types"],
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src", "{projectRoot}/testing.*", "{projectRoot}/index.*"],
+        "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/testing.*", "{projectRoot}/index.*"],
         "options": {
           "command": "cd .",
           "cwd": "packages/ui-extensions-server-kit"

--- a/packages/ui-extensions-test-utils/project.json
+++ b/packages/ui-extensions-test-utils/project.json
@@ -15,7 +15,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src"],
+        "inputs": ["{projectRoot}/src/**/*"],
         "options": {
           "command": "yarn tsc",
           "cwd": "packages/ui-extensions-test-utils"


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed that Nx cache doesn't get invalidated as expected when changing code. It turns out the `inputs` parameter expects a [glob](https://nx.dev/configuration/projectjson#inputs-&-namedinputs).

### WHAT is this pull request doing?

I'm adjusting all the `inputs` attributes in `project.json`'s to use globs.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### How to test your changes?
1. Clean your environment `yarn clean`.
2. Run `yarn shopify app --help` to see the help.
3. Update the description of any of the commands that you see there.
4. Run `yarn shopify app --help` again and you should see your changes.