### PR TITLE
[Feature] Change webhook topic DX offering autocompletion

### DIFF
--- a/packages/app/src/cli/prompts/webhook/options-prompt.test.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.test.ts
@@ -1,6 +1,5 @@
-import {optionsPrompt, WebhookTriggerFlags} from './options-prompt.js'
+import {collectAddressAndMethod, collectApiVersion, collectSecret, collectTopic} from './options-prompt.js'
 import {addressPrompt, apiVersionPrompt, deliveryMethodPrompt, sharedSecretPrompt, topicPrompt} from './trigger.js'
-import {WebhookTriggerOptions} from '../../services/webhook/trigger-options.js'
 import {describe, it, expect, vi, afterEach, beforeEach} from 'vitest'
 import {error} from '@shopify/cli-kit'
 
@@ -15,6 +14,7 @@ afterEach(async () => {
 const aTopic = 'A_TOPIC'
 const aVersion = 'A_VERSION'
 const unknownVersion = 'UNKNOWN_VERSION'
+const unknownTopic = 'UNKNOWN_TOPIC'
 const aSecret = 'A_SECRET'
 const aPort = '1234'
 const aUrlPath = '/a/url/path'
@@ -24,7 +24,6 @@ const aLocalAddress = `http://localhost:${aPort}${aUrlPath}`
 describe('optionsPrompt', () => {
   beforeEach(async () => {
     vi.mock('./trigger.js')
-    vi.mock('../../services/webhook/request-api-versions.js')
   })
 
   describe('without params', () => {
@@ -33,64 +32,33 @@ describe('optionsPrompt', () => {
       vi.mocked(sharedSecretPrompt).mockResolvedValue(aSecret)
     })
 
-    it('fails when unknown version passed', async () => {
-      // Given
-      vi.mocked(apiVersionPrompt).mockResolvedValue(unknownVersion)
-
-      // Then when
-      await expect(optionsPrompt({}, [aVersion])).rejects.toThrow(error.Abort)
-    })
-
     it('collects HTTP localhost params', async () => {
       // Given
-      vi.mocked(apiVersionPrompt).mockResolvedValue(aVersion)
       vi.mocked(deliveryMethodPrompt).mockResolvedValue('http')
       vi.mocked(addressPrompt).mockResolvedValue(aLocalAddress)
 
       // When
-      const options = await optionsPrompt({}, [aVersion])
+      const [method, address] = await collectAddressAndMethod(undefined, undefined)
 
       // Then
-      const expected: WebhookTriggerOptions = {
-        topic: aTopic,
-        apiVersion: aVersion,
-        sharedSecret: aSecret,
-        deliveryMethod: 'localhost',
-        address: aLocalAddress,
-      }
-      expect(options).toEqual(expected)
-      expectBasicPromptsToHaveBeenCalledOnce()
+      expect(method).toEqual('localhost')
+      expect(address).toEqual(aLocalAddress)
       expect(addressPrompt).toHaveBeenCalledOnce()
     })
 
     it('collects HTTP remote delivery params', async () => {
       // Given
-      vi.mocked(apiVersionPrompt).mockResolvedValue(aVersion)
       vi.mocked(deliveryMethodPrompt).mockResolvedValue('http')
       vi.mocked(addressPrompt).mockResolvedValue(anAddress)
 
       // When
-      const options = await optionsPrompt({}, [aVersion])
+      const [method, address] = await collectAddressAndMethod(undefined, undefined)
 
       // Then
-      const expected: WebhookTriggerOptions = {
-        topic: aTopic,
-        apiVersion: aVersion,
-        sharedSecret: aSecret,
-        deliveryMethod: 'http',
-        address: anAddress,
-      }
-      expect(options).toEqual(expected)
-      expectBasicPromptsToHaveBeenCalledOnce()
+      expect(method).toEqual('http')
+      expect(address).toEqual(anAddress)
       expect(addressPrompt).toHaveBeenCalledOnce()
     })
-
-    function expectBasicPromptsToHaveBeenCalledOnce() {
-      expect(topicPrompt).toHaveBeenCalledOnce()
-      expect(apiVersionPrompt).toHaveBeenCalledOnce()
-      expect(sharedSecretPrompt).toHaveBeenCalledOnce()
-      expect(deliveryMethodPrompt).toHaveBeenCalledOnce()
-    }
   })
 
   describe('with params', () => {
@@ -103,117 +71,61 @@ describe('optionsPrompt', () => {
     })
 
     it('fails when unknown version', async () => {
-      // Given
-      const flags: WebhookTriggerFlags = {
-        apiVersion: unknownVersion,
-      }
+      // When
+      await expect(collectApiVersion(unknownVersion, [aVersion])).rejects.toThrow(error.Abort)
+    })
 
-      // Then when
-      await expect(optionsPrompt(flags, [aVersion])).rejects.toThrow(error.Abort)
+    it('fails when unknown topic', async () => {
+      // When
+      await expect(collectTopic(unknownTopic, aVersion, [aTopic])).rejects.toThrow(error.Abort)
     })
 
     describe('all params', () => {
       it('collects localhost delivery method required params', async () => {
-        // Given
-        const flags: WebhookTriggerFlags = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          deliveryMethod: 'http',
-          address: aLocalAddress,
-        }
-
         // When
-        const options = await optionsPrompt(flags, [aVersion])
+        const version = await collectApiVersion(aVersion, [aVersion])
+        const topic = await collectTopic(aTopic, aVersion, [aTopic])
+        const secret = await collectSecret(aSecret)
+        const [deliveryMethod, address] = await collectAddressAndMethod('http', aLocalAddress)
 
         // Then
-        const expected: WebhookTriggerOptions = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          deliveryMethod: 'localhost',
-          address: aLocalAddress,
-        }
-        expect(options).toEqual(expected)
+        expect(version).toEqual(aVersion)
+        expect(topic).toEqual(aTopic)
+        expect(secret).toEqual(aSecret)
+        expect(deliveryMethod).toEqual('localhost')
+        expect(address).toEqual(aLocalAddress)
         expectNoPrompts()
       })
 
       it('collects remote delivery method required params', async () => {
-        // Given
-        const flags: WebhookTriggerFlags = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          deliveryMethod: 'http',
-          address: anAddress,
-        }
-
         // When
-        const options = await optionsPrompt(flags, [aVersion])
+        const [deliveryMethod, address] = await collectAddressAndMethod('http', anAddress)
 
         // Then
-        const expected: WebhookTriggerOptions = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          deliveryMethod: 'http',
-          address: anAddress,
-        }
-        expect(options).toEqual(expected)
+        expect(deliveryMethod).toEqual('http')
+        expect(address).toEqual(anAddress)
         expectNoPrompts()
       })
 
       it('fails when delivery method and address are not compatible', async () => {
-        // Given
-        const flags: WebhookTriggerFlags = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          deliveryMethod: 'google-pub-sub',
-          address: anAddress,
-        }
-
-        // Then when
-        await expect(optionsPrompt(flags, [aVersion])).rejects.toThrow(error.Abort)
+        // When
+        await expect(collectAddressAndMethod('google-pub-sub', anAddress)).rejects.toThrow(error.Abort)
       })
 
       it('fails when delivery method is not valid', async () => {
-        // Given
-        const flags: WebhookTriggerFlags = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          deliveryMethod: 'WRONG_METHOD',
-          address: anAddress,
-        }
-
-        // Then when
-        await expect(optionsPrompt(flags, [aVersion])).rejects.toThrow(error.Abort)
+        // When
+        await expect(collectAddressAndMethod('WRONG_METHOD', anAddress)).rejects.toThrow(error.Abort)
       })
     })
 
     describe('Address passed but not method', async () => {
       it('infers the method from the address', async () => {
-        // Given
-        const flags: WebhookTriggerFlags = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          address: aLocalAddress,
-        }
-
         // When
-        const options = await optionsPrompt(flags, [aVersion])
+        const [deliveryMethod, address] = await collectAddressAndMethod(undefined, aLocalAddress)
 
         // Then
-        const expected: WebhookTriggerOptions = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          deliveryMethod: 'localhost',
-          address: aLocalAddress,
-        }
-        expect(options).toEqual(expected)
+        expect(deliveryMethod).toEqual('localhost')
+        expect(address).toEqual(aLocalAddress)
         expectNoPrompts()
       })
     })
