### PR TITLE
Remove event trigger flags and hide command

### DIFF
--- a/packages/app/src/cli/commands/event/trigger.ts
+++ b/packages/app/src/cli/commands/event/trigger.ts
@@ -5,6 +5,7 @@ import {deliveryMethodInstructions} from '../../prompts/event/trigger.js'
 import {Command, Flags} from '@oclif/core'
 
 export default class TopicTesting extends Command {
+  static hidden = true
   static description = 'Trigger delivery of a sample event topic payload to a designated address'
 
   static flags = {

--- a/packages/app/src/cli/commands/event/trigger.ts
+++ b/packages/app/src/cli/commands/event/trigger.ts
@@ -11,28 +11,24 @@ export default class TopicTesting extends Command {
     help: Flags.help({
       required: false,
       hidden: false,
-      char: 'h',
       env: 'SHOPIFY_FLAG_HELP',
       description: `This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.`,
     }),
     topic: Flags.string({
       required: false,
       hidden: false,
-      char: 't',
       env: 'SHOPIFY_FLAG_TOPIC',
       description: 'The requested event topic.',
     }),
     'api-version': Flags.string({
       required: false,
       hidden: false,
-      char: 'v',
       env: 'SHOPIFY_FLAG_API_VERSION',
       description: 'The API Version of the event topic.',
     }),
     'delivery-method': Flags.string({
       required: false,
       hidden: false,
-      char: 'm',
       options: [DELIVERY_METHOD.HTTP, DELIVERY_METHOD.PUBSUB, DELIVERY_METHOD.EVENTBRIDGE],
       env: 'SHOPIFY_FLAG_DELIVERY_METHOD',
       description: `Method chosen to deliver the topic payload. If not passed, it's inferred from the address`,
@@ -40,20 +36,18 @@ export default class TopicTesting extends Command {
     'shared-secret': Flags.string({
       required: false,
       hidden: false,
-      char: 's',
       env: 'SHOPIFY_FLAG_SHARED_SECRET',
-      description: `Shared secret used to build the X-Shopify-Hmac-SHA256 header.`,
+      description: `Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.`,
     }),
     address: Flags.string({
       required: false,
       hidden: false,
-      char: 'a',
       env: 'SHOPIFY_FLAG_ADDRESS',
       description: `The URL where the webhook payload should be sent.
                     For each delivery-method you will need a different address type:
-                     - ${DELIVERY_METHOD.HTTP}: ${deliveryMethodInstructions(DELIVERY_METHOD.HTTP)}
-                     - ${DELIVERY_METHOD.PUBSUB}: ${deliveryMethodInstructions(DELIVERY_METHOD.PUBSUB)}
-                     - ${DELIVERY_METHOD.EVENTBRIDGE}: ${deliveryMethodInstructions(DELIVERY_METHOD.EVENTBRIDGE)}`,
+                     ${deliveryMethodInstructions(DELIVERY_METHOD.HTTP)}
+                     ${deliveryMethodInstructions(DELIVERY_METHOD.PUBSUB)}
+                     ${deliveryMethodInstructions(DELIVERY_METHOD.EVENTBRIDGE)}`,
     }),
   }
 

--- a/packages/app/src/cli/prompts/event/options-prompt.ts
+++ b/packages/app/src/cli/prompts/event/options-prompt.ts
@@ -52,7 +52,7 @@ export async function optionsPrompt(flags: EventTriggerFlags): Promise<EventTrig
 
   if (methodPassed && !validDeliveryMethodFlag(flags.deliveryMethod)) {
     throw new error.Abort(
-      'Invalid delivery-method passed',
+      'Invalid Delivery Method passed',
       `${DELIVERY_METHOD.HTTP}, ${DELIVERY_METHOD.PUBSUB}, and ${DELIVERY_METHOD.EVENTBRIDGE} are allowed`,
     )
   }
@@ -63,8 +63,8 @@ export async function optionsPrompt(flags: EventTriggerFlags): Promise<EventTrig
       options.deliveryMethod = inferMethodFromAddress(options.address)
     } else {
       throw new error.Abort(
-        'Invalid address for delivery method',
-        `${deliveryMethodInstructions(flags.deliveryMethod as string)} for ${flags.deliveryMethod}`,
+        "Can't deliver your webhook payload to this address. Run 'shopify event trigger --address=<VALUE>' with a valid URL",
+        `Try this\n\n   ${deliveryMethodInstructions(flags.deliveryMethod as string)}`,
       )
     }
   }

--- a/packages/app/src/cli/prompts/event/trigger.ts
+++ b/packages/app/src/cli/prompts/event/trigger.ts
@@ -102,13 +102,13 @@ export async function sharedSecretPrompt(): Promise<string> {
 
 export function deliveryMethodInstructions(method: string): string {
   if (method === DELIVERY_METHOD.HTTP) {
-    return `- For remote ${DELIVERY_METHOD.HTTP} testing, use a URL that starts with https://\n   - For local ${DELIVERY_METHOD.HTTP} testing, use http://localhost:{port}/{url-path}`
+    return `- For remote HTTP testing, use a URL that starts with https://\n   - For local HTTP testing, use http://localhost:{port}/{url-path}`
   }
   if (method === DELIVERY_METHOD.PUBSUB) {
-    return `- For ${DELIVERY_METHOD.PUBSUB} use pubsub://{project-id}:{topic-id}`
+    return `- For Google Pub/Sub, use pubsub://{project-id}:{topic-id}`
   }
   if (method === DELIVERY_METHOD.EVENTBRIDGE) {
-    return `- For ${DELIVERY_METHOD.EVENTBRIDGE} use an Amazon Resource Name (ARN) starting with arn:aws:events:`
+    return `- For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:`
   }
 
   return ''

--- a/packages/app/src/cli/prompts/event/trigger.ts
+++ b/packages/app/src/cli/prompts/event/trigger.ts
@@ -102,13 +102,13 @@ export async function sharedSecretPrompt(): Promise<string> {
 
 export function deliveryMethodInstructions(method: string): string {
   if (method === DELIVERY_METHOD.HTTP) {
-    return 'Use either https:// for remote or http://localhost:{port}/{url-path} for local'
+    return `- For remote ${DELIVERY_METHOD.HTTP} testing, use a URL that starts with https://\n   - For local ${DELIVERY_METHOD.HTTP} testing, use http://localhost:{port}/{url-path}`
   }
   if (method === DELIVERY_METHOD.PUBSUB) {
-    return 'Use pubsub://{project-id}:{topic-id}'
+    return `- For ${DELIVERY_METHOD.PUBSUB} use pubsub://{project-id}:{topic-id}`
   }
   if (method === DELIVERY_METHOD.EVENTBRIDGE) {
-    return 'Use an Amazon Resource Name (ARN) starting with arn:aws:events:'
+    return `- For ${DELIVERY_METHOD.EVENTBRIDGE} use an Amazon Resource Name (ARN) starting with arn:aws:events:`
   }
 
   return ''


### PR DESCRIPTION
### WHY are these changes introduced?

1. We want to hide the `event trigger` command (already merged to main) until we perform a bug bash exercise on its functionality
2. Apply reviews from @MeredithCastile about the error messages and flags (remove aliases)
  
### WHAT is this pull request doing?

- Add the hidden flag
- Remove aliases
- Update error messages

### How to test your changes?

For example:
```
yarn shopify event trigger --topic=t --api-version=2 --shared-secret=xxx --delivery-method=http --address ftp://user:pass@host
```

### Post-release steps

None yet. It's hidden
Before we make it public, apply improvements from this PR https://github.com/Shopify/cli/pull/711 (if already deployed)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
