### PR TITLE
Skip CI on PR for markdown files

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -10,9 +10,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
     paths-ignore:
       - '**.md'
-  pull_request:
 
 concurrency:
   group: shopify-cli-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/402 I tried to setup the CI to ignore markdown files, but it was added to the `push main` section instead of `pull_request`.

Example of the CI running after adding only a changelog file: https://github.com/Shopify/cli/pull/408#commits-pushed-78be5e8

### WHAT is this pull request doing?

Fix the workflow file to ignore md files on pull requests.

### How to test your changes?

Merge and try again

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
