### PR TITLE
Redirect extension output messages to concurrent output UI component

### DIFF
--- a/.changeset/eight-insects-hide.md
+++ b/.changeset/eight-insects-hide.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': patch
+'@shopify/cli-kit': patch
+---
+
+Redirect extension output messages to concurrent output UI component

--- a/packages/app/src/cli/services/dev/extension.test.ts
+++ b/packages/app/src/cli/services/dev/extension.test.ts
@@ -18,6 +18,8 @@ describe('devUIExtensions()', () => {
     mock: 'options',
     url: 'https://mock.url',
     signal: {addEventListener: vi.fn()},
+    stdout: process.stdout,
+    stderr: process.stderr,
   } as unknown as ExtensionDevOptions
 
   function spyOnEverything() {
@@ -81,6 +83,7 @@ describe('devUIExtensions()', () => {
 
     // THEN
     expect(websocket.setupWebsocketConnection).toHaveBeenCalledWith({
+      ...options,
       httpServer: expect.objectContaining({mock: 'http-server'}),
       payloadStore: {mock: 'payload-store'},
     })

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -90,15 +90,12 @@ export async function devUIExtensions(options: ExtensionDevOptions): Promise<voi
   const payloadStoreRawPayload = await getExtensionsPayloadStoreRawPayload(payloadStoreOptions)
   const payloadStore = new ExtensionsPayloadStore(payloadStoreRawPayload, payloadStoreOptions)
 
-  output.debug(`Setting up the UI extensions HTTP server...`)
+  output.debug(`Setting up the UI extensions HTTP server...`, options.stdout)
   const httpServer = setupHTTPServer({devOptions, payloadStore})
 
-  output.debug(`Setting up the UI extensions Websocket server...`)
-  const websocketConnection = setupWebsocketConnection({
-    httpServer,
-    payloadStore,
-  })
-  output.debug(`Setting up the UI extensions bundler and file watching...`)
+  output.debug(`Setting up the UI extensions Websocket server...`, options.stdout)
+  const websocketConnection = setupWebsocketConnection({...options, httpServer, payloadStore})
+  output.debug(`Setting up the UI extensions bundler and file watching...`, options.stdout)
   const fileWatcher = await setupBundlerAndFileWatcher({devOptions, payloadStore})
 
   options.signal.addEventListener('abort', () => {

--- a/packages/app/src/cli/services/dev/extension/bundler.test.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.test.ts
@@ -115,6 +115,7 @@ describe('setupBundlerAndFileWatcher()', () => {
     // THEN
     expect(fileWatcherOptions.payloadStore.updateExtension).toHaveBeenCalledWith(
       fileWatcherOptions.devOptions.extensions[0],
+      fileWatcherOptions.devOptions,
       {status: 'success'},
     )
   })
@@ -135,6 +136,7 @@ describe('setupBundlerAndFileWatcher()', () => {
     // THEN
     expect(fileWatcherOptions.payloadStore.updateExtension).toHaveBeenCalledWith(
       fileWatcherOptions.devOptions.extensions[0],
+      fileWatcherOptions.devOptions,
       {status: 'error'},
     )
   })
@@ -174,9 +176,11 @@ describe('setupBundlerAndFileWatcher()', () => {
     // THEN
     expect(fileWatcherOptions.payloadStore.updateExtension).toHaveBeenCalledWith(
       fileWatcherOptions.devOptions.extensions[0],
+      fileWatcherOptions.devOptions,
     )
     expect(fileWatcherOptions.payloadStore.updateExtension).toHaveBeenCalledWith(
       fileWatcherOptions.devOptions.extensions[1],
+      fileWatcherOptions.devOptions,
     )
   })
 })

--- a/packages/app/src/cli/services/dev/extension/bundler.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.ts
@@ -47,10 +47,11 @@ export async function setupBundlerAndFileWatcher(options: FileWatcherOptions) {
             `The Javascript bundle of the UI extension with ID ${extension.devUUID} has ${
               error ? 'an error' : 'changed'
             }`,
+            error ? options.devOptions.stderr : options.devOptions.stdout,
           )
 
           options.payloadStore
-            .updateExtension(extension, {
+            .updateExtension(extension, options.devOptions, {
               status: error ? 'error' : 'success',
             })
             // ESBuild handles error output
@@ -63,28 +64,28 @@ export async function setupBundlerAndFileWatcher(options: FileWatcherOptions) {
     const localeWatcher = chokidar
       .watch(path.join(extension.directory, 'locales', '**.json'))
       .on('change', (event, path) => {
-        output.debug(`Locale file at path ${path} changed`)
+        output.debug(`Locale file at path ${path} changed`, options.devOptions.stdout)
         options.payloadStore
-          .updateExtension(extension)
-          .then((closed) => {
-            output.debug(`Notified extension ${extension.devUUID} about the locale change.`)
+          .updateExtension(extension, options.devOptions)
+          .then((_closed) => {
+            output.debug(`Notified extension ${extension.devUUID} about the locale change.`, options.devOptions.stdout)
           })
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           .catch((_: any) => {})
       })
 
     abortController.signal.addEventListener('abort', () => {
-      output.debug(`Closing locale file watching for extension with ID ${extension.devUUID}`)
+      output.debug(`Closing locale file watching for extension with ID ${extension.devUUID}`, options.devOptions.stdout)
       localeWatcher
         .close()
         .then(() => {
-          output.debug(`Locale file watching closed for extension with ${extension.devUUID}`)
+          output.debug(`Locale file watching closed for extension with ${extension.devUUID}`, options.devOptions.stdout)
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .catch((error: any) => {
           output.debug(
             `Locale file watching failed to close for extension with ${extension.devUUID}: ${error.message}`,
-            output.consoleError,
+            options.devOptions.stderr,
           )
         })
     })

--- a/packages/app/src/cli/services/dev/extension/localization.test.ts
+++ b/packages/app/src/cli/services/dev/extension/localization.test.ts
@@ -1,9 +1,12 @@
 import {getLocalization, Localization} from './localization.js'
 import {testUIExtension} from '../../../models/app/app.test-data.js'
+import {ExtensionDevOptions} from '../extension.js'
 import {file, path, output} from '@shopify/cli-kit'
 import {describe, expect, it, vi} from 'vitest'
 
 async function testGetLocalization(tmpDir: string, currentLocalization?: Localization) {
+  const mockOptions = {} as unknown as ExtensionDevOptions
+
   const extension = await testUIExtension({
     configuration: {
       name: 'mock-name',
@@ -24,7 +27,7 @@ async function testGetLocalization(tmpDir: string, currentLocalization?: Localiz
     outputBundlePath: `${tmpDir}/dist/main.js`,
     entrySourceFilePath: `${tmpDir}/dist/main.js`,
   })
-  return getLocalization(extension, currentLocalization)
+  return getLocalization(extension, {...mockOptions, currentLocalizationPayload: currentLocalization})
 }
 
 describe('when there are no locale files', () => {
@@ -140,8 +143,8 @@ describe('when there are locale files', () => {
 
       const result = await testGetLocalization(tmpDir)
 
-      expect(output.info).toHaveBeenCalledWith(expect.stringContaining('mock-name'))
-      expect(output.info).toHaveBeenCalledWith(expect.stringContaining(tmpDir))
+      expect(output.info).toHaveBeenCalledWith(expect.stringContaining('mock-name'), undefined)
+      expect(output.info).toHaveBeenCalledWith(expect.stringContaining(tmpDir), undefined)
     })
   })
 

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -8,7 +8,7 @@ import {getUIExtensionRendererVersion} from '../../../models/app/app.js'
 import {NewExtensionPointSchemaType} from '../../../models/extensions/schemas.js'
 import {file} from '@shopify/cli-kit'
 
-type GetUIExtensionPayloadOptions = ExtensionDevOptions & {
+export type GetUIExtensionPayloadOptions = ExtensionDevOptions & {
   currentDevelopmentPayload?: Partial<UIExtensionPayload['development']>
   currentLocalizationPayload?: UIExtensionPayload['localization']
 }
@@ -18,10 +18,7 @@ export async function getUIExtensionPayload(
   options: GetUIExtensionPayloadOptions,
 ): Promise<UIExtensionPayload> {
   const url = `${options.url}/extensions/${extension.devUUID}`
-  const {localization, status: localizationStatus} = await getLocalization(
-    extension,
-    options.currentLocalizationPayload,
-  )
+  const {localization, status: localizationStatus} = await getLocalization(extension, options)
 
   const renderer = await getUIExtensionRendererVersion(extension.configuration.type, options.app)
   const defaultConfig = {

--- a/packages/app/src/cli/services/dev/extension/payload/store.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.test.ts
@@ -205,7 +205,7 @@ describe('ExtensionsPayloadStore()', () => {
       const updatedExtension = {devUUID: '123', updated: 'extension'} as unknown as UIExtension
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension, {hidden: true})
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions, {hidden: true})
 
       // Then
       expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, {
@@ -232,7 +232,7 @@ describe('ExtensionsPayloadStore()', () => {
       const updatedExtension = {devUUID: '123', updated: 'extension'} as unknown as UIExtension
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension)
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions)
 
       // Then
       expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, {
@@ -263,7 +263,7 @@ describe('ExtensionsPayloadStore()', () => {
       const updatedExtension = {devUUID: '123', updated: 'extension'} as unknown as UIExtension
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension)
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions)
 
       // Then
       expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, {
@@ -291,7 +291,7 @@ describe('ExtensionsPayloadStore()', () => {
       extensionsPayloadStore.on(ExtensionsPayloadStoreEvent.Update, onUpdateSpy)
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension)
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions)
 
       // Then
       expect(onUpdateSpy).toHaveBeenCalledWith(['123'])
@@ -311,7 +311,7 @@ describe('ExtensionsPayloadStore()', () => {
       extensionsPayloadStore.on(ExtensionsPayloadStoreEvent.Update, onUpdateSpy)
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension)
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions)
 
       // Then
       expect(initialRawPayload).toStrictEqual(extensionsPayloadStore.getRawPayload())

--- a/packages/app/src/cli/services/dev/extension/payload/store.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.ts
@@ -89,12 +89,19 @@ export class ExtensionsPayloadStore extends EventEmitter {
     this.emitUpdate(extensions.map((extension) => extension.uuid))
   }
 
-  async updateExtension(extension: UIExtension, development?: Partial<UIExtensionPayload['development']>) {
+  async updateExtension(
+    extension: UIExtension,
+    options: ExtensionDevOptions,
+    development?: Partial<UIExtensionPayload['development']>,
+  ) {
     const payloadExtensions = this.rawPayload.extensions
     const index = payloadExtensions.findIndex((extensionPayload) => extensionPayload.uuid === extension.devUUID)
 
     if (index === -1) {
-      output.debug(output.content`Could not updateExtension() for extension with uuid: ${extension.devUUID}`)
+      output.debug(
+        output.content`Could not updateExtension() for extension with uuid: ${extension.devUUID}`,
+        options.stderr,
+      )
       return
     }
 

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -152,9 +152,7 @@ export async function devConsoleAssetsMiddleware(
 
 export function getLogMiddleware({devOptions}: GetExtensionsMiddlewareOptions) {
   return async (request: http.IncomingMessage, response: http.ServerResponse, next: (err?: Error) => unknown) => {
-    output.debug(`UI extensions server received a ${request.method} request to URL ${request.url}`, (message) =>
-      devOptions.stdout.write(message, 'utf8'),
-    )
+    output.debug(`UI extensions server received a ${request.method} request to URL ${request.url}`, devOptions.stdout)
     next()
   }
 }

--- a/packages/app/src/cli/services/dev/extension/websocket.test.ts
+++ b/packages/app/src/cli/services/dev/extension/websocket.test.ts
@@ -1,6 +1,7 @@
 import {ExtensionsPayloadStore, ExtensionsPayloadStoreEvent} from './payload/store.js'
 import {setupWebsocketConnection} from './websocket.js'
 import {websocketUpgradeHandler, getPayloadUpdateHandler} from './websocket/handlers.js'
+import {ExtensionDevOptions} from '../extension.js'
 import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest'
 import {WebSocketServer} from 'ws'
 import {Server} from 'node:https'
@@ -13,7 +14,8 @@ describe('setupWebsocketConnection', () => {
   const handler: any = {}
   const payloadStore: ExtensionsPayloadStore = {on: vi.fn()} as any
   const httpServer: Server = {on: vi.fn()} as any
-  const options = {httpServer, payloadStore}
+  const devOptions = {} as unknown as ExtensionDevOptions
+  const options = {...devOptions, httpServer, payloadStore}
 
   beforeEach(() => {
     vi.useFakeTimers()

--- a/packages/app/src/cli/services/dev/extension/websocket/models.ts
+++ b/packages/app/src/cli/services/dev/extension/websocket/models.ts
@@ -1,4 +1,5 @@
 import {ExtensionsPayloadStore} from '../payload/store.js'
+import {ExtensionDevOptions} from '../../extension.js'
 import {Server} from 'node:http'
 
 export enum EventType {
@@ -15,7 +16,7 @@ export interface WebSocketEvent {
   data: any
 }
 
-export interface SetupWebSocketConnectionOptions {
+export type SetupWebSocketConnectionOptions = ExtensionDevOptions & {
   httpServer: Server
   payloadStore: ExtensionsPayloadStore
 }

--- a/packages/cli-kit/src/output.ts
+++ b/packages/cli-kit/src/output.ts
@@ -24,7 +24,7 @@ import type {Change} from 'diff'
 
 export {default as logUpdate} from 'log-update'
 
-export type Logger = (message: string) => void
+export type Logger = Writable | ((message: string) => void)
 
 export class TokenizedString {
   value: string
@@ -321,7 +321,11 @@ export function consoleWarn(message: string): void {
 
 export function outputWhereAppropriate(logLevel: LogLevel, logger: Logger, message: string): void {
   if (shouldOutput(logLevel)) {
-    logger(message)
+    if (logger instanceof Writable) {
+      logger.write(message)
+    } else {
+      logger(message)
+    }
   }
   logToFile(message, logLevel.toUpperCase())
 }

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -87,16 +87,23 @@ const ConcurrentOutput: FunctionComponent<Props> = ({processes, abortController,
   }
 
   const runProcesses = async () => {
-    await Promise.all(
-      processes.map(async (process, index) => {
-        const stdout = writableStream(process, index)
-        const stderr = writableStream(process, index)
+    try {
+      await Promise.all(
+        processes.map(async (process, index) => {
+          const stdout = writableStream(process, index)
+          stdout.write.bind(stdout)
+          const stderr = writableStream(process, index)
+          stderr.write.bind(stderr)
 
         await process.action(stdout, stderr, abortController.signal)
       }),
     )
 
     unmountInk()
+  } catch (error) {
+    abortController.abort()
+    unmountInk()
+    throw error
   }
 
   useEffect(() => {

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -87,22 +87,16 @@ const ConcurrentOutput: FunctionComponent<Props> = ({processes, abortController,
   }
 
   const runProcesses = async () => {
-    try {
-      await Promise.all(
-        processes.map(async (process, index) => {
-          const stdout = writableStream(process, index)
-          const stderr = writableStream(process, index)
+    await Promise.all(
+      processes.map(async (process, index) => {
+        const stdout = writableStream(process, index)
+        const stderr = writableStream(process, index)
 
-          await process.action(stdout, stderr, abortController.signal)
-        }),
-      )
+        await process.action(stdout, stderr, abortController.signal)
+      }),
+    )
 
-      unmountInk()
-    } catch (error) {
-      abortController.abort()
-      unmountInk()
-      throw error
-    }
+    unmountInk()
   }
 
   useEffect(() => {

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -91,19 +91,18 @@ const ConcurrentOutput: FunctionComponent<Props> = ({processes, abortController,
       await Promise.all(
         processes.map(async (process, index) => {
           const stdout = writableStream(process, index)
-          stdout.write.bind(stdout)
           const stderr = writableStream(process, index)
-          stderr.write.bind(stderr)
 
-        await process.action(stdout, stderr, abortController.signal)
-      }),
-    )
+          await process.action(stdout, stderr, abortController.signal)
+        }),
+      )
 
-    unmountInk()
-  } catch (error) {
-    abortController.abort()
-    unmountInk()
-    throw error
+      unmountInk()
+    } catch (error) {
+      abortController.abort()
+      unmountInk()
+      throw error
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
After the migration form the Go extension server to the Node extension server, output messages from extension server logic are not rendered using the UI ConcurrentOutput component.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Output messages in extension server should use the `stdout` and `stderr` writers that receives when the UI ConcurrentOutput initiates the server.

### How to test your changes?
- Run `yarn shopify app dev --verbose` command for an app that contains at least one extension.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
