### PR TITLE
Fix dev breakage when missing capabilities fields

### DIFF
--- a/packages/app/src/cli/models/app/extensions.ts
+++ b/packages/app/src/cli/models/app/extensions.ts
@@ -30,10 +30,14 @@ export const UIExtensionConfigurationSchema = schema.define.object({
   extensionPoints: schema.define.array(schema.define.string()).optional(),
   capabilities: schema.define
     .object({
-      block_progress: schema.define.boolean().optional(),
-      network_access: schema.define.boolean().optional(),
+      block_progress: schema.define.boolean().optional().default(false),
+      network_access: schema.define.boolean().optional().default(false),
     })
-    .optional(),
+    .optional()
+    .default({
+      block_progress: false,
+      network_access: false,
+    }),
 
   // Only for CheckoutUiExtension
   settings: schema.define.any().optional(),

--- a/packages/app/src/cli/models/app/extensions.ts
+++ b/packages/app/src/cli/models/app/extensions.ts
@@ -30,14 +30,10 @@ export const UIExtensionConfigurationSchema = schema.define.object({
   extensionPoints: schema.define.array(schema.define.string()).optional(),
   capabilities: schema.define
     .object({
-      block_progress: schema.define.boolean().optional().default(false),
-      network_access: schema.define.boolean().optional().default(false),
+      block_progress: schema.define.boolean().optional(),
+      network_access: schema.define.boolean().optional(),
     })
-    .optional()
-    .default({
-      block_progress: false,
-      network_access: false,
-    }),
+    .optional(),
 
   // Only for CheckoutUiExtension
   settings: schema.define.any().optional(),

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -8,8 +8,8 @@ import {file, path} from '@shopify/cli-kit'
 
 vi.mock('../../../models/app/app.js')
 
-describe('getUIExtensionPayload', () => {
-  test('returns the right payload', async () => {
+describe('returns the right payload', () => {
+  test('getUIExtensionPayload', async () => {
     await file.inTemporaryDirectory(async (tmpDir) => {
       // Given
       const outputBundlePath = path.join(tmpDir, 'main.js')
@@ -94,6 +94,42 @@ describe('getUIExtensionPayload', () => {
         type: 'product_subscription',
         uuid: 'devUUID',
         version: '1.2.3',
+      })
+    })
+  })
+
+  test('default values', async () => {
+    await file.inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const outputBundlePath = path.join(tmpDir, 'main.js')
+      await file.touch(outputBundlePath)
+      const signal: any = vi.fn()
+      const stdout: any = vi.fn()
+      const stderr: any = vi.fn()
+      vi.mocked(getUIExtensionRendererVersion).mockResolvedValue({
+        name: 'extension-renderer',
+        version: '1.2.3',
+      })
+
+      const uiExtension = testUIExtension()
+      const options: ExtensionDevOptions = {} as ExtensionDevOptions
+      const development: Partial<UIExtensionPayload['development']> = {}
+
+      // When
+      const got = await getUIExtensionPayload(uiExtension, {
+        ...options,
+        currentDevelopmentPayload: development,
+      })
+
+      // Then
+      expect(got).toMatchObject({
+        development: {
+          hidden: false,
+        },
+        capabilities: {
+          block_progress: false,
+          network_access: false,
+        },
       })
     })
   })

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -8,8 +8,8 @@ import {file, path} from '@shopify/cli-kit'
 
 vi.mock('../../../models/app/app.js')
 
-describe('returns the right payload', () => {
-  test('getUIExtensionPayload', async () => {
+describe('getUIExtensionPayload', () => {
+  test('returns the right payload', async () => {
     await file.inTemporaryDirectory(async (tmpDir) => {
       // Given
       const outputBundlePath = path.join(tmpDir, 'main.js')

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -101,16 +101,6 @@ describe('getUIExtensionPayload', () => {
   test('default values', async () => {
     await file.inTemporaryDirectory(async (tmpDir) => {
       // Given
-      const outputBundlePath = path.join(tmpDir, 'main.js')
-      await file.touch(outputBundlePath)
-      const signal: any = vi.fn()
-      const stdout: any = vi.fn()
-      const stderr: any = vi.fn()
-      vi.mocked(getUIExtensionRendererVersion).mockResolvedValue({
-        name: 'extension-renderer',
-        version: '1.2.3',
-      })
-
       const uiExtension = testUIExtension()
       const options: ExtensionDevOptions = {} as ExtensionDevOptions
       const development: Partial<UIExtensionPayload['development']> = {}

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -31,7 +31,12 @@ export async function getUIExtensionPayload(
         lastUpdated: (await file.lastUpdatedTimestamp(extension.outputBundlePath)) ?? 0,
       },
     },
-    capabilities: extension.configuration.capabilities,
+    capabilities: {
+      // defaults
+      block_progress: false,
+      network_access: false,
+      ...extension.configuration.capabilities,
+    },
     development: {
       ...options.currentDevelopmentPayload,
       resource: getUIExtensionResourceURL(extension.configuration.type, options),

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -32,10 +32,8 @@ export async function getUIExtensionPayload(
       },
     },
     capabilities: {
-      // defaults
-      block_progress: false,
-      network_access: false,
-      ...extension.configuration.capabilities,
+      block_progress: extension.configuration.capabilities?.block_progress || false,
+      network_access: extension.configuration.capabilities?.network_access || false,
     },
     development: {
       ...options.currentDevelopmentPayload,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #573 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

When `shopify.ui.extensions.toml` doesn't include a `capabilities` clause, the browser reports the following error:

```
vendors~app.latest.en.e5376343c5580b97aa7a.js:2 TypeError: Cannot read properties of undefined (reading 'networkAccess')
    at app.latest.en.280faa0996ccd0490853.js:1:183003
    at Array.map (<anonymous>)
    at app.latest.en.280faa0996ccd0490853.js:1:182862
````

### WHAT is this pull request doing?

This PR sets default values for `capabilities` and `capabilities.network_access` and `capabilities.blocks_progress`. Because omitting any of the defaulted fields in tests is regarded as a syntax error, there is no way I can see to write unit tests.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

Create a new checkout extension and `dev` it, ensuring the `shopify.ui.extensions.toml` file has no `capabilities` clause. Click the checkout extension preview link to ensure you are taken to the checkout screen.

Ensure you can see the checkout extension surface area and NOT this:

![image](https://user-images.githubusercontent.com/4490738/193926128-56113936-7e2d-4fe6-a274-1740a3ef5b49.png)


<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
