### PR TITLE
Fix link to "Get started" page in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you encounter issues using the CLI or have feedback you'd like to share with 
 
 ## Contribute 👩🏽‍💻
 
-If you'd like to contribute to the project, check out the [contributors docs](/docs) and the [steps to get started](/docs/get-started.md).
+If you'd like to contribute to the project, check out the [contributors docs](/docs) and the [steps to get started](/docs/cli/get-started.md).
 
 <p>&nbsp;</p>
 


### PR DESCRIPTION
### WHY are these changes introduced?

Link points to non-existing page.

### WHAT is this pull request doing?

Fixes aforementioned link.

### How to test your changes?

Verify that "steps to get started" in https://github.com/Shopify/cli/tree/fix-link-to-get-started-in-readme points to correct page.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
