### PR TITLE
Add nightly snapshots

### DIFF
--- a/shipit.nightly.yml
+++ b/shipit.nightly.yml
@@ -1,0 +1,18 @@
+ci:
+  require: []
+
+dependencies:
+  override:
+    # We are making sure the deploys point to the NPM registry to prevent
+    # 404 issues like the one described in this comment:
+    # https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
+    - echo 'registry "https://registry.npmjs.org/"' | tee .npmrc .yarnrc
+    - curl -fsSL https://get.pnpm.io/install.sh | SHELL=`which bash` bash -
+    - bash -i -c "pnpm install"
+deploy:
+  interval: 24h
+  override:
+    - bash -i -c "npm_config_loglevel=verbose pnpm changeset version --snapshot nightly"
+    - bash -i -c "npm_config_loglevel=verbose pnpm changeset publish --tag nightly"
+  post:
+    - bash -i -c "pnpm run update-bugsnag"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Provide nightly snapshots to avoid anyone being held up in development waiting for a release.

Based on docs and local testing, this should create a package of the form `0.0.0-nightly-20230108195058` where `20230108...` is a continuously incrementing datetime representing the moment of release.

Since the release is tagged, users can point to e.g. `@shopify/app@nightly`
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds a new shipit stack that will deploy continuously once in 24 hours.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

Enable it, hope it works!
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->
Maybe announce it, maybe not...

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

We will see in our analytics which version was used; nightly snapshots use very distinctive versions.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
