### PR TITLE
Disable threads in vitest

### DIFF
--- a/configurations/vite.config.ts
+++ b/configurations/vite.config.ts
@@ -16,6 +16,7 @@ export default function config(packagePath: string) {
       clearMocks: true,
       mockReset: true,
       setupFiles: [path.join(__dirname, './vitest/setup.js')],
+      threads: false,
     },
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Vitest enables threads by default in order to:
- run tests in parallel
- isolate each test so that there cannot be leaks in the global state

But actual measures show that disabling threading will make our test suits run twice as fast. 

### WHAT is this pull request doing?

Disable vitest threading.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

**before**
<img width="553" alt="before" src="https://user-images.githubusercontent.com/62895/195895415-933b31e8-0853-4a39-89a5-873797a674b4.png">

**after**
<img width="554" alt="after" src="https://user-images.githubusercontent.com/62895/195895440-6a658c53-3ee2-4a92-8359-6c218b1fb6e9.png">


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
