### PR TITLE
[Fix] Add missing await for call to retryOnError().

### DIFF
--- a/packages/cli-kit/src/port.ts
+++ b/packages/cli-kit/src/port.ts
@@ -9,7 +9,7 @@ import * as port from 'get-port-please'
  */
 export async function getRandomPort(): Promise<number> {
   debug(content`Getting a random port...`)
-  const randomPort = retryOnError(() => port.getRandomPort())
+  const randomPort = await retryOnError(() => port.getRandomPort())
   debug(content`Random port obtained: ${token.raw(`${randomPort}`)}`)
   return randomPort
 }


### PR DESCRIPTION
Output of `shopify app dev --verbose`:

Before patch:
```
Getting a random port...
Random port obtained: [object Promise]
```

After patch:
```
Getting a random port...
Random port obtained: 39097
```

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Output of `shopify app dev --verbose` was not correct.

### WHAT is this pull request doing?

Fixes the output of `shopify app dev --verbose`.

### How to test your changes?

Run `shopify app dev --verbose`.

### Measuring impact

This doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
