### PR TITLE
Localhost & tunnel prompts

### DIFF
--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -304,7 +304,7 @@ describe('tunnelConfigurationPrompt', () => {
       {
         type: 'select',
         name: 'value',
-        message: `We'll run your tunnel with ngrok. How would you like your tunnel to work in the future?`,
+        message: 'How would you like your tunnel to work in the future?',
         choices: [
           {name: 'Always use it by default', value: 'always'},
           {name: 'Use it now and ask me next time', value: 'yes'},

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -7,6 +7,7 @@ import {
   selectOrganizationPrompt,
   selectStorePrompt,
   updateURLsPrompt,
+  tunnelConfigurationPrompt,
 } from './dev.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
 import {describe, it, expect, vi, beforeEach} from 'vitest'
@@ -283,6 +284,31 @@ describe('updateURLsPrompt', () => {
           {name: 'Yes, this time', value: 'yes'},
           {name: 'No, not now', value: 'no'},
           {name: `Never, don't ask again`, value: 'never'},
+        ],
+      },
+    ])
+  })
+})
+
+describe('tunnelConfigurationPrompt', () => {
+  it('asks about the selected tunnel plugin configuration and shows 3 different options', async () => {
+    // Given
+    vi.mocked(ui.prompt).mockResolvedValue({value: 'always'})
+
+    // When
+    const got = await tunnelConfigurationPrompt()
+
+    // Then
+    expect(got).toEqual('always')
+    expect(ui.prompt).toHaveBeenCalledWith([
+      {
+        type: 'select',
+        name: 'value',
+        message: `We'll run your tunnel with ngrok. How would you like your tunnel to work in the future?`,
+        choices: [
+          {name: 'Always use it by default', value: 'always'},
+          {name: 'Use it now and ask me next time', value: 'yes'},
+          {name: 'Nevermind, cancel dev', value: 'cancel'},
         ],
       },
     ])

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -159,3 +159,21 @@ export async function updateURLsPrompt(): Promise<string> {
   ])
   return choice.value
 }
+
+export async function tunnelConfigurationPrompt(): Promise<'always' | 'yes' | 'cancel'> {
+  const options = [
+    {name: 'Always use it by default', value: 'always'},
+    {name: 'Use it now and ask me next time', value: 'yes'},
+    {name: 'Nevermind, cancel dev', value: 'cancel'},
+  ]
+
+  const choice: {value: 'always' | 'yes' | 'cancel'} = await ui.prompt([
+    {
+      type: 'select',
+      name: 'value',
+      message: "We'll run your tunnel with ngrok. How would you like your tunnel to work in the future?",
+      choices: options,
+    },
+  ])
+  return choice.value
+}

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -171,7 +171,7 @@ export async function tunnelConfigurationPrompt(): Promise<'always' | 'yes' | 'c
     {
       type: 'select',
       name: 'value',
-      message: "We'll run your tunnel with ngrok. How would you like your tunnel to work in the future?",
+      message: 'How would you like your tunnel to work in the future?',
       choices: options,
     },
   ])

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -47,10 +47,19 @@ async function dev(options: DevOptions) {
     }
   }
   const token = await session.ensureAuthenticatedPartners()
-  const {identifiers, storeFqdn, app, updateURLs: cachedUpdateURLs} = await ensureDevEnvironment(options, token)
+  const {
+    identifiers,
+    storeFqdn,
+    app,
+    updateURLs: cachedUpdateURLs,
+    tunnelPlugin,
+  } = await ensureDevEnvironment(options, token)
   const apiKey = identifiers.app
 
