### PR TITLE
Add backticks to command token

### DIFF
--- a/.changeset/healthy-tips-serve.md
+++ b/.changeset/healthy-tips-serve.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add backticks surrounding command tokens

--- a/packages/cli-kit/src/private/node/ui/components/Command.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Command.tsx
@@ -9,7 +9,7 @@ interface Props {
  * `Command` displays a command as non-dimmed text.
  */
 const Command: React.FC<Props> = ({command}: React.PropsWithChildren<Props>): JSX.Element => {
-  return <Text>{command}</Text>
+  return <Text>`{command}`</Text>
 }
 
 export {Command}

--- a/packages/cli-kit/src/public/node/ui.test.ts
+++ b/packages/cli-kit/src/public/node/ui.test.ts
@@ -71,12 +71,12 @@ describe('renderInfo', async () => {
       │  Body                                                                        │
       │                                                                              │
       │  Next steps                                                                  │
-      │    • Run cd santorini-goods                                                  │
-      │    • To preview your project, run npm app dev                                │
-      │    • To add extensions, run npm generate extension                           │
+      │    • Run \`cd santorini-goods\`                                                │
+      │    • To preview your project, run \`npm app dev\`                              │
+      │    • To add extensions, run \`npm generate extension\`                         │
       │                                                                              │
       │  Reference                                                                   │
-      │    • Run npm shopify help                                                    │
+      │    • Run \`npm shopify help\`                                                  │
       │    • Press 'return' to open the really amazing and clean dev docs:           │
       │      https://shopify.dev                                                     │
       │                                                                              │

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -54,12 +54,12 @@ type RenderAlertOptions = Omit<AlertProps, 'type'>
  * │  Body                                                    │
  * │                                                          │
  * │  Next steps                                              │
- * │    • Run cd santorini-goods                              │
- * │    • To preview your project, run npm app dev            │
- * │    • To add extensions, run npm generate extension       │
+ * │    • Run `cd santorini-goods`                            │
+ * │    • To preview your project, run `npm app dev`          │
+ * │    • To add extensions, run `npm generate extension`     │
  * │                                                          │
  * │  Reference                                               │
- * │    • Run npm shopify help                                │
+ * │    • Run `npm shopify help`                              │
  * │    • Press 'return' to open the dev docs:                │
  * │      https://shopify.dev                                 │
  * │                                                          │
@@ -94,12 +94,12 @@ export function renderInfo(options: RenderAlertOptions) {
  * │  Body                                                    │
  * │                                                          │
  * │  Next steps                                              │
- * │    • Run cd santorini-goods                              │
- * │    • To preview your project, run npm app dev            │
- * │    • To add extensions, run npm generate extension       │
+ * │    • Run `cd santorini-goods`                              │
+ * │    • To preview your project, run `npm app dev`            │
+ * │    • To add extensions, run `npm generate extension`       │
  * │                                                          │
  * │  Reference                                               │
- * │    • Run npm shopify help                                │
+ * │    • Run `npm shopify help`                                │
  * │    • Press 'return' to open the dev docs:                │
  * │      https://shopify.dev                                 │
  * │                                                          │
@@ -134,12 +134,12 @@ export function renderSuccess(options: RenderAlertOptions) {
  * │  Body                                                    │
  * │                                                          │
  * │  Next steps                                              │
- * │    • Run cd santorini-goods                              │
- * │    • To preview your project, run npm app dev            │
- * │    • To add extensions, run npm generate extension       │
+ * │    • Run `cd santorini-goods`                            │
+ * │    • To preview your project, run `npm app dev`          │
+ * │    • To add extensions, run `npm generate extension`     │
  * │                                                          │
  * │  Reference                                               │
- * │    • Run npm shopify help                                │
+ * │    • Run `npm shopify help`                              │
  * │    • Press 'return' to open the dev docs:                │
  * │      https://shopify.dev                                 │
  * │                                                          │


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/431

### WHAT is this pull request doing?

This PR adds backticks surrounding every command.

### How to test your changes?

- Run `yarn shopify kitchen-sink` to see that the example output always uses backticks for commands.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
