### PR TITLE
Take into account the Yarn lockfile and Git commit sha to calculate t…

### DIFF
--- a/bin/cache-inputs.js
+++ b/bin/cache-inputs.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+/**
+ * The output from this script is used by Nx to determine whether the cache should be invalidated
+ * or not at the workspace level. This file is referenced from the nx.json file.
+ */
+
+process.removeAllListeners('warning');
+
+import {dirname, join} from 'pathe'
+import {createRequire} from 'module'
+import {fileURLToPath} from 'url'
+import crypto from "crypto"
+
+const require = createRequire(import.meta.url)
+const execa = require('execa')
+const {readFile} = require('fs-extra')
+
+// Paths
+const binDirectory = dirname(fileURLToPath(import.meta.url))
+const rootDirectory = dirname(binDirectory)
+
+// Hashable inputs
+const nodeVersion = process.version;
+
+const {stdout: typescriptCompilerVersion} = await execa(join(rootDirectory, "node_modules/.bin/tsc"), ['--version'], {cwd: rootDirectory});
+const {stdout: gitSha} = await execa("git", ['rev-parse', '--short', 'HEAD'], {cwd: rootDirectory});
+const yarnLockfileContent = (await readFile(join(rootDirectory, "yarn.lock"))).toString();
+
+const hashableInputs = [
+  nodeVersion.trim(),
+  typescriptCompilerVersion.trim(),
+  gitSha.trim(),
+  crypto.createHash('md5').update(yarnLockfileContent).digest("hex")
+]
+
+console.log(hashableInputs.join("\n"))

--- a/nx.json
+++ b/nx.json
@@ -8,7 +8,9 @@
         "cacheableOperations": [
           "build"
         ],
-        "runtimeCacheInputs": ["node -v", "yarn tsc --version"]
+        "runtimeCacheInputs": [
+          "node ./bin/cache-inputs.js"
+        ]
       }
     }
   },

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -16,7 +16,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src/**/*"],
+        "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/app"

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -15,7 +15,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src/**/*"],
+        "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-hydrogen"

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -15,7 +15,7 @@
       "build": {
         "executor": "nx:run-commands",
         "outputs": ["dist"],
-        "inputs": ["{projectRoot}/src/**/*"],
+        "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
         "options": {
           "command": "yarn tsc -b ./tsconfig.build.json",
           "cwd": "packages/theme"


### PR DESCRIPTION
### WHY are these changes introduced?
@isaacroldan noticed that the cache was not getting invalidated when switching between branches.

### WHAT is this pull request doing?
I'm adjusting the input data that's used to calculate the cache to take into account the Git commit sha and the Yarn lockfile. When any of those change the cache will get invalidated.

### How to test your changes?
1. Run `yarn shopify app --help` to warm the cache.
2. Run it again. It should skip all the build steps and use the build artifacts from the cache.
3. Edit the `yarn.lock` file and add an empty line at the end.
4. Run it again. It should build the entire graph.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
