### PR TITLE
Update app init text with generate instead of scaffold

### DIFF
--- a/.changeset/heavy-ads-sit.md
+++ b/.changeset/heavy-ads-sit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': patch
+---
+
+Change 'scaffold' to 'generate' in init app text

--- a/packages/create-app/src/services/init.ts
+++ b/packages/create-app/src/services/init.ts
@@ -154,7 +154,7 @@ async function init(options: InitOptions) {
   ${hyphenizedName} is ready for you to build! Remember to ${output.token.genericShellCommand(`cd ${hyphenizedName}`)}
   Check the setup instructions in your README file
   To preview your project, run ${output.token.packagejsonScript(packageManager, 'dev')}
-  To add extensions, run ${output.token.packagejsonScript(packageManager, 'scaffold extension')}
+  To add extensions, run ${output.token.packagejsonScript(packageManager, 'generate extension')}
   For more details on all that you can build, see the docs: ${output.token.link(
     'shopify.dev',
     'https://shopify.dev',


### PR DESCRIPTION
### WHY are these changes introduced?

After creating an app the help text says to run the `scaffold extension` subcommand.

```bash
yarn create @shopify/app --template node
...

  synergistic-deal-app is ready for you to build! Remember to cd synergistic-deal-app
  Check the setup instructions in your README file
  To preview your project, run yarn dev
  To add extensions, run yarn scaffold extension

...
```

### WHAT is this pull request doing?

Updating the text to say `generate extension` instead.

### How to test your changes?

Locally

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
