### PR TITLE
Import `kill-port-process` dynamically

### DIFF
--- a/packages/cli-kit/src/session/authorize.ts
+++ b/packages/cli-kit/src/session/authorize.ts
@@ -7,7 +7,6 @@ import {identity as identityFqdn} from '../environment/fqdn.js'
 import * as output from '../output.js'
 import {keypress, terminateBlockingPortProcessPrompt} from '../ui.js'
 import {checkPort as isPortAvailable} from 'get-port-please'
-import {killPortProcess} from 'kill-port-process'
 
 export const MismatchStateError = new Abort(
   "The state received from the authentication doesn't match the one that initiated the authentication process.",
@@ -58,6 +57,8 @@ export async function authorize(scopes: string[], state: string = randomHex(30))
 }
 
 async function validateRedirectionPortAvailability(port: number) {
+  const {killPortProcess} = await import('kill-port-process')
+
   if (await isPortAvailable(port)) {
     return
   }


### PR DESCRIPTION
Related: https://github.com/Shopify/cli/issues/1012

### WHY are these changes introduced?
We are [improving](https://github.com/Shopify/cli/issues/1012) the launch time of the CLI.

### WHAT is this pull request doing?
I'm adjusting the function that uses `kill-port-process` to import it dynamically. That way the module is lazily loaded when needed.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
