### PR TITLE
[Bundles in Core] Add Bundle Management UI Extension

### DIFF
--- a/packages/app/src/cli/constants.test.ts
+++ b/packages/app/src/cli/constants.test.ts
@@ -148,4 +148,17 @@ describe('get extension type output configuration', () => {
       humanKey: 'Delivery option presenter',
     })
   })
+
+  it('obtain the correct configuration for extension type bundle_management_ui_extension', () => {
+    // Given
+    const extensionType = 'bundle_management_ui_extension'
+
+    // When
+    const extensionOutputConfig = getExtensionOutputConfig(extensionType)
+
+    // Then
+    expect(extensionOutputConfig).toEqual({
+      humanKey: 'Bundle management UI',
+    })
+  })
 })

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -51,7 +51,7 @@ export const limitedExtensions: {
   theme: ThemeExtensionTypes[]
   function: FunctionExtensionTypes[]
 } = {
-  ui: ['product_subscription', 'checkout_post_purchase', 'web_pixel_extension'],
+  ui: ['product_subscription', 'checkout_post_purchase', 'web_pixel_extension', 'bundle_management_ui_extension'],
   theme: ['theme'],
   function: [],
 }
@@ -82,11 +82,11 @@ export const publicUIExtensions = {
 } as const
 
 export const uiExtensions = {
-  types: [...publicUIExtensions.types, 'pos_ui_extension', 'customer_accounts_ui_extension', 'ui_extension'],
+  types: [...publicUIExtensions.types, 'pos_ui_extension', 'customer_accounts_ui_extension', 'bundle_management_ui_extension', 'ui_extension'],
 } as const
 
 export const activeUIExtensions = {
-  types: [...publicUIExtensions.types, 'pos_ui_extension', 'customer_accounts_ui_extension'].filter,
+  types: [...publicUIExtensions.types, 'pos_ui_extension', 'customer_accounts_ui_extension', 'bundle_management_ui_extension'].filter,
 }
 
 export type UIExtensionTypes = typeof uiExtensions.types[number] | string
@@ -145,6 +145,7 @@ export function extensionTypeIsGated(extensionType: ExtensionTypes): extensionTy
 export function getUIExtensionRendererDependency(extensionType: UIExtensionTypes): DependencyVersion | undefined {
   switch (extensionType) {
     case 'product_subscription':
+    case 'bundle_management_ui_extension':
       return {name: '@shopify/admin-ui-extensions-react', version: '^1.0.1'}
     case 'checkout_ui_extension':
       return {name: '@shopify/checkout-ui-extensions-react', version: '^0.20.0'}
@@ -160,7 +161,7 @@ export function getUIExtensionRendererDependency(extensionType: UIExtensionTypes
 }
 
 export const uiExternalExtensionTypes = {
-  types: ['web_pixel', 'post_purchase_ui', 'checkout_ui', 'pos_ui', 'subscription_ui', 'customer_accounts_ui'],
+  types: ['web_pixel', 'post_purchase_ui', 'checkout_ui', 'pos_ui', 'subscription_ui', 'customer_accounts_ui', 'bundle_management_ui'],
 } as const
 
 export type UIExternalExtensionTypes = typeof uiExternalExtensionTypes.types[number] | string
@@ -218,6 +219,7 @@ export const extensionTypesGroups: {name: string; extensions: ExtensionTypes[]}[
       'pos_ui_extension',
       'shipping_rate_presenter',
       'ui_extension',
+      'bundle_management_ui_extension', // TODO: Move this to 'Merchant admin' once it's public
     ],
   },
 ]
@@ -237,6 +239,7 @@ export const externalExtensionTypeNames = {
     'Payment customization',
     'Delivery option presenter',
     'Delivery customization',
+    'Bundle management UI',
   ],
 } as const
 
@@ -281,6 +284,8 @@ export function getExtensionOutputConfig(extensionType: ExtensionTypes): Extensi
       return buildExtensionOutputConfig('Delivery option presenter')
     case 'delivery_customization':
       return buildExtensionOutputConfig('Delivery customization')
+    case 'bundle_management_ui_extension':
+      return buildExtensionOutputConfig('Bundle management UI')
     default:
       return buildExtensionOutputConfig('Other')
   }
