### PR TITLE
Make using the Node logic for building UI extensions in `deploy` opt-in

### DIFF
--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -1,4 +1,4 @@
-import {buildThemeExtensions, buildFunctionExtension, buildUIExtension} from '../build/extension.js'
+import {buildThemeExtensions, buildFunctionExtension, buildUIExtensions} from '../build/extension.js'
 import {AppInterface} from '../../models/app/app.js'
 import {Identifiers} from '../../models/app/identifiers.js'
 import {path, output, file, abort} from '@shopify/cli-kit'
@@ -31,19 +31,21 @@ export async function bundleUIAndBuildFunctionExtensions(options: BundleOptions)
           })
         },
       },
-      ...options.app.extensions.ui.map((uiExtension) => {
-        return {
-          prefix: uiExtension.localIdentifier,
-          action: async (stdout: Writable, stderr: Writable, signal: abort.Signal) => {
-            const extensionId = options.identifiers.extensions[uiExtension.localIdentifier]!
-            const mappedUIExtension: typeof uiExtension = {
-              ...uiExtension,
-              outputBundlePath: path.join(bundleDirectory, extensionId, path.basename(uiExtension.outputBundlePath)),
-            }
-
-            await buildUIExtension(mappedUIExtension, {stdout, stderr, signal, app: options.app})
+      ...buildUIExtensions({
+        app: {
+          ...options.app,
+          extensions: {
+            ...options.app.extensions,
+            ui: options.app.extensions.ui.map((uiExtension) => {
+              const extensionId = options.identifiers.extensions[uiExtension.localIdentifier]!
+              const mappedUIExtension: typeof uiExtension = {
+                ...uiExtension,
+                outputBundlePath: path.join(bundleDirectory, extensionId, path.basename(uiExtension.outputBundlePath)),
+              }
+              return mappedUIExtension
+            }),
           },
-        }
+        },
       }),
       ...options.app.extensions.function.map((functionExtension) => {
         return {


### PR DESCRIPTION
### WHY are these changes introduced?
As part of [migrating the build of UI extensions from Go to Node](https://github.com/Shopify/cli/pull/437) I made it opt-in via an environment variable, `SHOPIFY_CLI_UI_EXTENSIONS_USE_NODE=1`. However, I forgot to update the `deploy` logic to make the new logic opt-in there as well.

### WHAT is this pull request doing?
I'm updating the `deploy` workflow to use the Node logic for building UI extensions only if the `SHOPIFY_CLI_UI_EXTENSIONS_USE_NODE` environment variable is truthy.

### How to test your changes?
Try to deploy a Shopify app with and without the `SHOPIFY_CLI_UI_EXTENSIONS_USE_NODE=1` environment variable.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
