### PR TITLE
Allow to enable tmate debugging when triggering a build manually

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -3,7 +3,7 @@ name: shopify-cli
 on:
   workflow_dispatch:
     inputs:
-      nxLevel:
+      nx_level:
         description: "command to pass to nx, to run everything: 'run-many --all'"
         required: true
         default: "affected"
@@ -110,16 +110,16 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Build
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=build
+        run: yarn nx ${{ inputs.nx_level || 'affected' }} --target=build
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
       - name: Lint
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=lint
+        run: yarn nx ${{ inputs.nx_level || 'affected' }} --target=lint
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
       - name: Type-check
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=type-check
+        run: yarn nx ${{ inputs.nx_level || 'affected' }} --target=type-check
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
       - name: Unit tests
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'affected' }} --target=test --exclude=features
+        run: yarn nx ${{ inputs.nx_level || 'affected' }} --target=test --exclude=features
       - name: Acceptance tests
         if: ${{ matrix.node == '18.7.0' }}
         run: yarn nx run features:test
@@ -165,7 +165,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: ${{ matrix.target }}
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'run-many --all --skip-nx-cache' }} --target=${{ matrix.target }}
+        run: yarn nx ${{ inputs.nx_level || 'run-many --all --skip-nx-cache' }} --target=${{ matrix.target }}
 
   pr-platform-dependent:
     name: Testing with Node ${{ matrix.node }} in ${{ matrix.os }}
@@ -216,7 +216,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Unit tests
-        run: yarn nx ${{ github.event.inputs.nxLevel || 'run-many --all --skip-nx-cache' }} --target=test --exclude=features
+        run: yarn nx ${{ inputs.nx_level || 'run-many --all --skip-nx-cache' }} --target=test --exclude=features
       - name: Acceptance tests
         if: ${{ matrix.node == '18.7.0' }}
         run: yarn nx run features:test

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -4,9 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       nx_level:
-        description: "command to pass to nx, to run everything: 'run-many --all'"
+        description: 'Command to pass to nx (if you want to run everything: run-many --all)'
         required: true
         default: "affected"
+      debug_enabled:
+        type: boolean
+        description: 'Enable tmate debugging'
+        required: false
+        default: false
   push:
     branches:
       - main
@@ -220,3 +225,8 @@ jobs:
       - name: Acceptance tests
         if: ${{ matrix.node == '18.7.0' }}
         run: yarn nx run features:test
+      - name: Setup tmate session
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true


### PR DESCRIPTION
### WHY are these changes introduced?

We have some flakey tests and no good ways to debug them. This PR allows to manually trigger a workflow and enable Tmate debugging. In this way, you can ssh into the running container and run commands manually.

### WHAT is this pull request doing?

- Add a new checkbox to the manual workflow trigger dialog
- Enable tmate debugging when it's checked

### Preview
<img width="923" alt="Screenshot 2022-10-05 at 16 36 19" src="https://user-images.githubusercontent.com/62895/194101998-b7d2c1d3-733c-40de-90c8-28747d263e3f.png">



### How to test your changes?

- Go to https://github.com/Shopify/cli/actions/workflows/shopify-cli.yml
- Click the Run workflow button
- Choose this branch from the dropdown
- Click on "Enable tmate debugging"
- Wait for the build to complete and you should see a ssh command in the terminal output
- Run that in your terminal and you'll be inside the running container

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
