### PR TITLE
Downgrade oclif and typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tmp": "^0.2.1",
     "ts-node": "^10.7.0",
     "tslib": "^2.3.1",
-    "typescript": "4.8.4"
+    "typescript": "4.6.4"
   },
   "workspaces": {
     "packages": [
@@ -104,6 +104,6 @@
   "resolutions": {
     "@types/react": "16.14.0",
     "vite": "2.9.12",
-    "@oclif/core": "1.16.4"
+    "@oclif/core": "1.9.2"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@luckycatfactory/esbuild-graphql-loader": "3.7.0",
-    "@oclif/core": "1.16.4",
+    "@oclif/core": "1.9.2",
     "@shopify/cli-kit": "3.19.0",
     "@shopify/shopify-cli-extensions": "3.19.0",
     "abort-controller": "^3.0.0",

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "dependencies": {
-    "@oclif/core": "1.16.4",
+    "@oclif/core": "1.9.2",
     "@shopify/hydrogen": "^0.26.0",
     "@shopify/mini-oxygen": "^0.2.0",
     "@types/prettier": "^2.6.3",

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "@bugsnag/js": "^7.16.7",
     "@iarna/toml": "^2.2.5",
-    "@oclif/core": "1.16.4",
+    "@oclif/core": "1.9.2",
     "@types/archiver": "^5.3.1",
     "abort-controller": "^3.0.0",
     "archiver": "^5.3.1",

--- a/packages/cli-kit/src/node/base-command.ts
+++ b/packages/cli-kit/src/node/base-command.ts
@@ -33,27 +33,25 @@ abstract class BaseCommand extends Command {
 
   protected async parse<
     TFlags extends Interfaces.FlagOutput & {path?: string; verbose?: boolean},
-    TGlobalFlags extends Interfaces.FlagOutput,
     TArgs extends Interfaces.OutputArgs,
   >(
-    options?: Interfaces.Input<TFlags, TGlobalFlags> | undefined,
+    options?: Interfaces.Input<TFlags> | undefined,
     argv?: string[] | undefined,
-  ): Promise<Interfaces.ParserOutput<TFlags, TGlobalFlags, TArgs>> {
-    let result = await super.parse<TFlags, TGlobalFlags, TArgs>(options, argv)
-    result = await this.resultWithPreset<TFlags, TGlobalFlags, TArgs>(options, argv, result)
+  ): Promise<Interfaces.ParserOutput<TFlags, TArgs>> {
+    let result = await super.parse<TFlags, TArgs>(options, argv)
+    result = await this.resultWithPreset<TFlags, TArgs>(options, argv, result)
     await addFromParsedFlags(result.flags)
     return result
   }
 
   protected async resultWithPreset<
     TFlags extends Interfaces.FlagOutput & {path?: string; verbose?: boolean},
-    TGlobalFlags extends Interfaces.FlagOutput,
     TArgs extends Interfaces.OutputArgs,
   >(
-    options: Interfaces.Input<TFlags, TGlobalFlags> | undefined,
+    options: Interfaces.Input<TFlags> | undefined,
     argv: string[] | undefined,
-    originalResult: Interfaces.ParserOutput<TFlags, TGlobalFlags, TArgs>,
-  ): Promise<Interfaces.ParserOutput<TFlags, TGlobalFlags, TArgs>> {
+    originalResult: Interfaces.ParserOutput<TFlags, TArgs>,
+  ): Promise<Interfaces.ParserOutput<TFlags, TArgs>> {
     // If no preset is specified, don't modify the results
     const flags = originalResult.flags as PresettableFlags
     if (!flags.preset) return originalResult
@@ -65,19 +63,19 @@ abstract class BaseCommand extends Command {
 
     // Parse using noDefaultsOptions to derive a list of flags specified as
     // command-line arguments.
-    const noDefaultsResult = await super.parse<TFlags, TGlobalFlags, TArgs>(noDefaultsOptions(options), argv)
+    const noDefaultsResult = await super.parse<TFlags, TArgs>(noDefaultsOptions(options), argv)
 
     // Add the preset's settings to argv and pass them to `super.parse`. This
     // invokes oclif's validation system without breaking the oclif black box.
     // Replace the original result with this one.
-    const result = await super.parse<TFlags, TGlobalFlags, TArgs>(options, [
+    const result = await super.parse<TFlags, TArgs>(options, [
       // Need to specify argv default because we're merging with argsFromPreset.
       ...(argv || this.argv),
-      ...argsFromPreset<TFlags, TGlobalFlags, TArgs>(preset, options, noDefaultsResult),
+      ...argsFromPreset<TFlags, TArgs>(preset, options, noDefaultsResult),
     ])
 
     // Report successful application of the preset.
-    reportPresetApplication<TFlags, TGlobalFlags, TArgs>(noDefaultsResult.flags, result.flags, flags.preset, preset)
+    reportPresetApplication<TFlags, TArgs>(noDefaultsResult.flags, result.flags, flags.preset, preset)
 
     return result
   }
@@ -111,13 +109,9 @@ export async function addFromParsedFlags(flags: {path?: string; verbose?: boolea
  * It doesn't matter if the preset flag's value was the same as the default; from
  * the user's perspective, they want to know their preset was applied.
  */
-function reportPresetApplication<
-  TFlags extends Interfaces.FlagOutput,
-  TGlobalFlags extends Interfaces.FlagOutput,
-  TArgs extends Interfaces.OutputArgs,
->(
-  noDefaultsFlags: Interfaces.ParserOutput<TFlags, TGlobalFlags, TArgs>['flags'],
-  flagsWithPresets: Interfaces.ParserOutput<TFlags, TGlobalFlags, TArgs>['flags'],
+function reportPresetApplication<TFlags extends Interfaces.FlagOutput, TArgs extends Interfaces.OutputArgs>(
+  noDefaultsFlags: Interfaces.ParserOutput<TFlags, TArgs>['flags'],
+  flagsWithPresets: Interfaces.ParserOutput<TFlags, TArgs>['flags'],
   presetName: string,
   preset: JsonMap,
 ): void {
@@ -157,9 +151,9 @@ ${Object.entries(changes)
  * the user actually passed on the command line.
  */
 
-function noDefaultsOptions<TFlags extends Interfaces.FlagOutput, TGlobalFlags extends Interfaces.FlagOutput>(
-  options: Interfaces.Input<TFlags, TGlobalFlags> | undefined,
-): Interfaces.Input<TFlags, TGlobalFlags> | undefined {
+function noDefaultsOptions<TFlags extends Interfaces.FlagOutput>(
+  options: Interfaces.Input<TFlags> | undefined,
+): Interfaces.Input<TFlags> | undefined {
   if (!options?.flags) return options
   return {
     ...options,
@@ -177,14 +171,10 @@ function noDefaultsOptions<TFlags extends Interfaces.FlagOutput, TGlobalFlags ex
  * Converts the preset's settings to arguments as though passed on the command
  * line, skipping any arguments the user specified on the command line.
  */
-function argsFromPreset<
-  TFlags extends Interfaces.FlagOutput,
-  TGlobalFlags extends Interfaces.FlagOutput,
-  TArgs extends Interfaces.OutputArgs,
->(
+function argsFromPreset<TFlags extends Interfaces.FlagOutput, TArgs extends Interfaces.OutputArgs>(
   preset: JsonMap,
-  options: Interfaces.Input<TFlags, TGlobalFlags> | undefined,
-  noDefaultsResult: Interfaces.ParserOutput<TFlags, TGlobalFlags, TArgs>,
+  options: Interfaces.Input<TFlags> | undefined,
+  noDefaultsResult: Interfaces.ParserOutput<TFlags, TArgs>,
 ): string[] {
   const args: string[] = []
   for (const [label, value] of Object.entries(preset)) {

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -51,7 +51,7 @@
     ]
   },
   "dependencies": {
-    "@oclif/core": "1.16.4",
+    "@oclif/core": "1.9.2",
     "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5.1.14",
     "@oclif/plugin-plugins": "^2.1.1",

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "dependencies": {
-    "@oclif/core": "1.16.4",
+    "@oclif/core": "1.9.2",
     "@shopify/cli-kit": "3.19.0"
   },
   "devDependencies": {

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -50,7 +50,7 @@
     }
   },
   "dependencies": {
-    "@oclif/core": "1.16.4",
+    "@oclif/core": "1.9.2",
     "@shopify/cli-kit": "3.19.0",
     "download": "8.0.0"
   },

--- a/packages/plugin-ngrok/package.json
+++ b/packages/plugin-ngrok/package.json
@@ -33,7 +33,7 @@
     "type-check": "nx type-check"
   },
   "dependencies": {
-    "@oclif/core": "1.16.4",
+    "@oclif/core": "1.9.2",
     "@shopify/cli-kit": "3.19.0",
     "@shopify/ngrok": "^4.3.2"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@oclif/core": "1.16.4",
+    "@oclif/core": "1.9.2",
     "@shopify/cli-kit": "3.19.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,10 +1700,10 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@1.16.4", "@oclif/core@^1.16.4":
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.16.4.tgz#fafa338ada0624d7f1adac036302b05a37cd96d0"
-  integrity sha512-l+xHtVMteJWeTZZ+f2yLyNjf69X0mhAH8GILXnmoAGAemXbc1DVstvloxOouarvm9xyHHhquzO1Qg5l6xa1VIw==
+"@oclif/core@1.9.2", "@oclif/core@^1.16.4", "@oclif/core@^1.2.0":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.9.2.tgz#19005ee1fbde16ed2b1926dfeb00e55fd7b45b4d"
+  integrity sha512-+qhfvDHn+tR4UN/Vk3UYIeM0Dm0XKsHrM4igJrUpJj/ZXXdaGbZEB+cMIRDZHGqBw+pcwP4+9zQFmxotMDIWcw==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
     "@oclif/screen" "^3.0.2"
@@ -12517,15 +12517,20 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.8.4, typescript@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 typescript@^4.7.2:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
   integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
+
+typescript@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Upgrading oclif introduced bugs with boolean flags. Need to downgrade again until https://github.com/oclif/core/pull/536 is merged to oclif.

This is an alternative approach vs https://github.com/Shopify/cli/pull/662

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Downgrades oclif and typescript, essentially reverting https://github.com/Shopify/cli/pull/555 (but with some extra work because the `base-command` code has changes)

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run the CLI...

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
