### PR TITLE
Apply fixes proposed on #370 + use previous selected app

### DIFF
--- a/.changeset/blue-boats-hug.md
+++ b/.changeset/blue-boats-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix an issue to avoid duplicated app selection when users execute `dev --reset`

--- a/packages/app/src/cli/services/dev/theme-extension-args.test.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.test.ts
@@ -1,6 +1,6 @@
 import {themeExtensionArgs} from './theme-extension-args'
 import {ensureThemeExtensionDevEnvironment} from '../environment'
-import {testApp, testThemeExtensions} from '../../models/app/app.test-data'
+import {testThemeExtensions} from '../../models/app/app.test-data'
 import {beforeAll, describe, expect, it, vi} from 'vitest'
 
 beforeAll(() => {
@@ -12,8 +12,7 @@ describe('themeExtensionArgs', async () => {
   it('returns valid theme extension arguments', async () => {
     const apiKey = 'api_key_0000_1111_2222'
     const token = 'token'
-    const reset = false
-    const options = {app: testApp(), reset, themeExtensionPort: 8282, theme: 'theme ID'}
+    const options = {themeExtensionPort: 8282, theme: 'theme ID'}
     const extension = testThemeExtensions()
 
     const registration = {

--- a/packages/app/src/cli/services/dev/theme-extension-args.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.ts
@@ -1,4 +1,3 @@
-import {AppInterface} from '../../models/app/app.js'
 import {ThemeExtension} from '../../models/app/extensions.js'
 import {ensureThemeExtensionDevEnvironment} from '../environment.js'
 
@@ -6,9 +5,9 @@ export async function themeExtensionArgs(
   extension: ThemeExtension,
   apiKey: string,
   token: string,
-  options: {app: AppInterface; theme?: string; themeExtensionPort?: number; reset: boolean},
+  options: {theme?: string; themeExtensionPort?: number},
 ) {
-  const extensionRegistration = await ensureThemeExtensionDevEnvironment(options, extension, token)
+  const extensionRegistration = await ensureThemeExtensionDevEnvironment(extension, apiKey, token)
   const extensionId = extensionRegistration.id
   const directory = extension.directory
   const extensionTitle = extension.localIdentifier

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -497,11 +497,10 @@ describe('ensureDeployEnvironment', () => {
 describe('ensureThemeExtensionDevEnvironment', () => {
   test('fetches theme extension when it exists', async () => {
     // Given
-    const app = testApp()
     const token = 'token'
+    const apiKey = 'apiKey'
     const extension = testThemeExtensions()
 
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({
       app: {
         extensionRegistrations: [
@@ -522,7 +521,7 @@ describe('ensureThemeExtensionDevEnvironment', () => {
     })
 
     // When
-    const got = await ensureThemeExtensionDevEnvironment({app, reset: false}, extension, token)
+    const got = await ensureThemeExtensionDevEnvironment(extension, apiKey, token)
 
     // Then
     expect('existing ID').toEqual(got.id)
@@ -533,11 +532,10 @@ describe('ensureThemeExtensionDevEnvironment', () => {
 
   test('creates theme extension when it does not exist', async () => {
     // Given
-    const app = testApp()
     const token = 'token'
+    const apiKey = 'apiKey'
     const extension = testThemeExtensions()
 
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({
       app: {extensionRegistrations: []},
     })
@@ -549,7 +547,7 @@ describe('ensureThemeExtensionDevEnvironment', () => {
     })
 
     // When
-    const got = await ensureThemeExtensionDevEnvironment({app, reset: false}, extension, token)
+    const got = await ensureThemeExtensionDevEnvironment(extension, apiKey, token)
 
     // Then
     expect('new ID').toEqual(got.id)

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -229,13 +229,10 @@ export async function fetchDevAppAndPrompt(app: AppInterface, token: string): Pr
 }
 
 export async function ensureThemeExtensionDevEnvironment(
-  options: DevEnvironmentOptions,
   extension: ThemeExtension,
+  apiKey: string,
   token: string,
 ): Promise<ExtensionRegistration> {
-  const [partnersApp, _] = await fetchAppAndIdentifiers(options, token)
-  const apiKey = partnersApp.apiKey
-
   const remoteSpecifications = await fetchAppExtensionRegistrations({token, apiKey})
   const remoteRegistrations = remoteSpecifications.app.extensionRegistrations.filter((extension) => {
     return extension.type === 'THEME_APP_EXTENSION'


### PR DESCRIPTION
### WHY are these changes introduced?

This PR applies fixes proposed by https://github.com/Shopify/cli/pull/370#discussion_r973151352 and https://github.com/Shopify/cli/pull/370#discussion_r973152222.

Also, it relies in the previous selected app.

### WHAT is this pull request doing?

This PR moves the fetch process of fetching the `adminSession` and `storefrontToken` to a more suitable place.

Also, it relies in the existing `apiKey` to create the theme app extension (in case it doesn't exist).

### How to test your changes?

- Create an app
- Generate a theme app extension with` yarn shopify app generate extension --path <app_directory>`
- Run yarn `shopify app dev --path <theme_app_extension_directory>`
- Notice the CLI 3.x is running the extension serve command
- Run `dev --reset`
- Notice you won't be prompted more than once

### Post-release steps

Merge the documentation PR https://github.com/Shopify/shopify-dev/pull/26125.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
