### PR TITLE
Add urls per extension point

### DIFF
--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -128,4 +128,59 @@ describe('getUIExtensionPayload', () => {
       })
     })
   })
+
+  test('adds root.url to extensionPoints[n] when extensionPoints[n] is an object', async () => {
+    await file.inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const uiExtension = await testUIExtension({
+        devUUID: 'devUUID',
+        configuration: {
+          name: 'UI Extension',
+          type: 'ui_extension',
+          metafields: [],
+          capabilities: {
+            block_progress: false,
+            network_access: false,
+          },
+          extensionPoints: [
+            {
+              target: 'Extension::Point::A',
+              module: './src/ExtensionPointA.js',
+            },
+            {
+              target: 'Extension::Point::B',
+              module: './src/ExtensionPointB.js',
+            },
+          ],
+        },
+      })
+      const options: ExtensionDevOptions = {} as ExtensionDevOptions
+      const development: Partial<UIExtensionPayload['development']> = {}
+
+      // When
+      const got = await getUIExtensionPayload(uiExtension, {
+        ...options,
+        currentDevelopmentPayload: development,
+        url: 'http://tunnel-url.com',
+      })
+
+      // Then
+      expect(got.extensionPoints).toStrictEqual([
+        {
+          target: 'Extension::Point::A',
+          module: './src/ExtensionPointA.js',
+          root: {
+            url: 'http://tunnel-url.com/extensions/devUUID/Extension::Point::A',
+          },
+        },
+        {
+          target: 'Extension::Point::B',
+          module: './src/ExtensionPointB.js',
+          root: {
+            url: 'http://tunnel-url.com/extensions/devUUID/Extension::Point::B',
+          },
+        },
+      ])
+    })
+  })
 })

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -40,13 +40,12 @@ export async function getUIExtensionPayload(
       root: {
         url,
       },
-
       hidden: options.currentDevelopmentPayload?.hidden || false,
       localizationStatus,
       status: options.currentDevelopmentPayload?.status || 'success',
       ...(options.currentDevelopmentPayload || {status: 'success'}),
     },
-    extensionPoints: extension.configuration.extensionPoints,
+    extensionPoints: getExtensionPoints(extension.configuration.extensionPoints, url),
     localization: localization ?? null,
     categories: extension.configuration.categories ?? null,
     metafields: extension.configuration.metafields.length === 0 ? null : extension.configuration.metafields,
@@ -65,4 +64,23 @@ export async function getUIExtensionPayload(
     approvalScopes: options.grantedScopes,
   }
   return defaultConfig
+}
+
+function getExtensionPoints(extensionPoints: UIExtension['configuration']['extensionPoints'], url: string) {
+  if (!extensionPoints) {
+    return extensionPoints
+  }
+
+  return extensionPoints.map((extensionPoint: unknown) => {
+    if (extensionPoint && typeof extensionPoint === 'object') {
+      return {
+        ...extensionPoint,
+        root: {
+          url: `${url}/${extensionPoint}`,
+        },
+      }
+    }
+
+    return extensionPoint
+  })
 }

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -73,10 +73,12 @@ function getExtensionPoints(extensionPoints: UIExtension['configuration']['exten
 
   return extensionPoints.map((extensionPoint: unknown) => {
     if (extensionPoint && typeof extensionPoint === 'object') {
+      const {target} = extensionPoint as {target: string}
+
       return {
         ...extensionPoint,
         root: {
-          url: `${url}/${extensionPoint}`,
+          url: `${url}/${target}`,
         },
       }
     }

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
@@ -147,7 +147,7 @@ declare global {
       interface Extension {
         assets: Assets
         development: Development
-        extensionPoints: string[] | null
+        extensionPoints: string[] | {target: string; module: string; main: {url: string}} | null
         surface: Surface
         name?: string
         title?: string

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -73,7 +73,7 @@ export interface ExtensionPayload {
   version: string
   surface: Surface
   title: string
-  extensionPoints?: string[]
+  extensionPoints?: string[] | {target: string; module: string; main: {url: string}}
   categories?: string[]
   localization?: {
     defaultLocale: string


### PR DESCRIPTION
### WHY are these changes introduced?
Previously there was only one preview link per extension.  That's because each extension would only render on one surface.  With the new `ui_extension` type an extension can render multiple extensions across multiple extensionPoints.

As such, the Dev Console needs to:

1. EITHER render one preview link per extensions (for every existing extension type).
2. OR render one preview link per extension point (for the new `ui_extension` extension type).

In this PR we update the JSON data that the dev console recieves from the CLI so that it it can handle either situation. In a future PR you can imagine that a `ui_extension` will have multiple rows of icons (one per extension point), but older extension types will only have one row of icons.

Fixes #1954

### WHAT is this pull request doing?

1. Update some types in `packages/ui-extensions-server-kit` to respect the fact that the JSON for extensionPoints has changed.
2. Add the logic to construct the URL for each `extensionPoint`

The end result is a JSON structure where the following is possible

```
extensions: [{
   extensionsPoints: null
   // ...etc
}, {
   extensionsPoints: ["Extension::Point::A"]
   // ...etc
}, {
   extensionsPoints: [{
      target: "Extension::Point::A",
      module: "./src/file.js"
      root: {
        url: "http://tunnel-url/extensions/[uuid]/Extension::Point::A"
      }
   }]
   // ...etc
}]
```

### How to test your changes?

1. `cd fixtures/app`
2. `yarn generate extension` (Choose the new UI extension)
3. `yarn dev`
4. Go to the dev console URL
5. Inspect the JSON that in the connected websocket message.  You should see something like the image below.  Make sure going to that URL redirects:

<img width="1105" alt="Screenshot 2022-11-28 at 3 50 26 PM" src="https://user-images.githubusercontent.com/690791/204378251-abae19c4-170d-44f6-8451-d5cc337fa9fd.png">

### Post-release steps

none

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
