### PR TITLE
Fix store and Bugsnag initialization for Homebrew

### DIFF
--- a/.changeset/itchy-cars-grab.md
+++ b/.changeset/itchy-cars-grab.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix pull command with --store flag

--- a/packages/cli-kit/src/node/cli.ts
+++ b/packages/cli-kit/src/node/cli.ts
@@ -2,10 +2,8 @@
 import {findUpAndReadPackageJson} from './node-package-manager.js'
 import {errorHandler} from './error-handler.js'
 import {isDevelopment} from '../environment/local.js'
-import constants, {bugsnagApiKey} from '../constants.js'
 import {moduleDirectory} from '../path.js'
 import {run, settings, flush} from '@oclif/core'
-import Bugsnag from '@bugsnag/js'
 
 interface RunCLIOptions {
   /** The value of import.meta.url of the CLI executable module */
@@ -20,15 +18,6 @@ interface RunCLIOptions {
 export async function runCLI(options: RunCLIOptions) {
   if (isDevelopment()) {
     settings.debug = true
-  } else {
-    Bugsnag.start({
-      appType: 'node',
-      apiKey: bugsnagApiKey,
-      logger: null,
-      appVersion: await constants.versions.cliKit(),
-      autoTrackSessions: false,
-      autoDetectErrors: false,
-    })
   }
 
   run(undefined, options.moduleURL).then(flush).catch(errorHandler)

--- a/packages/cli-kit/src/node/error-handler.test.ts
+++ b/packages/cli-kit/src/node/error-handler.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
           onNotify(reportedError)
           callback(null)
         },
+        isStarted: () => true,
       },
     }
   })

--- a/packages/cli-kit/src/node/error-handler.ts
+++ b/packages/cli-kit/src/node/error-handler.ts
@@ -11,6 +11,7 @@ import {getEnvironmentData, reportEvent} from '../analytics.js'
 import * as path from '../path.js'
 import * as metadata from '../metadata.js'
 import {fanoutHooks} from '../plugins.js'
+import constants, {bugsnagApiKey} from '../constants.js'
 import {settings, Interfaces} from '@oclif/core'
 import StackTracey from 'stacktracey'
 import Bugsnag, {Event} from '@bugsnag/js'
