### PR TITLE
Add workflow for cleaning workflows

### DIFF
--- a/.github/workflows/workflow-cleaner.yml
+++ b/.github/workflows/workflow-cleaner.yml
@@ -1,0 +1,60 @@
+name: Delete old workflow runs
+on:
+  schedule:
+    # Run monthly, at 00:00 on the 1st day of month.
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Number of days.'
+        required: true
+        default: 30
+      minimum_runs:
+        description: 'The minimum runs to keep for each workflow.'
+        required: true
+        default: 6
+      delete_workflow_pattern:
+        description: 'The name or filename of the workflow. if not set then it will target all workflows.'
+        required: false
+      delete_workflow_by_state_pattern:
+        description: 'Remove workflow by state: active, deleted, disabled_fork, disabled_inactivity, disabled_manually'
+        required: true
+        default: "All"
+        type: choice
+        options:
+          - "All"
+          - active
+          - deleted
+          - disabled_inactivity
+          - disabled_manually
+      delete_run_by_conclusion_pattern:
+        description: 'Remove workflow by conclusion: action_required, cancelled, failure, skipped, success'
+        required: true
+        default: "All"
+        type: choice
+        options:
+          - "All"
+          - action_required
+          - cancelled
+          - failure
+          - skipped
+          - success
+      dry_run:
+        description: 'Only log actions, do not perform any delete operations.'
+        required: false
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ inputs.days || 30 }}
+          keep_minimum_runs: ${{ inputs.minimum_runs || 6 }}
+          delete_workflow_pattern: ${{ inputs.delete_workflow_pattern }}
+          delete_workflow_by_state_pattern: ${{ inputs.delete_workflow_by_state_pattern || 'All' }}
+          delete_run_by_conclusion_pattern: ${{ inputs.delete_run_by_conclusion_pattern || 'All' }}
+          dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed that currently we have over 5000 stored workflow runs on this repository. This also includes previous workflow tests that don't exist any longer.

The super annoying thing is that you have to manually delete each workflow run inside a workflow in order to delete the workflow itself.

### WHAT is this pull request doing?

This PR introduces a new workflow (surprise!) that will automatically clean old workflow runs (and workflows). You will also be able to manually schedule the clean workflow from the github actions UI. It relies on [this action](https://github.com/marketplace/actions/delete-workflow-runs) under the hood.

### How to test your changes?

Unfortunately we'll be able to run this workflow manually only when this PR is merged.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
