### PR TITLE
Change windowsHide to false

### DIFF
--- a/.changeset/pink-pens-trade.md
+++ b/.changeset/pink-pens-trade.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix CLI not killing Node processes after quitting `dev` on Windows

--- a/packages/cli-kit/src/system.ts
+++ b/packages/cli-kit/src/system.ts
@@ -68,6 +68,7 @@ const buildExec = (command: string, args: string[], options?: ExecOptions): Exec
     stdin: options?.stdin,
     stdout: options?.stdout === 'inherit' ? 'inherit' : undefined,
     stderr: options?.stderr === 'inherit' ? 'inherit' : undefined,
+    windowsHide: false,
   })
   debug(`
 Running system process:


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/630

On Windows, processes are left hanging around after users terminate `dev` with `Ctrl+C`. Digging around I found an [issue](https://github.com/sindresorhus/execa/issues/433) open on the `execa` repo that mentioned [issues](https://github.com/nodejs/node/issues/29837) with `SIGINT` and child processes not getting killed properly on Windows if `windowsHide` is left to its default value of `true`.

### WHAT is this pull request doing?

This PR changes the value of `windowsHide` from its default of `true` to `false`. This did not seem to have any effect on the behavior of `dev`

### How to test your changes?

- Run `yarn shopify app dev --path fixtures/app` on Windows
- Open the task manager and see all the node processes that the terminal app spawned
- Press `Ctrl+C` and see all the node processes disappear.

There will be 1 node process remaining, but this behavior also happens on Mac and there we haven't had any problems with cleaning up child processes. If that single process becomes a problem we can investigate further, but for now this change should make the two platforms behave the same.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
