### PR TITLE
We want to update the lock file when doing a release

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:affected": "nx affected --target=build --all",
     "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache",
     "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache",
-    "changeset-manifests": "changeset version && pnpm install && pnpm refresh-manifests",
+    "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests",
     "postinstall": "patch-package"
   },
   "devDependencies": {


### PR DESCRIPTION
### WHY are these changes introduced?

By default on CI you are not supposed to change the pnpm lock file, but in this case we really want to do it, since the resulting diff will be automatically committed and create a new "Version Packages" pull request.