### PR TITLE
Disable max commits for nightly

### DIFF
--- a/shipit.nightly.yml
+++ b/shipit.nightly.yml
@@ -11,6 +11,7 @@ dependencies:
     - bash -i -c "pnpm install"
 deploy:
   interval: 24h
+  max_commits: null
   override:
     - |-
       bash -i -c 'echo -e "---\n'"'@shopify/cli'"': patch\n---" > .changeset/force-nightly-build.md'


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

By default, shipit continuous deployment is limited to 8 commits at a time.

Since nightly is supposed to be shipping whatever is on the tip of main, and it doesn't have to be stable, this limitation doesn't make sense.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Removes the commit limit for nightly CD

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
