### PR TITLE
Update authorize.ts

### DIFF
--- a/packages/cli-kit/src/session/authorize.ts
+++ b/packages/cli-kit/src/session/authorize.ts
@@ -20,8 +20,9 @@ export interface CodeAuthResult {
 
 export async function authorize(scopes: string[], state: string = randomHex(30)): Promise<CodeAuthResult> {
   const port = 3456
-  const host = '127.0.0.1'
-  const redirectUri = `http://${host}:${port}`
+  const host = '0.0.0.0'
+  const redirectHost = '127.0.0.1'
+  const redirectUri = `http://${redirectHost}:${port}`
   const fqdn = await identityFqdn()
   const identityClientId = await clientId()
 


### PR DESCRIPTION
[Fix] Login callback is not working when I use shopify-cli v3 in docker 

Fastify is not working when I use it on Docker.
Based on the fastly issue: https://github.com/fastify/fastify/issues/935 The listen host should be 0.0.0.0 instead of 127.0.0.1

### WHY are these changes introduced?

Based on the fastly issue: https://github.com/fastify/fastify/issues/935 

The listen host should be 0.0.0.0 instead of 127.0.0.1

### WHAT is this pull request doing?

Update fastly host from 127.0.0.1 to 0.0.0.0

### How to test your changes?

```
shopify theme pull
```
Login callback should work.

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [v] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [v] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [v] I've considered possible [documentation](https://shopify.dev) changes
- [v] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
