### PR TITLE
[Feature] Improve apiversion devx for webhook trigger

### DIFF
--- a/packages/app/src/cli/commands/webhook/trigger.ts
+++ b/packages/app/src/cli/commands/webhook/trigger.ts
@@ -1,5 +1,5 @@
 import {DELIVERY_METHOD} from '../../services/webhook/trigger-options.js'
-import {WebhookTriggerFlags, optionsPrompt} from '../../prompts/webhook/options-prompt.js'
+import {WebhookTriggerFlags} from '../../prompts/webhook/options-prompt.js'
 import {webhookTriggerService} from '../../services/webhook/trigger.js'
 import {deliveryMethodInstructionsAsString} from '../../prompts/webhook/trigger.js'
 import {Flags} from '@oclif/core'
@@ -63,8 +63,6 @@ export default class WebhookTrigger extends Command {
       sharedSecret: flags['shared-secret'],
     }
 
-    const options = await optionsPrompt(usedFlags)
-
-    await webhookTriggerService(options)
+    await webhookTriggerService(usedFlags)
   }
 }

--- a/packages/app/src/cli/prompts/webhook/options-prompt.test.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.test.ts
@@ -1,7 +1,6 @@
 import {optionsPrompt, WebhookTriggerFlags} from './options-prompt.js'
 import {addressPrompt, apiVersionPrompt, deliveryMethodPrompt, sharedSecretPrompt, topicPrompt} from './trigger.js'
 import {WebhookTriggerOptions} from '../../services/webhook/trigger-options.js'
-import {requestApiVersions} from '../../services/webhook/request-api-versions.js'
 import {describe, it, expect, vi, afterEach, beforeEach} from 'vitest'
 import {error} from '@shopify/cli-kit'
 
