### PR TITLE
Skip super flaky tests on windows while we investigate why they're flaking

### DIFF
--- a/packages/cli-hydrogen/src/cli/services/deploy/config.integration.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/deploy/config.integration.test.ts
@@ -3,6 +3,8 @@ import {gitInit} from '../../prompts/git-init.js'
 import {describe, it, expect, vi} from 'vitest'
 import {error, file, git} from '@shopify/cli-kit'
 
+const isWin = process.platform === 'win32'
+
 const defaultConfig = {
   deploymentToken: 'abcdefg',
   oxygenAddress: 'https://integration.test',
@@ -12,7 +14,7 @@ const defaultConfig = {
 
 describe('validateProject() & initializeGit()', () => {
   describe('User refuses to initialize new repository', () => {
-    it('silent abort since outside git directory', async () => {
+    it.skipIf(isWin)('silent abort since outside git directory', async () => {
       await file.inTemporaryDirectory(async (tmpDir) => {
         vi.mock('../../prompts/git-init.js')
         vi.mocked(gitInit).mockResolvedValue(false)
@@ -24,7 +26,7 @@ describe('validateProject() & initializeGit()', () => {
     })
   })
   describe('User accepts to initialize new repository', () => {
-    it(
+    it.skipIf(isWin)(
       'initializes new git repository',
       async () => {
         await file.inTemporaryDirectory(async (tmpDir) => {
@@ -42,7 +44,7 @@ describe('validateProject() & initializeGit()', () => {
 })
 
 describe('getDeployConfig()', () => {
-  it(
+  it.skipIf(isWin)(
     'extract basic information from git',
     async () => {
       await file.inTemporaryDirectory(async (tmpDir) => {


### PR DESCRIPTION
### WHY are these changes introduced?

We've witnessed some cli-hydrogen tests flaking very often on Windows

### WHAT is this pull request doing?

Skip those tests while we investigate what's causing the flakes

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
