### PR TITLE
Remove cli_three branch references

### DIFF
--- a/.changeset/breezy-bugs-develop.md
+++ b/.changeset/breezy-bugs-develop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': patch
+---
+
+Updating source repository references for Node and PHP apps

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -15,8 +15,8 @@ interface InitOutput {
 // Eventually this list should be taken from a remote location
 // That way we don't have to update the CLI every time we add a template
 export const templateURLMap = {
-  node: 'https://github.com/Shopify/shopify-app-template-node#cli_three',
-  php: 'https://github.com/Shopify/shopify-app-template-php#cli_three',
+  node: 'https://github.com/Shopify/shopify-app-template-node',
+  php: 'https://github.com/Shopify/shopify-app-template-php',
   ruby: 'https://github.com/Shopify/shopify-app-template-ruby',
 } as const
 


### PR DESCRIPTION
### WHY are these changes introduced?

We felt that enough time has elapsed since v2.18.1 of the CLI was released, and few enough apps are still created with version prior to that, that we can make the `cli_three` branches the `main`s in the Node and PHP templates.

### WHAT is this pull request doing?

Now that the branches were renamed, CLI 3 can clone the `main`s directly. We'll keep the `cli_three` branches around to give folks time to update to the version of CLI 3 that includes this PR before deleting / deprecating them.

### How to test your changes?

- Create a node or php app as you normally would
- App should work

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition

☝️ assuming that there is tracking of app creation by CLI version.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
