### PR TITLE
Make ui-extensions-dev-console dependency of @shopify/app

### DIFF
--- a/.changeset/kind-dodos-fry.md
+++ b/.changeset/kind-dodos-fry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix dev-console not loading because it can't be found

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -4,6 +4,7 @@
     "sourceRoot": "packages/app/src",
     "projectType": "library",
     "tags": ["scope:feature"],
+    "implicitDependencies": ["ui-extensions-dev-console"],
     "targets": {
       "clean": {
         "executor": "nx:run-commands",


### PR DESCRIPTION
### WHY are these changes introduced?
The dev-console fails to load in the most recent release, 3.22.0, because it can't be found:

```json
{
"statusCode": 404,
"statusMessage": "Could not find root directory for dev console",
"stack": []
}
```

### WHAT is this pull request doing?
It turns out with the removal of the Go binary, the `dev-console` stopped being a project dependency of the `@shopify/app` package and therefore it didn't get bundled when we deployed the packages in the Shipit environment. I'm adding it as a dependency to make sure it's built before the `@shopify/app` package is built.

<img width="507" alt="image" src="https://user-images.githubusercontent.com/663605/200550025-6914e153-a854-443e-9940-a2f1420eba56.png">


### How to test your changes?
1. Run `yarn clean`.
2. Go to `packages/app`
3. Run `yarn build`
4. The dev console should show up in `assets/dev-console`.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
