### PR TITLE
add extension name to generated checkout ui template

### DIFF
--- a/packages/app/templates/ui-extensions/projects/checkout_ui/src/index.liquid
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui/src/index.liquid
@@ -12,7 +12,11 @@ render('Checkout::Dynamic::Render', () => <App />);
 function App() {
   const {extensionPoint} = useExtensionApi();
   const translate = useTranslate();
-  return <Banner>{translate('welcome', {extensionPoint})}</Banner>;
+  return (
+    <Banner title="{{ name }}">
+      {translate('welcome', {extensionPoint})}
+    </Banner>
+  );
 }
 
 {%- else -%}
@@ -22,7 +26,7 @@ extend("Checkout::Dynamic::Render", (root, { extensionPoint, i18n }) => {
   root.appendChild(
     root.createComponent(
       Banner,
-      {},
+      { title: "{{ name }}" },
       i18n.translate('welcome', {extensionPoint})
     )
   );


### PR DESCRIPTION
Optional PR.

Generating multiple extensions for testing always requires manual template change after, to distinguish extension when rendered, to improve this I added the extension name to the welcome text
 
### WHY are these changes introduced?

Checkout extension UI template now will be generated with extension name.

### WHAT is this pull request doing?
Modifying the template to use the extension name.

### How to test your changes?

- Clone this branch
- Generate new extension using `yarn shopify app generate extension --path path-to-your-app`
- Banner should look like screenshot below
-
<img width="592" alt="Screenshot 2022-10-06 at 17 30 02" src="https://user-images.githubusercontent.com/4366612/194355321-2e4bd21d-45e6-4a6c-be5c-dd39ce6d39ba.png">

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
