### PR TITLE
Include headers that help with tracing in every request to Shopify services

### DIFF
--- a/packages/cli-kit/src/api/common.ts
+++ b/packages/cli-kit/src/api/common.ts
@@ -13,18 +13,21 @@ export class RequestClientError extends ExtendableError {
   }
 }
 
-export async function buildHeaders(token: string): Promise<{[key: string]: string}> {
+export async function buildHeaders(token?: string): Promise<{[key: string]: string}> {
   const userAgent = `Shopify CLI; v=${await constants.versions.cliKit()}`
 
-  const headers = {
+  const headers: {[header: string]: string} = {
     'User-Agent': userAgent,
     // 'Sec-CH-UA': secCHUA, This header requires the Git sha.
     'Sec-CH-UA-PLATFORM': process.platform,
     'X-Request-Id': randomUUID(),
-    authorization: `Bearer ${token}`,
-    'X-Shopify-Access-Token': `Bearer ${token}`,
     'Content-Type': 'application/json',
     ...(firstPartyDev() && {'X-Shopify-Cli-Employee': '1'}),
+  }
+  if (token) {
+    // eslint-disable-next-line dot-notation
+    headers['authorization'] = `Bearer ${token}`
+    headers['X-Shopify-Access-Token'] = `Bearer ${token}`
   }
 
   return headers
@@ -56,9 +59,9 @@ export function debugLogRequest<T>(
   variables?: Variables,
   headers: {[key: string]: string} = {},
 ) {
-  debug(`
+  debug(content`
 Sending ${token.json(api)} GraphQL request:
-${query}
+${token.raw(query.toString())}
 
 With variables:
 ${variables ? JSON.stringify(variables, null, 2) : ''}

--- a/packages/cli-kit/src/http/fetch.test.ts
+++ b/packages/cli-kit/src/http/fetch.test.ts
@@ -1,9 +1,11 @@
 import fetch from './fetch.js'
+import {buildHeaders} from '../api/common.js'
 import {describe, test, expect, vi} from 'vitest'
 import nodeFetch, {Response} from 'node-fetch'
 import type {RequestInit, RequestInfo} from 'node-fetch'
 
 vi.mock('node-fetch')
+vi.mock('../api/common.js')
 
 describe('fetch', () => {
   test('delegates the fetch to node-fetch', async () => {
@@ -12,6 +14,28 @@ describe('fetch', () => {
     const init: RequestInit = {}
     const response = new Response(null, undefined)
 
+    vi.mocked(nodeFetch).mockResolvedValue(response)
+
+    // When
+    const got = await fetch(url, init)
+
+    // Then
+    expect(vi.mocked(nodeFetch)).toHaveBeenCalledWith(url, init)
+    expect(got).toBe(response)
+  })
+})
+
+describe('shopifyFetch', () => {
+  test('it includes the default headers', async () => {
+    // Given
+    vi.mocked(buildHeaders).mockResolvedValue({foo: 'bar'})
+    const url: RequestInfo = 'https://shopify.com'
+    const init: RequestInit = {
+      headers: {
+        test: 'value',
+      },
+    }
+    const response = new Response(null, undefined)
     vi.mocked(nodeFetch).mockResolvedValue(response)
 
     // When

--- a/packages/cli-kit/src/http/fetch.ts
+++ b/packages/cli-kit/src/http/fetch.ts
@@ -1,4 +1,6 @@
 import {httpsAgent} from '../http.js'
+import {buildHeaders, sanitizedHeadersOutput} from '../api/common.js'
+import {content, debug} from '../output.js'
 import nodeFetch from 'node-fetch'
 import type {RequestInfo, RequestInit} from 'node-fetch'
 
@@ -25,6 +27,18 @@ export default async function fetch(url: RequestInfo, init?: RequestInit): Respo
  * (e.g. spin)
  */
 export async function shopifyFetch(url: RequestInfo, init?: RequestInit): Response {
+  const options: RequestInit = {
+    ...(init ?? {}),
+    headers: {
+      ...(await buildHeaders()),
+      ...(init?.headers ?? {}),
+    },
+  }
+
+  debug(content`
+Sending ${options.method ?? 'GET'} request to URL ${url.toString()} and headers:
+${sanitizedHeadersOutput((options?.headers ?? {}) as {[header: string]: string})}
+`)
   const response = await nodeFetch(url, {...init, agent: await httpsAgent()})
   return response
 }


### PR DESCRIPTION
### WHY are these changes introduced?
I just noticed that some headers that we use for telemetry and tracing (e.g., `Sec-CH-UA-PLATFORM`, `X-Request-Id`) were not included in the REST requests that we sent from the CLI. Because of it I could not debug an error returned after sending a REST request to an Identity endpoint.

### WHAT is this pull request doing?
I'm extending `shopifyFetch` to include the headers. I also took the opportunity to add additional verbose logging.

### How to test your changes?
If you logout with `pnpm shopify auth logout` and run `dev` against the fixture app with the `--verbose` flag you should see the requests that go to identity with the headers included.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
