### PR TITLE
Move the UI extensions' build logic from Go to Node

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,4 +8,3 @@ template/
 templates/
 fixtures/
 .eslintrc.cjs
-fastify-http-proxy

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -52,13 +52,13 @@
     "vitest": "^0.22.1"
   },
   "dependencies": {
-    "@fastify/reply-from": "^8.0.0",
+    "@luckycatfactory/esbuild-graphql-loader": "3.7.0",
     "@oclif/core": "1.9.2",
     "@shopify/cli-kit": "3.10.1",
     "@shopify/shopify-cli-extensions": "3.10.1",
     "http-proxy": "^1.18.1",
     "diff": "^5.1.0",
-    "ws": "^8.7.0"
+    "esbuild": "0.15.7"
   },
   "repository": {
     "type": "git",

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -26,7 +26,7 @@ export function testApp(app: Partial<AppInterface> = {}): AppInterface {
 export function testUIExtension(uiExtension: Partial<UIExtension> = {}): UIExtension {
   return {
     localIdentifier: uiExtension?.localIdentifier ?? 'test-ui-extension',
-    buildDirectory: uiExtension?.buildDirectory ?? '/tmp/project/extensions/test-ui-extension/dist',
+    outputBundlePath: uiExtension?.outputBundlePath ?? '/tmp/project/extensions/test-ui-extension/dist/main.js',
     configuration: uiExtension?.configuration ?? {
       name: uiExtension?.configuration?.name ?? 'test-ui-extension',
       type: uiExtension?.configuration?.type ?? 'product_subscription',

--- a/packages/app/src/cli/models/app/extensions.ts
+++ b/packages/app/src/cli/models/app/extensions.ts
@@ -95,8 +95,8 @@ export type ThemeExtension = Extension & {
 
 export type UIExtension = Extension & {
   configuration: UIExtensionConfiguration
-  buildDirectory: string
   entrySourceFilePath: string
+  outputBundlePath: string
   devUUID: string
 }
 

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -264,8 +264,8 @@ class AppLoader {
         configurationPath,
         type: configuration.type,
         graphQLType: extensionGraphqlId(configuration.type),
-        buildDirectory: path.join(directory, 'dist'),
         entrySourceFilePath: entrySourceFilePath ?? '',
+        outputBundlePath: path.join(directory, 'dist/main.js'),
         localIdentifier: path.basename(directory),
         // The convention is that unpublished extensions will have a random UUID with prefix `dev-`
         devUUID: `dev-${id.generateRandomUUID()}`,

--- a/packages/app/src/cli/services/build.ts
+++ b/packages/app/src/cli/services/build.ts
@@ -1,8 +1,10 @@
-import {buildThemeExtensions, buildUIExtensions, buildFunctionExtension} from './build/extension.js'
+import {buildThemeExtensions, buildFunctionExtension, buildUIExtension} from './build/extension.js'
 import buildWeb from './web.js'
 import {installAppDependencies} from './dependencies.js'
 import {AppInterface, Web} from '../models/app/app.js'
-import {error, output} from '@shopify/cli-kit'
+import {extensionConfig} from '../utilities/extensions/configuration.js'
+import {runGoExtensionsCLI} from '../utilities/extensions/cli.js'
+import {output, abort, yaml, environment} from '@shopify/cli-kit'
 import {Writable} from 'node:stream'
 
 interface BuildOptions {
@@ -11,61 +13,87 @@ interface BuildOptions {
   apiKey?: string
 }
 
-async function build({app, skipDependenciesInstallation, apiKey = undefined}: BuildOptions) {
-  if (!skipDependenciesInstallation) {
-    await installAppDependencies(app)
+async function build(options: BuildOptions) {
+  if (!options.skipDependenciesInstallation) {
+    await installAppDependencies(options.app)
   }
 
   const env: {SHOPIFY_API_KEY?: string} = {}
-  if (apiKey) {
-    env.SHOPIFY_API_KEY = apiKey
+  if (options.apiKey) {
+    env.SHOPIFY_API_KEY = options.apiKey
   }
 
   await output.concurrent([
-    ...app.webs.map((web: Web) => {
+    ...options.app.webs.map((web: Web) => {
       return {
         prefix: web.configuration.type,
-        action: async (stdout: Writable, stderr: Writable, signal: error.AbortSignal) => {
+        action: async (stdout: Writable, stderr: Writable, signal: abort.Signal) => {
           await buildWeb('build', {web, stdout, stderr, signal, env})
         },
       }
     }),
     {
       prefix: 'theme_extensions',
-      action: async (stdout: Writable, stderr: Writable, signal: error.AbortSignal) => {
+      action: async (stdout: Writable, stderr: Writable, signal: abort.Signal) => {
         await buildThemeExtensions({
-          app,
-          extensions: app.extensions.theme,
+          app: options.app,
+          extensions: options.app.extensions.theme,
           stdout,
           stderr,
           signal,
         })
       },
     },
-    {
-      prefix: 'extensions',
-      action: async (stdout: Writable, stderr: Writable, signal: error.AbortSignal) => {
-        await buildUIExtensions({
-          app,
-          extensions: app.extensions.ui,
-          stdout,
-          stderr,
-          signal,
-        })
-      },
-    },
-    ...app.extensions.function.map((functionExtension) => {
+    ...buildUIExtensions(options),
+    ...options.app.extensions.function.map((functionExtension) => {
       return {
         prefix: functionExtension.localIdentifier,
-        action: async (stdout: Writable, stderr: Writable, signal: error.AbortSignal) => {
-          await buildFunctionExtension(functionExtension, {stdout, stderr, signal, app})
+        action: async (stdout: Writable, stderr: Writable, signal: abort.Signal) => {
+          await buildFunctionExtension(functionExtension, {stdout, stderr, signal, app: options.app})
         },
       }
     }),
   ])
 
   output.newline()
-  output.success(`${app.name} built`)
+  output.success(`${options.app.name} built`)
+}
+
+function buildUIExtensions(options: BuildOptions): output.OutputProcess[] {
+  if (options.app.extensions.ui.length === 0) {
+    return []
+  }
+  if (environment.utilities.isTruthy(process.env.SHOPIFY_CLI_UI_EXTENSIONS_USE_NODE)) {
+    return options.app.extensions.ui.map((uiExtension) => {
+      return {
+        prefix: uiExtension.localIdentifier,
+        action: async (stdout: Writable, stderr: Writable, signal: abort.Signal) => {
+          await buildUIExtension(uiExtension, {stdout, stderr, signal, app: options.app})
+        },
+      }
+    })
+  } else {
+    return [
+      {
+        prefix: 'ui-extensions',
+        action: async (stdout: Writable, stderr: Writable, signal: abort.Signal) => {
+          stdout.write(`Building UI extensions...`)
+          const fullOptions = {...options, extensions: options.app.extensions.ui, includeResourceURL: false}
+          const configuration = await extensionConfig(fullOptions)
+          output.debug(output.content`Dev'ing extension with configuration:
+${output.token.json(configuration)}
+`)
+          const input = yaml.encode(configuration)
+          await runGoExtensionsCLI(['build', '-'], {
+            cwd: options.app.directory,
+            stdout,
+            stderr,
+            input,
+          })
+        },
+      },
+    ]
+  }
 }
 
 export default build

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -10,7 +10,7 @@ import {
 import {AppInterface, AppConfiguration, Web, WebType} from '../models/app/app.js'
 import {UIExtension} from '../models/app/extensions.js'
 import {fetchProductVariant} from '../utilities/extensions/fetch-product-variant.js'
-import {error, analytics, output, port, system, session} from '@shopify/cli-kit'
+import {error, analytics, output, port, system, session, abort} from '@shopify/cli-kit'
 import {Config} from '@oclif/core'
 import {Writable} from 'node:stream'
 
@@ -132,7 +132,7 @@ async function dev(options: DevOptions) {
     if (options.noTunnel) {
       const devFrontendProccess = {
         prefix: devFrontend.logPrefix,
-        action: async (stdout: Writable, stderr: Writable, signal: error.AbortSignal) => {
+        action: async (stdout: Writable, stderr: Writable, signal: abort.Signal) => {
           await devFrontend.action(stdout, stderr, signal, frontendPort)
         },
       }
@@ -170,7 +170,7 @@ function devFrontendTarget(options: DevFrontendTargetOptions): ReverseHTTPProxyT
 
   return {
     logPrefix: options.web.configuration.type,
-    action: async (stdout: Writable, stderr: Writable, signal: error.AbortSignal, port: number) => {
+    action: async (stdout: Writable, stderr: Writable, signal: abort.Signal, port: number) => {
       await system.exec(cmd!, args, {
         cwd: options.web.directory,
         stdout,
@@ -208,7 +208,7 @@ function devBackendTarget(web: Web, options: DevWebOptions): output.OutputProces
 
   return {
     prefix: web.configuration.type,
-    action: async (stdout: Writable, stderr: Writable, signal: error.AbortSignal) => {
+    action: async (stdout: Writable, stderr: Writable, signal: abort.Signal) => {
       await system.exec(cmd!, args, {
         cwd: web.directory,
         stdout,
@@ -235,7 +235,7 @@ async function devExtensionsTarget(
   return {
     logPrefix: 'extensions',
     pathPrefix: '/extensions',
-    action: async (stdout: Writable, stderr: Writable, signal: error.AbortSignal, port: number) => {
+    action: async (stdout: Writable, stderr: Writable, signal: abort.Signal, port: number) => {
       await devExtensions({
         app,
         extensions: app.extensions.ui,

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -2,7 +2,7 @@ import {AppInterface} from '../../models/app/app.js'
 import {UIExtension} from '../../models/app/extensions.js'
 import {runGoExtensionsCLI} from '../../utilities/extensions/cli.js'
 import {extensionConfig} from '../../utilities/extensions/configuration.js'
-import {error, yaml, output} from '@shopify/cli-kit'
+import {yaml, output, abort} from '@shopify/cli-kit'
 import {Writable} from 'node:stream'
 
 export interface ExtensionDevOptions {
@@ -18,7 +18,7 @@ export interface ExtensionDevOptions {
   /**
    * Signal to abort the build process.
    */
-  signal: error.AbortSignal
+  signal: abort.Signal
 
   /**
    * Overrides the default build directory.

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -96,8 +96,8 @@ const EXTENSION_A: UIExtension = {
   type: 'checkout_post_purchase',
   graphQLType: 'CHECKOUT_POST_PURCHASE',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
   entrySourceFilePath: '',
+  outputBundlePath: '',
   devUUID: 'devUUID',
 }
 

--- a/packages/app/src/cli/services/environment/id-manual-matching.test.ts
+++ b/packages/app/src/cli/services/environment/id-manual-matching.test.ts
@@ -26,7 +26,7 @@ const EXTENSION_A: UIExtension = {
   type: 'checkout_post_purchase',
   graphQLType: 'CHECKOUT_POST_PURCHASE',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }
@@ -39,7 +39,7 @@ const EXTENSION_A_2: UIExtension = {
   type: 'checkout_post_purchase',
   graphQLType: 'CHECKOUT_POST_PURCHASE',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }
@@ -52,7 +52,7 @@ const EXTENSION_B: UIExtension = {
   type: 'product_subscription',
   graphQLType: 'CHECKOUT_POST_PURCHASE',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }

--- a/packages/app/src/cli/services/environment/id-matching.test.ts
+++ b/packages/app/src/cli/services/environment/id-matching.test.ts
@@ -61,7 +61,7 @@ const EXTENSION_A: UIExtension = {
   type: 'checkout_post_purchase',
   graphQLType: 'CHECKOUT_POST_PURCHASE',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }
@@ -74,7 +74,7 @@ const EXTENSION_A_2: UIExtension = {
   type: 'checkout_post_purchase',
   graphQLType: 'CHECKOUT_POST_PURCHASE',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }
@@ -87,7 +87,7 @@ const EXTENSION_B: UIExtension = {
   type: 'product_subscription',
   graphQLType: 'SUBSCRIPTION_MANAGEMENT',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }
@@ -100,7 +100,7 @@ const EXTENSION_C: UIExtension = {
   type: 'theme',
   graphQLType: 'THEME_APP_EXTENSION',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }
@@ -113,7 +113,7 @@ const EXTENSION_D: UIExtension = {
   type: 'web_pixel_extension',
   graphQLType: 'WEB_PIXEL_EXTENSION',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }

--- a/packages/app/src/cli/services/environment/identifiers.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers.test.ts
@@ -46,7 +46,7 @@ const EXTENSION_A: UIExtension = {
   type: 'checkout_post_purchase',
   graphQLType: 'CHECKOUT_POST_PURCHASE',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }
@@ -59,7 +59,7 @@ const EXTENSION_A_2: UIExtension = {
   type: 'checkout_post_purchase',
   graphQLType: 'CHECKOUT_POST_PURCHASE',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }
@@ -72,7 +72,7 @@ const EXTENSION_B: UIExtension = {
   type: 'checkout_post_purchase',
   graphQLType: 'CHECKOUT_POST_PURCHASE',
   configuration: {name: '', type: 'checkout_post_purchase', metafields: []},
-  buildDirectory: '',
+  outputBundlePath: '',
   entrySourceFilePath: '',
   devUUID: 'devUUID',
 }

--- a/packages/app/src/cli/services/extensions/bundle.test.ts
+++ b/packages/app/src/cli/services/extensions/bundle.test.ts
@@ -1,0 +1,213 @@
+import {bundleExtension} from './bundle.js'
+import {testApp, testUIExtension} from '../../models/app/app.test-data.js'
+import {describe, expect, test, vi} from 'vitest'
+import {build as esBuild, BuildOptions, WatchMode} from 'esbuild'
+import {abort, path} from '@shopify/cli-kit'
+
+vi.mock('esbuild', async () => {
+  const esbuild: any = await vi.importActual('esbuild')
+  return {
+    ...esbuild,
+    build: vi.fn(),
+  }
+})
+
+describe('buildExtension', () => {
+  test('invokes ESBuild with the right options and forwards the logs', async () => {
+    // Given
+    const extension = testUIExtension()
+    const stdout: any = {
+      write: vi.fn(),
+    }
+    const stderr: any = {
+      write: vi.fn(),
+    }
+    const app = testApp({
+      directory: '/project',
+      dotenv: {
+        path: '/project/.env',
+        variables: {
+          FOO: 'BAR',
+        },
+      },
+      extensions: {
+        ui: [extension],
+        theme: [],
+        function: [],
+      },
+    })
+    vi.mocked(esBuild).mockResolvedValue(esbuildResultFixture())
+
+    // When
+    await bundleExtension({
+      env: app.dotenv?.variables ?? {},
+      outputBundlePath: extension.outputBundlePath,
+      minify: true,
+      environment: 'production',
+      sourceFilePath: extension.entrySourceFilePath,
+      stdout,
+      stderr,
+    })
+
+    // Then
+    const call = vi.mocked(esBuild).mock.calls[0] as any
+    expect(call).not.toBeUndefined()
+    const options: BuildOptions = call[0]
+
+    expect(options.bundle).toBeTruthy()
+    expect(options.entryPoints).toEqual([extension.entrySourceFilePath])
+    expect(options.outfile).toEqual(extension.outputBundlePath)
+    expect(options.sourceRoot).toEqual(path.dirname(extension.entrySourceFilePath))
+    expect(options.loader).toEqual({
+      '.esnext': 'ts',
+      '.js': 'jsx',
+    })
+    expect(options.legalComments).toEqual('none')
+    expect(options.minify).toBeTruthy()
+    expect(options.target).toEqual('es6')
+    expect(options.resolveExtensions).toEqual(['.tsx', '.ts', '.js', '.json', '.esnext', '.mjs', '.ejs'])
+    expect(options.define).toEqual({
+      'process.env.FOO': JSON.stringify('BAR'),
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    })
+    expect(vi.mocked(stdout.write).calls[0][0]).toMatchInlineSnapshot(`
+      "▲ [WARNING] [plugin plugin] warning text
+
+      "
+    `)
+    expect(vi.mocked(stdout.write).calls[0][0]).toMatchInlineSnapshot(`
+      "▲ [WARNING] [plugin plugin] warning text
+
+      "
+    `)
+  })
+
+  test('stops the ESBuild when the abort signal receives an event', async () => {
+    // Given
+    const extension = testUIExtension()
+    const app = testApp({
+      directory: '/project',
+      dotenv: {
+        path: '/project/.env',
+        variables: {
+          FOO: 'BAR',
+        },
+      },
+      extensions: {
+        ui: [extension],
+        theme: [],
+        function: [],
+      },
+    })
+    const stdout: any = {
+      write: vi.fn(),
+    }
+    const stderr: any = {
+      write: vi.fn(),
+    }
+    const esbuildStop: any = vi.fn()
+
+    vi.mocked(esBuild).mockResolvedValue({
+      errors: [],
+      warnings: [],
+      stop: esbuildStop,
+    })
+    const abortController = new abort.Controller()
+
+    // When
+    await bundleExtension({
+      env: app.dotenv?.variables ?? {},
+      outputBundlePath: extension.outputBundlePath,
+      minify: true,
+      environment: 'production',
+      sourceFilePath: extension.entrySourceFilePath,
+      stdout,
+      stderr,
+      watchSignal: abortController.signal,
+    })
+    abortController.abort()
+
+    // Then
+    expect(esbuildStop).toHaveBeenCalled()
+  })
+
+  test('forwards and outputs watch events', async () => {
+    // Given
+    const extension = testUIExtension()
+    const app = testApp({
+      directory: '/project',
+      dotenv: {
+        path: '/project/.env',
+        variables: {
+          FOO: 'BAR',
+        },
+      },
+      extensions: {
+        ui: [extension],
+        theme: [],
+        function: [],
+      },
+    })
+    const stdout: any = {
+      write: vi.fn(),
+    }
+    const stderr: any = {
+      write: vi.fn(),
+    }
+    const watcher = vi.fn()
+
+    // When
+    await bundleExtension({
+      env: app.dotenv?.variables ?? {},
+      outputBundlePath: extension.outputBundlePath,
+      minify: true,
+      environment: 'production',
+      sourceFilePath: extension.entrySourceFilePath,
+      stdout,
+      stderr,
+      watch: watcher,
+    })
+
+    // Then
+    const call = vi.mocked(esBuild).mock.calls[0] as any
+    expect(call).not.toBeUndefined()
+    const options: BuildOptions = call[0]
+    const onRebuild = (options.watch as any).onRebuild as NonNullable<WatchMode['onRebuild']>
+    onRebuild(null, esbuildResultFixture())
+    expect(vi.mocked(stdout.write).calls[0][0]).toMatchInlineSnapshot(`
+      "▲ [WARNING] [plugin plugin] warning text
+
+      "
+    `)
+    expect(vi.mocked(stdout.write).calls[0][0]).toMatchInlineSnapshot(`
+      "▲ [WARNING] [plugin plugin] warning text
+
+      "
+    `)
+  })
+
+  function esbuildResultFixture() {
+    return {
+      errors: [
+        {
+          id: 'error',
+          pluginName: 'plugin',
+          text: 'error text',
+          location: null,
+          notes: [],
+          detail: {},
+        },
+      ],
+      warnings: [
+        {
+          id: 'warning',
+          pluginName: 'plugin',
+          text: 'warning text',
+          location: null,
+          notes: [],
+          detail: {},
+        },
+      ],
+    }
+  }
+})

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -1,0 +1,142 @@
+import {abort, path} from '@shopify/cli-kit'
+import {build as esBuild, formatMessagesSync} from 'esbuild'
+import {Writable} from 'node:stream'
+
+interface BundleOptions {
+  minify: boolean
+  env: {[variable: string]: string}
+  outputBundlePath: string
+  sourceFilePath: string
+  stdout: Writable
+  stderr: Writable
+
+  /**
+   * When provided, the bundling process keeps running and notifying about changes.
+   * When ESBuild detects changes in any of the modules of the graph it re-bundles it
+   * and calls this watch function.
+   */
+  watch?: () => void
+
+  /**
+   * This signal allows the caller to stop the watching process.
+   */
+  watchSignal?: abort.Signal
+
+  /**
+   * Context:
+   * When the bundling extension lived in the Go binary, we tied the environment
+   * to the workflow being executed (i.e. development when running dev and production
+   * when running build) and expoed it through environment variables globally defined
+   * by ESBuild. This is a pattern we want to move away from because commands and
+   * environments are two different things. However, to do so we need to come up
+   * with a migration plan.
+   */
+  environment: 'development' | 'production'
+}
+
+/**
+ * Invokes ESBuild with the given options to bundle an extension.
+ * @param options {BundleOptions} ESBuild options
+ */
+export async function bundleExtension(options: BundleOptions) {
+  const esbuildOptions = getESBuildOptions(options)
+  const result = await esBuild(esbuildOptions)
+  if (options.watchSignal) {
+    options.watchSignal.addEventListener('abort', () => {
+      if (result.stop) {
+        result.stop()
+      }
+    })
+  }
+  onResult(result, options)
+}
+
+function onResult(result: Awaited<ReturnType<typeof esBuild>> | null, options: BundleOptions) {
+  const warnings = result?.warnings ?? []
+  const errors = result?.errors ?? []
+  if (warnings.length > 0) {
+    const formattedWarnings = formatMessagesSync(warnings, {kind: 'warning'})
+    formattedWarnings.forEach((warning) => {
+      options.stdout.write(warning)
+    })
+  }
+  if (errors.length > 0) {
+    const formattedErrors = formatMessagesSync(errors, {kind: 'error'})
+    formattedErrors.forEach((error) => {
+      options.stderr.write(error)
+    })
+  }
+}
+
+function getESBuildOptions(options: BundleOptions): Parameters<typeof esBuild>[0] {
+  const env: {[variable: string]: string} = options.env
+  const define = Object.keys(env || {}).reduce(
+    (acc, key) => ({
+      ...acc,
+      [`process.env.${key}`]: JSON.stringify(env[key]),
+    }),
+    {'process.env.NODE_ENV': JSON.stringify(options.environment)},
+  )
+  let esbuildOptions: Parameters<typeof esBuild>[0] = {
+    entryPoints: [options.sourceFilePath],
+    outfile: options.outputBundlePath,
+    sourceRoot: path.dirname(options.sourceFilePath),
+    bundle: true,
+    define,
+    loader: {
+      '.esnext': 'ts',
+      '.js': 'jsx',
+    },
+    legalComments: 'none',
+    minify: options.minify,
+    plugins: getPlugins(),
+    target: 'es6',
+    resolveExtensions: ['.tsx', '.ts', '.js', '.json', '.esnext', '.mjs', '.ejs'],
+  }
+  if (options.watch) {
+    esbuildOptions = {
+      ...esbuildOptions,
+      watch: {
+        // eslint-disable-next-line node/handle-callback-err
+        onRebuild: (_error, result) => {
+          onResult(result, options)
+        },
+      },
+    }
+  }
+  return esbuildOptions
+}
+
+type ESBuildPlugins = Parameters<typeof esBuild>[0]['plugins']
+
+/**
+ * It returns the plugins that should be used with ESBuild.
+ * @returns {ESBuildPlugins} List of plugins.
+ */
+function getPlugins(): ESBuildPlugins {
+  const plugins = []
+
+  if (isGraphqlPackageAvailable()) {
+    const {default: graphqlLoader} = require('@luckycatfactory/esbuild-graphql-loader')
+    plugins.push(graphqlLoader())
+  }
+
+  return plugins
+}
+
+/**
+ * Returns true if the "graphql" and "graphql-tag" packages can be
+ * resolved. This information is used to determine whether we should
+ * or not include the esbuild-graphql-loader plugin when invoking ESBuild
+ * @returns {boolean} Returns true if the "graphql" and "graphql-tag" can be resolved.
+ */
+function isGraphqlPackageAvailable(): boolean {
+  try {
+    // eslint-disable-next-line @babel/no-unused-expressions
+    require.resolve('graphql') && require.resolve('graphql-tag')
+    return true
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    return false
+  }
+}

--- a/packages/app/src/cli/services/web.ts
+++ b/packages/app/src/cli/services/web.ts
@@ -1,12 +1,12 @@
 import {Web, WebConfigurationCommands} from '../models/app/app.js'
-import {error, system} from '@shopify/cli-kit'
+import {system, abort} from '@shopify/cli-kit'
 import {Writable} from 'node:stream'
 
 interface WebOptions {
   web: Web
   stdout: Writable
   stderr: Writable
-  signal: error.AbortSignal
+  signal: abort.Signal
   env?: {[variable: string]: string}
 }
 

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
@@ -5,7 +5,6 @@ import {port, output, fastify} from '@shopify/cli-kit'
 
 beforeAll(() => {
   vi.mock('@shopify/cli-kit')
-  vi.mock('./fastify-http-proxy/index.cjs')
   vi.mock('http-proxy', () => {
     return {
       default: {

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -1,4 +1,4 @@
-import {port, output, error} from '@shopify/cli-kit'
+import {port, output, abort} from '@shopify/cli-kit'
 import httpProxy from 'http-proxy'
 import {Writable} from 'stream'
 import * as http from 'http'
@@ -19,7 +19,7 @@ export interface ReverseHTTPProxyTarget {
    * to send standard output and error data that gets formatted with the
    * right prefix.
    */
-  action: (stdout: Writable, stderr: Writable, signal: error.AbortSignal, port: number) => Promise<void> | void
+  action: (stdout: Writable, stderr: Writable, signal: abort.Signal, port: number) => Promise<void> | void
 }
 
 /**

--- a/packages/app/src/cli/utilities/extensions/configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/configuration.test.ts
@@ -42,7 +42,7 @@ describe('extensionConfig', () => {
     const extension: UIExtension = {
       localIdentifier: extensionName,
       idEnvironmentVariableName: 'SHOPIFY_MY_EXTENSION_ID',
-      buildDirectory: `${extensionRoot}/build`,
+      outputBundlePath: `${extensionRoot}/build/main.js`,
       configurationPath: path.join(appRoot, 'shopify.app.toml'),
       configuration: {
         name: 'My Extension Name',

--- a/packages/app/src/cli/utilities/extensions/configuration.ts
+++ b/packages/app/src/cli/utilities/extensions/configuration.ts
@@ -50,7 +50,7 @@ export async function extensionConfig(options: ExtensionConfigOptions): Promise<
           root_dir: path.relative(options.app.directory, extension.directory),
           build_dir: options.buildDirectory
             ? path.relative(extension.directory, options.buildDirectory)
-            : path.relative(extension.directory, extension.buildDirectory),
+            : path.relative(extension.directory, path.dirname(extension.outputBundlePath)),
           entries: {
             main: path.relative(extension.directory, extension.entrySourceFilePath),
           },

--- a/packages/cli-kit/src/error.ts
+++ b/packages/cli-kit/src/error.ts
@@ -3,7 +3,6 @@ import {normalize} from './path.js'
 import {Errors} from '@oclif/core'
 
 export {ExtendableError} from 'ts-error'
-export {AbortSignal} from 'abort-controller'
 
 enum FatalErrorType {
   Abort,

--- a/packages/features/steps/create-app.steps.ts
+++ b/packages/features/steps/create-app.steps.ts
@@ -9,7 +9,7 @@ interface ExtensionConfiguration {
   configuration: {
     name: string
   }
-  buildDirectory: string
+  outputBundlePath: string
 }
 
 When(
@@ -58,7 +58,7 @@ Then(/I build the app/, {timeout: 2 * 60 * 1000 * 1000}, async function () {
 Then(/The UI extensions are built/, {timeout: 2 * 60 * 1000 * 1000}, async function () {
   const appInfo = await this.appInfo()
   const extensionsMissingBuildFile = appInfo.extensions.ui.filter((extension: ExtensionConfiguration) => {
-    const buildFilePath = path.join(extension.buildDirectory, 'main.js')
+    const buildFilePath = extension.outputBundlePath
 
     return !fs.pathExistsSync(buildFilePath)
   })

--- a/packages/ui-extensions-go-cli/api/api.go
+++ b/packages/ui-extensions-go-cli/api/api.go
@@ -2,7 +2,6 @@
 // - serving build artifacts
 // - sending build status updates via websocket
 // - provide metadata in form of a manifest to the UI Extension host on the client
-//
 package api
 
 import (

--- a/packages/ui-extensions-go-cli/api/api.go
+++ b/packages/ui-extensions-go-cli/api/api.go
@@ -2,6 +2,7 @@
 // - serving build artifacts
 // - sending build status updates via websocket
 // - provide metadata in form of a manifest to the UI Extension host on the client
+//
 package api
 
 import (

--- a/packages/ui-extensions-go-cli/main.go
+++ b/packages/ui-extensions-go-cli/main.go
@@ -43,8 +43,6 @@ func main() {
 	}
 
 	switch cmd {
-	case "build":
-		cli.build(args...)
 	case "create":
 		cli.create(args...)
 	case "serve":
@@ -56,34 +54,6 @@ func main() {
 
 type CLI struct {
 	config *core.Config
-}
-
-func (cli *CLI) build(args ...string) {
-	builds := len(cli.config.Extensions)
-	results := make(chan build.Result)
-
-	for _, extension := range cli.config.Extensions {
-		go build.Build(extension, func(result build.Result) {
-			results <- result
-		})
-	}
-
-	failedBuilds := 0
-	for i := 0; i < builds; i++ {
-		result := <-results
-		if !result.Success {
-			fmt.Fprintln(os.Stderr, result)
-			failedBuilds += 1
-		} else {
-			fmt.Println(result)
-		}
-	}
-
-	if failedBuilds > 0 {
-		os.Exit(1)
-	} else {
-		os.Exit(0)
-	}
 }
 
 func (cli *CLI) create(args ...string) {

--- a/packages/ui-extensions-go-cli/main.go
+++ b/packages/ui-extensions-go-cli/main.go
@@ -43,6 +43,8 @@ func main() {
 	}
 
 	switch cmd {
+	case "build":
+		cli.build(args...)
 	case "create":
 		cli.create(args...)
 	case "serve":
@@ -54,6 +56,34 @@ func main() {
 
 type CLI struct {
 	config *core.Config
+}
+
+func (cli *CLI) build(args ...string) {
+	builds := len(cli.config.Extensions)
+	results := make(chan build.Result)
+
+	for _, extension := range cli.config.Extensions {
+		go build.Build(extension, func(result build.Result) {
+			results <- result
+		})
+	}
+
+	failedBuilds := 0
+	for i := 0; i < builds; i++ {
+		result := <-results
+		if !result.Success {
+			fmt.Fprintln(os.Stderr, result)
+			failedBuilds += 1
+		} else {
+			fmt.Println(result)
+		}
+	}
+
+	if failedBuilds > 0 {
+		os.Exit(1)
+	} else {
+		os.Exit(0)
+	}
 }
 
 func (cli *CLI) create(args ...string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz#de2a4be678bd4d0d1ffbb86e6de779cde5999028"
   integrity sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==
 
+"@esbuild/linux-loong64@0.15.7":
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.7.tgz#1ec4af4a16c554cbd402cc557ccdd874e3f7be53"
+  integrity sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==
+
 "@eslint/eslintrc@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.1.tgz#de0807bfeffc37b964a7d0400e0c348ce5a2543d"
@@ -968,19 +973,6 @@
   integrity sha512-cTKBV2J9+u6VaKDhX7HepSfPSzw+F+TSd+k0wzifj4rG+4E5PjSFJCk19P8R6tr/72cuzgGd+mbB3jFT6lvAgw==
   dependencies:
     fast-json-stringify "^5.0.0"
-
-"@fastify/reply-from@^8.0.0":
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/@fastify/reply-from/-/reply-from-8.2.1.tgz#590cf82148149ff5963b8b398a5f08259e79af12"
-  integrity sha512-vi0arBWSktvPEFA5cAtujrLYgt12a4HYLYE0CTgnX5YQUiEZXV5am85fHgswJtWgp5Wp/HF4cidHJuTMwLcGxQ==
-  dependencies:
-    "@fastify/error" "^3.0.0"
-    end-of-stream "^1.4.4"
-    fastify-plugin "^4.0.0"
-    pump "^3.0.0"
-    semver "^7.3.7"
-    tiny-lru "^8.0.2"
-    undici "^5.5.1"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -1425,7 +1417,7 @@
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
-"@luckycatfactory/esbuild-graphql-loader@^3.6.0":
+"@luckycatfactory/esbuild-graphql-loader@3.7.0", "@luckycatfactory/esbuild-graphql-loader@^3.6.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@luckycatfactory/esbuild-graphql-loader/-/esbuild-graphql-loader-3.7.0.tgz#0c84eb8f18f704e00463200001c0c9b520a41c34"
   integrity sha512-5IMQvIa2bCMASsdAsY+5xeLWCWULE6HBw5TeA7lsdfBUTs1qFuXbdvxnZhxLxiF8x7biokjCWKzb2WWNa1wthQ==
@@ -5177,7 +5169,7 @@ encoding@^0.1.12:
   dependencies:
     iconv-lite "^0.6.2"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1, end-of-stream@^1.4.4:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -5306,100 +5298,227 @@ esbuild-android-64@0.14.54:
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz#505f41832884313bbaffb27704b8bcaa2d8616be"
   integrity sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==
 
+esbuild-android-64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.7.tgz#a521604d8c4c6befc7affedc897df8ccde189bea"
+  integrity sha512-p7rCvdsldhxQr3YHxptf1Jcd86dlhvc3EQmQJaZzzuAxefO9PvcI0GLOa5nCWem1AJ8iMRu9w0r5TG8pHmbi9w==
+
 esbuild-android-arm64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz#8ce69d7caba49646e009968fe5754a21a9871771"
   integrity sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==
+
+esbuild-android-arm64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.7.tgz#307b81f1088bf1e81dfe5f3d1d63a2d2a2e3e68e"
+  integrity sha512-L775l9ynJT7rVqRM5vo+9w5g2ysbOCfsdLV4CWanTZ1k/9Jb3IYlQ06VCI1edhcosTYJRECQFJa3eAvkx72eyQ==
 
 esbuild-darwin-64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz#24ba67b9a8cb890a3c08d9018f887cc221cdda25"
   integrity sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==
 
+esbuild-darwin-64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.7.tgz#270117b0c4ec6bcbc5cf3a297a7d11954f007e11"
+  integrity sha512-KGPt3r1c9ww009t2xLB6Vk0YyNOXh7hbjZ3EecHoVDxgtbUlYstMPDaReimKe6eOEfyY4hBEEeTvKwPsiH5WZg==
+
 esbuild-darwin-arm64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz#3f7cdb78888ee05e488d250a2bdaab1fa671bf73"
   integrity sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==
+
+esbuild-darwin-arm64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.7.tgz#97851eacd11dacb7719713602e3319e16202fc77"
+  integrity sha512-kBIHvtVqbSGajN88lYMnR3aIleH3ABZLLFLxwL2stiuIGAjGlQW741NxVTpUHQXUmPzxi6POqc9npkXa8AcSZQ==
 
 esbuild-freebsd-64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz#09250f997a56ed4650f3e1979c905ffc40bbe94d"
   integrity sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==
 
+esbuild-freebsd-64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.7.tgz#1de15ffaf5ae916aa925800aa6d02579960dd8c4"
+  integrity sha512-hESZB91qDLV5MEwNxzMxPfbjAhOmtfsr9Wnuci7pY6TtEh4UDuevmGmkUIjX/b+e/k4tcNBMf7SRQ2mdNuK/HQ==
+
 esbuild-freebsd-arm64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz#bafb46ed04fc5f97cbdb016d86947a79579f8e48"
   integrity sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==
+
+esbuild-freebsd-arm64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.7.tgz#0f160dbf5c9a31a1d8dd87acbbcb1a04b7031594"
+  integrity sha512-dLFR0ChH5t+b3J8w0fVKGvtwSLWCv7GYT2Y2jFGulF1L5HftQLzVGN+6pi1SivuiVSmTh28FwUhi9PwQicXI6Q==
 
 esbuild-linux-32@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz#e2a8c4a8efdc355405325033fcebeb941f781fe5"
   integrity sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==
 
+esbuild-linux-32@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.7.tgz#422eb853370a5e40bdce8b39525380de11ccadec"
+  integrity sha512-v3gT/LsONGUZcjbt2swrMjwxo32NJzk+7sAgtxhGx1+ZmOFaTRXBAi1PPfgpeo/J//Un2jIKm/I+qqeo4caJvg==
+
 esbuild-linux-64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz#de5fdba1c95666cf72369f52b40b03be71226652"
   integrity sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==
+
+esbuild-linux-64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.7.tgz#f89c468453bb3194b14f19dc32e0b99612e81d2b"
+  integrity sha512-LxXEfLAKwOVmm1yecpMmWERBshl+Kv5YJ/1KnyAr6HRHFW8cxOEsEfisD3sVl/RvHyW//lhYUVSuy9jGEfIRAQ==
 
 esbuild-linux-arm64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz#dae4cd42ae9787468b6a5c158da4c84e83b0ce8b"
   integrity sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==
 
+esbuild-linux-arm64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.7.tgz#68a79d6eb5e032efb9168a0f340ccfd33d6350a1"
+  integrity sha512-P3cfhudpzWDkglutWgXcT2S7Ft7o2e3YDMrP1n0z2dlbUZghUkKCyaWw0zhp4KxEEzt/E7lmrtRu/pGWnwb9vw==
+
 esbuild-linux-arm@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz#a2c1dff6d0f21dbe8fc6998a122675533ddfcd59"
   integrity sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==
+
+esbuild-linux-arm@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.7.tgz#2b7c784d0b3339878013dfa82bf5eaf82c7ce7d3"
+  integrity sha512-JKgAHtMR5f75wJTeuNQbyznZZa+pjiUHV7sRZp42UNdyXC6TiUYMW/8z8yIBAr2Fpad8hM1royZKQisqPABPvQ==
 
 esbuild-linux-mips64le@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz#d9918e9e4cb972f8d6dae8e8655bf9ee131eda34"
   integrity sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==
 
+esbuild-linux-mips64le@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.7.tgz#bb8330a50b14aa84673816cb63cc6c8b9beb62cc"
+  integrity sha512-T7XKuxl0VpeFLCJXub6U+iybiqh0kM/bWOTb4qcPyDDwNVhLUiPcGdG2/0S7F93czUZOKP57YiLV8YQewgLHKw==
+
 esbuild-linux-ppc64le@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz#3f9a0f6d41073fb1a640680845c7de52995f137e"
   integrity sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==
+
+esbuild-linux-ppc64le@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.7.tgz#52544e7fa992811eb996674090d0bc41f067a14b"
+  integrity sha512-6mGuC19WpFN7NYbecMIJjeQgvDb5aMuvyk0PDYBJrqAEMkTwg3Z98kEKuCm6THHRnrgsdr7bp4SruSAxEM4eJw==
 
 esbuild-linux-riscv64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz#618853c028178a61837bc799d2013d4695e451c8"
   integrity sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==
 
+esbuild-linux-riscv64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.7.tgz#a43ae60697992b957e454cbb622f7ee5297e8159"
+  integrity sha512-uUJsezbswAYo/X7OU/P+PuL/EI9WzxsEQXDekfwpQ23uGiooxqoLFAPmXPcRAt941vjlY9jtITEEikWMBr+F/g==
+
 esbuild-linux-s390x@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz#d1885c4c5a76bbb5a0fe182e2c8c60eb9e29f2a6"
   integrity sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==
+
+esbuild-linux-s390x@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.7.tgz#8c76a125dd10a84c166294d77416caaf5e1c7b64"
+  integrity sha512-+tO+xOyTNMc34rXlSxK7aCwJgvQyffqEM5MMdNDEeMU3ss0S6wKvbBOQfgd5jRPblfwJ6b+bKiz0g5nABpY0QQ==
 
 esbuild-netbsd-64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz#69ae917a2ff241b7df1dbf22baf04bd330349e81"
   integrity sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==
 
+esbuild-netbsd-64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.7.tgz#19b2e75449d7d9c32b5d8a222bac2f1e0c3b08fd"
+  integrity sha512-yVc4Wz+Pu3cP5hzm5kIygNPrjar/v5WCSoRmIjCPWfBVJkZNb5brEGKUlf+0Y759D48BCWa0WHrWXaNy0DULTQ==
+
 esbuild-openbsd-64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz#db4c8495287a350a6790de22edea247a57c5d47b"
   integrity sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==
+
+esbuild-openbsd-64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.7.tgz#1357b2bf72fd037d9150e751420a1fe4c8618ad7"
+  integrity sha512-GsimbwC4FSR4lN3wf8XmTQ+r8/0YSQo21rWDL0XFFhLHKlzEA4SsT1Tl8bPYu00IU6UWSJ+b3fG/8SB69rcuEQ==
 
 esbuild-sunos-64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz#54287ee3da73d3844b721c21bc80c1dc7e1bf7da"
   integrity sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==
 
+esbuild-sunos-64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.7.tgz#87ab2c604592a9c3c763e72969da0d72bcde91d2"
+  integrity sha512-8CDI1aL/ts0mDGbWzjEOGKXnU7p3rDzggHSBtVryQzkSOsjCHRVe0iFYUuhczlxU1R3LN/E7HgUO4NXzGGP/Ag==
+
 esbuild-windows-32@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz#f8aaf9a5667630b40f0fb3aa37bf01bbd340ce31"
   integrity sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==
+
+esbuild-windows-32@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.7.tgz#c81e688c0457665a8d463a669e5bf60870323e99"
+  integrity sha512-cOnKXUEPS8EGCzRSFa1x6NQjGhGsFlVgjhqGEbLTPsA7x4RRYiy2RKoArNUU4iR2vHmzqS5Gr84MEumO/wxYKA==
 
 esbuild-windows-64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz#bf54b51bd3e9b0f1886ffdb224a4176031ea0af4"
   integrity sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==
 
+esbuild-windows-64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.7.tgz#2421d1ae34b0561a9d6767346b381961266c4eff"
+  integrity sha512-7MI08Ec2sTIDv+zH6StNBKO+2hGUYIT42GmFyW6MBBWWtJhTcQLinKS6ldIN1d52MXIbiJ6nXyCJ+LpL4jBm3Q==
+
 esbuild-windows-arm64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz#937d15675a15e4b0e4fafdbaa3a01a776a2be982"
   integrity sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==
+
+esbuild-windows-arm64@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.7.tgz#7d5e9e060a7b454cb2f57f84a3f3c23c8f30b7d2"
+  integrity sha512-R06nmqBlWjKHddhRJYlqDd3Fabx9LFdKcjoOy08YLimwmsswlFBJV4rXzZCxz/b7ZJXvrZgj8DDv1ewE9+StMw==
+
+esbuild@0.15.7:
+  version "0.15.7"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.15.7.tgz#8a1f1aff58671a3199dd24df95314122fc1ddee8"
+  integrity sha512-7V8tzllIbAQV1M4QoE52ImKu8hT/NLGlGXkiDsbEU5PS6K8Mn09ZnYoS+dcmHxOS9CRsV4IRAMdT3I67IyUNXw==
+  optionalDependencies:
+    "@esbuild/linux-loong64" "0.15.7"
+    esbuild-android-64 "0.15.7"
+    esbuild-android-arm64 "0.15.7"
+    esbuild-darwin-64 "0.15.7"
+    esbuild-darwin-arm64 "0.15.7"
+    esbuild-freebsd-64 "0.15.7"
+    esbuild-freebsd-arm64 "0.15.7"
+    esbuild-linux-32 "0.15.7"
+    esbuild-linux-64 "0.15.7"
+    esbuild-linux-arm "0.15.7"
+    esbuild-linux-arm64 "0.15.7"
+    esbuild-linux-mips64le "0.15.7"
+    esbuild-linux-ppc64le "0.15.7"
+    esbuild-linux-riscv64 "0.15.7"
+    esbuild-linux-s390x "0.15.7"
+    esbuild-netbsd-64 "0.15.7"
+    esbuild-openbsd-64 "0.15.7"
+    esbuild-sunos-64 "0.15.7"
+    esbuild-windows-32 "0.15.7"
+    esbuild-windows-64 "0.15.7"
+    esbuild-windows-arm64 "0.15.7"
 
 esbuild@^0.12.22:
   version "0.12.29"
@@ -6133,11 +6252,6 @@ fast-url-parser@1.1.3:
   integrity sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==
   dependencies:
     punycode "^1.3.2"
-
-fastify-plugin@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-4.2.1.tgz#4b80020957938dbc44b8ad4a898fd8bcfbab3f65"
-  integrity sha512-dlGKiwLzRBKkEf5J5ho0uAD/Jdv8GQVUbriB3tAX3ehRUXE4gTV3lRd5inEg9li1aLzb0EGj8y2K4/8g1TN06g==
 
 fastify@^4.2.1:
   version "4.5.3"
@@ -12757,11 +12871,6 @@ ws@7.4.5:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
-
-ws@^8.7.0:
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
-  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Continuation of: https://github.com/Shopify/cli/pull/423

### WHY are these changes introduced?

In the aim of removing the unnecessary indirection of having some UI extensions' business logic in Go, I'm moving the `build` workflow from the extensions' CLIs into the `@shopify/app` package.

### WHAT is this pull request doing?
- [x] Move the logic to a new module that does the bundling using ESBuild.
- [x] Adjust the `build` service to consume the new APIs.
- [x] Unit test the new module for bundling.  

### How to test your changes?
You can try to build the fixture or any other app.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
