### PR TITLE
add hydrogen deploy error handling & oxygen api service

### DIFF
--- a/.changeset/young-bobcats-end.md
+++ b/.changeset/young-bobcats-end.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/cli-hydrogen': patch
+---
+
+Create a new Oxygen service for interacting with Oxygen related services.

--- a/packages/cli-hydrogen/src/cli/services/deploy/error.ts
+++ b/packages/cli-hydrogen/src/cli/services/deploy/error.ts
@@ -3,3 +3,11 @@ import {error} from '@shopify/cli-kit'
 export const WebPageNotAvailable = () => {
   return new error.Abort('Web page not available.')
 }
+
+export const TooManyRequestsError = () => {
+  return new Error("You've made too many requests. Please try again later.")
+}
+
+export const UnrecoverableError = (message: string) => {
+  return new Error(`Unrecoverable: ${message}`)
+}

--- a/packages/cli-hydrogen/src/cli/services/deploy/graphql/upload_deployment.ts
+++ b/packages/cli-hydrogen/src/cli/services/deploy/graphql/upload_deployment.ts
@@ -6,6 +6,11 @@ export const UploadDeploymentQuery = gql`
       deployment {
         previewURL
       }
+      error {
+        code
+        unrecoverable
+        debugInfo
+      }
     }
   }
 `

--- a/packages/cli-hydrogen/src/cli/services/deploy/types.ts
+++ b/packages/cli-hydrogen/src/cli/services/deploy/types.ts
@@ -25,6 +25,16 @@ export interface UploadDeploymentResponse {
       deployment: {
         previewURL: string
       }
+      error: OxygenError
     }
+  }
+}
+
+export interface GraphQLError {
+  message: string
+  extensions?: Map<string, unknown>
+  locations: {
+    line: number
+    column: number
   }
 }

--- a/packages/cli-hydrogen/src/cli/services/deploy/upload.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/deploy/upload.test.ts
@@ -1,8 +1,11 @@
-import {ReqDeployConfig} from './types.js'
+import {GraphQLError, ReqDeployConfig} from './types.js'
 import {createDeployment, healthCheck, uploadDeployment} from './upload.js'
+import {TooManyRequestsError, UnrecoverableError} from './error.js'
+import {CreateDeploymentQuery} from './graphql/create_deployment.js'
 import {beforeEach, describe, it, expect, vi} from 'vitest'
-import {http, api} from '@shopify/cli-kit'
+import {http, api, file} from '@shopify/cli-kit'
 import {zip} from '@shopify/cli-kit/node/archiver'
