### PR TITLE
Force the registry in the deploy environment

### DIFF
--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -5,7 +5,7 @@ dependencies:
   override:
     - curl -fsSL https://get.pnpm.io/install.sh | SHELL=`which bash` bash -
     - bash -i -c "pnpm install"
-
+    - echo 'registry "https://registry.npmjs.org/"' | tee .npmrc
 deploy:
   override:
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset publish"


### PR DESCRIPTION
### WHY are these changes introduced?
@gonzaloriestra ran an issue deploying a new version of the CLI where changesets fails to push a version of the theme package that already exists in the registry. It happens because the [info](https://github.com/changesets/changesets/blob/e0459f7b2dbb8ebbb58f8e4d859d0cfb3e0eda1e/packages/cli/src/commands/publish/npm-utils.ts#L92) command returns a 404 for that version and package indicating that the version doesn't exist.

### WHAT is this pull request doing?

It's possible that the deployment environment is configured to point to the Yarn registry, `https://registry.yarnpkg.com`, which might be returning the invalid state due to some caching there. I couldn't find the rationale behind having another registry but it's possible that it's a proxy to the NPM registry to speed up dependency installs.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
