### PR TITLE
Fix theme initialization

### DIFF
--- a/.changeset/shaggy-ties-stare.md
+++ b/.changeset/shaggy-ties-stare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix initialization of themes not working due to invalid arguments being passed

--- a/packages/theme/src/cli/commands/theme/init.ts
+++ b/packages/theme/src/cli/commands/theme/init.ts
@@ -29,9 +29,11 @@ export default class Init extends Command {
   async run(): Promise<void> {
     const {args, flags} = await this.parse(Init)
     const directory = flags.path ? path.resolve(flags.path) : process.cwd()
-    const workingPath = args.name || (await this.promptName())
-    const command = ['theme', 'init', path.resolve(directory, workingPath)]
-    await execCLI2(command)
+    const name = args.name || (await this.promptName())
+    const command = ['theme', 'init', name]
+    await execCLI2(command, {
+      directory,
+    })
   }
 
   async promptName() {


### PR DESCRIPTION
### WHY are these changes introduced?
We were wrongly passing an absolute path as first argument to the CLI 2.0 theme init command when it expects the theme name. This leads to the following initialization error:

![image](https://user-images.githubusercontent.com/663605/188472421-b4fac0be-0062-4320-8e56-5c704b263886.png)

### WHAT is this pull request doing?
I'm passing the theme name instead and setting the working directory when executing the command.

### How to test your changes?
Run `yarn shopify theme init`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
