### PR TITLE
No hiding cursor in list prompt

### DIFF
--- a/.changeset/fast-cooks-switch.md
+++ b/.changeset/fast-cooks-switch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Avoid the loosing of terminal cursor when using crtl+c with and active list prompt

--- a/packages/cli-kit/src/ui/inquirer/autocomplete.ts
+++ b/packages/cli-kit/src/ui/inquirer/autocomplete.ts
@@ -23,9 +23,6 @@ export class CustomAutocomplete extends AutocompletePrompt {
 
     if (this.status !== 'answered') {
       content += colors.gray('… ')
-      if (!this.isAutocomplete) {
-        process.stdout.write('\u001b[?25l')
-      }
     }
 
     if (this.status === 'answered') {


### PR DESCRIPTION
### WHY are these changes introduced?
- The cursor is lost, when the user cancel the CLI process using `ctrl+c` while having an active list prompt
![16-37-2ddfr-50kqm](https://user-images.githubusercontent.com/105213827/190651882-a50d3bf3-73cb-4b5c-8c72-0ce0a35836d3.gif)


### WHAT is this pull request doing?
- The cursor is showed always in the prompt list, even if there is no change to use filtering
![16-39-g7vem-67hey](https://user-images.githubusercontent.com/105213827/190652318-307dbdb0-e367-4832-976a-07a5bb42a291.gif)

### How to test your changes?
- Run any command that prompts for a user selection using a list. Push `ctrl+c` and the cursor in the terminal must be shown

- [] I've made sure that any changes to `dev` or `deploy` have been reflected in the [the documentation](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
