### PR TITLE
Provide default 0 timestamp to lastUpdated

### DIFF
--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -28,7 +28,7 @@ export async function getUIExtensionPayload(
       main: {
         name: 'main',
         url: `${url}/assets/main.js`,
-        lastUpdated: await file.lastUpdatedTimestamp(extension.outputBundlePath),
+        lastUpdated: await file.lastUpdatedTimestamp(extension.outputBundlePath).catch((_) => 0),
       },
     },
     capabilities: extension.configuration.capabilities,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#561](https://github.com/Shopify/cli/issues/561)

Serving an extension failed if it was no build beforehand as it tried to get the bundled file modification timestamp before creating the actual file.

### WHAT is this pull request doing?
Fix the issue by providing a default timestamp of 0 when the file is not there.

### How to test your changes?
To reproduce in main:
1. Clean up all the `dist` folders of the fixture extensions: `fixtures/app/extensions/*/dist/`
2. Run `yarn shopify app dev --path fixtures/app` 
3. Watch it crash

To check if the fix is working:
1. Clean up all the `dist` folders of the fixture extensions: `fixtures/app/extensions/*/dist/`
2. Run `yarn shopify app dev --path fixtures/app`
4. check everything is being served properly

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
