### PR TITLE
Fix output for pnpm commands with parameters

### DIFF
--- a/.changeset/old-gifts-fold.md
+++ b/.changeset/old-gifts-fold.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix output for pnpm commands with parameters

--- a/packages/cli-kit/src/output.test.ts
+++ b/packages/cli-kit/src/output.test.ts
@@ -5,11 +5,11 @@ describe('Output helpers', () => {
   it('can format dependency manager commands with flags', () => {
     expect(token.packagejsonScript('yarn', 'dev', '--reset').value).toEqual('yarn dev --reset')
     expect(token.packagejsonScript('npm', 'dev', '--reset').value).toEqual('npm run dev -- --reset')
-    expect(token.packagejsonScript('pnpm', 'dev', '--reset').value).toEqual('pnpm run dev -- --reset')
+    expect(token.packagejsonScript('pnpm', 'dev', '--reset').value).toEqual('pnpm dev --reset')
   })
   it('can format dependency manager commands without flags', () => {
     expect(token.packagejsonScript('yarn', 'dev').value).toEqual('yarn dev')
     expect(token.packagejsonScript('npm', 'dev').value).toEqual('npm run dev')
-    expect(token.packagejsonScript('pnpm', 'dev').value).toEqual('pnpm run dev')
+    expect(token.packagejsonScript('pnpm', 'dev').value).toEqual('pnpm dev')
   })
 })

--- a/packages/cli-kit/src/output.ts
+++ b/packages/cli-kit/src/output.ts
@@ -95,13 +95,13 @@ export function formatPackageManagerCommand(
   ...scriptArgs: string[]
 ): string {
   switch (packageManager) {
+    case 'pnpm':
     case 'yarn': {
-      const pieces = ['yarn', scriptName, ...scriptArgs]
+      const pieces = [packageManager, scriptName, ...scriptArgs]
       return pieces.join(' ')
     }
-    case 'pnpm':
     case 'npm': {
-      const pieces = [packageManager, 'run', scriptName]
+      const pieces = ['npm', 'run', scriptName]
       if (scriptArgs.length > 0) {
         pieces.push('--')
         pieces.push(...scriptArgs)


### PR DESCRIPTION
### WHY are these changes introduced?

When running the dev command with pnpm, we show this message:
```
To reset your default dev config, run pnpm run dev -- --reset
```

But that command doesn't work:

![pnpm-reset](https://user-images.githubusercontent.com/14979109/212862129-89431a98-e07e-4a6d-9c1e-927415883bdc.png)

### WHAT is this pull request doing?

Pnmp works like Yarn and doesn't require `run` or `--` for the parameters, so I'm showing `pnpm dev --reset` instead of `pnpm run dev -- --reset` (and the same for any other command).

### How to test your changes?

- `pnpm create @shopify/app`
- `pnpm dev`
- `pnpm dev --reset`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
