### PR TITLE
Changeset version only accepts a single npm script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,5 @@ jobs:
         run: pnpm install
       - name: Create Release Pull Request
         uses: changesets/action@v1
-        with:
-          version: pnpm changeset version && pnpm refresh-manifests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### WHY are these changes introduced?

Yesterday I tried to get the changeset script (the one that generates the Version Packages pr) to also update the oclif manifests. But unfortunately the `version` field only accepts a single npm script. The current failure we are seeing is this:

```
/home/runner/setup-pnpm/node_modules/.bin/pnpm changeset version && pnpm refresh-manifests
🦋  error Too many arguments passed to changesets - we only accept the command name as an argument
```