@@ -221,27 +133,14 @@ describe('optionsPrompt', () => {
     describe('Method passed but not address', async () => {
       it('prompts for the address', async () => {
         // Given
-        const flags: WebhookTriggerFlags = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          deliveryMethod: 'http',
-        }
         vi.mocked(addressPrompt).mockResolvedValue(aLocalAddress)
 
         // When
-        const options = await optionsPrompt(flags, [aVersion])
+        const [deliveryMethod, address] = await collectAddressAndMethod('http', undefined)
 
         // Then
-        const expected: WebhookTriggerOptions = {
-          topic: aTopic,
-          apiVersion: aVersion,
-          sharedSecret: aSecret,
-          deliveryMethod: 'localhost',
-          address: aLocalAddress,
-        }
-        expect(options).toEqual(expected)
-        expect(addressPrompt).toHaveBeenCalledOnce()
+        expect(deliveryMethod).toEqual('localhost')
+        expect(address).toEqual(aLocalAddress)
       })
     })
 

--- a/packages/app/src/cli/prompts/webhook/options-prompt.test.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.test.ts
@@ -80,6 +80,11 @@ describe('optionsPrompt', () => {
       await expect(collectTopic(unknownTopic, aVersion, [aTopic])).rejects.toThrow(error.Abort)
     })
 
+    it('fails when no topics', async () => {
+      // When
+      await expect(collectTopic(aTopic, aVersion, [])).rejects.toThrow(error.Abort)
+    })
+
     describe('all params', () => {
       it('collects localhost delivery method required params', async () => {
         // When

--- a/packages/app/src/cli/prompts/webhook/options-prompt.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.ts
@@ -8,7 +8,6 @@ import {
 } from './trigger.js'
 import {
   DELIVERY_METHOD,
-  WebhookTriggerOptions,
   deliveryMethodForAddress,
   isAddressAllowedForDeliveryMethod,
 } from '../../services/webhook/trigger-options.js'
@@ -25,93 +24,105 @@ export interface WebhookTriggerFlags {
   sharedSecret?: string
 }
 
-/**
- * Collect all required data, validate and transform values into options for the Service
- * Some UX decisions:
- * - Flags validation will happen before we request any prompts
- * - Any option not passed as a flag will be requested via prompt
- * - In the case of having a flag for address and not for delivery-method, the delivery-method will be inferred from it
- * - An http delivery method sent to a localhost address will be transformed into a localhost delivery method.
- *   `localhost` is only internal: it requests core to return the data so that the plugin will deliver it locally without
- *   needing ngrok
- *
- * @param flags - Flags collected from the command-line arguments
- * @param availableVersions - Available API Versions
- * @returns flags/prompts transformed into WebhookTriggerOptions to pass to the service
- */
-export async function optionsPrompt(
-  flags: WebhookTriggerFlags,
-  availableVersions: string[],
-): Promise<WebhookTriggerOptions> {
-  const options: WebhookTriggerOptions = {
-    topic: '',
-    apiVersion: '',
-    sharedSecret: '',
-    deliveryMethod: '',
-    address: '',
-  }
-
-  const apiVersionPassed = flagPassed(flags.apiVersion)
+export async function collectApiVersion(apiVersion: string | undefined, availableVersions: string[]): Promise<string> {
+  const apiVersionPassed = flagPassed(apiVersion)
 
   if (apiVersionPassed) {
-    const passedApiVersion = (flags.apiVersion as string).trim()
+    const passedApiVersion = (apiVersion as string).trim()
     if (availableVersions.includes(passedApiVersion)) {
-      options.apiVersion = passedApiVersion
-    } else {
-      throw new error.Abort(
-        `Api Version '${passedApiVersion}' does not exist`,
-        `Allowed values: ${availableVersions.join(', ')}`,
-        ['Try again with a valid api-version value'],
-      )
+      return passedApiVersion
     }
-  } else {
-    options.apiVersion = await apiVersionPrompt(availableVersions)
+    throw new error.Abort(
+      `Api Version '${passedApiVersion}' does not exist`,
+      `Allowed values: ${availableVersions.join(', ')}`,
+      ['Try again with a valid api-version value'],
+    )
   }
 
-  const methodPassed = flagPassed(flags.deliveryMethod)
-  const addressPassed = flagPassed(flags.address)
+  const promptedApiVersion = await apiVersionPrompt(availableVersions)
 
-  if (methodPassed && !validDeliveryMethodFlag(flags.deliveryMethod)) {
+  return promptedApiVersion
+}
+
+export async function collectTopic(
+  topic: string | undefined,
+  apiVersion: string,
+  availableTopics: string[],
+): Promise<string> {
+  const topicPassed = flagPassed(topic)
+
+  if (topicPassed) {
+    const passedTopic = (topic as string).trim()
+    if (availableTopics.includes(passedTopic)) {
+      return passedTopic
+    }
+    throw new error.Abort(
+      `Topic '${passedTopic}' does not exist for ApiVersion '${apiVersion}'`,
+      `Allowed values: ${availableTopics.join(', ')}`,
+      ['Try again with a valid api-version - topic pair'],
+    )
+  }
+
+  const promptedTopic = await topicPrompt(availableTopics)
+
+  return promptedTopic
+}
+
+export async function collectAddressAndMethod(
+  deliveryMethod: string | undefined,
+  address: string | undefined,
+): Promise<[string, string]> {
+  const methodWasPassed = flagPassed(deliveryMethod)
+  const addressWasPassed = flagPassed(address)
+
+  if (methodWasPassed && !validDeliveryMethodFlag(deliveryMethod)) {
     throw new error.Abort(
       'Invalid Delivery Method passed',
       `${DELIVERY_METHOD.HTTP}, ${DELIVERY_METHOD.PUBSUB}, and ${DELIVERY_METHOD.EVENTBRIDGE} are allowed`,
       ['Try again with a valid delivery method'],
     )
   }
+  // Method is valid
 
-  if (methodPassed && addressPassed) {
-    if (isAddressAllowedForDeliveryMethod(flags.address as string, flags.deliveryMethod as string)) {
-      options.address = (flags.address as string).trim()
-      options.deliveryMethod = inferMethodFromAddress(options.address)
+  let actualAddress = ''
+  let actualMethod = ''
+
+  if (methodWasPassed && addressWasPassed) {
+    if (isAddressAllowedForDeliveryMethod(address as string, deliveryMethod as string)) {
+      actualAddress = (address as string).trim()
+      actualMethod = inferMethodFromAddress(actualAddress)
     } else {
       throw new error.Abort(
-        "Can't deliver your webhook payload to this address",
+        `Can't deliver your webhook payload to this address using '${deliveryMethod}'`,
         "Run 'shopify webhook trigger --address=<VALUE>' with a valid URL",
-        deliveryMethodInstructions(flags.deliveryMethod as string),
+        deliveryMethodInstructions(deliveryMethod as string),
       )
     }
   }
 
-  if (!methodPassed && addressPassed) {
-    options.address = (flags.address as string).trim()
-    options.deliveryMethod = inferMethodFromAddress(options.address)
+  if (!methodWasPassed && addressWasPassed) {
+    actualAddress = (address as string).trim()
+    actualMethod = inferMethodFromAddress(actualAddress)
   }
 
-  options.topic = await useFlagOrPrompt(flags.topic, topicPrompt)
-  options.sharedSecret = await useFlagOrPrompt(flags.sharedSecret, sharedSecretPrompt)
+  if (methodWasPassed && !addressWasPassed) {
+    actualAddress = await addressPrompt(deliveryMethod as string)
+    actualMethod = inferMethodFromAddress(actualAddress)
+  }
 
-  if (!methodPassed && !addressPassed) {
+  if (!methodWasPassed && !addressWasPassed) {
     const method = await deliveryMethodPrompt()
-    options.address = await addressPrompt(method)
-    options.deliveryMethod = inferMethodFromAddress(options.address)
+    actualAddress = await addressPrompt(method)
+    actualMethod = inferMethodFromAddress(actualAddress)
   }
 
-  if (methodPassed && !addressPassed) {
-    options.address = await addressPrompt(flags.deliveryMethod as string)
-    options.deliveryMethod = inferMethodFromAddress(options.address)
-  }
+  return [actualMethod, actualAddress]
+}
 
-  return options
+export async function collectSecret(sharedSecret: string | undefined): Promise<string> {
+  const secret = await useFlagOrPrompt(sharedSecret, sharedSecretPrompt)
+
+  return secret
 }
 
 async function useFlagOrPrompt(value: string | undefined, prompt: () => Promise<string>): Promise<string> {
@@ -132,7 +143,6 @@ function validDeliveryMethodFlag(value: string | undefined): boolean {
 
 function inferMethodFromAddress(address: string): string {
   const method = deliveryMethodForAddress(address)
-
   if (method === undefined) {
     throw new error.Abort(
       'No delivery method available for the address',

--- a/packages/app/src/cli/prompts/webhook/options-prompt.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.ts
@@ -63,6 +63,9 @@ export async function collectTopic(
     )
   }
 
+  if (availableTopics.length === 0) {
+    throw new error.Abort(`No topics found for '${apiVersion}'`)
+  }
   const promptedTopic = await topicPrompt(availableTopics)
 
   return promptedTopic

--- a/packages/app/src/cli/prompts/webhook/trigger.test.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.test.ts
@@ -17,17 +17,19 @@ describe('topicPrompt', () => {
     vi.mocked(ui.prompt).mockResolvedValue({topic: 'orders/create'})
 
     // When
-    const got = await topicPrompt()
+    const got = await topicPrompt(['orders/create', 'anything/else'])
 
     // Then
     expect(got).toEqual('orders/create')
     expect(ui.prompt).toHaveBeenCalledWith([
       {
-        type: 'input',
+        type: 'select',
         name: 'topic',
         message: 'Webhook Topic',
-        default: '',
-        validate: expect.any(Function),
+        choices: [
+          {name: 'orders/create', value: 'orders/create'},
+          {name: 'anything/else', value: 'anything/else'},
+        ],
       },
     ])
   })

--- a/packages/app/src/cli/prompts/webhook/trigger.test.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.test.ts
@@ -29,7 +29,6 @@ describe('topicPrompt', () => {
         {label: 'orders/create', value: 'orders/create'},
         {label: 'anything/else', value: 'anything/else'},
       ],
-      search: expect.any(Function),
     })
   })
 })

--- a/packages/app/src/cli/prompts/webhook/trigger.test.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.test.ts
@@ -2,9 +2,11 @@ import {addressPrompt, apiVersionPrompt, deliveryMethodPrompt, sharedSecretPromp
 import {DELIVERY_METHOD} from '../../services/webhook/trigger-options.js'
 import {describe, it, expect, vi, afterEach, beforeEach} from 'vitest'
 import {ui} from '@shopify/cli-kit'
+import {renderAutocompletePrompt} from '@shopify/cli-kit/node/ui'
 
 beforeEach(() => {
   vi.mock('@shopify/cli-kit')
+  vi.mock('@shopify/cli-kit/node/ui')
 })
 
 afterEach(async () => {
@@ -14,24 +16,21 @@ afterEach(async () => {
 describe('topicPrompt', () => {
   it('asks the user to enter a topic name', async () => {
     // Given
-    vi.mocked(ui.prompt).mockResolvedValue({topic: 'orders/create'})
+    vi.mocked(renderAutocompletePrompt).mockResolvedValue('orders/create')
 
     // When
     const got = await topicPrompt(['orders/create', 'anything/else'])
 
     // Then
     expect(got).toEqual('orders/create')
-    expect(ui.prompt).toHaveBeenCalledWith([
-      {
-        type: 'autocomplete',
-        name: 'topic',
-        message: 'Webhook Topic',
-        choices: [
-          {name: 'orders/create', value: 'orders/create'},
-          {name: 'anything/else', value: 'anything/else'},
-        ],
-      },
-    ])
+    expect(renderAutocompletePrompt).toHaveBeenCalledWith({
+      message: 'Webhook Topic',
+      choices: [
+        {label: 'orders/create', value: 'orders/create'},
+        {label: 'anything/else', value: 'anything/else'},
+      ],
+      search: expect.any(Function),
+    })
   })
 })
 

--- a/packages/app/src/cli/prompts/webhook/trigger.test.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.test.ts
@@ -23,7 +23,7 @@ describe('topicPrompt', () => {
     expect(got).toEqual('orders/create')
     expect(ui.prompt).toHaveBeenCalledWith([
       {
-        type: 'select',
+        type: 'autocomplete',
         name: 'topic',
         message: 'Webhook Topic',
         choices: [

--- a/packages/app/src/cli/prompts/webhook/trigger.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.ts
@@ -1,19 +1,19 @@
 import {DELIVERY_METHOD, isAddressAllowedForDeliveryMethod} from '../../services/webhook/trigger-options.js'
 import {ui, output} from '@shopify/cli-kit'
+import {renderAutocompletePrompt} from '@shopify/cli-kit/node/ui'
 
 export async function topicPrompt(availableTopics: string[]): Promise<string> {
-  const choices = availableTopics.map((topic) => ({name: topic, value: topic}))
+  const choicesList = availableTopics.map((topic) => ({label: topic, value: topic}))
 
-  const input = await ui.prompt([
-    {
-      type: 'autocomplete',
-      name: 'topic',
-      message: 'Webhook Topic',
-      choices,
+  const chosen = await renderAutocompletePrompt({
+    message: 'Webhook Topic',
+    choices: choicesList,
+    search(term: string) {
+      return Promise.resolve(choicesList.filter((item) => item.label.includes(term)))
     },
-  ])
+  })
 
-  return input.topic
+  return chosen
 }
 
 export async function apiVersionPrompt(availableVersions: string[]): Promise<string> {

--- a/packages/app/src/cli/prompts/webhook/trigger.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.ts
@@ -6,7 +6,7 @@ export async function topicPrompt(availableTopics: string[]): Promise<string> {
 
   const input = await ui.prompt([
     {
-      type: 'select',
+      type: 'autocomplete',
       name: 'topic',
       message: 'Webhook Topic',
       choices,

--- a/packages/app/src/cli/prompts/webhook/trigger.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.ts
@@ -1,19 +1,15 @@
 import {DELIVERY_METHOD, isAddressAllowedForDeliveryMethod} from '../../services/webhook/trigger-options.js'
 import {ui, output} from '@shopify/cli-kit'
 
-export async function topicPrompt(): Promise<string> {
+export async function topicPrompt(availableTopics: string[]): Promise<string> {
+  const choices = availableTopics.map((topic) => ({name: topic, value: topic}))
+
   const input = await ui.prompt([
     {
-      type: 'input',
+      type: 'select',
       name: 'topic',
       message: 'Webhook Topic',
-      default: '',
-      validate: (value: string) => {
-        if (value.length === 0) {
-          return "Topic name can't be empty"
-        }
-        return true
-      },
+      choices,
     },
   ])
 

--- a/packages/app/src/cli/prompts/webhook/trigger.ts
+++ b/packages/app/src/cli/prompts/webhook/trigger.ts
@@ -8,9 +8,6 @@ export async function topicPrompt(availableTopics: string[]): Promise<string> {
   const chosen = await renderAutocompletePrompt({
     message: 'Webhook Topic',
     choices: choicesList,
-    search(term: string) {
-      return Promise.resolve(choicesList.filter((item) => item.label.includes(term)))
-    },
   })
 
   return chosen

--- a/packages/app/src/cli/services/webhook/request-api-versions.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.ts
@@ -14,8 +14,9 @@ const getApiVersionsQuery = `
  * Requests available api-versions in order to validate flags or present a list of options
  *
  * @param token - Partners session token
+ * @returns List of public api-versions
  */
-export async function requestApiVersions(token: string) {
+export async function requestApiVersions(token: string): Promise<string[]> {
   const {publicApiVersions: result}: PublicApiVersionsSchema = await partnersRequest(getApiVersionsQuery, token)
 
   const unstableIdx = result.indexOf('unstable')

--- a/packages/app/src/cli/services/webhook/request-sample.ts
+++ b/packages/app/src/cli/services/webhook/request-sample.ts
@@ -1,12 +1,13 @@
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 
+interface SampleWebhook {
+  samplePayload: string
+  headers: string
+  success: boolean
+  userErrors: UserErrors[]
+}
 export interface SamplePayloadSchema {
-  sendSampleWebhook: {
-    samplePayload: string
-    headers: string
-    success: boolean
-    userErrors: UserErrors[]
-  }
+  sendSampleWebhook: SampleWebhook
 }
 
 export interface UserErrors {
@@ -49,7 +50,7 @@ export async function getWebhookSample(
   deliveryMethod: string,
   address: string,
   sharedSecret: string,
-) {
+): Promise<SampleWebhook> {
   const variables = {
     topic,
     api_version: apiVersion,

--- a/packages/app/src/cli/services/webhook/request-topics.test.ts
+++ b/packages/app/src/cli/services/webhook/request-topics.test.ts
@@ -11,6 +11,7 @@ afterEach(async () => {
 })
 
 const aToken = 'A_TOKEN'
+const aVersion = 'SOME_VERSION'
 
 describe('requestTopics', () => {
   it('calls partners to request topics data and returns array', async () => {
@@ -21,7 +22,7 @@ describe('requestTopics', () => {
     vi.mocked(partnersRequest).mockResolvedValue(graphQLResult)
 
     // When
-    const got = await requestTopics(aToken)
+    const got = await requestTopics(aToken, aVersion)
 
     // Then
     expect(got).toEqual(['orders/create', 'shop/redact'])

--- a/packages/app/src/cli/services/webhook/request-topics.test.ts
+++ b/packages/app/src/cli/services/webhook/request-topics.test.ts
@@ -1,0 +1,29 @@
+import {requestTopics} from './request-topics.js'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+
+beforeEach(async () => {
+  vi.mock('@shopify/cli-kit/node/api/partners')
+})
+
+afterEach(async () => {
+  vi.clearAllMocks()
+})
+
+const aToken = 'A_TOKEN'
+
+describe('requestTopics', () => {
+  it('calls partners to request topics data and returns array', async () => {
+    // Given
+    const graphQLResult = {
+      webhookTopics: ['orders/create', 'shop/redact'],
+    }
+    vi.mocked(partnersRequest).mockResolvedValue(graphQLResult)
+
+    // When
+    const got = await requestTopics(aToken)
+
+    // Then
+    expect(got).toEqual(['orders/create', 'shop/redact'])
+  })
+})

--- a/packages/app/src/cli/services/webhook/request-topics.ts
+++ b/packages/app/src/cli/services/webhook/request-topics.ts
@@ -1,0 +1,25 @@
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+
+export interface WebhookTopicsSchema {
+  webhookTopics: string[]
+}
+
+const getTopicsQuery = `
+  query getWebhookTopics($api_version: String!) {
+    webhookTopics(apiVersion: $api_version)
+  }
+`
+
+/**
+ * Requests topics for an api-version in order to validate flags or present a list of options
+ *
+ * @param token - Partners session token
+ * @param apiVersion - ApiVersion of the topics
+ * @returns - Available webhook topics for the api-version
+ */
+export async function requestTopics(token: string, apiVersion: string): Promise<string[]> {
+  const variables = {api_version: apiVersion}
+  const {webhookTopics: result}: WebhookTopicsSchema = await partnersRequest(getTopicsQuery, token, variables)
+
+  return result
+}

--- a/packages/app/src/cli/services/webhook/trigger-options.ts
+++ b/packages/app/src/cli/services/webhook/trigger-options.ts
@@ -13,17 +13,6 @@ const PROTOCOL = {
 }
 
 /**
- * Transformed flags
- */
-export interface WebhookTriggerOptions {
-  topic: string
-  apiVersion: string
-  deliveryMethod: string
-  sharedSecret: string
-  address: string
-}
-
-/**
  * Detect which delivery-method an address belongs to
  *
  * @param address - A target endpoint


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/orgs/Shopify/projects/4831/views/1?pane=issue&itemId=8991753

Fast follow up to our first version
We want to validate the topic ASAP in the client. For that means, we collect the available topics and force the user to use a valid one from an autocomplete list

### WHAT is this pull request doing?

**Before:** 
The user has to add a topic in an free text input box

**After:**
![demo](https://screenshot.click/16-39-nmkei-z11kb.gif)

### How to test your changes?

Use the following branches:
* Partners: available-webhook-topics-endpoint (https://github.com/Shopify/partners/pull/44762)
* Core: apiversion-topics-cli-endpoint (https://github.com/Shopify/shopify/pull/400352)


### Post-release steps

None yet

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
