### PR TITLE
Import performance from perf_hooks

### DIFF
--- a/packages/cli-kit/src/private/node/api/graphql.ts
+++ b/packages/cli-kit/src/private/node/api/graphql.ts
@@ -3,6 +3,7 @@ import {stringifyMessage, content, token as outputToken, token, debug} from '../
 import {Abort} from '../../../error.js'
 import {httpsAgent} from '../../../http.js'
 import {ClientError, GraphQLClient, RequestDocument, Variables} from 'graphql-request'
+import {performance} from 'perf_hooks'
 
 export interface GraphQLVariables {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
It only became a global object in Node 16+

### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1092

### WHAT is this pull request doing?

Import it explicitly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
