### PR TITLE
Fix auth_callback_path getting ignored issue

### DIFF
--- a/.changeset/unlucky-brooms-complain.md
+++ b/.changeset/unlucky-brooms-complain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fixed backend's shopify.web.toml parsing issue which causes auth_callback_path setting getting ignored

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -17,7 +17,7 @@ export enum WebType {
 
 export const WebConfigurationSchema = schema.define.object({
   type: schema.define.enum([WebType.Frontend, WebType.Backend]),
-  auth_callback_path: schema.define
+  authCallbackPath: schema.define
     .preprocess((arg) => (typeof arg === 'string' && !arg.startsWith('/') ? `/${arg}` : arg), schema.define.string())
     .optional(),
   commands: schema.define.object({

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -78,7 +78,7 @@ async function dev(options: DevOptions) {
   let shouldUpdateURLs = false
   if ((frontendConfig || backendConfig) && options.update) {
     const currentURLs = await getURLs(apiKey, token)
-    const newURLs = generatePartnersURLs(exposedUrl, backendConfig?.configuration.auth_callback_path)
+    const newURLs = generatePartnersURLs(exposedUrl, backendConfig?.configuration.authCallbackPath)
     shouldUpdateURLs = await shouldOrPromptUpdateURLs({
       currentURLs,
       appDirectory: options.app.directory,


### PR DESCRIPTION
Fixed backend's shopify.web.toml parsing issue which causes `auth_callback_path` setting getting ignored

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

`auth_callback_path` on backend's shopify.web.toml is mistakenly ignored when parsing the configuration file.
When decoding the file, the loader (  [`loadConfigurationFile()`](https://github.com/Shopify/cli/blob/ed76c2448345eb6a539c6600cdb023ebf744f3a4/packages/app/src/cli/models/app/loader.ts#L200-L204) ) internally converts all the keys from `snake_case` to `camelCase` so it becomes `authCallbackPath`, but the [`WebConfigurationSchema`](https://github.com/Shopify/cli/blob/8de55df366f6b9b6b7739c616efcc7419a67a2ff/packages/app/src/cli/models/app/app.ts#L20) defined it as `auth_callback_path` so the key won't match and the setting will not be loaded properly.

By fixing the schema, `auth_callback_path` will be properly decoded into `WebConfiguration`.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

1. Add `auth_callback_path = "/custom/auth/path"` to `fixtures/app/web/ahopify.web.toml`, so it looks like this:
   ```toml
   type="backend"

   auth_callback_path = "/custom/auth/path"

   [commands]
   dev = "npm run dev"
   build = "npm run build"
   ```
2. Inside `fixtures/app` directory, run `yarn dev`.
3. Follow the cli instructions to create a Shopify app.
4. Open the app settings in Shopify Partners dashboard, and verify that the redirect url whitelist setting matches `auth_callback_path`.


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
