### PR TITLE
Fix to missing React import when running Go build server for checkout ui extensions

### DIFF
--- a/.changeset/warm-beds-repair.md
+++ b/.changeset/warm-beds-repair.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Added back the React import for scaffolded checkout ui extensions.

--- a/packages/app/templates/ui-extensions/projects/checkout_ui/src/index.liquid
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/src/index.liquid
@@ -1,4 +1,5 @@
 {%- if flavor == "react" -%}
+import React from 'react';
 import {
   useExtensionApi,
   render,


### PR DESCRIPTION
Solves https://github.com/Shopify/cli/issues/587.

### WHY are these changes introduced?

In https://github.com/shopify/cli/pull/577, we implemented the jsx-transform in the new Node CLI flow, but not in the old Go CLI flow. Since publicly, the Node CLI is not being used yet, the jsx-transform is actually not in-place and we removed the import React from the generated template.

This results in a rendering error and the only workaround is to manually add `import React from 'react';` at the top of the file.

### WHAT is this pull request doing?

This pull request is adding back the React import so that it can be compatible with the Go CLI flow.

### How to test your changes?
Clone this repo.

Scaffold a new app with a React extension (`yarn create-app --path <path-to-app`).
Run `SHOPIFY_RUN_AS_USER=1 yarn shopify app dev --path <path-to-app>`.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [X] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
