### PR TITLE
`shopify theme check` no longer ignores the `.theme-check.yml` file

### DIFF
--- a/.changeset/mighty-squids-train.md
+++ b/.changeset/mighty-squids-train.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+`shopify theme check` no longer ignores the `.theme-check.yml` file

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -76,7 +76,7 @@ Excludes checks matching any category when specified more than once`,
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Check)
-    await execCLI2(['theme', 'check', ...this.passThroughFlags(flags, {exclude: ['path', 'verbose']})], {
+    await execCLI2(['theme', 'check', flags.path, ...this.passThroughFlags(flags, {exclude: ['path', 'verbose']})], {
       directory: flags.path,
     })
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/539

### WHAT is this pull request doing?

This PR changes the check command at the CLI 3.x to pass the `--path` flag to the CLI 2.x command.

### How to test your changes?

- Run `shopify theme check --path dist`
- Notice the CLI is now using the expected path

![image](https://user-images.githubusercontent.com/1079279/194903823-4f4044c0-ba49-41b9-b3c3-56a3c70febb9.png)


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
