### PR TITLE
Display correct usable HTML URL after opening Homebrew PR

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -67,7 +67,7 @@ program
             },
           ],
         })
-      console.log(`${colors.green(colors.bold("PR opened:"))} ${response.url}`)
+      console.log(`${colors.green(colors.bold("PR opened:"))} ${response.data.html_url}`)
     }
   })
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The displayed URL is from the GitHub JSON API. Not super useful if you'd like a big green button to merge your PR.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Changes the displayed URL to be the URL you'd actually see in your browser when navigating to the PR page.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
This code was written based on local testing with Octokit.

```js
const { request } = require("@octokit/request")
const result = await request("GET /repos/{owner}/{repo}/pulls/{id}", {owner: "Shopify", repo: "cli", id: 430})
result.url // 'https://api.github.com/repos/Shopify/cli/pulls/430'
result.data.html_url // 'https://github.com/Shopify/cli/pull/430'
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
