### PR TITLE
Import chokidar dynamically

### DIFF
--- a/packages/app/src/cli/services/dev/extension/bundler.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.ts
@@ -2,7 +2,6 @@ import {ExtensionsPayloadStore} from './payload/store.js'
 import {ExtensionDevOptions} from '../extension.js'
 import {bundleExtension} from '../../extensions/bundle.js'
 import {abort, path, output} from '@shopify/cli-kit'
-import chokidar from 'chokidar'
 
 export interface WatchEvent {
   path: string
@@ -19,6 +18,7 @@ export interface FileWatcher {
 }
 
 export async function setupBundlerAndFileWatcher(options: FileWatcherOptions) {
+  const {default: chokidar} = await import('chokidar')
   const abortController = new abort.Controller()
 
   const bundlers: Promise<void>[] = []


### PR DESCRIPTION
Related: https://github.com/Shopify/cli/issues/1012

### WHY are these changes introduced?
We are improving the CLI launch times

### WHAT is this pull request doing?
I'm updating the function that uses `chokidar` to import it dynamically.

### How to test your changes?
The dev'ing of functions should work.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
