### PR TITLE
Add appovalScopes to extensions content node serve API

### DIFF
--- a/.changeset/clean-kiwis-perform.md
+++ b/.changeset/clean-kiwis-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Add appovalScopes to extensions content API

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -94,6 +94,7 @@ describe('getUIExtensionPayload', () => {
         type: 'product_subscription',
         uuid: 'devUUID',
         version: '1.2.3',
+        approvalScopes: ['scope-a'],
       })
     })
   })

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -63,5 +63,7 @@ export async function getUIExtensionPayload(
     version: renderer?.version,
 
     title: extension.configuration.name,
+
+    approvalScopes: options.grantedScopes ?? null,
   }
 }

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -53,6 +53,7 @@ export interface UIExtensionPayload {
   version?: string
   surface: UIExtensionSurface
   title: string
+  approvalScopes?: string[] | null
 }
 
 export type ExtensionAssetBuildStatus = 'success' | 'error' | ''


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes #621

### WHAT is this pull request doing?
- Add the optional field `approvalScopes` to the extensions payload served by node 

### How to test your changes?
1. Create a new app
2. Change the distribution of the app with Choose `single-merchant install link`
3. Launch `yarn dev` for the app
4. Check the `/extensions` local endpoint to see if it includes the approvalScopes key, with an array of strings (scopes)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
