### PR TITLE
upped checkout-ui-extension version to 0.20.0

### DIFF
--- a/fixtures/app/package.json
+++ b/fixtures/app/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@shopify/admin-ui-extensions-react": "^1.0.1",
     "@shopify/app": "3.15.0",
-    "@shopify/checkout-ui-extensions-react": "^0.19.0",
+    "@shopify/checkout-ui-extensions-react": "^0.20.0",
     "@shopify/cli": "3.15.0",
     "@shopify/post-purchase-ui-extensions-react": "^0.13.3",
     "@shopify/web-pixels-extension": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@octokit/rest": "^19.0.4",
     "@shopify/admin-ui-extensions": "1.0.1",
     "@shopify/admin-ui-extensions-react": "1.0.1",
-    "@shopify/checkout-ui-extensions-react": "0.19.0",
+    "@shopify/checkout-ui-extensions-react": "0.20.0",
     "@shopify/customer-account-ui-extensions-react": "^0.0.8",
     "@shopify/eslint-plugin": "^41.3.0",
     "@shopify/post-purchase-ui-extensions-react": "0.13.3",

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -146,7 +146,7 @@ export function getUIExtensionRendererDependency(extensionType: UIExtensionTypes
     case 'product_subscription':
       return {name: '@shopify/admin-ui-extensions-react', version: '^1.0.1'}
     case 'checkout_ui_extension':
-      return {name: '@shopify/checkout-ui-extensions-react', version: '^0.19.0'}
+      return {name: '@shopify/checkout-ui-extensions-react', version: '^0.20.0'}
     case 'checkout_post_purchase':
       return {name: '@shopify/post-purchase-ui-extensions-react', version: '^0.13.2'}
     case 'pos_ui_extension':

--- a/packages/ui-extensions-go-cli/support/merge_config.rb
+++ b/packages/ui-extensions-go-cli/support/merge_config.rb
@@ -13,7 +13,7 @@ config = TomlRB.parse(STDIN.read).tap do |config|
   }
   config['development']['renderer'] ||= {
     'name' => '@shopify/checkout-ui-extensions',
-    'version' => '0.19.0'
+    'version' => '0.20.0'
   }
 end
 

--- a/packages/ui-extensions-go-cli/testdata/extension.config.integration.yml
+++ b/packages/ui-extensions-go-cli/testdata/extension.config.integration.yml
@@ -17,7 +17,7 @@ extensions:
       main: src/index.jsx
     renderer:
       name: "@shopify/checkout-ui-extensions"
-      version: 0.19.0
+      version: 0.20.0
     build:
       env:
         CUSTOM_VAR: bar

--- a/packages/ui-extensions-go-cli/testdata/extension.config.yml
+++ b/packages/ui-extensions-go-cli/testdata/extension.config.yml
@@ -20,7 +20,7 @@ extensions:
       template: 'javascript-react'
       renderer:
         name: '@shopify/checkout-ui-extensions'
-        version: '0.19.0'
+        version: '0.20.0'
       entries:
         main: 'src/index.jsx'
       resource:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2007,14 +2007,14 @@
     base64url "^3.0.1"
     web-vitals "^2.1.4"
 
-"@shopify/checkout-ui-extensions-react@0.19.0", "@shopify/checkout-ui-extensions-react@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@shopify/checkout-ui-extensions-react/-/checkout-ui-extensions-react-0.19.0.tgz#61e742e58406d3c6b0463ab15eac3033069d1dfd"
-  integrity sha512-1o0bPEH17MU9Ygb8cWzpwN3MEAeUc/nBuQm9MZWQapjG1L3Qkro6pEzM1K2qiEwGzMTOw67NW9at6nZ6zHxVHA==
+"@shopify/checkout-ui-extensions-react@0.20.0", "@shopify/checkout-ui-extensions-react@^0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@shopify/checkout-ui-extensions-react/-/checkout-ui-extensions-react-0.20.0.tgz#dd619f2aee7db700c6871ba46752588ffa53293e"
+  integrity sha512-G2B52oje2ODwWk4jJ5Qg6X2yq4Q3QAMyp2RlJt5d28lpoXHqon0oUnty1xfMK7HIlXJwasNCBer7uvRd4vJ9sA==
   dependencies:
     "@remote-ui/async-subscription" "^2.1.12"
     "@remote-ui/react" "^4.5.11"
-    "@shopify/checkout-ui-extensions" "^0.19.0"
+    "@shopify/checkout-ui-extensions" "^0.20.0"
     "@types/react" ">=17.0.0 <18.0.0"
 
 "@shopify/checkout-ui-extensions-react@^0.17.1":
@@ -2035,10 +2035,10 @@
     "@remote-ui/async-subscription" "^2.1.10"
     "@remote-ui/core" "^2.1.12"
 
-"@shopify/checkout-ui-extensions@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@shopify/checkout-ui-extensions/-/checkout-ui-extensions-0.19.0.tgz#8e50ec0e0cb8e2a76837879ae9cb62d9cf64c169"
-  integrity sha512-2efHL6GvrRxPYA/JCCfTIDwJeOCcvSce46T+4Duht+LinJ6mOJhjroX57zfwaU3V5jKUuFrj+XdVtKQvKcnhuw==
+"@shopify/checkout-ui-extensions@^0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@shopify/checkout-ui-extensions/-/checkout-ui-extensions-0.20.0.tgz#fe949eff62992f71362677e4ce9ce50b900430ca"
+  integrity sha512-mQCidC90I8sKc9IxXIBsxaKo6Lw1HcXTw5PfDyGKUoMkBUNzxR4ln/0XCRaj53/TSa/zY/HNJnlZSH7H6bIzdQ==
   dependencies:
     "@remote-ui/async-subscription" "^2.1.12"
     "@remote-ui/core" "^2.1.15"


### PR DESCRIPTION
### WHY are these changes introduced?

We need to update the cli template for scaffolded extensions to use version 0.20.0. This package was just released today.

### WHAT is this pull request doing?

Bumps up the version number.

### How to test your changes?

Scaffold a new app with a Checkout UI extension and validate the version `0.20.0` is present in the package.json of the app.

### Post-release steps
n/a

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
