### PR TITLE
Add tests for extension errors

### DIFF
--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -177,7 +177,7 @@ describe('info', () => {
     `)
   })
 
-  it.only('returns errors alongside extensions when extensions have errors', async () => {
+  it('returns errors alongside extensions when extensions have errors', async () => {
     // Given
     const uiExtension1 = await testUIExtension({
       configuration: {


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes [#0000](https://github.com/Shopify/cli/issues/821)

### WHAT is this pull request doing?
Adds a test to check that errors with extensions are output when running `yarn shopify app info`

### How to test your changes?
Do the changes look good?

To see the results of the code we are testing

1. `yarn && yarn build`
2. Edit some of the toml files in `fixtures/app/extensions` to make them invalid (Change `type`  to `typo` for example`
3. `cd fixtures/app`
4. `yarn shopify app info`
5. You should see red error messages alongside the output towards the bottom of the message.

### Post-release steps
None

### Measuring impact
How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
