### PR TITLE
Fix benchmark report

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -158,7 +158,7 @@ jobs:
         run: 'test -z "$(git status --porcelain "**/oclif.manifest.json" )" || { echo -e "Run pnpm refresh-manifests before pushing new commands or flags. Diff here:\n\n$(git diff)" ; exit 1; }'
 
   pr-platform-dependent:
-    name: Testing with Node ${{ matrix.node }} in ${{ matrix.os }}
+    name: test with Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: pr-platform-agnostic
     if: ${{ github.event_name == 'pull_request' }}
@@ -194,7 +194,7 @@ jobs:
           base-branch-name: "${{ github.base_ref }}"
       - name: Run and save benchmark
         uses: ./.github/actions/run-and-save-benchmark
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
+        if: ${{ matrix.os == 'macos-latest' && matrix.node == '18.7.0' }}
         with:
           branch-name: "${{ github.head_ref }}"
       - name: Download and publish benchmark
@@ -204,7 +204,7 @@ jobs:
           base-branch-name: "${{ github.base_ref }}"
 
   manually-triggered:
-    name: Testing with Node ${{ inputs.node-version }} in ${{ inputs.os }}
+    name: test with Node ${{ inputs.node-version }} in ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     if: ${{ github.event_name == 'workflow_dispatch' }}
     timeout-minutes: 60


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed the benchmark report broke after I set it up to run on `macos-latest`.

### WHAT is this pull request doing?
This PR fixes it by updating a step that I forgot to update.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
