### PR TITLE
Fix the Homebrew formula

### DIFF
--- a/.changeset/brown-ears-drum.md
+++ b/.changeset/brown-ears-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix syntax of the Homebrew formula

--- a/packaging/src/shopify-cli@3.rb.liquid
+++ b/packaging/src/shopify-cli@3.rb.liquid
@@ -40,7 +40,7 @@ class ShopifyCliAT3 < Formula
     executable_content = <<~SCRIPT
       #!/usr/bin/env node
 
-      process.env.SHOPIFY_RUBY_BINDIR = Formula["ruby"].opt_bin
+      process.env.SHOPIFY_RUBY_BINDIR = "#{Formula["ruby"].opt_bin}"
 
       import("./shopify");
     SCRIPT


### PR DESCRIPTION
### WHY are these changes introduced?
The Homebrew formula for installing the CLI globally has an issue that causes the installation to fail.

### WHAT is this pull request doing?
I'm interpolating `Formula["ruby"].opt_bin` in the script content.

### How to test your changes?
1. Run `brew upgrade`.
2. Edit the formula `/opt/homebrew/Library/Taps/shopify/homebrew-shopify/shopify-cli@3.rb`.
3. Move the fixes in this PR to that Ruby file.
4. Run `brew install shopify-cli@3`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
