### PR TITLE
Log request times for partners API and other HTTP fetch

### DIFF
--- a/.changeset/stupid-games-type.md
+++ b/.changeset/stupid-games-type.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add timing information to verbose logs

--- a/packages/cli-kit/src/api/partners.ts
+++ b/packages/cli-kit/src/api/partners.ts
@@ -2,6 +2,7 @@ import {buildHeaders, debugLogRequest, handlingErrors} from './common.js'
 import {ScriptServiceProxyQuery} from './graphql/index.js'
 import {partners as partnersFqdn} from '../environment/fqdn.js'
 import {graphqlClient} from '../http/graphql.js'
+import {debug} from '../output.js'
 import {Variables, RequestDocument} from 'graphql-request'
 
 export async function request<T>(query: RequestDocument, token: string, variables?: Variables): Promise<T> {
@@ -12,7 +13,10 @@ export async function request<T>(query: RequestDocument, token: string, variable
     const headers = await buildHeaders(token)
     debugLogRequest(api, query, variables, headers)
     const client = await graphqlClient({headers, url})
+    const t0 = performance.now()
     const response = await client.request<T>(query, variables)
+    const t1 = performance.now()
+    debug(`Request to ${url.toString()} completed in ${Math.round(t1 - t0)} ms`)
     return response
   })
 }

--- a/packages/cli-kit/src/api/partners.ts
+++ b/packages/cli-kit/src/api/partners.ts
@@ -4,6 +4,7 @@ import {partners as partnersFqdn} from '../environment/fqdn.js'
 import {graphqlClient} from '../http/graphql.js'
 import {debug} from '../output.js'
 import {Variables, RequestDocument} from 'graphql-request'
+import {performance} from 'perf_hooks'
 
 export async function request<T>(query: RequestDocument, token: string, variables?: Variables): Promise<T> {
   const api = 'Partners'

--- a/packages/cli-kit/src/http/fetch.ts
+++ b/packages/cli-kit/src/http/fetch.ts
@@ -2,6 +2,7 @@ import {httpsAgent} from '../http.js'
 import {buildHeaders, sanitizedHeadersOutput} from '../api/common.js'
 import {content, debug} from '../output.js'
 import nodeFetch from 'node-fetch'
+import {performance} from 'perf_hooks'
 import type {RequestInfo, RequestInit} from 'node-fetch'
 
 type Response = ReturnType<typeof nodeFetch>

--- a/packages/cli-kit/src/http/fetch.ts
+++ b/packages/cli-kit/src/http/fetch.ts
@@ -39,6 +39,9 @@ export async function shopifyFetch(url: RequestInfo, init?: RequestInit): Respon
 Sending ${options.method ?? 'GET'} request to URL ${url.toString()} and headers:
 ${sanitizedHeadersOutput((options?.headers ?? {}) as {[header: string]: string})}
 `)
+  const t0 = performance.now()
   const response = await nodeFetch(url, {...init, agent: await httpsAgent()})
+  const t1 = performance.now()
+  debug(`Request to ${url.toString()} completed with status ${response.status} in ${Math.round(t1 - t0)} ms`)
   return response
 }

--- a/packages/cli-kit/src/output.ts
+++ b/packages/cli-kit/src/output.ts
@@ -257,7 +257,7 @@ export const completed = (content: Message, logger: Logger = consoleLog) => {
 export const debug = (content: Message, logger: Logger = consoleLog) => {
   if (isUnitTest()) collectLog('debug', content)
   const message = colors.gray(stringifyMessage(content))
-  outputWhereAppropriate('debug', logger, message)
+  outputWhereAppropriate('debug', logger, `${new Date().toISOString()}: ${message}`)
 }
 
 /**


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Tracing performance of HTTP requests gives us visibility into what's taking the most time. Let's make the CLI faster.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Using the JS `performance` API, grab timestamps before and after the request, and print the total request time.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run `dev` with `--verbose` and see the extra log lines! (search for `completed`)

```
2022-12-23T13:11:08.294Z: Reading the content of file at package.json...
2022-12-23T13:11:08.294Z:
Sending "Partners" GraphQL request:

  {
    organizations(first: 200) {
      nodes {
        id
        businessName
        website
        appsNext
      }
    }
  }


With variables:


And headers:
 - User-Agent: Shopify CLI; v=3.30.0
 - Sec-CH-UA-PLATFORM: darwin
 - X-Request-Id: 70929890-3feb-4e11-b8a7-98dd49f063e1
 - Content-Type: application/json

2022-12-23T13:11:08.759Z: Request to https://partners.shopify.com/api/cli/graphql completed in 464 ms
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
