### PR TITLE
Activate webhook trigger and improve error message

### DIFF
--- a/.changeset/tough-houses-dress.md
+++ b/.changeset/tough-houses-dress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/features': minor
+---
+
+Add webhook trigger command

--- a/packages/app/src/cli/commands/webhook/trigger.ts
+++ b/packages/app/src/cli/commands/webhook/trigger.ts
@@ -5,7 +5,6 @@ import {deliveryMethodInstructionsAsString} from '../../prompts/webhook/trigger.
 import {Command, Flags} from '@oclif/core'
 
 export default class WebhookTrigger extends Command {
-  static hidden = true
   static description = 'Trigger delivery of a sample webhook topic payload to a designated address'
 
   static flags = {

--- a/packages/app/src/cli/prompts/webhook/options-prompt.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.ts
@@ -59,7 +59,7 @@ export async function optionsPrompt(flags: WebhookTriggerFlags): Promise<Webhook
 
   if (methodPassed && addressPassed) {
     if (isAddressAllowedForDeliveryMethod(flags.address as string, flags.deliveryMethod as string)) {
-      options.address = flags.address as string
+      options.address = (flags.address as string).trim()
       options.deliveryMethod = inferMethodFromAddress(options.address)
     } else {
       throw new error.Abort(
@@ -71,7 +71,7 @@ export async function optionsPrompt(flags: WebhookTriggerFlags): Promise<Webhook
   }
 
   if (!methodPassed && addressPassed) {
-    options.address = flags.address as string
+    options.address = (flags.address as string).trim()
     options.deliveryMethod = inferMethodFromAddress(options.address)
   }
 

--- a/packages/app/src/cli/prompts/webhook/trigger.test.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.test.ts
@@ -116,7 +116,8 @@ describe('sharedSecretPrompt', () => {
       {
         type: 'input',
         name: 'sharedSecret',
-        message: 'Shared Secret to encode the webhook payload',
+        message:
+          'Shared Secret to encode the webhook payload. If you are using the app template, this is your Client Secret, which can be found in the partners dashboard',
         default: 'shopify_test',
         validate: expect.any(Function),
       },

--- a/packages/app/src/cli/prompts/webhook/trigger.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.ts
@@ -66,10 +66,11 @@ export async function addressPrompt(deliveryMethod: string): Promise<string> {
       message: 'Address for delivery',
       default: '',
       validate: (value) => {
-        if (value.length === 0) {
+        const trimmed = value.trim()
+        if (trimmed.length === 0) {
           return "Address can't be empty"
         }
-        if (isAddressAllowedForDeliveryMethod(value, deliveryMethod)) {
+        if (isAddressAllowedForDeliveryMethod(trimmed, deliveryMethod)) {
           return true
         }
 
@@ -78,7 +79,7 @@ export async function addressPrompt(deliveryMethod: string): Promise<string> {
     },
   ])
 
-  return input.address
+  return input.address.trim()
 }
 
 export async function sharedSecretPrompt(): Promise<string> {

--- a/packages/app/src/cli/prompts/webhook/trigger.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.ts
@@ -87,7 +87,8 @@ export async function sharedSecretPrompt(): Promise<string> {
     {
       type: 'input',
       name: 'sharedSecret',
-      message: 'Shared Secret to encode the webhook payload',
+      message:
+        'Shared Secret to encode the webhook payload. If you are using the app template, this is your Client Secret, which can be found in the partners dashboard',
       default: 'shopify_test',
       validate: (value: string) => {
         if (value.length === 0) {

--- a/packages/app/src/cli/services/webhook/trigger.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger.test.ts
@@ -64,7 +64,7 @@ describe('execute', () => {
     )
   })
 
-  it('notifies about request errors', async () => {
+  it('Safe notification in case of unexpected request errors', async () => {
     // Given
     const response = {
       samplePayload: emptyJson,

--- a/packages/app/src/cli/services/webhook/trigger.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger.test.ts
@@ -47,8 +47,8 @@ describe('execute', () => {
       headers: emptyJson,
       success: false,
       userErrors: [
-        {message: 'Error 1', fields: ['field1']},
-        {message: 'Error 2', fields: ['field1']},
+        {message: '["Invalid topic pizza/update", "Invalid api_version 1942-13"]', fields: ['field1']},
+        {message: '["Unable to notify example"]', fields: ['field2']},
       ],
     }
     vi.mocked(getWebhookSample).mockResolvedValue(response)
@@ -59,7 +59,31 @@ describe('execute', () => {
     await webhookTriggerService(sampleOptions())
 
     // Then
-    expect(outputSpy).toHaveBeenCalledWith(JSON.stringify(response.userErrors))
+    expect(outputSpy).toHaveBeenCalledWith(
+      `Request errors:\n  · Invalid topic pizza/update\n  · Invalid api_version 1942-13\n  · Unable to notify example`,
+    )
+  })
+
+  it('notifies about request errors', async () => {
+    // Given
+    const response = {
+      samplePayload: emptyJson,
+      headers: emptyJson,
+      success: false,
+      userErrors: [
+        {message: 'Something not JSON', fields: ['field1']},
+        {message: 'Another invalid JSON', fields: ['field2']},
+      ],
+    }
+    vi.mocked(getWebhookSample).mockResolvedValue(response)
+
+    const outputSpy = vi.spyOn(output, 'consoleError')
+
+    // When
+    await webhookTriggerService(sampleOptions())
+
+    // Then
+    expect(outputSpy).toHaveBeenCalledWith(`Request errors:\n${JSON.stringify(response.userErrors)}`)
   })
 
   it('notifies about real delivery being sent', async () => {

--- a/packages/app/src/cli/services/webhook/trigger.ts
+++ b/packages/app/src/cli/services/webhook/trigger.ts
@@ -1,5 +1,5 @@
 import {DELIVERY_METHOD, WebhookTriggerOptions} from './trigger-options.js'
-import {getWebhookSample} from './request-sample.js'
+import {getWebhookSample, UserErrors} from './request-sample.js'
 import {triggerLocalWebhook} from './trigger-local-webhook.js'
 import {output} from '@shopify/cli-kit'
 
@@ -19,7 +19,7 @@ export async function webhookTriggerService(options: WebhookTriggerOptions) {
   )
 
   if (!sample.success) {
-    await output.consoleError(JSON.stringify(sample.userErrors))
+    await output.consoleError(`Request errors:\n${formatErrors(sample.userErrors)}`)
     return
   }
 
@@ -37,5 +37,19 @@ export async function webhookTriggerService(options: WebhookTriggerOptions) {
 
   if (sample.samplePayload === JSON.stringify({})) {
     output.success('Webhook has been enqueued for delivery')
+  }
+}
+function formatErrors(errors: UserErrors[]): string {
+  try {
+    return errors
+      .map((element) =>
+        JSON.parse(element.message)
+          .map((msg: string) => `  · ${msg}`)
+          .join('\n'),
+      )
+      .join('\n')
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (err) {
+    return JSON.stringify(errors)
   }
 }

--- a/packages/features/snapshots/commands.txt
+++ b/packages/features/snapshots/commands.txt
@@ -41,3 +41,4 @@
  theme share            @shopify/theme         
  upgrade                @shopify/cli           
  version                @shopify/cli           
+ webhook trigger        @shopify/app           


### PR DESCRIPTION
### WHY are these changes introduced?

1. To show the command in the list of available commands
2. To improve the error reporting when invalid values for topic and api-version are passed. Feedback received from @jhoffmcd during the bug bash 

### WHAT is this pull request doing?

For next steps we plan to add client validation to those two fields. Meanwhile, the CLI returns validation errors returned by Core. Those were printed in raw mode and we have added better formatting:

**BEFORE**

![Before](https://screenshot.click/Screenshot_2022-12-07_at_23.20.54.png)

**AFTER**

![After](https://screenshot.click/Screenshot_2022-12-07_at_23.18.55.png)

### How to test your changes?

Follow this, possibly, https://github.com/Shopify/cli/pull/870 if you're moving away from yarn for the 1st time.
In vs code, first do `dev up`, then:

1. Show the help and check that the new command appears:
```
pnpm shopify --help
```

2. Execute the command with invalid topic and api-version values:
```
pnpm shopify webhook trigger --topic=pizza/update --api-version=2028-10 --address=http://localhost:55925/api/webhooks
```

### Post-release steps

@pacocastrotech to:
1. Talk with @shainaraskas to deploy the following PR in shopify-dev: https://github.com/Shopify/shopify-dev/pull/28001
2. Talk with @mikedasilva and @anitameh to involve teams in charge of communications and support.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
