### PR TITLE
Load the `@oclif/plugin-plugins` plugin in `cli-main`

### DIFF
--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -77,7 +77,8 @@
       "@shopify/theme",
       "@shopify/cli-hydrogen",
       "@oclif/plugin-help",
-      "@shopify/plugin-ngrok"
+      "@shopify/plugin-ngrok",
+      "@oclif/plugin-plugins"
     ],
     "scope": "shopify",
     "topicSeparator": " ",


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed we are not currently loading the `@oclif/plugin-plugins` plugin in `cli-main` and therefore CLI users don't have access to the `shopify plugins` API for managing their plugins. Is there are a reason for it?

### WHAT is this pull request doing?
I'm adding the plugin to the list of plugins that get loaded with the CLI.

### How to test your changes?

`yarn shopify plugins` should show the help.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
