### PR TITLE
UI extension row

### DIFF
--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.module.scss
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.module.scss
@@ -4,21 +4,12 @@
 
   td {
     padding: 0.8rem 1.5rem;
+    vertical-align: top;
   }
 }
 
 .Title {
   font-weight: var(--dc-font-weight-subdued);
-}
-
-.NotApplicable {
-  font-family: var(--dc-font-compact);
-}
-
-.PreviewLinkCell {
-  display: flex;
-  align-items: center;
-  gap: 2.6rem;
 }
 
 .Status {

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
@@ -1,5 +1,6 @@
 import * as styles from './ExtensionRow.module.scss'
 import en from './translations/en.json'
+import {PreviewLinks} from './components/PreviewLinks'
 import {useExtensionsInternal} from '../../hooks/useExtensionsInternal.js'
 import React from 'react'
 import {useI18n} from '@shopify/react-i18n'
@@ -74,7 +75,9 @@ export function ExtensionRow({extension, onHighlight, onClearHighlight, onShowMo
       <td>
         <span className={styles.Title}>{extension.title}</span>
       </td>
-      <td className={styles.PreviewLinkCell}>{previewLink}</td>
+      <td>
+        <PreviewLinks extension={extension} />
+      </td>
       <td>
         <Button type="button" onClick={() => onShowMobileQRCode(extension)}>
           View mobile

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/PreviewLinks.module.scss
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/PreviewLinks.module.scss
@@ -1,0 +1,20 @@
+.NotApplicable {
+  font-family: var(--dc-font-compact);
+}
+
+.PreviewLinksTitle {
+  font-style: italic;
+}
+
+.PreviewLinks {
+  display: grid;
+  gap: 0.4rem;
+  padding-left: 0.6rem;
+  padding-right: 0.6rem;
+}
+
+.PreviewLink {
+  display: flex;
+  align-items: center;
+  gap: 2.6rem;
+}

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/PreviewLinks.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/PreviewLinks.tsx
@@ -1,0 +1,81 @@
+import * as styles from './PreviewLinks.module.scss'
+import en from './translations/en.json'
+import {useExtensionsInternal} from '../../../../hooks/useExtensionsInternal.js'
+import React from 'react'
+import {useI18n} from '@shopify/react-i18n'
+import {ExtensionPayload} from '@shopify/ui-extensions-server-kit'
+import {ClipboardMinor} from '@shopify/polaris-icons'
+import {toast} from 'react-toastify'
+import {IconButton} from '@/components/IconButton'
+
+export interface Props {
+  extension: ExtensionPayload
+}
+
+export function PreviewLinks({extension}: Props) {
+  if (extension.surface === 'pos') {
+    return <span className={styles.NotApplicable}>--</span>
+  }
+
+  if (extension.type === 'ui_extension') {
+    return (
+      <>
+        <span className={styles.PreviewLinksTitle}>Multiple locations:</span>
+        <span className={styles.PreviewLinks}>
+          {extension.extensionPoints?.map((extensionPoint) => {
+            if (typeof extensionPoint === 'string') {
+              return null
+            }
+
+            const {root, target} = extensionPoint
+
+            return <PreviewLink url={root.url} title={target} />
+          })}
+        </span>
+      </>
+    )
+  }
+
+  return <PreviewLink url={extension.development.root.url} title={extension.type.replaceAll('_', ' ')} />
+}
+
+function PreviewLink({url, title}: {url: string; title: string}) {
+  const [i18n] = useI18n({
+    id: 'PreviewLinks',
+    fallback: en,
+  })
+
+  const {embedded, navigate} = useExtensionsInternal()
+
+  const handleOpenRoot = (event: React.MouseEvent<HTMLElement>) => {
+    if (embedded && window.top) {
+      navigate(url)
+      event.preventDefault()
+    }
+  }
+
+  function handleCopyPreviewLink() {
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        toast(i18n.translate('copy.success'), {toastId: `copy-${url}`})
+      })
+      .catch(() => {
+        toast(i18n.translate('copy.error'), {type: 'error', toastId: `copy-${url}-error`})
+      })
+  }
+
+  return (
+    <span className={styles.PreviewLink}>
+      <a href={url} target="_blank" aria-label={i18n.translate('linkLabel', {title})} onClick={handleOpenRoot}>
+        {title}
+      </a>
+      <IconButton
+        type="button"
+        onClick={() => handleCopyPreviewLink()}
+        source={ClipboardMinor}
+        accessibilityLabel={i18n.translate('iconLabel', {title})}
+      />
+    </span>
+  )
+}

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/index.ts
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/index.ts
@@ -1,0 +1,1 @@
+export * from './PreviewLinks'

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/translations/en.json
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/translations/en.json
@@ -1,0 +1,8 @@
+{
+  "copy": {
+    "success": "URL copied",
+    "error": "Couldn't copy URL"
+  },
+  "linkLabel": "Preview {title}",
+  "iconLabel": "Copy preview link for {title} to clipboard"
+}

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/hooks/useExtensionsInternal.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/hooks/useExtensionsInternal.tsx
@@ -28,7 +28,6 @@ export function useExtensionsInternal() {
     // dispatch events
     focus: (extension: ExtensionPayload) => extensionServer.client.emit('focus', [{uuid: extension.uuid}]),
     unfocus: () => extensionServer.client.emit('unfocus'),
-    navigate: (extension: ExtensionPayload) =>
-      extensionServer.client.emit('navigate', {url: extension.development.resource.url}),
+    navigate: (url: string) => extensionServer.client.emit('navigate', url),
   }
 }

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -52,7 +52,7 @@ export interface ResourceURL {
 
 export type ExtensionPoints =
   | string[]
-  | {target: string; module: string; surface: Surface; main: {url: string}}[]
+  | {target: string; module: string; surface: Surface; root: {url: string}}[]
   | null
 
 export interface ExtensionPayload {


### PR DESCRIPTION
### WHY are these changes introduced?

A UI Extension renders multiple extension points.  Therefore we need multiple preview links for a UI extension.

Fixes #1006 

### WHAT is this pull request doing?

1. Fixes a type error in the server kit.
2. Introduce a new PreviewLinks component which handle the now 3 cases (POS extension, Legacy extension, UI Extension)
3. ExtensionRow that component to render the correct preview links

### How to test your changes?

1. `pnpm install && pnpm build`
2. `cd fixtures/app`
3. `pnpm generate extension` (Choose a UI Extension)
4. `pnpm dev`
5. Check the preview links for every extension is correct

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
