### PR TITLE
Tunnel by default again

### DIFF
--- a/.changeset/nervous-deers-play.md
+++ b/.changeset/nervous-deers-play.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/app': patch
+'@shopify/app': minor
 ---
 
 Use tunnel by default again (temporary change)

--- a/.changeset/nervous-deers-play.md
+++ b/.changeset/nervous-deers-play.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Use tunnel by default again (temporary change)

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -69,7 +69,7 @@ export default class Dev extends Command {
       hidden: false,
       description: 'Use ngrok to create a tunnel to your service entry point',
       env: 'SHOPIFY_FLAG_TUNNEL',
-      default: false,
+      default: true,
       exclusive: ['tunnel-url', 'no-tunnel'],
     }),
     theme: Flags.string({

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -338,24 +338,6 @@ describe('generateFrontendURL', () => {
     expect(got).toEqual({frontendUrl: 'https://fake-url.ngrok.io', frontendPort: 3042, usingLocalhost: false})
   })
 
-  it('generates a tunnel url when tunnel is false and there is no tunnelUrl and there are extensions', async () => {
-    // Given
-    vi.mocked(plugins.runTunnelPlugin).mockResolvedValueOnce({url: 'https://fake-url.ngrok.io'})
-    const options = {
-      app: testApp({hasUIExtensions: () => true}),
-      tunnel: false,
-      noTunnel: false,
-      commandConfig: new Config({root: ''}),
-    }
-
-    // When
-    const got = await generateFrontendURL(options)
-
-    // Then
-    expect(got).toEqual({frontendUrl: 'https://fake-url.ngrok.io', frontendPort: 3042, usingLocalhost: false})
-    expect(ui.prompt).toBeCalled()
-  })
-
   it('returns localhost if tunnel is false and there is no tunnelUrl nor extensions', async () => {
     // Given
     const options = {
@@ -422,25 +404,6 @@ describe('generateFrontendURL', () => {
 
     // Then
     await expect(got).rejects.toThrow()
-  })
-
-  it('Stores the tunnel plugin in your presets if you select always', async () => {
-    // Given
-    vi.mocked(plugins.runTunnelPlugin).mockResolvedValueOnce({url: 'https://fake-url.ngrok.io'})
-    vi.mocked(ui.prompt).mockResolvedValue({value: 'always'})
-    const options = {
-      app: testApp({hasUIExtensions: () => true, directory: '/app-path'}),
-      tunnel: true,
-      noTunnel: false,
-      commandConfig: new Config({root: ''}),
-    }
-
-    // When
-    const got = await generateFrontendURL(options)
-
-    // Then
-    expect(got).toEqual({frontendUrl: 'https://fake-url.ngrok.io', frontendPort: 3042, usingLocalhost: false})
-    expect(store.setAppInfo).toBeCalledWith({directory: '/app-path', tunnelPlugin: 'ngrok'})
   })
 
   it('Reuses tunnel option if cached even if tunnel is false and there are no extensions', async () => {

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -1,4 +1,4 @@
-import {tunnelConfigurationPrompt, updateURLsPrompt} from '../../prompts/dev.js'
+import {updateURLsPrompt} from '../../prompts/dev.js'
 import {AppInterface} from '../../models/app/app.js'
 import {api, environment, error, output, plugins, port, store} from '@shopify/cli-kit'
 import {Config} from '@oclif/core'
@@ -64,20 +64,6 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
     frontendPort = Number(matches[2])
     frontendUrl = matches[1]!
     return {frontendUrl, frontendPort, usingLocalhost}
-  }
-
-  if (needsTunnel && !options.cachedTunnelPlugin) {
-    let message = "We'll run your tunnel with ngrok."
-    const extensionsWarning = 'Some parts of your app can only be previewed with a tunnel to your dev store.'
-    if (hasExtensions) message = `${extensionsWarning} ${message}`
-
-    output.info(`\n${message}\n`)
-
-    const useTunnel = await tunnelConfigurationPrompt()
-    if (useTunnel === 'cancel') throw new error.CancelExecution()
-    if (useTunnel === 'always') {
-      await store.setAppInfo({directory: options.app.directory, tunnelPlugin: 'ngrok'})
-    }
   }
 
   if (needsTunnel) {


### PR DESCRIPTION
### WHY are these changes introduced?

In v3.13.0 we enabled localhost by default for `dev` (https://github.com/Shopify/cli/pull/389), but it's not working properly with old templates.

### WHAT is this pull request doing?

Enable the tunnel flag by default, so that a tunnel is always created unless `--tunnel-url` or `--no-tunnel` are provided. This is a temporal change until we find a way to detect if the current app supports localhost.

### How to test your changes?

- `shopify app dev`
- `shopify app dev --tunel-url https://example.com:3000`
- `shopify app dev --no-tunnel`

### Post-release steps

Merge documentation PR: https://github.com/Shopify/shopify-dev/pull/26435

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
