### PR TITLE
Disable coverage annotations on PRs

### DIFF
--- a/.github/actions/download-and-publish-test-coverage/action.yml
+++ b/.github/actions/download-and-publish-test-coverage/action.yml
@@ -30,6 +30,7 @@ runs:
     - uses: ArtiomTr/jest-coverage-report-action@v2.1.2
       id: coverage
       with:
+        annotations: none
         output: report-markdown
         coverage-file: "./report.json"
         base-coverage-file: "./baseline-report.json"


### PR DESCRIPTION
### WHY are these changes introduced?

The github action that we use was creating too many annotations on each PR. Example screenshot here:

<img width="705" alt="Screenshot 2022-12-14 at 13 35 19" src="https://user-images.githubusercontent.com/62895/207609204-08bd9952-ecec-4cd1-9592-a5a03362b109.png">
