### PR TITLE
pnpm run expects scripts inside bin

### DIFF
--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -8,7 +8,7 @@ dependencies:
 
 deploy:
   override:
-    - bash -i -c "npm_config_loglevel=verbose pnpm run changeset publish"
+    - bash -i -c "npm_config_loglevel=verbose pnpm changeset publish"
     - bash -i -c "./bin/package.js"
   post:
     - bash -i -c "pnpm run update-bugsnag"


### PR DESCRIPTION
### WHY are these changes introduced?

`pnpm run changeset publish` fails with: `ERR_PNPM_NO_SCRIPT  Missing script: changeset`, while `pnpm changeset publish` seems to work.