### PR TITLE
Output messages with partners urls fixed when running against an spin…

### DIFF
--- a/.changeset/ten-hornets-explode.md
+++ b/.changeset/ten-hornets-explode.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': patch
+'@shopify/cli-kit': patch
+---
+
+Output messages with partners urls fixed when running against an spin instance

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -84,7 +84,7 @@ async function dev(options: DevOptions) {
       newApp: app.newApp,
     })
     if (shouldUpdateURLs) await updateURLs(newURLs, apiKey, token)
-    outputUpdateURLsResult(shouldUpdateURLs, newURLs, app)
+    await outputUpdateURLsResult(shouldUpdateURLs, newURLs, app)
     outputAppURL(storeFqdn, exposedUrl)
   }
 

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -3,14 +3,14 @@ import {AppInterface} from '../../models/app/app.js'
 import {FunctionExtension, ThemeExtension, UIExtension} from '../../models/app/extensions.js'
 import {ExtensionTypes, getExtensionOutputConfig, UIExtensionTypes} from '../../constants.js'
 import {OrganizationApp} from '../../models/organization.js'
-import {output, string} from '@shopify/cli-kit'
+import {output, string, environment} from '@shopify/cli-kit'
 
-export function outputUpdateURLsResult(
+export async function outputUpdateURLsResult(
   updated: boolean,
   urls: PartnersURLs,
   app: Omit<OrganizationApp, 'apiSecretKeys' | 'apiKey'> & {apiSecret?: string},
 ) {
-  const dashboardURL = partnersURL(app.organizationId, app.id)
+  const dashboardURL = await partnersURL(app.organizationId, app.id)
   if (app.newApp) {
     outputUpdatedURLFirstTime(urls.applicationUrl, dashboardURL)
   } else if (updated) {
@@ -147,9 +147,9 @@ function getHumanKey(type: ExtensionTypes) {
   return string.capitalize(getExtensionOutputConfig(type).humanKey)
 }
 
-function partnersURL(organizationId: string, appId: string): string {
+async function partnersURL(organizationId: string, appId: string): Promise<string> {
   return output.content`${output.token.link(
     `Partners Dashboard`,
-    `https://partners.shopify.com/${organizationId}/apps/${appId}/edit`,
+    `https://${await environment.fqdn.partners()}/${organizationId}/apps/${appId}/edit`,
   )}`.value
 }

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -55,7 +55,7 @@ export async function selectStore(
     return store
   }
 
-  output.info(`\n${CreateStoreLink(org.id)}`)
+  output.info(`\n${await CreateStoreLink(org.id)}`)
   await system.sleep(5)
 
   const reload = await reloadStoreListPrompt(org)

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -17,8 +17,8 @@ const InvalidStore = (storeName: string) => {
   )
 }
 
-const CreateStoreLink = (orgId: string) => {
-  const url = `https://partners.shopify.com/${orgId}/stores/new?store_type=dev_store`
+const CreateStoreLink = async (orgId: string) => {
+  const url = `https://${await environment.fqdn.partners()}/${orgId}/stores/new?store_type=dev_store`
   return (
     `Looks like you don't have a dev store in the Partners org you selected. ` +
     `Keep going — create a dev store on Shopify Partners:\n${url}\n`
@@ -118,6 +118,15 @@ export async function convertToTestStoreIfNeeded(
   org: Organization,
   token: string,
 ): Promise<void> {
+  /**
+   * Is not possible to convert stores to dev ones in spin environmets. Should be created directly as development.
+   */
+  if (
+    environment.service.serviceEnvironment() === environment.network.Environment.Spin &&
+    environment.local.firstPartyDev()
+  ) {
+    return
+  }
   if (!store.transferDisabled && !store.convertableToPartnerTest) throw InvalidStore(store.shopDomain)
   if (!store.transferDisabled) await convertStoreToTest(store, org.id, token)
 }

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -121,12 +121,7 @@ export async function convertToTestStoreIfNeeded(
   /**
    * Is not possible to convert stores to dev ones in spin environmets. Should be created directly as development.
    */
-  if (
-    environment.service.serviceEnvironment() === environment.network.Environment.Spin &&
-    environment.local.firstPartyDev()
-  ) {
-    return
-  }
+  if (environment.service.isSpinEnvironment() && environment.local.firstPartyDev()) return
   if (!store.transferDisabled && !store.convertableToPartnerTest) throw InvalidStore(store.shopDomain)
   if (!store.transferDisabled) await convertStoreToTest(store, org.id, token)
 }

--- a/packages/app/src/cli/services/environment.ts
+++ b/packages/app/src/cli/services/environment.ts
@@ -47,10 +47,10 @@ const OrganizationNotFoundError = (orgId: string) => {
   return new error.Bug(`Could not find Organization for id ${orgId}.`)
 }
 
-const StoreNotFoundError = (storeName: string, org: Organization) => {
+const StoreNotFoundError = async (storeName: string, org: Organization) => {
   return new error.Bug(
     `Could not find ${storeName} in the Organization ${org.businessName} as a valid development store.`,
-    `Visit https://partners.shopify.com/${org.id}/stores to create a new store in your organization`,
+    `Visit https://${await environment.fqdn.partners()}/${org.id}/stores to create a new store in your organization`,
   )
 }
 
@@ -363,7 +363,7 @@ async function fetchDevDataFromOptions(
   if (options.storeFqdn) {
     const orgWithStore = await fetchStoreByDomain(orgId, token, options.storeFqdn)
     if (!orgWithStore) throw OrganizationNotFoundError(orgId)
-    if (!orgWithStore.store) throw StoreNotFoundError(options.storeFqdn, orgWithStore?.organization)
+    if (!orgWithStore.store) throw await StoreNotFoundError(options.storeFqdn, orgWithStore?.organization)
     await convertToTestStoreIfNeeded(orgWithStore.store, orgWithStore.organization, token)
     selectedStore = orgWithStore.store
   }

--- a/packages/cli-kit/src/environment.ts
+++ b/packages/cli-kit/src/environment.ts
@@ -2,5 +2,6 @@ import * as local from './environment/local.js'
 import * as service from './environment/service.js'
 import * as fqdn from './environment/fqdn.js'
 import * as utilities from './environment/utilities.js'
+import * as network from './network/service.js'
 
-export {local, service, fqdn, utilities}
+export {local, service, fqdn, utilities, network}

--- a/packages/cli-kit/src/environment/service.test.ts
+++ b/packages/cli-kit/src/environment/service.test.ts
@@ -1,4 +1,4 @@
-import {serviceEnvironment} from './service.js'
+import {isSpinEnvironment, serviceEnvironment} from './service.js'
 import {Environment} from '../network/service.js'
 import {expect, it, describe} from 'vitest'
 
@@ -56,5 +56,40 @@ describe('serviceEnvironment', () => {
 
     // Then
     expect(got).toBe(Environment.Spin)
+  })
+})
+
+describe('isSpinEnvironment', () => {
+  it('returns true when running against SPIN instance', () => {
+    // Given
+    process.env = {...process.env, SHOPIFY_SERVICE_ENV: 'spin'}
+
+    // When
+    const got = isSpinEnvironment()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  it('returns true when running inside a SPIN instance', () => {
+    // Given
+    process.env = {...process.env, SPIN: '1'}
+
+    // When
+    const got = isSpinEnvironment()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  it('returns false when not working with spin instances', () => {
+    // Given
+    process.env = {...process.env, SHOPIFY_SERVICE_ENV: 'local'}
+
+    // When
+    const got = isSpinEnvironment()
+
+    // Then
+    expect(got).toBe(false)
   })
 })

--- a/packages/cli-kit/src/environment/service.ts
+++ b/packages/cli-kit/src/environment/service.ts
@@ -12,3 +12,7 @@ export function serviceEnvironment(env = process.env): Environment {
     return Environment.Production
   }
 }
+
+export function isSpinEnvironment(env = process.env): boolean {
+  return serviceEnvironment(env) === Environment.Spin
+}

--- a/packages/cli-kit/src/session.ts
+++ b/packages/cli-kit/src/session.ts
@@ -2,7 +2,7 @@ import {applicationId} from './session/identity.js'
 import {Abort, Bug} from './error.js'
 import {validateSession} from './session/validate.js'
 import {allDefaultScopes, apiScopes} from './session/scopes.js'
-import {identity as identityFqdn} from './environment/fqdn.js'
+import {identity as identityFqdn, partners as partnersFqdn} from './environment/fqdn.js'
 import {open} from './system.js'
 import {
   exchangeAccessForApplicationTokens,
@@ -245,7 +245,7 @@ export async function ensureUserHasPartnerAccount(partnersToken: string) {
     output.info(`\nA Shopify Partners organization is needed to proceed.`)
     output.info(`👉 Press any key to create one`)
     await keypress()
-    await open(`https://partners.shopify.com/signup`)
+    await open(`https://${await partnersFqdn()}/signup`)
     output.info(output.content`👉 Press any key when you have ${output.token.cyan('created the organization')}`)
     output.warn(output.content`Make sure you've confirmed your Shopify and the Partner organization from the email`)
     await keypress()


### PR DESCRIPTION
### WHY are these changes introduced?
- It's is not possible to convert a dev store to a test one (transfer disabled, this is needed at least in production environment for the app to work) for `1Party users` in a spin instance. Next error is returned from partners
![image](https://user-images.githubusercontent.com/105213827/193870617-7c523e84-6aa4-4459-bc5c-b81278fdb3c6.png)
- After testing `dev` with the conversion logic removed and verifying that everything was working, the conclusion is that there is no needing for converting the stores to a test one for `1party users` in spin

### WHAT is this pull request doing?
- In case `1party user` in spin, the conversion of the dev store to a test one is not executed.

### How to test your changes?
- Create a spin instance
- Run `SHOPIFY_CLI_1P_DEV=1 SHOPIFY_SERVICE_ENV="spin" SPIN_INSTANCE="<your_spin_instance_here>" yarn shopify app dev` 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
