### PR TITLE
Add missing approval_scopes

### DIFF
--- a/.changeset/nine-beers-begin.md
+++ b/.changeset/nine-beers-begin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Include the approvalScopes attributes when serving extensions form the new extensions' server implemented in Node

--- a/fixtures/app/extensions/product-subscription/src/index.js
+++ b/fixtures/app/extensions/product-subscription/src/index.js
@@ -12,7 +12,7 @@ function App(root, { extensionPoint }) {
     root.createComponent(
       Text,
       {},
-      `It works the ${extensionPoint} extension! APP_URL is: ${process.env.APP_URL}`
+      `It works the ${extensionPoint} extension! API_KEY is: ${process.env.SHOPIFY_API_KEY}`
     )
   );
   root.mount();

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -63,5 +63,6 @@ export async function getUIExtensionPayload(
     version: renderer?.version,
 
     title: extension.configuration.name,
+    approvalScopes: options.grantedScopes,
   }
 }

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -53,6 +53,7 @@ export interface UIExtensionPayload {
   version?: string
   surface: UIExtensionSurface
   title: string
+  approvalScopes: string[]
 }
 
 export type ExtensionAssetBuildStatus = 'success' | 'error' | ''


### PR DESCRIPTION
Resolves: https://github.com/Shopify/cli/issues/621

### WHY are these changes introduced?
The extension payload returned by the extensions' HTTP and Websocket servers [must return](https://github.com/Shopify/cli/issues/621) the `approvalScopes` attribute when apps are set up as "single-merchant install link. This is the case when serving the extensions through the Go logic, but we introduced a regression in the new Node logic.

### WHAT is this pull request doing?
I'm making sure the attribute is included in the new Node logic.

### How to test your changes?

1. Create a new app
2. Change the distribution of the app with Choose single-merchant install link
3. Launch yarn dev for the app
4. Check the /extensions local endpoint to see if it includes the approvalScopes key, with an array of strings (scopes)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
