### PR TITLE
[Feature] Pass new permissions to apps during `yarn dev` to enable new functionality for Checkout UI Extensions

### DIFF
--- a/.changeset/spicy-parrots-reflect.md
+++ b/.changeset/spicy-parrots-reflect.md
@@ -1,0 +1,7 @@
+---
+'@shopify/app': minor
+'@shopify/cli-kit': minor
+'@shopify/ui-extensions-go-cli': minor
+---
+
+Added support for extension development server to pass permissions metadata about the parent app to extension host systems

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -15,6 +15,7 @@ export interface OrganizationApp {
   }[]
   appType?: string
   newApp?: boolean
+  grantedScopes: string[]
 }
 
 export interface OrganizationStore {

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -33,6 +33,7 @@ const APP1: OrganizationApp = {
   apiKey: 'key1',
   apiSecretKeys: [{secret: 'secret1'}],
   organizationId: '1',
+  grantedScopes: [],
 }
 const APP2: OrganizationApp = {
   id: '2',
@@ -40,6 +41,7 @@ const APP2: OrganizationApp = {
   apiKey: 'key2',
   apiSecretKeys: [{secret: 'secret2'}],
   organizationId: '1',
+  grantedScopes: [],
 }
 const STORE1: OrganizationStore = {
   shopId: '1',

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -102,6 +102,7 @@ async function dev(options: DevOptions) {
       apiKey,
       proxyUrl,
       storeFqdn,
+      app.grantedScopes,
       options.subscriptionProductUrl,
       options.checkoutCartUrl,
     )
@@ -228,6 +229,7 @@ async function devExtensionsTarget(
   apiKey: string,
   url: string,
   storeFqdn: string,
+  grantedScopes: string[],
   subscriptionProductUrl?: string,
   checkoutCartUrl?: string,
 ): Promise<ReverseHTTPProxyTarget> {
@@ -246,6 +248,7 @@ async function devExtensionsTarget(
         port,
         storeFqdn,
         apiKey,
+        grantedScopes,
         cartUrl,
         subscriptionProductUrl,
       })

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -57,6 +57,11 @@ export interface ExtensionDevOptions {
   storeFqdn: string
 
   /**
+   * List of granted approval scopes belonging to the parent app
+   */
+  grantedScopes: string[]
+
+  /**
    * Product variant ID, used for checkout_ui_extensions
    * If that extension is present, this is mandatory
    */

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -18,6 +18,7 @@ const APP1: OrganizationApp = {
   apiKey: 'key1',
   apiSecretKeys: [{secret: 'secret1'}],
   organizationId: '1',
+  grantedScopes: [],
 }
 const APP2: OrganizationApp = {
   id: '2',
@@ -25,6 +26,7 @@ const APP2: OrganizationApp = {
   apiKey: 'key2',
   apiSecretKeys: [{secret: 'secret2'}],
   organizationId: '1',
+  grantedScopes: [],
 }
 const STORE1: OrganizationStore = {
   shopId: '1',

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -30,6 +30,7 @@ const APP1: OrganizationApp = {
   apiKey: 'key1',
   apiSecretKeys: [{secret: 'secret1'}],
   organizationId: '1',
+  grantedScopes: [],
 }
 const APP2: OrganizationApp = {
   id: '2',
@@ -37,6 +38,7 @@ const APP2: OrganizationApp = {
   apiKey: 'key2',
   apiSecretKeys: [{secret: 'secret2'}],
   organizationId: '1',
+  grantedScopes: [],
 }
 
 beforeEach(() => {

--- a/packages/app/src/cli/services/env/pull.test.ts
+++ b/packages/app/src/cli/services/env/pull.test.ts
@@ -46,6 +46,7 @@ describe('env pull', () => {
         apiSecretKeys: [{secret: 'api-secret'}],
         organizationId: '1',
         apiKey: 'api-key',
+        grantedScopes: [],
       }
       vi.mocked(fetchOrganizations).mockResolvedValue([organization])
       vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)
@@ -96,6 +97,7 @@ describe('env pull', () => {
         apiSecretKeys: [{secret: 'api-secret'}],
         organizationId: '1',
         apiKey: 'api-key',
+        grantedScopes: [],
       }
       vi.mocked(fetchOrganizations).mockResolvedValue([organization])
       vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)
@@ -159,6 +161,7 @@ describe('env pull', () => {
         apiSecretKeys: [{secret: 'api-secret'}],
         organizationId: '1',
         apiKey: 'api-key',
+        grantedScopes: [],
       }
       vi.mocked(fetchOrganizations).mockResolvedValue([organization])
       vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)

--- a/packages/app/src/cli/services/env/show.test.ts
+++ b/packages/app/src/cli/services/env/show.test.ts
@@ -52,6 +52,7 @@ describe('env show', () => {
       apiSecretKeys: [{secret: apiSecret}],
       organizationId: '1',
       apiKey,
+      grantedScopes: [],
     }
     vi.mocked(fetchOrganizations).mockResolvedValue([organization])
     vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -49,6 +49,7 @@ const APP1: OrganizationApp = {
   apiKey: 'key1',
   organizationId: '1',
   apiSecretKeys: [{secret: 'secret1'}],
+  grantedScopes: [],
 }
 const APP2: OrganizationApp = {
   id: '2',
@@ -56,6 +57,7 @@ const APP2: OrganizationApp = {
   apiKey: 'key2',
   organizationId: '1',
   apiSecretKeys: [{secret: 'secret2'}],
+  grantedScopes: [],
 }
 
 const ORG1: api.graphql.AllOrganizationsQuerySchemaOrganization = {

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -268,6 +268,7 @@ export async function ensureDeployEnvironment(options: DeployEnvironmentOptions)
       title: partnersApp.title,
       appType: partnersApp.appType,
       organizationId: partnersApp.organizationId,
+      grantedScopes: partnersApp.grantedScopes,
     },
     partnersOrganizationId: partnersApp.organizationId,
     identifiers,

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -112,6 +112,7 @@ describe('info', () => {
       apiSecretKeys: [{secret: apiSecret}],
       organizationId: '1',
       apiKey,
+      grantedScopes: [],
     }
     vi.mocked(fetchOrganizations).mockResolvedValue([organization])
     vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)
@@ -156,6 +157,7 @@ describe('info', () => {
       apiSecretKeys: [{secret: apiSecret}],
       organizationId: '1',
       apiKey,
+      grantedScopes: [],
     }
     vi.mocked(fetchOrganizations).mockResolvedValue([organization])
     vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)

--- a/packages/app/src/cli/utilities/extensions/configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/configuration.test.ts
@@ -73,6 +73,7 @@ describe('extensionConfig', () => {
       port: 8000,
       storeFqdn: 'storeFqdn',
       includeResourceURL: true,
+      grantedScopes: ['read_customer_personal_data'],
     }
 
     // When
@@ -118,6 +119,7 @@ describe('extensionConfig', () => {
           },
 
           capabilities: {network_access: true},
+          approval_scopes: ['read_customer_personal_data'],
         },
       ],
     })

--- a/packages/app/src/cli/utilities/extensions/configuration.ts
+++ b/packages/app/src/cli/utilities/extensions/configuration.ts
@@ -22,6 +22,7 @@ export interface ExtensionConfigOptions {
   includeResourceURL?: boolean
   cartUrl?: string
   subscriptionProductUrl?: string
+  grantedScopes?: string[]
 }
 
 /**
@@ -67,6 +68,7 @@ export async function extensionConfig(options: ExtensionConfigOptions): Promise<
           },
         },
         capabilities: extension.configuration.capabilities,
+        approval_scopes: options.grantedScopes ?? [],
       }
     }),
   )

--- a/packages/cli-kit/src/api/graphql/create_app.ts
+++ b/packages/cli-kit/src/api/graphql/create_app.ts
@@ -22,6 +22,7 @@ export const CreateAppQuery = gql`
           secret
         }
         appType
+        grantedScopes
       }
       userErrors {
         field
@@ -52,6 +53,7 @@ export interface CreateAppQuerySchema {
         secret: string
       }[]
       appType: string
+      grantedScopes: string[]
     }
     userErrors: {
       field: string[]

--- a/packages/cli-kit/src/api/graphql/find_app.ts
+++ b/packages/cli-kit/src/api/graphql/find_app.ts
@@ -11,6 +11,7 @@ export const FindAppQuery = gql`
         secret
       }
       appType
+      grantedScopes
     }
   }
 `
@@ -25,5 +26,6 @@ export interface FindAppQuerySchema {
       secret: string
     }[]
     appType: string
+    grantedScopes: string[]
   }
 }

--- a/packages/cli-kit/src/api/graphql/find_org.ts
+++ b/packages/cli-kit/src/api/graphql/find_org.ts
@@ -18,6 +18,7 @@ export const FindOrganizationQuery = gql`
               secret
             }
             appType
+            grantedScopes
           }
         }
       }
@@ -42,6 +43,7 @@ export interface FindOrganizationQuerySchema {
             secret: string
           }[]
           appType: string
+          grantedScopes: string[]
         }[]
       }
     }[]

--- a/packages/ui-extensions-go-cli/core/core.go
+++ b/packages/ui-extensions-go-cli/core/core.go
@@ -155,6 +155,7 @@ type Extension struct {
 	Title           string           `json:"title,omitempty" yaml:"title,omitempty"`
 	Name            string           `json:"name,omitempty" yaml:"name,omitempty"`
 	NodeExecutable  string           `json:"-" yaml:"node_executable,omitempty"`
+	ApprovalScopes  []string         `json:"approvalScopes,omitempty" yaml:"approval_scopes,omitempty"`
 }
 
 func (e Extension) String() string {

--- a/packages/ui-extensions-go-cli/core/core_test.go
+++ b/packages/ui-extensions-go-cli/core/core_test.go
@@ -18,6 +18,9 @@ extensions:
 		capabilities:
 			network_access: true
 			block_progress: true
+    approval_scopes:
+      - read_customer_personal_data
+      - read_customer_email
 `)
 
 	config, err := core.LoadConfig(strings.NewReader(serializedConfig))
@@ -58,6 +61,14 @@ extensions:
 
 	if *extension.Capabilities.BlockProgress != true {
 		t.Errorf("invalid value for Capabilities - expected block_progress got %t", *extension.Capabilities.BlockProgress)
+	}
+
+	if extension.ApprovalScopes[0] != "read_customer_personal_data" {
+		t.Errorf("invalid ApprovalScope - expected read_customer_personal_data got %s", extension.ApprovalScopes[0])
+	}
+
+	if extension.ApprovalScopes[1] != "read_customer_email" {
+		t.Errorf("invalid ApprovalScope - expected read_customer_email got %s", extension.ApprovalScopes[1])
 	}
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/checkout-web/issues/13297
Fixes https://github.com/Shopify/checkout-web/issues/13298

Shopify is introducing [stricter controls](https://shopify.dev/apps/store/data-protection/protected-customer-data) for accessing customer data.  Since Checkout UI Extensions expose APIs which also access customer data, we are taking steps to implement similar protections.  This PR supports the use case of enabling Checkout to apply proper data protections when a Checkout UI Extension is being served from the CLI via `yarn dev`.

### WHAT is this pull request doing?

- `packages/cli-kit/src/api/graphql/*.ts`
  - Queries a newly-exposed field, `grantedScopes` from the Partners API
- `packages/app/src/cli/models/organization.ts`
  - Adds the new field to the `OrganizationApp` model
- `packages/app/src/cli/utilities/extensions/configuration.ts`
  - Passes the new array to the Go extension server configuration YAML as `approval_scopes` (this is for historical reasons)
- `packages/ui-extensions-go-cli/core/core.go`
  - Consumes the new configuration from the Node CLI and exposes to Checkout via the `/extensions` endpoint
### How to test your changes?

- Checkout this branch
- Create a new app with a checkout UI extension using the local CLI
  - `dev create-app`
  - `dev shopify app scaffold extension --path=path/to/your/app`
  - choose a Checkout UI extension
- Run the dev server locally and verify that `approvalScopes` are **not** returned when the extension is served up
  - This is the expected behavior for `undecided` apps
  - `dev shopify app dev --path=path/to/your/app`
  - Make sure your app and extension can connect to your Partners account & development store
  - Inspect the output of the Go extension server on your browser at the `/extensions` endpoint of your ngrok URL
    - Example: for the output `Shopify CLI Extensions Server is now available at https://5506-2603-8081-1702-ecca-4529-420e-536d-7115.ngrok.io/extensions/dev-console`, just chop off `dev-console` and instead go to `https://5506-2603-8081-1702-ecca-4529-420e-536d-7115.ngrok.io/extensions/`
  - Verify that the `approvalScopes` key is not present in the response
- Log in to the Partners dashboard and make your new app into a Custom / Single Merchant Install Link app
- Once the app is a Custom app, verify that `approvalScopes` **are** returned when the extension is served up
  - `dev shopify app dev --path=path/to/your/app`
  -  Inspect the output of the Go extension server on your browser at the `/extensions` endpoint of your ngrok URL
  - Verify that the `approvalScopes` key is present in the response and contains an array of at least five strings
- For more detailed instructions or more context, hit me up on internal comms if needed 👍 

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
