### PR TITLE
Ping websocket clients periodically

### DIFF
--- a/packages/app/src/cli/services/dev/extension/websocket.test.ts
+++ b/packages/app/src/cli/services/dev/extension/websocket.test.ts
@@ -1,0 +1,103 @@
+import {ExtensionsPayloadStore, ExtensionsPayloadStoreEvent} from './payload/store.js'
+import {setupWebsocketConnection} from './websocket.js'
+import {websocketUpgradeHandler, getPayloadUpdateHandler} from './websocket/handlers.js'
+import {describe, test, expect, vi} from 'vitest'
+import {WebSocketServer} from 'ws'
+import {Server} from 'node:https'
+
+vi.mock('./websocket/handlers.js')
+vi.mock('ws')
+
+describe('setupWebsocketConnection', () => {
+  test('handles upgrades in the HTTP server', () => {
+    // Given
+    const websocketServer = new WebSocketServer()
+    const handler: any = {}
+    const payloadStore: ExtensionsPayloadStore = {on: vi.fn()} as any
+    const httpServer: Server = {on: vi.fn()} as any
+    const options = {httpServer, payloadStore}
+    vi.mocked(websocketUpgradeHandler).mockReturnValue(handler)
+    vi.useFakeTimers()
+
+    // When
+    setupWebsocketConnection(options)
+
+    // Then
+    expect(websocketUpgradeHandler).toHaveBeenCalledWith(websocketServer, options)
+    expect(httpServer.on).toHaveBeenCalledWith('upgrade', handler)
+  })
+  test('handles payload store updates and notifies the clients', () => {
+    // Given
+    const websocketServer = new WebSocketServer()
+    const handler: any = {}
+    const payloadStore: ExtensionsPayloadStore = {on: vi.fn()} as any
+    const httpServer: Server = {on: vi.fn()} as any
+    const options = {httpServer, payloadStore}
+    vi.mocked(getPayloadUpdateHandler).mockReturnValue(handler)
+    vi.useFakeTimers()
+
+    // When
+    setupWebsocketConnection(options)
+
+    // Then
+    expect(getPayloadUpdateHandler).toHaveBeenCalledWith(websocketServer, options)
+    expect(payloadStore.on).toHaveBeenCalledWith(ExtensionsPayloadStoreEvent.Update, handler)
+  })
+
+  test('closes the connection when close is called', () => {
+    // Given
+    const websocketServer = new WebSocketServer()
+    const handler: any = {}
+    const payloadStore: ExtensionsPayloadStore = {on: vi.fn()} as any
+    const httpServer: Server = {on: vi.fn()} as any
+    const options = {httpServer, payloadStore}
+    vi.mocked(getPayloadUpdateHandler).mockReturnValue(handler)
+    vi.useFakeTimers()
+
+    // When
+    setupWebsocketConnection(options).close()
+
+    // Then
+    expect(websocketServer.close).toHaveBeenCalled()
+  })
+
+  test('pings alive clients periodically to keep the connection alive', () => {
+    // Given
+    const handler: any = {}
+    const payloadStore: ExtensionsPayloadStore = {on: vi.fn()} as any
+    const httpServer: Server = {on: vi.fn()} as any
+    const options = {httpServer, payloadStore}
+    const client = {readyState: 1, ping: vi.fn()}
+    WebSocketServer.prototype.clients = [client] as any
+
+    vi.mocked(getPayloadUpdateHandler).mockReturnValue(handler)
+    vi.useFakeTimers()
+
+    // When
+    setupWebsocketConnection(options)
+    vi.advanceTimersToNextTimer()
+
+    // Then
+    expect(client.ping).toHaveBeenCalled()
+  })
+
+  test("doesn't ping disconnected clients periodically", () => {
+    // Given
+    const handler: any = {}
+    const payloadStore: ExtensionsPayloadStore = {on: vi.fn()} as any
+    const httpServer: Server = {on: vi.fn()} as any
+    const options = {httpServer, payloadStore}
+    const client = {readyState: 3, ping: vi.fn()}
+    WebSocketServer.prototype.clients = [client] as any
+
+    vi.mocked(getPayloadUpdateHandler).mockReturnValue(handler)
+    vi.useFakeTimers()
+
+    // When
+    setupWebsocketConnection(options)
+    vi.advanceTimersToNextTimer()
+
+    // Then
+    expect(client.ping).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?
We [implemented](https://github.com/Shopify/cli/pull/38) a long ago some logic to automatically ping websocket clients to keep the connection alive through the tunnel. I'm bringing the logic back to the new Node-based workflow for serving extensions.

### WHAT is this pull request doing?
Extending the websocket setup logic to add the periodic pinger to clients.

### How to test your changes?

- `dev` and open the `dev-console`
- Make sure to open the chrome console and look for Network -> ws (if you don't see anything, reload)
- There should be a connection to `extensions`
- Do not interact with the page for 10 minutes and the connection should still be alive.


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
