### PR TITLE
Added app ID to URL

### DIFF
--- a/packages/ui-extensions-dev-console/src/QRCodeModal/QRCodeModal.test.tsx
+++ b/packages/ui-extensions-dev-console/src/QRCodeModal/QRCodeModal.test.tsx
@@ -1,78 +1,75 @@
-import React from 'react';
-import QRCode from 'qrcode.react';
-import {mockApp, mockExtension} from '@shopify/ui-extensions-server-kit/testing';
-import {render, withProviders} from '@shopify/ui-extensions-test-utils';
-import {ToastProvider} from '@/hooks/useToast';
-import {mockI18n} from 'tests/mock-i18n';
-import {DefaultProviders} from 'tests/DefaultProviders';
+import en from './translations/en.json'
+import {QRCodeModal} from './QRCodeModal'
+import React from 'react'
+import QRCode from 'qrcode.react'
+import {mockApp, mockExtension} from '@shopify/ui-extensions-server-kit/testing'
+import {render, withProviders} from '@shopify/ui-extensions-test-utils'
+import {mockI18n} from 'tests/mock-i18n'
+import {DefaultProviders} from 'tests/DefaultProviders'
+import {ToastProvider} from '@/hooks/useToast'
 
-import en from './translations/en.json';
-import {QRCodeModal} from './QRCodeModal';
+vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
 
-vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
-
-const i18n = mockI18n(en);
+const i18n = mockI18n(en)
 
 describe('QRCodeModal', () => {
   it('does not render QRCode if extension is not provided', async () => {
-    const app = mockApp();
-    const store = 'example.com';
-    const extension = mockExtension();
-    const container = render(
-      <QRCodeModal onClose={vi.fn()} open />,
-      withProviders(DefaultProviders, ToastProvider),
-      {state: {app, store, extensions: [extension]}},
-    );
+    const app = mockApp()
+    const store = 'example.com'
+    const extension = mockExtension()
+    const container = render(<QRCodeModal onClose={vi.fn()} open />, withProviders(DefaultProviders, ToastProvider), {
+      state: {app, store, extensions: [extension]},
+    })
 
-    expect(container).not.toContainReactComponent(QRCode);
-  });
+    expect(container).not.toContainReactComponent(QRCode)
+  })
 
   it('renders QRCode with mobile deep-link url', async () => {
-    const app = mockApp();
-    const store = 'example.com';
-    const extension = mockExtension();
+    const app = mockApp()
+    const store = 'example.com'
+    const extension = mockExtension()
     const container = render(
       <QRCodeModal extension={extension} onClose={vi.fn()} open />,
       withProviders(DefaultProviders, ToastProvider),
       {state: {app, store, extensions: [extension]}},
-    );
+    )
 
     expect(container?.find(QRCode)?.prop('value')).toStrictEqual(
       `https://example.com/admin/extensions-dev/mobile?url=${extension.development.root.url}`,
-    );
-  });
+    )
+  })
 
   it('renders error message when server is unsecure', async () => {
-    const store = 'example.com';
-    const extension = mockExtension();
+    const store = 'example.com'
+    const extension = mockExtension()
     extension.development.root.url = extension.development.root.url.replace(
       'https://secure-link.com',
       'http://localhost',
-    );
+    )
 
     const container = render(
       <QRCodeModal extension={extension} onClose={vi.fn()} open />,
       withProviders(DefaultProviders, ToastProvider),
       {state: {store, extensions: [extension]}},
-    );
+    )
 
     expect(container).toContainReactComponent('p', {
       children: i18n.translate('qrcode.useSecureURL'),
-    });
-  });
+    })
+  })
 
   it('renders QRCode with pos deep-link url when surface is POS', async () => {
-    const app = mockApp();
-    const store = 'example.com';
-    const extension = mockExtension({surface: 'pos'});
+    const app = mockApp()
+    const store = 'example.com'
+    const extension = mockExtension({surface: 'pos'})
     const container = render(
       <QRCodeModal extension={extension} onClose={vi.fn()} open />,
       withProviders(DefaultProviders, ToastProvider),
       {state: {app, store, extensions: [extension]}},
-    );
+    )
 
     expect(container?.find(QRCode)?.prop('value')).toStrictEqual(
-      `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}`,
-    );
-  });
-});
+      `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}&appId=${app.id}`,
+    )
+  })
+})

