### PR TITLE
Fix wasm file binary read failure

### DIFF
--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -484,7 +484,7 @@ describe('uploadFunctionExtensions', () => {
         token,
       )
       expect(http.fetch).toHaveBeenCalledWith(uploadUrl, {
-        body: '',
+        body: Buffer.from(''),
         headers: {'Content-Type': 'application/wasm'},
         method: 'PUT',
       })
@@ -555,7 +555,7 @@ describe('uploadFunctionExtensions', () => {
         token,
       )
       expect(http.fetch).toHaveBeenCalledWith(uploadUrl, {
-        body: '',
+        body: Buffer.from(''),
         headers: {'Content-Type': 'application/wasm'},
         method: 'PUT',
       })
@@ -623,7 +623,7 @@ describe('uploadFunctionExtensions', () => {
         token,
       )
       expect(http.fetch).toHaveBeenCalledWith(uploadUrl, {
-        body: '',
+        body: Buffer.from(''),
         headers: {'Content-Type': 'application/wasm'},
         method: 'PUT',
       })
@@ -746,7 +746,7 @@ describe('uploadFunctionExtensions', () => {
         token,
       )
       expect(http.fetch).toHaveBeenCalledWith(uploadUrl, {
-        body: '',
+        body: Buffer.from(''),
         headers: {'Content-Type': 'application/wasm'},
         method: 'PUT',
       })

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -241,7 +241,7 @@ async function uploadWasmBlob(extension: FunctionExtension, apiKey: string, toke
   const {url, headers, maxSize} = await getFunctionExtensionUploadURL({apiKey, token})
   headers['Content-Type'] = 'application/wasm'
 
-  const functionContent = await file.read(extension.buildWasmPath())
+  const functionContent = await file.read(extension.buildWasmPath(), {})
   const res = await http.fetch(url, {body: functionContent, headers, method: 'PUT'})
   const resBody = res.body?.read()?.toString() || ''
 


### PR DESCRIPTION
Released in https://github.com/Shopify/cli/pull/515, we changed the way we read the wasm file. This method seems to be unable to read binary files correctly so any new deploy will fail due to a compilation failure.

That PR has not been released yet, so no need for a new changelog. 

### How to test your changes?

Try to deploy a function.

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