@@ -88,6 +89,7 @@ export async function sendErrorToBugsnag(
   reportableError.stack = `Error: ${reportableError.message}\n${formattedStacktrace}`
 
   if (report) {
+    await initializeBugsnag()
     await new Promise((resolve, reject) => {
       Bugsnag.notify(reportableError, undefined, (error, event) => {
         if (error) {
@@ -142,6 +144,7 @@ export async function registerCleanBugsnagErrorsFromWithinPlugins(config: Interf
       return {name: plugin.name, pluginPath: path.normalize(followSymlinks)}
     }),
   )
+  await initializeBugsnag()
   Bugsnag.addOnError(async (event) => {
     event.errors.forEach((error) => {
       error.stacktrace.forEach((stackFrame) => {
@@ -203,5 +206,19 @@ export async function addBugsnagMetadata(event: Event, config: Interfaces.Config
   }
   Object.entries(bugsnagMetadata).forEach(([section, values]) => {
     event.addMetadata(section, values)
+  })
+}
+
+async function initializeBugsnag() {
+  if (Bugsnag.isStarted()) {
+    return
+  }
+  Bugsnag.start({
+    appType: 'node',
+    apiKey: bugsnagApiKey,
+    logger: null,
+    appVersion: await constants.versions.cliKit(),
+    autoTrackSessions: false,
+    autoDetectErrors: false,
   })
 }

--- a/packages/cli-kit/src/node/hooks/init.ts
+++ b/packages/cli-kit/src/node/hooks/init.ts
@@ -1,8 +1,6 @@
 import {initiateLogging} from '../../output.js'
-import {initializeCliKitStore} from '../../store.js'
 import {Hook} from '@oclif/core'
 
 export const hook: Hook.Init = async (options) => {
-  await initializeCliKitStore()
   initiateLogging()
 }

--- a/packages/cli-kit/src/node/ruby.test.ts
+++ b/packages/cli-kit/src/node/ruby.test.ts
@@ -26,24 +26,10 @@ describe('execCLI', () => {
     )
   })
 
-  it('throws an exception when RubyGems version requirement is not met', async () => {
-    const rubyVersion = '2.7.5'
-    const rubyGemsVersion = '2.3.0'
-    vi.mocked(file.exists).mockResolvedValue(true)
-    vi.mocked(system.captureOutput).mockResolvedValueOnce(rubyVersion)
-    vi.mocked(system.captureOutput).mockResolvedValueOnce(rubyGemsVersion)
-
-    await expect(() => execCLI2(['args'])).rejects.toThrowError(
-      `RubyGems version \u001b[33m${rubyGemsVersion}\u001b[39m is not supported`,
-    )
-  })
-
   it('throws an exception when Bundler is not installed', async () => {
     const rubyVersion = '2.7.5'
-    const rubyGemsVersion = '2.6.0'
     vi.mocked(file.exists).mockResolvedValue(true)
     vi.mocked(system.captureOutput).mockResolvedValueOnce(rubyVersion)
-    vi.mocked(system.captureOutput).mockResolvedValueOnce(rubyGemsVersion)
     vi.mocked(system.captureOutput).mockRejectedValue({})
 
     await expect(() => execCLI2(['args'])).rejects.toThrowError(`Bundler not found`)
@@ -51,11 +37,9 @@ describe('execCLI', () => {
 
   it('throws an exception when Bundler version requirement is not met', async () => {
     const rubyVersion = '2.7.5'
-    const rubyGemsVersion = '2.5.0'
     const bundlerVersion = '2.2.0'
     vi.mocked(file.exists).mockResolvedValue(true)
     vi.mocked(system.captureOutput).mockResolvedValueOnce(rubyVersion)
-    vi.mocked(system.captureOutput).mockResolvedValueOnce(rubyGemsVersion)
     vi.mocked(system.captureOutput).mockResolvedValueOnce(bundlerVersion)
 
     await expect(() => execCLI2(['args'])).rejects.toThrowError(
@@ -65,11 +49,9 @@ describe('execCLI', () => {
 
   it('throws an exception when creating CLI working directory', async () => {
     const rubyVersion = '2.7.5'
-    const rubyGemsVersion = '2.5.0'
     const bundlerVersion = '2.4.0'
     vi.mocked(file.exists).mockResolvedValue(true)
     vi.mocked(system.captureOutput).mockResolvedValueOnce(rubyVersion)
-    vi.mocked(system.captureOutput).mockResolvedValueOnce(rubyGemsVersion)
     vi.mocked(system.captureOutput).mockResolvedValueOnce(bundlerVersion)
     vi.mocked(file.mkdir).mockRejectedValue({message: 'Error'})
 

--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -13,7 +13,6 @@ const RubyCLIVersion = '2.23.0'
 const ThemeCheckVersion = '1.10.3'
 const MinBundlerVersion = '2.3.8'
 const MinRubyVersion = '2.7.5'
-const MinRubyGemVersion = '2.5.0'
 
 interface ExecCLI2Options {
   // Contains token and store to pass to CLI 2.0, which will be set as environment variables
@@ -171,7 +170,6 @@ async function installCLIDependencies() {
 
 async function validateRubyEnv() {
   await validateRuby()
-  await validateRubyGems()
   await validateBundler()
 }
 
@@ -195,21 +193,6 @@ async function validateRuby() {
       `Ruby version ${content`${token.yellow(version.raw)}`.value} is not supported`,
       `Make sure you have at least Ruby ${content`${token.yellow(MinRubyVersion)}`.value} installed on your system. ${
         content`${token.link('Documentation.', 'https://www.ruby-lang.org/en/documentation/installation/')}`.value
-      }`,
-    )
-  }
-}
-
-async function validateRubyGems() {
-  const stdout = await system.captureOutput(gemExecutable(), ['-v'])
-  const version = coerce(stdout)
-
-  const isValid = version?.compare(MinRubyGemVersion)
-  if (isValid === -1 || isValid === undefined) {
-    throw new Abort(
-      `RubyGems version ${content`${token.yellow(version.raw)}`.value} is not supported`,
-      `To update to the latest version of RubyGems, run ${
-        content`${token.genericShellCommand(`${gemExecutable()} update --system`)}`.value
       }`,
     )
   }

--- a/packages/cli-kit/src/store.ts
+++ b/packages/cli-kit/src/store.ts
@@ -1,6 +1,4 @@
 import {content, token, debug} from './output.js'
-import constants from './constants.js'
-import {Abort} from './error.js'
 import Conf, {Schema} from 'conf'
 
 const migrations = {}
@@ -44,21 +42,13 @@ let _instance: CLIKitStore | undefined
 
 export function cliKitStore() {
   if (!_instance) {
-    throw new Abort("The CLIKitStore instance hasn't been initialized")
-  }
-  return _instance
-}
-
-export async function initializeCliKitStore() {
-  if (!_instance) {
-    // eslint-disable-next-line require-atomic-updates
     _instance = new CLIKitStore({
       schema,
       migrations,
       projectName: 'shopify-cli-kit',
-      projectVersion: await constants.versions.cliKit(),
     })
   }
+  return _instance
 }
 
 export class CLIKitStore extends Conf<ConfSchema> {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -50,7 +50,7 @@
   "oclif": {
     "commands": "dist/cli/commands",
     "hooks": {
-      "init": "@shopify/cli-kit/node/hooks/init"
+      "init": "@shopify/theme/node_modules/@shopify/cli-kit/dist/node/hooks/init.js"
     }
   }
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -50,7 +50,7 @@
   "oclif": {
     "commands": "dist/cli/commands",
     "hooks": {
-      "init": "@shopify/theme/node_modules/@shopify/cli-kit/dist/node/hooks/init.js"
+      "init": "@shopify/cli-kit/node/hooks/init"
     }
   }
 }

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -59,7 +59,7 @@ export default class Pull extends ThemeCommand {
       validPath = path.resolve(flags.path)
     }
 
-    const flagsToPass = this.passThroughFlags(flags, {exclude: ['path', 'verbose']})
+    const flagsToPass = this.passThroughFlags(flags, {exclude: ['path', 'verbose', 'store']})
 
     const command = ['theme', 'pull', validPath, ...flagsToPass]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10233,15 +10233,6 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
-
 react-error-boundary@^3.1.3:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
@@ -10350,21 +10341,6 @@ react@^17.0.2:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-react@^18.1.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
-  dependencies:
-    loose-envify "^1.1.0"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
### WHY are these changes introduced?

The init hook for the theme package is not working correctly when installed through Homebrew, causing the CLIKitStore to fail to initialize:

<img width="506" alt="Screen Shot 2022-08-31 at 6 11 49 PM" src="https://user-images.githubusercontent.com/14979109/187869371-aaf207ad-ed43-4513-9da0-897c9effa11d.png">

The Homebrew installation is installing two Shopify libraries under node_modules: cli and theme, both of them containing a copy of cli-kit. And for some reason, the current init hook (`@shopify/cli-kit/node/hooks/init`) is calling the file from the cli package instead of theme.

![01-40-pn8c0-qvqz8](https://user-images.githubusercontent.com/14979109/187916269-64ddb089-2323-41be-9e26-0064ff07fc76.png)

### WHAT is this pull request doing?

- Remove the explicit initialization at the start for CLIKitStore and Bugsnag, and initialize them when used (only the first time). Both errors from the screenshot above should be gone.
- Remove `--store` from the flags passed to CLI2 for the pull command, as it's not required and throws an error now (`The option --store is not supported.`)
- Remove the RubyGems validation, as I was getting an error with the Homebrew installation, but we are not using it directly and [I think there's no need to validate it](https://github.com/Shopify/shopify-cli-next/pull/498#discussion_r894610664).

### How to test your changes?

Development:
- `yarn shopify theme pull --store wadus`
- Tweak the code to throw an error, with debug mode disabled, and check if it was sent to Bugsnag ([already tested](https://app.bugsnag.com/shopify/cli/errors/6311dd43e1a0a20008e8b9c0?event_id=6311dd430096490fb8ff0000&i=sk&m=nw))

Hombrew:
- `brew update`
- `brew install shopify-cli@3`
- Go to the CLI repo and run yarn build
- Update the changed dist files from this PR in `/opt/homebrew/Cellar/shopify-cli@3/3.9.0/libexec/lib/node_modules/@shopify`
`shopify3 theme pull --store wadus`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
