### PR TITLE
Add post-release steps to PR template and release doc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,14 @@ Fixes #0000 <!-- link to issue if one exists -->
   Please, provide steps for the reviewer to test your changes locally.
 -->
 
+### Post-release steps
+
+<!--
+  If changes require post-release steps, for example merging and publishing some documentation changes,
+  specify it in this section and add the label "includes-post-release-steps".
+  If it doesn't, feel free to remove this section.
+-->
+
 ### Measuring impact
 
 How do we know this change was effective? Please choose one:

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,3 +21,4 @@ The steps are:
        * Some of the binaries are not correctly uploaded to the release: The release should be deleted manually from Github and then retry again from _step 3_
     2. Publishing of the CLI packages to the [NPM registry](https://www.npmjs.com/package/@shopify/cli). In case an error is produced the extension binary release should be deleted manually from Github and retry again from _step 3_
 5. Once the deployment completes, [find the PR](https://github.com/Shopify/homebrew-shopify/pulls) in the homebrew-shopify repository and merge the changes in the formula.
+6. Go through all the [PRs labeled with `includes-post-release-steps`](https://github.com/Shopify/cli/issues?q=label%3Aincludes-post-release-steps+is%3Aclosed) and follow the post-release steps described in those PRs. Delete the labels afterward.


### PR DESCRIPTION
### WHY are these changes introduced?

We need a way to remember additional steps after releasing, like merging documentation. Example: https://github.com/Shopify/cli/pull/376

### WHAT is this pull request doing?

Adds the same flow we had in shopify-cli:
- Adds a new section to the PR template
- Adds a step in the release instructions to check post-release actions

### How to test your changes?

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
