### PR TITLE
Fix QRCode link when Surface is Point of Sale

### DIFF
--- a/fixtures/app/extensions/pos-ui-extension/shopify.ui.extension.toml
+++ b/fixtures/app/extensions/pos-ui-extension/shopify.ui.extension.toml
@@ -1,0 +1,11 @@
+type = "pos_ui_extension"
+name = "POS-UI-Extension"
+
+extension_points = [
+  'Retail::SmartGrid::Tile',
+  'Retail::SmartGrid::Modal'
+]
+
+[capabilities]
+network_access = true
+api_access = true

--- a/fixtures/app/extensions/pos-ui-extension/src/index.jsx
+++ b/fixtures/app/extensions/pos-ui-extension/src/index.jsx
@@ -1,0 +1,28 @@
+import { extend, Text } from "@shopify/retail-ui-extensions";
+
+extend('Retail::SmartGrid::Tile', (root, api) => {
+  const tileProps = {
+    title: 'My app',
+    subtitle: 'A test app',
+    enabled: true,
+    onPress: () => {
+      api.navigation.navigateToFullScreenModal();
+    }
+  }
+
+  const tile = root.createComponent('Tile', tileProps);
+
+  root.appendChild(tile);
+  root.mount();
+});
+
+extend('Retail::SmartGrid::Modal', (root, api) => {
+  root.appendChild(
+    root.createComponent(
+      Text,
+      {},
+      `Welcome to the ${api.extensionPoint} extension surface!`
+    )
+  );
+  root.mount();
+});

--- a/packages/app/src/cli/models/extensions/ui-specifications/pos_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/pos_ui_extension.ts
@@ -3,7 +3,7 @@ import {createUIExtensionSpecification} from '../ui.js'
 import {BaseUIExtensionSchema} from '../schemas.js'
 import {error} from '@shopify/cli-kit'
 
-const dependency = {name: '@shopify/retail-ui-extensions-react', version: '^0.19.0'}
+const dependency = {name: '@shopify/retail-ui-extensions-react', version: '^0.38.0'}
 
 const spec = createUIExtensionSpecification({
   identifier: 'pos_ui_extension',

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ActionSet/ActionSet.test.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ActionSet/ActionSet.test.tsx
@@ -84,8 +84,8 @@ describe('ActionSet', () => {
     )
   })
 
-  test('web url does not render if surface is pos', async () => {
-    const extension = mockExtension({surface: 'pos'})
+  test('web url does not render if surface is point_of_sale', async () => {
+    const extension = mockExtension({surface: 'point_of_sale'})
     const container = render(<ActionSet extension={extension} />, withProviders(DefaultProviders, TableWrapper), {
       client,
     })

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ActionSet/ActionSet.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ActionSet/ActionSet.tsx
@@ -25,7 +25,7 @@ export function ActionSet(props: ActionSetProps) {
   const {extension, className, onShowMobileQRCode} = props
   const {embedded, hide, navigate, refresh, show, state} = useExtensionsInternal()
   const hidden = extension.development.hidden
-  const hideWebUrl = extension.surface === 'pos'
+  const hideWebUrl = extension.surface === 'point_of_sale'
 
   const handleShowHide = useCallback(() => {
     if (hidden) {

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.test.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.test.tsx
@@ -61,7 +61,7 @@ describe('QRCodeModal', () => {
   test('renders QRCode with pos deep-link url when surface is POS', async () => {
     const app = mockApp()
     const store = 'example.com'
-    const extension = mockExtension({surface: 'pos'})
+    const extension = mockExtension({surface: 'point_of_sale'})
     const container = render(
       <QRCodeModal extension={extension} onClose={vi.fn()} open />,
       withProviders(DefaultProviders, ToastProvider),

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.tsx
@@ -41,7 +41,7 @@ export function QRCodeContent(props: Pick<QRCodeModalProps, 'extension'>) {
     if (!state.app || !extension) {
       return undefined
     }
-    console.log('surface:', extension)
+
     if (extension.surface === 'point_of_sale') {
       return `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}`
     } else {

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.tsx
@@ -41,8 +41,8 @@ export function QRCodeContent(props: Pick<QRCodeModalProps, 'extension'>) {
     if (!state.app || !extension) {
       return undefined
     }
-
-    if (extension.surface === 'pos') {
+    console.log('surface:', extension)
+    if (extension.surface === 'point_of_sale') {
       return `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}`
     } else {
       return `https://${state.store}/admin/extensions-dev/mobile?url=${extension.development.root.url}`

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
@@ -144,7 +144,7 @@ declare global {
   }
 }
 
-export const AVAILABLE_SURFACES = ['admin', 'checkout', 'post-checkout', 'pos', 'customer-accounts'] as const
+export const AVAILABLE_SURFACES = ['admin', 'checkout', 'post-checkout', 'point_of_sale', 'customer-accounts'] as const
 
 export type Surface = typeof AVAILABLE_SURFACES[number]
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/pos-next-react-native/issues/19682

For POS UI Extensions, scanning QRCode from developer console opens Shopify mobile instead of POS.

### WHAT is this pull request doing?

Fixes the wrong surface name and updating the `retail-ui-extensions` to point to the most recent version,

### How to test your changes?

1. Created a new Extension.
2. Updated Tests

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
