### PR TITLE
Map ia32 arch to 386

### DIFF
--- a/packages/cli-kit/src/os.test.ts
+++ b/packages/cli-kit/src/os.test.ts
@@ -18,6 +18,18 @@ describe('platformAndArch', () => {
     expect(got.arch).toEqual('amd64')
   })
 
+  it("returns the right architecture when it's ia32", () => {
+    // Given
+    vi.mocked(osArch).mockReturnValue('ia32')
+
+    // When
+    const got = platformAndArch('darwin')
+
+    // Got
+    expect(got.platform).toEqual('darwin')
+    expect(got.arch).toEqual('386')
+  })
+
   it('returns the right architecture', () => {
     // Given
     vi.mocked(osArch).mockReturnValue('arm64')

--- a/packages/cli-kit/src/os.ts
+++ b/packages/cli-kit/src/os.ts
@@ -71,6 +71,9 @@ export const platformAndArch = (
   if (arch === 'x64') {
     arch = 'amd64'
   }
+  if (arch === 'ia32') {
+    arch = '386'
+  }
   let platformString = platform as string
   if (platform.match(/^win.+/)) {
     platformString = 'windows'


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We weren't supporting architecture ia32 which is a 386 arch.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Map ia32 to 386 when fetching the go binary.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
If you have a really old 32 machine you could test this, otherwise... 🤷 
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
