### PR TITLE
[Feature] Add preview links for a ui_extension

### DIFF
--- a/packages/app/src/cli/models/app/extensions.ts
+++ b/packages/app/src/cli/models/app/extensions.ts
@@ -47,4 +47,6 @@ export type UIExtension<TConfiguration extends BaseConfigContents = BaseConfigCo
   preDeployValidation(): Promise<void>
   deployConfig(): Promise<{[key: string]: unknown}>
   previewMessage(url: string, storeFqdn: string): output.TokenizedString | undefined
+  shouldFetchCartUrl(): boolean
+  hasExtensionPointTarget(target: string): boolean
 }

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -287,6 +287,7 @@ class AppLoader {
         remoteSpecification: undefined,
         extensionPointSpecs: undefined,
       })
+
       if (configuration.type) {
         const validateResult = await extensionInstance.validate()
         if (validateResult.isErr()) {

--- a/packages/app/src/cli/models/extensions/extension-points.ts
+++ b/packages/app/src/cli/models/extensions/extension-points.ts
@@ -1,7 +1,7 @@
-import {ExtensionPointSchema} from './schemas.js'
+import {NewExtensionPointSchema} from './schemas.js'
 import {schema} from '@shopify/cli-kit'
 
-type BasePointConfigContents = schema.define.infer<typeof ExtensionPointSchema>
+type BasePointConfigContents = schema.define.infer<typeof NewExtensionPointSchema>
 
 /**
  * Extension Point specification

--- a/packages/app/src/cli/models/extensions/extension-specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/extension-specifications/checkout_ui_extension.ts
@@ -32,6 +32,7 @@ const spec = createExtensionSpec({
       localization: await loadLocalesConfig(directory, 'checkout_ui'),
     }
   },
+  shouldFetchCartUrl: () => true,
 })
 
 export default spec

--- a/packages/app/src/cli/models/extensions/extension-specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/extension-specifications/ui_extension.ts
@@ -26,7 +26,9 @@ const spec = createExtensionSpec({
     return validateUIExtensionPointConfig(directory, config.extensionPoints)
   },
   previewMessage(host, uuid, config, storeFqdn) {
-    const links = config.extensionPoints.map((point) => `Preview link: ${host}/extensions/${uuid}/${point.target}`)
+    const links = config.extensionPoints.map(
+      ({target}) => `${target} preview link: ${host}/extensions/${uuid}/${target}`,
+    )
     return output.content`${links.join('\n')}`
   },
   deployConfig: async (config, directory) => {

--- a/packages/app/src/cli/models/extensions/extension-specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/extension-specifications/ui_extension.ts
@@ -1,7 +1,8 @@
 import {createExtensionSpec} from '../extensions.js'
-import {BaseExtensionSchema, NewExtensionPointsSchema, NewExtensionPointType} from '../schemas.js'
+import {BaseExtensionSchema, NewExtensionPointsSchema, NewExtensionPointsSchemaType} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {configurationFileNames} from '../../../constants.js'
+import {getExtensionPointTargetSurface} from '../../../services/dev/extension/utilities.js'
 import {file, output, path, schema} from '@shopify/cli-kit'
 import {err, ok, Result} from '@shopify/cli-kit/common/result'
 
@@ -41,11 +42,25 @@ const spec = createExtensionSpec({
   getBundleExtensionStdinContent: (config) => {
     return config.extensionPoints.map(({module}) => `import '${module}';`).join('\n')
   },
+  shouldFetchCartUrl: (config) => {
+    return (
+      config.extensionPoints.find((extensionPoint) => {
+        return getExtensionPointTargetSurface(extensionPoint.target) === 'checkout'
+      }) !== undefined
+    )
+  },
+  hasExtensionPointTarget: (config, requestedTarget) => {
+    return (
+      config.extensionPoints.find((extensionPoint) => {
+        return extensionPoint.target === requestedTarget
+      }) !== undefined
+    )
+  },
 })
 
 async function validateUIExtensionPointConfig(
   directory: string,
-  extensionPoints: NewExtensionPointType,
+  extensionPoints: NewExtensionPointsSchemaType,
 ): Promise<Result<unknown, string>> {
   const errors: string[] = []
   const uniqueTargets: string[] = []

--- a/packages/app/src/cli/models/extensions/extension-specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/extension-specifications/ui_extension.ts
@@ -1,5 +1,5 @@
 import {createExtensionSpec} from '../extensions.js'
-import {BaseExtensionSchema, NewExtensionPointsSchema, NewExtensionPointsSchemaType} from '../schemas.js'
+import {BaseExtensionSchema, NewExtensionPointSchemaType, NewExtensionPointsSchema} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {configurationFileNames} from '../../../constants.js'
 import {getExtensionPointTargetSurface} from '../../../services/dev/extension/utilities.js'
@@ -60,7 +60,7 @@ const spec = createExtensionSpec({
 
 async function validateUIExtensionPointConfig(
   directory: string,
-  extensionPoints: NewExtensionPointsSchemaType,
+  extensionPoints: NewExtensionPointSchemaType[],
 ): Promise<Result<unknown, string>> {
   const errors: string[] = []
   const uniqueTargets: string[] = []

--- a/packages/app/src/cli/models/extensions/extensions.ts
+++ b/packages/app/src/cli/models/extensions/extensions.ts
@@ -1,4 +1,4 @@
-import {BaseExtensionSchema, ExtensionPointSchema, ZodSchemaType} from './schemas.js'
+import {BaseExtensionSchema, ZodSchemaType} from './schemas.js'
 import {ExtensionPointSpec} from './extension-points.js'
 import {allExtensionSpecifications} from './specifications.js'
 import {ExtensionIdentifier, ThemeExtension, UIExtension} from '../app/extensions.js'
@@ -7,7 +7,6 @@ import {ok, Result} from '@shopify/cli-kit/common/result'
 
 // Base config type that all config schemas must extend.
 export type BaseConfigContents = schema.define.infer<typeof BaseExtensionSchema>
-export type ExtensionPointContents = schema.define.infer<typeof ExtensionPointSchema>
 
 /**
  * Extension specification with all the needed properties and methods to load an extension.
@@ -36,6 +35,8 @@ export interface ExtensionSpec<TConfiguration extends BaseConfigContents = BaseC
     config: TConfiguration,
     storeFqdn: string,
   ) => output.TokenizedString | undefined
+  shouldFetchCartUrl?(config: TConfiguration): boolean
+  hasExtensionPointTarget?(config: TConfiguration, target: string): boolean
 }
 
 /**
@@ -178,6 +179,14 @@ export class ExtensionInstance<TConfiguration extends BaseConfigContents = BaseC
     const relativeImportPath = this.entrySourceFilePath?.replace(this.directory, '')
     return `import '.${relativeImportPath}';`
   }
+
+  shouldFetchCartUrl(): boolean {
+    return this.specification.shouldFetchCartUrl?.(this.configuration) || false
+  }
+
+  hasExtensionPointTarget(target: string): boolean {
+    return this.specification.hasExtensionPointTarget?.(this.configuration, target) || false
+  }
 }
 
 /**
@@ -216,6 +225,8 @@ export function createExtensionSpec<TConfiguration extends BaseConfigContents = 
     config: TConfiguration,
     storeFqdn: string,
   ) => output.TokenizedString | undefined
+  shouldFetchCartUrl?(config: TConfiguration): boolean
+  hasExtensionPointTarget?(config: TConfiguration, target: string): boolean
 }): ExtensionSpec<TConfiguration> {
   const defaults = {
     showInCLIHelp: true,

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -17,21 +17,15 @@ export const TypeSchema = schema.define.object({
   type: schema.define.string().default('ui_extension'),
 })
 
-export const ExtensionPointSchema = schema.define.object({
-  type: schema.define.string(),
+export const NewExtensionPointSchema = schema.define.object({
+  target: schema.define.string(),
   module: schema.define.string(),
   metafields: schema.define.array(MetafieldSchema).optional(),
-  capabilities: CapabilitiesSchema.optional(),
 })
 
 export const OldExtensionPointsSchema = schema.define.array(schema.define.string()).default([])
-export const NewExtensionPointsSchema = schema.define.array(
-  schema.define.object({
-    target: schema.define.string(),
-    module: schema.define.string(),
-    metafields: schema.define.array(MetafieldSchema).optional(),
-  }),
-)
+export const NewExtensionPointsSchema = schema.define.array(NewExtensionPointSchema)
+export const ExtensionPointSchema = schema.define.union([OldExtensionPointsSchema, NewExtensionPointsSchema])
 
 export const BaseExtensionSchema = schema.define.object({
   name: schema.define.string(),
@@ -78,4 +72,5 @@ export const BaseFunctionMetadataSchema = schema.define.object({
   ),
 })
 
-export type NewExtensionPointType = schema.define.infer<typeof NewExtensionPointsSchema>
+export type NewExtensionPointSchemaType = schema.define.infer<typeof NewExtensionPointSchema>
+export type NewExtensionPointsSchemaType = schema.define.infer<typeof NewExtensionPointsSchema>

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -73,4 +73,3 @@ export const BaseFunctionMetadataSchema = schema.define.object({
 })
 
 export type NewExtensionPointSchemaType = schema.define.infer<typeof NewExtensionPointSchema>
-export type NewExtensionPointsSchemaType = schema.define.infer<typeof NewExtensionPointsSchema>

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -65,7 +65,7 @@ export interface ExtensionDevOptions {
   grantedScopes: string[]
 
   /**
-   * Product variant ID, used for checkout_ui_extensions
+   * Product variant ID, used for UI extensions targeting Checkout
    * If that extension is present, this is mandatory
    */
   checkoutCartUrl?: string

--- a/packages/app/src/cli/services/dev/extension/server.ts
+++ b/packages/app/src/cli/services/dev/extension/server.ts
@@ -4,6 +4,7 @@ import {
   devConsoleIndexMiddleware,
   getExtensionAssetMiddleware,
   getExtensionPayloadMiddleware,
+  getExtensionPointMiddleware,
   getExtensionsPayloadMiddleware,
   getLogMiddleware,
   noCacheMiddleware,
@@ -30,6 +31,7 @@ export function setupHTTPServer(options: SetupHTTPServerOptions) {
   httpRouter.use('/extensions/dev-console/assets/**:assetPath', devConsoleAssetsMiddleware)
   httpRouter.use('/extensions/:extensionId', getExtensionPayloadMiddleware(options))
   httpRouter.use('/extensions/:extensionId/', getExtensionPayloadMiddleware(options))
+  httpRouter.use('/extensions/:extensionId/:extensionPointTarget', getExtensionPointMiddleware(options))
   httpRouter.use('/extensions/:extensionId/assets/**:assetPath', getExtensionAssetMiddleware(options))
   httpRouter.use('/extensions', getExtensionsPayloadMiddleware(options))
   httpRouter.use('/extensions/', getExtensionsPayloadMiddleware(options))

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
@@ -5,6 +5,7 @@ import {
   fileServerMiddleware,
   noCacheMiddleware,
   redirectToDevConsoleMiddleware,
+  getExtensionPointMiddleware,
 } from './middlewares.js'
 import * as utilities from './utilities.js'
 import {GetExtensionsMiddlewareOptions} from './models.js'
@@ -451,5 +452,185 @@ describe('getExtensionPayloadMiddleware()', () => {
         }),
       )
     })
+  })
+})
+
+describe('getExtensionPointMiddleware()', () => {
+  it('returns a 404 if the extension is not found', async () => {
+    vi.spyOn(utilities, 'sendError').mockImplementation(() => {})
+
+    const actualExtensionId = '123abc'
+    const requestedExtensionId = '456dev'
+    const options = {
+      devOptions: {
+        url: 'http://mock.url',
+        extensions: [
+          {
+            devUUID: actualExtensionId,
+            outputBundlePath: '/mock/output/bundle/path',
+          },
+        ],
+      },
+      payloadStore: {},
+    } as unknown as GetExtensionsMiddlewareOptions
+
+    const response = getMockResponse()
+
+    await getExtensionPointMiddleware(options)(
+      getMockRequest({
+        context: {
+          params: {
+            extensionId: requestedExtensionId,
+          },
+        },
+      }),
+      response,
+      getMockNext(),
+    )
+
+    expect(utilities.sendError).toHaveBeenCalledWith(response, {
+      statusCode: 404,
+      statusMessage: `Extension with id ${requestedExtensionId} not found`,
+    })
+  })
+
+  it('returns a 404 if requested extension point target is not configured', async () => {
+    vi.spyOn(utilities, 'sendError').mockImplementation(() => {})
+
+    const extensionId = '123abc'
+    const requestedExtensionPointTarget = 'Admin::CheckoutEditor::RenderSettings'
+    const options = {
+      devOptions: {
+        url: 'http://mock.url',
+        extensions: [
+          {
+            devUUID: extensionId,
+            outputBundlePath: '/mock/output/bundle/path',
+            configuration: {
+              extensionPoints: [
+                {
+                  target: 'Checkout::Dynamic::Render',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      payloadStore: {},
+    } as unknown as GetExtensionsMiddlewareOptions
+
+    const response = getMockResponse()
+
+    await getExtensionPointMiddleware(options)(
+      getMockRequest({
+        context: {
+          params: {
+            extensionId,
+            extensionPointTarget: requestedExtensionPointTarget,
+          },
+        },
+      }),
+      response,
+      getMockNext(),
+    )
+
+    expect(utilities.sendError).toHaveBeenCalledWith(response, {
+      statusCode: 404,
+      statusMessage: `Extension with id ${extensionId} has not configured the "${requestedExtensionPointTarget}" extension point`,
+    })
+  })
+
+  it('returns a 404 if requested extension point target is invalid and no redirect url can be constructed', async () => {
+    vi.spyOn(utilities, 'sendError').mockImplementation(() => {})
+
+    const extensionId = '123abc'
+    const extensionPointTarget = 'abc'
+    const options = {
+      devOptions: {
+        url: 'http://mock.url',
+        extensions: [
+          {
+            devUUID: extensionId,
+            outputBundlePath: '/mock/output/bundle/path',
+            configuration: {
+              extensionPoints: [
+                {
+                  target: extensionPointTarget,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      payloadStore: {},
+    } as unknown as GetExtensionsMiddlewareOptions
+
+    const response = getMockResponse()
+
+    await getExtensionPointMiddleware(options)(
+      getMockRequest({
+        context: {
+          params: {
+            extensionId,
+            extensionPointTarget,
+          },
+        },
+      }),
+      response,
+      getMockNext(),
+    )
+
+    expect(utilities.sendError).toHaveBeenCalledWith(response, {
+      statusCode: 404,
+      statusMessage: `Redirect url cannot be constructed for extension with id ${extensionId} and extension point "${extensionPointTarget}"`,
+    })
+  })
+
+  it('returns the redirect URL if the requested extension point target is configured', async () => {
+    vi.spyOn(http, 'sendRedirect')
+    vi.spyOn(utilities, 'getRedirectUrl').mockReturnValue('http://www.mock.com/redirect/url')
+
+    const extensionId = '123abc'
+    const extensionPointTarget = 'Checkout::Dynamic::Render'
+    const options = {
+      devOptions: {
+        url: 'http://mock.url',
+        storeFqdn: 'mock-store.myshopify.com',
+        extensions: [
+          {
+            devUUID: extensionId,
+            outputBundlePath: '/mock/output/bundle/path',
+            configuration: {
+              extensionPoints: [
+                {
+                  target: extensionPointTarget,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      payloadStore: {},
+    } as unknown as GetExtensionsMiddlewareOptions
+
+    const response = getMockResponse()
+
+    await getExtensionPayloadMiddleware(options)(
+      getMockRequest({
+        headers: {
+          accept: 'text/html',
+        },
+        context: {
+          params: {
+            extensionId,
+            extensionPointTarget,
+          },
+        },
+      }),
+      response,
+      getMockNext(),
+    )
+
+    expect(http.sendRedirect).toHaveBeenCalledWith(response.event, 'http://www.mock.com/redirect/url', 307)
   })
 })

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
@@ -190,10 +190,10 @@ describe('getExtensionAssetMiddleware()', () => {
       const options = {
         devOptions: {
           extensions: [
-            {
+            await testUIExtension({
               devUUID: '123abc',
               outputBundlePath: path.join(tmpDir, 'dist', 'main.js'),
-            },
+            }),
           ],
         },
         payloadStore: {},
@@ -273,10 +273,9 @@ describe('getExtensionPayloadMiddleware()', () => {
       devOptions: {
         url: 'http://mock.url',
         extensions: [
-          {
+          await testUIExtension({
             devUUID: actualExtensionId,
-            outputBundlePath: '/mock/output/bundle/path',
-          },
+          }),
         ],
       },
       payloadStore: {},
@@ -309,14 +308,15 @@ describe('getExtensionPayloadMiddleware()', () => {
       vi.spyOn(utilities, 'getExtensionUrl').mockReturnValue('http://www.mock.com/extension/url')
 
       const extensionId = '123abc'
-      const extension = await testUIExtension({
-        configuration: {type: 'checkout_post_purchase', name: 'name', metafields: []},
-        devUUID: extensionId,
-      })
       const options = {
         devOptions: {
           url: 'http://mock.url',
-          extensions: [extension],
+          extensions: [
+            await testUIExtension({
+              configuration: {type: 'checkout_post_purchase', name: 'name', metafields: []},
+              devUUID: extensionId,
+            }),
+          ],
         },
         payloadStore: {},
       } as unknown as GetExtensionsMiddlewareOptions
@@ -359,12 +359,14 @@ describe('getExtensionPayloadMiddleware()', () => {
           url: 'http://mock.url',
           storeFqdn: 'mock-store.myshopify.com',
           extensions: [
-            {
+            await testUIExtension({
               devUUID: extensionId,
               configuration: {
+                name: 'name',
+                metafields: [],
                 type: 'checkout_ui_extension',
               },
-            },
+            }),
           ],
         },
         payloadStore: {},
@@ -404,12 +406,9 @@ describe('getExtensionPayloadMiddleware()', () => {
           storeFqdn: 'mock-store.myshopify.com',
           apiKey: 'mock-api-key',
           extensions: [
-            {
+            await testUIExtension({
               devUUID: extensionId,
-              configuration: {
-                type: 'checkout_ui_extension',
-              },
-            },
+            }),
           ],
         },
         payloadStore: {},
@@ -465,10 +464,9 @@ describe('getExtensionPointMiddleware()', () => {
       devOptions: {
         url: 'http://mock.url',
         extensions: [
-          {
+          await testUIExtension({
             devUUID: actualExtensionId,
-            outputBundlePath: '/mock/output/bundle/path',
-          },
+          }),
         ],
       },
       payloadStore: {},
@@ -503,17 +501,19 @@ describe('getExtensionPointMiddleware()', () => {
       devOptions: {
         url: 'http://mock.url',
         extensions: [
-          {
+          await testUIExtension({
             devUUID: extensionId,
-            outputBundlePath: '/mock/output/bundle/path',
             configuration: {
+              name: 'testName',
+              type: 'ui_extension',
+              metafields: [],
               extensionPoints: [
                 {
                   target: 'Checkout::Dynamic::Render',
                 },
               ],
             },
-          },
+          }),
         ],
       },
       payloadStore: {},
@@ -549,17 +549,19 @@ describe('getExtensionPointMiddleware()', () => {
       devOptions: {
         url: 'http://mock.url',
         extensions: [
-          {
+          await testUIExtension({
             devUUID: extensionId,
-            outputBundlePath: '/mock/output/bundle/path',
             configuration: {
+              name: 'testName',
+              type: 'ui_extension',
+              metafields: [],
               extensionPoints: [
                 {
                   target: extensionPointTarget,
                 },
               ],
             },
-          },
+          }),
         ],
       },
       payloadStore: {},
@@ -582,7 +584,7 @@ describe('getExtensionPointMiddleware()', () => {
 
     expect(utilities.sendError).toHaveBeenCalledWith(response, {
       statusCode: 404,
-      statusMessage: `Redirect url cannot be constructed for extension with id ${extensionId} and extension point "${extensionPointTarget}"`,
+      statusMessage: `Redirect url can't be constructed for extension with id ${extensionId} and extension point "${extensionPointTarget}"`,
     })
   })
 
@@ -597,17 +599,19 @@ describe('getExtensionPointMiddleware()', () => {
         url: 'http://mock.url',
         storeFqdn: 'mock-store.myshopify.com',
         extensions: [
-          {
+          await testUIExtension({
             devUUID: extensionId,
-            outputBundlePath: '/mock/output/bundle/path',
             configuration: {
+              name: 'testName',
+              type: 'ui_extension',
+              metafields: [],
               extensionPoints: [
                 {
                   target: extensionPointTarget,
                 },
               ],
             },
-          },
+          }),
         ],
       },
       payloadStore: {},

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -238,7 +238,7 @@ export function getExtensionPointMiddleware({devOptions}: GetExtensionsMiddlewar
     if (!url) {
       return sendError(response, {
         statusCode: 404,
-        statusMessage: `Redirect url cannot be constructed for extension with id ${extensionID} and extension point "${requestedTarget}"`,
+        statusMessage: `Redirect url can't be constructed for extension with id ${extensionID} and extension point "${requestedTarget}"`,
       })
     }
 

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -1,4 +1,4 @@
-import {getExtensionUrl, getRedirectUrl, sendError} from './utilities.js'
+import {getExtensionPointRedirectUrl, getExtensionUrl, getRedirectUrl, sendError} from './utilities.js'
 import {GetExtensionsMiddlewareOptions} from './models.js'
 import {getUIExtensionPayload} from '../payload.js'
 import {getHTML} from '../templates.js'
@@ -211,6 +211,38 @@ export function getExtensionPayloadMiddleware({devOptions}: GetExtensionsMiddlew
         extension: await getUIExtensionPayload(extension, devOptions),
       }),
     )
+  }
+}
+
+export function getExtensionPointMiddleware({devOptions}: GetExtensionsMiddlewareOptions) {
+  return async (request: http.IncomingMessage, response: http.ServerResponse, _next: (err?: Error) => unknown) => {
+    const extensionID = request.context.params.extensionId
+    const requestedTarget = request.context.params.extensionPointTarget
+    const extension = devOptions.extensions.find((extension) => extension.devUUID === extensionID)
+
+    if (!extension) {
+      return sendError(response, {
+        statusCode: 404,
+        statusMessage: `Extension with id ${extensionID} not found`,
+      })
+    }
+
+    if (!extension.hasExtensionPointTarget(requestedTarget)) {
+      return sendError(response, {
+        statusCode: 404,
+        statusMessage: `Extension with id ${extensionID} has not configured the "${requestedTarget}" extension point`,
+      })
+    }
+
+    const url = getExtensionPointRedirectUrl(requestedTarget, extension, devOptions)
+    if (!url) {
+      return sendError(response, {
+        statusCode: 404,
+        statusMessage: `Redirect url cannot be constructed for extension with id ${extensionID} and extension point "${requestedTarget}"`,
+      })
+    }
+
+    await http.sendRedirect(response.event, url, 307)
   }
 }
 

--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -1,6 +1,7 @@
-import {getRedirectUrl} from './utilities.js'
+import {getRedirectUrl, getExtensionPointRedirectUrl} from './utilities.js'
 import {ExtensionDevOptions} from '../../extension.js'
 import {testUIExtension} from '../../../../models/app/app.test-data.js'
+import {UIExtension} from '../../../../models/app/extensions.js'
 import {describe, expect, it} from 'vitest'
 
 describe('getRedirectURL()', () => {
@@ -36,5 +37,55 @@ describe('getRedirectURL()', () => {
     const result = getRedirectUrl(extension, options)
 
     expect(result).toBe('https://example.myshopify.com/mock/cart/url?dev=https%3A%2F%2Flocalhost%3A8081%2Fextensions')
+  })
+})
+
+describe('getExtensionPointRedirectUrl()', () => {
+  it('returns Admin dev server URL if the extension point targets Admin', () => {
+    const extension = {
+      devUUID: '123abc',
+    } as UIExtension
+
+    const options = {
+      storeFqdn: 'example.myshopify.com',
+      url: 'https://localhost:8081',
+    } as unknown as ExtensionDevOptions
+
+    const result = getExtensionPointRedirectUrl('Admin::CheckoutEditor::RenderSettings', extension, options)
+
+    expect(result).toBe(
+      'https://example.myshopify.com/admin/extensions-dev?url=https%3A%2F%2Flocalhost%3A8081%2Fextensions%2F123abc',
+    )
+  })
+
+  it('returns Checkout dev server URL if the extension point targets Checkout', () => {
+    const extension = {
+      devUUID: '123abc',
+    } as UIExtension
+
+    const options = {
+      storeFqdn: 'example.myshopify.com',
+      url: 'https://localhost:8081',
+      checkoutCartUrl: 'mock/cart/url',
+    } as unknown as ExtensionDevOptions
+
+    const result = getExtensionPointRedirectUrl('Checkout::Dynamic::Render', extension, options)
+
+    expect(result).toBe('https://example.myshopify.com/mock/cart/url?dev=https%3A%2F%2Flocalhost%3A8081%2Fextensions')
+  })
+
+  it('returns undefined if the extension point surface is not supported', () => {
+    const extension = {
+      devUUID: '123abc',
+    } as UIExtension
+
+    const options = {
+      storeFqdn: 'example.myshopify.com',
+      url: 'https://localhost:8081',
+      checkoutCartUrl: 'mock/cart/url',
+    } as unknown as ExtensionDevOptions
+
+    expect(getExtensionPointRedirectUrl('ABC', extension, options)).toBeUndefined()
+    expect(getExtensionPointRedirectUrl('SomeOtherArea::Test::Extension', extension, options)).toBeUndefined()
   })
 })

--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -1,7 +1,8 @@
+import {http} from '@shopify/cli-kit'
 import {UIExtension} from '../../../../models/app/extensions.js'
 import {getUIExtensionResourceURL} from '../../../../utilities/extensions/configuration.js'
 import {ExtensionDevOptions} from '../../extension.js'
-import {http} from '@shopify/cli-kit'
+import {getExtensionPointTargetSurface} from '../utilities.js'
 
 export function getRedirectUrl(extension: UIExtension, options: ExtensionDevOptions): string {
   const {url: resourceUrl} = getUIExtensionResourceURL(extension.configuration.type, options)
@@ -19,6 +20,32 @@ export function getRedirectUrl(extension: UIExtension, options: ExtensionDevOpti
 
     return rawUrl.toString()
   }
+}
+
+export function getExtensionPointRedirectUrl(
+  requestedTarget: string,
+  extension: UIExtension,
+  options: ExtensionDevOptions,
+): string | undefined {
+  const surface = getExtensionPointTargetSurface(requestedTarget)
+  const rawUrl = new URL(`https://${options.storeFqdn}/`)
+
+  switch (surface) {
+    case 'checkout':
+      // This can never be null because we always generate it
+      // whenever there is an extension point targeting Checkout
+      rawUrl.pathname = options.checkoutCartUrl!
+      rawUrl.searchParams.append('dev', `${options.url}/extensions`)
+      break
+    case 'admin':
+      rawUrl.pathname = 'admin/extensions-dev'
+      rawUrl.searchParams.append('url', getExtensionUrl(extension, options))
+      break
+    default:
+      return undefined
+  }
+
+  return rawUrl.toString()
 }
 
 export function getExtensionUrl(extension: UIExtension, options: ExtensionDevOptions): string {

--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -1,8 +1,8 @@
-import {http} from '@shopify/cli-kit'
 import {UIExtension} from '../../../../models/app/extensions.js'
 import {getUIExtensionResourceURL} from '../../../../utilities/extensions/configuration.js'
 import {ExtensionDevOptions} from '../../extension.js'
 import {getExtensionPointTargetSurface} from '../utilities.js'
+import {http} from '@shopify/cli-kit'
 
 export function getRedirectUrl(extension: UIExtension, options: ExtensionDevOptions): string {
   const {url: resourceUrl} = getUIExtensionResourceURL(extension.configuration.type, options)

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -19,5 +19,5 @@ export async function getCartPathFromExtensions(extensions: UIExtension[], store
  * Returns the surface for UI extension from an extension point target
  */
 export function getExtensionPointTargetSurface(extensionPointTarget: string) {
-  return extensionPointTarget.toLowerCase().replace(/\:\:.+$/, '')
+  return extensionPointTarget.toLowerCase().replace(/::.+$/, '')
 }

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -1,13 +1,14 @@
 import {UIExtension} from '../../../models/app/extensions.js'
+
 import {fetchProductVariant} from '../../../utilities/extensions/fetch-product-variant.js'
 
 /**
- * To prepare Checkout UI Extensions for dev'ing we need to retrieve a valid product variant ID
+ * To prepare UI Extensions targeting Checkout for dev'ing we need to retrieve a valid product variant ID
  * @param extensions - The UI Extensions to dev
  * @param store - The store FQDN
  */
 export async function getCartPathFromExtensions(extensions: UIExtension[], store: string, checkoutCartUrl?: string) {
-  const hasUIExtension = extensions.filter(getExtensionNeedsCartURL).length > 0
+  const hasUIExtension = extensions.filter((extension) => extension.shouldFetchCartUrl()).length > 0
   if (!hasUIExtension) return undefined
   if (checkoutCartUrl) return checkoutCartUrl
   const variantId = await fetchProductVariant(store)
@@ -15,8 +16,8 @@ export async function getCartPathFromExtensions(extensions: UIExtension[], store
 }
 
 /**
- * Returns true if an extension needs a cart URL.
+ * Returns the surface for UI extension from an extension point target
  */
-export function getExtensionNeedsCartURL(extension: UIExtension) {
-  return extension.configuration.type === 'checkout_ui_extension'
+export function getExtensionPointTargetSurface(extensionPointTarget: string) {
+  return extensionPointTarget.toLowerCase().replace(/\:\:.+$/, '')
 }

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -3,6 +3,7 @@ import {
   fetchAppFromApiKey,
   fetchOrgAndApps,
   fetchOrganizations,
+  fetchOrgFromId,
   fetchStoreByDomain,
 } from './dev/fetch.js'
 import {selectOrCreateApp} from './dev/select-app.js'
@@ -13,6 +14,7 @@ import {
   ensureDevEnvironment,
   ensureDeployEnvironment,
   ensureThemeExtensionDevEnvironment,
+  ensureGenerateEnvironment,
 } from './environment.js'
 import {createExtension} from './dev/create-extension.js'
 import {OrganizationApp, OrganizationStore} from '../models/organization.js'
@@ -22,6 +24,7 @@ import {UIExtension} from '../models/app/extensions.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
 import {testApp, testThemeExtensions} from '../models/app/app.test-data.js'
 import metadata from '../metadata.js'
+import {loadAppName} from '../models/app/loader.js'
 import {store, api, outputMocker} from '@shopify/cli-kit'
 import {beforeEach, describe, expect, it, test, vi} from 'vitest'
 import {ok} from '@shopify/cli-kit/common/result.js'
@@ -35,6 +38,7 @@ beforeEach(() => {
   vi.mock('../models/app/app')
   vi.mock('../models/app/identifiers')
   vi.mock('./environment/identifiers')
+  vi.mock('../models/app/loader.js')
   vi.mock('@shopify/cli-kit', async () => {
     const cliKit: any = await vi.importActual('@shopify/cli-kit')
     return {
@@ -120,7 +124,7 @@ const EXTENSION_A: UIExtension = {
   entrySourceFilePath: '',
   outputBundlePath: '',
   devUUID: 'devUUID',
-  externalType: 'checkout_post_purchase',
+  externalType: 'checkout_ui',
   surface: 'surface',
   preDeployValidation: () => Promise.resolve(),
   deployConfig: () => Promise.resolve({}),
@@ -128,8 +132,6 @@ const EXTENSION_A: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
-  shouldFetchCartUrl: () => true,
-  hasExtensionPointTarget: (target: string) => true,
 }
 
 const LOCAL_APP = testApp({
@@ -181,6 +183,54 @@ beforeEach(async () => {
   vi.mocked(selectStore).mockResolvedValue(STORE1)
   vi.mocked(fetchOrganizations).mockResolvedValue([ORG1, ORG2])
   vi.mocked(fetchOrgAndApps).mockResolvedValue(FETCH_RESPONSE)
+})
+
+describe('ensureGenerateEnvironment', () => {
+  it('returns the provided app apiKey if valid, without cached state', async () => {
+    // Given
+    const input = {apiKey: 'key2', directory: '/app', reset: false, token: 'token'}
+    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+
+    // When
+    const got = await ensureGenerateEnvironment(input)
+
+    // Then
+    expect(got).toEqual(APP2.apiKey)
+  })
+  it('returns the cached api key', async () => {
+    // Given
+    const input = {directory: '/app', reset: false, token: 'token'}
+    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchOrgFromId).mockResolvedValueOnce(ORG1)
+    vi.mocked(store.getAppInfo).mockResolvedValue(CACHED1)
+
+    // When
+    const got = await ensureGenerateEnvironment(input)
+
+    // Then
+    expect(got).toEqual(APP2.apiKey)
+  })
+  it('selects a new app and returns the api key', async () => {
+    // Given
+    const input = {directory: '/app', reset: true, token: 'token'}
+    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(loadAppName).mockResolvedValueOnce('my-app')
+    vi.mocked(fetchOrgFromId).mockResolvedValueOnce(ORG1)
+    vi.mocked(store.getAppInfo).mockResolvedValue(undefined)
+
+    // When
+    const got = await ensureGenerateEnvironment(input)
+
+    // Then
+    expect(got).toEqual(APP1.apiKey)
+    expect(selectOrCreateApp).toHaveBeenCalledWith('my-app', [APP1, APP2], ORG1, 'token', undefined)
+    expect(store.setAppInfo).toHaveBeenCalledWith({
+      appId: APP1.apiKey,
+      title: APP1.title,
+      directory: '/app',
+      orgId: ORG1.id,
+    })
+  })
 })
 
 describe('ensureDevEnvironment', () => {
@@ -453,7 +503,7 @@ describe('ensureDeployEnvironment', () => {
 
     // Then
     expect(fetchOrganizations).toHaveBeenCalledWith('token')
-    expect(selectOrCreateApp).toHaveBeenCalledWith(app, [APP1, APP2], ORG1, 'token', undefined)
+    expect(selectOrCreateApp).toHaveBeenCalledWith(app.name, [APP1, APP2], ORG1, 'token', undefined)
     expect(updateAppIdentifiers).toBeCalledWith({
       app,
       identifiers,
@@ -496,7 +546,7 @@ describe('ensureDeployEnvironment', () => {
 
     // Then
     expect(fetchOrganizations).toHaveBeenCalledWith('token')
-    expect(selectOrCreateApp).toHaveBeenCalledWith(app, [APP1, APP2], ORG1, 'token', undefined)
+    expect(selectOrCreateApp).toHaveBeenCalledWith(app.name, [APP1, APP2], ORG1, 'token', undefined)
     expect(updateAppIdentifiers).toBeCalledWith({
       app,
       identifiers,

--- a/packages/app/src/cli/services/environment.test.ts
+++ b/packages/app/src/cli/services/environment.test.ts
@@ -108,6 +108,7 @@ const STORE2: OrganizationStore = {
   transferDisabled: false,
   convertableToPartnerTest: false,
 }
+
 const EXTENSION_A: UIExtension = {
   idEnvironmentVariableName: 'EXTENSION_A_ID',
   localIdentifier: 'EXTENSION_A',
@@ -132,6 +133,8 @@ const EXTENSION_A: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: () => true,
 }
 
 const LOCAL_APP = testApp({

--- a/packages/app/src/cli/services/environment/id-manual-matching.test.ts
+++ b/packages/app/src/cli/services/environment/id-manual-matching.test.ts
@@ -36,13 +36,15 @@ const EXTENSION_A: UIExtension = {
   entrySourceFilePath: '',
   devUUID: 'devUUID',
   externalType: 'checkout_ui',
+  publishURL: (_) => Promise.resolve(''),
   surface: 'surface',
+  validate: () => Promise.resolve({} as any),
   preDeployValidation: () => Promise.resolve(),
   deployConfig: () => Promise.resolve({}),
   previewMessage: (_) => undefined,
-  publishURL: (_) => Promise.resolve(''),
-  validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_A_2: UIExtension = {
@@ -69,6 +71,8 @@ const EXTENSION_A_2: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_B: UIExtension = {
@@ -95,6 +99,8 @@ const EXTENSION_B: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 beforeEach(() => {

--- a/packages/app/src/cli/services/environment/id-matching.test.ts
+++ b/packages/app/src/cli/services/environment/id-matching.test.ts
@@ -53,13 +53,6 @@ const REGISTRATION_B = {
   type: 'SUBSCRIPTION_MANAGEMENT',
 }
 
-const REGISTRATION_B_2 = {
-  uuid: 'UUID_B_2',
-  id: 'B_2',
-  title: 'EXTENSION_B_2',
-  type: 'SUBSCRIPTION_MANAGEMENT',
-}
-
 const REGISTRATION_C = {
   uuid: 'UUID_C',
   id: 'C',
@@ -98,6 +91,8 @@ const EXTENSION_A: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_A_2: UIExtension = {
@@ -124,6 +119,8 @@ const EXTENSION_A_2: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_B: UIExtension = {
@@ -143,13 +140,15 @@ const EXTENSION_B: UIExtension = {
   entrySourceFilePath: '',
   devUUID: 'devUUID',
   externalType: 'checkout_ui',
+  publishURL: (_) => Promise.resolve(''),
   surface: 'surface',
+  validate: () => Promise.resolve({} as any),
   preDeployValidation: () => Promise.resolve(),
   deployConfig: () => Promise.resolve({}),
   previewMessage: (_) => undefined,
-  publishURL: (_) => Promise.resolve(''),
-  validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_B_2: UIExtension = {
@@ -176,6 +175,8 @@ const EXTENSION_B_2: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_C: UIExtension = {
@@ -202,6 +203,8 @@ const EXTENSION_C: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_D: UIExtension = {
@@ -228,6 +231,8 @@ const EXTENSION_D: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 describe('automaticMatchmaking: case 3 some local extensions, no remote ones', () => {

--- a/packages/app/src/cli/services/environment/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers-extensions.test.ts
@@ -55,6 +55,8 @@ const EXTENSION_A: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_A_2: UIExtension = {
@@ -81,6 +83,8 @@ const EXTENSION_A_2: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_B: UIExtension = {
@@ -107,6 +111,8 @@ const EXTENSION_B: UIExtension = {
   publishURL: (_) => Promise.resolve(''),
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const LOCAL_APP = (uiExtensions: UIExtension[], functionExtensions: FunctionExtension[] = []): AppInterface => {

--- a/packages/app/src/cli/services/environment/identifiers.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers.test.ts
@@ -48,12 +48,14 @@ const EXTENSION_A: UIExtension = {
   devUUID: 'devUUID',
   externalType: 'checkout_ui',
   surface: 'surface',
+  validate: () => Promise.resolve({} as any),
   preDeployValidation: () => Promise.resolve(),
   deployConfig: () => Promise.resolve({}),
   previewMessage: (_) => undefined,
   publishURL: (_) => Promise.resolve(''),
-  validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const EXTENSION_A_2: UIExtension = {
@@ -74,12 +76,14 @@ const EXTENSION_A_2: UIExtension = {
   devUUID: 'devUUID',
   externalType: 'checkout_ui',
   surface: 'surface',
+  validate: () => Promise.resolve({} as any),
   preDeployValidation: () => Promise.resolve(),
   deployConfig: () => Promise.resolve({}),
   previewMessage: (_) => undefined,
   publishURL: (_) => Promise.resolve(''),
-  validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
+  shouldFetchCartUrl: () => true,
+  hasExtensionPointTarget: (target: string) => true,
 }
 
 const FUNCTION_C: FunctionExtension = {

--- a/packages/ui-extensions-dev-console/tests/mount.tsx
+++ b/packages/ui-extensions-dev-console/tests/mount.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useMemo} from 'react'
 import {createMount} from '@shopify/react-testing'
 import enTranslations from '@shopify/polaris/locales/en.json'
 import {AppProvider} from '@shopify/polaris'
@@ -29,14 +29,17 @@ export const mount = createMount<MountOptions, Context>({
   },
   render(element, context) {
     const locale = 'en'
-
-    const i18nManager = new I18nManager({
-      locale,
-      onError(error) {
-        // eslint-disable-next-line no-console
-        console.log(error)
-      },
-    })
+    const i18nManager = useMemo(
+      () =>
+        new I18nManager({
+          locale,
+          onError(error) {
+            // eslint-disable-next-line no-console
+            console.log(error)
+          },
+        }),
+      [],
+    )
 
     return (
       <I18nContext.Provider value={i18nManager}>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#1941](https://github.com/Shopify/ui-extensions-private/issues/1941)
Fixes [#1946](https://github.com/Shopify/ui-extensions-private/issues/1946)

A ui_extension supports multiple extension points.  Unlike previous extensions, those extension points can be across multiple surfaces.  Therefore we need a preview link per extension point that an extension supports.

### WHAT is this pull request doing?

* Add `shouldFetchCartUrl` to `ui_extension`.  This used to exist in the dev console code.  Moving it here means we get complete type safety because the `ui_extension` knows exactly the shape of `extensionPoints`, rather than knowing it's either `string[]` or `{}[]`.  The dev console now uses this code.
* Add `hasExtensionPointTarget` to `ui_extension`.  Same deal here.
* Add a new URL to the dev console, e.g: `/extensions/[uuid]/[extensionPointTarget]`
* Add a new middleware to handle the new URL.  This middleware:
  1. 404's if the extension ID can't be found
  2. 404's if the toml for the extension with that ID does not specify that extension point target.
  3. Infers the surface from the extension point target.  E.g: the surface for `Admin::Checkout::Editor:Settings` is `Admin`.  Then is constructs the redirect URL.
  4. 404's if a redirect URL could not be constructed.
  5. 307 redirects if a redirect URL can be constructed.

### How to test your changes?

1. `cd fixtures/app`
2. `yarn generate extension` (choose `ui_extension`
3. `yarn dev`
4. Do the preview links for `ui_extension` show up?
5. Do the links redirect correctly?
6. Do preview links for other extensions redirect correctly?

<img width="581" alt="Screenshot 2022-11-25 at 10 32 31 AM" src="https://user-images.githubusercontent.com/690791/204016822-f0a4a232-1623-43a5-a47e-ddeb69a54001.png">

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
