### PR TITLE
Add internal order_routing_location_rule extension type

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -95,7 +95,8 @@
           "shipping_discounts",
           "payment_customization",
           "shipping_rate_presenter",
-          "delivery_customization"
+          "delivery_customization",
+          "order_routing_location_rule",
         ],
         "default": "checkout_ui_extension",
     },

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -70,6 +70,7 @@ export const extensionTypesGroups: {name: string; extensions: string[]}[] = [
       'delivery_customization',
       'shipping_rate_presenter',
       'ui_extension',
+      'order_routing_location_rule',
     ],
   },
 ]

--- a/packages/app/src/cli/models/extensions/function-specifications/order_routing_location_rule.ts
+++ b/packages/app/src/cli/models/extensions/function-specifications/order_routing_location_rule.ts
@@ -1,0 +1,11 @@
+import {createFunctionSpec} from '../functions.js'
+
+const spec = createFunctionSpec({
+  identifier: 'order_routing_location_rule',
+  externalIdentifier: 'order_routing_location_rule',
+  externalName: 'Order routing location rule',
+  gated: true,
+  templatePath: (lang) => `order-routing/${lang}/rankers/default`,
+})
+
+export default spec


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This PR adds the ``order_routing_location_rule`` extension type.

Related Issue: https://github.com/Shopify/shopify/issues/393386

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This is one of [two changes](https://vault.shopify.io/page/Function-API-prototyping-guide~Dyet.md#registering-your-api-name) needed to register the ``order_routing_location_rule`` API name so that related functions can be deployed. 

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### WHAT should reviewers focus on?

I based the template paths on those that were originally written for ``order_routing_ranker`` but these might need to be changed.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
