### PR TITLE
Fixed wrong module imports

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -14,10 +14,7 @@ import {fetchProductVariant} from '../utilities/extensions/fetch-product-variant
 import metadata from '../metadata.js'
 import {analytics, output, port, system, session, abort, string} from '@shopify/cli-kit'
 import {Config} from '@oclif/core'
-import {OutputProcess} from '@shopify/cli-kit/src/output.js'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
-import {AdminSession} from '@shopify/cli-kit/src/session.js'
-import {getAnalyticsTunnelType} from '@shopify/cli-kit/src/analytics'
 import {Writable} from 'node:stream'
 
 export interface DevOptions {
@@ -169,7 +166,7 @@ interface DevFrontendTargetOptions extends DevWebOptions {
   backendPort: number
 }
 
-function devFrontendNonProxyTarget(options: DevFrontendTargetOptions, port: number): OutputProcess {
+function devFrontendNonProxyTarget(options: DevFrontendTargetOptions, port: number): output.OutputProcess {
   const devFrontend = devFrontendProxyTarget(options)
   return {
     prefix: devFrontend.logPrefix,
@@ -181,7 +178,7 @@ function devFrontendNonProxyTarget(options: DevFrontendTargetOptions, port: numb
 
 function devThemeExtensionTarget(
   args: string[],
-  adminSession: AdminSession,
+  adminSession: session.AdminSession,
   storefrontToken: string,
   token: string,
 ): output.OutputProcess {
@@ -311,7 +308,7 @@ async function logMetadataForDev(options: {
   shouldUpdateURLs: boolean
   storeFqdn: string
 }) {
-  const tunnelType = await getAnalyticsTunnelType(options.devOptions.commandConfig, options.tunnelUrl)
+  const tunnelType = await analytics.getAnalyticsTunnelType(options.devOptions.commandConfig, options.tunnelUrl)
   await metadata.addPublic(() => ({
     cmd_dev_tunnel_type: tunnelType,
     cmd_dev_tunnel_custom_hash: tunnelType === 'custom' ? string.hashString(options.tunnelUrl) : undefined,


### PR DESCRIPTION
### WHY are these changes introduced?
After merging https://github.com/Shopify/cli/pull/489 some wrong module imports were introduced while fixing the units tests.

### WHAT is this pull request doing?
- Fixed wrong module imports

### How to test your changes?
- `yarn shopify app dev` command should work properly

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
