### PR TITLE
Automatically refresh Theme session

### DIFF
--- a/.changeset/hip-dogs-kiss.md
+++ b/.changeset/hip-dogs-kiss.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+Refresh theme dev session every 90 minutes

--- a/packages/cli-kit/src/node/ruby.ts
+++ b/packages/cli-kit/src/node/ruby.ts
@@ -7,6 +7,7 @@ import constants from '../constants.js'
 import {coerce} from '../semver.js'
 import {AdminSession} from '../session.js'
 import {content, token} from '../output.js'
+import {AbortSignal} from 'abort-controller'
 import {Writable} from 'node:stream'
 
 const RubyCLIVersion = '2.29.0'
@@ -23,6 +24,8 @@ interface ExecCLI2Options {
   token?: string
   // Directory in which to execute the command. Otherwise the current directory will be used.
   directory?: string
+
+  signal?: AbortSignal
 }
 /**
  * Execute CLI 2.0 commands.
@@ -34,7 +37,7 @@ interface ExecCLI2Options {
  */
 export async function execCLI2(
   args: string[],
-  {adminSession, storefrontToken, token, directory}: ExecCLI2Options = {},
+  {adminSession, storefrontToken, token, directory, signal}: ExecCLI2Options = {},
 ) {
   await installCLIDependencies()
   const env = {
@@ -55,6 +58,7 @@ export async function execCLI2(
       stdio: 'inherit',
       cwd: directory ?? process.cwd(),
       env,
+      signal,
     })
   } catch (error) {
     // CLI2 will show it's own errors, we don't need to show an additional CLI3 error

--- a/packages/cli-kit/src/session.test.ts
+++ b/packages/cli-kit/src/session.test.ts
@@ -212,6 +212,23 @@ describe('when existing session is valid', () => {
     expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(expected)
   })
+
+  it('refreshes token if forceRefresh is true', async () => {
+    // Given
+    vi.mocked(validateSession).mockResolvedValueOnce('ok')
+    vi.mocked(secureFetch).mockResolvedValue(validSession)
+
+    // When
+    const got = await ensureAuthenticated(defaultApplications, process.env, true)
+
+    // Then
+    expect(authorize).not.toHaveBeenCalledOnce()
+    expect(exchangeCodeForAccessToken).not.toBeCalled()
+    expect(refreshAccessToken).toBeCalled()
+    expect(exchangeAccessForApplicationTokens).toBeCalled()
+    expect(secureStore).toBeCalledWith(validSession)
+    expect(got).toEqual(validTokens)
+  })
 })
 
 describe('when existing session is expired', () => {

--- a/packages/cli-kit/src/session.ts
+++ b/packages/cli-kit/src/session.ts
@@ -164,6 +164,7 @@ export async function ensureAuthenticatedThemes(
   store: string,
   password: string | undefined,
   scopes: string[] = [],
+  forceRefresh = false,
 ): Promise<AdminSession> {
   debug(content`Ensuring that the user is authenticated with the Theme API with the following scopes:
 ${token.json(scopes)}
@@ -177,7 +178,11 @@ ${token.json(scopes)}
  * @param applications - An object containing the applications we need to be authenticated with.
  * @returns An instance with the access tokens organized by application.
  */
-export async function ensureAuthenticated(applications: OAuthApplications, env = process.env): Promise<OAuthSession> {
+export async function ensureAuthenticated(
+  applications: OAuthApplications,
+  env = process.env,
+  forceRefresh = false,
+): Promise<OAuthSession> {
   const fqdn = await identityFqdn()
 
   if (applications.adminApi?.storeFqdn) {
@@ -200,7 +205,7 @@ ${token.json(applications)}
   if (validationResult === 'needs_full_auth') {
     debug(content`Initiating the full authentication flow...`)
     newSession = await executeCompleteFlow(applications, fqdn)
-  } else if (validationResult === 'needs_refresh') {
+  } else if (validationResult === 'needs_refresh' || forceRefresh) {
     debug(content`The current session is valid but needs refresh. Refreshing...`)
     try {
       newSession = await refreshTokens(fqdnSession.identity, applications, fqdn)

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -60,7 +60,7 @@ export default class Dev extends ThemeCommand {
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     setInterval(async () => {
-      output.debug('Refreshing theme session. Restarting theme serve.')
+      output.debug('Refreshing theme session...')
       controller.abort()
       controller = new abort.Controller()
       await this.execute(store, command, controller)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,7 +1700,7 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@1.16.4", "@oclif/core@^1.16.4", "@oclif/core@^1.2.0":
+"@oclif/core@1.16.4", "@oclif/core@^1.16.4":
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.16.4.tgz#fafa338ada0624d7f1adac036302b05a37cd96d0"
   integrity sha512-l+xHtVMteJWeTZZ+f2yLyNjf69X0mhAH8GILXnmoAGAemXbc1DVstvloxOouarvm9xyHHhquzO1Qg5l6xa1VIw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,7 +1700,7 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@1.16.4", "@oclif/core@^1.16.4":
+"@oclif/core@1.16.4", "@oclif/core@^1.16.4", "@oclif/core@^1.2.0":
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.16.4.tgz#fafa338ada0624d7f1adac036302b05a37cd96d0"
   integrity sha512-l+xHtVMteJWeTZZ+f2yLyNjf69X0mhAH8GILXnmoAGAemXbc1DVstvloxOouarvm9xyHHhquzO1Qg5l6xa1VIw==


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Up until now our commands execution only needed a valid token during the first seconds (maybe minutes). 
The only command with a long live period is `app dev` and it doesn't need a token once the servers are up.

But with themes this is different, during `theme dev` a valid token is always required to push changes to the remote store.

Fixes https://github.com/Shopify/cli/issues/546

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Before running `theme dev`, always refresh the tokens to be sure they are valid for at least 90min. 
- After running `theme dev` and every 90 min: close the ruby process, refresh tokens and execute it again with updated tokens.

❓  Tokens expire at 120min, should we refresh the tokens every 100, 110 or 115 min maybe?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- To test that the process finishes, refreshes and starts again, you can modify `ThemeRefreshTimeouInMinutes` to something smaller (maybe 0.5)
- To test that the process works always, just run `theme dev` for hours...

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
