### PR TITLE
Run performance benchmarking on macOS

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -108,7 +108,7 @@ jobs:
           branch-name: main
       - name: Run and save benchmark
         uses: ./.github/actions/run-and-save-benchmark
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
+        if: ${{ matrix.os == 'macos-latest' && matrix.node == '18.7.0' }}
         with:
           branch-name: main
 
@@ -199,7 +199,7 @@ jobs:
           branch-name: "${{ github.head_ref }}"
       - name: Download and publish benchmark
         uses: ./.github/actions/download-and-publish-benchmark
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
+        if: ${{ matrix.os == 'macos-latest' && matrix.node == '18.7.0' }}
         with:
           base-branch-name: "${{ github.base_ref }}"
 


### PR DESCRIPTION
### WHY are these changes introduced?
The benchmark reports on PRs sometimes yielded odd diffs beyond 20%.

### WHAT is this pull request doing?
I did a bit of investigation and we are always running it with the same OS, `ubuntu-latest`, and Node version, `18.7.0`, so my assumption is that GitHub Actions' virtualization doesn't consistently provide the same resources across builds. I'm adjusting the pipelines to use `macOS` instead where resources might be the same across builds.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
