### PR TITLE
Fix generation of extensions

### DIFF
--- a/.changeset/nervous-carpets-think.md
+++ b/.changeset/nervous-carpets-think.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix the loading of extensions failing because we treat .d.ts files as ESM modules

--- a/packages/app/src/cli/models/extensions/specification.integration.test.ts
+++ b/packages/app/src/cli/models/extensions/specification.integration.test.ts
@@ -1,0 +1,32 @@
+import {allFunctionSpecifications, allThemeSpecifications, allUISpecifications} from './specifications.js'
+import {describe, test, expect} from 'vitest'
+
+describe('allUISpecifications', () => {
+  test('loads the specifications successfully', async () => {
+    // When
+    const got = await allUISpecifications()
+
+    // Then
+    expect(got.length).not.toEqual(0)
+  })
+})
+
+describe('allFunctionSpecifications', () => {
+  test('loads the specifications successfully', async () => {
+    // When
+    const got = await allFunctionSpecifications()
+
+    // Then
+    expect(got.length).not.toEqual(0)
+  })
+})
+
+describe('allThemeSpecifications', () => {
+  test('loads the specifications successfully', async () => {
+    // When
+    const got = await allThemeSpecifications()
+
+    // Then
+    expect(got.length).not.toEqual(0)
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications.ts
+++ b/packages/app/src/cli/models/extensions/specifications.ts
@@ -26,7 +26,7 @@ async function loadSpecs(directoryName: string) {
    * in the list of files.
    */
   const url = path.join(path.dirname(fileURLToPath(import.meta.url)), path.join(directoryName, '*.{js,ts}'))
-  let files = await path.glob(url, {ignore: ['**.d.ts', '**.test.ts'], dot: true})
+  let files = await path.glob(url, {ignore: ['**.d.ts', '**.test.ts']})
 
   // From Node 18, all windows paths must start with file://
   const {platform} = os.platformAndArch()

--- a/packages/app/src/cli/models/extensions/specifications.ts
+++ b/packages/app/src/cli/models/extensions/specifications.ts
@@ -20,19 +20,13 @@ export async function allThemeSpecifications(): Promise<ThemeExtensionSpec[]> {
 const memLoadSpecs = memoize(loadSpecs)
 
 async function loadSpecs(directoryName: string) {
-  const url = path.join(path.dirname(fileURLToPath(import.meta.url)), directoryName)
   /**
    * When running tests, "await import('.../spec..ts')" is handled by Vitest which does
    * transform the TS module into a JS one before loading it. Hence the inclusion of .ts
    * in the list of files.
    */
-  let files = (await path.glob(path.join(url, '*'))).filter((filePath) => {
-    const isTest = filePath.endsWith('.test.ts')
-    const isTypescript = filePath.endsWith('.ts')
-    const isDeclaration = filePath.endsWith('.d.ts')
-    const isJS = filePath.endsWith('.js')
-    return isJS || (isTypescript && !isDeclaration && !isTest)
-  })
+  const url = path.join(path.dirname(fileURLToPath(import.meta.url)), path.join(directoryName, '*.{js,ts}'))
+  let files = await path.glob(url, {ignore: ['**.d.ts', '**.test.ts'], dot: true})
 
   // From Node 18, all windows paths must start with file://
   const {platform} = os.platformAndArch()

--- a/packages/app/src/cli/models/extensions/specifications.ts
+++ b/packages/app/src/cli/models/extensions/specifications.ts
@@ -26,11 +26,13 @@ async function loadSpecs(directoryName: string) {
    * transform the TS module into a JS one before loading it. Hence the inclusion of .ts
    * in the list of files.
    */
-  let files = await path.glob([
-    path.join(url, '*.{ts, js}'),
-    `!${path.join(url, '*.{d.ts}')}`,
-    `!${path.join(url, '*.{test.ts}')}`,
-  ])
+  let files = (await path.glob(path.join(url, '*'))).filter((filePath) => {
+    const isTest = filePath.endsWith('.test.ts')
+    const isTypescript = filePath.endsWith('.ts')
+    const isDeclaration = filePath.endsWith('.d.ts')
+    const isJS = filePath.endsWith('.js')
+    return isJS || (isTypescript && !isDeclaration && !isTest)
+  })
 
   // From Node 18, all windows paths must start with file://
   const {platform} = os.platformAndArch()

--- a/packages/app/src/cli/models/extensions/specifications.ts
+++ b/packages/app/src/cli/models/extensions/specifications.ts
@@ -20,8 +20,8 @@ export async function allThemeSpecifications(): Promise<ThemeExtensionSpec[]> {
 const memLoadSpecs = memoize(loadSpecs)
 
 async function loadSpecs(directoryName: string) {
-  const url = path.join(path.dirname(fileURLToPath(import.meta.url)), path.join(directoryName, '*.{js,ts}'))
-  let files = await path.glob(url, {ignore: ['**.d.ts', '**.test.ts']})
+  const url = path.join(path.dirname(fileURLToPath(import.meta.url)), path.join(directoryName, '*.js}'))
+  let files = await path.glob(url)
 
   // From Node 18, all windows paths must start with file://
   const {platform} = os.platformAndArch()

--- a/packages/app/src/cli/models/extensions/specifications.ts
+++ b/packages/app/src/cli/models/extensions/specifications.ts
@@ -26,7 +26,11 @@ async function loadSpecs(directoryName: string) {
    * transform the TS module into a JS one before loading it. Hence the inclusion of .ts
    * in the list of files.
    */
-  let files = await path.glob([path.join(url, '*.{ts, js}'), `!${path.join(url, '*.{d.ts}')}`])
+  let files = await path.glob([
+    path.join(url, '*.{ts, js}'),
+    `!${path.join(url, '*.{d.ts}')}`,
+    `!${path.join(url, '*.{test.ts}')}`,
+  ])
 
   // From Node 18, all windows paths must start with file://
   const {platform} = os.platformAndArch()

--- a/packages/app/src/cli/models/extensions/specifications.ts
+++ b/packages/app/src/cli/models/extensions/specifications.ts
@@ -20,8 +20,13 @@ export async function allThemeSpecifications(): Promise<ThemeExtensionSpec[]> {
 const memLoadSpecs = memoize(loadSpecs)
 
 async function loadSpecs(directoryName: string) {
-  const url = path.join(path.dirname(fileURLToPath(import.meta.url)), path.join(directoryName, '*.js}'))
-  let files = await path.glob(url)
+  const url = path.join(path.dirname(fileURLToPath(import.meta.url)), directoryName)
+  /**
+   * When running tests, "await import('.../spec..ts')" is handled by Vitest which does
+   * transform the TS module into a JS one before loading it. Hence the inclusion of .ts
+   * in the list of files.
+   */
+  let files = await path.glob([path.join(url, '*.{ts, js}'), `!${path.join(url, '*.{d.ts}')}`])
 
   // From Node 18, all windows paths must start with file://
   const {platform} = os.platformAndArch()

--- a/packages/cli-kit/src/path.ts
+++ b/packages/cli-kit/src/path.ts
@@ -2,11 +2,22 @@ import {OverloadParameters} from './typing/overloaded-parameters.js'
 import commondir from 'commondir'
 import {relative, dirname, join, normalize, resolve, basename, extname, isAbsolute, parse} from 'pathe'
 import {findUp as internalFindUp, Match as FindUpMatch} from 'find-up'
+import fastGlob from 'fast-glob'
 import {fileURLToPath} from 'url'
 
 export {join, relative, dirname, normalize, resolve, basename, extname, isAbsolute, parse}
 
-export {default as glob} from 'fast-glob'
+type FastGlobOptions = Parameters<typeof fastGlob>
+type FastGlobOutput = ReturnType<typeof fastGlob>
+
+export async function glob(...args: FastGlobOptions): FastGlobOutput {
+  // eslint-disable-next-line prefer-const
+  let [pattern, options] = args
+  if (options?.dot == null) {
+    options = {...options, dot: true}
+  }
+  return fastGlob(pattern, options)
+}
 export {pathToFileURL} from 'node:url'
 
 type FindUpMatcher = (directory: string) => FindUpMatch | Promise<FindUpMatch>


### PR DESCRIPTION
Fixes https://github.com/Shopify/cli/issues/864#issuecomment-1354088698

### WHY are these changes introduced?
The globbing to get the list of specification modules ignores the `ignore` value passed. 

### WHAT is this pull request doing?
Instead of using `ignore` I'm passing a list of patterns, the second which uses the `!` prefix to exclude the `.d.ts` modules from the list.

### How to test your changes?
Try to generate a new extension in a project.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
