### PR TITLE
Introduce `--only/--ignore` support in the `shopify theme dev` command

### DIFF
--- a/.changeset/serious-geese-sort.md
+++ b/.changeset/serious-geese-sort.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Introduce `--only/--ignore` support into the `shopify theme dev` command

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -43,6 +43,18 @@ export default class Dev extends ThemeCommand {
       description: 'Theme ID or name of the remote theme.',
       env: 'SHOPIFY_FLAG_THEME_ID',
     }),
+    only: Flags.string({
+      char: 'o',
+      multiple: true,
+      description: 'Hot reload only files that match the specified pattern.',
+      env: 'SHOPIFY_FLAG_ONLY',
+    }),
+    ignore: Flags.string({
+      char: 'x',
+      multiple: true,
+      description: 'Skip hot reloading any files that match the specified pattern.',
+      env: 'SHOPIFY_FLAG_IGNORE',
+    }),
   }
 
   async run(): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/Shopify/cli/issues/648

### WHY are these changes introduced?

The `theme/dev.ts` command was not passing the `--only/--ignore` flags to the Ruby CLI.

### WHAT is this pull request doing?

This PR introduces both flags in the `theme/dev.ts` command.

### How to test your changes?

##### `--only` flag steps
- Run `shopify theme dev --only sections/announcement-bar.liquid`
- Open the browser at http://127.0.0.1:9292
- Change the `sections/announcement-bar.liquid`
- Notice the file is not ignore (the browser responds and the CLI logs show the file being synced)
- Change the `layout/theme.liquid`
- Notice the file is not ignored by the browser and the CLI logs

##### `--ignore` flag steps
- Run `shopify theme dev --ignore sections/announcement-bar.liquid`
- Open the browser at http://127.0.0.1:9292
- Change the `sections/announcement-bar.liquid`
- Notice the file is not ignored by the browser and the CLI logs
- Change the `layout/theme.liquid`
- Notice the file is not ignore (the browser responds and the CLI logs show the file being synced)

<img width="1370" alt="image" src="https://user-images.githubusercontent.com/1079279/196932882-acd9a560-e4e3-483e-bbe3-7470d30d4140.png">


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
