### PR TITLE
Introduce ExternalError and output external errors with a new component

### DIFF
--- a/.changeset/thin-walls-lick.md
+++ b/.changeset/thin-walls-lick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fixed third party errors formatting issue

--- a/packages/cli-kit/src/error.ts
+++ b/packages/cli-kit/src/error.ts
@@ -56,6 +56,21 @@ export class Abort extends Fatal {
   }
 }
 
+/**
+ * An external error is similar to Abort but has extra command and args attributes.
+ * This is useful to represent errors coming from external commands, usually executed by execa.
+ */
+export class ExternalError extends Fatal {
+  command: string
+  args: string[]
+
+  constructor(message: Message, command: string, args: string[], tryMessage: TextTokenItem | Message | null = null) {
+    super(message, FatalErrorType.Abort, tryMessage)
+    this.command = command
+    this.args = args
+  }
+}
+
 export class AbortSilent extends Fatal {
   constructor() {
     super('', FatalErrorType.AbortSilent)

--- a/packages/cli-kit/src/private/node/ui/components/Alert.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Alert.tsx
@@ -6,7 +6,7 @@ import {Box, Text} from 'ink'
 import React from 'react'
 
 export interface AlertProps {
-  type: Exclude<BannerType, 'error'>
+  type: Exclude<BannerType, 'error' | 'external_error'>
   headline: string
   body?: TextTokenItem
   nextSteps?: TextTokenItem[]

--- a/packages/cli-kit/src/private/node/ui/components/Banner.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Banner.tsx
@@ -1,7 +1,7 @@
 import {Box, Text, useStdout} from 'ink'
 import React from 'react'
 
-export type BannerType = 'success' | 'error' | 'warning' | 'info'
+export type BannerType = 'success' | 'error' | 'warning' | 'info' | 'external_error'
 
 interface Props {
   type: BannerType
@@ -13,6 +13,7 @@ function typeToColor(type: Props['type']) {
     error: 'red',
     warning: 'yellow',
     info: 'dim',
+    external_error: 'red',
   }[type]
 }
 
@@ -34,7 +35,7 @@ function calculateWidth(stdout: NodeJS.WriteStream | undefined) {
   return width
 }
 
-const Banner: React.FC<Props> = ({type, children}) => {
+const BoxWithBorder: React.FC<Props> = ({type, children}) => {
   const {stdout} = useStdout()
 
   return (
@@ -47,11 +48,47 @@ const Banner: React.FC<Props> = ({type, children}) => {
       borderColor={typeToColor(type)}
     >
       <Box marginTop={-2} marginBottom={1} marginLeft={-1}>
-        <Text dimColor bold>{` ${type} `}</Text>
+        <Text dimColor bold>{` ${type.replace(/_/g, ' ')} `}</Text>
       </Box>
       {children}
     </Box>
   )
+}
+
+const BoxWithTopLine: React.FC<Props> = ({type, children}) => {
+  const {stdout} = useStdout()
+  const width = calculateWidth(stdout)
+
+  return (
+    <Box marginY={1} flexDirection="column">
+      <Box marginBottom={1}>
+        <Text>
+          <Text color={typeToColor(type)}>{'─'.repeat(2)}</Text>
+          <Text dimColor bold>{` ${type.replace(/_/g, ' ')} `}</Text>
+          {/* 2 initial dashes + 2 spaces surrounding the type */}
+          <Text color={typeToColor(type)}>{'─'.repeat(width - 2 - type.length - 2)}</Text>
+        </Text>
+      </Box>
+
+      {children}
+
+      <Box marginTop={1}>
+        <Text color={typeToColor(type)}>{'─'.repeat(width)}</Text>
+      </Box>
+    </Box>
+  )
+}
+
+const BannerBox: React.FC<Props> = ({type, children}) => {
+  if (type === 'external_error') {
+    return <BoxWithTopLine type={type}>{children}</BoxWithTopLine>
+  }
+
+  return <BoxWithBorder type={type}>{children}</BoxWithBorder>
+}
+
+const Banner: React.FC<Props> = ({type, children}) => {
+  return <BannerBox type={type}>{children}</BannerBox>
 }
 
 export {Banner}

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
@@ -4,6 +4,7 @@ import {Bug, cleanSingleStackTracePath, Fatal} from '../../../../error.js'
 import {Box, Text} from 'ink'
 import React from 'react'
 import StackTracey from 'stacktracey'
+import stripAnsi from 'strip-ansi'
 
 export interface FatalErrorProps {
   error: Fatal
@@ -34,7 +35,7 @@ const FatalError: React.FC<FatalErrorProps> = ({error}) => {
   return (
     <Banner type="error">
       <Box>
-        <Text>{error.message}</Text>
+        <Text>{stripAnsi(error.message)}</Text>
       </Box>
 
       {error.tryMessage && (

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
@@ -1,10 +1,10 @@
 import {Banner} from './Banner.js'
 import {TokenizedText} from './TokenizedText.js'
-import {Bug, cleanSingleStackTracePath, Fatal} from '../../../../error.js'
+import {Command} from './Command.js'
+import {Bug, cleanSingleStackTracePath, ExternalError, Fatal} from '../../../../error.js'
 import {Box, Text} from 'ink'
 import React from 'react'
 import StackTracey from 'stacktracey'
-import stripAnsi from 'strip-ansi'
 
 export interface FatalErrorProps {
   error: Fatal
@@ -12,6 +12,7 @@ export interface FatalErrorProps {
 
 const FatalError: React.FC<FatalErrorProps> = ({error}) => {
   let stack
+  let tool
 
   if (error instanceof Bug) {
     stack = new StackTracey(error)
@@ -32,10 +33,22 @@ const FatalError: React.FC<FatalErrorProps> = ({error}) => {
       })
   }
 
+  if (error instanceof ExternalError) {
+    tool = `${error.command} ${error.args.join(' ')}`
+  }
+
   return (
-    <Banner type="error">
+    <Banner type={tool ? 'external_error' : 'error'}>
+      {tool && (
+        <Box marginBottom={1}>
+          <Text>
+            Error coming from <Command command={tool} />
+          </Text>
+        </Box>
+      )}
+
       <Box>
-        <Text>{stripAnsi(error.message)}</Text>
+        <Text>{error.message}</Text>
       </Box>
 
       {error.tryMessage && (

--- a/packages/cli-kit/src/system.ts
+++ b/packages/cli-kit/src/system.ts
@@ -1,6 +1,6 @@
 import {shouldDisplayColors, debug} from './output.js'
 import {platformAndArch} from './os.js'
-import {Abort} from './error.js'
+import {ExternalError} from './error.js'
 import {renderConcurrent} from './public/node/ui.js'
 import {execa, ExecaChildProcess} from 'execa'
 import {AbortSignal} from 'abort-controller'
@@ -49,7 +49,7 @@ export const exec = async (command: string, args: string[], options?: ExecOption
     await commandProcess
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (processError: any) {
-    const abortError = new Abort(processError.message)
+    const abortError = new ExternalError(processError.message, command, args)
     abortError.stack = processError.stack
     throw abortError
   }


### PR DESCRIPTION
### WHY are these changes introduced?

@isaacroldan reported that he saw an error that broke the borders of the banner component.

<img width="751" alt="Captura de Pantalla 2022-10-20 a las 12 44 31" src="https://user-images.githubusercontent.com/151725/196962657-4d1a8796-ccf8-4111-acad-1a5954e7688a.png">

### WHAT is this pull request doing?

I've introduced a new type of error called `ExternalError`. This is used when rescuing errors from `execa` and allows us to print these kind of errors differently, like so:

<img width="817" alt="Screenshot 2022-11-01 at 13 49 19" src="https://user-images.githubusercontent.com/151725/199249309-67183bf7-e801-43f0-813f-ab1101adbdcb.png">

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
