### PR TITLE
[Functions] Use function-templates repo

### DIFF
--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -51,7 +51,7 @@ export default class AppScaffoldExtension extends Command {
       hidden: true,
       char: 'u',
       description:
-        'The Git URL to clone the function extensions templates from. Defaults to: https://github.com/Shopify/function-examples',
+        'The Git URL to clone the function extensions templates from. Defaults to: https://github.com/Shopify/function-templates',
       env: 'SHOPIFY_FLAG_CLONE_URL',
     }),
     template: Flags.string({

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -34,7 +34,7 @@ export const blocks = {
     configurationName: configurationFileNames.extension,
   },
   functions: {
-    defaultUrl: 'https://github.com/Shopify/function-examples',
+    defaultUrl: 'https://github.com/Shopify/function-templates',
     defaultLanguage: 'wasm',
   },
   web: {

--- a/packages/app/src/cli/models/extensions/functions.ts
+++ b/packages/app/src/cli/models/extensions/functions.ts
@@ -139,7 +139,7 @@ export function createFunctionSpec<TConfiguration extends FunctionConfigType = F
   templatePath: (lang: string) => string
 }): FunctionSpec {
   const defaults = {
-    templateURL: 'https://github.com/Shopify/function-examples',
+    templateURL: 'https://github.com/Shopify/function-templates',
     languages: [
       {name: 'Wasm', value: 'wasm'},
       {name: 'Rust', value: 'rust'},


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/script-service/issues/5959

### WHAT is this pull request doing?

Pull function extension templates from [`function-templates`](https://github.com/Shopify/function-templates) instead of `function-examples`

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

https://github.com/Shopify/function-examples/pull/131

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
