### PR TITLE
Fix typo in success message.

### DIFF
--- a/packages/cli-kit/assets/success.html
+++ b/packages/cli-kit/assets/success.html
@@ -12,7 +12,7 @@
 <body class="body-success">
     <div class="app-success">
         <div class="container">
-            <h1>You've successfuly logged into the Shopify CLI!</h1>
+            <h1>You've successfully logged into the Shopify CLI!</h1>
             <p>You can close this tab and return to your terminal.</p>
         </div>
     </div>


### PR DESCRIPTION
### WHY are these changes introduced?

There is a typo in the success message. `Successfuly` → `Successfully`. Here is a [relevant Stack Overflow post](https://english.stackexchange.com/questions/435232/successfully-vs-successfuly) about the correct spelling of the word.

### WHAT is this pull request doing?

Updates the string to the correct spelling. There is a similar PR available for the [`2.x` version](https://github.com/Shopify/shopify-cli/pull/2658)