### PR TITLE
Allow function specifications to use a custom template repository

### DIFF
--- a/.changeset/little-adults-obey.md
+++ b/.changeset/little-adults-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix bug in functions using a custom template repository

--- a/packages/app/src/cli/models/extensions/functions.ts
+++ b/packages/app/src/cli/models/extensions/functions.ts
@@ -17,7 +17,7 @@ export interface FunctionSpec<TConfiguration extends FunctionConfigType = Functi
   externalName: string
   helpURL?: string
   gated: boolean
-  templateURL?: string
+  templateURL: string
   supportedFlavors: {name: string; value: string}[]
   configSchema: ZodSchemaType<TConfiguration>
   registrationLimit: number

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -38,7 +38,7 @@ interface ExtensionDirectory {
   extensionDirectory: string
 }
 
-export type ExtensionFlavor = 'vanilla-js' | 'react' | 'typescript' | 'typescript-react'
+export type ExtensionFlavor = 'vanilla-js' | 'react' | 'typescript' | 'typescript-react' | string
 
 type FunctionExtensionInitOptions = ExtensionInitOptions<FunctionSpec> & ExtensionDirectory
 type UIExtensionInitOptions = ExtensionInitOptions<UIExtensionSpec> & ExtensionDirectory
@@ -147,7 +147,7 @@ function getSrcFileExtension(extensionFlavor: ExtensionFlavor): SrcFileExtension
     'typescript-react': 'tsx',
   }
 
-  return flavorToSrcFileExtension[extensionFlavor]
+  return flavorToSrcFileExtension[extensionFlavor] ?? 'js'
 }
 
 export function getRuntimeDependencies({
@@ -185,7 +185,7 @@ async function removeUnwantedTemplateFilesPerFlavor(extensionDirectory: string, 
 }
 
 async function functionExtensionInit(options: FunctionExtensionInitOptions) {
-  const url = options.cloneUrl || blocks.functions.defaultUrl
+  const url = options.cloneUrl || options.specification.templateURL
   const spec = options.specification
   await file.inTemporaryDirectory(async (tmpDir) => {
     const templateDownloadDir = path.join(tmpDir, 'download')


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Functions were always using the default template repo, even if a new function specified a custom repo.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Allow to use custom templateURL paths in function specifications
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
