### PR TITLE
[Feature] Add the APP_URL to the enviroment variables when running yarn dev

### DIFF
--- a/fixtures/app/extensions/product-subscription/src/index.js
+++ b/fixtures/app/extensions/product-subscription/src/index.js
@@ -12,7 +12,7 @@ function App(root, { extensionPoint }) {
     root.createComponent(
       Text,
       {},
-      `It works the ${extensionPoint} extension!`
+      `It works the ${extensionPoint} extension! APP_URL is: ${process.env.APP_URL}`
     )
   );
   root.mount();

--- a/packages/app/src/cli/services/dev/extension/bundler.test.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.test.ts
@@ -24,10 +24,11 @@ async function testBundlerAndFileWatcher() {
       app: {
         dotenv: {
           variables: {
-            some_key: 'SOME_VALUE',
+            SOME_KEY: 'SOME_VALUE',
           },
         },
       },
+      url: 'mock/url',
       stderr: {
         mockStdErr: 'STD_ERR',
       },
@@ -57,7 +58,8 @@ describe('setupBundlerAndFileWatcher()', () => {
         sourceFilePath: 'source/file/path/1',
         environment: 'development',
         env: {
-          some_key: 'SOME_VALUE',
+          SOME_KEY: 'SOME_VALUE',
+          APP_URL: 'mock/url',
         },
         stderr: {
           mockStdErr: 'STD_ERR',
@@ -74,7 +76,8 @@ describe('setupBundlerAndFileWatcher()', () => {
         sourceFilePath: 'source/file/path/2',
         environment: 'development',
         env: {
-          some_key: 'SOME_VALUE',
+          SOME_KEY: 'SOME_VALUE',
+          APP_URL: 'mock/url',
         },
         stderr: {
           mockStdErr: 'STD_ERR',

--- a/packages/app/src/cli/services/dev/extension/bundler.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.ts
@@ -30,7 +30,10 @@ export async function setupBundlerAndFileWatcher(options: FileWatcherOptions) {
         outputBundlePath: extension.outputBundlePath,
         sourceFilePath: extension.entrySourceFilePath,
         environment: 'development',
-        env: options.devOptions.app.dotenv?.variables ?? {},
+        env: {
+          ...(options.devOptions.app.dotenv?.variables ?? {}),
+          APP_URL: options.devOptions.url,
+        },
         stderr: options.devOptions.stderr,
         stdout: options.devOptions.stdout,
         watchSignal: abortController.signal,


### PR DESCRIPTION
### WHY are these changes introduced?
When developing a UI extension the UI may request data from the app backend.  Unless you specify a tunnel URL when running `yarn dev`, the URL for the app backend may change every time you run `yarn dev`.  This means the developer needs to update the URL to their backend, in their extension src every time they run `yarn dev`, which is not a great experience.

In this PR we introduce an `APP_URL` environment variable, which the UI extension can use to acess it's backend end.

### WHAT is this pull request doing?

1. Add a new `APP_URL` to the esbuild process when running `yarn dev`
2. Update tests.
3. Update a fixture to test that the `APP_URL` env var can be accessed.

### How to test your changes?
Note the new env var only exists for Node Path. This means it will only exist for Shopifolk until we fully migrate away from the Go CLI.

Run `yarn shopify app dev --path ./fixtures/app`. Now open `fixtures/app/extensions/product-subscription/dist/main.js` and search for `APP_URL is:`.  Right next to that text you should see your APP URL.  Check that it lines up with the App URL the CLI outputs, here:

<img width="773" alt="Screen Shot 2022-09-30 at 3 22 56 PM" src="https://user-images.githubusercontent.com/690791/193342166-71a864ac-d67f-4055-93b6-a4f78a45c75d.png">

### Questions I'd appreciate input on:

1. Do we also want to pass env vars to esbuild when the user runs other commands? E.g: `build`, `dev`, `push`, `deploy`?
2. Do we want to pass other Env vars?
3. How do we want to document this for 3P developers?

### Post-release steps
We might need to update documentation.

### Measuring impact
How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
