### PR TITLE
Bootstrap import linting

### DIFF
--- a/eslint-rules/specific-imports-in-bootstrap-code.cjs
+++ b/eslint-rules/specific-imports-in-bootstrap-code.cjs
@@ -38,7 +38,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description:
-        "This rule blocks imports that have not been explicitly allowed - it's ideal for bootstrapping code that needs to minimise the overhead of importing",
+        "This rule blocks imports that have not been explicitly allowed - it's ideal for bootstrapping code that needs to minimise the number of modules imported (and hence start-up time)",
     },
     schema: [
       {

--- a/eslint-rules/specific-imports-in-bootstrap-code.cjs
+++ b/eslint-rules/specific-imports-in-bootstrap-code.cjs
@@ -1,0 +1,83 @@
+// https://eslint.org/docs/developer-guide/working-with-rules
+
+/**
+ * Check if importing is allowed for static or dynamic definition
+ *
+ * @param {Record<string, string[]>} allowList
+ * @param {import('eslint').Rule.RuleContext} context
+ * @param {import('estree').ImportDeclaration | import('estree').ImportExpression} node
+ */
+function checkImport(allowList, context, node) {
+  const importTarget = node.source?.value
+  if (typeof importTarget !== 'string') {
+    return
+  }
+  const sourceFile = context.getFilename()
+
+  let gotMatch = false
+  Object.entries(allowList).forEach(([globPath, allowedImports]) => {
+    if (gotMatch) {
+      return
+    }
+    const re = new RegExp(globPath)
+    if (sourceFile.match(re)) {
+      if (allowedImports.includes(importTarget)) {
+        gotMatch = true
+      }
+    }
+  })
+
+  if (!gotMatch) {
+    context.report(node, `Forbidden import source "${importTarget}", update allow list if required`)
+  }
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "This rule blocks imports that have not been explicitly allowed - it's ideal for bootstrapping code that needs to minimise the overhead of importing",
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allow: {
+            type: 'object',
+            patternProperties: {
+              '.*': {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+          enableStaticImports: {type: 'boolean'},
+        },
+      },
+    ],
+  },
+  create(context) {
+    /** @type {{enableStaticImports?: boolean, allow?: Record<string, string[]>}} */
+    const options = context.options[0] ?? {}
+
+    const allowList = options?.allow ?? {}
+    const enableStaticImports = options?.enableStaticImports ?? false
+
+    return {
+      ImportDeclaration(node) {
+        if (!enableStaticImports) {
+          context.report(node, 'Only dynamic imports via `await import(...)` are allowed in bootstrap code')
+          return
+        }
+        checkImport(allowList, context, node)
+      },
+      ImportExpression(node) {
+        checkImport(allowList, context, node)
+      },
+    }
+  },
+}

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -52,6 +52,19 @@
   "eslintConfig": {
     "extends": [
       "../../.eslintrc.cjs"
+    ],
+    "overrides": [
+      {
+        "files": ["**/node/cli.ts"],
+        "rules": {
+          "rulesdir/specific-imports-in-bootstrap-code": ["error", {
+            "allow": {
+              ".*/public/node/cli\\.ts$": ["./node-package-manager.js", "./error-handler.js", "../../environment/local.js", "@oclif/core", "../../environment/utilities.js", "../../constants.js", "../../path.js", "../../system.js"]
+            },
+            "enableStaticImports": false
+          }]
+        }
+      }
     ]
   },
   "engine-strict": true,

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -58,10 +58,8 @@
         "files": ["**/node/cli.ts"],
         "rules": {
           "rulesdir/specific-imports-in-bootstrap-code": ["error", {
-            "allow": {
-              ".*/public/node/cli\\.ts$": ["./node-package-manager.js", "./error-handler.js", "../../environment/local.js", "@oclif/core", "../../environment/utilities.js", "../../constants.js", "../../path.js", "../../system.js"]
-            },
-            "enableStaticImports": false
+            "dynamic": ["./node-package-manager.js", "./error-handler.js", "../../environment/local.js", "@oclif/core", "../../environment/utilities.js", "../../constants.js", "../../path.js", "../../system.js"],
+            "static": []
           }]
         }
       }

