### PR TITLE
Import `fast-glob` dynamically and use the ESm version of `del`

### DIFF
--- a/packages/cli-kit/src/file.ts
+++ b/packages/cli-kit/src/file.ts
@@ -1,6 +1,5 @@
 import {content as outputContent, token, debug} from './output.js'
 import fs from 'fs-extra'
-import del from 'del'
 import {temporaryDirectoryTask} from 'tempy'
 import {sep, join, extname} from 'pathe'
 import prettier from 'prettier'
@@ -122,6 +121,7 @@ export function removeSync(path: string) {
 }
 
 export async function rmdir(path: string, {force}: {force?: boolean} = {}): Promise<void> {
+  const {default: del} = await import('del')
   debug(outputContent`Removing directory at ${token.path(path)}...`)
   await del(path, {force})
 }

--- a/packages/cli-kit/src/path.ts
+++ b/packages/cli-kit/src/path.ts
@@ -1,26 +1,21 @@
 import {OverloadParameters} from './typing/overloaded-parameters.js'
 import commondir from 'commondir'
 import {relative, dirname, join, normalize, resolve, basename, extname, isAbsolute, parse} from 'pathe'
-import {findUp as internalFindUp, Match as FindUpMatch} from 'find-up'
-import fastGlob from 'fast-glob'
+import {findUp as internalFindUp} from 'find-up'
 import {fileURLToPath} from 'url'
+import type {Pattern, Options} from 'fast-glob'
 
 export {join, relative, dirname, normalize, resolve, basename, extname, isAbsolute, parse}
 
-type FastGlobOptions = Parameters<typeof fastGlob>
-type FastGlobOutput = ReturnType<typeof fastGlob>
-
-export async function glob(...args: FastGlobOptions): FastGlobOutput {
-  // eslint-disable-next-line prefer-const
-  let [pattern, options] = args
+export async function glob(pattern: Pattern | Pattern[], options?: Options): Promise<string[]> {
+  const {default: fastGlob} = await import('fast-glob')
+  let overridenOptions = options
   if (options?.dot == null) {
-    options = {...options, dot: true}
+    overridenOptions = {...options, dot: true}
   }
   return fastGlob(pattern, options)
 }
 export {pathToFileURL} from 'node:url'
-
-type FindUpMatcher = (directory: string) => FindUpMatch | Promise<FindUpMatch>
 
 export async function findUp(
   matcher: OverloadParameters<typeof internalFindUp>[0],


### PR DESCRIPTION
Related: https://github.com/Shopify/cli/issues/1012

### WHY are these changes introduced?


### WHAT is this pull request doing?
I'm updating the function that uses `fast-glob` to import it dynamically, and updating `del` to the ESM version.

### How to test your changes?
Building and dev'ing the fixture app should work and tests should pass.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
