### PR TITLE
Feature/support parsing structured logs

### DIFF
--- a/.changeset/spicy-jars-shake.md
+++ b/.changeset/spicy-jars-shake.md
@@ -1,0 +1,8 @@
+---
+'@shopify/app': patch
+'@shopify/cli-kit': patch
+'@shopify/shopify-cli-extensions': patch
+'@shopify/ui-extensions-go-cli': patch
+---
+
+Added structured logs to Extension Server and parsing for them in CLI

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,7 +36,6 @@
   },
   "eslint.workingDirectories": [{ "pattern": "packages/*" }],
   "vitest.enable": true,
-  "testing.automaticallyOpenPeekView": "never",
   "javascript.preferences.importModuleSpecifierEnding": "js",
   "typescript.preferences.importModuleSpecifierEnding": "js",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,7 @@
   },
   "eslint.workingDirectories": [{ "pattern": "packages/*" }],
   "vitest.enable": true,
+  "testing.automaticallyOpenPeekView": "never",
   "javascript.preferences.importModuleSpecifierEnding": "js",
   "typescript.preferences.importModuleSpecifierEnding": "js",
 }

--- a/packages/app/src/cli/utilities/extensions/cli.test.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.test.ts
@@ -1,4 +1,4 @@
-import {runGoExtensionsCLI, nodeExtensionsCLIPath, parseGoLogs} from './cli.js'
+import {runGoExtensionsCLI, nodeExtensionsCLIPath, goLogWritable} from './cli.js'
 import {getBinaryPathOrDownload} from './binary.js'
 import {describe, test, expect, vi, beforeAll} from 'vitest'
 import {system, environment, path} from '@shopify/cli-kit'
