### PR TITLE
Add missing import that causes the production version of the CLI to fail

### DIFF
--- a/.changeset/large-dodos-unite.md
+++ b/.changeset/large-dodos-unite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Add missing import that causes the CLI execution to fail in production

--- a/packages/cli-main/bin/run.js
+++ b/packages/cli-main/bin/run.js
@@ -2,4 +2,6 @@
 
 process.removeAllListeners('warning');
 
+import runCLI from "../dist/index.js";
+
 runCLI({development: false})

--- a/packages/features/lib/constants.ts
+++ b/packages/features/lib/constants.ts
@@ -11,7 +11,7 @@ export const directories = {
 }
 
 export const executables = {
-  cli: path.resolve(__dirname, '../../../packages/cli-main/bin/dev.js'),
-  createApp: path.resolve(__dirname, '../../../packages/create-app/bin/dev.js'),
-  createHydrogen: path.resolve(__dirname, '../../../packages/create-hydrogen/bin/dev.js'),
+  cli: path.resolve(__dirname, '../../../packages/cli-main/bin/run.js'),
+  createApp: path.resolve(__dirname, '../../../packages/create-app/bin/run.js'),
+  createHydrogen: path.resolve(__dirname, '../../../packages/create-hydrogen/bin/run.js'),
 }


### PR DESCRIPTION
### WHY are these changes introduced?
A recent refactoring in the executables led to a missing import that will cause the production version of the CLI not to work.

### WHAT is this pull request doing?
I'm adding the missing import.

### How to test your changes?
1. `yarn build`.
2. `node packages/cli-main/bin/run.js` should run.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
