### PR TITLE
Clear app info when logging out

### DIFF
--- a/packages/cli-kit/src/store.ts
+++ b/packages/cli-kit/src/store.ts
@@ -101,6 +101,11 @@ export async function removeSession(): Promise<void> {
   store.removeSession()
 }
 
+export async function clearAllAppInfo(): Promise<void> {
+  const store = await cliKitStore()
+  store.clearAllAppInfo()
+}
+
 export class CLIKitStore extends Conf<ConfSchema> {
   getAppInfo(directory: string): CachedAppInfo | undefined {
     debug(content`Reading cached app information for directory ${token.path(directory)}...`)
@@ -143,6 +148,11 @@ export class CLIKitStore extends Conf<ConfSchema> {
       apps.splice(index, 1)
     }
     this.set('appInfo', apps)
+  }
+
+  clearAllAppInfo(): void {
+    debug(content`Clearning all app information...`)
+    this.set('appInfo', [])
   }
 
   getThemeStore(): string | undefined {

--- a/packages/cli-main/src/cli/commands/auth/logout.test.ts
+++ b/packages/cli-main/src/cli/commands/auth/logout.test.ts
@@ -1,0 +1,36 @@
+import Logout from './logout'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {session, store} from '@shopify/cli-kit'
+
+beforeEach(() => {
+  vi.mock('@shopify/cli-kit', async () => {
+    const module: any = await vi.importActual('@shopify/cli-kit')
+    return {
+      ...module,
+      session: {
+        ...module.session,
+        logout: vi.fn(),
+      },
+      store: {
+        ...module.store,
+        removeSession: vi.fn(),
+        clearAllAppInfo: vi.fn(),
+      },
+    }
+  })
+})
+
+describe('logs out', () => {
+  it('removes session', async () => {
+    await Logout.run()
+
+    expect(session.logout).toHaveBeenCalledOnce()
+    expect(store.removeSession).toHaveBeenCalledOnce()
+  })
+
+  it('removes all app information', async () => {
+    await Logout.run()
+
+    expect(store.clearAllAppInfo).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/cli-main/src/cli/commands/auth/logout.ts
+++ b/packages/cli-main/src/cli/commands/auth/logout.ts
@@ -7,6 +7,7 @@ export default class Logout extends Command {
   async run(): Promise<void> {
     await session.logout()
     await store.removeSession()
+    await store.clearAllAppInfo()
     output.success('Logged out from Shopify')
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/383

### WHAT is this pull request doing?

After logging out, we also clear all app information

### How to test your changes?

- create an app using the CLI
- run `app dev` so you have to authenticate against the Shopify API
- run `auth logout` 
- when you run `app dev` again it should ask you if you want to create a new app or link to an existing one

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
