### PR TITLE
Fix theme push command with --store

### DIFF
--- a/.changeset/sharp-rockets-clap.md
+++ b/.changeset/sharp-rockets-clap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix push command with --store flag

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -75,7 +75,7 @@ export default class Push extends ThemeCommand {
   async run(): Promise<void> {
     const {flags} = await this.parse(Push)
 
-    const flagsToPass = this.passThroughFlags(flags, {exclude: ['path', 'verbose']})
+    const flagsToPass = this.passThroughFlags(flags, {exclude: ['path', 'store', 'verbose']})
     const command = ['theme', 'push', flags.path, ...flagsToPass]
 
     const store = await getThemeStore(flags)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/571

When the `--store` flag is provided for theme commands, its value is cached and used to authenticate. Then, it's removed from the list of params passed to CLI2, as store is not one of the expected ones.

But we forgot to remove the parameter for the push command in https://github.com/Shopify/cli/pull/408

I've checked that the flag is required (when not cached) and works as expected for the following commands:
- delete
- dev
- list
- open
- publish
- pull
- push
- share

The rest doesn't need it:
- check
- help-old
- info
- init
- language-server
- package

### WHAT is this pull request doing?

Exclude the `--store` flag from the list passed to CLI2 in `theme push`

### How to test your changes?

- Remove your local cache (In Mac: `rm ~/Library/Preferences/shopify-cli-kit-nodejs/config.json`)
- `yarn shopify theme push --store wadus`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
