### PR TITLE
[Fix] localization typing inside ExtensionPayload (ui-extensions-server-kit)

### DIFF
--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -78,7 +78,7 @@ export interface ExtensionPayload {
   localization?: {
     defaultLocale: string
     lastUpdated: number
-    translations: {[locale: string]: string}
+    translations: {[locale: string]: ExtensionTranslationMap}
   }
 }
 
@@ -102,4 +102,8 @@ export interface App {
   }
   supportEmail?: string
   supportLocales?: string[]
+}
+
+interface ExtensionTranslationMap {
+  [key: string]: string
 }


### PR DESCRIPTION
Fixes a false typing for the ExtensionPayload interface (inside of `ui-extensions-server-kit`). 

The received localizations inside the DEV-CLI have the following format:

```
{
  "defaultLocale": "en",
  "translations": {
    "fr": {
      "welcome": "Bienvenue dans l'extension customer-accounts-ui!",
      "apples.one": "Tu as {{count}} pomme",
      "apples.other": "Tu as {{count}} pommes"
    },
    "en": {
      "welcome": "Welcome to the customer-accounts-ui extension!",
      "apples.one": "You have {{count}} apple",
      "apples.other": "You have {{count}} apples"
    }
  },
  "lastUpdated": 1665411936350
}
```

As a result the old (broken) typing doesn't match the received format:

OLD:
```
translations: {[locale: string]: string}
```

NEW:
```
translations: {[locale: string]: ExtensionTranslationMap}
```

### WHY are these changes introduced?

I need this fix in order to have the correct typing inside of the customer-accounts-web project, which makes uses of the `ui-extensions-server-kit`. The following PR requires the typing fix: https://github.com/Shopify/customer-account-web/pull/1023



### WHAT is this pull request doing?

It just updates a single falsely typed property.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
