### PR TITLE
Don't use the Go version as a runtime cache input

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -8,7 +8,7 @@
         "cacheableOperations": [
           "build"
         ],
-        "runtimeCacheInputs": ["node -v", "yarn tsc --version", "go version"]
+        "runtimeCacheInputs": ["node -v", "yarn tsc --version"]
       }
     }
   },


### PR DESCRIPTION
### WHY are these changes introduced?
The [release pipeline](https://shipit.shopify.io/shopify/cli/production/deploys/1786802) is failing when Nx tries to obtain the Go version to calculate the projects' hashes for caching purposes.

### WHAT is this pull request doing?
Since we rarely change the Go version and we'll remove the dependency with Go in the near future we can drop the Go version from the list of inputs that are considered when calculating the hash. 

### How to test your changes?
CI should pass

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
