### PR TITLE
Move the Ngrok plugin to App

### DIFF
--- a/.changeset/heavy-oranges-joke.md
+++ b/.changeset/heavy-oranges-joke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Add the @shopify/ngrok plugin to the @shopify/app package

--- a/.changeset/old-tomatoes-pump.md
+++ b/.changeset/old-tomatoes-pump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': minor
+---
+
+Remove the @shopify/ngrok plugin from @shopify/cli

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -52,7 +52,8 @@
     "graphql-request": "4.3.0",
     "http-proxy": "1.18.1",
     "serve-static": "1.15.0",
-    "ws": "8.8.1"
+    "ws": "8.8.1",
+    "@shopify/plugin-ngrok": "3.32.1"
   },
   "devDependencies": {
     "@types/diff": "^5.0.2",
@@ -84,6 +85,9 @@
     "hooks": {
       "public_command_metadata": "./dist/cli/hooks/public_metadata",
       "sensitive_command_metadata": "./dist/cli/hooks/sensitive_metadata"
-    }
+    },
+    "plugins": [
+      "@shopify/plugin-ngrok"
+    ]
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -97,8 +97,7 @@
     "@oclif/plugin-commands": "2.2.0",
     "@oclif/plugin-help": "5.1.12",
     "@oclif/plugin-plugins": "2.1.0",
-    "@shopify/cli-kit": "3.32.1",
-    "@shopify/plugin-ngrok": "3.32.1"
+    "@shopify/cli-kit": "3.32.1"
   },
   "devDependencies": {
     "@shopify/app": "3.32.1",
@@ -130,7 +129,6 @@
       "@shopify/theme",
       "@shopify/cli-hydrogen",
       "@oclif/plugin-help",
-      "@shopify/plugin-ngrok",
       "@oclif/plugin-plugins",
       "@oclif/plugin-commands"
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,7 @@ importers:
       '@luckycatfactory/esbuild-graphql-loader': 3.7.0
       '@oclif/core': 1.21.0
       '@shopify/cli-kit': 3.32.1
+      '@shopify/plugin-ngrok': 3.32.1
       '@shopify/shopify-cli-extensions': 3.21.0
       '@types/diff': ^5.0.2
       '@types/http-proxy': ^1.17.9
@@ -249,6 +250,7 @@ importers:
       '@luckycatfactory/esbuild-graphql-loader': 3.7.0_t5hz6ir3hkf4yglirnvrkce4ii
       '@oclif/core': 1.21.0
       '@shopify/cli-kit': link:../cli-kit
+      '@shopify/plugin-ngrok': link:../plugin-ngrok
       '@shopify/shopify-cli-extensions': 3.21.0_graphql-tag@2.12.6
       abort-controller: 3.0.0
       chokidar: 3.5.3
@@ -279,7 +281,6 @@ importers:
       '@shopify/app': 3.32.1
       '@shopify/cli-hydrogen': 3.32.1
       '@shopify/cli-kit': 3.32.1
-      '@shopify/plugin-ngrok': 3.32.1
       '@shopify/theme': 3.32.1
       '@types/node': 14.17.0
       '@vitest/coverage-istanbul': ^0.26.3
@@ -291,7 +292,6 @@ importers:
       '@oclif/plugin-help': 5.1.12
       '@oclif/plugin-plugins': 2.1.0
       '@shopify/cli-kit': link:../cli-kit
-      '@shopify/plugin-ngrok': link:../plugin-ngrok
     devDependencies:
       '@shopify/app': link:../app
       '@shopify/cli-hydrogen': link:../cli-hydrogen


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed that the Ngrok is tied to the CLI which leads to the plugin loading for theme and hydrogen development too.

### WHAT is this pull request doing?
I'm removing it from `@shopify/cli` and adding it to `@shopify/app`.

### How to test your changes?
Try to `dev` the fixture app. It should generate the tunnel URL successfully.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
