### PR TITLE
Fix dev extension flake

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -28,9 +28,11 @@ export function testApp(app: Partial<AppInterface> = {}): AppInterface {
 }
 
 export function testUIExtension(uiExtension: Partial<UIExtension> = {}): UIExtension {
+  const directory = uiExtension?.directory ?? '/tmp/project/extensions/test-ui-extension'
+
   return {
     localIdentifier: uiExtension?.localIdentifier ?? 'test-ui-extension',
-    outputBundlePath: uiExtension?.outputBundlePath ?? '/tmp/project/extensions/test-ui-extension/dist/main.js',
+    outputBundlePath: uiExtension?.outputBundlePath ?? `${directory}/dist/main.js`,
     configuration: uiExtension?.configuration ?? {
       name: uiExtension?.configuration?.name ?? 'test-ui-extension',
       type: uiExtension?.configuration?.type ?? 'product_subscription',
@@ -42,10 +44,9 @@ export function testUIExtension(uiExtension: Partial<UIExtension> = {}): UIExten
     },
     type: 'checkout_post_purchase',
     graphQLType: 'CHECKOUT_POST_PURCHASE',
-    configurationPath:
-      uiExtension?.configurationPath ?? '/tmp/project/extensions/test-ui-extension/shopify.ui.extension.toml',
-    directory: uiExtension?.directory ?? '/tmp/project/extensions/test-ui-extension',
-    entrySourceFilePath: uiExtension?.entrySourceFilePath ?? '/tmp/project/extensions/test-ui-extension/src/index.js',
+    configurationPath: uiExtension?.configurationPath ?? `${directory}/shopify.ui.extension.toml`,
+    directory,
+    entrySourceFilePath: uiExtension?.entrySourceFilePath ?? `${directory}/src/index.js`,
     idEnvironmentVariableName: uiExtension?.idEnvironmentVariableName ?? 'SHOPIFY_TET_UI_EXTENSION_ID',
     devUUID: 'devUUID',
   }

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -24,6 +24,7 @@ describe('getUIExtensionPayload', () => {
 
       const uiExtension = testUIExtension({
         outputBundlePath,
+        directory: tmpDir,
         configuration: {
           name: 'test-ui-extension',
           type: 'product_subscription',
@@ -101,7 +102,7 @@ describe('getUIExtensionPayload', () => {
   test('default values', async () => {
     await file.inTemporaryDirectory(async (tmpDir) => {
       // Given
-      const uiExtension = testUIExtension()
+      const uiExtension = testUIExtension({directory: tmpDir})
       const options: ExtensionDevOptions = {} as ExtensionDevOptions
       const development: Partial<UIExtensionPayload['development']> = {}
 


### PR DESCRIPTION
### WHY are these changes introduced?

When running the `packages/app` tests in a tight loop we would observe this flake

```
 FAIL  src/cli/services/dev/extension/payload.test.ts > getUIExtensionPayload > returns the right payload
 FAIL  src/cli/services/dev/extension/payload.test.ts > getUIExtensionPayload > default values
Error: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
```

After some debugging I noticed that the call that was hanging was `fast-glob`.

A bit later, I found this issue: https://github.com/mrmlnc/fast-glob/issues/362

I was able to find some tests regarding websockets that were calling `useFakeTimers` and never restoring them using `useRealTimers`.

### WHAT is this pull request doing?

Call `useRealTimer` after calling `useFakeTimers`

### How to test your changes?

* `cd packages/app`
* `while true; do DEBUG=1 yarn vitest run || break; done`

**before**
it would flake out after a few minutes

**after**
it doesn't flake even if you leave it for an hour

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
