### PR TITLE
Use dot instead of source to load env vars

### DIFF
--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -4,7 +4,7 @@ ci:
 dependencies:
   override:
     - curl -fsSL https://get.pnpm.io/install.sh | SHELL=`which bash` bash -
-    - source ~/.bashrc
+    - . ~/.bashrc
     - pnpm install
 
 deploy:


### PR DESCRIPTION
### WHY are these changes introduced?

TIL that `source` only exists in bash :) this attempts to fix our shipit deploy pipeline.