### PR TITLE
Add a README.md to the template

### DIFF
--- a/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
@@ -1,0 +1,89 @@
+# Checkout-UI extension README
+
+Checkout UI extensions let app developers build custom functionality that merchants can install at defined points in the checkout flow. [More info](https://shopify.dev/api/checkout-extensions/checkout)
+
+
+## Prerequisites
+---
+Make sure you've completed the following prerequisites to develop a Checkout UI extension:
+
+* You have a [Partner Account](https://www.shopify.com/partners).
+* You created a [Development Store](https://shopify.dev/apps/tools/development-stores) and [enabled the developer preview](https://shopify.dev/api/release-notes/developer-previews#previewing-new-features) for checkout UI extensions.
+* Your store is populated with [test products](https://shopify.dev/apps/getting-started/create#step-4-add-and-publish-products-to-your-development-store-for-testing).
+* You have an [ngrok account](https://ngrok.com/) and [auth token](https://dashboard.ngrok.com/auth/your-authtoken).
+    * This is used to preview apps that contain UI extensions with Shopify CLI. More info inthe [ngrok’s documentation](https://ngrok.com/docs#config).
+* You've created a Shopify app that uses [Shopify CLI 3.0 or higher](https://shopify.dev/apps/getting-started/create) (or you've [migrated your existing app](https://shopify.dev/apps/tools/cli/migrate)).
+* You’ve [Created](https://shopify.dev/apps/checkout/custom-banners/getting-started#step-1-generate-a-new-extension) a [Checkout UI extension](https://shopify.dev/api/checkout-extensions/checkout) that you can [Preview](https://shopify.dev/apps/checkout/custom-banners/getting-started#step-2-preview-your-extension) and [Deploy](https://shopify.dev/apps/checkout/custom-banners/getting-started#step-3-deploy-the-extension).
+
+## Tutorials
+---
+The best way to get started is to follow some of the available Extension Tutorials:
+
+
+For creating an extensionL
+* [Enable Extended Delivery Instructions](https://shopify.dev/apps/checkout/delivery-instructions) - Static Renderer
+* [Adding Product Offer Recommendations](https://shopify.dev/apps/checkout/product-offers) - Static Renderer
+* [Creating a Custom Banner](https://shopify.dev/apps/checkout/custom-banners) - Dynamic Renderer
+
+To add specific features to an extension
+* [Adding Field Validation](https://shopify.dev/apps/checkout/validation)
+* [How to Localize an extension](https://shopify.dev/apps/checkout/localize-ui-extensions)
+
+
+## Getting Started
+---
+Initially, your extension will look like the following:
+
+```
+└── my-app
+  └── extensions
+    └── my-checkout-ui-extension
+        ├── src
+        │   └── index.jsx OR index.js // The index page of the checkout UI extension
+        ├── locales
+        │   ├── en.default.json // The default locale for the checkout UI extension
+        │   └── fr.json // The locale file for non-regional French translations
+        └── shopify.ui.extension.toml // The config file for the checkout UI extension
+
+```
+
+Start writing code for your extension simply editing the `src/index.js` file (or equivalent file extension of your choice).
+
+> [!NOTE]
+> By default, the Checkout UI Extension is preconfigured as a [`Dynamic Extension Point`](https://shopify.dev/api/checkout-extensions/checkout#extension-points).
+> You can change it to your desired Extension Point location.
+
+
+To shape your extension you have the following collection of tools available:
+* [UI Components](https://shopify.dev/api/checkout-extensions/checkout/components)
+* [Shopify APIs](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api).
+
+With these tools you'll get access to Shopify-enabled resources (such as [Analytics](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#analytics), [Localization](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#localization) or [Storage](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#storage)) and the frameworks that you need to read (and mutate) data for your Checkout-UI extension (like Shop, Customer, CartLine, MetaFields, etc.).
+
+> [!IMPORTANT]
+> If you are using React, there is also a large collection of [React Hooks available](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks) to ease access to these operations, otherwise you'll need to manually subscribe to the subscribable value directly with a callback.
+
+## FAQ
+---
+* **How can I preview my extension**
+
+    Depending on your extension location they may be either `dynamic` or `static` renderers, which diferr slightly on the process to place them for testing.
+    - `Dynamic renderers`: Using a [query string parameter](https://shopify.dev/apps/checkout/test-ui-extensions#dynamic-extension-points) at the end of the URL you can place your renderer in the desired renderer point.
+    - `Static renderer`: No special work is required here, just note that a static renders is shown only if the section that they are attached to is enabled.
+
+* **How can I change my extension renderer type?**
+
+    To change your extension render type, be mindful that you have to change it in the following places:
+    1. In your `script file`, where you declared the extension (will be either _render()_ or _extend()_), you'll have to change the declared Extension Point.
+    2. In your `settings TOML file` (shopify.ui.extension.toml) you'll have to change the `extension_points` declaration for your new desired type.
+
+## Useful Links
+---
+
+- [Checkout app documentation](https://shopify.dev/apps/checkout)
+
+- [Checkout UI extension documentation](https://shopify.dev/api/checkout-extensions)
+  - [Configuration](https://shopify.dev/api/checkout-extensions/checkout/configuration)
+  - [API Reference](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api)
+  - [UI Components](https://shopify.dev/api/checkout-extensions/checkout/components)
+  - [Available React Hooks](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks)

--- a/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
@@ -7,11 +7,9 @@ Checkout UI extensions let app developers build custom functionality that mercha
 ---
 Make sure to complete [all the prerequisites](https://shopify.dev/apps/checkout/delivery-instructions/getting-started#requirements) from any tutorials to develop a Checkout UI extension.
 
-
 ## Tutorials
 ---
 The best way to get started is to follow some of the available Extension Tutorials:
-
 
 For creating an extension:
 * [Enable extended delivery instructions](https://shopify.dev/apps/checkout/delivery-instructions)

--- a/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
@@ -56,17 +56,24 @@ With these tools you'll get access to Shopify-enabled resources (such as [Analyt
 
 ## FAQ
 ---
-* **How can I preview my extension**
+* **How can I preview my extension?**
 
-    Depending on your extension location they may be either `dynamic` or `static` renderers, which diferr slightly on the process to place them for testing.
-    - `Dynamic renderers`: Using a [query string parameter](https://shopify.dev/apps/checkout/test-ui-extensions#dynamic-extension-points) at the end of the URL you can place your renderer in the desired renderer point.
-    - `Static renderer`: No special work is required here, just note that a static renders is shown only if the section that they are attached to is enabled.
+  1. Make sure you've started your local development server using `npm|yarn|pnpm dev`
+  2. Depending on your selected location they may be either `dynamic` or `static` extension points, which diferr slightly on the process to preview them.
+      - `Dynamic extensions` can be placed using a [query string parameter](https://shopify.dev/apps/checkout/test-ui-extensions#dynamic-extension-points).
+      - `Static extensions` require no extra work, just note that a static extension is shown only if the section that they are attached to is enabled.
 
-* **How can I change my extension renderer type?**
+* **How can I change my extension type?**
 
-    To change your extension render type, be mindful that you have to change it in the following places:
+    To change your extension type, be mindful that you have to change it in the following places:
     1. In your `script file`, where you declared the extension (will be either _render()_ or _extend()_), you'll have to change the declared Extension Point.
     2. In your `settings TOML file` (shopify.ui.extension.toml) you'll have to change the `extension_points` declaration for your new desired type.
+
+* **How do I let merchants customize my extension?**
+
+    You can enable merchants to customize your extension through the [checkout ui extension settings](https://shopify.dev/api/checkout-extensions/checkout/configuration#settings-definition) which define a set of fields and values that the merchant can set from the checkout editor. You can use validation options to apply additional constraints to the data that the setting can store, such as a minimum or maximum value.
+
+    To learn more, you can follow the step-by-step process in the tutorial to [add a custom banner](https://shopify.dev/apps/checkout/custom-banners/add-custom-banner).
 
 ## Useful Links
 ---

--- a/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
@@ -44,8 +44,6 @@ To shape your extension you have the following collection of tools available:
 * [UI components](https://shopify.dev/api/checkout-extensions/checkout/components), the visual elements you can render in your extension.
 * [Extension APIs](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api), which give you access to read and write data in the checkout.
 
-With these tools you'll get access to Shopify-enabled resources (such as [Analytics](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#analytics), [Localization](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#localization) or [Storage](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#storage)) and the frameworks that you need to read (and mutate) data for your Checkout-UI extension (like Shop, Customer, CartLine, MetaFields, etc.).
-
 > If you are using React, there is also a large collection of [React Hooks available](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks) to ease access to these operations, otherwise you'll need to manually subscribe to the subscribable value directly with a callback.
 
 ## FAQ

--- a/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
@@ -5,34 +5,27 @@ Checkout UI extensions let app developers build custom functionality that mercha
 
 ## Prerequisites
 ---
-Make sure you've completed the following prerequisites to develop a Checkout UI extension:
+Make sure to complete [all the prerequisites](https://shopify.dev/apps/checkout/delivery-instructions/getting-started#requirements) from any tutorials to develop a Checkout UI extension.
 
-* You have a [Partner Account](https://www.shopify.com/partners).
-* You created a [Development Store](https://shopify.dev/apps/tools/development-stores) and [enabled the developer preview](https://shopify.dev/api/release-notes/developer-previews#previewing-new-features) for checkout UI extensions.
-* Your store is populated with [test products](https://shopify.dev/apps/getting-started/create#step-4-add-and-publish-products-to-your-development-store-for-testing).
-* You have an [ngrok account](https://ngrok.com/) and [auth token](https://dashboard.ngrok.com/auth/your-authtoken).
-    * This is used to preview apps that contain UI extensions with Shopify CLI. More info inthe [ngrok’s documentation](https://ngrok.com/docs#config).
-* You've created a Shopify app that uses [Shopify CLI 3.0 or higher](https://shopify.dev/apps/getting-started/create) (or you've [migrated your existing app](https://shopify.dev/apps/tools/cli/migrate)).
-* You’ve [Created](https://shopify.dev/apps/checkout/custom-banners/getting-started#step-1-generate-a-new-extension) a [Checkout UI extension](https://shopify.dev/api/checkout-extensions/checkout) that you can [Preview](https://shopify.dev/apps/checkout/custom-banners/getting-started#step-2-preview-your-extension) and [Deploy](https://shopify.dev/apps/checkout/custom-banners/getting-started#step-3-deploy-the-extension).
 
 ## Tutorials
 ---
 The best way to get started is to follow some of the available Extension Tutorials:
 
 
-For creating an extensionL
-* [Enable Extended Delivery Instructions](https://shopify.dev/apps/checkout/delivery-instructions) - Static Renderer
-* [Adding Product Offer Recommendations](https://shopify.dev/apps/checkout/product-offers) - Static Renderer
-* [Creating a Custom Banner](https://shopify.dev/apps/checkout/custom-banners) - Dynamic Renderer
+For creating an extension:
+* [Enable extended delivery instructions](https://shopify.dev/apps/checkout/delivery-instructions)
+* [Adding product offer recommendations](https://shopify.dev/apps/checkout/product-offers)
+* [Creating a custom banner](https://shopify.dev/apps/checkout/custom-banners)
 
 To add specific features to an extension
-* [Adding Field Validation](https://shopify.dev/apps/checkout/validation)
-* [How to Localize an extension](https://shopify.dev/apps/checkout/localize-ui-extensions)
+* [Adding field validation](https://shopify.dev/apps/checkout/validation)
+* [Localizing an exstension](https://shopify.dev/apps/checkout/localize-ui-extensions)
 
 
 ## Getting Started
 ---
-Initially, your extension will look like the following:
+Initially, your extension will have the following files:
 
 ```
 └── my-app
@@ -47,18 +40,18 @@ Initially, your extension will look like the following:
 
 ```
 
-Start writing code for your extension simply editing the `src/index.js` file (or equivalent file extension of your choice).
+You can customize your new extension by editing the code in the `src/index.js` or `src/index.jsx` file.
 
-> By default, the Checkout UI Extension is preconfigured as a [`Dynamic Extension Point`](https://shopify.dev/api/checkout-extensions/checkout#extension-points).
-> You can change it to your desired Extension Point location.
+> By default, your extension is configured to target the `Checkout::Dynamic::Render` [extension point](https://shopify.dev/api/checkout-extensions/checkout#extension-points). This extension point does not have a single location in the checkout where it will appear; instead, a merchant installing your extension will configure where *they* want your extension to show up.
+> If you are building an extension that is tied to existing UI element in the checkout, such as the cart lines or shipping method, you can change the extension point so that your UI extension will render in the correct location. Check out the list of [all available extension points](https://shopify.dev/api/checkout-extensions/checkout#extension-points) to get some inspiration for the kinds of content you can provide with checkout UI extensions.
 
 
 To shape your extension you have the following collection of tools available:
-* [UI Components](https://shopify.dev/api/checkout-extensions/checkout/components)
-* [Shopify APIs](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api).
+* [UI components](https://shopify.dev/api/checkout-extensions/checkout/components), the visual elements you can render in your extension.
+* [Extension APIs](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api), which give you access to read and write data in the checkout.
 
 With these tools you'll get access to Shopify-enabled resources (such as [Analytics](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#analytics), [Localization](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#localization) or [Storage](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#storage)) and the frameworks that you need to read (and mutate) data for your Checkout-UI extension (like Shop, Customer, CartLine, MetaFields, etc.).
-
+4
 > If you are using React, there is also a large collection of [React Hooks available](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks) to ease access to these operations, otherwise you'll need to manually subscribe to the subscribable value directly with a callback.
 
 ## FAQ

--- a/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
@@ -49,7 +49,6 @@ Initially, your extension will look like the following:
 
 Start writing code for your extension simply editing the `src/index.js` file (or equivalent file extension of your choice).
 
-> [!NOTE]
 > By default, the Checkout UI Extension is preconfigured as a [`Dynamic Extension Point`](https://shopify.dev/api/checkout-extensions/checkout#extension-points).
 > You can change it to your desired Extension Point location.
 
@@ -60,7 +59,6 @@ To shape your extension you have the following collection of tools available:
 
 With these tools you'll get access to Shopify-enabled resources (such as [Analytics](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#analytics), [Localization](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#localization) or [Storage](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#storage)) and the frameworks that you need to read (and mutate) data for your Checkout-UI extension (like Shop, Customer, CartLine, MetaFields, etc.).
 
-> [!IMPORTANT]
 > If you are using React, there is also a large collection of [React Hooks available](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks) to ease access to these operations, otherwise you'll need to manually subscribe to the subscribable value directly with a callback.
 
 ## FAQ

--- a/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/README.md
@@ -4,11 +4,9 @@ Checkout UI extensions let app developers build custom functionality that mercha
 
 
 ## Prerequisites
----
 Make sure to complete [all the prerequisites](https://shopify.dev/apps/checkout/delivery-instructions/getting-started#requirements) from any tutorials to develop a Checkout UI extension.
 
 ## Tutorials
----
 The best way to get started is to follow some of the available Extension Tutorials:
 
 For creating an extension:
@@ -21,7 +19,6 @@ To add specific features to an extension
 * [Localizing an exstension](https://shopify.dev/apps/checkout/localize-ui-extensions)
 
 ## Getting Started
----
 Initially, your extension will have the following files:
 
 ```
@@ -52,7 +49,6 @@ With these tools you'll get access to Shopify-enabled resources (such as [Analyt
 > If you are using React, there is also a large collection of [React Hooks available](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks) to ease access to these operations, otherwise you'll need to manually subscribe to the subscribable value directly with a callback.
 
 ## FAQ
----
 * **How can I preview my extension?**
 
   1. Make sure you've started your local development server using `npm|yarn|pnpm dev`
@@ -73,7 +69,6 @@ With these tools you'll get access to Shopify-enabled resources (such as [Analyt
     To learn more, you can follow the step-by-step process in the tutorial to [add a custom banner](https://shopify.dev/apps/checkout/custom-banners/add-custom-banner).
 
 ## Useful Links
----
 
 - [Checkout app documentation](https://shopify.dev/apps/checkout)
 


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, the template for a Checkout UI extension doesn't contain a basic README.md file that helps guiding developers into what the project contains and how can they work with it. This was reflected in the following Issue:

Fixes https://github.com/Shopify/shopify-cli-extensions/issues/300

The Checkout UI GA Launch will take place next 3rd October, which will make the project template to become more exposed. Therefore, providing a README before the date will improve the developer experience when it becomes more used.

### WHAT is this pull request doing?

This PR adds a README.md file to the template so that every generated extension in an app contains this guide.

### How to test your changes?

* In this branch, generate a scaffold for Checkout-UI extension
`yarn shopify app generate extension --path ./fixtures/app`

* If the extension created, will be inside `/fixtures/app` folder should contain the README

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [X] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
