### PR TITLE
[Fix] Undeployable customer accounts extensions

### DIFF
--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -19,13 +19,6 @@ import {OrganizationApp} from '../models/organization.js'
 import {path, output, file, error, environment} from '@shopify/cli-kit'
 import {AllAppExtensionRegistrationsQuerySchema} from '@shopify/cli-kit/src/api/graphql'
 
-const RendererNotFoundBug = (extension: string) => {
-  return new error.Bug(
-    `Couldn't find renderer version for extension ${extension}`,
-    'Make sure you have all your dependencies up to date',
-  )
-}
-
 interface DeployOptions {
   /** The app to be built and uploaded */
   app: AppInterface
@@ -184,7 +177,12 @@ async function configFor(extension: UIExtension, app: AppInterface) {
     case 'pos_ui_extension':
     case 'product_subscription': {
       const result = await getUIExtensionRendererVersion(type, app)
-      if (result === 'not_found') throw RendererNotFoundBug(type)
+      if (result === 'not_found') {
+        throw new error.Bug(
+          `Couldn't find renderer version for extension ${type}`,
+          'Make sure you have all your dependencies up to date',
+        )
+      }
       return {renderer_version: result?.version}
     }
     case 'checkout_ui_extension': {
@@ -202,7 +200,6 @@ async function configFor(extension: UIExtension, app: AppInterface) {
         extension_points: extension.configuration.extensionPoints,
         name: extension.configuration.name,
         categories: extension.configuration.categories,
-        localization: await loadLocalesConfig(extension.directory),
       }
     }
     case 'web_pixel_extension': {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes undeployable customer-accounts extensions that do not contain a `locales` folder. 
This PR unblocks the returns team from deploying their current customer-accounts extension (which does not contain a locales folder). We will re-add the removed line, once all the work on shopify core to fully support our new localization system is fully shipped.

### WHAT is this pull request doing?

Removes the `localization` property when deploying an customer-accounts extension.

### How to test your changes?

1. Generate a new customer-accounts extension
3. Execute `yarn shopify app dev --path <path-to-your-extension> --reset` 
4. Install the app: 
   -> Browser -> Shopify partners -> Apps -> Click on the name you choose earlier 
   -> Click on "Select Store"  -> Install App
6. Deploy the extension, execute `yarn shopify app deploy --path <path-to-your-extension>`
7. The CLI should not throw any error while deploying

✅ I Tophatted the change 🎩
<img width="1163" alt="Screenshot 2022-11-07 at 09 19 29" src="https://user-images.githubusercontent.com/3514796/200264053-6b36eec6-40bd-486c-96e8-d114db0751ea.png">


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
