### PR TITLE
Skip CI for markdown files

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
### WHY are these changes introduced?

Everytime we push changes including only md files (for example, adding a changeset), we have to wait for the CI to run, but it's not needed actually.

### WHAT is this pull request doing?

Updates the main workflow to not run it when it only includes md files.

Documentation: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

### How to test your changes?

Not possible until we merge it.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
