### PR TITLE
Fix pnpm installation script

### DIFF
--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -3,7 +3,7 @@ ci:
 
 dependencies:
   override:
-    - curl -fsSL https://get.pnpm.io/install.sh | sh -
+    - curl -fsSL https://get.pnpm.io/install.sh | SHELL=`which bash` bash -
     - pnpm install
 
 deploy:


### PR DESCRIPTION
### WHY are these changes introduced?

Otherwise the installation fails with this error:
```
$ curl -fsSL https://get.pnpm.io/install.sh | sh -
pid: 161517
==> Extracting pnpm binaries 7.18.2
Copying pnpm CLI from /tmp/tmp.kc910Aopme/pnpm to /app/home/.local/share/pnpm/pnpm
 ERR_PNPM_UNSUPPORTED_SHELL  Can't setup configuration for "" shell. Supported shell languages are bash, zsh, and fish.
Install Error!
curl -fsSL https://get.pnpm.io/install.sh | sh - terminated with exit status 1
```

In this thread: https://github.com/pnpm/pnpm/issues/3319 they recommend the fix which I've applied