@@ -126,8 +126,8 @@ describe('goLogsParser', () => {
   test('parses correctly the json logs', async () => {
     // Given
     const validJsonLog =
-      '{"extensionId":"test_id","workflowStep":"serve.build","payload":{"message":"test message"}, "status":"succeed", "level":"info"}'
-    const parsedStream: Writable = parseGoLogs(stdout)
+      '{"extensionId":"test_id","workflowStep":"serve.build","payload":{"message":"test message"}, "status":"succeed", "level":"info"}###LOG_END###'
+    const parsedStream: Writable = goLogWritable(stdout)
 
     // When
     parsedStream.write(validJsonLog)
@@ -136,16 +136,16 @@ describe('goLogsParser', () => {
     console.log('## Succeed ##')
     expect(result).toBe('test message')
   })
-  // test('fails to parse the json logs and keeps the log as it is', async () => {
-  //   // Given
-  //   const inValidJsonLog = 'This is just a simple log'
-  //   const parsedStream: Writable = parseGoLogs(stdout)
-  //   const result = streamToString(parsedStream).then((result) => {
-  //     expect(result).toBe(inValidJsonLog)
-  //   })
-  //   // When
-  //   parsedStream.write(inValidJsonLog)
-  // })
+  test('fails to parse the json logs and keeps the log as it is', async () => {
+    // Given
+    const inValidJsonLog = 'basic simple log'
+    const parsedStream: Writable = goLogWritable(stdout)
+    const result = streamToString(parsedStream).then((result) => {
+      expect(result).toBe(inValidJsonLog)
+    })
+    // When
+    parsedStream.write(`${inValidJsonLog}###LOG_END###`)
+  })
 })
 
 function streamToString(stream: Writable) {

--- a/packages/app/src/cli/utilities/extensions/cli.ts
+++ b/packages/app/src/cli/utilities/extensions/cli.ts
@@ -87,8 +87,8 @@ export async function nodeExtensionsCLIPath(): Promise<string> {
 
 /**
  * This method provides a Writable wraper which parses the incoming chunks as GoLog from Json and writes them back to
- * the Writable given as parameter. If PArsing to Json fails it wirtes the chunk as it is and thows an error.
- * @param output {Writable} A Writable which will be wrapped and in which the parsed chanks will be written.
+ * the Writable given as parameter. If Parsing to Json fails it wirtes the chunk as it is and thows an error.
+ * @param output {Writable} A Writable which will be wrapped and in which the parsed chunks will be written.
  * @returns {Writable} A Writable wrapping the parameter.
  */
 export function goLogWritable(output: Writable): Writable {
@@ -100,9 +100,9 @@ export function goLogWritable(output: Writable): Writable {
           try {
             const log = JSON.parse(line) as GoLog
             output.write(parseGoLogMessage(log))
+            // eslint-disable-next-line no-catch-all/no-catch-all
           } catch (err) {
             output.write(line)
-            throw err
           }
         }
       }

--- a/packages/cli-kit/src/output.ts
+++ b/packages/cli-kit/src/output.ts
@@ -481,7 +481,7 @@ const eraseCursorAnsiRegex = [
  * @param value {string} String whose erase cursor escape characters will be stripped.
  * @returns {string} Stripped string.
  */
-function stripAnsiEraseCursorEscapeCharacters(value: string): string {
+export function stripAnsiEraseCursorEscapeCharacters(value: string): string {
   return value.replace(/(\n)$/, '').replace(new RegExp(eraseCursorAnsiRegex, 'g'), '')
 }
 

--- a/packages/ui-extensions-cli/src/build.ts
+++ b/packages/ui-extensions-cli/src/build.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import {getConfigs} from './configs'
-import {build as esBuild, BuildFailure, BuildResult, formatMessagesSync} from 'esbuild'
+import {build as esBuild, BuildFailure, BuildResult} from 'esbuild'
 
 export interface Options {
   mode: 'development' | 'production'
@@ -91,8 +91,8 @@ function logResult(result: BuildResult | null) {
 }
 
 function logErrors(result: BuildResult) {
-  const errors = formatMessagesSync(result.errors, {kind: 'error'})
-  const warnings = formatMessagesSync(result.warnings, {kind: 'warning'})
+  const errors = result.errors.map((err) => err.detail)
+  const warnings = result.warnings.map((err) => err.detail)
   if (errors.length > 0) console.error(errors.join('\n'))
   if (warnings.length > 0) console.error(errors.join('\n'))
 }

--- a/packages/ui-extensions-go-cli/api/api.go
+++ b/packages/ui-extensions-go-cli/api/api.go
@@ -52,7 +52,7 @@ func (api *ExtensionsApi) notifyClients(createNotification func() (message notif
 		notification, err := createNotification()
 		if err != nil {
 			api.LogEntryBuilder.SetStatus(logging.Failure)
-			api.LogEntryBuilder.Build("", fmt.Sprintf("failed to construct notification with error: %v", err)).WriteErrorLog(os.Stdout)
+			api.LogEntryBuilder.Build(fmt.Sprintf("failed to construct notification with error: %v", err)).WriteErrorLog(os.Stdout)
 			return false
 		}
 		clientHandlers.(client).notify(notification)
@@ -134,11 +134,11 @@ func interfaceToMap(data interface{}, logBuilder logging.LogEntryBuilder) (resul
 	logBuilder.SetStatus(logging.Failure)
 	converted, err := json.Marshal(data)
 	if err != nil {
-		logBuilder.Build("", fmt.Sprintf("error converting to JSON %v", err)).WriteErrorLog(os.Stdout)
+		logBuilder.Build(fmt.Sprintf("error converting to JSON %v", err)).WriteErrorLog(os.Stdout)
 		return
 	}
 	if err = json.Unmarshal(converted, &result); err != nil {
-		logBuilder.Build("", fmt.Sprintf("error converting to map %v", err)).WriteErrorLog(os.Stdout)
+		logBuilder.Build(fmt.Sprintf("error converting to map %v", err)).WriteErrorLog(os.Stdout)
 		return
 	}
 	return
@@ -149,14 +149,14 @@ func (api *ExtensionsApi) getMergedAppMap(additionalInfo map[string]interface{},
 	if additionalInfo["apiKey"] == app["apiKey"] {
 		if err := mergo.MapWithOverwrite(&app, additionalInfo); err != nil {
 			api.LogEntryBuilder.SetStatus(logging.Failure)
-			api.LogEntryBuilder.Build("", fmt.Sprintf("error merging app info, %v", err)).WriteErrorLog(os.Stdout)
+			api.LogEntryBuilder.Build(fmt.Sprintf("error merging app info, %v", err)).WriteErrorLog(os.Stdout)
 			return
 		}
 
 		if overwrite {
 			if err := mergo.MapWithOverwrite(&api.App, formatData(app, strcase.ToSnake)); err != nil {
 				api.LogEntryBuilder.SetStatus(logging.Failure)
-				api.LogEntryBuilder.Build("", fmt.Sprintf("error merging app info, %v", err)).WriteErrorLog(os.Stdout)
+				api.LogEntryBuilder.Build(fmt.Sprintf("error merging app info, %v", err)).WriteErrorLog(os.Stdout)
 				return
 			}
 		}
@@ -182,7 +182,7 @@ func (api *ExtensionsApi) getMergedExtensionsMap(extensions []map[string]interfa
 			err = mergo.MapWithOverwrite(&extensionData, &target)
 			if err != nil {
 				api.LogEntryBuilder.SetStatus(logging.Failure)
-				api.LogEntryBuilder.Build("", fmt.Sprintf("failed to merge update data %v", err)).WriteErrorLog(os.Stdout)
+				api.LogEntryBuilder.Build(fmt.Sprintf("failed to merge update data %v", err)).WriteErrorLog(os.Stdout)
 				continue
 			}
 			results = append(results, extensionData)
@@ -205,7 +205,7 @@ func (api *ExtensionsApi) Notify(extensions []core.Extension) {
 			castedData := updateData.(core.Extension)
 			if err := mergeWithOverwrite(&castedData, &extensions); err != nil {
 				api.LogEntryBuilder.SetStatus(logging.Failure)
-				api.LogEntryBuilder.Build("", fmt.Sprintf("failed to merge update data %v", err)).WriteErrorLog(os.Stdout)
+				api.LogEntryBuilder.Build(fmt.Sprintf("failed to merge update data %v", err)).WriteErrorLog(os.Stdout)
 			}
 		} else {
 			api.updates.Store(extension.UUID, extension)
@@ -220,7 +220,7 @@ func (api *ExtensionsApi) Notify(extensions []core.Extension) {
 			err := mergeWithOverwrite(&api.Extensions[index], &castedData)
 			if err != nil {
 				api.LogEntryBuilder.SetStatus(logging.Failure)
-				api.LogEntryBuilder.Build("", fmt.Sprintf("failed to merge update data %v", err)).WriteErrorLog(os.Stdout)
+				api.LogEntryBuilder.Build(fmt.Sprintf("failed to merge update data %v", err)).WriteErrorLog(os.Stdout)
 			}
 			updatedExtensions = append(updatedExtensions, api.Extensions[index])
 		}
@@ -341,7 +341,7 @@ func (api *ExtensionsApi) sendStatusUpdates(rw http.ResponseWriter, r *http.Requ
 					return
 				}
 				api.LogEntryBuilder.SetStatus(logging.Failure)
-				api.LogEntryBuilder.Build("", fmt.Sprintf("error writing JSON message: %v", err)).WriteErrorLog(os.Stdout)
+				api.LogEntryBuilder.Build(fmt.Sprintf("error writing JSON message: %v", err)).WriteErrorLog(os.Stdout)
 				break
 			}
 		}
@@ -443,7 +443,7 @@ func (api *ExtensionsApi) handleClientMessages(ws *websocketConnection) {
 		err = json.Unmarshal(message, &jsonMessage)
 		if err != nil {
 			api.LogEntryBuilder.SetStatus(logging.Failure)
-			api.LogEntryBuilder.Build("", fmt.Sprintf("failed to read client JSON message %v", err)).WriteErrorLog(os.Stdout)
+			api.LogEntryBuilder.Build(fmt.Sprintf("failed to read client JSON message %v", err)).WriteErrorLog(os.Stdout)
 		}
 
 		switch jsonMessage.Event {

--- a/packages/ui-extensions-go-cli/api/api_test.go
+++ b/packages/ui-extensions-go-cli/api/api_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Shopify/shopify-cli-extensions/core"
+	"github.com/Shopify/shopify-cli-extensions/logging"
 	"github.com/gorilla/websocket"
 	"github.com/iancoleman/strcase"
 )
@@ -48,7 +49,7 @@ func init() {
 }
 
 func TestInitializeWithProvidedConfigOptions(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 
 	if api.ApiRoot != apiRoot {
 		t.Errorf("Expected api root to be %s but got %v", apiRoot, api.ApiRoot)
@@ -92,7 +93,7 @@ func TestInitializeWithProvidedConfigOptions(t *testing.T) {
 }
 
 func TestGetExtensions(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 
 	response := extensionsResponse{}
 
@@ -161,7 +162,7 @@ func TestGetExtensions(t *testing.T) {
 }
 
 func TestGetSingleExtension(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	response := singleExtensionResponse{}
 
 	getSingleExtensionJSONResponse(api, t, api.Extensions[0].UUID, &response)
@@ -234,7 +235,7 @@ func TestGetSingleExtension(t *testing.T) {
 }
 
 func TestServeAssets(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	mainAssetUrl := fmt.Sprintf("%s/%s/assets/main.js", api.ApiRoot, api.Extensions[0].UUID)
 	response := getHTMLRequest(api, t, mainAssetUrl)
 
@@ -255,7 +256,7 @@ func TestServeAssets(t *testing.T) {
 }
 
 func TestCheckoutTunnelError(t *testing.T) {
-	api := New(noPublicUrlConfig)
+	api := New(noPublicUrlConfig, &logging.LogEntryBuilder{})
 	uuid := api.Extensions[0].UUID
 	response := getSingleExtensionHTMLResponse(api, t, uuid)
 
@@ -269,7 +270,7 @@ func TestCheckoutTunnelError(t *testing.T) {
 }
 
 func TestAdminTunnelError(t *testing.T) {
-	api := New(noPublicUrlConfig)
+	api := New(noPublicUrlConfig, &logging.LogEntryBuilder{})
 	uuid := api.Extensions[1].UUID
 	response := getSingleExtensionHTMLResponse(api, t, uuid)
 
@@ -283,7 +284,7 @@ func TestAdminTunnelError(t *testing.T) {
 }
 
 func TestPostPurchaseTunnelError(t *testing.T) {
-	api := New(noPublicUrlConfig)
+	api := New(noPublicUrlConfig, &logging.LogEntryBuilder{})
 	uuid := api.Extensions[2].UUID
 	response := getSingleExtensionHTMLResponse(api, t, api.Extensions[2].UUID)
 
@@ -297,7 +298,7 @@ func TestPostPurchaseTunnelError(t *testing.T) {
 }
 
 func TestCheckoutRedirect(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	rec := getSingleExtensionHTMLRequest(api, t, api.Extensions[0].UUID)
 
 	if rec.Code != http.StatusTemporaryRedirect {
@@ -314,7 +315,7 @@ func TestCheckoutRedirect(t *testing.T) {
 }
 
 func TestAdminRedirect(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	uuid := api.Extensions[1].UUID
 	rec := getSingleExtensionHTMLRequest(api, t, uuid)
 
@@ -332,7 +333,7 @@ func TestAdminRedirect(t *testing.T) {
 }
 
 func TestPostPurchaseIndex(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	uuid := api.Extensions[2].UUID
 	response := getSingleExtensionHTMLResponse(api, t, uuid)
 
@@ -357,7 +358,7 @@ func TestPostPurchaseIndex(t *testing.T) {
 }
 
 func TestWebsocketNotify(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	server := httptest.NewServer(api)
 
 	firstConnection, err := createWebsocket(server)
@@ -392,7 +393,7 @@ func TestWebsocketNotify(t *testing.T) {
 }
 
 func TestWebsocketNotifyBuildStatusWithLastUpdatedValue(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	server := httptest.NewServer(api)
 
 	ws, err := createWebsocket(server)
@@ -429,7 +430,7 @@ func TestWebsocketConnectionStartAndShutdown(t *testing.T) {
 	// FIXME;
 	return
 
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	server := httptest.NewServer(api)
 	first_connection, err := createWebsocket(server)
 	second_connection, err := createWebsocket(server)
@@ -475,7 +476,7 @@ func TestWebsocketConnectionClientClose(t *testing.T) {
 	// FIXME
 	return
 
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	server := httptest.NewServer(api)
 	first_connection, err := createWebsocket(server)
 	second_connection, err := createWebsocket(server)
@@ -513,7 +514,7 @@ func TestWebsocketConnectionClientClose(t *testing.T) {
 }
 
 func TestWebsocketClientUpdateAppEvent(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	server := httptest.NewServer(api)
 
 	ws, err := createWebsocket(server)
@@ -558,7 +559,7 @@ func TestWebsocketClientUpdateAppEvent(t *testing.T) {
 }
 
 func TestWebsocketClientUpdateMatchingExtensionsEvent(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	server := httptest.NewServer(api)
 
 	ws, err := createWebsocket(server)
@@ -638,7 +639,7 @@ func TestWebsocketClientUpdateMatchingExtensionsEvent(t *testing.T) {
 }
 
 func TestWebsocketClientUpdateBooleanValue(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	updateExtension := api.Extensions[0]
 
 	*updateExtension.Development.Hidden = true
@@ -693,7 +694,7 @@ func TestWebsocketClientUpdateBooleanValue(t *testing.T) {
 }
 
 func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
-	api := New(config)
+	api := New(config, &logging.LogEntryBuilder{})
 	server := httptest.NewServer(api)
 
 	dispatchExtensionUUID := api.Extensions[0].UUID

--- a/packages/ui-extensions-go-cli/build/build_test.go
+++ b/packages/ui-extensions-go-cli/build/build_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Shopify/shopify-cli-extensions/core"
+	"github.com/Shopify/shopify-cli-extensions/logging"
 )
 
 var config *core.Config
@@ -116,7 +117,7 @@ func TestWatchLocalization(t *testing.T) {
 		defer wg.Done()
 		WatchLocalization(ctx, extension, func(result Result) {
 			results = append(results, result)
-		})
+		}, logging.Builder().AddWorkflowSteps("test"))
 	}()
 
 	// done
@@ -124,8 +125,8 @@ func TestWatchLocalization(t *testing.T) {
 	// wait while all goroutines will end their job
 	wg.Wait()
 
-	if len(results) != 2 {
-		t.Errorf("expected 2 result but got %d\n", len(results))
+	if len(results) != 1 {
+		t.Errorf("expected 1 result but got %d\n", len(results))
 	}
 
 	if !results[0].Success {

--- a/packages/ui-extensions-go-cli/build/build_test.go
+++ b/packages/ui-extensions-go-cli/build/build_test.go
@@ -124,8 +124,8 @@ func TestWatchLocalization(t *testing.T) {
 	// wait while all goroutines will end their job
 	wg.Wait()
 
-	if len(results) != 1 {
-		t.Errorf("expected 1 result but got %d\n", len(results))
+	if len(results) != 2 {
+		t.Errorf("expected 2 result but got %d\n", len(results))
 	}
 
 	if !results[0].Success {

--- a/packages/ui-extensions-go-cli/build/localization.go
+++ b/packages/ui-extensions-go-cli/build/localization.go
@@ -89,10 +89,10 @@ func getLocalization(extension *core.Extension) (*core.Localization, error) {
 	} else {
 
 		if len(defaultLocalesFound) == 0 {
-			log.Println("could not determine a default locale, please ensure you have a {locale}.default.json file")
+			log.Print("could not determine a default locale, please ensure you have a {locale}.default.json file")
 		} else {
 			if len(defaultLocalesFound) > 1 {
-				log.Println("multiple default locales found, please ensure you only have a single {locale}.default.json file")
+				log.Print("multiple default locales found, please ensure you only have a single {locale}.default.json file")
 			}
 			defaultLocale = defaultLocalesFound[0]
 		}
@@ -108,7 +108,6 @@ func setLocalization(extension *core.Extension) error {
 	localization, err := getLocalization(extension)
 
 	if err != nil {
-		log.Println(err)
 		return err
 	}
 	extension.Localization = localization
@@ -165,7 +164,7 @@ func WatchLocalization(ctx context.Context, extension core.Extension, report Res
 					if err != nil {
 						reportAndUpdateLocalizationStatus(Result{
 							false,
-							fmt.Sprintf("could not resolve localization, error: %s\n", err.Error()),
+							fmt.Sprintf("could not resolve localization, error: %s", err.Error()),
 							extension,
 						}, report)
 					}
@@ -175,13 +174,17 @@ func WatchLocalization(ctx context.Context, extension core.Extension, report Res
 				if !ok {
 					return
 				}
-				log.Println("error:", err)
+				log.Print("error:", err)
 			}
 		}
 	}()
 
 	err = watcher.Add(directory)
-	log.Println("Watcher added for:", directory)
+  reportAndUpdateLocalizationStatus(Result{
+    true,
+    fmt.Sprintf("Watcher added for %s", directory),
+    extension,
+    }, report)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/packages/ui-extensions-go-cli/build/log_processing.go
+++ b/packages/ui-extensions-go-cli/build/log_processing.go
@@ -22,7 +22,7 @@ func processLogs(reader io.Reader, handlers logProcessingHandlers) {
 		scanner := bufio.NewScanner(reader)
 		scanner.Split(bufio.ScanLines)
 		for scanner.Scan() {
-			fragments <- fmt.Sprintf("%s\n", scanner.Text())
+			fragments <- fmt.Sprintf("%s", scanner.Text())
 		}
 		done <- struct{}{}
 	}()

--- a/packages/ui-extensions-go-cli/create/process.go
+++ b/packages/ui-extensions-go-cli/create/process.go
@@ -21,7 +21,7 @@ func (p *Process) Run() (err error) {
 		if err = task.Run(); err != nil {
 			p.status[taskId] = "fail"
 			if undoErr := p.Undo(); undoErr != nil {
-				log.Printf("Failed to undo with error: %v\n", undoErr)
+				log.Printf("Failed to undo with error: %v", undoErr)
 			}
 			return
 		}

--- a/packages/ui-extensions-go-cli/create/templating.go
+++ b/packages/ui-extensions-go-cli/create/templating.go
@@ -164,7 +164,7 @@ func buildTemplateHelpers(t *template.Template, extension core.Extension, shared
 				for _, fragment := range fragments[1:] {
 					err := mergo.Merge(&merged, &fragment, mergo.WithAppendSlice)
 					if err != nil {
-						fmt.Println(err)
+						fmt.Print(err)
 					}
 				}
 				return merged

--- a/packages/ui-extensions-go-cli/logging/log_entry.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry.go
@@ -1,0 +1,103 @@
+package logging
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+)
+
+type EntryType string
+
+const (
+	// Create flow
+	Create_started   EntryType = "create.started"
+	Create_info      EntryType = "create.progress"
+	Create_completed EntryType = "create.completed"
+	Create_error     EntryType = "create.error"
+	// Build Flow
+	Build_started   EntryType = "build.started"
+	Build_info      EntryType = "build.progress"
+	Build_completed EntryType = "build.completed"
+	Build_error     EntryType = "build.error"
+	// Serve flow
+	Serve_started   EntryType = "serve.started"
+	Serve_info      EntryType = "serve.progress"
+	Serve_completed EntryType = "serve.completed"
+	Serve_error     EntryType = "serve.error"
+	//api
+	Api_started   EntryType = "api.started"
+	Api_error     EntryType = "api.error"
+	Api_completed EntryType = "api.completed"
+	// General
+	General_error EntryType = "general.error"
+	General_info  EntryType = "general.progress"
+	General_config_error EntryType = "general.config.error"
+)
+
+func (et EntryType) String() string {
+	switch et {
+	case Create_started:
+		return "create.started"
+	case Create_info:
+		return "create.progress"
+	case Create_completed:
+		return "create.completed"
+	case Create_error:
+		return "create.error"
+	case Build_started:
+		return "build.started"
+	case Build_info:
+		return "build.progress"
+	case Build_completed:
+		return "build.completed"
+	case Build_error:
+		return "build.error"
+	case Serve_started:
+		return "serve.started"
+	case Serve_info:
+		return "serve.progress"
+	case Serve_completed:
+		return "serve.completed"
+	case Serve_error:
+		return "serve.error"
+	case General_error:
+		return "general.error"
+	case General_info:
+		return "general.progress"
+	default:
+		panic("")
+	}
+}
+
+type LogEntry struct {
+	Type        EntryType
+	ExtensionId string
+	Payload     interface{}
+}
+
+func (l LogEntry) to_json() string {
+	json_log, err := json.Marshal(l)
+	if err != nil {
+		panic(err)
+	}
+	return string(json_log)
+}
+func (l LogEntry) WriteLog() {
+	log.SetOutput(os.Stdout)
+	log.Println("#START_LOG_ENTRY#")
+	log.Println(l.to_json())
+	log.Println("#END_LOG_ENTRY#")
+}
+
+func (l LogEntry) WriteErrorLog() {
+	log.SetOutput(os.Stderr)
+	log.Println("#START_LOG_ENTRY#")
+	log.Println(l.to_json())
+	log.Println("#END_LOG_ENTRY#")
+}
+
+func (t EntryType) CreateLogEntry(extensionId string, message string) LogEntry {
+	entry := LogEntry{Type: t, ExtensionId: extensionId}
+	entry.Payload = t.CreatePayload(message)
+	return entry
+}

--- a/packages/ui-extensions-go-cli/logging/log_entry.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry.go
@@ -29,8 +29,8 @@ const (
 	Api_error     EntryType = "api.error"
 	Api_completed EntryType = "api.completed"
 	// General
-	General_error EntryType = "general.error"
-	General_info  EntryType = "general.progress"
+	General_error        EntryType = "general.error"
+	General_info         EntryType = "general.progress"
 	General_config_error EntryType = "general.config.error"
 )
 

--- a/packages/ui-extensions-go-cli/logging/log_entry.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry.go
@@ -7,36 +7,39 @@ import (
 )
 
 type LogType string
+
 const (
-  Serve LogType = "serve"
-  Api LogType = "api"
-  Server LogType = "server"
-  Build LogType = "build"
-  Watch LogType = "watch"
-  WatchLocalization LogType = "watchLocalization"
-  Create LogType = "create"
-  Config LogType = "config"
-  Validate LogType = "validate"
+	Serve             LogType = "serve"
+	Api               LogType = "api"
+	Server            LogType = "server"
+	Build             LogType = "build"
+	Watch             LogType = "watch"
+	WatchLocalization LogType = "watchLocalization"
+	Create            LogType = "create"
+	Config            LogType = "config"
+	Validate          LogType = "validate"
 )
 
 type LogStatus string
+
 const (
-  Started LogStatus ="start"
-  Progress LogStatus = "progress"
-  Failed LogStatus = "fail"
-  Completed LogStatus ="complete"
+	Started   LogStatus = "start"
+	Progress  LogStatus = "progress"
+	Failed    LogStatus = "fail"
+	Completed LogStatus = "complete"
 )
 
 type LogLevel string
+
 const (
-  Info LogLevel = "info"
-  Error LogLevel ="error"
+	Info  LogLevel = "info"
+	Error LogLevel = "error"
 )
 
 type LogEntry struct {
 	Context     string
-  Status   LogStatus
-  Level       LogLevel
+	Status      LogStatus
+	Level       LogLevel
 	ExtensionId string
 	Payload     interface{}
 }
@@ -49,7 +52,7 @@ func (l LogEntry) to_json() string {
 	return string(json_log)
 }
 func (l LogEntry) WriteLog(outputStream *os.File) {
-  l.Level = Info
+	l.Level = Info
 	log.SetOutput(outputStream)
 	log.Println("#START_LOG_ENTRY#")
 	log.Println(l.to_json())
@@ -57,29 +60,28 @@ func (l LogEntry) WriteLog(outputStream *os.File) {
 }
 
 func (l LogEntry) WriteErrorLog(outputStream *os.File) {
-  l.Level = Error
+	l.Level = Error
 	log.SetOutput(outputStream)
 	log.Println("#START_LOG_ENTRY#")
 	log.Println(l.to_json())
 	log.Println("#END_LOG_ENTRY#")
 }
 
-
 type LogEntryBuilder struct {
-  Context string
+	Context string
 }
 
 func NewLogEntryBuilder() LogEntryBuilder {
-  return LogEntryBuilder{Context:""}
+	return LogEntryBuilder{Context: ""}
 }
 
-func (b LogEntryBuilder)AddContext(context LogType) LogEntryBuilder {
-  if b.Context!="" {
-    return LogEntryBuilder{Context: b.Context + "." + string(context)}
-  }
-  return LogEntryBuilder{Context: string(context)}
+func (b LogEntryBuilder) AddContext(context LogType) LogEntryBuilder {
+	if b.Context != "" {
+		return LogEntryBuilder{Context: b.Context + "." + string(context)}
+	}
+	return LogEntryBuilder{Context: string(context)}
 }
 
-func (b LogEntryBuilder)Build(status LogStatus, extensionId string, message string) LogEntry {
-  return LogEntry{Context:b.Context, Status: status, ExtensionId: extensionId, Payload: status.CreatePayload(message)}
+func (b LogEntryBuilder) Build(status LogStatus, extensionId string, message string) LogEntry {
+	return LogEntry{Context: b.Context, Status: status, ExtensionId: extensionId, Payload: status.CreatePayload(message)}
 }

--- a/packages/ui-extensions-go-cli/logging/log_entry.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry.go
@@ -6,71 +6,37 @@ import (
 	"os"
 )
 
-type EntryType string
-
+type LogType string
 const (
-	// Create flow
-	Create_started   EntryType = "create.started"
-	Create_info      EntryType = "create.progress"
-	Create_completed EntryType = "create.completed"
-	Create_error     EntryType = "create.error"
-	// Build Flow
-	Build_started   EntryType = "build.started"
-	Build_info      EntryType = "build.progress"
-	Build_completed EntryType = "build.completed"
-	Build_error     EntryType = "build.error"
-	// Serve flow
-	Serve_started   EntryType = "serve.started"
-	Serve_info      EntryType = "serve.progress"
-	Serve_completed EntryType = "serve.completed"
-	Serve_error     EntryType = "serve.error"
-	//api
-	Api_started   EntryType = "api.started"
-	Api_error     EntryType = "api.error"
-	Api_completed EntryType = "api.completed"
-	// General
-	General_error        EntryType = "general.error"
-	General_info         EntryType = "general.progress"
-	General_config_error EntryType = "general.config.error"
+  Serve LogType = "serve"
+  Api LogType = "api"
+  Server LogType = "server"
+  Build LogType = "build"
+  Watch LogType = "watch"
+  WatchLocalization LogType = "watchLocalization"
+  Create LogType = "create"
+  Config LogType = "config"
+  Validate LogType = "validate"
 )
 
-func (et EntryType) String() string {
-	switch et {
-	case Create_started:
-		return "create.started"
-	case Create_info:
-		return "create.progress"
-	case Create_completed:
-		return "create.completed"
-	case Create_error:
-		return "create.error"
-	case Build_started:
-		return "build.started"
-	case Build_info:
-		return "build.progress"
-	case Build_completed:
-		return "build.completed"
-	case Build_error:
-		return "build.error"
-	case Serve_started:
-		return "serve.started"
-	case Serve_info:
-		return "serve.progress"
-	case Serve_completed:
-		return "serve.completed"
-	case Serve_error:
-		return "serve.error"
-	case General_error:
-		return "general.error"
-	case General_info:
-		return "general.progress"
-	default:
-		panic("")
-	}
-}
+type LogStatus string
+const (
+  Started LogStatus ="start"
+  Progress LogStatus = "progress"
+  Failed LogStatus = "fail"
+  Completed LogStatus ="complete"
+)
+
+type LogLevel string
+const (
+  Info LogLevel = "info"
+  Error LogLevel ="error"
+)
 
 type LogEntry struct {
-	Type        EntryType
+	Context     string
+  Status   LogStatus
+  Level       LogLevel
 	ExtensionId string
 	Payload     interface{}
 }
@@ -82,22 +48,38 @@ func (l LogEntry) to_json() string {
 	}
 	return string(json_log)
 }
-func (l LogEntry) WriteLog() {
-	log.SetOutput(os.Stdout)
+func (l LogEntry) WriteLog(outputStream *os.File) {
+  l.Level = Info
+	log.SetOutput(outputStream)
 	log.Println("#START_LOG_ENTRY#")
 	log.Println(l.to_json())
 	log.Println("#END_LOG_ENTRY#")
 }
 
-func (l LogEntry) WriteErrorLog() {
-	log.SetOutput(os.Stderr)
+func (l LogEntry) WriteErrorLog(outputStream *os.File) {
+  l.Level = Error
+	log.SetOutput(outputStream)
 	log.Println("#START_LOG_ENTRY#")
 	log.Println(l.to_json())
 	log.Println("#END_LOG_ENTRY#")
 }
 
-func (t EntryType) CreateLogEntry(extensionId string, message string) LogEntry {
-	entry := LogEntry{Type: t, ExtensionId: extensionId}
-	entry.Payload = t.CreatePayload(message)
-	return entry
+
+type LogEntryBuilder struct {
+  Context string
+}
+
+func NewLogEntryBuilder() LogEntryBuilder {
+  return LogEntryBuilder{Context:""}
+}
+
+func (b LogEntryBuilder)AddContext(context LogType) LogEntryBuilder {
+  if b.Context!="" {
+    return LogEntryBuilder{Context: b.Context + "." + string(context)}
+  }
+  return LogEntryBuilder{Context: string(context)}
+}
+
+func (b LogEntryBuilder)Build(status LogStatus, extensionId string, message string) LogEntry {
+  return LogEntry{Context:b.Context, Status: status, ExtensionId: extensionId, Payload: status.CreatePayload(message)}
 }

--- a/packages/ui-extensions-go-cli/logging/log_entry.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry.go
@@ -8,16 +8,19 @@ import (
 )
 
 type LogEntry struct {
-	WorkflowStep string      `json:"workflowStep,omitempty"`
-	Status       LogStatus   `json:"status,omitempty"`
-	Level        LogLevel    `json:"level,omitempty"`
-	ExtensionID  string      `json:"extensionId,omitempty"`
-	Payload      interface{} `json:"payload,omitempty"`
+	WorkflowStep  string      `json:"workflowStep,omitempty"`
+	Status        LogStatus   `json:"status,omitempty"`
+	Level         LogLevel    `json:"level,omitempty"`
+	ExtensionID   string      `json:"extensionId,omitempty"`
+	ExtensionName string      `json:"extensionName,omitempty"`
+	Payload       interface{} `json:"payload,omitempty"`
 }
 
 type LogEntryBuilder struct {
-	WorkflowStep string
-	Status       LogStatus
+	WorkflowStep  string
+	Status        LogStatus
+	ExtensionID   string
+	ExtensionName string
 }
 
 func Builder() LogEntryBuilder {
@@ -27,21 +30,17 @@ func Builder() LogEntryBuilder {
 func (l *LogEntry) WriteLog(outputStream *os.File) {
 	l.Level = Info
 	log.SetOutput(outputStream)
-	log.Println("#START_LOG_ENTRY#")
-	log.Println(l.toJson())
-	log.Println("#END_LOG_ENTRY#")
+	log.Print(l.toJson() + "###LOG_END###")
 }
 
 func (l *LogEntry) WriteErrorLog(outputStream *os.File) {
 	l.Level = Error
 	log.SetOutput(outputStream)
-	log.Println("#START_LOG_ENTRY#")
-	log.Println(l.toJson())
-	log.Println("#END_LOG_ENTRY#")
+	log.Print(l.toJson() + "###LOG_END###")
 }
 
-func (b *LogEntryBuilder) Build(extensionId string, message string) *LogEntry {
-	return &LogEntry{WorkflowStep: b.WorkflowStep, Status: b.Status, ExtensionID: extensionId, Payload: b.Status.CreatePayload(message)}
+func (b *LogEntryBuilder) Build(message string) *LogEntry {
+	return &LogEntry{WorkflowStep: b.WorkflowStep, Status: b.Status, ExtensionName: b.ExtensionName, ExtensionID: b.ExtensionID, Payload: b.Status.CreatePayload(message)}
 }
 
 func (l *LogEntry) toJson() string {
@@ -66,4 +65,12 @@ func (b LogEntryBuilder) AddWorkflowSteps(steps ...WorkflowStep) LogEntryBuilder
 
 func (b *LogEntryBuilder) SetStatus(status LogStatus) {
 	b.Status = status
+}
+
+func (b *LogEntryBuilder) SetExtensionName(name string) {
+	b.ExtensionName = name
+}
+
+func (b *LogEntryBuilder) SetExtensionId(id string) {
+	b.ExtensionID = id
 }

--- a/packages/ui-extensions-go-cli/logging/log_entry_test.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry_test.go
@@ -8,11 +8,11 @@ func TestParseToJson(t *testing.T) {
 
 	Init()
 
-  logBuilder := NewLogEntryBuilder()
-  LogBuilderBase := logBuilder.AddContext("Base")
-  logBuilderBaseExtendend := LogBuilderBase.AddContext("Extended")
-  log_entry := logBuilderBaseExtendend.Build(Started,"ext_id", "test_message")
+	logBuilder := NewLogEntryBuilder()
+	LogBuilderBase := logBuilder.AddContext("Base")
+	logBuilderBaseExtendend := LogBuilderBase.AddContext("Extended")
+	log_entry := logBuilderBaseExtendend.Build(Started, "ext_id", "test_message")
 
-  log_entry.to_json()
+	log_entry.to_json()
 
 }

--- a/packages/ui-extensions-go-cli/logging/log_entry_test.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry_test.go
@@ -13,7 +13,9 @@ func TestParseToJson(t *testing.T) {
 	LogBuilderBase := logBuilder.AddWorkflowSteps("Base", "Extended")
 	logBuilderBaseExtendend := LogBuilderBase.AddWorkflowSteps("Extra")
 	logBuilderBaseExtendend.SetStatus(InProgress)
-	logEntry := logBuilderBaseExtendend.Build("ext_id", "test_message")
+  logBuilderBaseExtendend.SetExtensionId("ext_id")
+  logBuilderBaseExtendend.SetExtensionName("ext name")
+	logEntry := logBuilderBaseExtendend.Build("test_message")
 
 	jsonString := logEntry.toJson()
 
@@ -26,6 +28,10 @@ func TestParseToJson(t *testing.T) {
 
 	if parsedLogEntry.ExtensionID != logEntry.ExtensionID {
 		t.Error("Json mapping failed: extension ID is not equal")
+	}
+
+  if parsedLogEntry.ExtensionName != logEntry.ExtensionName {
+		t.Error("Json mapping failed: extension Name is not equal")
 	}
 
 	if parsedLogEntry.Status != logEntry.Status {

--- a/packages/ui-extensions-go-cli/logging/log_entry_test.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry_test.go
@@ -1,0 +1,18 @@
+package logging
+
+import (
+	"testing"
+)
+
+func TestParseToJson(t *testing.T) {
+
+	Init()
+
+	log_entry :=LogEntry{
+    Type: General_info,
+    ExtensionId: "ext-id",
+    Payload: InfoPayload{ Message:"test Log info"},
+  }
+  log_entry.to_json()
+
+}

--- a/packages/ui-extensions-go-cli/logging/log_entry_test.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry_test.go
@@ -8,11 +8,11 @@ func TestParseToJson(t *testing.T) {
 
 	Init()
 
-	log_entry :=LogEntry{
-    Type: General_info,
-    ExtensionId: "ext-id",
-    Payload: InfoPayload{ Message:"test Log info"},
-  }
+  logBuilder := NewLogEntryBuilder()
+  LogBuilderBase := logBuilder.AddContext("Base")
+  logBuilderBaseExtendend := LogBuilderBase.AddContext("Extended")
+  log_entry := logBuilderBaseExtendend.Build(Started,"ext_id", "test_message")
+
   log_entry.to_json()
 
 }

--- a/packages/ui-extensions-go-cli/logging/log_entry_test.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -8,11 +9,30 @@ func TestParseToJson(t *testing.T) {
 
 	Init()
 
-	logBuilder := NewLogEntryBuilder()
-	LogBuilderBase := logBuilder.AddContext("Base")
-	logBuilderBaseExtendend := LogBuilderBase.AddContext("Extended")
-	log_entry := logBuilderBaseExtendend.Build(Started, "ext_id", "test_message")
+	logBuilder := Builder()
+	LogBuilderBase := logBuilder.AddWorkflowSteps("Base", "Extended")
+	logBuilderBaseExtendend := LogBuilderBase.AddWorkflowSteps("Extra")
+	logBuilderBaseExtendend.SetStatus(InProgress)
+	logEntry := logBuilderBaseExtendend.Build("ext_id", "test_message")
 
-	log_entry.to_json()
+	jsonString := logEntry.toJson()
 
+	parsedLogEntry := LogEntry{}
+	json.Unmarshal([]byte(jsonString), &parsedLogEntry)
+
+	if parsedLogEntry.WorkflowStep != logEntry.WorkflowStep {
+		t.Error("Json mapping failed: context is not equal")
+	}
+
+	if parsedLogEntry.ExtensionID != logEntry.ExtensionID {
+		t.Error("Json mapping failed: extension ID is not equal")
+	}
+
+	if parsedLogEntry.Status != logEntry.Status {
+		t.Error("Json mapping failed: status is not equal")
+	}
+
+	if parsedLogEntry.Level != logEntry.Level {
+		t.Error("Json mapping failed: level is not equal")
+	}
 }

--- a/packages/ui-extensions-go-cli/logging/log_entry_utils.go
+++ b/packages/ui-extensions-go-cli/logging/log_entry_utils.go
@@ -1,0 +1,31 @@
+package logging
+
+type WorkflowStep string
+
+const (
+	Serve        WorkflowStep = "serve"
+	Api          WorkflowStep = "api"
+	Server       WorkflowStep = "server"
+	Build        WorkflowStep = "build"
+	Watch        WorkflowStep = "watch"
+	Localization WorkflowStep = "localization"
+	Sources      WorkflowStep = "sources"
+	Create       WorkflowStep = "create"
+	Config       WorkflowStep = "config"
+	Validate     WorkflowStep = "validate"
+)
+
+type LogStatus string
+
+const (
+	InProgress LogStatus = "inProgress"
+	Failure    LogStatus = "failure"
+	Success    LogStatus = "success"
+)
+
+type LogLevel string
+
+const (
+	Info  LogLevel = "info"
+	Error LogLevel = "error"
+)

--- a/packages/ui-extensions-go-cli/logging/log_payload.go
+++ b/packages/ui-extensions-go-cli/logging/log_payload.go
@@ -1,0 +1,24 @@
+package logging
+
+import (
+  "regexp"
+)
+type ErrorPayload struct {
+  Message string
+  StackTrace string
+  RecoveryStep string
+}
+
+type InfoPayload struct {
+  Message string
+}
+var errorPayload = regexp.MustCompile(`\.error$`)
+func (t EntryType)CreatePayload(message string) interface{} {
+  switch  {
+  case errorPayload.MatchString(t.String()):
+    return ErrorPayload{Message: message}
+
+  default:
+    return InfoPayload{Message: message}
+  }
+}

--- a/packages/ui-extensions-go-cli/logging/log_payload.go
+++ b/packages/ui-extensions-go-cli/logging/log_payload.go
@@ -1,24 +1,34 @@
 package logging
 
-import "regexp"
-
 type ErrorPayload struct {
 	Message      string
 	StackTrace   string
 	RecoveryStep string
 }
 
+type FilePayload struct {
+	Message  string
+	FilePath string
+}
+type CompletedPayload struct {
+	Message   string
+	Success   bool
+	Timestamp int64
+}
+type StartedPayload struct {
+	Message   string
+	Timestamp int64
+}
+
 type InfoPayload struct {
 	Message string
 }
 
-var errorPayload = regexp.MustCompile(`\.error$`)
-
-func (t EntryType) CreatePayload(message string) interface{} {
-	switch {
-	case errorPayload.MatchString(t.String()):
-		return ErrorPayload{Message: message}
-
+func (t LogStatus) CreatePayload(message string) interface{} {
+	// TODO is the payload status specific?
+  switch t {
+	case Failed:
+		return FilePayload{Message: message}
 	default:
 		return InfoPayload{Message: message}
 	}

--- a/packages/ui-extensions-go-cli/logging/log_payload.go
+++ b/packages/ui-extensions-go-cli/logging/log_payload.go
@@ -26,7 +26,7 @@ type InfoPayload struct {
 
 func (t LogStatus) CreatePayload(message string) interface{} {
 	// TODO is the payload status specific?
-  switch t {
+	switch t {
 	case Failed:
 		return FilePayload{Message: message}
 	default:

--- a/packages/ui-extensions-go-cli/logging/log_payload.go
+++ b/packages/ui-extensions-go-cli/logging/log_payload.go
@@ -1,5 +1,9 @@
 package logging
 
+import (
+	"encoding/json"
+)
+
 type ErrorPayload struct {
 	Message      string `json:"message,omitempty"`
 	StackTrace   string `json:"stackTrace,omitempty"`
@@ -12,10 +16,12 @@ type InfoPayload struct {
 
 func (t LogStatus) CreatePayload(message string) interface{} {
 	// TODO is the payload status specific?
+
+  encodedMessage, _ := json.Marshal(message)
 	switch t {
 	case Failure:
-		return ErrorPayload{Message: message}
+		return ErrorPayload{Message: string(encodedMessage[1:len(encodedMessage)-1])}
 	default:
-		return InfoPayload{Message: message}
+		return InfoPayload{Message: string(encodedMessage[1:len(encodedMessage)-1])}
 	}
 }

--- a/packages/ui-extensions-go-cli/logging/log_payload.go
+++ b/packages/ui-extensions-go-cli/logging/log_payload.go
@@ -1,24 +1,25 @@
 package logging
 
-import (
-  "regexp"
-)
+import "regexp"
+
 type ErrorPayload struct {
-  Message string
-  StackTrace string
-  RecoveryStep string
+	Message      string
+	StackTrace   string
+	RecoveryStep string
 }
 
 type InfoPayload struct {
-  Message string
+	Message string
 }
-var errorPayload = regexp.MustCompile(`\.error$`)
-func (t EntryType)CreatePayload(message string) interface{} {
-  switch  {
-  case errorPayload.MatchString(t.String()):
-    return ErrorPayload{Message: message}
 
-  default:
-    return InfoPayload{Message: message}
-  }
+var errorPayload = regexp.MustCompile(`\.error$`)
+
+func (t EntryType) CreatePayload(message string) interface{} {
+	switch {
+	case errorPayload.MatchString(t.String()):
+		return ErrorPayload{Message: message}
+
+	default:
+		return InfoPayload{Message: message}
+	}
 }

--- a/packages/ui-extensions-go-cli/logging/log_payload.go
+++ b/packages/ui-extensions-go-cli/logging/log_payload.go
@@ -1,34 +1,20 @@
 package logging
 
 type ErrorPayload struct {
-	Message      string
-	StackTrace   string
-	RecoveryStep string
-}
-
-type FilePayload struct {
-	Message  string
-	FilePath string
-}
-type CompletedPayload struct {
-	Message   string
-	Success   bool
-	Timestamp int64
-}
-type StartedPayload struct {
-	Message   string
-	Timestamp int64
+	Message      string `json:"message,omitempty"`
+	StackTrace   string `json:"stackTrace,omitempty"`
+	RecoveryStep string `json:"recoveryStep,omitempty"`
 }
 
 type InfoPayload struct {
-	Message string
+	Message string `json:"message,omitempty"`
 }
 
 func (t LogStatus) CreatePayload(message string) interface{} {
 	// TODO is the payload status specific?
 	switch t {
-	case Failed:
-		return FilePayload{Message: message}
+	case Failure:
+		return ErrorPayload{Message: message}
 	default:
 		return InfoPayload{Message: message}
 	}

--- a/packages/ui-extensions-go-cli/logging/log_setup.go
+++ b/packages/ui-extensions-go-cli/logging/log_setup.go
@@ -1,0 +1,7 @@
+package logging
+
+import "log"
+
+func Init() {
+  log.SetFlags(0)
+}

--- a/packages/ui-extensions-go-cli/logging/log_setup.go
+++ b/packages/ui-extensions-go-cli/logging/log_setup.go
@@ -3,5 +3,5 @@ package logging
 import "log"
 
 func Init() {
-  log.SetFlags(0)
+	log.SetFlags(0)
 }

--- a/packages/ui-extensions-go-cli/main.go
+++ b/packages/ui-extensions-go-cli/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Shopify/shopify-cli-extensions/build"
 	"github.com/Shopify/shopify-cli-extensions/core"
 	"github.com/Shopify/shopify-cli-extensions/create"
-  "github.com/Shopify/shopify-cli-extensions/logging"
+	"github.com/Shopify/shopify-cli-extensions/logging"
 )
 
 var ctx context.Context
@@ -23,15 +23,15 @@ const version = "v0.0.0"
 
 func init() {
 	ctx = context.Background()
-  logging.Init()
+	logging.Init()
 }
 
 func main() {
 	cli := CLI{}
 	if len(os.Args) < 3 {
-    logging.LogEntry{
-      Type: logging.General_error,
-      Payload: logging.ErrorPayload{Message: "Invalid CLI input: You need to provide at least 2 arguments"}}.WriteLog()
+		logging.LogEntry{
+			Type:    logging.General_error,
+			Payload: logging.ErrorPayload{Message: "Invalid CLI input: You need to provide at least 2 arguments"}}.WriteLog()
 		os.Exit(1)
 	}
 
@@ -54,9 +54,9 @@ func main() {
 	case "serve":
 		cli.serve(args...)
 	case "version":
-    logging.LogEntry{
-      Type: logging.General_info,
-      Payload: logging.InfoPayload{ Message: version}}.WriteLog()
+		logging.LogEntry{
+			Type:    logging.General_info,
+			Payload: logging.InfoPayload{Message: version}}.WriteLog()
 	}
 }
 
@@ -78,13 +78,13 @@ func (cli *CLI) build(args ...string) {
 	for i := 0; i < builds; i++ {
 		result := <-results
 		if !result.Success {
-      buildErrorLog := logging.Build_error.CreateLogEntry(result.Extension.UUID, result.Message)
-      buildErrorLog.WriteLog()
-      buildErrorLog.WriteErrorLog()
+			buildErrorLog := logging.Build_error.CreateLogEntry(result.Extension.UUID, result.Message)
+			buildErrorLog.WriteLog()
+			buildErrorLog.WriteErrorLog()
 			// fmt.Fprintln(os.Stderr, result)
 			failedBuilds += 1
 		} else {
-      logging.Build_completed.CreateLogEntry(result.Extension.UUID, result.Message).WriteLog()
+			logging.Build_completed.CreateLogEntry(result.Extension.UUID, result.Message).WriteLog()
 			// fmt.Println(result)
 		}
 	}
@@ -98,15 +98,15 @@ func (cli *CLI) build(args ...string) {
 
 func (cli *CLI) create(args ...string) {
 	for _, extension := range cli.config.Extensions {
-    logging.Create_started.CreateLogEntry(extension.UUID, "Extension create command started").WriteLog()
+		logging.Create_started.CreateLogEntry(extension.UUID, "Extension create command started").WriteLog()
 		err := create.NewExtensionProject(extension)
 		if err != nil {
-      errorLog := logging.Create_error.CreateLogEntry(extension.UUID, err.Error())
-      errorLog.WriteLog()
-      errorLog.WriteErrorLog()
+			errorLog := logging.Create_error.CreateLogEntry(extension.UUID, err.Error())
+			errorLog.WriteLog()
+			errorLog.WriteErrorLog()
 			panic(fmt.Errorf("failed to create a new extension: %w", err))
 		}
-    logging.Create_completed.CreateLogEntry(extension.UUID, "Extension create command completed").WriteLog()
+		logging.Create_completed.CreateLogEntry(extension.UUID, "Extension create command completed").WriteLog()
 	}
 }
 
@@ -116,12 +116,12 @@ func (cli *CLI) serve(args ...string) {
 	for _, extension := range cli.config.Extensions {
 		go build.Watch(extension, func(result build.Result) {
 			if result.Success {
-        logging.Serve_completed.CreateLogEntry(result.Extension.UUID, result.Message).WriteLog()
+				logging.Serve_completed.CreateLogEntry(result.Extension.UUID, result.Message).WriteLog()
 				//fmt.Println(result)
 			} else {
-        errorLog := logging.Serve_error.CreateLogEntry(result.Extension.UUID, result.Message)
-        errorLog.WriteLog()
-        errorLog.WriteErrorLog()
+				errorLog := logging.Serve_error.CreateLogEntry(result.Extension.UUID, result.Message)
+				errorLog.WriteLog()
+				errorLog.WriteErrorLog()
 				//fmt.Fprintln(os.Stderr, result)
 			}
 
@@ -131,13 +131,13 @@ func (cli *CLI) serve(args ...string) {
 		go build.WatchLocalization(ctx, extension, func(result build.Result) {
 			if result.Success {
 				api.Notify([]core.Extension{result.Extension})
-        logging.Serve_completed.CreateLogEntry(result.Extension.UUID, result.Message).WriteLog()
+				logging.Serve_completed.CreateLogEntry(result.Extension.UUID, result.Message).WriteLog()
 				//fmt.Println(result)
 			} else {
 				errorLog := logging.Serve_error.CreateLogEntry(result.Extension.UUID, result.Message)
-        errorLog.WriteLog()
-        errorLog.WriteErrorLog()
-        //fmt.Fprintln(os.Stderr, result)
+				errorLog.WriteLog()
+				errorLog.WriteErrorLog()
+				//fmt.Fprintln(os.Stderr, result)
 			}
 		})
 	}
@@ -150,9 +150,9 @@ func (cli *CLI) serve(args ...string) {
 		server.Shutdown(ctx)
 	})
 
-  logging.LogEntry{
-    Type: logging.General_info,
-    Payload: logging.InfoPayload{ Message: fmt.Sprintf("Shopify CLI Extensions Server is now available at %s\n", api.GetDevConsoleUrl())}}.WriteLog()
+	logging.LogEntry{
+		Type:    logging.General_info,
+		Payload: logging.InfoPayload{Message: fmt.Sprintf("Shopify CLI Extensions Server is now available at %s\n", api.GetDevConsoleUrl())}}.WriteLog()
 
 	if err := server.ListenAndServe(); err != http.ErrServerClosed {
 		panic(err)

--- a/packages/ui-extensions-go-cli/main.go
+++ b/packages/ui-extensions-go-cli/main.go
@@ -27,13 +27,13 @@ func init() {
 }
 
 func main() {
-  baseLogEntryBuilder := logging.NewLogEntryBuilder()
+	baseLogEntryBuilder := logging.NewLogEntryBuilder()
 	cli := CLI{}
 
-  validationLogBuilder := baseLogEntryBuilder.AddContext(logging.Config).AddContext(logging.Validate)
-  validationLogBuilder.Build(logging.Started,"", "Starting input validation").WriteErrorLog(os.Stdout)
+	validationLogBuilder := baseLogEntryBuilder.AddContext(logging.Config).AddContext(logging.Validate)
+	validationLogBuilder.Build(logging.Started, "", "Starting input validation").WriteErrorLog(os.Stdout)
 	if len(os.Args) < 3 {
-    validationLogBuilder.Build(logging.Started,"", "Invalid CLI input: You need to provide at least 2 arguments").WriteErrorLog(os.Stdout)
+		validationLogBuilder.Build(logging.Started, "", "Invalid CLI input: You need to provide at least 2 arguments").WriteErrorLog(os.Stdout)
 		os.Exit(1)
 	}
 
@@ -42,24 +42,24 @@ func main() {
 	if len(args) > 0 {
 		config, err := loadConfigFrom(args[0])
 		if err != nil {
-      validationLogBuilder.Build(logging.Failed,"", err.Error()).WriteErrorLog(os.Stdout)
+			validationLogBuilder.Build(logging.Failed, "", err.Error()).WriteErrorLog(os.Stdout)
 			panic(err)
 		}
 		cli.config = config
 		args = args[1:]
 	}
-  validationLogBuilder.Build(logging.Completed,"", "Succesfully loaded configuration").WriteLog(os.Stdout)
+	validationLogBuilder.Build(logging.Completed, "", "Succesfully loaded configuration").WriteLog(os.Stdout)
 
-  switch cmd {
-    case "build":
-      cli.build(args...)
-    case "create":
-      cli.create(args...)
-    case "serve":
-      cli.serve(args...)
-    case "version":
-      baseLogEntryBuilder.Build(logging.Completed, "", version).WriteLog(os.Stdout)
-    }
+	switch cmd {
+	case "build":
+		cli.build(args...)
+	case "create":
+		cli.create(args...)
+	case "serve":
+		cli.serve(args...)
+	case "version":
+		baseLogEntryBuilder.Build(logging.Completed, "", version).WriteLog(os.Stdout)
+	}
 }
 
 type CLI struct {
@@ -67,7 +67,7 @@ type CLI struct {
 }
 
 func (cli *CLI) build(args ...string) {
-  logBuilder := logging.NewLogEntryBuilder().AddContext(logging.Build)
+	logBuilder := logging.NewLogEntryBuilder().AddContext(logging.Build)
 	builds := len(cli.config.Extensions)
 	results := make(chan build.Result)
 
@@ -81,12 +81,12 @@ func (cli *CLI) build(args ...string) {
 	for i := 0; i < builds; i++ {
 		result := <-results
 		if !result.Success {
-      logBuilder.Build(logging.Completed, result.Extension.UUID, result.Message).WriteErrorLog(os.Stdout)
+			logBuilder.Build(logging.Completed, result.Extension.UUID, result.Message).WriteErrorLog(os.Stdout)
 			// fmt.Fprintln(os.Stderr, result)
 			failedBuilds += 1
 		} else {
 			completedLog := logBuilder.Build(logging.Completed, result.Extension.UUID, result.Message)
-      completedLog.WriteLog(os.Stdout)
+			completedLog.WriteLog(os.Stdout)
 			// fmt.Println(result)
 		}
 	}
@@ -99,7 +99,7 @@ func (cli *CLI) build(args ...string) {
 }
 
 func (cli *CLI) create(args ...string) {
-  logBuilder := logging.NewLogEntryBuilder().AddContext(logging.Create)
+	logBuilder := logging.NewLogEntryBuilder().AddContext(logging.Create)
 	for _, extension := range cli.config.Extensions {
 		logBuilder.Build(logging.Started, extension.UUID, "Extension create command started").WriteLog(os.Stdout)
 		err := create.NewExtensionProject(extension)
@@ -108,23 +108,23 @@ func (cli *CLI) create(args ...string) {
 			errorLog.WriteErrorLog(os.Stdout)
 			panic(fmt.Errorf("failed to create a new extension: %w", err))
 		}
-    logBuilder.Build(logging.Completed, extension.UUID, "Extension create command completed").WriteLog(os.Stdout)
+		logBuilder.Build(logging.Completed, extension.UUID, "Extension create command completed").WriteLog(os.Stdout)
 	}
 }
 
 func (cli *CLI) serve(args ...string) {
-  logBuilder := logging.NewLogEntryBuilder().AddContext(logging.Serve)
+	logBuilder := logging.NewLogEntryBuilder().AddContext(logging.Serve)
 
 	api := api.New(cli.config)
 
 	for _, extension := range cli.config.Extensions {
 		go build.Watch(extension, func(result build.Result) {
-      logWatchBuilder := logBuilder.AddContext(logging.Build).AddContext(logging.Watch)
+			logWatchBuilder := logBuilder.AddContext(logging.Build).AddContext(logging.Watch)
 			if result.Success {
 				logWatchBuilder.Build(logging.Completed, result.Extension.UUID, result.Message).WriteLog(os.Stdout)
 				//fmt.Println(result)
 			} else {
-        logWatchBuilder.Build(logging.Progress, result.Extension.UUID, result.Message).WriteLog(os.Stdout)
+				logWatchBuilder.Build(logging.Progress, result.Extension.UUID, result.Message).WriteLog(os.Stdout)
 				//fmt.Fprintln(os.Stderr, result)
 			}
 
@@ -132,7 +132,7 @@ func (cli *CLI) serve(args ...string) {
 		})
 
 		go build.WatchLocalization(ctx, extension, func(result build.Result) {
-      logWatchLocalizationBuilder := logBuilder.AddContext(logging.Build).AddContext(logging.WatchLocalization)
+			logWatchLocalizationBuilder := logBuilder.AddContext(logging.Build).AddContext(logging.WatchLocalization)
 			if result.Success {
 				logCompleted := logWatchLocalizationBuilder.Build(logging.Completed, result.Extension.UUID, result.Message)
 				logCompleted.WriteLog(os.Stdout)
@@ -152,9 +152,9 @@ func (cli *CLI) serve(args ...string) {
 		server.Shutdown(ctx)
 	})
 
-  logBuilder.Build(logging.Started, "", fmt.Sprintf("Shopify CLI Extensions Server is now available at %s\n", api.GetDevConsoleUrl())).WriteLog(os.Stdout)
+	logBuilder.Build(logging.Started, "", fmt.Sprintf("Shopify CLI Extensions Server is now available at %s\n", api.GetDevConsoleUrl())).WriteLog(os.Stdout)
 	if err := server.ListenAndServe(); err != http.ErrServerClosed {
-    logBuilder.Build(logging.Failed, "", err.Error()).WriteErrorLog(os.Stdout)
+		logBuilder.Build(logging.Failed, "", err.Error()).WriteErrorLog(os.Stdout)
 		panic(err)
 	}
 }

--- a/packages/ui-extensions-go-cli/main.go
+++ b/packages/ui-extensions-go-cli/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Shopify/shopify-cli-extensions/build"
 	"github.com/Shopify/shopify-cli-extensions/core"
 	"github.com/Shopify/shopify-cli-extensions/create"
+  "github.com/Shopify/shopify-cli-extensions/logging"
 )
 
 var ctx context.Context
@@ -22,12 +23,15 @@ const version = "v0.0.0"
 
 func init() {
 	ctx = context.Background()
+  logging.Init()
 }
 
 func main() {
 	cli := CLI{}
 	if len(os.Args) < 3 {
-		fmt.Println("You need to provide at least 2 arguments")
+    logging.LogEntry{
+      Type: logging.General_error,
+      Payload: logging.ErrorPayload{Message: "Invalid CLI input: You need to provide at least 2 arguments"}}.WriteLog()
 		os.Exit(1)
 	}
 
@@ -50,7 +54,9 @@ func main() {
 	case "serve":
 		cli.serve(args...)
 	case "version":
-		fmt.Printf("%s\n", version)
+    logging.LogEntry{
+      Type: logging.General_info,
+      Payload: logging.InfoPayload{ Message: version}}.WriteLog()
 	}
 }
 
@@ -72,10 +78,14 @@ func (cli *CLI) build(args ...string) {
 	for i := 0; i < builds; i++ {
 		result := <-results
 		if !result.Success {
-			fmt.Fprintln(os.Stderr, result)
+      buildErrorLog := logging.Build_error.CreateLogEntry(result.Extension.UUID, result.Message)
+      buildErrorLog.WriteLog()
+      buildErrorLog.WriteErrorLog()
+			// fmt.Fprintln(os.Stderr, result)
 			failedBuilds += 1
 		} else {
-			fmt.Println(result)
+      logging.Build_completed.CreateLogEntry(result.Extension.UUID, result.Message).WriteLog()
+			// fmt.Println(result)
 		}
 	}
 
@@ -88,10 +98,15 @@ func (cli *CLI) build(args ...string) {
 
 func (cli *CLI) create(args ...string) {
 	for _, extension := range cli.config.Extensions {
+    logging.Create_started.CreateLogEntry(extension.UUID, "Extension create command started").WriteLog()
 		err := create.NewExtensionProject(extension)
 		if err != nil {
+      errorLog := logging.Create_error.CreateLogEntry(extension.UUID, err.Error())
+      errorLog.WriteLog()
+      errorLog.WriteErrorLog()
 			panic(fmt.Errorf("failed to create a new extension: %w", err))
 		}
+    logging.Create_completed.CreateLogEntry(extension.UUID, "Extension create command completed").WriteLog()
 	}
 }
 
@@ -101,9 +116,13 @@ func (cli *CLI) serve(args ...string) {
 	for _, extension := range cli.config.Extensions {
 		go build.Watch(extension, func(result build.Result) {
 			if result.Success {
-				fmt.Println(result)
+        logging.Serve_completed.CreateLogEntry(result.Extension.UUID, result.Message).WriteLog()
+				//fmt.Println(result)
 			} else {
-				fmt.Fprintln(os.Stderr, result)
+        errorLog := logging.Serve_error.CreateLogEntry(result.Extension.UUID, result.Message)
+        errorLog.WriteLog()
+        errorLog.WriteErrorLog()
+				//fmt.Fprintln(os.Stderr, result)
 			}
 
 			api.Notify([]core.Extension{result.Extension})
@@ -112,9 +131,13 @@ func (cli *CLI) serve(args ...string) {
 		go build.WatchLocalization(ctx, extension, func(result build.Result) {
 			if result.Success {
 				api.Notify([]core.Extension{result.Extension})
-				fmt.Println(result)
+        logging.Serve_completed.CreateLogEntry(result.Extension.UUID, result.Message).WriteLog()
+				//fmt.Println(result)
 			} else {
-				fmt.Fprintln(os.Stderr, result)
+				errorLog := logging.Serve_error.CreateLogEntry(result.Extension.UUID, result.Message)
+        errorLog.WriteLog()
+        errorLog.WriteErrorLog()
+        //fmt.Fprintln(os.Stderr, result)
 			}
 		})
 	}
@@ -127,7 +150,9 @@ func (cli *CLI) serve(args ...string) {
 		server.Shutdown(ctx)
 	})
 
-	fmt.Printf("Shopify CLI Extensions Server is now available at %s\n", api.GetDevConsoleUrl())
+  logging.LogEntry{
+    Type: logging.General_info,
+    Payload: logging.InfoPayload{ Message: fmt.Sprintf("Shopify CLI Extensions Server is now available at %s\n", api.GetDevConsoleUrl())}}.WriteLog()
 
 	if err := server.ListenAndServe(); err != http.ErrServerClosed {
 		panic(err)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#364](https://github.com/Shopify/cli/pull/364)
The Extension server is now logging structured logs and the CLI needs to be able to parse them in to the desired format.
The problem is describe further in this [document](https://docs.google.com/document/d/1EaxKuiDOHuukkqayNr_Ot-7JcAwomjhDYnLcwfNuLko/edit#)


### WHAT is this pull request doing?
Added Structured logging to the Extension server and parsing of the structured logging in the CLI

### How to test your changes?

- Create an App through the CLI `yarn create app --local`
- Go the the app folder and create an extension in the app `yarn scaffold extension`
- Serve the app&extension `yarn dev`
- check the output logs
- Introduce a breaking change in the extension template like changing an HTML tag and see the error log

