### PR TITLE
Fix shipit configuration

### DIFF
--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -11,7 +11,7 @@ dependencies:
 deploy:
   override:
     - PATHGO=/tmp/go/bin bin/release.js
-    - npm_config_loglevel=verbose yarn run changeset publish
+    - PATH=$PATH:/tmp/go/bin npm_config_loglevel=verbose yarn run changeset publish
     - ./bin/package.js
   post:
     - yarn run update-bugsnag


### PR DESCRIPTION
### WHY are these changes introduced?

The [deploy with shipit](https://shipit.shopify.io/shopify/cli/production/deploys/1786884) is failing because the extensions build, run as part of the prepack task of cli/app, is missing the go binary path.

### WHAT is this pull request doing?

Adds the go binary to the path before running `changeset publish`

### How to test your changes?
shipit

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
