### PR TITLE
Revert "Source changelogs from GitHub"

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.6.3/schema.json",
-  "changelog": ["@changesets/changelog-github", {"repo": "Shopify/cli"}],
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "__comment": "//All versions must be fixed, we read cli-kit version and assume all other packages have the same one//",
   "fixed": [[


### PR DESCRIPTION
Reverts Shopify/cli#513

Our [changeset workflow](https://github.com/Shopify/cli/actions/workflows/release.yml) is broken since that PR. I'm just reverting for now as I'd like to make a release.