### PR TITLE
Fix template for Delivery Customization extensions

### DIFF
--- a/.changeset/thin-students-smile.md
+++ b/.changeset/thin-students-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix template for Delivery Customization extensions

--- a/packages/app/src/cli/models/extensions/function-specifications/delivery_customization.ts
+++ b/packages/app/src/cli/models/extensions/function-specifications/delivery_customization.ts
@@ -5,7 +5,7 @@ const spec = createFunctionSpec({
   externalIdentifier: 'delivery_customization',
   externalName: 'Delivery customization',
   gated: true,
-  templatePath: (lang) => `checkout/${lang}/delivery-customization/defaultt`,
+  templatePath: (lang) => `checkout/${lang}/delivery-customization/default`,
 })
 
 export default spec


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/cli/pull/727#pullrequestreview-1216457506

### WHAT is this pull request doing?

Fix a typo in the delivery-customization template name

### How to test your changes?

`pnpm shopify app generate extension` and choose Delivery Customization

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
