### PR TITLE
Add an alias, `p`, for `pnpm` that gets activated by `shadowenv`

### DIFF
--- a/bin/shadowenv/p
+++ b/bin/shadowenv/p
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+printf "\033[0;32mNote that p is an alias for pnpm activated by shadowenv in the CLI repository\n\033[0m"
+pnpm $@


### PR DESCRIPTION
### WHY are these changes introduced?
It's common for developers to make typos when running `pnpm`.

### WHAT is this pull request doing?
I'm introducing an alias, `p`, that's activated by [shadowenv](https://shopify.github.io/shadowenv/) when we are positioned in the CLI directory or any sub-directory.

### How to test your changes?
Check out the branch and run `p install`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
