### PR TITLE
Use `test` over `it` throughout the codebase

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -106,6 +106,13 @@ module.exports = {
         ],
       },
     ],
+    'jest/consistent-test-it': [
+      'error',
+      {
+        fn: 'test',
+        withinDescribe: 'test',
+      },
+    ],
     'jest/max-nested-describe': [
       'error',
       {

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
@@ -19,7 +19,7 @@ describe('ExtensionServerClient', () => {
   }
 
   describe('initialization', () => {
-    it('connects to the target websocket', async () => {
+    test('connects to the target websocket', async () => {
       const {socket, client} = setup()
 
       expect(client.connection).toBeDefined()
@@ -28,7 +28,7 @@ describe('ExtensionServerClient', () => {
       socket.close()
     })
 
-    it('does not connect to the target websocket if "automaticConnect" is false', async () => {
+    test('does not connect to the target websocket if "automaticConnect" is false', async () => {
       const {client, socket} = setup({
         connection: {automaticConnect: false, url: 'ws://example-host.com:8000/extensions/'},
       })
@@ -41,7 +41,7 @@ describe('ExtensionServerClient', () => {
 
     // eslint-disable-next-line jest/max-nested-describe
     describe('API client', () => {
-      it('is initialized with the given URL', () => {
+      test('is initialized with the given URL', () => {
         const url = 'ws://initial.socket.com'
 
         const client = new ExtensionServerClient({connection: {url}})
@@ -49,7 +49,7 @@ describe('ExtensionServerClient', () => {
         expect(client.api.url).toBe(url.replace('ws', 'http'))
       })
 
-      it('is initialized with a secure URL', () => {
+      test('is initialized with a secure URL', () => {
         const url = 'wss://initial.socket.com'
 
         const client = new ExtensionServerClient({connection: {url}})
@@ -57,7 +57,7 @@ describe('ExtensionServerClient', () => {
         expect(client.api.url).toBe(url.replace('wss', 'https'))
       })
 
-      it('returns extensions filtered by surface option', async () => {
+      test('returns extensions filtered by surface option', async () => {
         const extensions = [
           {uuid: '123', surface: 'admin'},
           {uuid: '456', surface: 'checkout'},
@@ -73,7 +73,7 @@ describe('ExtensionServerClient', () => {
         socket.close()
       })
 
-      it('returns all extensions when surface option is not valid', async () => {
+      test('returns all extensions when surface option is not valid', async () => {
         const extensions = [
           {uuid: '123', surface: 'admin'},
           {uuid: '456', surface: 'checkout'},
@@ -92,7 +92,7 @@ describe('ExtensionServerClient', () => {
   })
 
   describe('on()', () => {
-    it('sends data with extensions filtered by surface option on "connected" event', async () => {
+    test('sends data with extensions filtered by surface option on "connected" event', async () => {
       const {socket, client} = setup({...defaultOptions, surface: 'admin'})
       const connectSpy = vi.fn()
       const data = {
@@ -116,7 +116,7 @@ describe('ExtensionServerClient', () => {
       socket.close()
     })
 
-    it('sends data with all extensions when surface option is not valid on "connected" event', async () => {
+    test('sends data with all extensions when surface option is not valid on "connected" event', async () => {
       const {socket, client} = setup({...defaultOptions, surface: 'abc' as any})
       const connectSpy = vi.fn()
       const data = {
@@ -140,7 +140,7 @@ describe('ExtensionServerClient', () => {
       socket.close()
     })
 
-    it('sends data with extensions filtered by surface option on "update" event', async () => {
+    test('sends data with extensions filtered by surface option on "update" event', async () => {
       const {socket, client} = setup({...defaultOptions, surface: 'admin'})
       const updateSpy = vi.fn()
       const data = {
@@ -164,7 +164,7 @@ describe('ExtensionServerClient', () => {
       socket.close()
     })
 
-    it('sends data with all extensions when surface option is not valid on "update" event', async () => {
+    test('sends data with all extensions when surface option is not valid on "update" event', async () => {
       const {socket, client} = setup({...defaultOptions, surface: 'abc' as any})
       const updateSpy = vi.fn()
       const data = {
@@ -188,7 +188,7 @@ describe('ExtensionServerClient', () => {
       socket.close()
     })
 
-    it('listens to persist events', async () => {
+    test('listens to persist events', async () => {
       const {socket, client} = setup()
       const updateSpy = vi.fn()
       const data = {
@@ -204,7 +204,7 @@ describe('ExtensionServerClient', () => {
       socket.close()
     })
 
-    it('unsubscribes from persist events', async () => {
+    test('unsubscribes from persist events', async () => {
       const {socket, client} = setup()
       const updateSpy = vi.fn()
       const unsubscribe = client.on('update', updateSpy)
@@ -222,7 +222,7 @@ describe('ExtensionServerClient', () => {
       socket.close()
     })
 
-    it('listens to dispatch events', async () => {
+    test('listens to dispatch events', async () => {
       const {socket, client} = setup()
       const unfocusSpy = vi.fn()
 
@@ -237,7 +237,7 @@ describe('ExtensionServerClient', () => {
   })
 
   describe('emit()', () => {
-    it('emits an event', async () => {
+    test('emits an event', async () => {
       const {socket, client} = setup()
       const data = {data: {type: 'unfocus'}, event: 'dispatch'}
 
@@ -248,7 +248,7 @@ describe('ExtensionServerClient', () => {
       socket.close()
     })
 
-    it('warns if trying to "emit" a persist event', async () => {
+    test('warns if trying to "emit" a persist event', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
       const {socket, client} = setup()
 
@@ -262,7 +262,7 @@ describe('ExtensionServerClient', () => {
   })
 
   describe('persist()', () => {
-    it('persists a mutation', async () => {
+    test('persists a mutation', async () => {
       const {socket, client} = setup()
       const data = {event: 'update', data: {extensions: [{uuid: '123'}]}}
 
@@ -273,7 +273,7 @@ describe('ExtensionServerClient', () => {
       socket.close()
     })
 
-    it('warns if trying to "persist" a dispatch event', async () => {
+    test('warns if trying to "persist" a dispatch event', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
       const {socket, client} = setup()
 
@@ -287,7 +287,7 @@ describe('ExtensionServerClient', () => {
   })
 
   describe('connect()', () => {
-    it('updates the client options', () => {
+    test('updates the client options', () => {
       const client = new ExtensionServerClient()
 
       client.connect({connection: {automaticConnect: false}})
@@ -300,7 +300,7 @@ describe('ExtensionServerClient', () => {
       })
     })
 
-    it('does not attempt to connect if the URL is undefined', () => {
+    test('does not attempt to connect if the URL is undefined', () => {
       const client = new ExtensionServerClient()
 
       client.connect()
@@ -308,7 +308,7 @@ describe('ExtensionServerClient', () => {
       expect(client.connection).toBeUndefined()
     })
 
-    it('does not attempt to connect if the URL is empty', () => {
+    test('does not attempt to connect if the URL is empty', () => {
       const client = new ExtensionServerClient({connection: {url: ''}})
 
       client.connect()
@@ -316,7 +316,7 @@ describe('ExtensionServerClient', () => {
       expect(client.connection).toBeUndefined()
     })
 
-    it('re-use existing connection if connect options have not changed', async () => {
+    test('re-use existing connection if connect options have not changed', async () => {
       const initialURL = 'ws://initial.socket.com'
       const initialSocket = new WS(initialURL)
       const client = new ExtensionServerClient({connection: {url: initialURL}})
@@ -335,7 +335,7 @@ describe('ExtensionServerClient', () => {
       initialSocket.close()
     })
 
-    it('creates a new connection if the URL has changed', async () => {
+    test('creates a new connection if the URL has changed', async () => {
       const initialURL = 'ws://initial.socket.com'
       const initialSocket = new WS(initialURL)
       const updatedURL = 'ws://updated.socket.com'
@@ -358,7 +358,7 @@ describe('ExtensionServerClient', () => {
       updatedSocket.close()
     })
 
-    it('initializes the API client if the URL was changed', () => {
+    test('initializes the API client if the URL was changed', () => {
       const initialURL = 'ws://initial.socket.com'
       const updatedURL = 'ws://updated.socket.com'
       const client = new ExtensionServerClient({connection: {url: initialURL}})

--- a/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
+++ b/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
@@ -12,7 +12,7 @@ import {
 import type {ExtensionServerState} from './types'
 
 describe('extensionServerReducer()', () => {
-  it('connects to server', () => {
+  test('connects to server', () => {
     const app = mockApp()
     const extension = mockExtension()
     const action = createConnectedAction({app, extensions: [extension], store: 'test-store.com'})
@@ -25,7 +25,7 @@ describe('extensionServerReducer()', () => {
     })
   })
 
-  it('replaces existing app and extensions when connecting twice', () => {
+  test('replaces existing app and extensions when connecting twice', () => {
     const app = mockApp()
     const extension = mockExtension()
     const action1 = createConnectedAction({app, extensions: [extension], store: 'test-store.com'})
@@ -50,7 +50,7 @@ describe('extensionServerReducer()', () => {
     })
   })
 
-  it('receives updates from the server', () => {
+  test('receives updates from the server', () => {
     const extension1 = mockExtension()
     const extension2 = mockExtension()
     const previousState: ExtensionServerState = {
@@ -71,7 +71,7 @@ describe('extensionServerReducer()', () => {
     })
   })
 
-  it('maintains extension order after update', () => {
+  test('maintains extension order after update', () => {
     const extension1 = mockExtension()
     const extension2 = mockExtension()
     const previousState: ExtensionServerState = {
@@ -93,7 +93,7 @@ describe('extensionServerReducer()', () => {
   })
 
   // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('refreshes extension url', async () => {
+  test.skip('refreshes extension url', async () => {
     const extension = mockExtension()
     const previousState: ExtensionServerState = {
       store: 'test-store.com',
@@ -122,7 +122,7 @@ describe('extensionServerReducer()', () => {
   })
 
   describe('focus', () => {
-    it('focuses only one extension', () => {
+    test('focuses only one extension', () => {
       const extension1 = mockExtension()
       const extension2 = mockExtension()
 
@@ -143,7 +143,7 @@ describe('extensionServerReducer()', () => {
       expect(state2.extensions[1].development.focused).toBe(true)
     })
 
-    it('unfocuses extension', () => {
+    test('unfocuses extension', () => {
       const extension = mockExtension({development: {focused: true}})
 
       const previousState: ExtensionServerState = {

--- a/packages/ui-extensions-server-kit/src/utilities/replaceUpdated.test.ts
+++ b/packages/ui-extensions-server-kit/src/utilities/replaceUpdated.test.ts
@@ -2,7 +2,7 @@
 import {replaceUpdated} from './replaceUpdated'
 
 describe('replaceUpdated', () => {
-  it('replaces updated items in place, and appends new items', () => {
+  test('replaces updated items in place, and appends new items', () => {
     const arr = [
       {id: 1, a: 'a'},
       {id: 2, a: 'b'},

--- a/packages/ui-extensions-server-kit/src/utilities/resourceURLtoString.test.ts
+++ b/packages/ui-extensions-server-kit/src/utilities/resourceURLtoString.test.ts
@@ -2,7 +2,7 @@ import {resourceURLtoString} from './resourceURLtoString'
 import type {ResourceURL} from '../types'
 
 describe('resourceURLtoString tests', () => {
-  it('creates a URL string from a resource url', () => {
+  test('creates a URL string from a resource url', () => {
     const resource: ResourceURL = {
       name: 'main',
       url: 'http://localhost:8000/extensions/00000000/assets/main.js',

--- a/packages/ui-extensions-server-kit/src/utilities/set.test.ts
+++ b/packages/ui-extensions-server-kit/src/utilities/set.test.ts
@@ -2,7 +2,7 @@
 import {set} from './set'
 
 describe('set()', () => {
-  it('deep sets object without mutation', () => {
+  test('deep sets object without mutation', () => {
     const obj = {
       a: {b: {c: {d: '123'}}},
     }


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed we are inconsistently using `it` and `test` when defining test cases so I'm adding a linting rule to ensure we all use the same one.

### WHAT is this pull request doing?
`it` seems to exist in Vitest for compatibility reasons with Jest because all [the references](https://vitest.dev/api/#test) in their documentation are to the `test` API so I'm defaulting to that one to align with Vitest's defaults.

### How to test your changes?
Run `yarn lint`.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
