### PR TITLE
Add snapshot test to verify all commands load properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:fix:affected": "nx affected --target=lint:fix --all",
     "test": "nx run-many --target=test --all --skip-nx-cache",
     "test:affected": "nx affected --target=test --all",
+    "test:regenerate-snapshots": "nx build cli-main && packages/features/snapshots/regenerate.sh",
     "type-check": "nx run-many --target=type-check --all --skip-nx-cache",
     "type-check:affected": "nx affected --target=type-check --all",
     "build": "nx run-many --target=build --all --skip-nx-cache",

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@oclif/core": "1.9.2",
+    "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5.1.12",
     "@oclif/plugin-plugins": "^2.1.0",
     "@shopify/plugin-ngrok": "^3.15.0",
@@ -78,7 +79,8 @@
       "@shopify/cli-hydrogen",
       "@oclif/plugin-help",
       "@shopify/plugin-ngrok",
-      "@oclif/plugin-plugins"
+      "@oclif/plugin-plugins",
+      "@oclif/plugin-commands"
     ],
     "scope": "shopify",
     "topicSeparator": " ",

--- a/packages/features/features/commands.feature
+++ b/packages/features/features/commands.feature
@@ -1,0 +1,4 @@
+Feature: Loading all commands
+
+Scenario: No runtime errors happen when loading the CLI modules graph
+   Then I see all available commands and they match the snapshot

--- a/packages/features/features/commands.feature
+++ b/packages/features/features/commands.feature
@@ -1,4 +1,5 @@
 Feature: Loading all commands
 
 Scenario: No runtime errors happen when loading the CLI modules graph
-   Then I see all available commands and they match the snapshot
+   When I list the available commands
+   Then I see all commands matching the snapshot

--- a/packages/features/snapshots/commands.txt
+++ b/packages/features/snapshots/commands.txt
@@ -1,0 +1,41 @@
+ app build              @shopify/app           
+ app deploy             @shopify/app           
+ app dev                @shopify/app           
+ app env pull           @shopify/app           
+ app env show           @shopify/app           
+ app generate extension @shopify/app           
+ app info               @shopify/app           
+ auth logout            @shopify/cli           
+ commands               @oclif/plugin-commands 
+ help                   @oclif/plugin-help     
+ hydrogen add tailwind  @shopify/cli-hydrogen  
+ hydrogen build         @shopify/cli-hydrogen  
+ hydrogen dev           @shopify/cli-hydrogen  
+ hydrogen info          @shopify/cli-hydrogen  
+ hydrogen preview       @shopify/cli-hydrogen  
+ logs                   @shopify/cli           
+ ngrok auth             @shopify/plugin-ngrok  
+ plugins                @oclif/plugin-plugins  
+ plugins add            @oclif/plugin-plugins  
+ plugins inspect        @oclif/plugin-plugins  
+ plugins install        @oclif/plugin-plugins  
+ plugins link           @oclif/plugin-plugins  
+ plugins remove         @oclif/plugin-plugins  
+ plugins uninstall      @oclif/plugin-plugins  
+ plugins unlink         @oclif/plugin-plugins  
+ plugins update         @oclif/plugin-plugins  
+ theme check            @shopify/theme         
+ theme delete           @shopify/theme         
+ theme dev              @shopify/theme         
+ theme info             @shopify/theme         
+ theme init             @shopify/theme         
+ theme language-server  @shopify/theme         
+ theme list             @shopify/theme         
+ theme open             @shopify/theme         
+ theme package          @shopify/theme         
+ theme publish          @shopify/theme         
+ theme pull             @shopify/theme         
+ theme push             @shopify/theme         
+ theme share            @shopify/theme         
+ upgrade                @shopify/cli           
+ version                @shopify/cli           

--- a/packages/features/snapshots/regenerate.sh
+++ b/packages/features/snapshots/regenerate.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+# enter this dir so that we can run this script from the top-level
+cd "$(dirname "$0")"
+
+# regenerate commands snapshot file
+../../cli-main/bin/dev.js commands --no-header --columns=Command,Plugin > commands.txt

--- a/packages/features/steps/commands.steps.ts
+++ b/packages/features/steps/commands.steps.ts
@@ -1,0 +1,32 @@
+import {executables} from '../lib/constants'
+import {exec} from '../lib/system'
+import {Then} from '@cucumber/cucumber'
+import * as fs from 'fs/promises'
+import {strict as assert} from 'assert'
+
+const errorMessage = `
+SNAPSHOT TEST FAILED!
+
+The result of 'yarn shopify commands' has changed! We run this to check that
+all commands can load successfully.
+
+It's normal to see this test fail when you add or remove a command in the CLI.
+In this case you can run this command to regenerate the snapshot file:
+
+$ yarn test:regenerate-snapshots
+
+Then you can commit this change and this test will pass.
+
+If instead you didn't mean to change a command, UH OH. Check the commands in
+the diff below and figure out what is broken.
+`
+
+Then(/I see all available commands and they match the snapshot/, async function () {
+  const commandFlags = ['commands', '--no-header', '--columns=Command,Plugin']
+  const result: string = (
+    await exec('node', [executables.cli, ...commandFlags], {env: {...process.env, ...this.temporaryEnv}})
+  ).stdout.trimEnd()
+  const snapshot: string = (await fs.readFile('snapshots/commands.txt', {encoding: 'utf8'})).trimEnd()
+
+  assert.equal(snapshot, result, errorMessage)
+})

