### PR TITLE
Correct changeset package reference

### DIFF
--- a/.changeset/manual-log-refactor.md
+++ b/.changeset/manual-log-refactor.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/cli-main': minor
+'@shopify/cli': minor
 '@shopify/cli-kit': minor
 ---
 


### PR DESCRIPTION
Apparently `@shopify/cli-main` is not a thing according to changesets.