### PR TITLE
Fix product subscription react template

### DIFF
--- a/packages/ui-extensions-go-cli/create/templates/shared/product_subscription/react.js
+++ b/packages/ui-extensions-go-cli/create/templates/shared/product_subscription/react.js
@@ -1,12 +1,25 @@
-import React from "react";
-import { render, extend, Text } from "@shopify/admin-ui-extensions-react";
+import React from 'react'
+import {render, extend, Text, useExtensionApi} from '@shopify/admin-ui-extensions-react'
 
 // Your extension must render all four modes
-extend("Admin::Product::SubscriptionPlan::Add", render(App));
-extend("Admin::Product::SubscriptionPlan::Create", render(App));
-extend("Admin::Product::SubscriptionPlan::Remove", render(App));
-extend("Admin::Product::SubscriptionPlan::Edit", render(App));
+extend(
+  'Admin::Product::SubscriptionPlan::Add',
+  render(() => <App />),
+)
+extend(
+  'Admin::Product::SubscriptionPlan::Create',
+  render(() => <App />),
+)
+extend(
+  'Admin::Product::SubscriptionPlan::Remove',
+  render(() => <App />),
+)
+extend(
+  'Admin::Product::SubscriptionPlan::Edit',
+  render(() => <App />),
+)
 
-function App({ extensionPoint }) {
-  return <Text>Welcome to the {extensionPoint} extension!</Text>;
+function App() {
+  const {extensionPoint} = useExtensionApi()
+  return <Text>Welcome to the {extensionPoint} extension!</Text>
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This PR fixes product subscription react template. Generally, it works right now. However, as soon as we add hook to App component, it breaks. The reason is because the `render` function expects a function returning a React element.

### WHAT is this pull request doing?

Fix the render call and use `useExtensionApi` to query for `extensionPoint`.

### How to test your changes?

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
