### PR TITLE
Connect UI extensions dev console with cli

### DIFF
--- a/packages/ui-extensions-dev-console/README.md
+++ b/packages/ui-extensions-dev-console/README.md
@@ -1,0 +1,33 @@
+# The extension dev console
+A tool for developing extensions locally.
+
+## Local development
+
+In terminal 1:
+
+1. `dev cd cli`
+2. `cd fixtures/app`
+3. `yarn dev`
+4. Copy the **Shopify extension dev console URL** e.g: `https://d1b8-2a09-bac1-14c0-188-00-b-224.ngrok.io/extensions/dev-console`
+
+In terminal 2:
+
+1. `dev cd cli`
+2. `cd packages/ui-extensions-dev-console`
+3. `VITE_CONNECTION_URL=[SHOPIFY_EXTENSION_DEV_CONSOLE_URL] yarn dev`
+
+Go to: localhost:3000
+
+### Limitations
+
+When you run `yarn dev` a version of the dev console will be run, which is served from a static build.  If you go to a preview URL Shopify web will load the dev console from this URL, rather than the vite dev server which is on localhost:3000.
+
+If you want to see your changes on Shopify web:
+
+1. `dev cd cli`
+2. `cd packages/ui-extensions-dev-console`
+3. `yarn build`
+
+
+
+

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -7,8 +7,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "serve": "vite preview",
-    "start": "nx start",
+    "dev": "nx dev",
     "test": "nx run ui-extensions-dev-console:test",
     "test:watch": "nx test:watch"
   },

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -35,10 +35,10 @@
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
-      "start": {
+      "dev": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "yarn vite start",
+          "command": "yarn vite dev",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },

--- a/packages/ui-extensions-dev-console/src/App.tsx
+++ b/packages/ui-extensions-dev-console/src/App.tsx
@@ -9,7 +9,7 @@ import {ExtensionServerProvider, isValidSurface} from '@shopify/ui-extensions-se
 
 function getConnectionUrl() {
   if (import.meta.env.VITE_CONNECTION_URL) {
-    return import.meta.env.VITE_CONNECTION_URL.replace("https", "wss").replace("dev-console", "")
+    return import.meta.env.VITE_CONNECTION_URL.replace("https", "wss").replace("/dev-console", "")
   }
 
   const protocol = location.protocol === 'http:' ? 'ws:' : 'wss:'

--- a/packages/ui-extensions-dev-console/src/App.tsx
+++ b/packages/ui-extensions-dev-console/src/App.tsx
@@ -9,7 +9,7 @@ import {ExtensionServerProvider, isValidSurface} from '@shopify/ui-extensions-se
 
 function getConnectionUrl() {
   if (import.meta.env.VITE_CONNECTION_URL) {
-    return import.meta.env.VITE_CONNECTION_URL.replace("https", "wss").replace("/dev-console", "")
+    return import.meta.env.VITE_CONNECTION_URL.replace('https', 'wss').replace('/dev-console', '')
   }
 
   const protocol = location.protocol === 'http:' ? 'ws:' : 'wss:'

--- a/packages/ui-extensions-dev-console/src/App.tsx
+++ b/packages/ui-extensions-dev-console/src/App.tsx
@@ -7,12 +7,20 @@ import {AppProvider} from '@shopify/polaris'
 import {I18nContext, I18nManager} from '@shopify/react-i18n'
 import {ExtensionServerProvider, isValidSurface} from '@shopify/ui-extensions-server-kit'
 
-const protocol = location.protocol === 'http:' ? 'ws:' : 'wss:'
-const host = (import.meta.env.VITE_WEBSOCKET_HOST as string) || location.host
+function getConnectionUrl() {
+  if (import.meta.env.VITE_CONNECTION_URL) {
+    return import.meta.env.VITE_CONNECTION_URL.replace("https", "wss").replace("dev-console", "")
+  }
+
+  const protocol = location.protocol === 'http:' ? 'ws:' : 'wss:'
+
+  return `${protocol}//${location.host}/extensions`
+}
+
 const surface = new URLSearchParams(location.search).get('surface')
 const extensionServerOptions = {
   connection: {
-    url: `${protocol}//${host}/extensions`,
+    url: getConnectionUrl(),
   },
   surface: isValidSurface(surface) ? surface : undefined,
 }


### PR DESCRIPTION
### WHY are these changes introduced?
To develop the extensions dev console it would be handy if:

1. you could connect the UI with real data provided by the CLI.  
2. You could work with vite's dev server so that you have hot module reloading.

In this PR we make these things a little easier.

### WHAT is this pull request doing?

1. Change `import.meta.env.VITE_WEBSOCKET_HOST` to `VITE_CONNECTION_URL`
2. Parse the env var so that we end up with the correct URL, e.g: `wss://ngrok.url/extensions`
3. Add a README with steps on how to run the dev console 
4. Replace the `start` command wth a `dev` command to run Vite's dev server.  Not sure why we had a start command ? 

### How to test your changes?

1. Read the readme.
2. Follow the steps in the readme.

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
