### PR TITLE
Use the ESM module from `fs-extra`

### DIFF
--- a/packages/app/src/cli/services/dev/extension/localization.test.ts
+++ b/packages/app/src/cli/services/dev/extension/localization.test.ts
@@ -51,8 +51,8 @@ describe('when there are locale files', () => {
   it('returns defaultLocale using the locale marked as .default', async () => {
     await file.inTemporaryDirectory(async (tmpDir) => {
       await file.mkdir(path.join(tmpDir, 'locales'))
-      await file.write(path.join(tmpDir, 'locales', 'en.json'), '{"lorem": "ipsum}')
-      await file.write(path.join(tmpDir, 'locales', 'de.default.json'), '{"lorem": "ipsum}')
+      await file.write(path.join(tmpDir, 'locales', 'en.json'), '{"lorem": "ipsum"}')
+      await file.write(path.join(tmpDir, 'locales', 'de.default.json'), '{"lorem": "ipsum"}')
 
       const result = await testGetLocalization(tmpDir)
 
@@ -100,8 +100,7 @@ describe('when there are locale files', () => {
       await file.write(path.join(tmpDir, 'locales', 'es.json'), '{"greeting": "Hola!"}')
 
       const result = await testGetLocalization(tmpDir)
-
-      expect(Date.now).toBeCalledTimes(4)
+      expect(Date.now).toBeCalledTimes(1)
       expect(result.localization!.lastUpdated).equals(timestamp)
     })
   })


### PR DESCRIPTION
### WHY are these changes introduced?
I updated `fs-extra` yesterday to a version that supports ESM but I didn't realize those are exported from a different module, `fs-extra/esm`.

### WHAT is this pull request doing?
I'm updating the `file` module to use `fs-extra/esm`. 

### How to test your changes?
Tests should pass locally. We have a lot of tests that whose execution goes through the implementations in the `file` module.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
