### PR TITLE
Add 'wdm' to bundled CLI 2.x Gemfile

### DIFF
--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -7,6 +7,7 @@ import {glob, join} from '../../path.js'
 import constants from '../../constants.js'
 import {AdminSession} from '../../session.js'
 import {content, token} from '../../output.js'
+import {platformAndArch} from '../../os.js'
 import {AbortSignal} from 'abort-controller'
 import {Writable} from 'node:stream'
 
@@ -243,7 +244,13 @@ function createThemeCheckCLIWorkingDirectory() {
 
 async function createShopifyCLIGemfile() {
   const gemPath = join(shopifyCLIDirectory(), 'Gemfile')
-  await file.write(gemPath, `source 'https://rubygems.org'\ngem 'shopify-cli', '${RubyCLIVersion}'`)
+  const gemFileContent = ["source 'https://rubygems.org'", `gem 'shopify-cli', '${RubyCLIVersion}'`]
+  const {platform} = platformAndArch()
+  if (platform === 'windows') {
+    // 'wdm' is required by 'listen', see https://github.com/Shopify/cli/issues/780
+    gemFileContent.push("gem 'wdm'")
+  }
+  await file.write(gemPath, gemFileContent.join('\n'))
 }
 
 async function createThemeCheckGemfile() {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #780 

### WHAT is this pull request doing?

`shopify-cli` is using the gem `listen`, which [calls `require 'wdm'`](https://github.com/guard/listen/blob/master/lib/listen/adapter/windows.rb#L17), without having it mentioned in its `Gemfile` (→ https://github.com/guard/listen/issues/553).

To solve this, we install `wdm` via the bundled CLI's Gemfile.

### How to test your changes?

#### Windows
1. Open your Windows environment
1. Clone `cli` repo and `cd` into it
1. `yarn install` and `yarn build`
1. `cd` into a valid theme directory
1. Make sure that `gem which wdm` returns `Can't find Ruby library file or shared library wdm`
1. run `node ../cli/packages/cli-main/bin/dev.js theme dev`
1. (potentially log in into your store)
1. No error regarding `wdm` should appear anymore
1. Open `C:\Users\<YOUR USER NAME>\AppData\Local\shopify-cli-nodejs\Cache\vendor\ruby-cli\<2.x.x>\Gemfile` and make sure that `gem 'wdm'` is mentioned there

#### macOS
1. Repeat the same steps on macOS
1. Open `/Users/<YOUR USER NAME>/Library/Caches/shopify-cli-nodejs/vendor/ruby-cli/<2.x.x>/Gemfile` and make sure that `gem 'wdm'` is **not** mentioned there

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
