### PR TITLE
Remove the truncate log

### DIFF
--- a/.changeset/angry-goats-double.md
+++ b/.changeset/angry-goats-double.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Not show a message when we truncate the logs file


### PR DESCRIPTION
### WHY are these changes introduced?
When we truncate the logs file we output a message to the user leaking implementation details of our logging system

### WHAT is this pull request doing?
I'm adjusting the logic to output a `debug` message instead. Users will only see it if they use `--verbose`.

### How to test your changes?
Try to run any CLI command. You shouldn't see the message.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