--- a/packages/cli-main/bin/dev.js
+++ b/packages/cli-main/bin/dev.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-process.removeAllListeners('warning');
+process.removeAllListeners('warning')
 
-import runCLI from "../dist/index.js";
+import runCLI from '../dist/index.js'
 
-runCLI({development: true});
+runCLI({development: true})

--- a/packages/cli-main/bin/run.js
+++ b/packages/cli-main/bin/run.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-process.removeAllListeners('warning');
+process.removeAllListeners('warning')
 
-import runCLI from "../dist/index.js";
+import runCLI from '../dist/index.js'
 
 runCLI({development: false})

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -49,6 +49,38 @@
   "eslintConfig": {
     "extends": [
       "../../.eslintrc.cjs"
+    ],
+    "overrides": [
+      {
+        "files": ["**/bin/*.js"],
+        "parser": "espree",
+        "rules": {
+          "rulesdir/specific-imports-in-bootstrap-code": ["error", {
+            "allow": {
+              ".*\\.js$": ["../dist/index.js"]
+            },
+            "enableStaticImports": true
+          }],
+          "@typescript-eslint/switch-exhaustiveness-check": "off",
+          "@typescript-eslint/naming-convention": "off",
+          "@typescript-eslint/no-misused-promises": "off",
+          "@typescript-eslint/no-floating-promises": "off",
+          "@typescript-eslint/no-unnecessary-type-assertion": "off",
+          "node/shebang": "off",
+          "import/first": "off"
+        }
+      },
+      {
+        "files": ["src/index.ts"],
+        "rules": {
+          "rulesdir/specific-imports-in-bootstrap-code": ["error", {
+            "allow": {
+              "\\.ts$": ["@shopify/cli-kit/node/cli"]
+            },
+            "enableStaticImports": true
+          }]
+        }
+      }
     ]
   },
   "dependencies": {

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -67,7 +67,8 @@
           "@typescript-eslint/no-floating-promises": "off",
           "@typescript-eslint/no-unnecessary-type-assertion": "off",
           "node/shebang": "off",
-          "import/first": "off"
+          "import/first": "off",
+          "import/no-unresolved": "off"
         }
       },
       {

--- a/packages/cli-main/package.json
+++ b/packages/cli-main/package.json
@@ -56,10 +56,7 @@
         "parser": "espree",
         "rules": {
           "rulesdir/specific-imports-in-bootstrap-code": ["error", {
-            "allow": {
-              ".*\\.js$": ["../dist/index.js"]
-            },
-            "enableStaticImports": true
+            "static": ["../dist/index.js"]
           }],
           "@typescript-eslint/switch-exhaustiveness-check": "off",
           "@typescript-eslint/naming-convention": "off",
@@ -75,10 +72,7 @@
         "files": ["src/index.ts"],
         "rules": {
           "rulesdir/specific-imports-in-bootstrap-code": ["error", {
-            "allow": {
-              "\\.ts$": ["@shopify/cli-kit/node/cli"]
-            },
-            "enableStaticImports": true
+            "static": ["@shopify/cli-kit/node/cli"]
           }]
         }
       }

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -24,14 +24,14 @@
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint \"src/**/*.ts\"",
+          "command": "pnpm eslint \"src/**/*.ts\" 'bin/*.js' ",
           "cwd": "packages/cli-main"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint 'src/**/*.ts' --fix",
+          "command": "pnpm eslint 'src/**/*.ts' 'bin/*.js' --fix",
           "cwd": "packages/cli-main"
         }
       },


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Necessary step to ensure bootstrap code path can be carefully monitored

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Adds an ESLint rule that ensures only specific imports can be used in a file
- Rule can optionally allow/disallow static imports (`import x from 'y'`)
- Rule has been configured for current bootstrap code

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

- Run eslint
- Try adding a new import to any of the bootstrapping code
