### PR TITLE
Update the Ruby CLI version

### DIFF
--- a/.changeset/dry-llamas-travel.md
+++ b/.changeset/dry-llamas-travel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Update the version of the Ruby CLI

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -10,7 +10,7 @@ import {content, token} from '../../output.js'
 import {AbortSignal} from 'abort-controller'
 import {Writable} from 'node:stream'
 
-const RubyCLIVersion = '2.29.0'
+const RubyCLIVersion = '2.31.0'
 const ThemeCheckVersion = '1.10.3'
 const MinBundlerVersion = '2.3.8'
 const MinRubyVersion = '2.7.5'


### PR DESCRIPTION
### WHY are these changes introduced?
I'm releasing the [Ruby CLI 2.31.0](https://github.com/Shopify/shopify-cli/pull/2679) so I'm updating the Node CLI to use the that version. This PR should only be merged when the release has happened.

### WHAT is this pull request doing?
Updating the version of the Ruby CLI

### How to test your changes?
Try to run a command that runs through the Ruby CLI, for example `theme pull` and `theme push`. It should work successfully.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
