### PR TITLE
Add `--api-key` flag to `shopify app deploy`

### DIFF
--- a/.changeset/polite-carpets-roll.md
+++ b/.changeset/polite-carpets-roll.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Add --api-key flag for app deploy

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -12,6 +12,11 @@ export default class Deploy extends Command {
   static flags = {
     ...cli.globalFlags,
     ...appFlags,
+    'api-key': Flags.string({
+      hidden: false,
+      description: 'The API key of your app.',
+      env: 'SHOPIFY_FLAG_APP_API_KEY',
+    }),
     reset: Flags.boolean({
       hidden: false,
       description: 'Reset all your settings.',
@@ -24,6 +29,6 @@ export default class Deploy extends Command {
     const {args, flags} = await this.parse(Deploy)
     const directory = flags.path ? path.resolve(flags.path) : process.cwd()
     const app: AppInterface = await loadApp(directory)
-    await deploy({app, reset: flags.reset})
+    await deploy({app, apiKey: flags['api-key'], reset: flags.reset})
   }
 }

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -30,6 +30,9 @@ interface DeployOptions {
   /** The app to be built and uploaded */
   app: AppInterface
 
+  /** API key of the app in Partners admin */
+  apiKey?: string
+
   /** If true, ignore any cached appId or extensionId */
   reset: boolean
 }

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -188,6 +188,7 @@ async function updateDevOptions(options: DevEnvironmentOptions & {apiKey: string
 
 export interface DeployEnvironmentOptions {
   app: AppInterface
+  apiKey?: string
   reset: boolean
 }
 
@@ -230,7 +231,7 @@ export async function ensureDeployEnvironment(options: DeployEnvironmentOptions)
   if (options.reset) {
     envIdentifiers = {app: undefined, extensions: {}}
   } else if (envIdentifiers.app) {
-    partnersApp = await fetchAppFromApiKey(envIdentifiers.app, token)
+    partnersApp = await fetchAppFromApiKey(options.apiKey ?? envIdentifiers.app, token)
     if (!partnersApp) throw DeployAppNotFound(envIdentifiers.app, options.app.packageManager)
   } else {
     partnersApp = await fetchDevAppAndPrompt(options.app, token)

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -231,8 +231,9 @@ export async function ensureDeployEnvironment(options: DeployEnvironmentOptions)
   if (options.reset) {
     envIdentifiers = {app: undefined, extensions: {}}
   } else if (envIdentifiers.app) {
-    partnersApp = await fetchAppFromApiKey(options.apiKey ?? envIdentifiers.app, token)
-    if (!partnersApp) throw DeployAppNotFound(envIdentifiers.app, options.app.packageManager)
+    const apiKey = options.apiKey ?? envIdentifiers.app
+    partnersApp = await fetchAppFromApiKey(apiKey, token)
+    if (!partnersApp) throw DeployAppNotFound(apiKey, options.app.packageManager)
   } else {
     partnersApp = await fetchDevAppAndPrompt(options.app, token)
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We have it for app dev. It makes sense to add it here, too.

Also serves as a critical workaround in [1 known case](https://github.com/Shopify/cli/issues/317#issuecomment-1232143625).

And eventually will allow users to automate deploys to multiple Partner admin apps from the same codebase.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Adds a flag `--api-key` to `shopify app deploy`. The implementation is nearly identical to the same flag for `shopify app dev`.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`shopify app deploy` without this flag. Then, `shopify app deploy --api-key=WHATEVER` to deploy to another app using its API key. Then `shopify app deploy` and note that your change sticks.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

Would be good to check this is used, but I think down the road we'll see tons of use as we roll out more flag automation.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
