### PR TITLE
Fix error handling on session refresh

### DIFF
--- a/packages/cli-kit/src/session.ts
+++ b/packages/cli-kit/src/session.ts
@@ -11,6 +11,7 @@ import {
   ExchangeScopes,
   refreshAccessToken,
   InvalidGrantError,
+  InvalidRequestError,
 } from './session/exchange.js'
 
 import {content, token, debug} from './output.js'
@@ -26,6 +27,7 @@ import {partners} from './api.js'
 import {RequestClientError} from './api/common.js'
 import {firstPartyDev, useDeviceAuth} from './environment/local.js'
 import {pollForDeviceAuthorization, requestDeviceAuthorization} from './session/device-authorization.js'
+import {AbortError} from './public/node/error.js'
 import {gql} from 'graphql-request'
 
 const NoSessionError = new Bug('No session found after ensuring authenticated')
@@ -215,6 +217,9 @@ ${token.json(applications)}
     } catch (error) {
       if (error instanceof InvalidGrantError) {
         newSession = await executeCompleteFlow(applications, fqdn)
+      } else if (error instanceof InvalidRequestError) {
+        await secureStore.remove()
+        throw new AbortError('\nError validating auth session', "We've cleared the current session, please try again")
       } else {
         throw error
       }


### PR DESCRIPTION
### WHY are these changes introduced?

When the session refresh fails, we are showing this ugly error instead of running the full authentication flow again:

```
╭─ error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                           │
│                                                                                                                                                           │
│  To investigate the issue, examine this stack trace:                                                                                                      │
│  at tokenRequestErrorHandler (cli-kit/src/session/exchange.ts:175)                                                                                        │
│   return new InvalidGrantError()                                                                                                                          │
│  at mapError (cli-kit/src/public/node/result.ts:143)                                                                                                      │
│   return err(mapper(this.error))                                                                                                                          │
│  at refreshAccessToken (cli-kit/src/session/exchange.ts:85)                                                                                               │
│   const value = tokenResult.mapError(tokenRequestErrorHandler).valueOrBug()                                                                               │
│  at processTicksAndRejections (node:internal/process/task_queues:95)                                                                                      │
│  at async refreshTokens (cli-kit/src/session.ts:336)                                                                                                      │
│   const identityToken = await refreshAccessToken(token)                                                                                                   │
│  at async ensureAuthenticated (cli-kit/src/session.ts:214)                                                                                                │
│   newSession = await refreshTokens(fqdnSession.identity, applications, fqdn)                                                                              │
│  at ensureAuthenticatedPartners (cli-kit/src/session.ts:106)                                                                                              │
│   const tokens = await ensureAuthenticated({partnersApi: {scopes}})                                                                                       │
│  at async dev (app/src/cli/services/dev.ts:52)                                                                                                            │
│   const token = await session.ensureAuthenticatedPartners()                                                                                               │
│  at run (app/src/cli/commands/app/dev.ts:97)                                                                                                              │
│   await dev({                                                                                                                                             │
│                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

``` 

Since https://github.com/Shopify/cli/pull/950 we are trying to refresh the tokens in more situations. But apparently we were not handling the errors properly, and [there's a peak of these errors since the release](https://app.bugsnag.com/shopify/cli/errors/6332f63be4c6b00008465919?filters[event.since]=30d&filters[error.status]=open).

The problem is that the [tokenRequestErrorHandler](https://github.com/Shopify/cli/blob/48f8494e188c85d7b4c8f732a430793b2329bd9f/packages/cli-kit/src/session/exchange.ts#L170) function is async, but we are not waiting for the result [here](https://github.com/Shopify/cli/blob/48f8494e188c85d7b4c8f732a430793b2329bd9f/packages/cli-kit/src/session/exchange.ts#L85), so the `ensureAuthenticated` method is finally getting a Promise instead of a `InvalidGrantError` [here](https://github.com/Shopify/cli/blob/48f8494e188c85d7b4c8f732a430793b2329bd9f/packages/cli-kit/src/session.ts#L215).

### WHAT is this pull request doing?



### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