--- a/packages/ui-extensions-dev-console/src/QRCodeModal/QRCodeModal.tsx
+++ b/packages/ui-extensions-dev-console/src/QRCodeModal/QRCodeModal.tsx
@@ -1,79 +1,75 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {CircleAlertMajor, DuplicateMinor} from '@shopify/polaris-icons';
-import {Button, Icon, Link, Modal, ModalProps, Stack} from '@shopify/polaris';
-import {useI18n} from '@shopify/react-i18n';
-import copyToClipboard from 'copy-to-clipboard';
-import QRCode from 'qrcode.react';
-import {ExtensionPayload} from '@shopify/ui-extensions-server-kit';
-import {useDevConsoleInternal} from '@/hooks/useDevConsoleInternal';
-import {useToast} from '@/hooks/useToast';
-
-import en from './translations/en.json';
-import * as styles from './QRCodeModal.module.scss';
+import en from './translations/en.json'
+import * as styles from './QRCodeModal.module.scss'
+import React, {useCallback, useMemo} from 'react'
+import {CircleAlertMajor, DuplicateMinor} from '@shopify/polaris-icons'
+import {Button, Icon, Modal, ModalProps, Stack} from '@shopify/polaris'
+import {useI18n} from '@shopify/react-i18n'
+import copyToClipboard from 'copy-to-clipboard'
+import QRCode from 'qrcode.react'
+import {ExtensionPayload} from '@shopify/ui-extensions-server-kit'
+import {useDevConsoleInternal} from '@/hooks/useDevConsoleInternal'
+import {useToast} from '@/hooks/useToast'
 
 export interface QRCodeModalProps extends Pick<ModalProps, 'open' | 'onClose'> {
-  extension?: ExtensionPayload;
+  extension?: ExtensionPayload
 }
 
 export function QRCodeModal({extension, open, onClose}: QRCodeModalProps) {
   const [i18n] = useI18n({
     id: 'QRCodeModal',
     fallback: en,
-  });
+  })
 
   return (
-    <Modal
-      title={i18n.translate('title')}
-      titleHidden
-      open={open}
-      onClose={onClose}
-      sectioned
-      small
-      noScroll
-    >
+    <Modal title={i18n.translate('title')} titleHidden open={open} onClose={onClose} sectioned small noScroll>
       <QRCodeContent extension={extension} />
     </Modal>
-  );
+  )
 }
 
 export function QRCodeContent(props: Pick<QRCodeModalProps, 'extension'>) {
   const [i18n] = useI18n({
     id: 'QRCodeModal',
     fallback: en,
-  });
-  const {extension} = props;
-  const {state} = useDevConsoleInternal();
+  })
+  const {extension} = props
+  const {state} = useDevConsoleInternal()
 
-  const showToast = useToast();
+  const showToast = useToast()
 
   const mobileQRCode = useMemo(() => {
     if (!state.app || !extension) {
-      return undefined;
+      return undefined
     }
 
     if (extension.surface === 'pos') {
-      return `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}`;
+      const posUrl = `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}`
+      if (state.app.id) {
+        return `${posUrl}&appId=${state.app.id}`
+      } else {
+        return `${posUrl}`
+      }
     } else {
-      return `https://${state.store}/admin/extensions-dev/mobile?url=${extension.development.root.url}`;
+      return `https://${state.store}/admin/extensions-dev/mobile?url=${extension.development.root.url}`
     }
-  }, [extension, state.app, state.store]);
+  }, [extension, state.app, state.store])
 
   const onButtonClick = useCallback(() => {
     if (mobileQRCode && copyToClipboard(mobileQRCode)) {
       showToast({
         content: i18n.translate('qrcode.copied'),
-      });
+      })
     }
-  }, [mobileQRCode, showToast, i18n]);
+  }, [mobileQRCode, showToast, i18n])
 
   // We should be checking for development with the code below
   // const isDevelopment = Boolean(import.meta.env.VITE_WEBSOCKET_HOST);
   // Unfortunately, ts-jest is throwing errors. See issue for more details.
   // https://github.com/kulshekhar/ts-jest/issues/1174
-  const isDevelopment = false;
+  const isDevelopment = false
 
   if (!extension) {
-    return null;
+    return null
   }
 
   if (!isDevelopment && extension.development.root.url.includes('localhost')) {
@@ -84,7 +80,7 @@ export function QRCodeContent(props: Pick<QRCodeModalProps, 'extension'>) {
           <p>{i18n.translate('qrcode.useSecureURL')}</p>
         </Stack>
       </div>
-    );
+    )
   }
 
   if (mobileQRCode) {
@@ -95,7 +91,7 @@ export function QRCodeContent(props: Pick<QRCodeModalProps, 'extension'>) {
             {i18n.translate('qrcode.copy')}
           </Button>
         </div>
-        <QRCode value={mobileQRCode!} />
+        <QRCode value={mobileQRCode} />
         <div className={styles.PopoverContent}>
           <p>
             {i18n.translate('qrcode.content', {
@@ -104,8 +100,8 @@ export function QRCodeContent(props: Pick<QRCodeModalProps, 'extension'>) {
           </p>
         </div>
       </div>
-    );
+    )
   }
 
-  return null;
+  return null
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds the appId to the mobile QR code generated for POS. The appId is required for certain APIs that POS makes available to UI extensions. In a dev environment, this is the only way for POS to access the appId for a dev app.

### WHAT is this pull request doing?

It checks to make sure the app exists, and if so adds the appId in the URL QR code.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
