### PR TITLE
Reload bashrc after installing pnpm on shipit

### DIFF
--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -4,6 +4,7 @@ ci:
 dependencies:
   override:
     - curl -fsSL https://get.pnpm.io/install.sh | SHELL=`which bash` bash -
+    - source ~/.bashrc
     - pnpm install
 
 deploy:


### PR DESCRIPTION
### WHY are these changes introduced?

After installing pnpm on shipit, we must reload the bashrc to get to use `pnpm`. Otherwise this error happens:
```
To start using pnpm, run:
source /app/home/.bashrc
pid: 170108 finished in: 4.084698989056051 seconds
pnpm: command not found
```