### PR TITLE
Add the hidden `--stable` flag in the `theme dev/push` commands

### DIFF
--- a/.changeset/gorgeous-penguins-teach.md
+++ b/.changeset/gorgeous-penguins-teach.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Add the hidden `--stable` flag in the `theme dev/push` commands

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -55,6 +55,12 @@ export default class Dev extends ThemeCommand {
       description: 'Skip hot reloading any files that match the specified pattern.',
       env: 'SHOPIFY_FLAG_IGNORE',
     }),
+    stable: Flags.boolean({
+      hidden: true,
+      description:
+        'Performs the upload by relying in the legacy upload approach (slower, but it might be more stable in some scenarios)',
+      env: 'SHOPIFY_FLAG_STABLE',
+    }),
   }
 
   // Tokens are valid for 120m, better to be safe and refresh every 90min

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -64,6 +64,12 @@ export default class Push extends ThemeCommand {
       description: 'Publish as the live theme after uploading.',
       env: 'SHOPIFY_FLAG_PUBLISH',
     }),
+    stable: Flags.boolean({
+      hidden: true,
+      description:
+        'Performs the upload by relying in the legacy upload approach (slower, but it might be more stable in some scenarios)',
+      env: 'SHOPIFY_FLAG_STABLE',
+    }),
   }
 
   async run(): Promise<void> {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/667

### WHAT is this pull request doing?

This PR introduces the hidden `--stable` flag in the `theme dev/push` commands.

Hopefully, it won't be used at the CLI 3.x, as we've fixed (https://github.com/Shopify/shopify-cli/pull/2650) the corner cases related to the performance enhancements in the upload of the CLI (https://github.com/Shopify/shopify-cli/pull/2368).

### How to test your changes?

- Run `DEBUG=1 yarn run shopify theme dev --path <theme_dir>`
- Notice the PUT requests use the bulk endpoint
- Run `DEBUG=1 yarn run shopify theme dev --path <theme_dir> --stable`
- Notice the PUT requests don't use the bulk endpoint
\-
- Run `DEBUG=1 yarn run shopify theme push --path <theme_dir>`
- Notice the PUT requests use the bulk endpoint
- Run `DEBUG=1 yarn run shopify theme push --path <theme_dir> --stable`
- Notice the PUT requests don't use the bulk endpoint

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
