### PR TITLE
Make clear which prompt is for

### DIFF
--- a/packages/app/src/cli/services/environment/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers-extensions.test.ts
@@ -401,6 +401,7 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
 
     // Then
     expect(deployConfirmationPrompt).toBeCalledWith({
+      question: 'Make the following changes to your extensions in Shopify Partners?',
       identifiers: {
         EXTENSION_A: 'UUID_A',
         EXTENSION_A_2: 'UUID_A_2',

--- a/packages/app/src/cli/services/environment/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/environment/identifiers-extensions.ts
@@ -39,6 +39,7 @@ export async function ensureExtensionsIds(
 
   if (!options.force) {
     const confirmed = await deployConfirmationPrompt({
+      question: 'Make the following changes to your extensions in Shopify Partners?',
       identifiers: validMatches,
       toCreate: extensionsToCreate,
       onlyRemote: onlyRemoteExtensions,

--- a/packages/app/src/cli/services/environment/identifiers-functions.test.ts
+++ b/packages/app/src/cli/services/environment/identifiers-functions.test.ts
@@ -326,6 +326,7 @@ describe('ensureFunctionsIds: asks user to confirm deploy', () => {
 
     // Then
     expect(deployConfirmationPrompt).toBeCalledWith({
+      question: 'Make the following changes to your functions in Shopify Partners?',
       identifiers: {
         FUNCTION_A: 'ID_A',
         FUNCTION_A_2: 'ID_A_2',

--- a/packages/app/src/cli/services/environment/identifiers-functions.ts
+++ b/packages/app/src/cli/services/environment/identifiers-functions.ts
@@ -34,6 +34,7 @@ export async function ensureFunctionsIds(
 
   if (!options.force) {
     const confirmed = await deployConfirmationPrompt({
+      question: 'Make the following changes to your functions in Shopify Partners?',
       identifiers: validMatches,
       toCreate: functionsToCreate,
       onlyRemote: onlyRemoteFunctions,

--- a/packages/app/src/cli/services/environment/prompts.ts
+++ b/packages/app/src/cli/services/environment/prompts.ts
@@ -41,6 +41,7 @@ export async function selectRemoteSourcePrompt(
 }
 
 interface SourceSummary {
+  question: string
   identifiers: IdentifiersExtensions
   toCreate: LocalSource[]
   onlyRemote: RemoteSource[]
@@ -64,7 +65,7 @@ export async function deployConfirmationPrompt(summary: SourceSummary): Promise<
   }
 
   return renderSelectPrompt({
-    message: 'Make the following changes in Shopify Partners?',
+    message: summary.question,
     choices: [
       {label: 'Yes, deploy to push changes', value: true, key: 'y'},
       {label: 'No, cancel', value: false, key: 'n'},


### PR DESCRIPTION
### WHY are these changes introduced?

We show two confirmation prompts, one for functions and one for extensions. It's a bit confusing now because we don't tell the user which is which.

### WHAT is this pull request doing?

Customize the label so that the user knows what's going on.

<img width="528" alt="Screenshot 2023-01-12 at 17 06 57" src="https://user-images.githubusercontent.com/62895/212318579-4bc9312f-3be6-44a3-81b8-8c7ec1747ad5.png">


### How to test your changes?

- Create a new app
- Add a function
- Add an extension
- Deploy


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
