### PR TITLE
Fix Node imports

### DIFF
--- a/bin/update-bugsnag.js
+++ b/bin/update-bugsnag.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'fs';
-import fsPromise from 'node:fs/promises'
+import fsPromise from 'fs/promises'
 import path from 'node:path';
 import { fileURLToPath } from 'url';
 import { node } from "@bugsnag/source-maps";

--- a/docs/cli/conventions.md
+++ b/docs/cli/conventions.md
@@ -26,7 +26,7 @@ Modules must not perform any side effect when they are imported. For example, do
 ```ts
 // some-module.ts
 
-import { fs } from "node:fs"
+import { fs } from "fs"
 
 const content = fs.readSync("./package.json")
 ```

--- a/eslint-rules/no-error-factory-functions.cjs
+++ b/eslint-rules/no-error-factory-functions.cjs
@@ -1,6 +1,6 @@
 // https://eslint.org/docs/developer-guide/working-with-rules
 const path = require('pathe')
-const file = require('node:fs')
+const file = require('fs')
 const execa = require('execa')
 
 const errors = ['Abort', 'AbortSilent', 'Bug', 'BugSilent']

--- a/packages/cli-hydrogen/src/cli/services/deploy/upload.test.ts
+++ b/packages/cli-hydrogen/src/cli/services/deploy/upload.test.ts
@@ -25,7 +25,7 @@ const defaultConfig: ReqDeployConfig = {
 beforeEach(() => {
   vi.mock('@shopify/cli-kit')
   vi.mock('@shopify/cli-kit/node/archiver')
-  vi.mock('node:fs')
+  vi.mock('fs')
 })
 
 describe('createDeploymentStep()', () => {

--- a/packages/cli-kit/src/file.ts
+++ b/packages/cli-kit/src/file.ts
@@ -20,7 +20,7 @@ import {
   statSync as fsStatSync,
   createReadStream as fsCreateReadStream,
   constants as fsConstants,
-} from 'node:fs'
+} from 'fs'
 import {
   mkdir as fsMkdir,
   writeFile as fsWriteFile,
@@ -32,7 +32,7 @@ import {
   lstat as fsLstat,
   chmod as fsChmod,
   access as fsAccess,
-} from 'node:fs/promises'
+} from 'fs/promises'
 import type {Options} from 'prettier'
 
 const DEFAULT_PRETTIER_CONFIG: Options = {


### PR DESCRIPTION
### WHY are these changes introduced?
The recent downgrade of the `@types/node` version doesn't support Node modules being imported with the `node:...` prefix. Due to a race condition merging that and [this other PR](https://github.com/Shopify/cli/pull/1027) we ended up with a broken `main`.

### WHAT is this pull request doing?
I'm adjusting the imports to fix CI.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