@@ -308,6 +313,8 @@ export const extensionGraphqlId = (type: ExtensionTypes) => {
       return 'WEB_PIXEL_EXTENSION'
     case 'customer_accounts_ui_extension':
       return 'CUSTOMER_ACCOUNTS_UI_EXTENSION'
+    case 'bundle_management_ui_extension':
+      return 'BUNDLE_MANAGEMENT_UI_EXTENSION'
     default:
       // As we add new extensions, this bug will force us to add a new case here.
       return type.toUpperCase()

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -82,11 +82,22 @@ export const publicUIExtensions = {
 } as const
 
 export const uiExtensions = {
-  types: [...publicUIExtensions.types, 'pos_ui_extension', 'customer_accounts_ui_extension', 'bundle_management_ui_extension', 'ui_extension'],
+  types: [
+    ...publicUIExtensions.types,
+    'pos_ui_extension',
+    'customer_accounts_ui_extension',
+    'bundle_management_ui_extension',
+    'ui_extension',
+  ],
 } as const
 
 export const activeUIExtensions = {
-  types: [...publicUIExtensions.types, 'pos_ui_extension', 'customer_accounts_ui_extension', 'bundle_management_ui_extension'].filter,
+  types: [
+    ...publicUIExtensions.types,
+    'pos_ui_extension',
+    'customer_accounts_ui_extension',
+    'bundle_management_ui_extension',
+  ].filter,
 }
 
 export type UIExtensionTypes = typeof uiExtensions.types[number] | string
@@ -161,7 +172,15 @@ export function getUIExtensionRendererDependency(extensionType: UIExtensionTypes
 }
 
 export const uiExternalExtensionTypes = {
-  types: ['web_pixel', 'post_purchase_ui', 'checkout_ui', 'pos_ui', 'subscription_ui', 'customer_accounts_ui', 'bundle_management_ui'],
+  types: [
+    'web_pixel',
+    'post_purchase_ui',
+    'checkout_ui',
+    'pos_ui',
+    'subscription_ui',
+    'customer_accounts_ui',
+    'bundle_management_ui',
+  ],
 } as const
 
 export type UIExternalExtensionTypes = typeof uiExternalExtensionTypes.types[number] | string
@@ -219,7 +238,7 @@ export const extensionTypesGroups: {name: string; extensions: ExtensionTypes[]}[
       'pos_ui_extension',
       'shipping_rate_presenter',
       'ui_extension',
-      'bundle_management_ui_extension', // TODO: Move this to 'Merchant admin' once it's public
+      'bundle_management_ui_extension',
     ],
   },
 ]

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -74,6 +74,23 @@ describe('getUIExtensionRendererVersion', () => {
     })
   })
 