+import {ClientError} from 'graphql-request'
 import {createReadStream} from 'node:fs'
 
 const defaultConfig: ReqDeployConfig = {
@@ -26,77 +29,239 @@ beforeEach(() => {
 })
 
 describe('createDeploymentStep()', () => {
-  it('calls Oxygen with proper variables and headers', async () => {
-    const headers = {value: 'key'}
-    const mockedRequest = vi.fn().mockResolvedValue({createDeployment: 'mock'})
-    const mockedGraphqlClient = vi.fn().mockResolvedValue({request: mockedRequest})
-    vi.mocked(api.buildHeaders).mockResolvedValue(headers)
-    vi.mocked(http.graphqlClient).mockImplementation(mockedGraphqlClient)
+  it('makes a call to Oxygen to create the deployment', async () => {
+    const deploymentResponse = {
+      createDeployment: {
+        deploymentID: 'gid://shopify/OxygenDeployment/g8e2k49rt',
+        assetBaseURL: 'https://cdn.shopify.com/oxygen/1/1/g8e2k49rt/',
+        error: null,
+      },
+    }
 
-    await createDeployment({
+    const mockedResponse = vi.fn().mockResolvedValue(deploymentResponse)
+    const mockedRequest = vi.fn().mockResolvedValue(mockedResponse)
+    vi.mocked(api.oxygen.request).mockImplementation(mockedRequest)
+    const cfg = {
       ...defaultConfig,
       commitRef: 'ref/branch',
       commitAuthor: 'Unit Test',
       commitSha: 'abcd1234',
       commitMessage: 'message',
       timestamp: '1999-01-01',
+    }
+
+    await createDeployment(cfg)
+
+    expect(mockedRequest).toHaveBeenCalledOnce()
+    expect(mockedRequest).toHaveBeenCalledWith(
+      defaultConfig.oxygenAddress,
+      CreateDeploymentQuery,
+      defaultConfig.deploymentToken,
+      {
+        input: {
+          branch: 'ref/branch',
+          commitAuthor: 'Unit Test',
+          commitHash: 'abcd1234',
+          commitMessage: 'message',
+          commitTimestamp: '1999-01-01',
+        },
+      },
+    )
+  })
+
+  describe('failure', () => {
+    it('throws a rate limit error if we are getting ratelimited', async () => {
+      const graphQLError = new ClientError({status: 429}, {query: ''})
+      vi.mocked(api.oxygen.request).mockRejectedValueOnce(graphQLError)
+
+      await expect(() => {
+        return createDeployment(defaultConfig)
+      }).rejects.toThrowError(TooManyRequestsError())
     })
 
-    expect(mockedGraphqlClient).toHaveBeenCalledOnce()
-    expect(mockedGraphqlClient).toHaveBeenCalledWith({
-      headers,
-      url: `https://${defaultConfig.oxygenAddress}/api/graphql/deploy/v1`,
+    it('throws if we are getting a non-200 status code', async () => {
+      const graphQLError = new ClientError({status: 500}, {query: ''})
+      vi.mocked(api.oxygen.request).mockRejectedValueOnce(graphQLError)
+
+      await expect(() => {
+        return createDeployment(defaultConfig)
+      }).rejects.toThrowError('GraphQL Error (Code: 500)')
     })
-    expect(mockedRequest).toHaveBeenCalledOnce()
-    expect(mockedRequest.mock.calls[0]?.[1]).toStrictEqual({
-      input: {
-        branch: 'ref/branch',
-        commitAuthor: 'Unit Test',
-        commitHash: 'abcd1234',
-        commitMessage: 'message',
-        commitTimestamp: '1999-01-01',
-      },
+
+    it('throws a generic error if we are getting a user error', async () => {
+      const oxygenResponse = {
+        createDeployment: {
+          deploymentID: '',
+          assetBaseURL: '',
+          error: {
+            unrecoverable: false,
+            code: 'SomeGenericError',
+            debugInfo: 'Some generic error message',
+          },
+        },
+      }
+      vi.mocked(api.oxygen.request).mockResolvedValue(oxygenResponse)
+
+      await expect(() => {
+        return createDeployment(defaultConfig)
+      }).rejects.toThrowError('Some generic error message')
+    })
+
+    it('throws an unrecoverable exception if we get an unrecoverable error', async () => {
+      const errMsg = 'Some generic error message'
+      const oxygenResponse = {
+        createDeployment: {
+          deploymentID: '',
+          assetBaseURL: '',
+          error: {
+            unrecoverable: true,
+            code: 'SomeGenericError',
+            debugInfo: errMsg,
+          },
+        },
+      }
+      vi.mocked(api.oxygen.request).mockResolvedValue(oxygenResponse)
+
+      await expect(() => {
+        return createDeployment(defaultConfig)
+      }).rejects.toThrowError(UnrecoverableError(errMsg))
     })
   })
 })
 
 describe('uploadDeploymentStep()', async () => {
-  it('calls Oxygen with proper formData and headers', async () => {
-    const deploymentId = '123'
-    vi.mocked(createReadStream)
-    const mockedZip = vi.fn()
-    vi.mocked(zip).mockImplementation(mockedZip)
-    const mockedFormDataAppend = vi.fn()
-    const formData = {append: mockedFormDataAppend, getHeaders: vi.fn()}
-    vi.mocked<any>(http.formData).mockReturnValue(formData)
-    const headers = {value: 'key', 'Content-Type': 'key'}
-    vi.mocked(api.buildHeaders).mockResolvedValue(headers)
-    const previewURL = 'https://preview.url'
-    const oxygenResponse = {
-      data: {
-        uploadDeployment: {
-          deployment: {
-            previewURL,
+  describe('success', async () => {
+    it('makes a call to Oxygen to upload the deployment files', async () => {
+      const deploymentId = '123'
+      vi.mocked(createReadStream)
+      const mockedZip = vi.fn()
+      vi.mocked(zip).mockImplementation(mockedZip)
+      const mockedFormDataAppend = vi.fn()
+      const formData = {append: mockedFormDataAppend, getHeaders: vi.fn()}
+      vi.mocked<any>(http.formData).mockReturnValue(formData)
+      const previewURL = 'https://preview.url'
+      const oxygenResponse = {
+        data: {
+          uploadDeployment: {
+            deployment: {
+              previewURL,
+            },
+            error: null,
           },
         },
-      },
-    }
-    const mockedShopifyFetch = vi.fn().mockResolvedValue({json: vi.fn().mockResolvedValue(oxygenResponse)})
-    vi.mocked<any>(http.shopifyFetch).mockImplementation(mockedShopifyFetch)
+      }
+      const mockedUploadDeployment = vi
+        .fn()
+        .mockResolvedValue({json: vi.fn().mockResolvedValue(oxygenResponse), status: 200})
+      vi.mocked<any>(api.oxygen.uploadDeploymentFile).mockImplementation(mockedUploadDeployment)
+      const tmpDir = 'tmp/dir'
+      vi.mocked<any>(file.inTemporaryDirectory).mockImplementation(async (runner: (tmpDir: string) => Promise<void>) =>
+        runner(tmpDir),
+      )
 
-    const result = await uploadDeployment(
-      {...defaultConfig, path: '/unit/test', oxygenAddress: 'oxygen.address'},
-      deploymentId,
-    )
+      const result = await uploadDeployment(
+        {...defaultConfig, path: 'unit/test', oxygenAddress: 'oxygen.address'},
+        deploymentId,
+      )
 
-    expect(result).toBe(previewURL)
-    expect(mockedFormDataAppend).toHaveBeenCalledTimes(3)
-    expect(mockedZip).toHaveBeenCalledWith('/unit/test/dist', '/unit/test/dist/dist.zip')
-    expect(headers).toStrictEqual({value: 'key'})
-    expect(mockedShopifyFetch).toHaveBeenCalledWith(`https://oxygen.address/api/graphql/deploy/v1`, {
-      method: 'POST',
-      body: formData,
-      headers,
+      expect(result).toBe(previewURL)
+      expect(mockedFormDataAppend).toHaveBeenCalledTimes(3)
+      expect(mockedZip).toHaveBeenCalledWith(`unit/test/dist`, `${tmpDir}/dist.zip`)
+      expect(api.oxygen.uploadDeploymentFile).toHaveBeenCalledWith('oxygen.address', '123', formData)
+    })
+  })
+
+  describe('failure', async () => {
+    beforeEach(() => {
+      vi.mocked(createReadStream)
+      vi.mocked<any>(zip).mockImplementation(vi.fn())
+      vi.mocked<any>(http.formData).mockReturnValue({append: vi.fn(), getHeaders: vi.fn()})
+      vi.mocked<any>(file.inTemporaryDirectory).mockImplementation(async (runner: (tmpDir: string) => Promise<void>) =>
+        runner('tmp/dir'),
+      )
+    })
+
+    it('throws an exception if Oxygen returns a non-200 status code', async () => {
+      const oxygenResponse: GraphQLError = {
+        message: 'invalid schema',
+        locations: {
+          line: 1,
+          column: 1,
+        },
+      }
+      const mockedUploadDeployment = vi
+        .fn()
+        .mockResolvedValue({json: vi.fn().mockResolvedValue(oxygenResponse), status: 500})
+      vi.mocked<any>(api.oxygen.uploadDeploymentFile).mockImplementation(mockedUploadDeployment)
+      const tmpDir = 'tmp/dir'
+      vi.mocked<any>(file.inTemporaryDirectory).mockImplementation(async (runner: (tmpDir: string) => Promise<void>) =>
+        runner(tmpDir),
+      )
+
+      await expect(() => {
+        return uploadDeployment({...defaultConfig, path: 'unit/test'}, '123')
+      }).rejects.toThrowError('Failed to upload deployment')
+    })
+
+    it('throws an exception if Oxygen returns a user error', async () => {
+      const oxygenResponse = {
+        data: {
+          uploadDeployment: {
+            deployment: {
+              previewURL: '',
+            },
+            error: {
+              code: 'GenericError',
+              unrecoverable: false,
+              debugInfo: 'dunno what happened',
+            },
+          },
+        },
+      }
+      const mockedUploadDeployment = vi
+        .fn()
+        .mockResolvedValue({json: vi.fn().mockResolvedValue(oxygenResponse), status: 200})
+      vi.mocked<any>(api.oxygen.uploadDeploymentFile).mockImplementation(mockedUploadDeployment)
+
+      await expect(() => {
+        return uploadDeployment({...defaultConfig, path: 'unit/test'}, '123')
+      }).rejects.toThrowError('dunno what happened')
+    })
+
+    it('throws an ratelimit exception if being ratelimited by Oxygen', async () => {
+      const mockedUploadDeployment = vi
+        .fn()
+        .mockResolvedValue({json: vi.fn().mockResolvedValue('Too Many Requests'), status: 429})
+      vi.mocked<any>(api.oxygen.uploadDeploymentFile).mockImplementation(mockedUploadDeployment)
+
+      await expect(() => {
+        return uploadDeployment({...defaultConfig, path: 'unit/test'}, '123')
+      }).rejects.toThrowError(TooManyRequestsError())
+    })
+
+    it('throws an unrecoverable exception if we receive an unrecoverable user error', async () => {
+      const oxygenResponse = {
+        data: {
+          uploadDeployment: {
+            deployment: {
+              previewURL: '',
+            },
+            error: {
+              code: 'UnrecoverableError',
+              unrecoverable: true,
+              debugInfo: 'dunno what happened',
+            },
+          },
+        },
+      }
+      const mockedUploadDeployment = vi
+        .fn()
+        .mockResolvedValue({json: vi.fn().mockResolvedValue(oxygenResponse), status: 200})
+      vi.mocked<any>(api.oxygen.uploadDeploymentFile).mockImplementation(mockedUploadDeployment)
+
+      await expect(() => {
+        return uploadDeployment({...defaultConfig, path: 'unit/test'}, '123')
+      }).rejects.toThrowError('Unrecoverable: dunno what happened')
     })
   })
 })

--- a/packages/cli-kit/src/api.ts
+++ b/packages/cli-kit/src/api.ts
@@ -2,6 +2,6 @@ import * as admin from './api/admin.js'
 import * as partners from './api/partners.js'
 import * as graphql from './api/graphql/index.js'
 import * as identity from './api/identity.js'
-import {buildHeaders} from './api/common.js'
+import * as oxygen from './api/oxygen.js'
 
-export {admin, partners, graphql, identity, buildHeaders}
+export {admin, partners, graphql, identity, oxygen}

--- a/packages/cli-kit/src/api/oxygen.test.ts
+++ b/packages/cli-kit/src/api/oxygen.test.ts
@@ -1,0 +1,89 @@
+import * as oxygenApi from './oxygen.js'
+import {buildHeaders} from './common.js'
+import {graphqlClient} from '../http/graphql.js'
+import {shopifyFetch, formData} from '../http.js'
+import {test, vi, describe, beforeEach, expect} from 'vitest'
+import {GraphQLClient} from 'graphql-request'
+import {Response} from 'node-fetch'
+
+vi.mock('../http/graphql.js')
+vi.mock('../http.js')
+vi.mock('./common.js', async () => {
+  const module: any = await vi.importActual('./common.js')
+  return {
+    ...module,
+    buildHeaders: vi.fn(),
+  }
+})
+
+const mockedResult = 'OK'
+const mockedToken = 'token'
+const oxygenAddress = 'oxygen-dms.shopifycloud.com'
+
+let client: GraphQLClient
+beforeEach(() => {
+  client = {
+    request: vi.fn(),
+  } as any
+  vi.mocked(graphqlClient).mockResolvedValue(client)
+})
+
+describe('oxygen-api', () => {
+  test('calls the graphql client once', async () => {
+    vi.mocked(client.request).mockResolvedValue(mockedResult)
+
+    await oxygenApi.request(oxygenAddress, 'query', mockedToken, {some: 'variables'})
+
+    expect(client.request).toHaveBeenCalledOnce()
+  })
+
+  test('request is called with the correct parameters', async () => {
+    const headers = {'custom-header': mockedToken}
+    vi.mocked(client.request).mockResolvedValue(mockedResult)
+    vi.mocked(client.request).mockResolvedValue(headers)
+
+    await oxygenApi.request(oxygenAddress, 'query', mockedToken, {variables: 'variables'})
+
+    expect(client.request).toHaveBeenLastCalledWith('query', {variables: 'variables'})
+  })
+
+  test('buildHeaders is called with the deployment token', async () => {
+    vi.mocked(client.request).mockResolvedValue(mockedResult)
+
+    await oxygenApi.request(oxygenAddress, 'query', mockedToken, {})
+
+    expect(buildHeaders).toHaveBeenCalledWith(mockedToken)
+  })
+})
+
+describe('uploadDeploymentFile', () => {
+  test('makes a post request to Oxygen using the provided form data', async () => {
+    const responseBody = {
+      data: {
+        uploadDeployment: {
+          deployment: {
+            previewURL: 'https://preview.com',
+          },
+          error: null,
+        },
+      },
+    }
+    const headers = {'custom-header': 'header'}
+    vi.mocked(buildHeaders).mockResolvedValue(headers)
+    const mockedFormData = {append: vi.fn(), getHeaders: vi.fn()}
+    vi.mocked<any>(formData).mockReturnValue(mockedFormData)
+    const response = new Response(JSON.stringify(responseBody), {status: 200})
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+
+    const gotResponse = await oxygenApi.uploadDeploymentFile(oxygenAddress, mockedToken, mockedFormData as any)
+    expect(shopifyFetch).toBeCalledWith(`https://${oxygenAddress}/api/graphql/deploy/v1`, {
+      method: 'POST',
+      body: mockedFormData,
+      headers,
+    })
+
+    expect(gotResponse.status).toBe(200)
+    expect(await response.json()).toEqual(responseBody)
+    expect(buildHeaders).toHaveBeenCalledWith(mockedToken)
+  })
+})

--- a/packages/cli-kit/src/api/oxygen.ts
+++ b/packages/cli-kit/src/api/oxygen.ts
@@ -1,0 +1,43 @@
+import {buildHeaders, debugLogRequest} from './common.js'
+import {graphqlClient} from '../http/graphql.js'
+import {shopifyFetch} from '../http.js'
+import {Variables, RequestDocument} from 'graphql-request'
+import FormData from 'form-data'
+import {Response} from 'node-fetch'
+
+export async function request<T>(
+  oxygenAddress: string,
+  query: RequestDocument,
+  token: string,
+  variables?: Variables,
+): Promise<T> {
+  const headers = await buildHeaders(token)
+  debugLogRequest('Oxygen', query, variables, headers)
+  const client = await graphqlClient({
+    headers,
+    url: getOxygenAddress(oxygenAddress),
+  })
+
+  const response = await client.request<T>(query, variables)
+  return response
+}
+
+export async function uploadDeploymentFile(oxygenAddress: string, token: string, data: FormData): Promise<Response> {
+  const headers = await buildHeaders(token)
+  delete headers['Content-Type']
+
+  const response = await shopifyFetch(getOxygenAddress(oxygenAddress), {
+    method: 'POST',
+    body: data,
+    headers: {
+      ...headers,
+      ...data.getHeaders(),
+    },
+  })
+
+  return response
+}
+
+const getOxygenAddress = (oxygenHost: string): string => {
+  return `https://${oxygenHost}/api/graphql/deploy/v1`
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/oxygen-platform/issues/528

This PR introduces error handling and retry logic for the various calls that we make to DMS so that we can be more resilient / provide context to the user on why their deploy might be failing, etc. I also greatly increased the scope of what the unit tests cover.

I also created a new service within the CLI kit that is used for interacting with DMS as it seems this is the pattern and convention that is being used to interact with other APIs (identity, partners, shopify, etc) and removes the need for the CLI kit to export internal functionality (namely `buildHeaders`)

This PR also places the zip file of built assets into a temporary directory to follow the convention that `oxygenctl` is currently using instead of just placing the zip in the dist.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
