### PR TITLE
Add `extension_directories` attribute to `shopify.app.toml`

### DIFF
--- a/.changeset/cyan-tables-retire.md
+++ b/.changeset/cyan-tables-retire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Add support for configuring extensions' directories via the attribute extension_paths in the shopify.app.toml file

--- a/.changeset/cyan-tables-retire.md
+++ b/.changeset/cyan-tables-retire.md
@@ -2,4 +2,4 @@
 '@shopify/app': minor
 ---
 
-Add support for configuring extensions' directories via the attribute additional_extension_directories in the shopify.app.toml file
+Add support for configuring extensions' directories via the attribute extension_directories in the shopify.app.toml file

--- a/.changeset/cyan-tables-retire.md
+++ b/.changeset/cyan-tables-retire.md
@@ -2,4 +2,4 @@
 '@shopify/app': minor
 ---
 
-Add support for configuring extensions' directories via the attribute extension_paths in the shopify.app.toml file
+Add support for configuring extensions' directories via the attribute extension_directories in the shopify.app.toml file

--- a/.changeset/cyan-tables-retire.md
+++ b/.changeset/cyan-tables-retire.md
@@ -2,4 +2,4 @@
 '@shopify/app': minor
 ---
 
-Add support for configuring extensions' directories via the attribute extension_directories in the shopify.app.toml file
+Add support for configuring extensions' directories via the attribute additional_extension_directories in the shopify.app.toml file

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -7,7 +7,7 @@ export function testApp(app: Partial<AppInterface> = {}): AppInterface {
     app.idEnvironmentVariableName ?? 'SHOPIFY_API_KEY',
     app.directory ?? '/tmp/project',
     app.packageManager ?? 'yarn',
-    app.configuration ?? {scopes: ''},
+    app.configuration ?? {scopes: '', extension_paths: ['extensions/*']},
     app.configurationPath ?? '/tmp/project/shopify.app.toml',
     app.nodeDependencies ?? {},
     app.webs ?? [],

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -7,7 +7,7 @@ export function testApp(app: Partial<AppInterface> = {}): AppInterface {
     app.idEnvironmentVariableName ?? 'SHOPIFY_API_KEY',
     app.directory ?? '/tmp/project',
     app.packageManager ?? 'yarn',
-    app.configuration ?? {scopes: '', additionalExtensionDirectories: []},
+    app.configuration ?? {scopes: '', extensionDirectories: []},
     app.configurationPath ?? '/tmp/project/shopify.app.toml',
     app.nodeDependencies ?? {},
     app.webs ?? [],

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -7,7 +7,7 @@ export function testApp(app: Partial<AppInterface> = {}): AppInterface {
     app.idEnvironmentVariableName ?? 'SHOPIFY_API_KEY',
     app.directory ?? '/tmp/project',
     app.packageManager ?? 'yarn',
-    app.configuration ?? {scopes: '', extension_paths: ['extensions/*']},
+    app.configuration ?? {scopes: '', extensionPaths: ['extensions/*']},
     app.configurationPath ?? '/tmp/project/shopify.app.toml',
     app.nodeDependencies ?? {},
     app.webs ?? [],

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -7,7 +7,7 @@ export function testApp(app: Partial<AppInterface> = {}): AppInterface {
     app.idEnvironmentVariableName ?? 'SHOPIFY_API_KEY',
     app.directory ?? '/tmp/project',
     app.packageManager ?? 'yarn',
-    app.configuration ?? {scopes: '', extensionDirectories: ['extensions/*']},
+    app.configuration ?? {scopes: '', additionalExtensionDirectories: []},
     app.configurationPath ?? '/tmp/project/shopify.app.toml',
     app.nodeDependencies ?? {},
     app.webs ?? [],

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -7,7 +7,7 @@ export function testApp(app: Partial<AppInterface> = {}): AppInterface {
     app.idEnvironmentVariableName ?? 'SHOPIFY_API_KEY',
     app.directory ?? '/tmp/project',
     app.packageManager ?? 'yarn',
-    app.configuration ?? {scopes: '', extensionPaths: ['extensions/*']},
+    app.configuration ?? {scopes: '', extensionDirectories: ['extensions/*']},
     app.configurationPath ?? '/tmp/project/shopify.app.toml',
     app.nodeDependencies ?? {},
     app.webs ?? [],

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -7,6 +7,7 @@ import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify
 
 export const AppConfigurationSchema = schema.define.object({
   scopes: schema.define.string().default(''),
+  extension_paths: schema.define.string().default('extensions/*'),
 })
 
 export enum WebType {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -7,7 +7,7 @@ import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify
 
 export const AppConfigurationSchema = schema.define.object({
   scopes: schema.define.string().default(''),
-  extensionDirectories: schema.define.array(schema.define.string()).default(['extensions/*']),
+  extensionDirectories: schema.define.array(schema.define.string()).optional(),
 })
 
 export enum WebType {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -7,7 +7,7 @@ import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify
 
 export const AppConfigurationSchema = schema.define.object({
   scopes: schema.define.string().default(''),
-  extension_paths: schema.define.array(schema.define.string()).default(['extensions/*']),
+  extensionDirectories: schema.define.array(schema.define.string()).default(['extensions/*']),
 })
 
 export enum WebType {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -7,7 +7,7 @@ import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify
 
 export const AppConfigurationSchema = schema.define.object({
   scopes: schema.define.string().default(''),
-  additionalExtensionDirectories: schema.define.array(schema.define.string()).default([]),
+  extensionDirectories: schema.define.array(schema.define.string()).default(['extensions/*']),
 })
 
 export enum WebType {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -7,7 +7,7 @@ import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify
 
 export const AppConfigurationSchema = schema.define.object({
   scopes: schema.define.string().default(''),
-  extension_paths: schema.define.string().default('extensions/*'),
+  extension_paths: schema.define.array(schema.define.string()).default(['extensions/*']),
 })
 
 export enum WebType {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -7,7 +7,7 @@ import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify
 
 export const AppConfigurationSchema = schema.define.object({
   scopes: schema.define.string().default(''),
-  extensionDirectories: schema.define.array(schema.define.string()).default(['extensions/*']),
+  additionalExtensionDirectories: schema.define.array(schema.define.string()).default([]),
 })
 
 export enum WebType {

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -249,7 +249,7 @@ scopes = "read_products"
     // Given
     await writeConfig(`
     scopes = ""
-    extension_directories = ["custom_extension"]
+    additional_extension_directories = ["custom_extension"]
     `)
     const customExtensionDirectory = path.join(tmpDir, 'custom_extension')
     await file.mkdir(customExtensionDirectory)

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -249,7 +249,7 @@ scopes = "read_products"
     // Given
     await writeConfig(`
     scopes = ""
-    additional_extension_directories = ["custom_extension"]
+    extension_directories = ["custom_extension"]
     `)
     const customExtensionDirectory = path.join(tmpDir, 'custom_extension')
     await file.mkdir(customExtensionDirectory)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -65,18 +65,18 @@ class AppLoader {
     this.appDirectory = await this.findAppDirectory()
     const configurationPath = await this.getConfigurationPath()
     const configuration = await this.parseConfigurationFile(AppConfigurationSchema, configurationPath)
-    const extensionPaths = configuration.extension_paths.map((extensionPath) => {
-      return path.join(this.appDirectory, extensionPath)
+    const extensionDirectories = configuration.extensionDirectories.map((extensionDirectory) => {
+      return path.join(this.appDirectory, extensionDirectory)
     })
     const dotenv = await this.loadDotEnv()
     const {functions, usedCustomLayout: usedCustomLayoutForFunctionExtensions} = await this.loadFunctions(
-      extensionPaths,
+      extensionDirectories,
     )
     const {uiExtensions, usedCustomLayout: usedCustomLayoutForUIExtensions} = await this.loadUIExtensions(
-      extensionPaths,
+      extensionDirectories,
     )
     const {themeExtensions, usedCustomLayout: usedCustomLayoutForThemeExtensions} = await this.loadThemeExtensions(
-      extensionPaths,
+      extensionDirectories,
     )
     const packageJSONPath = path.join(this.appDirectory, 'package.json')
     const name = (await getPackageName(packageJSONPath)) ?? path.basename(this.appDirectory)
@@ -225,8 +225,10 @@ class AppLoader {
     return parseResult.data
   }
 
-  async loadUIExtensions(extensionPaths: string[]): Promise<{uiExtensions: UIExtension[]; usedCustomLayout: boolean}> {
-    const extensionConfigPaths = extensionPaths.map((extensionPath) => {
+  async loadUIExtensions(
+    extensionDirectories: string[],
+  ): Promise<{uiExtensions: UIExtension[]; usedCustomLayout: boolean}> {
+    const extensionConfigPaths = extensionDirectories.map((extensionPath) => {
       return path.join(extensionPath, `${configurationFileNames.extension.ui}`)
     })
     const configPaths = await path.glob(extensionConfigPaths)
@@ -278,8 +280,10 @@ class AppLoader {
     return {uiExtensions: await Promise.all(extensions), usedCustomLayout: false}
   }
 
-  async loadFunctions(extensionPaths: string[]): Promise<{functions: FunctionExtension[]; usedCustomLayout: boolean}> {
-    const functionConfigPaths = extensionPaths.map((extensionPath) => {
+  async loadFunctions(
+    extensionDirectories: string[],
+  ): Promise<{functions: FunctionExtension[]; usedCustomLayout: boolean}> {
+    const functionConfigPaths = extensionDirectories.map((extensionPath) => {
       return path.join(extensionPath, `${configurationFileNames.extension.function}`)
     })
     const configPaths = await path.glob(functionConfigPaths)
@@ -315,9 +319,9 @@ class AppLoader {
   }
 
   async loadThemeExtensions(
-    extensionPaths: string[],
+    extensionDirectories: string[],
   ): Promise<{themeExtensions: ThemeExtension[]; usedCustomLayout: boolean}> {
-    const themeConfigPaths = extensionPaths.map((extensionPath) => {
+    const themeConfigPaths = extensionDirectories.map((extensionPath) => {
       return path.join(extensionPath, `${configurationFileNames.extension.theme}`)
     })
     const configPaths = await path.glob(themeConfigPaths)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -9,7 +9,7 @@ import {
   Extension,
 } from './extensions.js'
 import {AppConfigurationSchema, Web, WebConfigurationSchema, App, AppInterface, WebType} from './app.js'
-import {blocks, configurationFileNames, dotEnvFileNames, extensionGraphqlId} from '../../constants.js'
+import {configurationFileNames, dotEnvFileNames, extensionGraphqlId} from '../../constants.js'
 import {mapUIExternalExtensionTypeToUIExtensionType} from '../../utilities/extensions/name-mapper.js'
 import metadata from '../../metadata.js'
 import {error, file, id, path, schema, string, toml, output} from '@shopify/cli-kit'
@@ -65,16 +65,16 @@ class AppLoader {
     this.appDirectory = await this.findAppDirectory()
     const configurationPath = await this.getConfigurationPath()
     const configuration = await this.parseConfigurationFile(AppConfigurationSchema, configurationPath)
-    const extensionsPath = path.join(this.appDirectory, `${blocks.extensions.directoryName}`)
+    const extensionPaths = path.join(this.appDirectory, `${configuration.extension_paths}`)
     const dotenv = await this.loadDotEnv()
     const {functions, usedCustomLayout: usedCustomLayoutForFunctionExtensions} = await this.loadFunctions(
-      extensionsPath,
+      extensionPaths,
     )
     const {uiExtensions, usedCustomLayout: usedCustomLayoutForUIExtensions} = await this.loadUIExtensions(
-      extensionsPath,
+      extensionPaths,
     )
     const {themeExtensions, usedCustomLayout: usedCustomLayoutForThemeExtensions} = await this.loadThemeExtensions(
-      extensionsPath,
+      extensionPaths,
     )
     const packageJSONPath = path.join(this.appDirectory, 'package.json')
     const name = (await getPackageName(packageJSONPath)) ?? path.basename(this.appDirectory)
@@ -223,8 +223,8 @@ class AppLoader {
     return parseResult.data
   }
 
-  async loadUIExtensions(extensionsPath: string): Promise<{uiExtensions: UIExtension[]; usedCustomLayout: boolean}> {
-    const extensionConfigPaths = path.join(extensionsPath, `*/${configurationFileNames.extension.ui}`)
+  async loadUIExtensions(extensionPaths: string): Promise<{uiExtensions: UIExtension[]; usedCustomLayout: boolean}> {
+    const extensionConfigPaths = path.join(extensionPaths, `${configurationFileNames.extension.ui}`)
     const configPaths = await path.glob(extensionConfigPaths)
 
     const extensions = configPaths.map(async (configurationPath) => {
@@ -274,8 +274,8 @@ class AppLoader {
     return {uiExtensions: await Promise.all(extensions), usedCustomLayout: false}
   }
 
-  async loadFunctions(extensionsPath: string): Promise<{functions: FunctionExtension[]; usedCustomLayout: boolean}> {
-    const functionConfigPaths = await path.join(extensionsPath, `*/${configurationFileNames.extension.function}`)
+  async loadFunctions(extensionPaths: string): Promise<{functions: FunctionExtension[]; usedCustomLayout: boolean}> {
+    const functionConfigPaths = await path.join(extensionPaths, `${configurationFileNames.extension.function}`)
     const configPaths = await path.glob(functionConfigPaths)
 
     const functions = configPaths.map(async (configurationPath) => {
@@ -309,9 +309,9 @@ class AppLoader {
   }
 
   async loadThemeExtensions(
-    extensionsPath: string,
+    extensionPaths: string,
   ): Promise<{themeExtensions: ThemeExtension[]; usedCustomLayout: boolean}> {
-    const themeConfigPaths = await path.join(extensionsPath, `*/${configurationFileNames.extension.theme}`)
+    const themeConfigPaths = await path.join(extensionPaths, `${configurationFileNames.extension.theme}`)
     const configPaths = await path.glob(themeConfigPaths)
 
     const themeExtensions = configPaths.map(async (configurationPath) => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -65,9 +65,12 @@ class AppLoader {
     this.appDirectory = await this.findAppDirectory()
     const configurationPath = await this.getConfigurationPath()
     const configuration = await this.parseConfigurationFile(AppConfigurationSchema, configurationPath)
-    const extensionDirectories = configuration.extensionDirectories.map((extensionDirectory) => {
-      return path.join(this.appDirectory, extensionDirectory)
-    })
+    const extensionDirectories = [
+      path.join(this.appDirectory, 'extensions/*'),
+      ...configuration.additionalExtensionDirectories.map((extensionDirectory) => {
+        return path.join(this.appDirectory, extensionDirectory)
+      }),
+    ]
     const dotenv = await this.loadDotEnv()
     const {functions, usedCustomLayout: usedCustomLayoutForFunctionExtensions} = await this.loadFunctions(
       extensionDirectories,

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -18,8 +18,6 @@ import {getDependencies, getPackageManager, getPackageName} from '@shopify/cli-k
 
 export type AppLoaderMode = 'strict' | 'report'
 
-const extensionsDefaultDirectory = 'extensions/*'
-
 export class AppErrors {
   private errors: {
     [key: string]: output.Message
@@ -69,13 +67,13 @@ class AppLoader {
     const configuration = await this.parseConfigurationFile(AppConfigurationSchema, configurationPath)
     const dotenv = await this.loadDotEnv()
     const {functions, usedCustomLayout: usedCustomLayoutForFunctionExtensions} = await this.loadFunctions(
-      configuration.additionalExtensionDirectories,
+      configuration.extensionDirectories,
     )
     const {uiExtensions, usedCustomLayout: usedCustomLayoutForUIExtensions} = await this.loadUIExtensions(
-      configuration.additionalExtensionDirectories,
+      configuration.extensionDirectories,
     )
     const {themeExtensions, usedCustomLayout: usedCustomLayoutForThemeExtensions} = await this.loadThemeExtensions(
-      configuration.additionalExtensionDirectories,
+      configuration.extensionDirectories,
     )
     const packageJSONPath = path.join(this.appDirectory, 'package.json')
     const name = (await getPackageName(packageJSONPath)) ?? path.basename(this.appDirectory)
@@ -225,13 +223,11 @@ class AppLoader {
   }
 
   async loadUIExtensions(
-    additionalExtensionDirectories: string[],
+    extensionDirectories: string[],
   ): Promise<{uiExtensions: UIExtension[]; usedCustomLayout: boolean}> {
-    const extensionConfigPaths = [extensionsDefaultDirectory, ...additionalExtensionDirectories].map(
-      (extensionPath) => {
-        return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.ui}`)
-      },
-    )
+    const extensionConfigPaths = [...extensionDirectories].map((extensionPath) => {
+      return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.ui}`)
+    })
     const configPaths = await path.glob(extensionConfigPaths)
 
     const extensions = configPaths.map(async (configurationPath) => {
@@ -278,13 +274,13 @@ class AppLoader {
         devUUID: `dev-${id.generateRandomUUID()}`,
       }
     })
-    return {uiExtensions: await Promise.all(extensions), usedCustomLayout: additionalExtensionDirectories.length !== 0}
+    return {uiExtensions: await Promise.all(extensions), usedCustomLayout: extensionDirectories.length !== 0}
   }
 
   async loadFunctions(
-    additionalExtensionDirectories: string[],
+    extensionDirectories: string[],
   ): Promise<{functions: FunctionExtension[]; usedCustomLayout: boolean}> {
-    const functionConfigPaths = [extensionsDefaultDirectory, ...additionalExtensionDirectories].map((extensionPath) => {
+    const functionConfigPaths = [...extensionDirectories].map((extensionPath) => {
       return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.function}`)
     })
     const configPaths = await path.glob(functionConfigPaths)
@@ -316,13 +312,13 @@ class AppLoader {
         },
       }
     })
-    return {functions: await Promise.all(functions), usedCustomLayout: additionalExtensionDirectories.length !== 0}
+    return {functions: await Promise.all(functions), usedCustomLayout: extensionDirectories.length !== 0}
   }
 
   async loadThemeExtensions(
-    additionalExtensionDirectories: string[],
+    extensionDirectories: string[],
   ): Promise<{themeExtensions: ThemeExtension[]; usedCustomLayout: boolean}> {
-    const themeConfigPaths = [extensionsDefaultDirectory, ...additionalExtensionDirectories].map((extensionPath) => {
+    const themeConfigPaths = [...extensionDirectories].map((extensionPath) => {
       return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.theme}`)
     })
     const configPaths = await path.glob(themeConfigPaths)
@@ -342,7 +338,7 @@ class AppLoader {
     })
     return {
       themeExtensions: await Promise.all(themeExtensions),
-      usedCustomLayout: additionalExtensionDirectories.length !== 0,
+      usedCustomLayout: extensionDirectories.length !== 0,
     }
   }
 

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -278,7 +278,7 @@ class AppLoader {
         devUUID: `dev-${id.generateRandomUUID()}`,
       }
     })
-    return {uiExtensions: await Promise.all(extensions), usedCustomLayout: false}
+    return {uiExtensions: await Promise.all(extensions), usedCustomLayout: additionalExtensionDirectories.length !== 0}
   }
 
   async loadFunctions(
@@ -316,7 +316,7 @@ class AppLoader {
         },
       }
     })
-    return {functions: await Promise.all(functions), usedCustomLayout: false}
+    return {functions: await Promise.all(functions), usedCustomLayout: additionalExtensionDirectories.length !== 0}
   }
 
   async loadThemeExtensions(
@@ -340,7 +340,10 @@ class AppLoader {
         localIdentifier: path.basename(directory),
       }
     })
-    return {themeExtensions: await Promise.all(themeExtensions), usedCustomLayout: false}
+    return {
+      themeExtensions: await Promise.all(themeExtensions),
+      usedCustomLayout: additionalExtensionDirectories.length !== 0,
+    }
   }
 
   abortOrReport<T>(errorMessage: output.Message, fallback: T, configurationPath: string): T {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -227,7 +227,7 @@ class AppLoader {
   async loadUIExtensions(
     extensionDirectories?: string[],
   ): Promise<{uiExtensions: UIExtension[]; usedCustomLayout: boolean}> {
-    const extensionConfigPaths = [...(extensionDirectories ?? defaultExtensionDirectory)].map((extensionPath) => {
+    const extensionConfigPaths = [...(extensionDirectories ?? [defaultExtensionDirectory])].map((extensionPath) => {
       return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.ui}`)
     })
     const configPaths = await path.glob(extensionConfigPaths)
@@ -282,7 +282,7 @@ class AppLoader {
   async loadFunctions(
     extensionDirectories?: string[],
   ): Promise<{functions: FunctionExtension[]; usedCustomLayout: boolean}> {
-    const functionConfigPaths = [...(extensionDirectories ?? defaultExtensionDirectory)].map((extensionPath) => {
+    const functionConfigPaths = [...(extensionDirectories ?? [defaultExtensionDirectory])].map((extensionPath) => {
       return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.function}`)
     })
     const configPaths = await path.glob(functionConfigPaths)
@@ -320,7 +320,7 @@ class AppLoader {
   async loadThemeExtensions(
     extensionDirectories?: string[],
   ): Promise<{themeExtensions: ThemeExtension[]; usedCustomLayout: boolean}> {
-    const themeConfigPaths = [...(extensionDirectories ?? defaultExtensionDirectory)].map((extensionPath) => {
+    const themeConfigPaths = [...(extensionDirectories ?? [defaultExtensionDirectory])].map((extensionPath) => {
       return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.theme}`)
     })
     const configPaths = await path.glob(themeConfigPaths)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -16,6 +16,8 @@ import {error, file, id, path, schema, string, toml, output} from '@shopify/cli-
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {getDependencies, getPackageManager, getPackageName} from '@shopify/cli-kit/node/node-package-manager'
 
+const defaultExtensionDirectory = 'extensions/*'
+
 export type AppLoaderMode = 'strict' | 'report'
 
 export class AppErrors {
@@ -223,9 +225,9 @@ class AppLoader {
   }
 
   async loadUIExtensions(
-    extensionDirectories: string[],
+    extensionDirectories?: string[],
   ): Promise<{uiExtensions: UIExtension[]; usedCustomLayout: boolean}> {
-    const extensionConfigPaths = [...extensionDirectories].map((extensionPath) => {
+    const extensionConfigPaths = [...(extensionDirectories ?? defaultExtensionDirectory)].map((extensionPath) => {
       return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.ui}`)
     })
     const configPaths = await path.glob(extensionConfigPaths)
@@ -274,13 +276,13 @@ class AppLoader {
         devUUID: `dev-${id.generateRandomUUID()}`,
       }
     })
-    return {uiExtensions: await Promise.all(extensions), usedCustomLayout: extensionDirectories.length !== 0}
+    return {uiExtensions: await Promise.all(extensions), usedCustomLayout: extensionDirectories !== undefined}
   }
 
   async loadFunctions(
-    extensionDirectories: string[],
+    extensionDirectories?: string[],
   ): Promise<{functions: FunctionExtension[]; usedCustomLayout: boolean}> {
-    const functionConfigPaths = [...extensionDirectories].map((extensionPath) => {
+    const functionConfigPaths = [...(extensionDirectories ?? defaultExtensionDirectory)].map((extensionPath) => {
       return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.function}`)
     })
     const configPaths = await path.glob(functionConfigPaths)
@@ -312,13 +314,13 @@ class AppLoader {
         },
       }
     })
-    return {functions: await Promise.all(functions), usedCustomLayout: extensionDirectories.length !== 0}
+    return {functions: await Promise.all(functions), usedCustomLayout: extensionDirectories !== undefined}
   }
 
   async loadThemeExtensions(
-    extensionDirectories: string[],
+    extensionDirectories?: string[],
   ): Promise<{themeExtensions: ThemeExtension[]; usedCustomLayout: boolean}> {
-    const themeConfigPaths = [...extensionDirectories].map((extensionPath) => {
+    const themeConfigPaths = [...(extensionDirectories ?? defaultExtensionDirectory)].map((extensionPath) => {
       return path.join(this.appDirectory, extensionPath, `${configurationFileNames.extension.theme}`)
     })
     const configPaths = await path.glob(themeConfigPaths)
@@ -338,7 +340,7 @@ class AppLoader {
     })
     return {
       themeExtensions: await Promise.all(themeExtensions),
-      usedCustomLayout: extensionDirectories.length !== 0,
+      usedCustomLayout: extensionDirectories !== undefined,
     }
   }
 

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -65,7 +65,9 @@ class AppLoader {
     this.appDirectory = await this.findAppDirectory()
     const configurationPath = await this.getConfigurationPath()
     const configuration = await this.parseConfigurationFile(AppConfigurationSchema, configurationPath)
-    const extensionPaths = path.join(this.appDirectory, `${configuration.extension_paths}`)
+    const extensionPaths = configuration.extension_paths.map((extensionPath) => {
+      return path.join(this.appDirectory, extensionPath)
+    })
     const dotenv = await this.loadDotEnv()
     const {functions, usedCustomLayout: usedCustomLayoutForFunctionExtensions} = await this.loadFunctions(
       extensionPaths,
@@ -223,8 +225,10 @@ class AppLoader {
     return parseResult.data
   }
 
-  async loadUIExtensions(extensionPaths: string): Promise<{uiExtensions: UIExtension[]; usedCustomLayout: boolean}> {
-    const extensionConfigPaths = path.join(extensionPaths, `${configurationFileNames.extension.ui}`)
+  async loadUIExtensions(extensionPaths: string[]): Promise<{uiExtensions: UIExtension[]; usedCustomLayout: boolean}> {
+    const extensionConfigPaths = extensionPaths.map((extensionPath) => {
+      return path.join(extensionPath, `${configurationFileNames.extension.ui}`)
+    })
     const configPaths = await path.glob(extensionConfigPaths)
 
     const extensions = configPaths.map(async (configurationPath) => {
@@ -274,8 +278,10 @@ class AppLoader {
     return {uiExtensions: await Promise.all(extensions), usedCustomLayout: false}
   }
 
-  async loadFunctions(extensionPaths: string): Promise<{functions: FunctionExtension[]; usedCustomLayout: boolean}> {
-    const functionConfigPaths = await path.join(extensionPaths, `${configurationFileNames.extension.function}`)
+  async loadFunctions(extensionPaths: string[]): Promise<{functions: FunctionExtension[]; usedCustomLayout: boolean}> {
+    const functionConfigPaths = extensionPaths.map((extensionPath) => {
+      return path.join(extensionPath, `${configurationFileNames.extension.function}`)
+    })
     const configPaths = await path.glob(functionConfigPaths)
 
     const functions = configPaths.map(async (configurationPath) => {
@@ -309,9 +315,11 @@ class AppLoader {
   }
 
   async loadThemeExtensions(
-    extensionPaths: string,
+    extensionPaths: string[],
   ): Promise<{themeExtensions: ThemeExtension[]; usedCustomLayout: boolean}> {
-    const themeConfigPaths = await path.join(extensionPaths, `${configurationFileNames.extension.theme}`)
+    const themeConfigPaths = extensionPaths.map((extensionPath) => {
+      return path.join(extensionPath, `${configurationFileNames.extension.theme}`)
+    })
     const configPaths = await path.glob(themeConfigPaths)
 
     const themeExtensions = configPaths.map(async (configurationPath) => {

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -9,7 +9,7 @@ import {api} from '@shopify/cli-kit'
 const LOCAL_APP: AppInterface = testApp({
   directory: '',
   configurationPath: '/shopify.app.toml',
-  configuration: {scopes: 'read_products', additionalExtensionDirectories: ['extensions/*']},
+  configuration: {scopes: 'read_products', extensionDirectories: ['extensions/*']},
   webs: [
     {
       directory: '',

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -9,7 +9,7 @@ import {api} from '@shopify/cli-kit'
 const LOCAL_APP: AppInterface = testApp({
   directory: '',
   configurationPath: '/shopify.app.toml',
-  configuration: {scopes: 'read_products', extensionDirectories: ['extensions/*']},
+  configuration: {scopes: 'read_products', additionalExtensionDirectories: ['extensions/*']},
   webs: [
     {
       directory: '',

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -9,7 +9,7 @@ import {api} from '@shopify/cli-kit'
 const LOCAL_APP: AppInterface = testApp({
   directory: '',
   configurationPath: '/shopify.app.toml',
-  configuration: {scopes: 'read_products'},
+  configuration: {scopes: 'read_products', extensionDirectories: ['extensions/*']},
   webs: [
     {
       directory: '',

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -105,7 +105,7 @@ const LOCAL_APP = testApp({
   name: 'my-app',
   directory: '/app',
   configurationPath: '/shopify.app.toml',
-  configuration: {scopes: 'read_products', extensionDirectories: ['extensions/*']},
+  configuration: {scopes: 'read_products', additionalExtensionDirectories: ['extensions/*']},
   webs: [
     {
       directory: '',

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -105,7 +105,7 @@ const LOCAL_APP = testApp({
   name: 'my-app',
   directory: '/app',
   configurationPath: '/shopify.app.toml',
-  configuration: {scopes: 'read_products'},
+  configuration: {scopes: 'read_products', extensionDirectories: ['extensions/*']},
   webs: [
     {
       directory: '',

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -105,7 +105,7 @@ const LOCAL_APP = testApp({
   name: 'my-app',
   directory: '/app',
   configurationPath: '/shopify.app.toml',
-  configuration: {scopes: 'read_products', additionalExtensionDirectories: ['extensions/*']},
+  configuration: {scopes: 'read_products', extensionDirectories: ['extensions/*']},
   webs: [
     {
       directory: '',

--- a/packages/app/src/cli/services/environment/identifiers.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers.test.ts
@@ -107,7 +107,7 @@ const LOCAL_APP = (uiExtensions: UIExtension[], functionExtensions: FunctionExte
     name: 'my-app',
     directory: '/app',
     configurationPath: '/shopify.app.toml',
-    configuration: {scopes: 'read_products', extensionDirectories: ['extensions/*']},
+    configuration: {scopes: 'read_products', additionalExtensionDirectories: ['extensions/*']},
     extensions: {ui: uiExtensions, theme: [], function: functionExtensions},
   })
 }

--- a/packages/app/src/cli/services/environment/identifiers.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers.test.ts
@@ -107,7 +107,7 @@ const LOCAL_APP = (uiExtensions: UIExtension[], functionExtensions: FunctionExte
     name: 'my-app',
     directory: '/app',
     configurationPath: '/shopify.app.toml',
-    configuration: {scopes: 'read_products', additionalExtensionDirectories: ['extensions/*']},
+    configuration: {scopes: 'read_products', extensionDirectories: ['extensions/*']},
     extensions: {ui: uiExtensions, theme: [], function: functionExtensions},
   })
 }

--- a/packages/app/src/cli/services/environment/identifiers.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers.test.ts
@@ -107,7 +107,7 @@ const LOCAL_APP = (uiExtensions: UIExtension[], functionExtensions: FunctionExte
     name: 'my-app',
     directory: '/app',
     configurationPath: '/shopify.app.toml',
-    configuration: {scopes: 'read_products'},
+    configuration: {scopes: 'read_products', extensionDirectories: ['extensions/*']},
     extensions: {ui: uiExtensions, theme: [], function: functionExtensions},
   })
 }

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -190,7 +190,7 @@ function mockApp(currentVersion = '2.2.2'): AppInterface {
     configurationPath: path.join('/', 'shopify.app.toml'),
     configuration: {
       scopes: 'my-scope',
-      additionalExtensionDirectories: ['extensions/*'],
+      extensionDirectories: ['extensions/*'],
     },
     nodeDependencies,
   })

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -190,6 +190,7 @@ function mockApp(currentVersion = '2.2.2'): AppInterface {
     configurationPath: path.join('/', 'shopify.app.toml'),
     configuration: {
       scopes: 'my-scope',
+      extensionDirectories: ['extensions/*'],
     },
     nodeDependencies,
   })

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -190,7 +190,7 @@ function mockApp(currentVersion = '2.2.2'): AppInterface {
     configurationPath: path.join('/', 'shopify.app.toml'),
     configuration: {
       scopes: 'my-scope',
-      extensionDirectories: ['extensions/*'],
+      additionalExtensionDirectories: ['extensions/*'],
     },
     nodeDependencies,
   })

--- a/packages/app/src/cli/services/web-env.test.ts
+++ b/packages/app/src/cli/services/web-env.test.ts
@@ -243,7 +243,7 @@ function mockApp(currentVersion = '2.2.2'): AppInterface {
     configurationPath: path.join('/', 'shopify.app.toml'),
     configuration: {
       scopes: 'my-scope',
-      additionalExtensionDirectories: ['extensions/*'],
+      extensionDirectories: ['extensions/*'],
     },
     nodeDependencies,
   })

--- a/packages/app/src/cli/services/web-env.test.ts
+++ b/packages/app/src/cli/services/web-env.test.ts
@@ -243,7 +243,7 @@ function mockApp(currentVersion = '2.2.2'): AppInterface {
     configurationPath: path.join('/', 'shopify.app.toml'),
     configuration: {
       scopes: 'my-scope',
-      extensionDirectories: ['extensions/*'],
+      additionalExtensionDirectories: ['extensions/*'],
     },
     nodeDependencies,
   })

--- a/packages/app/src/cli/services/web-env.test.ts
+++ b/packages/app/src/cli/services/web-env.test.ts
@@ -243,6 +243,7 @@ function mockApp(currentVersion = '2.2.2'): AppInterface {
     configurationPath: path.join('/', 'shopify.app.toml'),
     configuration: {
       scopes: 'my-scope',
+      extensionDirectories: ['extensions/*'],
     },
     nodeDependencies,
   })


### PR DESCRIPTION
Resolves https://github.com/Shopify/shopify-cli-planning/issues/310
Documentation PR: https://github.com/Shopify/shopify-dev/pull/26029

### WHY are these changes introduced?
Some partners [reported](https://shopify.slack.com/archives/C03NT4BP8N9/p1661967429402539) that the opinion around where extensions should be located within an app is too strong and they can't adopt it easily due to how they are organizing extensions in multiple repositories.

### WHAT is this pull request doing?
I'm adding support for a new attribute in the `shopify.app.toml`, `extension_directories`, that's an array of glob expressions pointing to directories containing extensions:

```toml
extension_directories = [
  "my_other_extension",
  "other_directory/extensions/*"
]
``` 
The default value of the attribute is `extensions/*`.

### How to test your changes?
1. Rename the `extensions` directory in the `fixtures/app` directory to `my-extensions`.
2. Edit the app configuration file and add `extension_directories = ["my-extensions"]`
3. Run `yarn shopify app info --path ./fixtures/app`

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
