### PR TITLE
defaulting capabilities to expected values

### DIFF
--- a/packages/app/src/cli/models/app/extensions.ts
+++ b/packages/app/src/cli/models/app/extensions.ts
@@ -30,10 +30,13 @@ export const UIExtensionConfigurationSchema = schema.define.object({
   extensionPoints: schema.define.array(schema.define.string()).optional(),
   capabilities: schema.define
     .object({
-      block_progress: schema.define.boolean().optional(),
-      network_access: schema.define.boolean().optional(),
+      block_progress: schema.define.boolean().default(false),
+      network_access: schema.define.boolean().default(false),
     })
-    .optional(),
+    .default({
+      block_progress: false,
+      network_access: false,
+    }),
 
   // Only for CheckoutUiExtension
   settings: schema.define.any().optional(),


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

resolves https://github.com/Shopify/temp-project-mover-megswim-20250326195306/issues/231

`extension.capabilities` should have default settings and have regressed from their [former implementation in the Go server](https://github.com/Shopify/cli/blob/main/packages/ui-extensions-go-cli/core/core.go#L73-L99).

An extension author shouldn't need to update their toml file with capabilities they're not using or not aware of; the CLI should deal with setting sane defaults in their stead.

### WHAT is this pull request doing?

setting defaults as expected by checkout-web

### How to test your changes?

* create a new extension without this patch, `extension.capabilities` is undefined and leads to a type error
* create a new extension with this patch, without populating the values in the extension's TOML config, both `network_access` and `block_progress` will default to false

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
