### PR TITLE
[Fix] remove auth redirect property from base extension schema

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -39,8 +39,6 @@ export const BaseExtensionSchema = schema.define.object({
     .optional(),
   metafields: schema.define.array(MetafieldSchema).optional().default([]),
   categories: schema.define.array(schema.define.string()).optional(),
-  authenticatedRedirectStartUrl: schema.define.string().optional(),
-  authenticatedRedirectRedirectUrls: schema.define.array(schema.define.string()).optional(),
 })
 
 export const BaseFunctionConfigurationSchema = schema.define.object({

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -52,9 +52,6 @@ export async function getUIExtensionPayload(
     metafields: extension.configuration.metafields.length === 0 ? null : extension.configuration.metafields,
     type: extension.configuration.type,
 
-    authenticatedRedirectStartUrl: extension.configuration.authenticatedRedirectStartUrl,
-    authenticatedRedirectRedirectUrls: extension.configuration.authenticatedRedirectRedirectUrls,
-
     externalType: extension.externalType,
     uuid: extension.devUUID,
 


### PR DESCRIPTION
### WHY are these changes introduced?

This PR removes `authenticatedRedirectStartUrl` and `authenticatedRedirectRedirectUrls` from the base extension schema. I mistakenly added those properties in the already merged PR: https://github.com/Shopify/cli/pull/741

For more information please refer to Richard's comments:
https://github.com/Shopify/cli/pull/741/files/c2261a3b6c58880c3228bf8bbe3344a0d6ec4a39#r1035107327

<br/>

@byrichardpowell I decided to leave the `authenticatedRedirectStartUrl` and `authenticatedRedirectRedirectUrls` inside of the `customer_accounts` config instead of using settings, as on the customer_accounts side we currently are only making use of the config so far (see `categories` for example).

Kudos go to @byrichardpowell for bringing this topic up 🙏

### WHAT is this pull request doing?

- Remove `authenticatedRedirectStartUrl` and `authenticatedRedirectRedirectUrls` from the base extension schema
- Remove `authenticatedRedirectStartUrl` and `authenticatedRedirectRedirectUrls` from the payload, as we don't need  it in the JSON data that the extensions dev console receives

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
