### PR TITLE
Expose extension points and categories in ExtensionPayload

### DIFF
--- a/packages/app/src/cli/utilities/extensions/configuration.ts
+++ b/packages/app/src/cli/utilities/extensions/configuration.ts
@@ -43,6 +43,7 @@ export async function extensionConfig(options: ExtensionConfigOptions): Promise<
         external_type: mapExtensionTypeToExternalExtensionType(extension.configuration.type),
         metafields: extension.configuration.metafields,
         extension_points: extension.configuration.extensionPoints || [],
+        categories: extension.configuration.categories,
         node_executable: await nodeExtensionsCLIPath(),
         surface: getUIExtensionSurface(extension.configuration.type),
         version: renderer?.version,

--- a/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.test.tsx
+++ b/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.test.tsx
@@ -106,7 +106,7 @@ describe('ExtensionServerProvider tests', () => {
 
       wrapper.act(() => socket.send({event: 'connected', data}));
 
-      expect(wrapper.result.state).toStrictEqual({
+      expect(wrapper.result.state).toEqual({
         app,
         extensions: [extension],
         store: 'test-store.com',
@@ -130,7 +130,7 @@ describe('ExtensionServerProvider tests', () => {
         socket.send({event: 'update', data: {...data, extensions: [update]}});
       });
 
-      expect(wrapper.result.state).toStrictEqual({
+      expect(wrapper.result.state).toEqual({
         app,
         extensions: [update],
         store: 'test-store.com',

--- a/packages/ui-extensions-server-kit/src/testing/extensions.ts
+++ b/packages/ui-extensions-server-kit/src/testing/extensions.ts
@@ -44,6 +44,14 @@ export function mockExtension(obj: DeepPartial<ExtensionPayload> = {}): Extensio
       },
       ...((obj.development || {}) as any),
     },
+    // this is due to the naive DeepPartial but also more complex ones
+    // [see stackoverflow](https://stackoverflow.com/a/68699273) assume that
+    // `DeepPartial<Array<T>> === Array<T | undefined>` while we are looking for
+    // `DeepPartial<Array<T>> === Array<T> | undefined`.
+    // This is the case for extension points and also categories and seems hard to fix
+    // in a generalized, non-surprising way
+    extensionPoints: obj.extensionPoints as any,
+    categories: obj.categories as any,
   }
 }
 

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -73,6 +73,8 @@ export interface ExtensionPayload {
   version: string
   surface: Surface
   title: string
+  extensionPoints?: string[]
+  categories?: string[]
 }
 
 export enum Status {


### PR DESCRIPTION
### WHY are these changes introduced?

We introduced a categories [here](https://github.com/Shopify/shopify/pull/362279) in order to support the [returns mission](https://vault.shopify.io/gsd/projects/23677).
In order to improve the dev experience we are now integrating `ui-extensions-server-kit` and the neither categories nor extension points are exposed on the `ExtensionPayload` type.

This is part of [this issue](https://github.com/Shopify/core-issues/issues/43741)

paired with @Safi1012 


### WHAT is this pull request doing?

Expose the categories and extensionPoints properties in the `ExtensionPayload` type - both are optional.

### How to test your changes?

They can't be tested in isolation but nothing should break.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
