### PR TITLE
Fix using the wrong path with cache-inputs.js

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -9,7 +9,7 @@
           "build"
         ],
         "runtimeCacheInputs": [
-          "node ./bin/cache-inputs.js"
+          "node bin/cache-inputs.js || node ../../bin/cache-inputs.js"
         ]
       }
     }


### PR DESCRIPTION
### WHY are these changes introduced?
This [recently-merged PR](https://github.com/Shopify/cli/pull/388) assumed the path in the `runtimeCacheInputs` property of `nx` has to be relative o the workspace directory but it turns out is relative to either the project or the workspace.

### WHAT is this pull request doing?

I tried using the `{workspaceRoot}` variable as is supported in other attributes but Nx doesn't replace it. A temporary solution that I found works is having the command for the workspace with a fallback for projects. I'll open an issue in the Nx repository to see if there's a better way to address this.

### How to test your changes?
Run `yarn test` in the repository root in any package under `packages`. The command must succeed.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
