### PR TITLE
Fix authentication issue when token is expired and invalid/revoked

### DIFF
--- a/.changeset/breezy-spiders-explain.md
+++ b/.changeset/breezy-spiders-explain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix authentication issue when token is expired and invalid/revoked

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,8 +35,6 @@ Fixes #0000 <!-- link to issue if one exists -->
   If it doesn't, feel free to remove this section.
 -->
 
-- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [the documentation](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
-
 ### Measuring impact
 
 How do we know this change was effective? Please choose one:
@@ -49,3 +47,4 @@ How do we know this change was effective? Please choose one:
 
 - [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
 - [ ] I've considered possible [documentation](https://shopify.dev) changes
+- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).

--- a/docs/release.md
+++ b/docs/release.md
@@ -12,7 +12,7 @@ CI will fail and prevent you from merging the PR.
 
 ### Creating a new version
 The steps are:
-1. Locate the [opened PR](https://github.com/Shopify/cli/pulls?q=is%3Apr+is%3Aopen+%22Version+Packages%22+) named **Version Packages**. This PR is automatically created with the first merge in main after a previous release is published. _Changesets_ will automatically detect changes with each merge to main and update automatically the PR and consequently the package.jsons and the dependencies between them
+1. Locate the [opened PR](https://github.com/Shopify/cli/pulls?q=is%3Apr+is%3Aopen+name%3A%22Version+Packages%22) named **Version Packages**. This PR is automatically created with the first merge in main after a previous release is published. _Changesets_ will automatically detect changes with each merge to main and update automatically the PR and consequently the package.jsons and the dependencies between them
 2. Verify that the correct version is updated in every _package.json_, <ins>paying special attention that there is no **major** bump</ins>. Merge the **Version Packages** PR when all checks have passed
 3. Wait until the commit for **Version Packages** becomes <font color="gree">green</font> in [CLI Production Shipit](https://shipit.shopify.io/shopify/cli/production) and push the _Deploy_ button.
 4. Push again on the _Create deploy_ button to start the deployment. Two main tasks are executed:
@@ -20,5 +20,5 @@ The steps are:
        * The release is not created: Retry again from _step 3_
        * Some of the binaries are not correctly uploaded to the release: The release should be deleted manually from Github and then retry again from _step 3_
     2. Publishing of the CLI packages to the [NPM registry](https://www.npmjs.com/package/@shopify/cli). In case an error is produced the extension binary release should be deleted manually from Github and retry again from _step 3_
-5. Once the deployment completes, [find the PR](https://github.com/Shopify/homebrew-shopify/pulls) in the homebrew-shopify repository and merge the changes in the formula.
+5. Once the deployment completes, [find the PR](https://github.com/Shopify/homebrew-shopify/pulls?q=is%3Apr+is%3Aopen+Shopify+CLI) in the homebrew-shopify repository and merge the changes in the formula.
 6. Go through all the [PRs labeled with `includes-post-release-steps`](https://github.com/Shopify/cli/issues?q=label%3Aincludes-post-release-steps+is%3Aclosed) and follow the post-release steps described in those PRs. Delete the labels afterward.

--- a/packages/cli-kit/src/session/validate.test.ts
+++ b/packages/cli-kit/src/session/validate.test.ts
@@ -148,6 +148,21 @@ describe('validateSession', () => {
     expect(got).toBe('needs_full_auth')
   })
 
+  it('returns needs_full_auth if identity token is invalid and partners token is revoked', async () => {
+    // Given
+    const session = {
+      identity: expiredIdentity,
+      applications: validApplications,
+    }
+    vi.mocked(partners.checkIfTokenIsRevoked).mockResolvedValueOnce(true)
+
+    // When
+    const got = await validateSession(requestedScopes, defaultApps, session)
+
+    // Then
+    expect(got).toBe('needs_full_auth')
+  })
+
   it('returns needs_refresh if identity is expired', async () => {
     // Given
     const session = {

--- a/packages/cli-kit/src/session/validate.ts
+++ b/packages/cli-kit/src/session/validate.ts
@@ -69,9 +69,9 @@ The validation of the token for application/identity completed with the followin
 - It's invalid in identity: ${!identityIsValid}
   `)
 
-  if (tokensAreExpired) return 'needs_refresh'
   if (tokensAreRevoked) return 'needs_full_auth'
   if (!identityIsValid) return 'needs_full_auth'
+  if (tokensAreExpired) return 'needs_refresh'
   return 'ok'
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/500

I'm not able to reproduce the issue, but the logs shows:
```
The validation of the token for application/identity completed with the following results:
- It's expired: true
- It's been revoked: true
- It's invalid in identity: true

The current session is valid but needs refresh. Refreshing...
```

If the session is actually invalid, it doesn't need a refresh, but a full re-authentication.

### WHAT is this pull request doing?

- Ensure full re-auth when tokens are invalid or revoked
- Fix the PR template
- Improve some links in the release documentation

### How to test your changes?

Not sure how to reproduce without tweaking the code. But CI must work and also regular authentication:

- `yarn shopify auth logout`
- `yarn dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [the documentation](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