-  const {frontendUrl, frontendPort, usingTunnel} = await generateFrontendURL(options)
+  const {frontendUrl, frontendPort, usingTunnel} = await generateFrontendURL({
+    ...options,
+    cachedTunnelPlugin: tunnelPlugin,
+  })
 
   const backendPort = await port.getRandomPort()
 

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -32,7 +32,7 @@ export function outputUpdatedURLFirstTime(url: string, dashboardURL: string) {
 }
 
 export function outputAppURL(storeFqdn: string, url: string) {
-  const heading = output.token.heading('Shareable app URL')
+  const heading = output.token.heading('App URL')
   const appURL = buildAppURL(storeFqdn, url)
   output.info(output.content`\n\n${heading}\n\n  ${appURL}\n`)
 }

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -32,7 +32,8 @@ export function outputUpdatedURLFirstTime(url: string, dashboardURL: string) {
 }
 
 export function outputAppURL(storeFqdn: string, url: string) {
-  const heading = output.token.heading('App URL')
+  const title = url.includes('localhost') ? 'App URL' : 'Shareable app URL'
+  const heading = output.token.heading(title)
   const appURL = buildAppURL(storeFqdn, url)
   output.info(output.content`\n\n${heading}\n\n  ${appURL}\n`)
 }

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -325,6 +325,7 @@ describe('generateFrontendURL', () => {
 
     // Then
     expect(got).toEqual({frontendUrl: 'https://fake-url.ngrok.io', frontendPort: 3042, usingTunnel: true})
+    expect(ui.prompt).toBeCalled()
   })
 
   it('returns localhost if tunnel is false and there is no tunnelUrl nor extensions', async () => {
@@ -341,6 +342,7 @@ describe('generateFrontendURL', () => {
 
     // Then
     expect(got).toEqual({frontendUrl: 'http://localhost', frontendPort: 3042, usingTunnel: false})
+    expect(ui.prompt).not.toBeCalled()
   })
 
   it('returns localhost if noTunnel is true even if there are extensions', async () => {
@@ -357,6 +359,7 @@ describe('generateFrontendURL', () => {
 
     // Then
     expect(got).toEqual({frontendUrl: 'http://localhost', frontendPort: 3042, usingTunnel: false})
+    expect(ui.prompt).not.toBeCalled()
   })
 
   it('raises error if tunnelUrl does not include port', async () => {
@@ -409,5 +412,24 @@ describe('generateFrontendURL', () => {
     // Then
     expect(got).toEqual({frontendUrl: 'https://fake-url.ngrok.io', frontendPort: 3042, usingTunnel: true})
     expect(store.cliKitStore().setAppInfo).toBeCalledWith({directory: '/app-path', tunnelPlugin: 'ngrok'})
+  })
+
+  it('Reuses tunnel option if cached even if tunnel is false and there are no extensions', async () => {
+    // Given
+    const options = {
+      app: testApp({hasUIExtensions: () => false, directory: '/app-path'}),
+      tunnel: false,
+      noTunnel: false,
+      cachedTunnelPlugin: 'ngrok',
+      commandConfig: {plugins: []},
+    }
+
+    // When
+    const got = await generateFrontendURL(options)
+
+    // Then
+    expect(got).toEqual({frontendUrl: 'https://fake-url.ngrok.io', frontendPort: 3042, usingTunnel: true})
+    expect(store.cliKitStore().setAppInfo).not.toBeCalled()
+    expect(ui.prompt).not.toBeCalled()
   })
 })

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -39,9 +39,9 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
   let frontendPort: number
   let frontendUrl: string
   let usingTunnel = true
+  const hasExtensions = options.app.hasUIExtensions()
 
-  const needsTunnel =
-    (options.app.hasUIExtensions() || options.tunnel || options.cachedTunnelPlugin) && !options.noTunnel
+  const needsTunnel = (hasExtensions || options.tunnel || options.cachedTunnelPlugin) && !options.noTunnel
 
   if (options.tunnelUrl) {
     const matches = options.tunnelUrl.match(/(https:\/\/[^:]+):([0-9]+)/)
@@ -54,9 +54,12 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
   }
 
   if (needsTunnel && !options.cachedTunnelPlugin) {
-    output.info(
-      "\nSome parts of your app can only be previewed with a tunnel to your dev store. We'll run your tunnel with ngrok.\n",
-    )
+    let message = "We'll run your tunnel with ngrok."
+    const extensionsWarning = 'Some parts of your app can only be previewed with a tunnel to your dev store.'
+    if (hasExtensions) message = `${extensionsWarning} ${message}`
+
+    output.info(`\n${message}\n`)
+
     const useTunnel = await tunnelConfigurationPrompt()
     if (useTunnel === 'cancel') throw new error.CancelExecution()
     if (useTunnel === 'always') {

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -1,4 +1,4 @@
-import {updateURLsPrompt} from '../../prompts/dev.js'
+import {tunnelConfigurationPrompt, updateURLsPrompt} from '../../prompts/dev.js'
 import {AppInterface} from '../../models/app/app.js'
 import {api, error, output, plugins, port, store} from '@shopify/cli-kit'
 import {Plugin} from '@oclif/core/lib/interfaces'
@@ -13,6 +13,7 @@ export interface FrontendURLOptions {
   tunnel: boolean
   noTunnel: boolean
   tunnelUrl?: string
+  cachedTunnelPlugin?: string
   commandConfig: {plugins: Plugin[]}
 }
 
@@ -23,18 +24,24 @@ export interface FrontendURLResult {
 }
 
 /**
- * The tunnel creation logic depends on 4 variables:
+ * The tunnel creation logic depends on 5 variables:
  * - If a tunnelUrl is provided, that takes preference and is returned as the frontendURL
  * - If noTunnel is true, that takes second preference and localhost is used
- * - If tunnel is true OR app.hasUIExtensions() is true, that takes third preference and a tunnel is created
- * - Otherwise, no tunnel is created and localhost is used.
+ * - A Tunnel is created then if any of these are conditions are met:
+ *   - Tunnel flag is true
+ *   - The app has UI extensions
+ *   - In a previous run, the user selected to always use a tunnel (cachedTunnelPlugin)
+ * - Otherwise, localhost is used
+ *
+ * If there is no cached tunnel plugin and a tunnel is necessary, we'll ask the user to confirm.
  */
 export async function generateFrontendURL(options: FrontendURLOptions): Promise<FrontendURLResult> {
   let frontendPort: number
   let frontendUrl: string
   let usingTunnel = true
 
-  const needsTunnel = (options.app.hasUIExtensions() || options.tunnel) && !options.noTunnel
+  const needsTunnel =
+    (options.app.hasUIExtensions() || options.tunnel || options.cachedTunnelPlugin) && !options.noTunnel
 
   if (options.tunnelUrl) {
     const matches = options.tunnelUrl.match(/(https:\/\/[^:]+):([0-9]+)/)
@@ -43,7 +50,18 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
     }
     frontendPort = Number(matches[2])
     frontendUrl = matches[1]!
-  } else if (needsTunnel) {
+    return {frontendUrl, frontendPort, usingTunnel}
+  }
+
+  if (needsTunnel && !options.cachedTunnelPlugin) {
+    const useTunnel = await tunnelConfigurationPrompt()
+    if (useTunnel === 'cancel') throw new error.CancelExecution()
+    if (useTunnel === 'always') {
+      store.cliKitStore().setAppInfo({directory: options.app.directory, tunnelPlugin: 'ngrok'})
+    }
+  }
+
+  if (needsTunnel) {
     frontendPort = await port.getRandomPort()
     frontendUrl = await generateURL(options.commandConfig.plugins, frontendPort)
   } else {

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -54,6 +54,9 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
   }
 
   if (needsTunnel && !options.cachedTunnelPlugin) {
+    output.info(
+      "\nSome parts of your app can only be previewed with a tunnel to your dev store. We'll run your tunnel with ngrok.\n",
+    )
     const useTunnel = await tunnelConfigurationPrompt()
     if (useTunnel === 'cancel') throw new error.CancelExecution()
     if (useTunnel === 'always') {

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -27,7 +27,7 @@ export interface FrontendURLResult {
  * The tunnel creation logic depends on 5 variables:
  * - If a tunnelUrl is provided, that takes preference and is returned as the frontendURL
  * - If noTunnel is true, that takes second preference and localhost is used
- * - A Tunnel is created then if any of these are conditions are met:
+ * - A Tunnel is created then if any of these conditions are met:
  *   - Tunnel flag is true
  *   - The app has UI extensions
  *   - In a previous run, the user selected to always use a tunnel (cachedTunnelPlugin)

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -63,6 +63,7 @@ interface DevEnvironmentOutput {
   storeFqdn: string
   identifiers: UuidOnlyIdentifiers
   updateURLs: boolean | undefined
+  tunnelPlugin: string | undefined
 }
 
 /**
@@ -125,6 +126,7 @@ export async function ensureDevEnvironment(
         extensions,
       },
       updateURLs: cachedInfo?.updateURLs,
+      tunnelPlugin: cachedInfo?.tunnelPlugin,
     }
   }
 
@@ -166,6 +168,7 @@ export async function ensureDevEnvironment(
       extensions,
     },
     updateURLs: cachedInfo?.updateURLs,
+    tunnelPlugin: cachedInfo?.tunnelPlugin,
   }
   await logMetadataForLoadedDevEnvironment(result)
   return result
@@ -370,9 +373,12 @@ function showReusedValues(org: string, cachedAppInfo: store.CachedAppInfo, packa
   output.info(`- Org:          ${org}`)
   output.info(`- App:          ${cachedAppInfo.title}`)
   output.info(`- Dev store:    ${cachedAppInfo.storeFqdn}`)
-  output.info(`- Update URLs:  ${updateURLs}\n`)
+  output.info(`- Update URLs:  ${updateURLs}`)
+  if (cachedAppInfo.tunnelPlugin) {
+    output.info(`- Tunnel:       ${cachedAppInfo.tunnelPlugin}`)
+  }
   output.info(
-    output.content`To reset your default dev config, run ${output.token.packagejsonScript(
+    output.content`\nTo reset your default dev config, run ${output.token.packagejsonScript(
       packageManager,
       'dev',
       '--reset',

--- a/packages/cli-kit/src/store.ts
+++ b/packages/cli-kit/src/store.ts
@@ -12,6 +12,7 @@ export interface CachedAppInfo {
   orgId?: string
   storeFqdn?: string
   updateURLs?: boolean
+  tunnelPlugin?: string
 }
 
 interface ConfSchema {
@@ -75,6 +76,7 @@ export class CLIKitStore extends Conf<ConfSchema> {
     storeFqdn?: string
     orgId?: string
     updateURLs?: boolean
+    tunnelPlugin?: string
   }): void {
     debug(content`Storing app information for directory ${token.path(options.directory)}:${token.json(options)}`)
     const apps = this.get('appInfo') ?? []
@@ -90,6 +92,7 @@ export class CLIKitStore extends Conf<ConfSchema> {
         storeFqdn: options.storeFqdn ?? app.storeFqdn,
         orgId: options.orgId ?? app.orgId,
         updateURLs: options.updateURLs ?? app.updateURLs,
+        tunnelPlugin: options.tunnelPlugin ?? app.tunnelPlugin,
       }
     }
     this.set('appInfo', apps)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
As part of the `dev` flow revamp, this PR contributes to the "make localhost default" by adding a prompt when you select to use tunnels.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add a prompt to confirm tunnel configuration if a tunnel will be created, this allows the user to "always" use that tunnel, or configure it to ask everytime.
- Add more tests
- Some copies improvements
- ⚠️ Some copies are temporary for this iteration and will change once the full new flow is implemented.

⚠️ ❗ This PR is pointing to `localhost-urls` branch. This work complements the work in that branch, that work is already approved but can't be merged yet. But this PR can be merged against that branch and next week we can merge everything to main
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Execute `dev` with tunnel, either via flag or having extensions.
- You should see the new prompt. 
- If you choose "always", then we will always create a tunnel even if no tunnel flag is passed and won't ask you again until you `--reset`

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes

<img width="905" alt="Captura de Pantalla 2022-08-31 a las 18 16 20" src="https://user-images.githubusercontent.com/3757193/187728292-a4292153-b8f8-416e-a5b5-dd2e118374c0.png">


