### PR TITLE
Render fatal errors with `Banner`

### DIFF
--- a/.changeset/angry-socks-develop.md
+++ b/.changeset/angry-socks-develop.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/cli': patch
+'@shopify/plugin-ngrok': patch
+---
+
+Improve error outputs by using the new Banner component

--- a/packages/cli-kit/src/error.test.ts
+++ b/packages/cli-kit/src/error.test.ts
@@ -1,46 +1,46 @@
 import {Abort, Bug, handler, cleanSingleStackTracePath} from './error.js'
-import {error} from './output.js'
 import {describe, expect, test, vi, beforeEach, it} from 'vitest'
+import {renderFatalError} from '@shopify/cli-kit/node/ui'
 
 beforeEach(() => {
-  vi.mock('./output')
+  vi.mock('@shopify/cli-kit/node/ui')
 })
 
 describe('handler', () => {
   test('error output uses same input error instance when the error type is abort', async () => {
     // Given
     const abortError = new Abort('error message', 'try message')
-    vi.mocked(error).mockResolvedValue()
+    vi.mocked(renderFatalError).mockResolvedValue()
 
     // When
     await handler(abortError)
 
     // Then
-    expect(error).toHaveBeenCalledWith(abortError)
+    expect(renderFatalError).toHaveBeenCalledWith(abortError)
   })
 
   test('error output uses same input error instance when the error type is bug', async () => {
     // Given
     const bugError = new Bug('error message', 'try message')
-    vi.mocked(error).mockResolvedValue()
+    vi.mocked(renderFatalError).mockResolvedValue()
 
     // When
     await handler(bugError)
 
     // Then
-    expect(error).toHaveBeenCalledWith(bugError)
+    expect(renderFatalError).toHaveBeenCalledWith(bugError)
   })
 
   test('error output uses a Bug instance instance when the error type not extends from fatal', async () => {
     // Given
     const unknownError = new Error('Unknown')
-    vi.mocked(error).mockResolvedValue()
+    vi.mocked(renderFatalError).mockResolvedValue()
 
     // When
     await handler(unknownError)
 
     // Then
-    expect(error).toHaveBeenCalledWith(expect.objectContaining({type: expect.any(Number)}))
+    expect(renderFatalError).toHaveBeenCalledWith(expect.objectContaining({type: expect.any(Number)}))
     expect(unknownError).not.contains({type: expect.any(Number)})
   })
 })

--- a/packages/cli-kit/src/error.ts
+++ b/packages/cli-kit/src/error.ts
@@ -1,5 +1,6 @@
-import {Message, stringifyMessage, error as outputError} from './output.js'
+import {Message, stringifyMessage} from './output.js'
 import {normalize} from './path.js'
+import {renderFatalError} from './public/node/ui.js'
 import {Errors} from '@oclif/core'
 
 export {ExtendableError} from 'ts-error'
@@ -75,7 +76,7 @@ export async function handler(error: unknown): Promise<unknown> {
     }
   }
 
-  await outputError(fatal)
+  renderFatalError(fatal)
   return Promise.resolve(error)
 }
 

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
@@ -1,21 +1,60 @@
 import {Banner} from './Banner.js'
 import {List} from './List.js'
-import {Fatal} from '../../../../error.js'
+import {Bug, cleanSingleStackTracePath, Fatal} from '../../../../error.js'
+import {colors} from '../../../../node/colors.js'
 import {Box, Text} from 'ink'
 import React from 'react'
