### PR TITLE
Automatically refresh oclif manifests on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,7 @@ jobs:
         run: pnpm install
       - name: Create Release Pull Request
         uses: changesets/action@v1
+        with:
+          version: pnpm changeset version && pnpm refresh-manifests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Refresh manifests
         run: pnpm refresh-manifests
       - name: Check if there are changes
-        run: 'test -z "$(git status --porcelain "**/oclif.manifest.json" )" || { echo "Run pnpm refresh-manifests before pushing new commands or flags. Diff here:\n\n$(git diff)" ; exit 1; }'
+        run: 'test -z "$(git status --porcelain "**/oclif.manifest.json" )" || { echo -e "Run pnpm refresh-manifests before pushing new commands or flags. Diff here:\n\n$(git diff)" ; exit 1; }'
 
   pr-platform-dependent:
     name: Testing with Node ${{ matrix.node }} in ${{ matrix.os }}


### PR DESCRIPTION
### WHY are these changes introduced?

We have a workflow which automatically aggregates all changesets and updates all versions of all CLI packages. But we recently added oclif manifests to speed up load times.

The issue is that oclif manifests refer to the npm package versions, which means that all changes made in the "Version Packages" pull request would invalidate our oclif manifests. Sad times.

### WHAT is this pull request doing?

When generating the changeset pull request, we're going to also update the oclif manifests.

### How to test your changes?

- make a changeset with `pnpm changeset add`
- try running `pnpm changeset version && pnpm refresh-manifests`
- you should see all package.json and README file updates, but also oclif manifests being changed

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
