### PR TITLE
Fix flaky test in sessions

### DIFF
--- a/packages/cli-kit/src/environment/service.test.ts
+++ b/packages/cli-kit/src/environment/service.test.ts
@@ -1,6 +1,12 @@
 import {isSpinEnvironment, serviceEnvironment} from './service.js'
 import {Environment} from '../network/service.js'
-import {expect, it, describe} from 'vitest'
+import {expect, it, describe, afterEach} from 'vitest'
+
+const OLD_ENV = {...process.env}
+
+afterEach(() => {
+  process.env = {...OLD_ENV}
+})
 
 describe('serviceEnvironment', () => {
   it('returns local when the environment variable points to the local environment', () => {

--- a/packages/cli-kit/src/environment/service.test.ts
+++ b/packages/cli-kit/src/environment/service.test.ts
@@ -1,12 +1,6 @@
 import {isSpinEnvironment, serviceEnvironment} from './service.js'
 import {Environment} from '../network/service.js'
-import {expect, it, describe, afterEach} from 'vitest'
-
-const OLD_ENV = {...process.env}
-
-afterEach(() => {
-  process.env = {...OLD_ENV}
-})
+import {expect, it, describe} from 'vitest'
 
 describe('serviceEnvironment', () => {
   it('returns local when the environment variable points to the local environment', () => {
@@ -68,10 +62,10 @@ describe('serviceEnvironment', () => {
 describe('isSpinEnvironment', () => {
   it('returns true when running against SPIN instance', () => {
     // Given
-    process.env = {...process.env, SHOPIFY_SERVICE_ENV: 'spin'}
+    const env = {SHOPIFY_SERVICE_ENV: 'spin'}
 
     // When
-    const got = isSpinEnvironment()
+    const got = isSpinEnvironment(env)
 
     // Then
     expect(got).toBe(true)
@@ -79,10 +73,10 @@ describe('isSpinEnvironment', () => {
 
   it('returns true when running inside a SPIN instance', () => {
     // Given
-    process.env = {...process.env, SPIN: '1'}
+    const env = {SPIN: '1'}
 
     // When
-    const got = isSpinEnvironment()
+    const got = isSpinEnvironment(env)
 
     // Then
     expect(got).toBe(true)
@@ -90,10 +84,10 @@ describe('isSpinEnvironment', () => {
 
   it('returns false when not working with spin instances', () => {
     // Given
-    process.env = {...process.env, SHOPIFY_SERVICE_ENV: 'local'}
+    const env = {SHOPIFY_SERVICE_ENV: 'local'}
 
     // When
-    const got = isSpinEnvironment()
+    const got = isSpinEnvironment(env)
 
     // Then
     expect(got).toBe(false)

--- a/packages/cli-kit/src/session.test.ts
+++ b/packages/cli-kit/src/session.test.ts
@@ -22,6 +22,7 @@ import {
 import {partners} from './api.js'
 
 import {identity} from './environment/fqdn.js'
+import {useDeviceAuth} from './environment/local.js'
 import {authorize} from './session/authorize.js'
 import {vi, describe, expect, it, beforeAll, beforeEach} from 'vitest'
 
@@ -98,6 +99,7 @@ const invalidSession: Session = {
 
 beforeAll(() => {
   vi.mock('./environment/fqdn')
+  vi.mock('./environment/local')
   vi.mock('./session/identity')
   vi.mock('./session/authorize')
   vi.mock('./session/exchange')
@@ -106,11 +108,11 @@ beforeAll(() => {
   vi.mock('./session/validate')
   vi.mock('./api')
   vi.mock('./store')
-  vi.mocked(allDefaultScopes).mockImplementation((scopes) => scopes || [])
 })
 
 beforeEach(() => {
   vi.mocked(identity).mockResolvedValue(fqdn)
+  vi.mocked(useDeviceAuth).mockReturnValue(false)
   vi.mocked(authorize).mockResolvedValue(code)
   vi.mocked(exchangeCodeForAccessToken).mockResolvedValue(validIdentityToken)
   vi.mocked(exchangeAccessForApplicationTokens).mockResolvedValue(appTokens)
@@ -120,6 +122,7 @@ beforeEach(() => {
   // eslint-disable-next-line no-warning-comments
   // TODO: Add tests for ensureUserHasPartnerAccount
   vi.mocked(partners.request).mockResolvedValue(undefined)
+  vi.mocked(allDefaultScopes).mockImplementation((scopes) => scopes || [])
 })
 
 describe('ensureAuthenticated when previous session is invalid', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/internal-cli-foundations/issues/476

- There were some tests that sets some environment variables globally. This could cause collateral problems in other tests executed before that depends on that environment variables.
- For instance, the tests in `session.test.ts` don't support executing the device authentication method. There was a condition that checks some environment variables modified in the first point. In case those are modified before some flaky errors are generated

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Restore the original environment variables values, after running each test

### How to test your changes?
- Simulate setting env variable SPIN 1 when running session tests
- `cd packages/cli-kit`
- `SPIN=1 pnpm nx run test session` 
- Errors appeared should match the ones from the flaky test issue

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
