### PR TITLE
Remove end of line new lines from chunks

### DIFF
--- a/packages/cli-kit/src/output.ts
+++ b/packages/cli-kit/src/output.ts
@@ -303,20 +303,6 @@ export interface OutputProcess {
   action: (stdout: Writable, stderr: Writable, signal: AbortSignal) => Promise<void>
 }
 
-/**
- * This regex can be used to find the erase cursor Ansii characters
- * to strip them from the string.
- * https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#erase-functions
- */
-const eraseCursorAnsiRegex = [
-  // Erase the entire line
-  '2K',
-  // Clear vertical tab stop at current line
-  '1G',
-]
-  .map((element) => `[\\u001B\\u009B][[\\]()#;?]*${element}`)
-  .join('|')
-
 export function consoleLog(message: string): void {
   console.log(withOrWithoutStyle(message))
 }

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -72,7 +72,7 @@ const ConcurrentOutput: FunctionComponent<Props> = ({processes, abortController,
   const writableStream = (process: OutputProcess, index: number) => {
     return new Writable({
       write(chunk, _encoding, next) {
-        const lines = stripAnsi(chunk.toString('ascii')).split(/\n/)
+        const lines = stripAnsi(chunk.toString('ascii').replace(/(\n)$/, '')).split(/\n/)
 
         setProcessOutput((previousProcessOutput) => [
           ...previousProcessOutput,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/464

We used to have a function that cleaned just the ansi characters that moved the cursor before displaying concurrent output. I removed this function replacing it with `stripAnsi` which just strips every ansi character. This is so that we can have total control of the formatting, including color.

Part of this function was also a replacement of the end of line `\n` characters which I inadvertedly removed.

### WHAT is this pull request doing?

This PR puts that replacement back.

### How to test your changes?

- Run `yarn shopify app dev --path fixtures/app`
- Change something in the backend `index.js`
- There should be no line breaks between the nodemon logs

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
