### PR TITLE
add react import for public extension build

### DIFF
--- a/.changeset/brave-rats-cry.md
+++ b/.changeset/brave-rats-cry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+add react import only for public extension build

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -124,7 +124,10 @@ async function uiExtensionInit({
           }
 
           const flavor = extensionFlavor?.includes('react') ? 'react' : ''
+          const isShopify = await environment.local.isShopify()
+
           await template.recursiveDirectoryCopy(templateDirectory, extensionDirectory, {
+            isShopify,
             flavor,
             type: extensionType,
             name,
@@ -132,7 +135,7 @@ async function uiExtensionInit({
 
           if (extensionFlavor) {
             await changeIndexFileExtension(extensionDirectory, extensionFlavor)
-            await removeUnwantedTemplateFilesPerFlavor(extensionDirectory, extensionFlavor)
+            await removeUnwantedTemplateFilesPerFlavor(extensionDirectory, extensionFlavor, isShopify)
           }
 
           task.title = `${getExtensionOutputConfig(extensionType).humanKey} extension generated`
@@ -186,10 +189,14 @@ async function changeIndexFileExtension(extensionDirectory: string, extensionFla
   }
 }
 
-async function removeUnwantedTemplateFilesPerFlavor(extensionDirectory: string, extensionFlavor: ExtensionFlavor) {
+async function removeUnwantedTemplateFilesPerFlavor(
+  extensionDirectory: string,
+  extensionFlavor: ExtensionFlavor,
+  isShopify: boolean,
+) {
   // tsconfig.json file is only needed in extension folder to inform the IDE
   // About the `react-jsx` tsconfig option, so IDE don't complain about missing react import
-  if (extensionFlavor !== 'typescript-react') {
+  if (!isShopify || extensionFlavor !== 'typescript-react') {
     await file.remove(path.join(extensionDirectory, 'tsconfig.json'))
   }
 }

--- a/packages/app/templates/ui-extensions/projects/checkout_ui/src/index.liquid
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/src/index.liquid
@@ -1,5 +1,8 @@
 {%- if flavor == "react" -%}
+{%- if isShopify == false -%}
 import React from 'react';
+{%- endif -%}
+
 import {
   useExtensionApi,
   render,


### PR DESCRIPTION
This is just an improvement PR Related to https://github.com/Shopify/shopify-cli-extensions/issues/127, https://github.com/Shopify/cli/pull/577, https://github.com/Shopify/cli/pull/588 and https://github.com/Shopify/cli/issues/587

Conditionally remove `react` import from checkout-ui react template when using node build (`isShopify`)
 
### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

Public build:
- Clone this branch
- Generate new app
- Geneate new extension using `yarn shopify app generate extension --path path-to-app`
- you should see `react import` at the top of `src/index.(t/j)sx` file

Shopify build:
- Clone this branch
- Generate new app
- Geneate new extension using `SHOPIFY_RUN_AS_USER=1 yarn shopify app generate extension --path path-to-app`
- `react import` should no exist at the top of `src/index.(t/j)sx` file

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
