### PR TITLE
Try overriding profile in shipit

### DIFF
--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -4,7 +4,7 @@ ci:
 dependencies:
   override:
     - curl -fsSL https://get.pnpm.io/install.sh | SHELL=`which bash` bash -
-    - . ~/.bashrc
+    - cat ~/.bashrc >> ~/.profile
     - pnpm install
 
 deploy:


### PR DESCRIPTION
### WHY are these changes introduced?

the pnpm install script does not support `sh`, so before I tried to force it to load `~/.bashrc`. It seems that each command runs in a separate context, so this attempts to modify the `~/.profile` config which every shell should load. Previous error looked like this:

```
$ curl -fsSL https://get.pnpm.io/install.sh | SHELL=`which bash` bash -
pid: 206941
==> Extracting pnpm binaries 7.18.2
Copying pnpm CLI from /tmp/tmp.dXL72YTlDX/pnpm to /app/home/.local/share/pnpm/pnpm
Created /app/home/.bashrc
Next configuration changes were made:
export PNPM_HOME="/app/home/.local/share/pnpm"
export PATH="$PNPM_HOME:$PATH"
To start using pnpm, run:
source /app/home/.bashrc
pid: 206941 finished in: 3.085007023997605 seconds

$ . ~/.bashrc
pid: 206987
pid: 206987 finished in: 0.0037733064964413643 seconds

pnpm: command not found
```