+  test('returns the version of the dependency package for bundle_management_ui_extension', async () => {
+    await file.inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      await createPackageJson(tmpDir, 'admin-ui-extensions', '2.4.5')
+      DEFAULT_APP.directory = tmpDir
+
+      // When
+      const got = await getUIExtensionRendererVersion('bundle_management_ui_extension', DEFAULT_APP)
+
+      // Then
+      expect(got).not.toEqual('not-found')
+      if (got === 'not_found') return
+      expect(got?.name).to.toEqual('@shopify/admin-ui-extensions')
+      expect(got?.version).toEqual('2.4.5')
+    })
+  })
+
   test('returns not_found if there is no renderer package', async () => {
     await file.inTemporaryDirectory(async (tmpDir) => {
       DEFAULT_APP.directory = tmpDir

--- a/packages/app/src/cli/models/extensions/extension-specifications/bundle_management_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/extension-specifications/bundle_management_ui_extension.ts
@@ -1,0 +1,23 @@
+import {getDependencyVersion} from '../../app/app.js'
+import {createExtensionSpec} from '../extensions.js'
+import {BaseExtensionSchema} from '../schemas.js'
+import {error} from '@shopify/cli-kit'
+
+const dependency = {name: '@shopify/admin-ui-extensions-react', version: '^1.0.1'}
+
+const spec = createExtensionSpec({
+  identifier: 'bundle_management_ui_extension',
+  externalIdentifier: 'bundle_management_ui',
+  externalName: 'Bundle management UI',
+  surface: 'admin',
+  dependency,
+  partnersWebIdentifier: 'bundle_management_ui_extension',
+  schema: BaseExtensionSchema,
+  deployConfig: async (_, directory) => {
+    const result = await getDependencyVersion(dependency.name, directory)
+    if (result === 'not_found') throw new error.Bug('Dependency @shopify/admin-ui-extensions-react not found')
+    return {renderer_version: result?.version}
+  },
+})
+
+export default spec

--- a/packages/app/src/cli/utilities/extensions/name-mapper.ts
+++ b/packages/app/src/cli/utilities/extensions/name-mapper.ts
@@ -29,6 +29,8 @@ export function mapExtensionTypeToExternalExtensionType(extensionType: Extension
       return 'theme_app_extension'
     case 'customer_accounts_ui_extension':
       return 'customer_accounts_ui'
+    case 'bundle_management_ui_extension':
+      return 'bundle_management_ui'
     default:
       return extensionType
   }
@@ -50,6 +52,8 @@ export function mapUIExternalExtensionTypeToUIExtensionType(
       return 'pos_ui_extension'
     case 'customer_accounts_ui':
       return 'customer_accounts_ui_extension'
+    case 'bundle_management_ui':
+      return 'bundle_management_ui_extension'
     default:
       return externalExtensionType
   }
@@ -81,6 +85,8 @@ export function mapExternalExtensionTypeToExtensionType(
       return 'theme'
     case 'customer_accounts_ui':
       return 'customer_accounts_ui_extension'
+    case 'bundle_management_ui':
+      return 'bundle_management_ui_extension'
     default:
       return externalExtensionType
   }

--- a/packages/app/templates/ui-extensions/projects/bundle_management_ui/shopify.ui.extension.toml.liquid
+++ b/packages/app/templates/ui-extensions/projects/bundle_management_ui/shopify.ui.extension.toml.liquid
@@ -1,0 +1,2 @@
+type = "{{ type }}"
+name = "{{ name }}"

--- a/packages/app/templates/ui-extensions/projects/bundle_management_ui/src/index.liquid
+++ b/packages/app/templates/ui-extensions/projects/bundle_management_ui/src/index.liquid
@@ -1,0 +1,34 @@
+{%- if flavor contains "react" -%}
+import React from 'react'
+import {render, extend, Text, useExtensionApi} from '@shopify/admin-ui-extensions-react'
+
+extend(
+  'Admin::ProductDetails::RenderBundlesCard',
+  render(() => <App />),
+)
+extend(
+  'Admin::ProductVariantDetails::RenderBundlesCard',
+  render(() => <App />),
+)
+
+function App() {
+  const {extensionPoint} = useExtensionApi()
+  return <Text>Welcome to the {extensionPoint} extension!</Text>
+}
+{%- else -%}
+import { Text, extend } from "@shopify/admin-ui-extensions";
+
+extend("Admin::ProductDetails::RenderBundlesCard", App);
+extend("Admin::ProductVariantDetails::RenderBundlesCard", App);
+
+function App(root, { extensionPoint }) {
+  root.appendChild(
+    root.createComponent(
+      Text,
+      {},
+      `Welcome to the ${extensionPoint} extension!`
+    )
+  );
+  root.mount();
+}
+{%- endif -%}


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/core-issues/issues/47187

Corresponding Shopify/shopify PR: [#392603](https://github.com/Shopify/shopify/pull/392603)

### WHAT is this pull request doing?

This PR adds a new ui extension type for Bundles

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

- spin up bundles-reference-app
- spin shell
- cd shopify
- git checkout kd/20221130/bundle-management-extension-specification
- cd ..
- git clone https://github.com/Shopify/cli.git
- cd cli
- git checkout kd/20221201/bundle-management
- yarn
- yarn build
- yarn shopify app generate extension --path ../bundles-reference-app
- login as partners
- choose italic apps
- enter `shоpify-bundles-app` or `Shоpify Bundles™` as app name
> NOTE: the `o` in `shopify` has been replaced with `о` which is a unicode character
> WHY? because 3rd party apps include `shopify` in their name. Muahahahaha
> so, just copy pasta -- or give it any name you want :p
- select `Product - Bundle UI`
<img width="622" alt="Screenshot 2022-12-05 at 1 52 20 PM" src="https://user-images.githubusercontent.com/132806/206273400-4055c655-d78a-4830-9022-e800d11b74e9.png">

- generated extension should show up under the extensions folder in the target repo, and it should target the `Admin::ProductDetails::RenderBundlesCard` extension point.
- TODO: extension is missing from generated file
- in the cli repo, cd packages/app && `yarn link`
- in the target repo, `yarn link @shopify/app`
- in your repo, `yarn add @shopify/admin-ui-extensions`
- in your repo, `NODE_TLS_REJECT_UNAUTHORIZED=0 yarn shopify app dev`
- when prompted to select a dev store, select the 1st option
- goto https://cli.bundles-reference-app-2fv8.kevan-davis.us.spin.dev/extensions/dev-console (in your spinstance)
- you should see the `bundle_management_ui` extension listed
<img width="882" alt="Screenshot 2022-12-07 at 1 06 29 PM" src="https://user-images.githubusercontent.com/132806/206273138-5c369468-f121-4faf-a665-aacd416427b4.png">



### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] ~I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).~
