### PR TITLE
[WIP] Add the ability to parse the new schema format

### DIFF
--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -43,7 +43,7 @@ export interface UIExtensionPayload {
     status: ExtensionAssetBuildStatus
     localizationStatus: ExtensionAssetBuildStatus
   }
-  extensionPoints: string[] | null
+  extensionPoints: string[] | null | {metafields?: {namespace: string; key: string}[]; target: string; module: string}[]
   localization: Localization | null
   categories: string[] | null
   metafields?: {namespace: string; key: string}[] | null


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #685

We want to be able to parse the new toml format (See [this doc](https://docs.google.com/document/d/1rlv3DcgGZi4_Hf_Ekd14DnYWJ1rjsfZlMBVC80gFWjc/edit#bookmark=id.ri74g3odxziy))

Note, this implementation kinda bad. Because of all the different schema formats, bascially every field becomes optional, which reduces type safety and validation posibilities a lot.  But, I don't want to spend much time on this right now because:

1. This will be merged into a feature branch and then refactored with Isaac's new approach to initializing extensions
2. After this project we will migrate all ui extensions to this new format, so this we can simplify these schemas a lot and reclaim some type safety.

### WHAT is this pull request doing?

**1) Updates the zod schema** 
This is what the CLI uses to parse the toml file into memory.  This then becomes part of the apps configuration.

Note, this implementation kinda bad. Because of all the different schema formats, basically every field becomes optional, which reduces type safety and validation possibilities a lot.  But, I don't want to spend much time on this right now because:

1. This will be merged into a feature branch and then refactored with Isaac's new approach to initializing extensions
2. After this project we will migrate all ui extensions to this new format, so this we can simplify these schemas a lot and reclaim some type safety.

**2) Updates the App Loader to load the new format**

| Previously  |  Now |
|---|---|
|  A UI extension could only have one `/src/**` file | A UI extension can have multiple `src/**` files    |
|  The file in `/src/**` would always be called `index` | Files in `/src/**` can be called anything   |

To support these changes we need to update how we do validation:

| Previously  |  Now |
|---|---|
|  Throw or report an error if there is no `src/index.js|ts|jsx|tsx` file | Throw an error if there is no `src/**.js|ts|jsx|tsx` file    |

### How to test your changes?
Note that this is incomplete functionality.  The CLI can load the new format, but it will not be able to build it.  That will come in another PR.

To test this:

1. `cd fictures/app`
2. `yarn generate extension`

You will see an error that is related to esbuild, but the toml file should be loaded.

### Post-release steps
None, this will be refactored after Isaac's changes.

### Measuring impact
How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
