### PR TITLE
Fix issue with prompt not being cleared correctly

### DIFF
--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -88,6 +88,7 @@
     "@oclif/core": "1.21.0",
     "@types/archiver": "5.3.1",
     "abort-controller": "3.0.0",
+    "ansi-escapes": "6.0.0",
     "archiver": "5.3.1",
     "chalk": "5.1.0",
     "change-case": "4.1.2",

--- a/packages/cli-kit/src/private/node/ui/components/FullScreen.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FullScreen.tsx
@@ -8,31 +8,28 @@ import React, {useEffect, useState} from 'react'
  */
 const FullScreen: React.FC = ({children}): JSX.Element => {
   const {stdout} = useStdout()
-
-  if (!stdout) {
-    throw new Error('Could not find stdout')
-  }
+  const standardOutput = stdout!
 
   const [size, setSize] = useState({
-    columns: stdout.columns,
-    rows: stdout.rows,
+    columns: standardOutput.columns,
+    rows: standardOutput.rows,
   })
 
   useEffect(() => {
     function onResize() {
       setSize({
-        columns: stdout!.columns,
-        rows: stdout!.rows,
+        columns: standardOutput.columns,
+        rows: standardOutput.rows,
       })
     }
 
-    stdout.on('resize', onResize)
+    standardOutput.on('resize', onResize)
     // switch to an alternate buffer
-    stdout.write('\u001B[?1049h')
+    standardOutput.write('\u001B[?1049h')
     return () => {
-      stdout.off('resize', onResize)
+      standardOutput.off('resize', onResize)
       // switch back to the main buffer
-      stdout.write('\u001B[?1049l')
+      standardOutput.write('\u001B[?1049l')
     }
   }, [])
 

--- a/packages/cli-kit/src/private/node/ui/components/FullScreen.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FullScreen.tsx
@@ -1,4 +1,4 @@
-import {Box} from 'ink'
+import {Box, useStdout} from 'ink'
 import React, {useEffect, useState} from 'react'
 
 /**
@@ -7,26 +7,32 @@ import React, {useEffect, useState} from 'react'
  * - You want to respond to the resize event of the terminal. Whenever the user resizes their terminal window the output's height and width will be recalculated and re-rendered properly.
  */
 const FullScreen: React.FC = ({children}): JSX.Element => {
+  const {stdout} = useStdout()
+
+  if (!stdout) {
+    throw new Error('Could not find stdout')
+  }
+
   const [size, setSize] = useState({
-    columns: process.stdout.columns,
-    rows: process.stdout.rows,
+    columns: stdout.columns,
+    rows: stdout.rows,
   })
 
   useEffect(() => {
     function onResize() {
       setSize({
-        columns: process.stdout.columns,
-        rows: process.stdout.rows,
+        columns: stdout!.columns,
+        rows: stdout!.rows,
       })
     }
 
-    process.stdout.on('resize', onResize)
+    stdout.on('resize', onResize)
     // switch to an alternate buffer
-    process.stdout.write('\u001B[?1049h')
+    stdout.write('\u001B[?1049h')
     return () => {
-      process.stdout.off('resize', onResize)
+      stdout.off('resize', onResize)
       // switch back to the main buffer
-      process.stdout.write('\u001B[?1049l')
+      stdout.write('\u001B[?1049l')
     }
   }, [])
 

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -2,8 +2,9 @@ import SelectInput, {Props as SelectProps, Item as SelectItem, Item} from './Sel
 import Table, {Props as TableProps} from './Table.js'
 import {handleCtrlC} from '../../ui.js'
 import React, {ReactElement, useCallback, useState} from 'react'
-import {Box, Text, useApp, useInput} from 'ink'
+import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
 import {figures} from 'listr2'
+import ansiEscapes from 'ansi-escapes'
 
 export interface Props<T> {
   message: string
@@ -21,6 +22,15 @@ function SelectPrompt<T>({
   const [answer, setAnswer] = useState<SelectItem<T>>(choices[0]!)
   const {exit: unmountInk} = useApp()
   const [submitted, setSubmitted] = useState(false)
+  const {stdout} = useStdout()
+  const [height, setHeight] = useState(0)
+
+  const measuredRef = useCallback((node) => {
+    if (node !== null) {
+      const {height} = measureElement(node)
+      setHeight(height)
+    }
+  }, [])
 
   useInput(
     useCallback(
@@ -28,17 +38,20 @@ function SelectPrompt<T>({
         handleCtrlC(input, key)
 
         if (key.return) {
+          if (stdout && height >= stdout.rows) {
+            stdout.write(ansiEscapes.clearTerminal)
+          }
           setSubmitted(true)
           unmountInk()
           onSubmit(answer.value)
         }
       },
-      [answer, onSubmit],
+      [answer, onSubmit, height],
     ),
   )
 
   return (
-    <Box flexDirection="column" marginBottom={1}>
+    <Box flexDirection="column" marginBottom={1} ref={measuredRef}>
       <Box>
         <Box marginRight={2}>
           <Text>?</Text>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,7 @@ importers:
       '@types/semver': ^7.3.9
       '@vitest/coverage-istanbul': ^0.26.3
       abort-controller: 3.0.0
+      ansi-escapes: 6.0.0
       archiver: 5.3.1
       chalk: 5.1.0
       change-case: 4.1.2
@@ -424,6 +425,7 @@ importers:
       '@oclif/core': 1.21.0
       '@types/archiver': 5.3.1
       abort-controller: 3.0.0
+      ansi-escapes: 6.0.0
       archiver: 5.3.1
       chalk: 5.1.0
       change-case: 4.1.2


### PR DESCRIPTION
### WHY are these changes introduced?

I accidentally found a bug with prompts not being cleared properly after submission if the height of the terminal is lower than the height of the prompt itself.

### WHAT is this pull request doing?

Current implementation doesn't clean the prompt after submission and keeps the last 2 renders in the terminal output:

![](https://screenshot.click/06-54-f1u3d-tegv4.gif)

New implementation:

![](https://screenshot.click/06-52-9b5gr-yr3i2.gif)

### How to test your changes?

Use kitchen sink to test prompts at different terminal heights.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
