### PR TITLE
Build before refreshing the manifest

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -24,6 +24,9 @@
     "build": {
       "dependsOn": ["^build"]
     },
+    "refresh-manifests": {
+      "dependsOn": ["^build"]
+    },
     "lint": {
     },
     "lint:fix": {


### PR DESCRIPTION
### WHY are these changes introduced?
The new `refresh-manifest` task requires the module graph to be built first so I've adjusted the Nx configuration to declare that dependency. 

### How to test your changes?
You should be able to clean and then run `refresh-manifess` in every package of the project that has the task defined.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
