### PR TITLE
Admin UI extension redirect

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -54,7 +54,7 @@ describe('getExtensionPointRedirectUrl()', () => {
     const result = getExtensionPointRedirectUrl('Admin::CheckoutEditor::RenderSettings', extension, options)
 
     expect(result).toBe(
-      'https://example.myshopify.com/admin/extensions-dev?url=https%3A%2F%2Flocalhost%3A8081%2Fextensions%2F123abc',
+      'https://example.myshopify.com/admin/extensions-dev?url=https%3A%2F%2Flocalhost%3A8081%2Fextensions%2F123abc&target=Admin%3A%3ACheckoutEditor%3A%3ARenderSettings',
     )
   })
 

--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -40,6 +40,7 @@ export function getExtensionPointRedirectUrl(
     case 'admin':
       rawUrl.pathname = 'admin/extensions-dev'
       rawUrl.searchParams.append('url', getExtensionUrl(extension, options))
+      rawUrl.searchParams.append('target', requestedTarget)
       break
     default:
       return undefined


### PR DESCRIPTION
### WHY are these changes introduced?

The new UI Extension specification contains multiple extension point targets. In order to support the preview link in Admin we need to include the target as a query param so Admin knows where to redirect to.

### WHAT is this pull request doing?

Add the extension point target to the query param for Admin redirect urls

### How to test your changes?

No manual testing is needed for this change. The unit test should be sufficient.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
