### PR TITLE
Document how to style error tryMessage

### DIFF
--- a/.changeset/dull-bugs-shop.md
+++ b/.changeset/dull-bugs-shop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Document how to style error messages

--- a/packages/cli-kit/src/error.ts
+++ b/packages/cli-kit/src/error.ts
@@ -25,7 +25,7 @@ export abstract class Fatal extends Error {
    *
    * @param message - The error message
    * @param type - The type of fatal error
-   * @param tryMessage - The message that recomments next steps to the user.
+   * @param tryMessage - The message that recommends next steps to the user.
    *                     You can pass a string a {@link TokenizedString} or a {@link TextTokenItem}
    *                     if you need to style the message inside the error Banner component.
    */

--- a/packages/cli-kit/src/private/node/ui/components/Link.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Link.tsx
@@ -4,7 +4,7 @@ import terminalLink from 'terminal-link'
 
 interface Props {
   url: string
-  label: string
+  label?: string
 }
 
 /**
@@ -13,7 +13,7 @@ interface Props {
 const Link: React.FC<Props> = ({url, label}: React.PropsWithChildren<Props>): JSX.Element => {
   return (
     <Text>
-      <Text dimColor>{`${label}: `}</Text>
+      {label && <Text dimColor>{`${label}: `}</Text>}
       <Transform transform={(children) => terminalLink(children, url, {fallback: false})}>
         <Text underline>{url}</Text>
       </Transform>

--- a/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
@@ -9,7 +9,7 @@ interface CommandToken {
 
 interface LinkToken {
   link: {
-    label: string
+    label?: string
     url: string
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

From now on we should be trying to style errors better and one step towards that is adding the `Link` and `Command` tokens as part of our `tryMessages` so that the get highlighted by the new error component.

### WHAT is this pull request doing?

This PR allows developers to build errors by using `TextTokenItem` as the `tryMessage`, so if they need to style a command to run they can do so by doing something like:

```
throw new error.Abort('Unexpected Error', ['Fix this by running', { command: 'npm install' }])
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
