### PR TITLE
Added app id to retail mobile qr code

### DIFF
--- a/packages/ui-extensions-dev-console/src/QRCodeModal/QRCodeModal.test.tsx
+++ b/packages/ui-extensions-dev-console/src/QRCodeModal/QRCodeModal.test.tsx
@@ -72,7 +72,7 @@ describe('QRCodeModal', () => {
     );
 
     expect(container?.find(QRCode)?.prop('value')).toStrictEqual(
-      `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}`,
+      `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}&appId=${app.id}`,
     );
   });
 });

--- a/packages/ui-extensions-dev-console/src/QRCodeModal/QRCodeModal.tsx
+++ b/packages/ui-extensions-dev-console/src/QRCodeModal/QRCodeModal.tsx
@@ -52,7 +52,7 @@ export function QRCodeContent(props: Pick<QRCodeModalProps, 'extension'>) {
     }
 
     if (extension.surface === 'pos') {
-      return `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}`;
+      return `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}&appId=${state.app.id}`;
     } else {
       return `https://${state.store}/admin/extensions-dev/mobile?url=${extension.development.root.url}`;
     }


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds the appId to the mobile QR code generated for POS. The appId is required for certain APIs that POS makes available to UI extensions. In a dev environment, this is the only way for POS to access the appId for a dev app.

### WHAT is this pull request doing?

It checks to make sure the app exists, and if so adds the appId in the URL QR code.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
