### PR TITLE
Add upgrade message to hydrogen info for CLI packages

### DIFF
--- a/.changeset/tough-bees-end.md
+++ b/.changeset/tough-bees-end.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+The `hydrogen info` command will display a message if an update is available to the cli dependencies.

--- a/packages/cli-hydrogen/src/cli/commands/hydrogen/info.ts
+++ b/packages/cli-hydrogen/src/cli/commands/hydrogen/info.ts
@@ -24,7 +24,7 @@ export default class Info extends Command {
     const directory = flags.path ? path.resolve(flags.path) : process.cwd()
     const app: HydrogenApp = await loadApp(directory)
 
-    output.info(info(app, {showPrivateData: flags.showToken}))
+    output.info(await info(app, {showPrivateData: flags.showToken}))
     if (app.errors) process.exit(2)
   }
 }


### PR DESCRIPTION

### WHAT is this pull request doing?

This PR prints a notification to upgrade when running `shopify hydrogen info` if the cli-related dependencies are out of date. 

| Before             |  After |
:-------------------------:|:-------------------------:
<img width="443" alt="Screenshot 2022-09-20 at 13 33 48" src="https://user-images.githubusercontent.com/462077/191248291-5de9e7f0-a190-4932-8354-ee3df031e95e.png"> | <img width="674" alt="Screenshot 2022-09-20 at 13 33 23" src="https://user-images.githubusercontent.com/462077/191248282-94ac3e6f-0e96-40c8-baaf-3f70069e174f.png"> 

### How to test your changes?

Pull this branch and run `yarn shopify hydrogen info --path ../../hydrogen-app` with a path to your local hydrogen app. @mynameisadamf @gfscott would love to get your thoughts on the UI and text. I tried some ideas where maybe we print the message at the end and not repeat it, but nothing feels exactly right to me yet.

Will add a similar PR for the hydrogen framework library next.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [the documentation](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
