### PR TITLE
Fix load store from theme info

### DIFF
--- a/packages/theme/src/cli/services/info.ts
+++ b/packages/theme/src/cli/services/info.ts
@@ -1,5 +1,4 @@
-import {getTheme} from '../utilities/theme-store.js'
-import {os, output, string} from '@shopify/cli-kit'
+import {os, output, string, store as conf} from '@shopify/cli-kit'
 import {version as rubyVersion} from '@shopify/cli-kit/node/ruby'
 import {checkForNewVersion} from '@shopify/cli-kit/node/node-package-manager'
 
@@ -11,7 +10,7 @@ export async function themeInfo(config: {cliVersion: string}): Promise<output.Me
 
 async function themeConfigSection(): Promise<[string, string]> {
   const title = 'Theme Configuration'
-  const store = getTheme({store: undefined})
+  const store = (await conf.getThemeStore()) || 'Not configured'
   const lines: string[][] = [['Store', store]]
   return [title, `${string.linesToColumns(lines)}`]
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
After merging the PR for theme info command I introduced an issue that should've been picked up by CI but didn't.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Make sure to read the store from `conf.getThemeStore()` and show "Not configured" if there is no saved store.
- Can't read the store from `getThemeStore()` directly because that method throws if there is no store and is intended to ensure that there a store either in flags or cached.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
