### PR TITLE
Use ListTokenItem instead of custom made list

### DIFF
--- a/packages/cli-hydrogen/src/cli/services/build/check-lockfile.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/build/check-lockfile.test.ts
@@ -120,8 +120,8 @@ describe('checkLockfileStatus()', () => {
           │  conflicts when installing and deploying your app. The following lockfiles   │
           │  were detected:                                                              │
           │                                                                              │
-          │   • yarn.lock (created by yarn)                                              │
-          │   • package-lock.json (created by npm)                                       │
+          │    • yarn.lock (created by yarn)                                             │
+          │    • package-lock.json (created by npm)                                      │
           │                                                                              │
           │  Next steps                                                                  │
           │    • Delete any unneeded lockfiles                                           │

--- a/packages/cli-hydrogen/src/cli/services/build/check-lockfile.ts
+++ b/packages/cli-hydrogen/src/cli/services/build/check-lockfile.ts
@@ -30,7 +30,7 @@ function multipleLockfilesWarning(lockfiles: Lockfile[]) {
   }
 
   const lockfileList = lockfiles.map((lockfile) => {
-    return `• ${lockfile} (created by ${packageManagers[lockfile]})`
+    return `${lockfile} (created by ${packageManagers[lockfile]})`
   })
 
   renderWarning({
@@ -38,8 +38,8 @@ function multipleLockfilesWarning(lockfiles: Lockfile[]) {
     body: [
       `Your project contains more than one lockfile. This can cause version ` +
         `conflicts when installing and deploying your app. The following ` +
-        `lockfiles were detected:\n\n`,
-      lockfileList.join('\n '),
+        `lockfiles were detected:\n`,
+      {list: {items: lockfileList}},
     ],
     nextSteps: ['Delete any unneeded lockfiles', 'Commit the change to your repository'],
   })


### PR DESCRIPTION
### WHY are these changes introduced?

As pointed out [here](https://github.com/Shopify/cli/pull/746/files#r1023870786) we can now leverage the new `List` token to refactor some custom made output.

### WHAT is this pull request doing?

Remove a custom made list and replace it with `List`.

### How to test your changes?

You can follow the same steps outlined in the [original PR](https://github.com/Shopify/cli/pull/746). Output should be the same, with lists always aligned.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
