### PR TITLE
Support testing modules individually with `yarn test`

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,7 +21,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test",
+    "test": "nx run app:test",
     "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -27,7 +27,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test",
+    "test": "nx run cli-hydrogen:test",
     "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -52,7 +52,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test",
+    "test": "nx run cli-kit:test",
     "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -41,7 +41,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test",
+    "test": "nx run cli-main:test",
     "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -36,7 +36,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test",
+    "test": "nx run create-app:test",
     "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -37,7 +37,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test",
+    "test": "nx run create-hydrogen:test",
     "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test",
+    "test": "nx run features:test",
     "type-check": "nx type-check"
   },
   "devDependencies": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -22,7 +22,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test",
+    "test": "nx run theme:test",
     "test:watch": "nx test:watch",
     "type-check": "nx type-check"
   },

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "nx lint:fix",
     "serve": "vite preview",
     "start": "nx start",
-    "test": "nx test",
+    "test": "nx run ui-extensions-dev-console:test",
     "test:watch": "nx test:watch"
   },
   "dependencies": {

--- a/packages/ui-extensions-go-cli/package.json
+++ b/packages/ui-extensions-go-cli/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "nx clean",
     "build": "nx build",
-    "test": "nx test",
+    "test": "nx run ui-extensions-go-cli:test",
     "package": "nx package",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix"

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -26,7 +26,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx test",
+    "test": "nx run ui-extensions-server-kit:test",
     "test:watch": "nx test:watch"
   },
   "peerDependencies": {


### PR DESCRIPTION
### WHY are these changes introduced?
The recent adoption of Nx as the default build tool broke the convenient workflow: `yarn test {path-to-test-module}`.

### WHAT is this pull request doing?

Nx was treating the module path as the test target so I adjusted the `test` script in the package.json to be more explicit about the project that's being tested. With that change any additional arguments are forwarded to the underlying process.

### How to test your changes?
Run `yarn test` in a package passing the path to a test module contained in that package.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
