### PR TITLE
Improve dev localization watcher tests

### DIFF
--- a/packages/app/src/cli/services/dev/extension/localization.test.ts
+++ b/packages/app/src/cli/services/dev/extension/localization.test.ts
@@ -1,28 +1,31 @@
-import {getLocalization} from './localization.js'
+import {getLocalization, Localization} from './localization.js'
 import {file, path, output} from '@shopify/cli-kit'
 import {describe, expect, it, vi} from 'vitest'
 
-async function testGetLocalization(tmpDir: string) {
-  return getLocalization({
-    configuration: {
-      name: 'mock-name',
-      type: 'checkout_ui_extension',
-      metafields: [],
-      capabilities: {
-        blockProgress: false,
-        networkAccess: false,
+async function testGetLocalization(tmpDir: string, currentLocalization?: Localization) {
+  return getLocalization(
+    {
+      configuration: {
+        name: 'mock-name',
+        type: 'checkout_ui_extension',
+        metafields: [],
+        capabilities: {
+          blockProgress: false,
+          networkAccess: false,
+        },
       },
+      idEnvironmentVariableName: 'mockId',
+      localIdentifier: 'localIdentifier',
+      configurationPath: `${tmpDir}/shopify.ui.extension.toml`,
+      directory: tmpDir,
+      type: 'checkout_ui_extension',
+      graphQLType: 'graphQLType',
+      devUUID: 'dev-uuid',
+      outputBundlePath: `${tmpDir}/dist/main.js`,
+      entrySourceFilePath: `${tmpDir}/dist/main.js`,
     },
-    idEnvironmentVariableName: 'mockId',
-    localIdentifier: 'localIdentifier',
-    configurationPath: `${tmpDir}/shopify.ui.extension.toml`,
-    directory: tmpDir,
-    type: 'checkout_ui_extension',
-    graphQLType: 'graphQLType',
-    devUUID: 'dev-uuid',
-    outputBundlePath: `${tmpDir}/dist/main.js`,
-    entrySourceFilePath: `${tmpDir}/dist/main.js`,
-  })
+    currentLocalization,
+  )
 }
 
 describe('when there are no locale files', () => {
@@ -99,7 +102,24 @@ describe('when there are locale files', () => {
       expect(result.localization!.lastUpdated).equals(timestamp)
     })
   })
+  it('returns the last succesful locale built when there are JSON errors', async () => {
+    let timestamp = 0
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      return (timestamp += 1)
+    })
 
+    await file.inTemporaryDirectory(async (tmpDir) => {
+      await file.mkdir(path.join(tmpDir, 'locales'))
+      await file.write(path.join(tmpDir, 'locales', 'en.json'), '{"greeting": "Hi!"}')
+      const {localization: lastSuccesfulLocalization} = await testGetLocalization(tmpDir)
+
+      await file.write(path.join(tmpDir, 'locales', 'es.json'), '{"greeting: "Hola!"}')
+
+      const result = await testGetLocalization(tmpDir, lastSuccesfulLocalization)
+
+      expect(result.localization!.lastUpdated).equals(lastSuccesfulLocalization!.lastUpdated)
+    })
+  })
   it("returns 'success' as the status when there are no JSON errors", async () => {
     await file.inTemporaryDirectory(async (tmpDir) => {
       await file.mkdir(path.join(tmpDir, 'locales'))
@@ -111,7 +131,6 @@ describe('when there are locale files', () => {
       expect(result.status).toBe('success')
     })
   })
-
   it('outputs message when there are no JSON errors', async () => {
     await file.inTemporaryDirectory(async (tmpDir) => {
       vi.spyOn(output, 'info')

--- a/packages/app/src/cli/services/dev/extension/localization.test.ts
+++ b/packages/app/src/cli/services/dev/extension/localization.test.ts
@@ -41,7 +41,7 @@ describe('when there are no locale files', () => {
   })
 })
 
-describe('when there locale files', () => {
+describe('when there are locale files', () => {
   it('returns defaultLocale using the locale marked as .default', async () => {
     await file.inTemporaryDirectory(async (tmpDir) => {
       await file.mkdir(path.join(tmpDir, 'locales'))
@@ -82,6 +82,11 @@ describe('when there locale files', () => {
   })
 
   it('returns the lastUpdated timestamp of the most recently updated locale', async () => {
+    let timestamp = 0
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      return (timestamp += 1)
+    })
+
     await file.inTemporaryDirectory(async (tmpDir) => {
       await file.mkdir(path.join(tmpDir, 'locales'))
       await file.write(path.join(tmpDir, 'locales', 'en.json'), '{"greeting": "Hi!"}')
@@ -90,7 +95,8 @@ describe('when there locale files', () => {
 
       const result = await testGetLocalization(tmpDir)
 
-      expect(result.localization!.lastUpdated).toBeLessThanOrEqual(Date.now())
+      expect(Date.now).toBeCalledTimes(4)
+      expect(result.localization!.lastUpdated).equals(timestamp)
     })
   })
 

--- a/packages/app/src/cli/services/dev/extension/payload/store.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.test.ts
@@ -246,6 +246,34 @@ describe('ExtensionsPayloadStore()', () => {
         extensions: [{mock: 'getExtensionsPayloadResponse'}, {uuid: '456', development: {status: 'error'}}],
       })
     })
+    test('defaults localization to the current value', async () => {
+      // Given
+      const mockPayload = {
+        mock: 'payload',
+        extensions: [
+          {
+            uuid: '123',
+            development: {status: 'success'},
+            localization: {defaultLocale: 'en', lastUpdated: 100, translations: {en: {welcome: 'Welcome!'}}},
+          },
+        ],
+      } as unknown as ExtensionsEndpointPayload
+
+      const extensionsPayloadStore = new ExtensionsPayloadStore(mockPayload, mockOptions)
+      const updatedExtension = {devUUID: '123', updated: 'extension'} as unknown as UIExtension
+
+      // When
+      await extensionsPayloadStore.updateExtension(updatedExtension)
+
+      // Then
+      expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, {
+        ...mockOptions,
+        currentDevelopmentPayload: {
+          status: 'success',
+        },
+        currentLocalizationPayload: {defaultLocale: 'en', lastUpdated: 100, translations: {en: {welcome: 'Welcome!'}}},
+      })
+    })
 
     test('informs event listeners of the updated extension', async () => {
       // Given


### PR DESCRIPTION
### WHY are these changes introduced?

The flow of fallback to previous successful localization build and lastUpdated timestamp when the current files fail to be parsed is not covered by tests.

### WHAT is this pull request doing?

Added test coverage to the previously described flow

### How to test your changes?

Just run the tests to check if they pass.


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
