### PR TITLE
[Feature] Add `api_version` to UI extension type

### DIFF
--- a/.changeset/fast-ants-invite.md
+++ b/.changeset/fast-ants-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': minor
+---
+
+Enable configuring api_version for ui_extension

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -27,11 +27,15 @@ export const NewExtensionPointSchema = schema.object({
 export const OldExtensionPointsSchema = schema.array(schema.string()).default([])
 export const NewExtensionPointsSchema = schema.array(NewExtensionPointSchema)
 export const ExtensionPointSchema = schema.union([OldExtensionPointsSchema, NewExtensionPointsSchema])
+export const ApiVersionSchema = schema.string()
+
+export type ApiVersionSchemaType = schema.infer<typeof ApiVersionSchema>
 
 export const BaseUIExtensionSchema = schema.object({
   name: schema.string(),
   description: schema.string().optional(),
   type: schema.string().default('ui_extension'),
+  apiVersion: ApiVersionSchema.optional(),
   extensionPoints: schema.any().optional(),
   capabilities: CapabilitiesSchema.optional(),
   metafields: schema.array(MetafieldSchema).optional().default([]),

--- a/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.test.ts
@@ -19,6 +19,7 @@ describe('ui_extension', async () => {
     const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension') as UIExtensionSpec
     const configuration = {
       extensionPoints,
+      apiVersion: '2023-01' as const,
       name: 'UI Extension',
       type: 'ui_extension',
       metafields: [],
@@ -192,6 +193,7 @@ Please check the configuration in ${tomlPath}`),
           extension_points: uiExtension.configuration.extensionPoints,
           capabilities: uiExtension.configuration.capabilities,
           name: uiExtension.configuration.name,
+          api_version: uiExtension.configuration.apiVersion,
           settings: uiExtension.configuration.settings,
         })
       })

--- a/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
@@ -40,6 +40,7 @@ const spec = createUIExtensionSpecification({
   },
   deployConfig: async (config, directory) => {
     return {
+      api_version: config.apiVersion,
       extension_points: config.extensionPoints,
       capabilities: config.capabilities,
       name: config.name,

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -197,4 +197,44 @@ describe('getUIExtensionPayload', () => {
       ])
     })
   })
+
+  test('adds apiVersion when present in the configuration', async () => {
+    await inTemporaryDirectory(async () => {
+      // Given
+      const apiVersion = '2023-01'
+      const uiExtension = await testUIExtension({
+        devUUID: 'devUUID',
+        configuration: {
+          name: 'UI Extension',
+          type: 'ui_extension',
+          apiVersion,
+          metafields: [],
+          capabilities: {
+            block_progress: false,
+            network_access: false,
+            api_access: false,
+          },
+          extensionPoints: [
+            {
+              target: 'Admin::Checkout::Editor::Settings',
+              module: './src/AdminCheckoutEditorSettings.js',
+            },
+          ],
+        },
+      })
+
+      const options: ExtensionDevOptions = {} as ExtensionDevOptions
+      const development: Partial<UIExtensionPayload['development']> = {}
+
+      // When
+      const got = await getUIExtensionPayload(uiExtension, {
+        ...options,
+        currentDevelopmentPayload: development,
+        url: 'http://tunnel-url.com',
+      })
+
+      // Then
+      expect(got).toHaveProperty('apiVersion', apiVersion)
+    })
+  })
 })

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -60,6 +60,7 @@ export async function getUIExtensionPayload(
     version: renderer?.version,
 
     title: extension.configuration.name,
+    apiVersion: extension.configuration.apiVersion,
     approvalScopes: options.grantedScopes,
   }
   return defaultConfig

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -1,5 +1,5 @@
-import {NewExtensionPointSchemaType} from '../../../../models/extensions/schemas.js'
 import {Localization} from '../localization.js'
+import type {NewExtensionPointSchemaType, ApiVersionSchemaType} from '../../../../models/extensions/schemas.js'
 
 export interface ExtensionsPayloadInterface {
   app: {
@@ -62,6 +62,7 @@ export interface UIExtensionPayload {
   metafields?: {namespace: string; key: string}[] | null
   type: string
   externalType: string
+  apiVersion?: ApiVersionSchemaType
   uuid: string
   version?: string
   surface: string


### PR DESCRIPTION
### WHY are these changes introduced?

We are working on adding [API versioning](https://github.com/Shopify/ui-extensions-private/discussions/1931) to checkout UI extensions, and are planning to do it as part of migrating to the new UI extension type. This PR adds the code to the CLI to have it pass the API version from a developer's extension configuration file, to the dev server and deploy commands.

In this PR, I've included the four versions we are likely to care about for the initial release: `2023-01` (the first real version), `2022-10` (a backfilled version that gets developers on the new UI extension, without the breaking API changes introduced in `2023-01`), `unstable` (the most recent public version of the API), and `internal` (the most recent private version of the API). There is more detail about the proposed versioning flow in [this discussion](https://github.com/Shopify/ui-extensions-private/discussions/1806).

### How to test your changes?

Add an `api_version` field to a `ui_extension`. Run the `app dev` command locally to see the extension dev server passing this information to the dev command:

```
pnpm shopify app dev --path /path/to/my/extension
```

<img width="936" alt="Screenshot 2023-01-05 at 3 51 25 PM" src="https://user-images.githubusercontent.com/3012583/210882306-207a747c-4527-4584-957c-a1785959dc27.png">

If you try to deploy this extension, it seems to work, but there is a validation error because I have not yet added handling of this new field on the backend (working on it now):

<img width="602" alt="Screenshot 2023-01-05 at 4 22 11 PM" src="https://user-images.githubusercontent.com/3012583/210882447-881c03f4-9c08-43fc-8e4a-9e180ae405b5.png">

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
