### PR TITLE
Add extra timeout before restarting `theme dev`

### DIFF
--- a/.changeset/blue-items-mate.md
+++ b/.changeset/blue-items-mate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Add extra timeout when restarting theme dev

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -7,6 +7,7 @@ import {output} from '@shopify/cli-kit'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import {ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
+import {sleep} from '@shopify/cli-kit/node/system'
 
 export default class Dev extends ThemeCommand {
   static description =
@@ -117,6 +118,7 @@ export default class Dev extends ThemeCommand {
   }
 
   async execute(store: string, password: string | undefined, command: string[], controller: AbortController) {
+    await sleep(3)
     const adminSession = await ensureAuthenticatedThemes(store, password, [], true)
     const storefrontToken = await ensureAuthenticatedStorefront([], password)
     return execCLI2(command, {adminSession, storefrontToken, signal: controller.signal})


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
`theme dev` restarts itself after 2h to refresh tokens, but there seems to be a race condition where we start the new `dev` process before the previous one has been completely closed (so the port 9292 might not be free yet)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Wait for 3 seconds before starting the process again
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
