### PR TITLE
Env vars consistency

### DIFF
--- a/.changeset/spicy-seas-play.md
+++ b/.changeset/spicy-seas-play.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Bring consistency to the environment variables that we pass to the web frontend and backend processes


### PR DESCRIPTION
### WHY are these changes introduced?
During the migration of the [Forms](https://github.com/shopify/forms) 1P app, which doesn't adhere to the most recent setup proposed by our templates, we realized that some variables were not passed to the frontend process. For instance, one of them is `SHOP_CUSTOM_DOMAIN`, which we need to initialize the Shopify App gem in a single-process app where the main process is of type `frontend`.

### WHAT is this pull request doing?
I added a new function to obtain the environment variables that are common in the frontend and backend processes. Note that we include `SHOP_CUSTOM_DOMAIN` when we are running the CLI in Spin.

### How to test your changes?
Try to `dev` the fixture app locally and in Spin.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