--- a/packages/features/steps/commands.steps.ts
+++ b/packages/features/steps/commands.steps.ts
@@ -1,6 +1,6 @@
 import {executables} from '../lib/constants'
 import {exec} from '../lib/system'
-import {Then} from '@cucumber/cucumber'
+import {When, Then} from '@cucumber/cucumber'
 import * as fs from 'fs/promises'
 import {strict as assert} from 'assert'
 
@@ -21,13 +21,15 @@ If instead you didn't mean to change a command, UH OH. Check the commands in
 the diff below and figure out what is broken.
 `
 
-Then(/I see all available commands and they match the snapshot/, async function () {
+When(/I list the available commands/, async function () {
   const commandFlags = ['commands', '--no-header', '--columns=Command,Plugin']
-  const result: string = (
+  this.commandResult = (
     await exec('node', [executables.cli, ...commandFlags], {env: {...process.env, ...this.temporaryEnv}})
   ).stdout
-  const snapshot: string = await fs.readFile('snapshots/commands.txt', {encoding: 'utf8'})
+})
 
+Then(/I see all commands matching the snapshot/, async function () {
+  const snapshot: string = await fs.readFile('snapshots/commands.txt', {encoding: 'utf8'})
   const normalize = (value: string) => value.replace(/\r\n/g, '\n').trimEnd()
-  assert.equal(normalize(snapshot), normalize(result), errorMessage)
+  assert.equal(normalize(snapshot), normalize(this.commandResult), errorMessage)
 })

--- a/packages/features/steps/commands.steps.ts
+++ b/packages/features/steps/commands.steps.ts
@@ -25,8 +25,9 @@ Then(/I see all available commands and they match the snapshot/, async function 
   const commandFlags = ['commands', '--no-header', '--columns=Command,Plugin']
   const result: string = (
     await exec('node', [executables.cli, ...commandFlags], {env: {...process.env, ...this.temporaryEnv}})
-  ).stdout.trimEnd()
-  const snapshot: string = (await fs.readFile('snapshots/commands.txt', {encoding: 'utf8'})).trimEnd()
+  ).stdout
+  const snapshot: string = await fs.readFile('snapshots/commands.txt', {encoding: 'utf8'})
 
-  assert.equal(snapshot, result, errorMessage)
+  const normalize = (value: string) => value.replace(/\r\n/g, '\n').trimEnd()
+  assert.equal(normalize(snapshot), normalize(result), errorMessage)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1715,6 +1715,14 @@
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
+"@oclif/plugin-commands@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-commands/-/plugin-commands-2.2.0.tgz#149e33c496b1159dab104232e5944dc702d3e2ef"
+  integrity sha512-l/iQ+LFd02VXUISY7YcIH9NLPlTaqiqtTK640dorTPag0pJHCH9q0HqiK8apBUhLW7ZfF6c/+wkINJQgz5sgdw==
+  dependencies:
+    "@oclif/core" "^1.2.0"
+    lodash "^4.17.11"
+
 "@oclif/plugin-help@^5.1.12":
   version "5.1.12"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-5.1.12.tgz#24a18631eb9b22cb55e1a3b8e4f6039fd42727e6"
@@ -8599,7 +8607,7 @@ lodash.without@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha512-M3MefBwfDhgKgINVuBJCO1YR3+gf6s9HNJsIiZ/Ru77Ws6uTb9eBuvrkpzO+9iLoAaRodGuq7tyrPCx+74QYGQ==
 
-lodash@4.17.21, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
### WHY are these changes introduced?

We recently broke cli ([here](https://github.com/Shopify/cli/pull/494) and [here](https://github.com/Shopify/cli/pull/528)) by messing up the imports.

This PR introduces a simple [Golden test](https://ro-che.info/articles/2017-12-04-golden-tests) to ensure that all commands that we expect to be present DO load correctly.

### WHAT is this pull request doing?

It creates a snapshot of loaded CLI commands inside the `packages/features/snapshots/commands.txt` file.

### How to test your changes?

- Cd into `packages/features`
- Run `FEATURE=features/commands.feature yarn test`, it should say all good
- Change `./snapshots/commands.txt` and add a new line, i.e. `app fun                @shopify/app`
- Run `FEATURE=features/commands.feature yarn test` again and it should complain in this fashion:
```
1) Scenario: No runtime errors happen when loading the CLI modules graph # features/commands.feature:3
   ✖ Then I see all available commands and they match the snapshot # steps/commands.steps.ts:24
       AssertionError [ERR_ASSERTION]: 
       SNAPSHOT TEST FAILED!
       
       The result of 'yarn shopify commands' has changed! We run this to check that
       all commands can load successfully.
       
       It's normal to see this test fail when you add or remove a command in the CLI.
       In this case you can run this command to regenerate the snapshot file:
       
       $ yarn test:regenerate-snapshots
       
       Then you can commit this change and this test will pass.
       
       If instead you didn't mean to change a command, UH OH. Check the commands in
       the diff below and figure out what is broken.
       
           + expected - actual
       
             app build              @shopify/app           
             app deploy             @shopify/app           
           - app fun                @shopify/app           
             app dev                @shopify/app           
             app env pull           @shopify/app           
             app env show           @shopify/app           
             app generate extension @shopify/app
```
- also test that running `yarn test:regenerate-snapshots` does not create a diff 🙏 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
