### PR TITLE
always use extension dev uuid for dev

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -89,9 +89,6 @@ async function dev(options: DevOptions) {
     outputAppURL(storeFqdn, exposedUrl)
   }
 
-  // If we have a real UUID for an extension, use that instead of a random one
-  options.app.extensions.ui.forEach((ext) => (ext.devUUID = identifiers.extensions[ext.localIdentifier] ?? ext.devUUID))
-
   const backendOptions = {
     apiKey,
     backendPort,


### PR DESCRIPTION
Closes https://github.com/Shopify/checkout-web/issues/15057

Extensions should be using a `dev-uuid` formatted id during development. This allows them to be ignored from reports. Currently after a local extension is published and activated it is using the registration id instead of this `dev-uuid`.

### WHAT is this pull request doing?
Use dev UUID for the dev extensions

### How to test your changes?
- Checkout branch
- Create app + extension
- Persist the extension 
- (Observe the extension id in monorail events - is should not be prefixed with `dev-`)
- Open the extension id dev mode from CLI
- (Observe the extension id in monorail events - should be prefixed with `dev-`)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
