### PR TITLE
Add missing postinstall step

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "type-check:affected": "nx affected --target=type-check --all",
     "build": "nx run-many --target=build --all --skip-nx-cache",
     "build:affected": "nx affected --target=build --all",
-    "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache"
+    "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@apollo/client": "^3.4.8",


### PR DESCRIPTION
### WHY are these changes introduced?
Patches are not getting applied because a `script` is missing in the `package.json`.

### WHAT is this pull request doing?
Adding the missing script.

### How to test your changes?
If you run `yarn install` on this branch. The code under `node_modules/@changesets/cli` should have received the patches.