### PR TITLE
Not cancel CLI runs in `main` when new PRs land

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -13,7 +13,7 @@ on:
   pull_request:
 
 concurrency:
-  group: shopify-cli-${{ github.head_ref }}
+  group: shopify-cli-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
### WHY are these changes introduced?
As stated [here](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value), `github.head_ref` is only present in PRs. That causes the concurrency group to be `shopify-cli-` in `main` builds and that leads to cancellation of builds for some commits.

### WHAT is this pull request doing?
We don't want to cancel CI builds in `main` when new PRs land because that makes it hard to trace back which merges might have caused `main` to get red and revert it. 

### How to test your changes?
CI should pass in this PR.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
