### PR TITLE
Only trigger main workflow on push events

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -56,6 +56,7 @@ jobs:
   fixture:
     name: Fixture
     runs-on: 'ubuntu-latest'
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
@@ -72,7 +73,7 @@ jobs:
   main:
     name: Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' }}
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
### WHY are these changes introduced?

Only run main workflow on push events on main. Weirdly, even `workflow_dispatch` events have their github ref set to the main branch, so they would end up being triggered there as well.