### PR TITLE
[CI bug] Coverage storage actions should use input

### DIFF
--- a/.github/actions/download-and-publish-test-coverage/action.yml
+++ b/.github/actions/download-and-publish-test-coverage/action.yml
@@ -1,5 +1,9 @@
 name: "Download and publish test coverage"
 description: "Downloads test coverage stats from the base branch, publishes a comment with a summary"
+inputs:
+  base-branch-name:
+    required: true
+    description: "Name of the branch to compare coverage with"
 runs:
   using: "composite"
   steps:
@@ -7,7 +11,7 @@ runs:
     - name: Clean base ref name
       shell: bash
       env:
-          SAFE_BASE_REF_NAME: "${{ github.base_ref }}"
+          SAFE_BASE_REF_NAME: "${{ inputs.base-branch-name }}"
       run: |
         SAFE_BASE_REF_NAME=${{ env.SAFE_BASE_REF_NAME }}
         SAFE_BASE_REF_NAME=${SAFE_BASE_REF_NAME//[\/.]/}

--- a/.github/actions/run-and-save-test-coverage/action.yml
+++ b/.github/actions/run-and-save-test-coverage/action.yml
@@ -1,5 +1,9 @@
 name: "Run and save test coverage"
 description: "Runs unit tests in coverage mode, merges results across packages, and uploads for future comparisons"
+inputs:
+  branch-name:
+    required: true
+    description: "Name of the branch being tested"
 runs:
   using: "composite"
   steps:
@@ -19,7 +23,7 @@ runs:
     - name: Clean ref name
       shell: bash
       env:
-          SAFE_REF_NAME: "${{ github.head_ref }}"
+          SAFE_REF_NAME: "${{ inputs.branch-name }}"
       run: |
         SAFE_REF_NAME=${{ env.SAFE_REF_NAME }}
         SAFE_REF_NAME=${SAFE_REF_NAME//[\/.]/}

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -104,6 +104,8 @@ jobs:
       - name: Run and save test coverage
         uses: ./.github/actions/run-and-save-test-coverage
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
+        with:
+          branch-name: main
 
   pr-platform-agnostic:
     name: ${{ matrix.target }} with Node ${{ matrix.node }} in ${{ matrix.os }}
@@ -156,9 +158,13 @@ jobs:
       - name: Run and save test coverage
         uses: ./.github/actions/run-and-save-test-coverage
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
+        with:
+          branch-name: "${{ github.head_ref }}"
       - name: Download and publish test coverage
         uses: ./.github/actions/download-and-publish-test-coverage
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
+        with:
+          base-branch-name: "${{ github.base_ref }}"
 
   manually-triggered:
     name: Testing with Node ${{ inputs.node-version }} in ${{ inputs.os }}


### PR DESCRIPTION
Ensures that runs on `main` have coverage stored correctly for future comparison.