### PR TITLE
Require explicit return types on public functions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -172,5 +172,11 @@ module.exports = {
         'no-restricted-syntax': 'off',
       },
     },
+    {
+      files: ['src/public/**/*.ts'],
+      rules: {
+        '@typescript-eslint/explicit-module-boundary-types': 'error',
+      },
+    },
   ],
 }

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -3,8 +3,8 @@
  * @param array - Array from which we'll select a random item.
  * @returns A random element from the array.
  */
-export function takeRandomFromArray<T>(array: T[]) {
-  return array[Math.floor(Math.random() * array.length)]
+export function takeRandomFromArray<T>(array: T[]): T {
+  return array[Math.floor(Math.random() * array.length)]!
 }
 
 /**
@@ -20,6 +20,6 @@ export function getArrayRejectingUndefined<T>(array: (T | undefined)[]): T[] {
  * Returns true if an array contains duplicates.
  * @returns True if the array contains duplicates.
  */
-export function getArrayContainsDuplicates<T>(array: T[]) {
+export function getArrayContainsDuplicates<T>(array: T[]): boolean {
   return array.length !== new Set(array).size
 }

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -19,7 +19,7 @@ abstract class BaseCommand extends Command {
     return undefined
   }
 
-  async catch(error: Error & {exitCode?: number | undefined}) {
+  async catch(error: Error & {exitCode?: number | undefined}): Promise<void> {
     await errorHandler(error, this.config)
   }
 
@@ -93,7 +93,7 @@ abstract class BaseCommand extends Command {
   }
 }
 
-export async function addFromParsedFlags(flags: {path?: string; verbose?: boolean}) {
+export async function addFromParsedFlags(flags: {path?: string; verbose?: boolean}): Promise<void> {
   await addPublic(() => ({
     cmd_all_verbose: flags.verbose,
     cmd_all_path_override: flags.path !== undefined,

--- a/packages/cli-kit/src/public/node/checksum.ts
+++ b/packages/cli-kit/src/public/node/checksum.ts
@@ -8,7 +8,15 @@ import md5File from 'md5-file'
  * @param options - An options object that includes the file path, and the expected and actual MD5.
  * @returns An instance of Abort.
  */
-export const InvalidChecksumError = ({file, expected, got}: {file: string; expected: string; got: string}) => {
+export const InvalidChecksumError = ({
+  file,
+  expected,
+  got,
+}: {
+  file: string
+  expected: string
+  got: string
+}): AbortError => {
   return new AbortError(`The validation of ${file} failed. We expected the checksum ${expected}, but got ${got})`)
 }
 /**
@@ -16,7 +24,7 @@ export const InvalidChecksumError = ({file, expected, got}: {file: string; expec
  * it validates the authenticity of the binary using an MD5 checksum.
  * @param options - The file to validate and the URL that points to the file containing the MD5.
  */
-export async function validateMD5({file, md5FileURL}: {file: string; md5FileURL: string}) {
+export async function validateMD5({file, md5FileURL}: {file: string; md5FileURL: string}): Promise<void> {
   debug(`Checking MD5 of file ${token.path(file)} against the MD5 in ${token.link('URL', md5FileURL)}`)
   const md5Digest = await md5File(file)
   const md5Response = await fetch(md5FileURL)

--- a/packages/cli-kit/src/public/node/cli.ts
+++ b/packages/cli-kit/src/public/node/cli.ts
@@ -28,7 +28,7 @@ function setupEnvironmentVariables(options: Pick<RunCLIOptions, 'development'>) 
  * a CLI
  * @param options - Options.
  */
-export async function runCLI(options: RunCLIOptions) {
+export async function runCLI(options: RunCLIOptions): Promise<void> {
   setupEnvironmentVariables(options)
   /**
    * These imports need to be dynamic because if they are static
@@ -51,7 +51,7 @@ export async function runCLI(options: RunCLIOptions) {
 /**
  * A function for create-x CLIs that automatically runs the "init" command.
  */
-export async function runCreateCLI(options: RunCLIOptions) {
+export async function runCreateCLI(options: RunCLIOptions): Promise<void> {
   setupEnvironmentVariables(options)
 
   const {findUpAndReadPackageJson} = await import('./node-package-manager.js')

--- a/packages/cli-kit/src/public/node/dot-env.ts
+++ b/packages/cli-kit/src/public/node/dot-env.ts
@@ -8,7 +8,7 @@ import {parse, stringify} from 'envfile'
  * @param path - Path to the .env file.
  * @returns An abort error.
  */
-export const DotEnvNotFoundError = (path: string) => {
+export const DotEnvNotFoundError = (path: string): AbortError => {
   return new AbortError(`The environment file at ${path} does not exist.`)
 }
 
@@ -47,7 +47,7 @@ export async function readAndParseDotEnv(path: string): Promise<DotEnvFile> {
  * Writes a .env file to disk.
  * @param file - .env file to be written.
  */
-export async function writeDotEnv(file: DotEnvFile) {
+export async function writeDotEnv(file: DotEnvFile): Promise<void> {
   await writeFile(file.path, stringify(file.variables))
 }
 

--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -17,7 +17,12 @@ import StackTracey from 'stacktracey'
 import Bugsnag, {Event} from '@bugsnag/js'
 import {realpath} from 'fs/promises'
 
-export function errorHandler(error: Error & {exitCode?: number | undefined}, config?: Interfaces.Config) {
+export function errorHandler(
+  error: (CancelExecution | AbortSilent) & {exitCode?: number | undefined},
+  config?: Interfaces.Config,
+): void
+export function errorHandler(error: Error & {exitCode?: number | undefined}, config?: Interfaces.Config): Promise<void>
+export function errorHandler(error: Error & {exitCode?: number | undefined}, config?: Interfaces.Config): unknown {
   if (error instanceof CancelExecution) {
     if (error.message && error.message !== '') {
       info(`✨  ${error.message}`)
@@ -135,7 +140,7 @@ export function cleanStackFrameFilePath({
  * Register a Bugsnag error listener to clean up stack traces for errors within plugin code.
  *
  */
-export async function registerCleanBugsnagErrorsFromWithinPlugins(config: Interfaces.Config) {
+export async function registerCleanBugsnagErrorsFromWithinPlugins(config: Interfaces.Config): Promise<void> {
   // Bugsnag have their own plug-ins that use this private field
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const bugsnagConfigProjectRoot: string = (Bugsnag as any)?._client?._config?.projectRoot ?? process.cwd()
@@ -162,7 +167,7 @@ export async function registerCleanBugsnagErrorsFromWithinPlugins(config: Interf
   })
 }
 
-export async function addBugsnagMetadata(event: Event, config: Interfaces.Config) {
+export async function addBugsnagMetadata(event: Event, config: Interfaces.Config): Promise<void> {
   const publicData = metadata.getAllPublic()
   const {commandStartOptions} = metadata.getAllSensitive()
   const {startCommand} = commandStartOptions ?? {}

--- a/packages/cli-kit/src/public/node/framework.ts
+++ b/packages/cli-kit/src/public/node/framework.ts
@@ -148,7 +148,7 @@ const frameworks: Framework[] = [
  * @param rootDirectory - Directory from which the files required for each framework are searched
  * @returns The name of the framework used or 'unknown' otherwise
  */
-export async function resolveFramework(rootDirectory: string) {
+export async function resolveFramework(rootDirectory: string): Promise<string> {
   const fwConfigFiles: {[key: string]: string | undefined} = {}
 
   const matchedFramework = frameworks.find(

--- a/packages/cli-kit/src/public/node/hooks/prerun.ts
+++ b/packages/cli-kit/src/public/node/hooks/prerun.ts
@@ -20,7 +20,7 @@ export const hook: Hook.Prerun = async (options) => {
   await start({commandContent, args, commandClass: options.Command as unknown as typeof Command})
 }
 
-export function parseCommandContent(cmdInfo: {id: string; aliases: string[]; pluginAlias?: string}) {
+export function parseCommandContent(cmdInfo: {id: string; aliases: string[]; pluginAlias?: string}): CommandContent {
   let commandContent = parseCreateCommand(cmdInfo.pluginAlias)
   if (!commandContent) {
     commandContent = parseNormalCommand(cmdInfo.id, cmdInfo.aliases)

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -46,7 +46,7 @@ export type PackageManager = typeof packageManager[number]
  * @param directory - The path to the directory that should contain a package.json
  * @returns An abort error.
  */
-export const PackageJsonNotFoundError = (directory: string) => {
+export const PackageJsonNotFoundError = (directory: string): AbortError => {
   return new AbortError(`The directory ${directory} doesn't have a package.json.`)
 }
 
@@ -56,7 +56,7 @@ export const PackageJsonNotFoundError = (directory: string) => {
  * @param directory - The directory from which the traverse has been done
  * @returns An abort error.
  */
-export const FindUpAndReadPackageJsonNotFoundError = (directory: string) => {
+export const FindUpAndReadPackageJsonNotFoundError = (directory: string): BugError => {
   return new BugError(content`Couldn't find a a package.json traversing directories from ${token.path(directory)}`)
 }
 
@@ -116,7 +116,9 @@ interface InstallNPMDependenciesRecursivelyOptions {
  * provided by dependency managers.
  * @param options - Options to install dependencies recursively.
  */
-export async function installNPMDependenciesRecursively(options: InstallNPMDependenciesRecursivelyOptions) {
+export async function installNPMDependenciesRecursively(
+  options: InstallNPMDependenciesRecursivelyOptions,
+): Promise<void> {
   const packageJsons = await glob(pathJoin(options.directory, '**/package.json'), {
     ignore: [pathJoin(options.directory, 'node_modules/**/package.json')],
     cwd: options.directory,
@@ -153,7 +155,7 @@ interface InstallNodeModulesOptions {
   signal?: AbortSignal
 }
 
-export async function installNodeModules(options: InstallNodeModulesOptions) {
+export async function installNodeModules(options: InstallNodeModulesOptions): Promise<void> {
   const execOptions: ExecOptions = {
     cwd: options.directory,
     stdin: undefined,
@@ -345,7 +347,7 @@ export interface DependencyVersion {
 export async function addNPMDependenciesIfNeeded(
   dependencies: DependencyVersion[],
   options: AddNPMDependenciesIfNeededOptions,
-) {
+): Promise<void> {
   debug(content`Adding the following dependencies if needed:
 ${token.json(dependencies)}
 With options:
@@ -369,7 +371,7 @@ ${token.json(options)}
 export async function addNPMDependencies(
   dependencies: DependencyVersion[],
   options: AddNPMDependenciesIfNeededOptions,
-) {
+): Promise<void> {
   let args: string[]
   const depedenciesWithVersion = dependencies.map((dep) => {
     return dep.version ? `${dep.name}@${dep.version}` : dep.name
@@ -397,7 +399,7 @@ export async function addNPMDependencies(
 export async function addNPMDependenciesWithoutVersionIfNeeded(
   dependencies: string[],
   options: AddNPMDependenciesIfNeededOptions,
-) {
+): Promise<void> {
   await addNPMDependenciesIfNeeded(
     dependencies.map((dependency) => {
       return {name: dependency, version: undefined}
@@ -492,7 +494,7 @@ export async function findUpAndReadPackageJson(fromDirectory: string): Promise<{
   }
 }
 
-export async function addResolutionOrOverride(directory: string, dependencies: {[key: string]: string}) {
+export async function addResolutionOrOverride(directory: string, dependencies: {[key: string]: string}): Promise<void> {
   const packageManager = await getPackageManager(directory)
   const packageJsonPath = pathJoin(directory, 'package.json')
   const packageJsonContent = await readAndParsePackageJson(packageJsonPath)

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -39,7 +39,7 @@ interface ExecCLI2Options {
 export async function execCLI2(
   args: string[],
   {adminSession, storefrontToken, token, directory, signal}: ExecCLI2Options = {},
-) {
+): Promise<void> {
   await installCLIDependencies()
   const env = {
     ...process.env,

--- a/packages/create-app/src/commands/init.test.ts
+++ b/packages/create-app/src/commands/init.test.ts
@@ -42,7 +42,7 @@ describe('create app command', () => {
   })
 
   it('throw an error when using a non supported template alias name', async () => {
-    vi.mocked(errorHandler).mockReturnValue(undefined)
+    vi.mocked(errorHandler).mockImplementation(async () => {})
 
     // When
     await Init.run(['--template', 'java'])


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Related to https://github.com/Shopify/internal-cli-foundations/issues/491, we need to have our public interface be locked down. This will make us aware of breaking changes.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Enforces that `public` ts files (i.e. anything we expose as an importable file) have explicit interfaces for functions, so we know if the return types have accidentally changed.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`dev lint` should succeed.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
