### PR TITLE
Link to customer account extensions in dev mode

### DIFF
--- a/packages/app/src/cli/services/dev/output.test.ts
+++ b/packages/app/src/cli/services/dev/output.test.ts
@@ -1,0 +1,60 @@
+import {outputExtensionsMessages} from './output.js'
+import {testApp} from '../../models/app/app.test-data.js'
+import {AppInterface} from '../../models/app/app.js'
+import {describe, expect, it} from 'vitest'
+import {outputMocker, path} from '@shopify/cli-kit'
+
+describe('output', () => {
+  it('logs the correct output extension message when the given app contains a customer-accounts-ui-extension', async () => {
+    const outputMock = outputMocker.mockAndCaptureOutput()
+    const appMock = mockApp()
+
+    outputExtensionsMessages(appMock, 'shop1010', 'https://f97b-95-91-224-153.eu.ngrok.io')
+
+    const expectedOutput = `
+      customer-accounts-ui-extension (Customer accounts UI)
+      Please open https://f97b-95-91-224-153.eu.ngrok.io and click on 'Visit Site' and then close the tab to allow connections.
+      Preview link: https://shop1010.account./extensions-development?origin=https%3A%2F%2Ff97b-95-91-224-153.eu.ngrok.io%2Fextensions&extensionId=dev-94b5f0a6-1264-461d-8f78-08db4565b044
+    `.replace(/\s/g, '')
+
+    expect(outputMock.output().replace(/\s/g, '')).toStrictEqual(expectedOutput)
+  })
+})
+
+function mockApp(currentVersion = '2.2.2'): AppInterface {
+  const nodeDependencies: {[key: string]: string} = {}
+  nodeDependencies['@shopify/cli'] = currentVersion
+  return testApp({
+    name: 'my-super-customer-accounts-app',
+    directory: '/',
+    configurationPath: path.join('/', 'shopify.app.toml'),
+    configuration: {
+      scopes: 'my-scope',
+    },
+    nodeDependencies,
+    extensions: {
+      ui: [
+        {
+          configuration: {
+            name: 'customer-accounts-ui-extension',
+            type: 'customer_accounts_ui_extension',
+            version: '1.0.0',
+            categories: ['returns'],
+            metafields: [{key: '', namespace: ''}],
+          },
+          devUUID: 'dev-94b5f0a6-1264-461d-8f78-08db4565b044',
+          outputBundlePath: '/extensions/ui-extension',
+          entrySourceFilePath: '/extensions/ui-extension/index.js',
+          configurationPath: '/extensions/ui-extension/shopify.app.yml',
+          directory: '/extensions/ui-extension',
+          graphQLType: 'CustomerAccountsUiExtension',
+          idEnvironmentVariableName: 'SHOPIFY_UI_EXTENSION_ID',
+          localIdentifier: 'ui-extension',
+          type: 'customer_accounts_ui_extension',
+        },
+      ],
+      theme: [],
+      function: [],
+    },
+  })
+}

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -58,7 +58,7 @@ function outputUIExtensionsURLs(extensions: UIExtension[], storeFqdn: string, ur
         break
       }
       case 'customer_accounts_ui_extension': {
-        message = customerAccountsUIMessage(url, extension).value
+        message = customerAccountsUIMessage(storeFqdn, url, extension).value
         break
       }
       case 'product_subscription': {
@@ -122,9 +122,13 @@ function checkoutUIMessage(url: string, extension: UIExtension) {
   return output.content`Preview link: ${publicURL}`
 }
 
-function customerAccountsUIMessage(url: string, extension: UIExtension) {
-  const publicURL = `${url}/extensions/${extension.devUUID}`
-  return output.content`Preview link: ${publicURL}`
+function customerAccountsUIMessage(storeFqdn: string, url: string, extension: UIExtension) {
+  const [storeName, ...storeDomainParts] = storeFqdn.split('.')
+  const accountsUrl = `${storeName}.account.${storeDomainParts.join('.')}`
+  const origin = encodeURIComponent(`${url}/extensions`)
+  const publicURL = `https://${accountsUrl}/extensions-development?origin=${origin}&extensionId=${extension.devUUID}`
+  const notice = `Please open ${url} and click on 'Visit Site' and then close the tab to allow connections.\n`
+  return output.content`${notice}Preview link: ${publicURL}`
 }
 
 function productSubscriptionMessage(url: string, extension: UIExtension) {


### PR DESCRIPTION
This prints a link when developing customer account ui extensions that will set up the developer experience for your dev store (also works in spin) to load extensions via the cli/ngrok.

### WHY are these changes introduced?

This is part of https://github.com/Shopify/core-issues/issues/43741


### WHAT is this pull request doing?

It constructs a url that will set up customer accounts web to use the local extensions. The construction of the url is not very nice, but given that we will migrate to shopify.com with customer accounts in the near-ish future we did not want to spend a lot of time making this work nicely just to throw it away.

### How to test your changes?

Create a new customer accounts ui extension and run `yarn dev` from this branch - the new url should show up.
For it to work you also need to make sure this [core pr](https://github.com/Shopify/shopify/pull/377520) is either merged or you use spin and this [customer accounts web PR] is either merged or you are in spin.

It is okay to deploy those changes before the other PRs land since customer account ui extensions are not public yet.

### Post-release steps

- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [the documentation](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
