### PR TITLE
Decouple the project setup from the package manager

### DIFF
--- a/docs/decision-record/2022_08-automation-via-nx.md
+++ b/docs/decision-record/2022_08-automation-via-nx.md
@@ -5,7 +5,7 @@
 ```json
 {
   "scripts": {
-    "build": "pnpm clean && tsc",
+    "build": "$npm_execpath clean && tsc",
     "clean": "rm -rf dist/"
   }
 }

--- a/fixtures/app/web/package.json
+++ b/fixtures/app/web/package.json
@@ -6,7 +6,7 @@
     "build": "vite build frontend --outDir ../dist --emptyOutDir",
     "debug": "node --inspect-brk backend/index.js",
     "dev": "cross-env NODE_ENV=development nodemon backend/index.js --watch ./backend",
-    "preserve": "pnpm run build",
+    "preserve": "$npm_execpath run build",
     "serve": "cross-env NODE_ENV=production node backend/index.js",
     "test": "vitest --reporter=verbose"
   },

--- a/fixtures/app/web/shopify.web.toml
+++ b/fixtures/app/web/shopify.web.toml
@@ -2,4 +2,4 @@ type="backend"
 
 [commands]
 dev = "npm run dev"
-build = "pnpm run build"
+build = "$npm_execpath run build"

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -9,7 +9,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/",
+          "command": "$npm_execpath rimraf dist/",
           "cwd": "packages/app"
         }
       },
@@ -18,21 +18,21 @@
         "outputs": ["dist"],
         "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
         "options": {
-          "command": "pnpm tsc -b ./tsconfig.build.json",
+          "command": "$npm_execpath tsc -b ./tsconfig.build.json",
           "cwd": "packages/app"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint \"src/**/*.ts\"",
+          "command": "$npm_execpath eslint \"src/**/*.ts\"",
           "cwd": "packages/app"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint 'src/**/*.ts' --fix",
+          "command": "$npm_execpath eslint 'src/**/*.ts' --fix",
           "cwd": "packages/app"
         }
       },
@@ -40,7 +40,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest run",
+          "command": "$npm_execpath vitest run",
           "cwd": "packages/app"
         }
       },
@@ -48,7 +48,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["build"],
         "options": {
-          "command": "pnpm vitest run --reporter json --coverage --outputFile ./coverage/report.json",
+          "command": "$npm_execpath vitest run --reporter json --coverage --outputFile ./coverage/report.json",
           "cwd": "packages/app"
         }
       },
@@ -56,21 +56,21 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest watch",
+          "command": "$npm_execpath vitest watch",
           "cwd": "packages/app"
         }
       },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm tsc --noEmit",
+          "command": "$npm_execpath tsc --noEmit",
           "cwd": "packages/app"
         }
       },
       "refresh-manifests": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm oclif manifest",
+          "command": "$npm_execpath oclif manifest",
           "cwd": "packages/app"
         }
       }

--- a/packages/cli-hydrogen/project.json
+++ b/packages/cli-hydrogen/project.json
@@ -8,7 +8,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/",
+          "command": "$npm_execpath rimraf dist/",
           "cwd": "packages/cli-hydrogen"
         }
       },
@@ -17,28 +17,28 @@
         "outputs": ["dist"],
         "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
         "options": {
-          "command": "pnpm tsc -b ./tsconfig.build.json",
+          "command": "$npm_execpath tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint \"src/**/*.ts\"",
+          "command": "$npm_execpath eslint \"src/**/*.ts\"",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint 'src/**/*.ts' --fix",
+          "command": "$npm_execpath eslint 'src/**/*.ts' --fix",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm vitest run",
+          "command": "$npm_execpath vitest run",
           "cwd": "packages/cli-hydrogen"
         }
       },
@@ -46,21 +46,21 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest watch",
+          "command": "$npm_execpath vitest watch",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm tsc --noEmit",
+          "command": "$npm_execpath tsc --noEmit",
           "cwd": "packages/cli-hydrogen"
         }
       },
       "refresh-manifests": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm oclif manifest",
+          "command": "$npm_execpath oclif manifest",
           "cwd": "packages/cli-hydrogen"
         }
       }

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -8,7 +8,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/",
+          "command": "$npm_execpath rimraf dist/",
           "cwd": "packages/cli-kit"
         }
       },
@@ -17,21 +17,21 @@
         "outputs": ["dist"],
         "inputs": ["{projectRoot}/src/**/*"],
         "options": {
-          "command": "pnpm tsc -b ./tsconfig.build.json",
+          "command": "$npm_execpath tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-kit"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint \"src/**/*.ts\"",
+          "command": "$npm_execpath eslint \"src/**/*.ts\"",
           "cwd": "packages/cli-kit"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint 'src/**/*.ts' --fix",
+          "command": "$npm_execpath eslint 'src/**/*.ts' --fix",
           "cwd": "packages/cli-kit"
         }
       },
@@ -39,7 +39,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["build"],
         "options": {
-          "command": "pnpm vitest run",
+          "command": "$npm_execpath vitest run",
           "cwd": "packages/cli-kit"
         }
       },
@@ -47,7 +47,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["build"],
         "options": {
-          "command": "pnpm vitest run --reporter json --coverage --outputFile ./coverage/report.json",
+          "command": "$npm_execpath vitest run --reporter json --coverage --outputFile ./coverage/report.json",
           "cwd": "packages/cli-kit"
         }
       },
@@ -55,14 +55,14 @@
         "executor": "nx:run-commands",
         "dependsOn": ["build"],
         "options": {
-          "command": "pnpm vitest watch",
+          "command": "$npm_execpath vitest watch",
           "cwd": "packages/cli-kit"
         }
       },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm tsc --noEmit",
+          "command": "$npm_execpath tsc --noEmit",
           "cwd": "packages/cli-kit"
         }
       }

--- a/packages/cli-main/project.json
+++ b/packages/cli-main/project.json
@@ -8,7 +8,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/",
+          "command": "$npm_execpath rimraf dist/",
           "cwd": "packages/cli-main"
         }
       },
@@ -17,35 +17,35 @@
         "outputs": ["dist"],
         "inputs": ["{projectRoot}/src/**/*"],
         "options": {
-          "command": "pnpm tsc -b ./tsconfig.build.json",
+          "command": "$npm_execpath tsc -b ./tsconfig.build.json",
           "cwd": "packages/cli-main"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint \"src/**/*.ts\" 'bin/*.js' ",
+          "command": "$npm_execpath eslint \"src/**/*.ts\" 'bin/*.js' ",
           "cwd": "packages/cli-main"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint 'src/**/*.ts' 'bin/*.js' --fix",
+          "command": "$npm_execpath eslint 'src/**/*.ts' 'bin/*.js' --fix",
           "cwd": "packages/cli-main"
         }
       },
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm vitest run",
+          "command": "$npm_execpath vitest run",
           "cwd": "packages/cli-main"
         }
       },
       "test:coverage": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm vitest run --reporter json --coverage --outputFile ./coverage/report.json",
+          "command": "$npm_execpath vitest run --reporter json --coverage --outputFile ./coverage/report.json",
           "cwd": "packages/cli-main"
         }
       },
@@ -53,21 +53,21 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest watch",
+          "command": "$npm_execpath vitest watch",
           "cwd": "packages/cli-main"
         }
       },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm tsc --noEmit",
+          "command": "$npm_execpath tsc --noEmit",
           "cwd": "packages/cli-main"
         }
       },
       "refresh-manifests": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm oclif manifest",
+          "command": "$npm_execpath oclif manifest",
           "cwd": "packages/cli-main"
         }
       }

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -8,7 +8,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/",
+          "command": "$npm_execpath rimraf dist/",
           "cwd": "packages/create-app"
         }
       },
@@ -17,28 +17,28 @@
         "outputs": ["dist"],
         "inputs": ["{projectRoot}/src/**/*"],
         "options": {
-          "command": "pnpm tsc -b ./tsconfig.build.json",
+          "command": "$npm_execpath tsc -b ./tsconfig.build.json",
           "cwd": "packages/create-app"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint \"src/**/*.ts\"",
+          "command": "$npm_execpath eslint \"src/**/*.ts\"",
           "cwd": "packages/create-app"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint 'src/**/*.ts' --fix",
+          "command": "$npm_execpath eslint 'src/**/*.ts' --fix",
           "cwd": "packages/create-app"
         }
       },
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm vitest run",
+          "command": "$npm_execpath vitest run",
           "cwd": "packages/create-app"
         }
       },
@@ -46,21 +46,21 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest watch",
+          "command": "$npm_execpath vitest watch",
           "cwd": "packages/create-app"
         }
       },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm tsc --noEmit",
+          "command": "$npm_execpath tsc --noEmit",
           "cwd": "packages/create-app"
         }
       },
       "refresh-manifests": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm oclif manifest",
+          "command": "$npm_execpath oclif manifest",
           "cwd": "packages/create-app"
         }
       }

--- a/packages/create-hydrogen/project.json
+++ b/packages/create-hydrogen/project.json
@@ -8,7 +8,7 @@
     "clean": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm rimraf dist/",
+        "command": "$npm_execpath rimraf dist/",
         "cwd": "packages/create-hydrogen"
       }
     },
@@ -17,28 +17,28 @@
       "outputs": ["dist"],
       "inputs": ["{projectRoot}/src/**/*"],
       "options": {
-        "command": "pnpm tsc -b ./tsconfig.build.json",
+        "command": "$npm_execpath tsc -b ./tsconfig.build.json",
         "cwd": "packages/create-hydrogen"
       }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm eslint \"src/**/*.ts\"",
+        "command": "$npm_execpath eslint \"src/**/*.ts\"",
         "cwd": "packages/create-hydrogen"
       }
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm eslint 'src/**/*.ts' --fix",
+        "command": "$npm_execpath eslint 'src/**/*.ts' --fix",
         "cwd": "packages/create-hydrogen"
       }
     },
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm vitest run",
+        "command": "$npm_execpath vitest run",
         "cwd": "packages/create-hydrogen"
       }
     },
@@ -46,21 +46,21 @@
       "executor": "nx:run-commands",
       "dependsOn": ["^build"],
       "options": {
-        "command": "pnpm vitest watch",
+        "command": "$npm_execpath vitest watch",
         "cwd": "packages/create-hydrogen"
       }
     },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm tsc --noEmit",
+        "command": "$npm_execpath tsc --noEmit",
         "cwd": "packages/create-hydrogen"
       }
     },
     "refresh-manifests": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm oclif manifest",
+        "command": "$npm_execpath oclif manifest",
         "cwd": "packages/create-hydrogen"
       }
     }

--- a/packages/features/project.json
+++ b/packages/features/project.json
@@ -10,28 +10,28 @@
       "executor": "nx:run-commands",
       "dependsOn": ["^build"],
       "options": {
-        "command": "pnpm cucumber-js -p default -c cucumber.js",
+        "command": "$npm_execpath cucumber-js -p default -c cucumber.js",
         "cwd": "packages/features"
       }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm eslint \"**/*.ts\"",
+        "command": "$npm_execpath eslint \"**/*.ts\"",
         "cwd": "packages/features"
       }
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm eslint '**/*.ts' --fix",
+        "command": "$npm_execpath eslint '**/*.ts' --fix",
         "cwd": "packages/features"
       }
     },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm tsc --noEmit",
+        "command": "$npm_execpath tsc --noEmit",
         "cwd": "packages/features"
       }
     }

--- a/packages/plugin-ngrok/project.json
+++ b/packages/plugin-ngrok/project.json
@@ -8,7 +8,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/",
+          "command": "$npm_execpath rimraf dist/",
           "cwd": "packages/plugin-ngrok"
         }
       },
@@ -17,21 +17,21 @@
         "outputs": ["dist"],
         "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
         "options": {
-          "command": "pnpm tsc -b ./tsconfig.build.json",
+          "command": "$npm_execpath tsc -b ./tsconfig.build.json",
           "cwd": "packages/plugin-ngrok"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint \"src/**/*.ts\"",
+          "command": "$npm_execpath eslint \"src/**/*.ts\"",
           "cwd": "packages/plugin-ngrok"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint 'src/**/*.ts' --fix",
+          "command": "$npm_execpath eslint 'src/**/*.ts' --fix",
           "cwd": "packages/plugin-ngrok"
         }
       },
@@ -39,7 +39,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest run",
+          "command": "$npm_execpath vitest run",
           "cwd": "packages/plugin-ngrok"
         }
       },
@@ -47,21 +47,21 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest watch",
+          "command": "$npm_execpath vitest watch",
           "cwd": "packages/plugin-ngrok"
         }
       },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm tsc --noEmit",
+          "command": "$npm_execpath tsc --noEmit",
           "cwd": "packages/plugin-ngrok"
         }
       },
       "refresh-manifests": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm oclif manifest",
+          "command": "$npm_execpath oclif manifest",
           "cwd": "packages/plugin-ngrok"
         }
       }

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -8,7 +8,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/",
+          "command": "$npm_execpath rimraf dist/",
           "cwd": "packages/theme"
         }
       },
@@ -17,21 +17,21 @@
         "outputs": ["dist"],
         "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
         "options": {
-          "command": "pnpm tsc -b ./tsconfig.build.json",
+          "command": "$npm_execpath tsc -b ./tsconfig.build.json",
           "cwd": "packages/theme"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint \"src/**/*.ts\"",
+          "command": "$npm_execpath eslint \"src/**/*.ts\"",
           "cwd": "packages/theme"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint 'src/**/*.ts' --fix",
+          "command": "$npm_execpath eslint 'src/**/*.ts' --fix",
           "cwd": "packages/theme"
         }
       },
@@ -39,7 +39,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest run",
+          "command": "$npm_execpath vitest run",
           "cwd": "packages/theme"
         }
       },
@@ -47,21 +47,21 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest watch",
+          "command": "$npm_execpath vitest watch",
           "cwd": "packages/theme"
         }
       },
       "type-check": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm tsc --noEmit",
+          "command": "$npm_execpath tsc --noEmit",
           "cwd": "packages/theme"
         }
       },
       "refresh-manifests": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm oclif manifest",
+          "command": "$npm_execpath oclif manifest",
           "cwd": "packages/theme"
         }
       }

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -9,7 +9,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/ ../app/assets/dev-console",
+          "command": "$npm_execpath rimraf dist/ ../app/assets/dev-console",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
@@ -17,28 +17,28 @@
         "outputs": ["../app/assets/dev-console"],
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm vite build",
+          "command": "$npm_execpath vite build",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint src tests",
+          "command": "$npm_execpath eslint src tests",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint src tests --fix",
+          "command": "$npm_execpath eslint src tests --fix",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
       "dev": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm vite dev",
+          "command": "$npm_execpath vite dev",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
@@ -46,7 +46,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest run",
+          "command": "$npm_execpath vitest run",
           "cwd": "packages/ui-extensions-dev-console"
         }
       },
@@ -54,7 +54,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest watch",
+          "command": "$npm_execpath vitest watch",
           "cwd": "packages/ui-extensions-dev-console"
         }
       }

--- a/packages/ui-extensions-server-kit/project.json
+++ b/packages/ui-extensions-server-kit/project.json
@@ -9,14 +9,14 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/",
+          "command": "$npm_execpath rimraf dist/",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
       "build:code": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm vite build --config vite.config.ts",
+          "command": "$npm_execpath vite build --config vite.config.ts",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
@@ -24,7 +24,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm tsc --emitDeclarationOnly",
+          "command": "$npm_execpath tsc --emitDeclarationOnly",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
@@ -41,14 +41,14 @@
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint src",
+          "command": "$npm_execpath eslint src",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint src --fix",
+          "command": "$npm_execpath eslint src --fix",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
@@ -56,7 +56,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest run",
+          "command": "$npm_execpath vitest run",
           "cwd": "packages/ui-extensions-server-kit"
         }
       },
@@ -64,7 +64,7 @@
         "executor": "nx:run-commands",
         "dependsOn": ["^build"],
         "options": {
-          "command": "pnpm vitest watch",
+          "command": "$npm_execpath vitest watch",
           "cwd": "packages/ui-extensions-server-kit"
         }
       }

--- a/packages/ui-extensions-test-utils/project.json
+++ b/packages/ui-extensions-test-utils/project.json
@@ -8,7 +8,7 @@
       "clean": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm rimraf dist/",
+          "command": "$npm_execpath rimraf dist/",
           "cwd": "packages/ui-extensions-test-utils"
         }
       },
@@ -17,21 +17,21 @@
         "outputs": ["dist"],
         "inputs": ["{projectRoot}/src/**/*"],
         "options": {
-          "command": "pnpm tsc",
+          "command": "$npm_execpath tsc",
           "cwd": "packages/ui-extensions-test-utils"
         }
       },
       "lint": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint src",
+          "command": "$npm_execpath eslint src",
           "cwd": "packages/ui-extensions-test-utils"
         }
       },
       "lint:fix": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm eslint src --fix",
+          "command": "$npm_execpath eslint src --fix",
           "cwd": "packages/ui-extensions-test-utils"
         }
       }


### PR DESCRIPTION
### WHY are these changes introduced?
Package managers [expose](https://flaming.codes/posts/package-agnostic-scripts-with-node-js) a variable when running scripts, `$npm_execpath`, to have scripts that are not coupled to a particular dependency manager. 

### WHAT is this pull request doing?
I'm adjusting all the scripts to use that variable instead of having the `pnpm` value hardcoded in our scripts. This means the only reference to `pnpm` is the lockfile, so developers are free to use other package managers as long as they don't commit the generated lockfiles.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
