### PR TITLE
Add reviewers reminder for new PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,0 @@
-*       @shopify/cli-foundations
-
-packages/cli-hydrogen/ @shopify/hydrogen
-packages/create-hydrogen/ @shopify/hydrogen
-
-packages/theme/ @shopify/theme-developer-tools
-
-packages/app/src/cli/services/dev/extension/ @shopify/ui-extensions-cli
-packages/app/src/cli/services/dev/extension.ts @shopify/ui-extensions-cli

--- a/.github/workflows/reviewers-reminder.yml
+++ b/.github/workflows/reviewers-reminder.yml
@@ -1,0 +1,24 @@
+name: Reviewers reminder
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: comment PR
+        uses: unsplash/comment-on-pr@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: |
+            Thanks for your contribution!
+
+            Depending on what you are working on, you may want to request a review from a Shopify team:
+            - Themes: @shopify/theme-developer-tools
+            - UI extensions: @shopify/ui-extensions-cli
+            - Hydrogen: @shopify/hydrogen
+            - Other: @shopify/cli-foundations


### PR DESCRIPTION
### WHY are these changes introduced?

We (CLI Foundations) are getting too many notifications, not always from work that actually requires our review.

### WHAT is this pull request doing?

- Add a new workflow that comments on new PRs suggesting possible reviewers
- Remove CODEOWNERS, so that review requests are not automatically sent

### How to test your changes?

https://github.com/Shopify/cli/pull/770#issuecomment-1313417291

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
