### PR TITLE
Fix theme dev session refresh

### DIFF
--- a/.changeset/cold-clocks-fly.md
+++ b/.changeset/cold-clocks-fly.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix intervals to be less than INT max

--- a/.changeset/cold-clocks-fly.md
+++ b/.changeset/cold-clocks-fly.md
@@ -2,4 +2,4 @@
 '@shopify/theme': patch
 ---
 
-Fix intervals to be less than INT max
+Fix theme dev not refreshing session automatically

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -87,8 +87,9 @@ export default class Dev extends ThemeCommand {
   // Tokens are valid for 120m, better to be safe and refresh every 110min
   ThemeRefreshTimeoutInMs = 110 * 60 * 1000
 
-  // Sleep timeout, server could run forever but we need to put a number. 1 Year.
-  HardTimeoutInSeconds = 60 * 60 * 24 * 365
+  // Sleep timeout, server could run forever but we need to put a number. 15 Days.
+  // Once converted to miliseconds, it MUST be less than INT32 max value (2147483647)
+  HardTimeoutInSeconds = 60 * 60 * 24 * 15
 
   /**
    * Executes the theme serve command.

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -2,7 +2,7 @@ import {themeFlags} from '../../flags.js'
 import {getThemeStore} from '../../utilities/theme-store.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {Flags} from '@oclif/core'
-import {cli, session, abort, system, output} from '@shopify/cli-kit'
+import {cli, session, abort, output} from '@shopify/cli-kit'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 
 export default class Dev extends ThemeCommand {
@@ -87,10 +87,6 @@ export default class Dev extends ThemeCommand {
   // Tokens are valid for 120m, better to be safe and refresh every 110min
   ThemeRefreshTimeoutInMs = 110 * 60 * 1000
 
-  // Sleep timeout, server could run forever but we need to put a number. 15 Days.
-  // Once converted to miliseconds, it MUST be less than INT32 max value (2147483647)
-  HardTimeoutInSeconds = 60 * 60 * 24 * 15
-
   /**
    * Executes the theme serve command.
    * Every 110 minutes, it will refresh the session token and restart the server.
@@ -105,7 +101,7 @@ export default class Dev extends ThemeCommand {
 
     let controller: abort.Controller = new abort.Controller()
 
-    const refreshThemeSessionInterval = setInterval(() => {
+    setInterval(() => {
       output.debug('Refreshing theme session token and restarting theme server...')
       controller.abort()
       controller = new abort.Controller()
@@ -115,8 +111,6 @@ export default class Dev extends ThemeCommand {
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.execute(store, flags.password, command, controller)
-    await system.sleep(this.HardTimeoutInSeconds)
-    clearInterval(refreshThemeSessionInterval)
   }
 
   async execute(store: string, password: string | undefined, command: string[], controller: abort.Controller) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Apparently `setTimeout` accepts any number, but crashes silently if it's bigger than INT32 max value...
This was preventing OTHER timers to be triggered, which is weird.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Simplified how theme dev timers work, we only need one `setInterval`

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
