### PR TITLE
Fix password flag for theme open/publish

### DIFF
--- a/.changeset/sharp-items-walk.md
+++ b/.changeset/sharp-items-walk.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix password flag for theme open/publish

--- a/packages/theme/src/cli/commands/theme/open.ts
+++ b/packages/theme/src/cli/commands/theme/open.ts
@@ -36,7 +36,7 @@ export default class Open extends ThemeCommand {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Open)
-    const flagsToPass = this.passThroughFlags(flags, {exclude: ['store', 'verbose']})
+    const flagsToPass = this.passThroughFlags(flags, {exclude: ['store', 'verbose', 'password']})
     const command = ['theme', 'open', ...flagsToPass]
 
     const store = await getThemeStore(flags)

--- a/packages/theme/src/cli/commands/theme/publish.ts
+++ b/packages/theme/src/cli/commands/theme/publish.ts
@@ -25,7 +25,7 @@ export default class Publish extends ThemeCommand {
     const {flags, args} = await this.parse(Publish)
 
     const store = await getThemeStore(flags)
-    const flagsToPass = this.passThroughFlags(flags, {exclude: ['path', 'store', 'verbose']})
+    const flagsToPass = this.passThroughFlags(flags, {exclude: ['path', 'store', 'verbose', 'password']})
     const command = ['theme', 'publish']
     if (args.themeId) {
       command.push(args.themeId)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/651

### WHAT is this pull request doing?

Remove the `password` flag from the ones we are sending to CLI2 for `theme open` and `theme publish` commands, as the CLI2 is not expecting it. 

### How to test your changes?

- `yarn shopify theme open --password whatever`
- `yarn shopify theme publish --password whatever`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
