### PR TITLE
Stop calling localCliPackage because it's super slow

### DIFF
--- a/packages/cli-kit/src/analytics.ts
+++ b/packages/cli-kit/src/analytics.ts
@@ -11,7 +11,6 @@ import BaseCommand from './public/node/base-command.js'
 import {CommandContent} from './public/node/hooks/prerun.js'
 import {hashString} from './string.js'
 import {macAddress} from './environment/local.js'
-import {localCliPackage} from './public/node/cli.js'
 import {Config, Interfaces} from '@oclif/core'
 
 interface StartOptions {
@@ -171,7 +170,7 @@ export async function getEnvironmentData(config: Interfaces.Config) {
       : undefined,
     env_device_id: hashString(await macAddress()),
     env_cloud: environment.local.cloudEnvironment().platform,
-    env_package_manager: (await localCliPackage()) ? await getPackageManager(process.cwd()) : undefined,
+    env_package_manager: await getPackageManager(process.cwd()),
   }
 }
 


### PR DESCRIPTION
It adds 5 seconds of wait time at the end of each command

### WHY are these changes introduced?

*before*
```
$ time pnpm shopify help
real	0m7.918s
user	0m7.181s
sys	0m1.501s
```

*after*
```
$ time pnpm shopify help
real	0m2.723s
user	0m1.253s
sys	0m0.362s
```

### WHAT is this pull request doing?

Stop calling `localCliPackage`, which in turn calls `npm list` to check if the CLI package used is a local one. I think that originally the intent of the code was to verify that we were NOT using a global version (for example installed through homebrew). But I don't think the accuracy of analytics is worth the time we are spending.

### How to test your changes?

`$ time pnpm shopify help`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
