### PR TITLE
React types dependency version should be overwritten when generating React Typescript extensions

### DIFF
--- a/.changeset/rude-impalas-cheat.md
+++ b/.changeset/rude-impalas-cheat.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': patch
+'@shopify/cli-kit': patch
+---
+
+React types dependency version should be overwritten when generating React Typescript extensions

--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -10,7 +10,7 @@ import {
 import {load as loadApp} from '../../models/app/loader.js'
 import {describe, it, expect, vi, test, beforeEach} from 'vitest'
 import {file, output, path, template} from '@shopify/cli-kit'
-import {addNPMDependenciesIfNeeded} from '@shopify/cli-kit/node/node-package-manager'
+import {addNPMDependenciesIfNeeded, addResolutionOrOverride} from '@shopify/cli-kit/node/node-package-manager'
 import type {ExtensionFlavor} from './extension.js'
 
 beforeEach(() => {
@@ -120,6 +120,13 @@ describe('initialize a extension', () => {
 
         await createFromTemplate({name, extensionType, extensionFlavor, appDirectory: tmpDir})
 
+        const addDependenciesCalls = vi.mocked(addResolutionOrOverride).mock.calls
+        if (extensionFlavor === 'typescript-react') {
+          expect(addDependenciesCalls.length).toEqual(1)
+        } else {
+          expect(addDependenciesCalls.length).toEqual(0)
+        }
+
         const srcIndexFile = await file.read(path.join(tmpDir, 'extensions', name, 'src', `index.${fileExtension}`))
         expect(srcIndexFile.trim()).not.toBe('')
       })
@@ -147,6 +154,13 @@ describe('initialize a extension', () => {
         const name = 'extension-name'
 
         await createFromTemplate({name, extensionType, extensionFlavor, appDirectory: tmpDir})
+
+        const addDependenciesCalls = vi.mocked(addResolutionOrOverride).mock.calls
+        if (extensionFlavor === 'typescript-react') {
+          expect(addDependenciesCalls.length).toEqual(1)
+        } else {
+          expect(addDependenciesCalls.length).toEqual(0)
+        }
 
         expect(recursiveDirectoryCopySpy).toHaveBeenCalledWith(expect.any(String), expect.any(String), {
           flavor: liquidFlavor,

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -12,7 +12,11 @@ import {
 import {AppInterface} from '../../models/app/app.js'
 import {mapExtensionTypeToExternalExtensionType} from '../../utilities/extensions/name-mapper.js'
 import {error, file, git, path, string, template, ui, environment} from '@shopify/cli-kit'
-import {addNPMDependenciesIfNeeded, DependencyVersion} from '@shopify/cli-kit/node/node-package-manager'
+import {
+  addNPMDependenciesIfNeeded,
+  addResolutionOrOverride,
+  DependencyVersion,
+} from '@shopify/cli-kit/node/node-package-manager'
 import {fileURLToPath} from 'url'
 import stream from 'node:stream'
 
@@ -80,6 +84,7 @@ async function uiExtensionInit({
         title: 'Install additional dependencies',
         task: async (_, task) => {
           task.title = 'Installing additional dependencies...'
+          await addResolutionOrOverrideIfNeeded(app.directory, extensionFlavor)
           const requiredDependencies = getRuntimeDependencies({extensionType, extensionFlavor})
           await addNPMDependenciesIfNeeded(requiredDependencies, {
             packageManager: app.packageManager,
@@ -236,6 +241,14 @@ async function ensureExtensionDirectoryExists({name, app}: {name: string; app: A
   }
   await file.mkdir(extensionDirectory)
   return extensionDirectory
+}
+
+async function addResolutionOrOverrideIfNeeded(directory: string, extensionFlavor?: ExtensionFlavor) {
+  if (extensionFlavor === undefined || extensionFlavor !== 'typescript-react') {
+    return
+  }
+
+  addResolutionOrOverride(directory, {'@types/react': '17.0.30'})
 }
 
 export default extensionInit

--- a/packages/cli-kit/src/node/node-package-manager.ts
+++ b/packages/cli-kit/src/node/node-package-manager.ts
@@ -1,5 +1,5 @@
 import {exec} from '../system.js'
-import {exists as fileExists, read as readFile} from '../file.js'
+import {exists as fileExists, read as readFile, write as writeFile} from '../file.js'
 import {glob, dirname, join as pathJoin, findUp} from '../path.js'
 import {Abort, Bug} from '../error.js'
 import {latestNpmPackageVersion} from '../version.js'
@@ -255,6 +255,16 @@ export interface PackageJson {
    * The workspaces attribute of the package.json
    */
   workspaces?: string[]
+
+  /**
+   * The resolutions attribute of the package.json. Only useful when using yarn as package manager
+   */
+  resolutions?: {[key: string]: string}
+
+  /**
+   * The overrides attribute of the package.json. Only useful when using npm o npmn as package managers
+   */
+  overrides?: {[key: string]: string}
 }
 
 /**
@@ -471,4 +481,23 @@ export async function findUpAndReadPackageJson(fromDirectory: string): Promise<{
   } else {
     throw FindUpAndReadPackageJsonNotFoundError(fromDirectory)
   }
+}
+
+export async function addResolutionOrOverride(directory: string, dependencies: {[key: string]: string}) {
+  const packageManager = await getPackageManager(directory)
+  const packageJsonPath = pathJoin(directory, 'package.json')
+  const packageJsonContent = await readAndParsePackageJson(packageJsonPath)
+
+  if (packageManager === 'yarn') {
+    packageJsonContent.resolutions = packageJsonContent.resolutions
+      ? {...packageJsonContent.resolutions, ...dependencies}
+      : dependencies
+  }
+  if (packageManager === 'npm' || packageManager === 'pnpm') {
+    packageJsonContent.overrides = packageJsonContent.overrides
+      ? {...packageJsonContent.overrides, ...dependencies}
+      : dependencies
+  }
+
+  writeFile(packageJsonPath, JSON.stringify(packageJsonContent, null, 2))
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #395

### WHAT is this pull request doing?
- When generating a `Typescript React` extension, `"@types/react": "17.0.30"` dependency is add inside the `resolutions` or `overrides` block inside the root `package.json` of the app directory
- Depending on the package manager used to create the app, either `resolution` (yarn) or `overrides` (npm, pnpm) are set

### How to test your changes?
- Run `yarn shopify app generate extension`
- Select `checkout UI` and `Typescript React` as flavor
- Open the app with VS Code and there should be no problems with React components resolution

### Post-release steps
- Maybe there should be added some instructions for users that have generated `Typescript React` extensions without this dependency

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
