### PR TITLE
Pin nx-set-shas version to 2.2.5

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -83,7 +83,7 @@ jobs:
           git config --global user.email "development-lifecycle@shopify.com"
           git config --global user.name "Development Lifecycle"
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
+        uses: nrwl/nx-set-shas@v2.2.5
       - name: Set Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -145,7 +145,7 @@ jobs:
           git config --global user.email "development-lifecycle@shopify.com"
           git config --global user.name "Development Lifecycle"
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
+        uses: nrwl/nx-set-shas@v2.2.5
       - name: Setup build toolchain
         uses: actions/setup-go@v2
         with:
@@ -188,7 +188,7 @@ jobs:
           git config --global user.email "development-lifecycle@shopify.com"
           git config --global user.name "Development Lifecycle"
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
+        uses: nrwl/nx-set-shas@v2.2.5
       - name: Set Ruby on MacOS
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
### WHY are these changes introduced?

The CI is suddenly failing in the step `Derive appropriate SHAs for base and head for 'nx affected' commands`, which uses https://github.com/nrwl/nx-set-shas. They recently released the version ([2.2.6](https://github.com/nrwl/nx-set-shas/releases/tag/v2.2.6)) and that could be the cause.

### WHAT is this pull request doing?

Pin the version on the workflows to 2.2.5

### How to test your changes?

Merge and check CI

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
