### PR TITLE
Fix id matching for functions

### DIFF
--- a/packages/app/src/cli/models/extensions/functions.ts
+++ b/packages/app/src/cli/models/extensions/functions.ts
@@ -62,7 +62,7 @@ export class FunctionInstance<TConfiguration extends FunctionConfigType = Functi
   }
 
   get graphQLType() {
-    return this.specification.identifier
+    return this.specification.identifier.toUpperCase()
   }
 
   get identifier() {

--- a/packages/app/src/cli/services/environment/id-matching.ts
+++ b/packages/app/src/cli/services/environment/id-matching.ts
@@ -112,11 +112,13 @@ export async function automaticMatchmaking(
   identifiers: IdentifiersExtensions,
   remoteIdField: 'id' | 'uuid',
 ): Promise<MatchResult> {
-  const localUUIDs = Object.values(identifiers)
+  const localSourcesIds = localSources.map((source) => source.localIdentifier)
+  const ids = pickBy(identifiers, (_, id) => localSourcesIds.includes(id))
+  const localUUIDs = Object.values(ids)
   const existsRemotely = (local: LocalSource) => {
     return Boolean(
       remoteSources.find(
-        (remote) => remote[remoteIdField] === identifiers[local.localIdentifier] && remote.type === local.graphQLType,
+        (remote) => remote[remoteIdField] === ids[local.localIdentifier] && remote.type === local.graphQLType,
       ),
     )
   }
@@ -137,7 +139,7 @@ export async function automaticMatchmaking(
   const {toConfirm, toCreate, pending} = matchByUniqueType(matchResult.local, matchResult.remote)
 
   return {
-    identifiers: {...identifiers, ...matchedByNameAndType},
+    identifiers: {...ids, ...matchedByNameAndType},
     toConfirm,
     toCreate,
     toManualMatch: pending,


### PR DESCRIPTION
### WHY are these changes introduced?

It turns out that the automatic id matching logic wasn't fully working for functions. Also functions were being picked up by the extension matching logic.

### WHAT is this pull request doing?

- fix automatic id matching for functions
- isolate matchmaking between functions and extensions so that existing identifiers only apply for the correct type

### How to test your changes?

- create a new app
- add a function
- deploy
- deploy again
- everything should be normal


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