@@ -30,8 +29,6 @@ describe('optionsPrompt', () => {
 
   describe('without params', () => {
     beforeEach(async () => {
-      vi.mocked(requestApiVersions).mockResolvedValue([aVersion])
-
       vi.mocked(topicPrompt).mockResolvedValue(aTopic)
       vi.mocked(sharedSecretPrompt).mockResolvedValue(aSecret)
     })
@@ -41,7 +38,7 @@ describe('optionsPrompt', () => {
       vi.mocked(apiVersionPrompt).mockResolvedValue(unknownVersion)
 
       // Then when
-      await expect(optionsPrompt({})).rejects.toThrow(error.Abort)
+      await expect(optionsPrompt({}, [aVersion])).rejects.toThrow(error.Abort)
     })
 
     it('collects HTTP localhost params', async () => {
@@ -51,7 +48,7 @@ describe('optionsPrompt', () => {
       vi.mocked(addressPrompt).mockResolvedValue(aLocalAddress)
 
       // When
-      const options = await optionsPrompt({})
+      const options = await optionsPrompt({}, [aVersion])
 
       // Then
       const expected: WebhookTriggerOptions = {
@@ -73,7 +70,7 @@ describe('optionsPrompt', () => {
       vi.mocked(addressPrompt).mockResolvedValue(anAddress)
 
       // When
-      const options = await optionsPrompt({})
+      const options = await optionsPrompt({}, [aVersion])
 
       // Then
       const expected: WebhookTriggerOptions = {
@@ -98,8 +95,6 @@ describe('optionsPrompt', () => {
 
   describe('with params', () => {
     beforeEach(async () => {
-      vi.mocked(requestApiVersions).mockResolvedValue([aVersion])
-
       vi.mocked(topicPrompt)
       vi.mocked(apiVersionPrompt)
       vi.mocked(sharedSecretPrompt)
@@ -114,7 +109,7 @@ describe('optionsPrompt', () => {
       }
 
       // Then when
-      await expect(optionsPrompt(flags)).rejects.toThrow(error.Abort)
+      await expect(optionsPrompt(flags, [aVersion])).rejects.toThrow(error.Abort)
     })
 
     describe('all params', () => {
@@ -129,7 +124,7 @@ describe('optionsPrompt', () => {
         }
 
         // When
-        const options = await optionsPrompt(flags)
+        const options = await optionsPrompt(flags, [aVersion])
 
         // Then
         const expected: WebhookTriggerOptions = {
@@ -154,7 +149,7 @@ describe('optionsPrompt', () => {
         }
 
         // When
-        const options = await optionsPrompt(flags)
+        const options = await optionsPrompt(flags, [aVersion])
 
         // Then
         const expected: WebhookTriggerOptions = {
@@ -179,7 +174,7 @@ describe('optionsPrompt', () => {
         }
 
         // Then when
-        await expect(optionsPrompt(flags)).rejects.toThrow(error.Abort)
+        await expect(optionsPrompt(flags, [aVersion])).rejects.toThrow(error.Abort)
       })
 
       it('fails when delivery method is not valid', async () => {
@@ -193,7 +188,7 @@ describe('optionsPrompt', () => {
         }
 
         // Then when
-        await expect(optionsPrompt(flags)).rejects.toThrow(error.Abort)
+        await expect(optionsPrompt(flags, [aVersion])).rejects.toThrow(error.Abort)
       })
     })
 
@@ -208,7 +203,7 @@ describe('optionsPrompt', () => {
         }
 
         // When
-        const options = await optionsPrompt(flags)
+        const options = await optionsPrompt(flags, [aVersion])
 
         // Then
         const expected: WebhookTriggerOptions = {
@@ -235,7 +230,7 @@ describe('optionsPrompt', () => {
         vi.mocked(addressPrompt).mockResolvedValue(aLocalAddress)
 
         // When
-        const options = await optionsPrompt(flags)
+        const options = await optionsPrompt(flags, [aVersion])
 
         // Then
         const expected: WebhookTriggerOptions = {

--- a/packages/app/src/cli/prompts/webhook/options-prompt.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.ts
@@ -13,7 +13,7 @@ import {
   isAddressAllowedForDeliveryMethod,
 } from '../../services/webhook/trigger-options.js'
 import {requestApiVersions} from '../../services/webhook/request-api-versions.js'
-import {error, output} from '@shopify/cli-kit'
+import {error} from '@shopify/cli-kit'
 
 /**
  * Flags collected from the command line parameters
@@ -57,11 +57,14 @@ export async function optionsPrompt(flags: WebhookTriggerFlags): Promise<Webhook
     if (availableVersions.includes(passedApiVersion)) {
       options.apiVersion = passedApiVersion
     } else {
-      await output.consoleError(
-        `Api Version ${passedApiVersion} does not exist. Allowed values: ${availableVersions.join(', ')}`,
+      throw new error.Abort(
+        `Api Version '${passedApiVersion}' does not exist`,
+        `Allowed values: ${availableVersions.join(', ')}`,
+        ['Try again with a valid api-version value'],
       )
-      options.apiVersion = await apiVersionPrompt(availableVersions)
     }
+  } else {
+    options.apiVersion = await apiVersionPrompt(availableVersions)
   }
 
   const methodPassed = flagPassed(flags.deliveryMethod)
@@ -71,6 +74,7 @@ export async function optionsPrompt(flags: WebhookTriggerFlags): Promise<Webhook
     throw new error.Abort(
       'Invalid Delivery Method passed',
       `${DELIVERY_METHOD.HTTP}, ${DELIVERY_METHOD.PUBSUB}, and ${DELIVERY_METHOD.EVENTBRIDGE} are allowed`,
+      ['Try again with a valid delivery method'],
     )
   }
 
@@ -80,8 +84,8 @@ export async function optionsPrompt(flags: WebhookTriggerFlags): Promise<Webhook
       options.deliveryMethod = inferMethodFromAddress(options.address)
     } else {
       throw new error.Abort(
-        "Can't deliver your webhook payload to this address. Run 'shopify webhook trigger --address=<VALUE>' with a valid URL",
-        undefined,
+        "Can't deliver your webhook payload to this address",
+        "Run 'shopify webhook trigger --address=<VALUE>' with a valid URL",
         deliveryMethodInstructions(flags.deliveryMethod as string),
       )
     }

--- a/packages/app/src/cli/prompts/webhook/options-prompt.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.ts
@@ -12,7 +12,6 @@ import {
   deliveryMethodForAddress,
   isAddressAllowedForDeliveryMethod,
 } from '../../services/webhook/trigger-options.js'
-import {requestApiVersions} from '../../services/webhook/request-api-versions.js'
 import {error} from '@shopify/cli-kit'
 
 /**
@@ -37,9 +36,13 @@ export interface WebhookTriggerFlags {
  *   needing ngrok
  *
  * @param flags - Flags collected from the command-line arguments
+ * @param availableVersions - Available API Versions
  * @returns flags/prompts transformed into WebhookTriggerOptions to pass to the service
  */
-export async function optionsPrompt(flags: WebhookTriggerFlags): Promise<WebhookTriggerOptions> {
+export async function optionsPrompt(
+  flags: WebhookTriggerFlags,
+  availableVersions: string[],
+): Promise<WebhookTriggerOptions> {
   const options: WebhookTriggerOptions = {
     topic: '',
     apiVersion: '',
@@ -47,8 +50,6 @@ export async function optionsPrompt(flags: WebhookTriggerFlags): Promise<Webhook
     deliveryMethod: '',
     address: '',
   }
-
-  const availableVersions = await requestApiVersions()
 
   const apiVersionPassed = flagPassed(flags.apiVersion)
 

--- a/packages/app/src/cli/prompts/webhook/trigger.test.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.test.ts
@@ -36,20 +36,23 @@ describe('topicPrompt', () => {
 describe('apiVersionPrompt', () => {
   it('asks the user to enter an api_version', async () => {
     // Given
-    vi.mocked(ui.prompt).mockResolvedValue({apiVersion: '2022-01'})
+    vi.mocked(ui.prompt).mockResolvedValue({apiVersion: '2022-10'})
 
     // When
-    const got = await apiVersionPrompt()
+    const got = await apiVersionPrompt(['2023-01', '2022-10', 'unstable'])
 
     // Then
-    expect(got).toEqual('2022-01')
+    expect(got).toEqual('2022-10')
     expect(ui.prompt).toHaveBeenCalledWith([
       {
-        type: 'input',
+        type: 'select',
         name: 'apiVersion',
         message: 'Webhook ApiVersion',
-        default: '2022-10',
-        validate: expect.any(Function),
+        choices: [
+          {name: '2023-01', value: '2023-01'},
+          {name: '2022-10', value: '2022-10'},
+          {name: 'unstable', value: 'unstable'},
+        ],
       },
     ])
   })

--- a/packages/app/src/cli/prompts/webhook/trigger.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.ts
@@ -20,19 +20,15 @@ export async function topicPrompt(): Promise<string> {
   return input.topic
 }
 
-export async function apiVersionPrompt(): Promise<string> {
+export async function apiVersionPrompt(availableVersions: string[]): Promise<string> {
+  const choices = availableVersions.map((version) => ({name: version, value: version}))
+
   const input = await ui.prompt([
     {
-      type: 'input',
+      type: 'select',
       name: 'apiVersion',
       message: 'Webhook ApiVersion',
-      default: '2022-10',
-      validate: (value: string) => {
-        if (value.length === 0) {
-          return "ApiVersion name can't be empty"
-        }
-        return true
-      },
+      choices,
     },
   ])
 

--- a/packages/app/src/cli/services/webhook/request-api-versions.test.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.test.ts
@@ -1,6 +1,6 @@
 import {requestApiVersions} from './request-api-versions.js'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {api, session} from '@shopify/cli-kit'
+import {api} from '@shopify/cli-kit'
 
 beforeEach(async () => {
   vi.mock('@shopify/cli-kit')
@@ -10,11 +10,9 @@ afterEach(async () => {
   vi.clearAllMocks()
 })
 
-describe('requestApiVersions', () => {
-  beforeEach(async () => {
-    vi.mocked(session.ensureAuthenticatedPartners).mockResolvedValue('A_TOKEN')
-  })
+const aToken = 'A_TOKEN'
 
+describe('requestApiVersions', () => {
   it('calls partners to request data and returns ordered array', async () => {
     // Given
     const graphQLResult = {
@@ -23,14 +21,12 @@ describe('requestApiVersions', () => {
     vi.mocked(api.partners.request).mockResolvedValue(graphQLResult)
 
     const requestSpy = vi.spyOn(api.partners, 'request')
-    const sessionSpy = vi.spyOn(session, 'ensureAuthenticatedPartners')
 
     // When
-    const got = await requestApiVersions()
+    const got = await requestApiVersions(aToken)
 
     // Then
-    expect(sessionSpy).toHaveBeenCalledOnce()
-    expect(requestSpy).toHaveBeenCalledWith(expect.any(String), 'A_TOKEN')
+    expect(requestSpy).toHaveBeenCalledWith(expect.any(String), aToken)
     expect(got).toEqual(['2023', '2022', 'unstable'])
   })
 })

--- a/packages/app/src/cli/services/webhook/request-api-versions.test.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.test.ts
@@ -15,10 +15,10 @@ describe('requestApiVersions', () => {
     vi.mocked(session.ensureAuthenticatedPartners).mockResolvedValue('A_TOKEN')
   })
 
-  it('calls partners to request data', async () => {
+  it('calls partners to request data and returns ordered array', async () => {
     // Given
     const graphQLResult = {
-      apiVersions: ['version1', 'version2'],
+      publicApiVersions: ['2022', 'unstable', '2023'],
     }
     vi.mocked(api.partners.request).mockResolvedValue(graphQLResult)
 
@@ -31,6 +31,6 @@ describe('requestApiVersions', () => {
     // Then
     expect(sessionSpy).toHaveBeenCalledOnce()
     expect(requestSpy).toHaveBeenCalledWith(expect.any(String), 'A_TOKEN')
-    expect(got).toEqual(['version1', 'version2'])
+    expect(got).toEqual(['2023', '2022', 'unstable'])
   })
 })

--- a/packages/app/src/cli/services/webhook/request-api-versions.test.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.test.ts
@@ -1,0 +1,36 @@
+import {requestApiVersions} from './request-api-versions.js'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {api, session} from '@shopify/cli-kit'
+
+beforeEach(async () => {
+  vi.mock('@shopify/cli-kit')
+})
+
+afterEach(async () => {
+  vi.clearAllMocks()
+})
+
+describe('requestApiVersions', () => {
+  beforeEach(async () => {
+    vi.mocked(session.ensureAuthenticatedPartners).mockResolvedValue('A_TOKEN')
+  })
+
+  it('calls partners to request data', async () => {
+    // Given
+    const graphQLResult = {
+      apiVersions: ['version1', 'version2'],
+    }
+    vi.mocked(api.partners.request).mockResolvedValue(graphQLResult)
+
+    const requestSpy = vi.spyOn(api.partners, 'request')
+    const sessionSpy = vi.spyOn(session, 'ensureAuthenticatedPartners')
+
+    // When
+    const got = await requestApiVersions()
+
+    // Then
+    expect(sessionSpy).toHaveBeenCalledOnce()
+    expect(requestSpy).toHaveBeenCalledWith(expect.any(String), 'A_TOKEN')
+    expect(got).toEqual(['version1', 'version2'])
+  })
+})

--- a/packages/app/src/cli/services/webhook/request-api-versions.test.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.test.ts
@@ -1,9 +1,9 @@
 import {requestApiVersions} from './request-api-versions.js'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {api} from '@shopify/cli-kit'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 
 beforeEach(async () => {
-  vi.mock('@shopify/cli-kit')
+  vi.mock('@shopify/cli-kit/node/api/partners')
 })
 
 afterEach(async () => {
@@ -18,15 +18,12 @@ describe('requestApiVersions', () => {
     const graphQLResult = {
       publicApiVersions: ['2022', 'unstable', '2023'],
     }
-    vi.mocked(api.partners.request).mockResolvedValue(graphQLResult)
-
-    const requestSpy = vi.spyOn(api.partners, 'request')
+    vi.mocked(partnersRequest).mockResolvedValue(graphQLResult)
 
     // When
     const got = await requestApiVersions(aToken)
 
     // Then
-    expect(requestSpy).toHaveBeenCalledWith(expect.any(String), aToken)
     expect(got).toEqual(['2023', '2022', 'unstable'])
   })
 })

--- a/packages/app/src/cli/services/webhook/request-api-versions.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.ts
@@ -1,4 +1,4 @@
-import {api} from '@shopify/cli-kit'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 
 export interface PublicApiVersionsSchema {
   publicApiVersions: string[]
@@ -16,7 +16,7 @@ const getApiVersionsQuery = `
  * @param token - Partners session token
  */
 export async function requestApiVersions(token: string) {
-  const {publicApiVersions: result}: PublicApiVersionsSchema = await api.partners.request(getApiVersionsQuery, token)
+  const {publicApiVersions: result}: PublicApiVersionsSchema = await partnersRequest(getApiVersionsQuery, token)
 
   const unstableIdx = result.indexOf('unstable')
   if (unstableIdx === -1) {

--- a/packages/app/src/cli/services/webhook/request-api-versions.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.ts
@@ -1,0 +1,19 @@
+import {api, session} from '@shopify/cli-kit'
+
+export interface ApiVersionsSchema {
+  apiVersions: string[]
+}
+
+const getApiVersionsQuery = `
+  query getApiVersions {
+    apiVersions
+  }
+`
+
+export async function requestApiVersions() {
+  const token = await session.ensureAuthenticatedPartners()
+
+  const {apiVersions: result}: ApiVersionsSchema = await api.partners.request(getApiVersionsQuery, token)
+
+  return result
+}

--- a/packages/app/src/cli/services/webhook/request-api-versions.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.ts
@@ -1,19 +1,28 @@
 import {api, session} from '@shopify/cli-kit'
 
-export interface ApiVersionsSchema {
-  apiVersions: string[]
+export interface PublicApiVersionsSchema {
+  publicApiVersions: string[]
 }
 
 const getApiVersionsQuery = `
   query getApiVersions {
-    apiVersions
+    publicApiVersions
   }
 `
 
 export async function requestApiVersions() {
   const token = await session.ensureAuthenticatedPartners()
 
-  const {apiVersions: result}: ApiVersionsSchema = await api.partners.request(getApiVersionsQuery, token)
+  const {publicApiVersions: result}: PublicApiVersionsSchema = await api.partners.request(getApiVersionsQuery, token)
+
+  const unstableIdx = result.indexOf('unstable')
+  if (unstableIdx === -1) {
+    result.sort().reverse()
+  } else {
+    result.splice(unstableIdx, 1)
+    result.sort().reverse()
+    result.push('unstable')
+  }
 
   return result
 }

--- a/packages/app/src/cli/services/webhook/request-api-versions.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.ts
@@ -1,4 +1,4 @@
-import {api, session} from '@shopify/cli-kit'
+import {api} from '@shopify/cli-kit'
 
 export interface PublicApiVersionsSchema {
   publicApiVersions: string[]
@@ -10,9 +10,12 @@ const getApiVersionsQuery = `
   }
 `
 
-export async function requestApiVersions() {
-  const token = await session.ensureAuthenticatedPartners()
-
+/**
+ * Requests available api-versions in order to validate flags or present a list of options
+ *
+ * @param token - Partners session token
+ */
+export async function requestApiVersions(token: string) {
   const {publicApiVersions: result}: PublicApiVersionsSchema = await api.partners.request(getApiVersionsQuery, token)
 
   const unstableIdx = result.indexOf('unstable')

--- a/packages/app/src/cli/services/webhook/request-sample.test.ts
+++ b/packages/app/src/cli/services/webhook/request-sample.test.ts
@@ -7,8 +7,6 @@ const sampleHeaders = '{ "header": "Header Value" }'
 
 beforeEach(async () => {
   vi.mock('@shopify/cli-kit/node/api/partners')
-  vi.mock('@shopify/cli-kit')
-  vi.mock('@shopify/cli-kit/node/session')
 })
 
 afterEach(async () => {

--- a/packages/app/src/cli/services/webhook/request-sample.test.ts
+++ b/packages/app/src/cli/services/webhook/request-sample.test.ts
@@ -1,7 +1,6 @@
 import {getWebhookSample} from './request-sample.js'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners.js'
-import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 
 const samplePayload = '{ "sampleField": "SampleValue" }'
 const sampleHeaders = '{ "header": "Header Value" }'
@@ -16,11 +15,9 @@ afterEach(async () => {
   vi.clearAllMocks()
 })
 
-describe('getWebhookSample', () => {
-  beforeEach(async () => {
-    vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('A_TOKEN')
-  })
+const aToken = 'A_TOKEN'
 
+describe('getWebhookSample', () => {
   it('calls partners to request data', async () => {
     // Given
     const inputValues = {
@@ -52,6 +49,7 @@ describe('getWebhookSample', () => {
 
     // When
     const got = await getWebhookSample(
+      aToken,
       inputValues.topic,
       inputValues.apiVersion,
       inputValues.value,
@@ -60,7 +58,6 @@ describe('getWebhookSample', () => {
     )
 
     // Then
-    expect(ensureAuthenticatedPartners).toHaveBeenCalledOnce()
     expect(partnersRequest).toHaveBeenCalledWith(expect.any(String), 'A_TOKEN', requestValues)
     expect(got.samplePayload).toEqual(samplePayload)
     expect(got.headers).toEqual(sampleHeaders)

--- a/packages/app/src/cli/services/webhook/request-sample.ts
+++ b/packages/app/src/cli/services/webhook/request-sample.ts
@@ -1,5 +1,4 @@
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
-import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 
 export interface SamplePayloadSchema {
   sendSampleWebhook: {
@@ -35,6 +34,7 @@ const sendSampleWebhookMutation = `
  * In all the other cases, core creates a job that sends the request to Captain-Hook. Captain-Hook will be in
  * charge of delivering the webhook payload to the requested destination.
  *
+ * @param token - Partners session token
  * @param topic - A webhook topic (eg: orders/create)
  * @param apiVersion - Api version for the topic
  * @param deliveryMethod - one of DELIVERY_METHOD
@@ -43,14 +43,13 @@ const sendSampleWebhookMutation = `
  * @returns Empty if a remote delivery was requested, payload data if a local delivery was requested
  */
 export async function getWebhookSample(
+  token: string,
   topic: string,
   apiVersion: string,
   deliveryMethod: string,
   address: string,
   sharedSecret: string,
 ) {
-  const token = await ensureAuthenticatedPartners()
-
   const variables = {
     topic,
     api_version: apiVersion,

--- a/packages/app/src/cli/services/webhook/trigger-local-webhook.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger-local-webhook.test.ts
@@ -1,5 +1,4 @@
 import {triggerLocalWebhook} from './trigger-local-webhook.js'
-
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {http} from '@shopify/cli-kit'
 

--- a/packages/app/src/cli/services/webhook/trigger.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger.test.ts
@@ -4,7 +4,8 @@ import {getWebhookSample} from './request-sample.js'
 import {requestApiVersions} from './request-api-versions.js'
 import {triggerLocalWebhook} from './trigger-local-webhook.js'
 import {optionsPrompt, WebhookTriggerFlags} from '../../prompts/webhook/options-prompt.js'
-import {output, session} from '@shopify/cli-kit'
+import {output} from '@shopify/cli-kit'
+import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 const aToken = 'A_TOKEN'
@@ -19,6 +20,7 @@ const anAddress = 'http://example.org'
 
 beforeEach(async () => {
   vi.mock('@shopify/cli-kit')
+  vi.mock('@shopify/cli-kit/node/session')
   vi.mock('../../prompts/webhook/options-prompt.js')
   vi.mock('./request-sample.js')
   vi.mock('./request-api-versions.js')
@@ -46,7 +48,7 @@ const aFullLocalAddress = `http://localhost:${aPort}${aUrlPath}`
 
 describe('execute', () => {
   beforeEach(async () => {
-    vi.mocked(session.ensureAuthenticatedPartners).mockResolvedValue(aToken)
+    vi.mocked(ensureAuthenticatedPartners).mockResolvedValue(aToken)
   })
 
   it('notifies about request errors', async () => {
@@ -60,7 +62,6 @@ describe('execute', () => {
         {message: '["Unable to notify example"]', fields: ['field2']},
       ],
     }
-    const sessionSpy = vi.spyOn(session, 'ensureAuthenticatedPartners')
     vi.mocked(getWebhookSample).mockResolvedValue(response)
     vi.mocked(requestApiVersions).mockResolvedValue([aVersion])
     vi.mocked(optionsPrompt).mockResolvedValue(sampleOptions())
@@ -74,7 +75,6 @@ describe('execute', () => {
     expect(outputSpy).toHaveBeenCalledWith(
       `Request errors:\n  · Invalid topic pizza/update\n  · Unable to notify example`,
     )
-    expect(sessionSpy).toHaveBeenCalledOnce()
     expect(requestApiVersions).toHaveBeenCalledWith(aToken)
   })
 

--- a/packages/app/src/cli/services/webhook/trigger.ts
+++ b/packages/app/src/cli/services/webhook/trigger.ts
@@ -1,16 +1,25 @@
-import {DELIVERY_METHOD, WebhookTriggerOptions} from './trigger-options.js'
+import {DELIVERY_METHOD} from './trigger-options.js'
 import {getWebhookSample, UserErrors} from './request-sample.js'
 import {triggerLocalWebhook} from './trigger-local-webhook.js'
-import {output} from '@shopify/cli-kit'
+import {requestApiVersions} from './request-api-versions.js'
+import {optionsPrompt, WebhookTriggerFlags} from '../../prompts/webhook/options-prompt.js'
+import {output, session} from '@shopify/cli-kit'
 
 /**
  * Orchestrates the command request by requesting the sample and sending it to localhost if required.
  * It outputs the result in console
  *
- * @param options - Request options once the flags, prompts, and transformations have been performed
+ * @param flags - Passed flags
  */
-export async function webhookTriggerService(options: WebhookTriggerOptions) {
+export async function webhookTriggerService(flags: WebhookTriggerFlags) {
+  const token = await session.ensureAuthenticatedPartners()
+
+  const availableVersions = await requestApiVersions(token)
+
+  const options = await optionsPrompt(flags, availableVersions)
+
   const sample = await getWebhookSample(
+    token,
     options.topic,
     options.apiVersion,
     options.deliveryMethod,

--- a/packages/app/src/cli/services/webhook/trigger.ts
+++ b/packages/app/src/cli/services/webhook/trigger.ts
@@ -3,7 +3,8 @@ import {getWebhookSample, UserErrors} from './request-sample.js'
 import {triggerLocalWebhook} from './trigger-local-webhook.js'
 import {requestApiVersions} from './request-api-versions.js'
 import {optionsPrompt, WebhookTriggerFlags} from '../../prompts/webhook/options-prompt.js'
-import {output, session} from '@shopify/cli-kit'
+import {output} from '@shopify/cli-kit'
+import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 
 /**
  * Orchestrates the command request by requesting the sample and sending it to localhost if required.
@@ -12,7 +13,7 @@ import {output, session} from '@shopify/cli-kit'
  * @param flags - Passed flags
  */
 export async function webhookTriggerService(flags: WebhookTriggerFlags) {
-  const token = await session.ensureAuthenticatedPartners()
+  const token = await ensureAuthenticatedPartners()
 
   const availableVersions = await requestApiVersions(token)
 


### PR DESCRIPTION
### WHY are these changes introduced?

In the initial version of webhook trigger, several flags that requested as free text fields can be requested as options list. i.e. api-version and topic

This PR addresses the api-version flag and includes several improvements:

1. It is requested before the topic (in a future PR the list of available topics will depend on the api-version you selected)
2. If using prompt, the valid values are presented as a list of options
3. If passed as a flag, the flag value is validated against the list of valid values. If it fails, the whole process stops (no more flags will be requested) 

### WHAT is this pull request doing?

```
pnpm shopify webhook trigger --api-version=unknown
```
returns:
```
╭─ error ────────────────────────────────────────────────────────────────────────────╮
│                                                                                    │
│  Api Version 'unknown' does not exist                                              │
│                                                                                    │
│  Allowed values: 2023-04, 2023-01, 2022-10, 2022-07, 2022-04, 2022-01, unstable    │
│                                                                                    │
│  Next steps                                                                        │
│    • Try again with a valid api-version value                                      │
│                                                                                    │
╰────────────────────────────────────────────────────────────────────────────────────╯
```
```
pnpm shopify webhook trigger
```
prompts:
```
? Webhook ApiVersion …
> 2023-04
  2023-01
  2022-10
  2022-07
  2022-04
  2022-01
  unstable
```

### How to test your changes?

Spin up a constellation such as this one:
```
schema: v1
extend: identity
repos:
  - partners:
      env:
        DISABLE_SHOPIFY_INTERNAL_API_INTERCEPTOR: "1"
  - captain-hook
  - shopify
  - storefront-renderer
  - web
```

With the Partners branch that contains the endpoint to request api versions:
```
spin up cli-constellation.yml -c partners.branch=apiversions-cli-endpoint
```

Get the github repo, change to the PR branch and execute the webhook trigger command against the spin instance:
```
NODE_TLS_REJECT_UNAUTHORIZED=0 SPIN=1 SHOPIFY_PARTNERS_ENV=spin SHOPIFY_SHOPIFY_ENV=spin SHOPIFY_IDENTITY_ENV=spin SPIN_INSTANCE=cli-constellation-tc1e SPIN_WORKSPACE=1 SPIN_NAMESPACE=1 pnpm shopify webhook trigger
```

### Pre-release steps

**The Partners branch needs to be deployed first**
https://github.com/Shopify/partners/pull/44590

That's deployed and I re-tested the cli part against Partners production to make sure it still works ✅ 

### Post-release steps

None, I think

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
