### PR TITLE
Fix release pipeline that started failing after making `pnpm` the package manager of the repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ concurrency:
   group: changeset-${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  PNPM_VERSION: "7.18.1"
+
 jobs:
   release:
     name: Release
@@ -21,14 +24,14 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: latest
+          version: ${{ env.PNPM_VERSION }}
       - name: Set Node.js
         uses: actions/setup-node@master
         with:
           node-version: '16'
-          cache: 'yarn'
+          cache: 'pnpm'
       - name: Install dependencies
-        run: yarn install
+        run: pnpm install
       - name: Create Release Pull Request
         uses: changesets/action@v1
         env:

--- a/docs/cli/cross-os-compatibility.md
+++ b/docs/cli/cross-os-compatibility.md
@@ -54,10 +54,10 @@ Then you can clone the CLI repository:
 git clone https://github.com/Shopify/cli.git
 ```
 
-Now you can install dependencies with `yarn install`. If Yarn yields "unsigned scripts" errors execute the following command:
+Now you can install dependencies with `pnpm install`. If Yarn yields "unsigned scripts" errors execute the following command:
 
 ```bash
 Set-ExecutionPolicy Unrestricted -Scope LocalMachine
 ```
 
-Now you can run the test suite with `yarn test` and verify that everything works properly.
+Now you can run the test suite with `pnpm test` and verify that everything works properly.


### PR DESCRIPTION
### WHY are these changes introduced?
I missed adjusting the release GitHub Action workflow to use `pnpm` instead of Yarn. Because the workflow only runs in `main` I only [noticed](https://github.com/Shopify/cli/actions/runs/3638603628/jobs/6140991207) it after I merged the work.

### WHAT is this pull request doing?
I'm adjusting the pipeline to use `pnpm` instead of Yarn.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