+import StackTracey from 'stacktracey'
 
 export interface FatalErrorProps {
   error: Fatal
 }
 
 const FatalError: React.FC<FatalErrorProps> = ({error}) => {
+  let stack
+
+  if (error instanceof Bug) {
+    stack = new StackTracey(error)
+    stack.items.forEach((item) => {
+      item.file = cleanSingleStackTracePath(item.file)
+    })
+
+    stack = stack.withSources()
+    stack = stack
+      .filter((entry) => {
+        return !entry.file.includes('@oclif/core')
+      })
+      .map((item) => {
+        item.calleeShort = colors.yellow(item.calleeShort)
+        /** We make the paths relative to the packages/ directory */
+        const fileShortComponents = item.fileShort.split('packages/')
+        item.fileShort = fileShortComponents.length === 2 ? fileShortComponents[1]! : fileShortComponents[0]!
+        return item
+      })
+  }
+
   return (
     <Banner type="error">
-      <Box marginBottom={1}>
+      <Box>
         <Text>{error.message}</Text>
       </Box>
 
-      {error.tryMessage && <List title="What to try" items={[error.tryMessage]} />}
+      {error.tryMessage && (
+        <Box marginTop={1}>
+          <List title="What to try" items={[error.tryMessage]} />
+        </Box>
+      )}
+      {stack && stack.items.length !== 0 && (
+        <Box marginTop={1} flexDirection="column">
+          <Text bold>Stack trace:</Text>
+          {stack
+            .asTable({})
+            .split('\n')
+            .map((line, index) => (
+              <Text key={index}>{line}</Text>
+            ))}
+        </Box>
+      )}
     </Banner>
   )
 }

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
@@ -46,17 +46,15 @@ const FatalError: React.FC<FatalErrorProps> = ({error}) => {
         <Box marginTop={1} flexDirection="column">
           <Text bold>Stack trace:</Text>
           {stack.items.map((item, index) => (
-            <Box key={index}>
-              <Box width="20%" paddingRight={1}>
-                <Text wrap="truncate-end">
+            <Box flexDirection="column" key={index}>
+              <Box>
+                <Text>
                   at <Text color="yellow">{item.calleeShort}</Text>
+                  <Text>{item.fileShort && ` (${item.fileShort}:${item.line})`}</Text>
                 </Text>
               </Box>
-              <Box width="35%" paddingRight={1}>
-                <Text wrap="truncate-start">{item.fileShort && `${item.fileShort}: ${item.line}`}</Text>
-              </Box>
-              <Box width="45%">
-                <Text wrap="truncate-end">{item.sourceLine?.trim()}</Text>
+              <Box paddingLeft={1}>
+                <Text dimColor>{item.sourceLine?.trim()}</Text>
               </Box>
             </Box>
           ))}

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
@@ -1,7 +1,6 @@
 import {Banner} from './Banner.js'
 import {List} from './List.js'
 import {Bug, cleanSingleStackTracePath, Fatal} from '../../../../error.js'
-import {colors} from '../../../../node/colors.js'
 import {Box, Text} from 'ink'
 import React from 'react'
 import StackTracey from 'stacktracey'
@@ -25,7 +24,6 @@ const FatalError: React.FC<FatalErrorProps> = ({error}) => {
         return !entry.file.includes('@oclif/core')
       })
       .map((item) => {
-        item.calleeShort = colors.yellow(item.calleeShort)
         /** We make the paths relative to the packages/ directory */
         const fileShortComponents = item.fileShort.split('packages/')
         item.fileShort = fileShortComponents.length === 2 ? fileShortComponents[1]! : fileShortComponents[0]!
@@ -47,12 +45,21 @@ const FatalError: React.FC<FatalErrorProps> = ({error}) => {
       {stack && stack.items.length !== 0 && (
         <Box marginTop={1} flexDirection="column">
           <Text bold>Stack trace:</Text>
-          {stack
-            .asTable({})
-            .split('\n')
-            .map((line, index) => (
-              <Text key={index}>{line}</Text>
-            ))}
+          {stack.items.map((item, index) => (
+            <Box key={index}>
+              <Box width="20%" paddingRight={1}>
+                <Text wrap="truncate-end">
+                  at <Text color="yellow">{item.calleeShort}</Text>
+                </Text>
+              </Box>
+              <Box width="35%" paddingRight={1}>
+                <Text wrap="truncate-start">{item.fileShort && `${item.fileShort}: ${item.line}`}</Text>
+              </Box>
+              <Box width="45%">
+                <Text wrap="truncate-end">{item.sourceLine?.trim()}</Text>
+              </Box>
+            </Box>
+          ))}
         </Box>
       )}
     </Banner>

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
@@ -47,12 +47,10 @@ const FatalError: React.FC<FatalErrorProps> = ({error}) => {
           <Text bold>Stack trace:</Text>
           {stack.items.map((item, index) => (
             <Box flexDirection="column" key={index}>
-              <Box>
-                <Text>
-                  at <Text color="yellow">{item.calleeShort}</Text>
-                  <Text>{item.fileShort && ` (${item.fileShort}:${item.line})`}</Text>
-                </Text>
-              </Box>
+              <Text>
+                at{item.calleeShort && <Text color="yellow">{` ${item.calleeShort}`}</Text>}
+                {item.fileShort && ` (${item.fileShort}:${item.line})`}
+              </Text>
               <Box paddingLeft={1}>
                 <Text dimColor>{item.sourceLine?.trim()}</Text>
               </Box>

--- a/packages/cli-kit/src/public/node/ui.test.ts
+++ b/packages/cli-kit/src/public/node/ui.test.ts
@@ -206,7 +206,6 @@ describe('renderFatalError', async () => {
     const error = new Bug('Unexpected error')
     error.stack = `
       Error: Unexpected error
-          at Object.<anonymous> (/Users/username/Projects/shopify-app-cli/test/shopify-cli/ui/error_test.rb:1:1)
           at Module._compile (internal/modules/cjs/loader.js:1137:30)
           at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
           at Module.load (internal/modules/cjs/loader.js:985:32)
@@ -221,8 +220,6 @@ describe('renderFatalError', async () => {
       │  Unexpected error                                                            │
       │                                                                              │
       │  Stack trace:                                                                │
-      │  at <anonymous> (../../../../../../../username/Projects/shopify-app-cli/tes  │
-      │  t/shopify-cli/ui/error_test.rb:1)                                           │
       │  at _compile (internal/modules/cjs/loader.js:1137)                           │
       │  at js (internal/modules/cjs/loader.js:1157)                                 │
       │  at load (internal/modules/cjs/loader.js:985)                                │

--- a/packages/cli-kit/src/public/node/ui.test.ts
+++ b/packages/cli-kit/src/public/node/ui.test.ts
@@ -1,5 +1,5 @@
 import {renderError, renderFatalError, renderInfo, renderSuccess, renderWarning} from './ui.js'
-import {Abort} from '../../error.js'
+import {Abort, Bug} from '../../error.js'
 import * as outputMocker from '../../testing/output.js'
 import {run} from '../../testing/ui.js'
 import {afterEach, describe, expect, test} from 'vitest'
@@ -193,6 +193,40 @@ describe('renderFatalError', async () => {
       │                                                                              │
       │  What to try                                                                 │
       │    • Check your internet connection and try again.                           │
+      │                                                                              │
+      ╰──────────────────────────────────────────────────────────────────────────────╯"
+    `)
+  })
+
+  test('renders a fatal error inside a banner with a stack trace', async () => {
+    // Given
+    const mockOutput = outputMocker.mockAndCaptureOutput()
+
+    // When
+    const error = new Bug('Unexpected error')
+    error.stack = `
+      Error: Unexpected error
+          at Object.<anonymous> (/Users/username/Projects/shopify-app-cli/test/shopify-cli/ui/error_test.rb:1:1)
+          at Module._compile (internal/modules/cjs/loader.js:1137:30)
+          at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
+          at Module.load (internal/modules/cjs/loader.js:985:32)
+          at Function.Module._load (internal/modules/cjs/loader.js:878:14)
+    `
+    renderFatalError(error)
+
+    // Then
+    expect(mockOutput.error()).toMatchInlineSnapshot(`
+      "╭─ error ──────────────────────────────────────────────────────────────────────╮
+      │                                                                              │
+      │  Unexpected error                                                            │
+      │                                                                              │
+      │  Stack trace:                                                                │
+      │  at <anonymous> (../../../../../../../username/Projects/shopify-app-cli/tes  │
+      │  t/shopify-cli/ui/error_test.rb:1)                                           │
+      │  at _compile (internal/modules/cjs/loader.js:1137)                           │
+      │  at js (internal/modules/cjs/loader.js:1157)                                 │
+      │  at load (internal/modules/cjs/loader.js:985)                                │
+      │  at _load (internal/modules/cjs/loader.js:878)                               │
       │                                                                              │
       ╰──────────────────────────────────────────────────────────────────────────────╯"
     `)

--- a/packages/cli-main/src/cli/services/kitchen-sink.ts
+++ b/packages/cli-main/src/cli/services/kitchen-sink.ts
@@ -66,11 +66,10 @@ export async function kitchenSink() {
     ),
   )
 
+  renderFatalError(new error.Bug('Unexpected error'))
+
   renderError({
     headline: 'Something went wrong.',
     tryMessages: ['Check your internet connection.', 'Try again.'],
   })
-
-  // test stack trackes
-  throw new Error('Unknown error')
 }

--- a/packages/cli-main/src/cli/services/kitchen-sink.ts
+++ b/packages/cli-main/src/cli/services/kitchen-sink.ts
@@ -70,4 +70,7 @@ export async function kitchenSink() {
     headline: 'Something went wrong.',
     tryMessages: ['Check your internet connection.', 'Try again.'],
   })
+
+  // test stack trackes
+  throw new Error('Unknown error')
 }

--- a/packages/plugin-ngrok/src/tunnel.test.ts
+++ b/packages/plugin-ngrok/src/tunnel.test.ts
@@ -1,12 +1,14 @@
 import {authenticate, hookStart} from './tunnel.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {ui, os, output, error} from '@shopify/cli-kit'
+import {ui, os, error} from '@shopify/cli-kit'
 import ngrok from '@shopify/ngrok'
+import {renderFatalError} from '@shopify/cli-kit/node/ui'
 
 const port = 1234
 
 beforeEach(async () => {
   vi.mock('@shopify/ngrok')
+  vi.mock('@shopify/cli-kit/node/ui')
   vi.mocked(ngrok.connect).mockResolvedValue('https://fake.ngrok.io')
   vi.mocked(ngrok.authtoken).mockResolvedValue(undefined)
   vi.mocked(ngrok.validConfig).mockResolvedValue(true)
@@ -22,10 +24,6 @@ beforeEach(async () => {
       environment: vi.fn(),
       os: {
         platformAndArch: vi.fn(),
-      },
-      output: {
-        ...cliKit.output,
-        error: vi.fn(),
       },
       error: {
         Abort: vi.fn(),
@@ -69,7 +67,7 @@ describe('start', () => {
       'The ngrok tunnel could not be started.\n\nYour account has been suspended',
       undefined,
     )
-    expect(output.error).toHaveBeenCalledWith(expect.any(error.Abort))
+    expect(renderFatalError).toHaveBeenCalledWith(expect.any(error.Abort))
     expect(got).toEqual({url: undefined})
   })
 
@@ -86,7 +84,7 @@ describe('start', () => {
       'The ngrok tunnel could not be started.\n\nerror message contains code err_ngrok_108',
       expect.stringContaining('Kill all the ngrok processes with \u001b[1m\u001b[33mkillall ngrok\u001b[39m\u001b[22m'),
     )
-    expect(output.error).toHaveBeenCalledWith(expect.any(error.Abort))
+    expect(renderFatalError).toHaveBeenCalledWith(expect.any(error.Abort))
   })
 
   it('outputs an error if the ngrok tunnel fails to start because of another tunnel is already running in windows platform', async () => {
@@ -104,7 +102,7 @@ describe('start', () => {
         'Kill all the ngrok processes with \u001b[1m\u001b[33mtaskkill /f /im ngrok.exe\u001b[39m\u001b[22m',
       ),
     )
-    expect(output.error).toHaveBeenCalledWith(expect.any(error.Abort))
+    expect(renderFatalError).toHaveBeenCalledWith(expect.any(error.Abort))
   })
 
   it.each(['err_ngrok_105', 'err_ngrok_106', 'err_ngrok_107'])(
@@ -122,7 +120,7 @@ describe('start', () => {
           'Update your ngrok token with \u001b[1m\u001b[33mshopify ngrok auth\u001b[39m\u001b[22m',
         ),
       )
-      expect(output.error).toHaveBeenCalledWith(expect.any(error.Abort))
+      expect(renderFatalError).toHaveBeenCalledWith(expect.any(error.Abort))
     },
   )
 })

--- a/packages/plugin-ngrok/src/tunnel.ts
+++ b/packages/plugin-ngrok/src/tunnel.ts
@@ -2,6 +2,7 @@ import {TUNNEL_PROVIDER} from './provider.js'
 import {error, os, output, ui} from '@shopify/cli-kit'
 import {startTunnel} from '@shopify/cli-kit/plugins/tunnel'
 import ngrok from '@shopify/ngrok'
+import {renderFatalError} from '@shopify/cli-kit/node/ui'
 
 export default startTunnel({provider: TUNNEL_PROVIDER, action: hookStart})
 
@@ -19,7 +20,7 @@ export async function hookStart(port: number): Promise<{url: string | undefined}
     return {url}
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
-    await output.error(error as error.Abort)
+    renderFatalError(error as error.Abort)
     return {url: undefined}
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We want to render all our errors consistently with the new `Banner` component.
This PR is stacked on top of https://github.com/Shopify/cli/pull/512 so we need to wait for that to be merged first.
You can look at the last few commits related to errors to see changes specific to this PR. 

### WHAT is this pull request doing?

Render all `Fatal` errors by using the new `Banner` component. For example:

Before:
<img width="670" alt="Screenshot 2022-10-04 at 16 50 29" src="https://user-images.githubusercontent.com/151725/193866233-91233d69-0b65-4fd4-8c2e-b764e4ecc8d4.png">

After:
<img width="759" alt="Screenshot 2022-10-04 at 16 47 55" src="https://user-images.githubusercontent.com/151725/193866003-3025d24c-4f38-40e0-97f1-644045a37b42.png">

### How to test your changes?

- Run `yarn shopify kitchen-sink`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
