### PR TITLE
Fixed executable path to always point to a node file

### DIFF
--- a/packages/app/src/cli/utilities/extensions/cli.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.ts
@@ -57,7 +57,7 @@ export async function nodeExtensionsCLIPath(): Promise<string> {
       cwd,
     })) as string
   } else {
-    const executablePath = await path.findUp('node_modules/.bin/shopify-cli-extensions', {
+    const executablePath = await path.findUp('node_modules/@shopify/shopify-cli-extensions/dist/cli.js', {
       type: 'file',
       cwd,
       allowSymlinks: true,


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes [#355](https://github.com/Shopify/cli/issues/355)

Currently we rely on node to generate the os dependant executable files pointing to the node cli.js and add the path to one of them as the node_executable field in the configuration given to the extension server. The Go binary then tries to execute with node this path. This causes an error in Windows as it creates both bash and a cmd files which are not supported by node.

### WHAT is this pull request doing?

Instead of relying on the node generated files point directly cli.js path in the configuration.

### How to test your changes?

- create an app `yarn create-app`
- create an extension for the app:
  - `cd app-folder
  - `yarn scaffold extension`
- dev the app+extension `yarn dev`

