### PR TITLE
Fix issues with the deployment payload for ui_extension

### DIFF
--- a/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
@@ -9,7 +9,11 @@ import {err, ok, Result} from '@shopify/cli-kit/node/result'
 const dependency = {name: '@shopify/checkout-ui-extensions-react', version: '^0.21.2'}
 
 const UIExtensionSchema = BaseUIExtensionSchema.extend({
-  settings: schema.define.string().optional(),
+  settings: schema.define
+    .object({
+      fields: schema.define.any().optional(),
+    })
+    .optional(),
   extensionPoints: NewExtensionPointsSchema,
 })
 
@@ -35,7 +39,6 @@ const spec = createUIExtensionSpec({
     return {
       extension_points: config.extensionPoints,
       capabilities: config.capabilities,
-      metafields: config.metafields,
       name: config.name,
       settings: config.settings,
       localization: await loadLocalesConfig(directory, config.type),

--- a/packages/app/src/cli/utilities/extensions/fetch-product-variant.ts
+++ b/packages/app/src/cli/utilities/extensions/fetch-product-variant.ts
@@ -13,7 +13,7 @@ export async function fetchProductVariant(store: string) {
   if (products.length === 0)
     throw new error.Abort(
       'Could not find a product variant',
-      `Your store needs to have at least one product to test a 'checktout_ui' extension\n
+      `Your store needs to have at least one product to test a 'checkout_ui' extension\n
 You can add a new product here: https://${store}/admin/products/new`,
     )
   const variantURL = result.products.edges[0]!.node.variants.edges[0]!.node.id


### PR DESCRIPTION
### WHY are these changes introduced?
I think we've somehow lost some of the changes we made to introduce the new `ui_extension` specification. The deployment payload is not populated as expect.

### WHAT is this pull request doing?

Fix the payload for `ui_extension` to match expected payload.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
