### PR TITLE
Fixed analytics name overriding

### DIFF
--- a/.changeset/fresh-insects-heal.md
+++ b/.changeset/fresh-insects-heal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+The overriden command name is correctly used

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -67,7 +67,7 @@ export default class AppScaffoldExtension extends Command {
   static args = [{name: 'file'}]
 
   public static analyticsNameOverride(): string | undefined {
-    return 'scaffold'
+    return 'dev scaffold extension'
   }
 
   public async run(): Promise<void> {

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -67,7 +67,7 @@ export default class AppScaffoldExtension extends Command {
   static args = [{name: 'file'}]
 
   public static analyticsNameOverride(): string | undefined {
-    return 'dev scaffold extension'
+    return 'app scaffold extension'
   }
 
   public async run(): Promise<void> {

--- a/packages/cli-kit/src/analytics.ts
+++ b/packages/cli-kit/src/analytics.ts
@@ -19,7 +19,7 @@ interface StartOptions {
 
 export const start = async ({command, args, currentTime = new Date().getTime(), commandClass}: StartOptions) => {
   let startCommand: string = command
-  if (commandClass && Object.prototype.hasOwnProperty.call(command, 'analyticsNameOverride')) {
+  if (commandClass && Object.prototype.hasOwnProperty.call(commandClass, 'analyticsNameOverride')) {
     startCommand = (commandClass as typeof BaseCommand).analyticsNameOverride() ?? command
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?
- New feature for overriding default command name was not working properly.

### WHAT is this pull request doing?
- Fixes command name overriding feature
- `generate` command sends `dev scaffold extension` like it was be doing by `scaffold` command previously

### How to test your changes?
- Run the command `yarn shopify app generate extension --verbose` the command name  `dev scaffold extension` should be shown

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
