### PR TITLE
Extract the business logic of the version command into a service

### DIFF
--- a/packages/cli-main/src/cli/commands/version.ts
+++ b/packages/cli-main/src/cli/commands/version.ts
@@ -1,23 +1,12 @@
+import {versionService} from '../services/commands/version.js'
 import Command from '@shopify/cli-kit/node/base-command'
-import {output, error} from '@shopify/cli-kit'
-import {checkForNewVersion, packageManagerUsedForCreating} from '@shopify/cli-kit/node/node-package-manager'
 
 export default class Version extends Command {
   static description = 'Shopify CLI version'
 
   async run(): Promise<void> {
-    const cliDependency = '@shopify/cli'
-    const currentVersion = this.getCurrentVersion()
-    output.info(output.content`Current ${Version.description}: ${output.token.yellow(currentVersion)}`.value)
-    const lastVersion = await checkForNewVersion(cliDependency, currentVersion)
-    if (lastVersion) {
-      const packageManager = packageManagerUsedForCreating()
-      output.info(output.getOutputUpdateCLIReminder(packageManager === 'unknown' ? 'npm' : packageManager, lastVersion))
-    }
-    throw new error.CancelExecution()
-  }
-
-  getCurrentVersion(): string {
-    return this.config.version
+    await versionService({
+      currentVersion: this.config.version,
+    })
   }
 }

--- a/packages/cli-main/src/cli/services/commands/version.test.ts
+++ b/packages/cli-main/src/cli/services/commands/version.test.ts
@@ -1,6 +1,6 @@
-import Version from './version'
+import {versionService} from './version'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {outputMocker, output} from '@shopify/cli-kit'
+import {outputMocker, output, error} from '@shopify/cli-kit'
 import {
   checkForNewVersion,
   PackageManager,
@@ -9,7 +9,6 @@ import {
 
 const currentVersion = '2.2.2'
 beforeEach(() => {
-  vi.spyOn(Version.prototype as any, 'getCurrentVersion').mockReturnValue(currentVersion)
   vi.mock('@shopify/cli-kit/node/node-package-manager')
   vi.mock('@shopify/cli-kit', async () => {
     const module: any = await vi.importActual('@shopify/cli-kit')
@@ -40,7 +39,9 @@ describe('check CLI version', () => {
       const outputReminder = vi.mocked(output.getOutputUpdateCLIReminder).mockReturnValue('CLI reminder')
 
       // When
-      await Version.run()
+      await expect(async () => {
+        await versionService({currentVersion})
+      }).rejects.toThrowError(new error.CancelExecution())
 
       // Then
       expect(outputMock.info()).toMatchInlineSnapshot(`
@@ -58,7 +59,9 @@ describe('check CLI version', () => {
     vi.mocked(checkForNewVersion).mockResolvedValue(currentVersion)
 
     // When
-    await Version.run()
+    await expect(async () => {
+      await versionService({currentVersion})
+    }).rejects.toThrowError(new error.CancelExecution())
 
     // Then
     expect(outputMock.info()).toMatchInlineSnapshot(`
@@ -74,7 +77,9 @@ describe('check CLI version', () => {
     vi.mocked(checkForNewVersion).mockResolvedValue(undefined)
 
     // When
-    await Version.run()
+    await expect(async () => {
+      await versionService({currentVersion})
+    }).rejects.toThrowError(new error.CancelExecution())
 
     // Then
     expect(outputMock.info()).toMatchInlineSnapshot('"Current Shopify CLI version: 2.2.2"')

--- a/packages/cli-main/src/cli/services/commands/version.ts
+++ b/packages/cli-main/src/cli/services/commands/version.ts
@@ -1,0 +1,18 @@
+import {output, error} from '@shopify/cli-kit'
+import {checkForNewVersion, packageManagerUsedForCreating} from '@shopify/cli-kit/node/node-package-manager'
+
+interface VersionServiceOptions {
+  currentVersion: string
+}
+
+export async function versionService(options: VersionServiceOptions): Promise<void> {
+  const cliDependency = '@shopify/cli'
+  const currentVersion = options.currentVersion
+  output.info(output.content`Current Shopify CLI version: ${output.token.yellow(currentVersion)}`.value)
+  const lastVersion = await checkForNewVersion(cliDependency, currentVersion)
+  if (lastVersion) {
+    const packageManager = packageManagerUsedForCreating()
+    output.info(output.getOutputUpdateCLIReminder(packageManager === 'unknown' ? 'npm' : packageManager, lastVersion))
+  }
+  throw new error.CancelExecution()
+}


### PR DESCRIPTION
### WHY are these changes introduced?
While working on the migration from Go to Node I noticed the tests of the `version` command started failing even though there's no connection between that command and the extensions' serve logic.

### WHAT is this pull request doing?
Placing business logic in commands is a discouraged pattern because it leads to integration tests that test the integration of the business logic and oclif's setup. Therefore I created a service, `versionService` that allows unit-testing the logic in isolation.

### How to test your changes?
Tests should pass and `version` should yield the right content.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
