### PR TITLE
Enable manual dispatch of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: changeset
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Sometimes the (changeset) release workflow breaks, in which case we need to close the PR, delete the branch, and re-trigger.