### PR TITLE
[Feature] Add short flag "-e" for "--theme-editor-sync"

### DIFF
--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -30,6 +30,7 @@ export default class Dev extends ThemeCommand {
       env: 'SHOPIFY_FLAG_POLL',
     }),
     'theme-editor-sync': Flags.boolean({
+      char: 'e',
       description: 'Synchronize Theme Editor updates in the local theme files.',
       env: 'SHOPIFY_FLAG_THEME_EDITOR_SYNC',
     }),


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2587

### WHAT is this pull request doing?

Adds short flag `-e` for `--theme-editor-sync`.

### How to test your changes?

1. `shopify-dev theme serve -e`
2. Open the theme editor and make some changes.
3. Verify that these changes are now visible in your source code.

### Post-release steps

- [ ] Create update request to shopify.dev docs ([example](https://github.com/Shopify/shopify-dev/issues/18455)) and assign it to shainaraskas

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
