### PR TITLE
Add customer-accounts surface to ui-extensions-server-kit

### DIFF
--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
@@ -229,7 +229,7 @@ declare global {
   }
 }
 
-export const AVAILABLE_SURFACES = ['admin', 'checkout', 'post-checkout', 'pos'] as const
+export const AVAILABLE_SURFACES = ['admin', 'checkout', 'post-checkout', 'pos', 'customer-accounts'] as const
 
 export type Surface = typeof AVAILABLE_SURFACES[number]
 


### PR DESCRIPTION
### WHY are these changes introduced?

We introduced a new surface [here](https://github.com/Shopify/shopify/pull/362279) in order to support the [returns mission](https://vault.shopify.io/gsd/projects/23677).
In order to improve the dev experience we are now integrating `ui-extensions-server-kit` and the surface is missing.

This is part of [this issue](https://github.com/Shopify/core-issues/issues/43741)

paired with @Safi1012 

### WHAT is this pull request doing?

Add a surface to the `Surface` type in `ui-extensions-server-kit`


### How to test your changes?

They can't be tested in isolation but nothing should break.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
