### PR TITLE
Only request granted scopes on selected app

### DIFF
--- a/.changeset/strong-dolls-pay.md
+++ b/.changeset/strong-dolls-pay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Only request necessary information to speed up fetching apps list

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -5,10 +5,13 @@ export interface Organization {
   appsNext: boolean
 }
 
-export interface OrganizationApp {
+export interface MinimalOrganizationApp {
   id: string
   title: string
   apiKey: string
+}
+
+export type OrganizationApp = MinimalOrganizationApp & {
   organizationId: string
   apiSecretKeys: {
     secret: string
@@ -17,8 +20,6 @@ export interface OrganizationApp {
   newApp?: boolean
   grantedScopes: string[]
 }
-
-export type ScopelessOrganizationApp = Omit<OrganizationApp, 'grantedScopes'>
 
 export interface OrganizationStore {
   shopId: string

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -18,6 +18,8 @@ export interface OrganizationApp {
   grantedScopes: string[]
 }
 
+export type ScopelessOrganizationApp = Omit<OrganizationApp, 'grantedScopes'>
+
 export interface OrganizationStore {
   shopId: string
   link: string

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -1,4 +1,4 @@
-import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
+import {Organization, ScopelessOrganizationApp, OrganizationStore} from '../models/organization.js'
 import {output, ui} from '@shopify/cli-kit'
 
 export async function selectOrganizationPrompt(organizations: Organization[]): Promise<Organization> {
@@ -17,7 +17,7 @@ export async function selectOrganizationPrompt(organizations: Organization[]): P
   return organizations.find((org) => org.id === choice.id)!
 }
 
-export async function selectAppPrompt(apps: OrganizationApp[]): Promise<OrganizationApp> {
+export async function selectAppPrompt(apps: ScopelessOrganizationApp[]): Promise<ScopelessOrganizationApp> {
   const appList = apps.map((app) => ({name: app.title, value: app.apiKey}))
   const choice = await ui.prompt([
     {

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -1,4 +1,4 @@
-import {Organization, ScopelessOrganizationApp, OrganizationStore} from '../models/organization.js'
+import {Organization, MinimalOrganizationApp, OrganizationStore} from '../models/organization.js'
 import {output, ui} from '@shopify/cli-kit'
 
 export async function selectOrganizationPrompt(organizations: Organization[]): Promise<Organization> {
@@ -17,7 +17,7 @@ export async function selectOrganizationPrompt(organizations: Organization[]): P
   return organizations.find((org) => org.id === choice.id)!
 }
 
-export async function selectAppPrompt(apps: ScopelessOrganizationApp[]): Promise<ScopelessOrganizationApp> {
+export async function selectAppPrompt(apps: MinimalOrganizationApp[]): Promise<MinimalOrganizationApp> {
   const appList = apps.map((app) => ({name: app.title, value: app.apiKey}))
   const choice = await ui.prompt([
     {

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -1,6 +1,6 @@
 import {OrganizationApp} from '../../models/organization.js'
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
-import {fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
+import {fetchAppFromApiKey, fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
 import {session} from '@shopify/cli-kit'
 
 export async function selectApp(): Promise<OrganizationApp> {
@@ -9,5 +9,6 @@ export async function selectApp(): Promise<OrganizationApp> {
   const org = await selectOrganizationPrompt(orgs)
   const {apps} = await fetchOrgAndApps(org.id, token)
   const selectedApp = await selectAppPrompt(apps)
-  return selectedApp
+  const fullSelectedApp = await fetchAppFromApiKey(selectedApp.apiKey, token)
+  return fullSelectedApp!
 }

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -1,4 +1,4 @@
-import {Organization, OrganizationApp, ScopelessOrganizationApp, OrganizationStore} from '../../models/organization.js'
+import {Organization, OrganizationApp, MinimalOrganizationApp, OrganizationStore} from '../../models/organization.js'
 import {api, error} from '@shopify/cli-kit'
 
 export const NoOrgError = (organizationId?: string) => {
@@ -36,7 +36,7 @@ export const NoOrgError = (organizationId?: string) => {
 
 export interface FetchResponse {
   organization: Organization
-  apps: ScopelessOrganizationApp[]
+  apps: MinimalOrganizationApp[]
   stores: OrganizationStore[]
 }
 

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -1,4 +1,4 @@
-import {Organization, OrganizationApp, OrganizationStore} from '../../models/organization.js'
+import {Organization, OrganizationApp, ScopelessOrganizationApp, OrganizationStore} from '../../models/organization.js'
 import {api, error} from '@shopify/cli-kit'
 
 export const NoOrgError = (organizationId?: string) => {
@@ -36,7 +36,7 @@ export const NoOrgError = (organizationId?: string) => {
 
 export interface FetchResponse {
   organization: Organization
-  apps: OrganizationApp[]
+  apps: ScopelessOrganizationApp[]
   stores: OrganizationStore[]
 }
 

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -1,6 +1,6 @@
 import {createApp, selectOrCreateApp} from './select-app.js'
 import {AppInterface, WebType} from '../../models/app/app.js'
-import {Organization, OrganizationApp} from '../../models/organization.js'
+import {MinimalOrganizationApp, Organization, OrganizationApp} from '../../models/organization.js'
 import {appNamePrompt, appTypePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {testApp} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
@@ -40,6 +40,10 @@ const APP2: OrganizationApp = {
   organizationId: '1',
   grantedScopes: [],
 }
+const APP_LIST: MinimalOrganizationApp[] = [
+  {id: APP1.id, title: APP1.title, apiKey: APP1.apiKey},
+  {id: APP2.id, title: APP2.title, apiKey: APP2.apiKey},
+]
 
 beforeEach(() => {
   vi.mock('../../prompts/dev')
@@ -101,13 +105,14 @@ describe('selectOrCreateApp', () => {
     // Given
     vi.mocked(selectAppPrompt).mockResolvedValueOnce(APP1)
     vi.mocked(createAsNewAppPrompt).mockResolvedValue(false)
+    vi.mocked(api.partners.request).mockResolvedValueOnce({app: APP1})
 
     // When
-    const got = await selectOrCreateApp(LOCAL_APP.name, [APP1, APP2], ORG1, 'token')
+    const got = await selectOrCreateApp(LOCAL_APP.name, APP_LIST, ORG1, 'token')
 
     // Then
     expect(got).toEqual(APP1)
-    expect(selectAppPrompt).toHaveBeenCalledWith([APP1, APP2])
+    expect(selectAppPrompt).toHaveBeenCalledWith(APP_LIST)
   })
 
   it('prompts user to create if chooses to create', async () => {
@@ -124,7 +129,7 @@ describe('selectOrCreateApp', () => {
     }
 
     // When
-    const got = await selectOrCreateApp(LOCAL_APP.name, [APP1, APP2], ORG1, 'token')
+    const got = await selectOrCreateApp(LOCAL_APP.name, APP_LIST, ORG1, 'token')
 
     // Then
     expect(got).toEqual(APP1)

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -1,5 +1,5 @@
 import {appNamePrompt, appTypePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
-import {Organization, OrganizationApp, ScopelessOrganizationApp} from '../../models/organization.js'
+import {Organization, OrganizationApp, MinimalOrganizationApp} from '../../models/organization.js'
 import {fetchAppFromApiKey} from '../dev/fetch.js'
 import {api, error, output} from '@shopify/cli-kit'
 
@@ -16,7 +16,7 @@ import {api, error, output} from '@shopify/cli-kit'
  */
 export async function selectOrCreateApp(
   localAppName: string,
-  apps: ScopelessOrganizationApp[],
+  apps: MinimalOrganizationApp[],
   org: Organization,
   token: string,
 ): Promise<OrganizationApp> {

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -1,5 +1,6 @@
 import {appNamePrompt, appTypePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
-import {Organization, OrganizationApp} from '../../models/organization.js'
+import {Organization, OrganizationApp, ScopelessOrganizationApp} from '../../models/organization.js'
+import {fetchAppFromApiKey} from '../dev/fetch.js'
 import {api, error, output} from '@shopify/cli-kit'
 
 /**
@@ -15,7 +16,7 @@ import {api, error, output} from '@shopify/cli-kit'
  */
 export async function selectOrCreateApp(
   localAppName: string,
-  apps: OrganizationApp[],
+  apps: ScopelessOrganizationApp[],
   org: Organization,
   token: string,
 ): Promise<OrganizationApp> {
@@ -24,8 +25,13 @@ export async function selectOrCreateApp(
     output.info(`\nBefore you preview your work, it needs to be associated with an app.\n`)
     createNewApp = await createAsNewAppPrompt()
   }
-  const app = createNewApp ? await createApp(org, localAppName, token) : await selectAppPrompt(apps)
-  return app
+  if (createNewApp) {
+    return createApp(org, localAppName, token)
+  } else {
+    const selectedApp = await selectAppPrompt(apps)
+    const fullSelectedApp = await fetchAppFromApiKey(selectedApp.apiKey, token)
+    return fullSelectedApp!
+  }
 }
 
 export async function createApp(org: Organization, appName: string, token: string): Promise<OrganizationApp> {

--- a/packages/cli-kit/src/api/graphql/find_org.ts
+++ b/packages/cli-kit/src/api/graphql/find_org.ts
@@ -13,11 +13,6 @@ export const FindOrganizationQuery = gql`
             id
             title
             apiKey
-            organizationId
-            apiSecretKeys {
-              secret
-            }
-            appType
           }
         }
       }
@@ -37,11 +32,6 @@ export interface FindOrganizationQuerySchema {
           id: string
           title: string
           apiKey: string
-          organizationId: string
-          apiSecretKeys: {
-            secret: string
-          }[]
-          appType: string
         }[]
       }
     }[]

--- a/packages/cli-kit/src/api/graphql/find_org.ts
+++ b/packages/cli-kit/src/api/graphql/find_org.ts
@@ -18,7 +18,6 @@ export const FindOrganizationQuery = gql`
               secret
             }
             appType
-            grantedScopes
           }
         }
       }
@@ -43,7 +42,6 @@ export interface FindOrganizationQuerySchema {
             secret: string
           }[]
           appType: string
-          grantedScopes: string[]
         }[]
       }
     }[]


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes the request for an org's apps taking way too long (>10 seconds in some cases if there are many apps!)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
It turns out most of the time is spent fetching granted scopes for each app. Given how expensive this is, so we should only request it once on the selected app, not on each returned app.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Any operation (simplest is `shopify app env show --verbose`) you should see the request time for the app list decrease dramatically.

Worth tophatting various affected flows (`dev` and `deploy`) as well.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
