### PR TITLE
Add schema specification for settings in a UI extension

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/extension-specifications/checkout_ui_extension.ts
@@ -7,7 +7,42 @@ const dependency = {name: '@shopify/checkout-ui-extensions-react', version: '^0.
 
 const CheckoutSchema = BaseExtensionSchema.extend({
   extensionPoints: schema.define.array(schema.define.string()).optional(),
-  settings: schema.define.string().optional(),
+  // https://shopify.dev/api/checkout-extensions/checkout/configuration#settings-definition
+  settings: schema.define
+    .object({
+      fields: schema.define.array(
+        schema.define.object({
+          key: schema.define.string(),
+          type: schema.define.union([
+            schema.define.literal('boolean'),
+            schema.define.literal('date'),
+            schema.define.literal('date_time'),
+            schema.define.literal('single_line_text_field'),
+            schema.define.literal('multi_line_text_field'),
+            schema.define.literal('number_integer'),
+            schema.define.literal('number_decimal'),
+            schema.define.literal('variant_reference'),
+          ]),
+          name: schema.define.string(),
+          description: schema.define.string().optional(),
+          validations: schema.define
+            .array(
+              schema.define.object({
+                name: schema.define.string(),
+                value: schema.define.union([
+                  schema.define.literal('min'),
+                  schema.define.literal('max'),
+                  schema.define.literal('regex'),
+                  schema.define.literal('choices'),
+                  schema.define.literal('max_precision'),
+                ]),
+              }),
+            )
+            .optional(),
+        }),
+      ),
+    })
+    .optional(),
 })
 
 const spec = createExtensionSpec({


### PR DESCRIPTION
### WHY are these changes introduced?
Currently the toml schema for a checkout_ui extension expects settings to be a string.  This is wrong.  Trish and I think this is breaking checkout ui extensions.

### WHAT is this pull request doing?
Here we add the schema definitions from [the docs](https://shopify.dev/api/checkout-extensions/checkout/configuration#settings-definition) to the checkout_ui specification.

I've gone for fairly strict schema specification.  For example we have unions for `setting type` and `validation name` that only allow exactly the values specified in [the docs](https://shopify.dev/api/checkout-extensions/checkout/configuration#settings-definition), but this may be too strict. I can see an argument that we should loosen these to be just a string type.

### How to test your changes?
1. cd `fixtures/app`
2. `yarn dev`
3. Add valid settings, following the example [here](https://shopify.dev/api/checkout-extensions/checkout/configuration#example-settings-definition)
4. `yarn dev` should succeed
5. Add invalid settings.
6. `yarn dev` should not succeed.

### Post-release steps
None

### Measuring impact
How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
