### PR TITLE
ESLint rules to enforce/ban extensions in imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -73,6 +73,7 @@ module.exports = {
         format: null,
       },
     ],
+    'import/extensions': ['error', 'always', {ignorePackages: true}],
     '@typescript-eslint/no-misused-promises': 'error',
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',

--- a/packages/app/src/cli/models/app/identifiers.ts
+++ b/packages/app/src/cli/models/app/identifiers.ts
@@ -1,8 +1,8 @@
 import {Extension} from './extensions.js'
-import {AppInterface} from './app'
 import {dotEnvFileNames} from '../../constants.js'
 import {path, string} from '@shopify/cli-kit'
 import {writeDotEnv} from '@shopify/cli-kit/node/dot-env'
+import type {AppInterface} from './app'
 
 export interface IdentifiersExtensions {
   [localIdentifier: string]: string

--- a/packages/app/src/cli/services/app/env/pull.test.ts
+++ b/packages/app/src/cli/services/app/env/pull.test.ts
@@ -1,4 +1,4 @@
-import {pullEnv} from './pull'
+import {pullEnv} from './pull.js'
 import {fetchOrgAndApps, fetchOrganizations} from '../../dev/fetch.js'
 import {selectApp} from '../select-app.js'
 import {AppInterface} from '../../../models/app/app.js'

--- a/packages/app/src/cli/services/dev/theme-extension-args.test.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.test.ts
@@ -1,6 +1,6 @@
-import {themeExtensionArgs} from './theme-extension-args'
-import {ensureThemeExtensionDevEnvironment} from '../environment'
-import {testThemeExtensions} from '../../models/app/app.test-data'
+import {themeExtensionArgs} from './theme-extension-args.js'
+import {ensureThemeExtensionDevEnvironment} from '../environment.js'
+import {testThemeExtensions} from '../../models/app/app.test-data.js'
 import {beforeAll, describe, expect, it, vi} from 'vitest'
 
 beforeAll(() => {

--- a/packages/app/src/cli/services/environment/id-matching.ts
+++ b/packages/app/src/cli/services/environment/id-matching.ts
@@ -1,9 +1,9 @@
-import {LocalSource} from './identifiers'
 import {MatchingError, RemoteSource} from './identifiers.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {err, ok, Result} from '@shopify/cli-kit/common/result'
 import {string} from '@shopify/cli-kit'
 import {difference, partition, pickBy, uniqBy, groupBy} from 'lodash-es'
+import type {LocalSource} from './identifiers'
 
 export interface MatchResult {
   identifiers: IdentifiersExtensions

--- a/packages/app/src/cli/services/generate-schema.test.ts
+++ b/packages/app/src/cli/services/generate-schema.test.ts
@@ -1,7 +1,7 @@
-import {generateSchemaService} from './generate-schema'
+import {generateSchemaService} from './generate-schema.js'
 import * as localEnvironment from './environment.js'
 import * as identifiers from '../models/app/identifiers.js'
-import {testApp, testFunctionExtension} from '../models/app/app.test-data'
+import {testApp, testFunctionExtension} from '../models/app/app.test-data.js'
 import {api, environment, error} from '@shopify/cli-kit'
 import {beforeEach, describe, expect, it, MockedFunction, vi} from 'vitest'
 

--- a/packages/app/src/cli/utilities/extensions/name-mapper.ts
+++ b/packages/app/src/cli/utilities/extensions/name-mapper.ts
@@ -1,4 +1,4 @@
-import {ExtensionTypes, ExternalExtensionTypes, UIExtensionTypes, UIExternalExtensionTypes} from '../../constants'
+import type {ExtensionTypes, ExternalExtensionTypes, UIExtensionTypes, UIExternalExtensionTypes} from '../../constants'
 
 export function mapExtensionTypesToExternalExtensionTypes(extensionTypes: ExtensionTypes[]): ExternalExtensionTypes[] {
   return extensionTypes.map(mapExtensionTypeToExternalExtensionType)

--- a/packages/cli-hydrogen/src/cli/services/eslint.ts
+++ b/packages/cli-hydrogen/src/cli/services/eslint.ts
@@ -1,5 +1,5 @@
-import {HydrogenApp} from '../models/hydrogen'
-import {genericConfigurationFileNames} from '../constants'
+import {HydrogenApp} from '../models/hydrogen.js'
+import {genericConfigurationFileNames} from '../constants.js'
 import {ui, vscode, npm, file, path, error, environment} from '@shopify/cli-kit'
 import {addNPMDependenciesWithoutVersionIfNeeded} from '@shopify/cli-kit/node/node-package-manager'
 import stream from 'node:stream'

--- a/packages/cli-kit/src/node/error-handler.test.ts
+++ b/packages/cli-kit/src/node/error-handler.test.ts
@@ -1,7 +1,7 @@
-import {errorHandler, cleanStackFrameFilePath, addBugsnagMetadata, sendErrorToBugsnag} from './error-handler'
+import {errorHandler, cleanStackFrameFilePath, addBugsnagMetadata, sendErrorToBugsnag} from './error-handler.js'
 import * as environment from '../environment.js'
-import * as error from '../error'
-import * as outputMocker from '../testing/output'
+import * as error from '../error.js'
+import * as outputMocker from '../testing/output.js'
 import {hashString} from '../string.js'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 

--- a/packages/cli-kit/src/npm.test.ts
+++ b/packages/cli-kit/src/npm.test.ts
@@ -1,6 +1,6 @@
 import {file, npm, os, path} from '.'
 import {updateAppData} from './npm.js'
-import {inTemporaryDirectory} from './file'
+import {inTemporaryDirectory} from './file.js'
 import {describe, it, expect, vi} from 'vitest'
 
 vi.mock('node:os')

--- a/packages/cli-kit/src/port.test.ts
+++ b/packages/cli-kit/src/port.test.ts
@@ -1,6 +1,6 @@
-import {getRandomPort} from './port'
-import * as System from './system'
-import {Abort} from './error'
+import {getRandomPort} from './port.js'
+import * as System from './system.js'
+import {Abort} from './error.js'
 import * as port from 'get-port-please'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 

--- a/packages/cli-kit/src/testing/ui.ts
+++ b/packages/cli-kit/src/testing/ui.ts
@@ -1,4 +1,4 @@
-import * as path from '../path'
+import * as path from '../path.js'
 import {ExecaChildProcess, execaNode} from 'execa'
 
 type Run = (fixture: string, props?: {env?: {[key: string]: unknown}}) => ExecaChildProcess<string>

--- a/packages/cli-kit/src/ui/inquirer/autocomplete.ts
+++ b/packages/cli-kit/src/ui/inquirer/autocomplete.ts
@@ -2,7 +2,7 @@ import {colors} from '../../node/colors.js'
 import AutocompletePrompt from 'inquirer-autocomplete-prompt'
 import DistinctChoice from 'inquirer/lib/objects/choices'
 import inquirer from 'inquirer'
-// eslint-disable-next-line import/extensions
+
 import Paginator from 'inquirer/lib/utils/paginator.js'
 import {Interface} from 'readline'
 

--- a/packages/cli-kit/src/ui/inquirer/input.ts
+++ b/packages/cli-kit/src/ui/inquirer/input.ts
@@ -1,5 +1,5 @@
 import {colors} from '../../node/colors.js'
-// eslint-disable-next-line import/extensions
+
 import Input from 'inquirer/lib/prompts/input.js'
 import inquirer from 'inquirer'
 import readline, {Interface} from 'readline'

--- a/packages/cli-kit/src/ui/inquirer/select.ts
+++ b/packages/cli-kit/src/ui/inquirer/select.ts
@@ -1,5 +1,5 @@
 import {CustomAutocomplete} from './autocomplete.js'
-// eslint-disable-next-line import/extensions
+
 import utils from 'inquirer/lib/utils/readline.js'
 import inquirer from 'inquirer'
 import {Interface} from 'readline'

--- a/packages/cli-main/src/cli/commands/auth/logout.test.ts
+++ b/packages/cli-main/src/cli/commands/auth/logout.test.ts
@@ -1,4 +1,4 @@
-import Logout from './logout'
+import Logout from './logout.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {session, outputMocker} from '@shopify/cli-kit'
 

--- a/packages/cli-main/src/cli/services/commands/version.test.ts
+++ b/packages/cli-main/src/cli/services/commands/version.test.ts
@@ -1,4 +1,4 @@
-import {versionService} from './version'
+import {versionService} from './version.js'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {outputMocker, output, error} from '@shopify/cli-kit'
 import {

--- a/packages/create-hydrogen/src/commands/init.test.ts
+++ b/packages/create-hydrogen/src/commands/init.test.ts
@@ -1,6 +1,6 @@
-import Init from './init'
-import initService from '../services/init'
-import initPrompt from '../prompts/init'
+import Init from './init.js'
+import initService from '../services/init.js'
+import initPrompt from '../prompts/init.js'
 import {describe, it, expect, vi} from 'vitest'
 
 vi.mock('../utils/paths')

--- a/packages/create-hydrogen/src/prompts/init.test.ts
+++ b/packages/create-hydrogen/src/prompts/init.test.ts
@@ -1,4 +1,4 @@
-import init from './init'
+import init from './init.js'
 import {describe, test, it, expect, vi} from 'vitest'
 
 describe('init', () => {

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -30,7 +30,8 @@
       "../../.eslintrc.cjs"
     ],
     "rules": {
-      "no-console": "off"
+      "no-console": "off",
+      "import/extensions": ["error", "never", {"ignorePackages": true}]
     }
   }
 }

--- a/packages/features/snapshots/commands.txt
+++ b/packages/features/snapshots/commands.txt
@@ -9,6 +9,7 @@
  auth logout            @shopify/cli           
  commands               @oclif/plugin-commands 
  help                   @oclif/plugin-help     
+ hydrogen add eslint    @shopify/cli-hydrogen  
  hydrogen add tailwind  @shopify/cli-hydrogen  
  hydrogen build         @shopify/cli-hydrogen  
  hydrogen dev           @shopify/cli-hydrogen  

--- a/packages/ui-extensions-cli/package.json
+++ b/packages/ui-extensions-cli/package.json
@@ -28,7 +28,8 @@
       "../../.eslintrc.cjs"
     ],
     "rules": {
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "import/extensions": ["error", "never", {"ignorePackages": true}]
     }
   },
   "devDependencies": {

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -28,7 +28,8 @@
       "../../.eslintrc.cjs"
     ],
     "rules": {
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "import/extensions": ["error", "never", {"ignorePackages": true}]
     }
   },
   "devDependencies": {

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -39,7 +39,8 @@
       "../../.eslintrc.cjs"
     ],
     "rules": {
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "import/extensions": ["error", "never", {"ignorePackages": true}]
     }
   },
   "devDependencies": {

--- a/packages/ui-extensions-test-utils/package.json
+++ b/packages/ui-extensions-test-utils/package.json
@@ -19,7 +19,8 @@
       "../../.eslintrc.cjs"
     ],
     "rules": {
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "import/extensions": ["error", "never", {"ignorePackages": true}]
     }
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/446
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Forces extensions to be used in most imports; Bans them in commonjs packages

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Run `lint`!

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
