### PR TITLE
Update app deploy CLI UI

### DIFF
--- a/nano
+++ b/nano
@@ -1,0 +1,2 @@
+/Users/nausherrao/.bash_profile
+/Users/nausherrao/.bash_profile $

--- a/nano
+++ b/nano
@@ -1,2 +1,0 @@
-/Users/nausherrao/.bash_profile
-/Users/nausherrao/.bash_profile $

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -14,6 +14,7 @@ import {Identifiers, updateAppIdentifiers} from '../models/app/identifiers.js'
 import {Extension} from '../models/app/extensions.js'
 import {validateExtensions} from '../validators/extensions.js'
 import {OrganizationApp} from '../models/organization.js'
+import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {path, output, file, environment} from '@shopify/cli-kit'
 import {AllAppExtensionRegistrationsQuerySchema} from '@shopify/cli-kit/src/api/graphql'
 
@@ -101,9 +102,6 @@ export const deploy = async (options: DeployOptions) => {
       } else {
         output.success('Deployed to Shopify')
       }
-
-      output.completed(`You can view the current deployment state here: ${'https://partners.shopify.com/'}`)
-
       const registrations = await fetchAppExtensionRegistrations({token, apiKey: identifiers.app})
 
       await outputCompletionMessage({
@@ -141,10 +139,19 @@ async function outputCompletionMessage({
   registrations: AllAppExtensionRegistrationsQuerySchema
   validationErrors: UploadExtensionValidationError[]
 }) {
-  output.newline()
-  output.info('  Summary:')
   const outputDeployedButNotLiveMessage = (extension: Extension) => {
-    output.info(output.content`    • ${extension.localIdentifier} is deployed to Shopify but not yet live`)
+    renderSuccess({
+      headline: 'Deployment successful.',
+      body: 'Your extensions have been uploaded to your Shopify Partners Dashboard.',
+      nextSteps: [
+        {
+          link: {
+            label: 'See your deployment and set it live',
+            url: 'https://partners.shopify.com/1797046/apps/4523695/deployments',
+          },
+        },
+      ],
+    })
     const uuid = identifiers.extensions[extension.localIdentifier]
     const validationError = validationErrors.find((error) => error.uuid === uuid)
 

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -102,6 +102,8 @@ export const deploy = async (options: DeployOptions) => {
         output.success('Deployed to Shopify')
       }
 
+      output.completed(`You can view the current deployment state here: ${'https://partners.shopify.com/'}`)
+
       const registrations = await fetchAppExtensionRegistrations({token, apiKey: identifiers.app})
 
       await outputCompletionMessage({


### PR DESCRIPTION
### WHY are these changes introduced?
Fixed [#87](https://github.com/Shopify/app-deploys/issues/87)

### WHAT is this pull request doing?
Adding more information to the summary of a deployment to allow the user to go to the deployment page straight away.

### How to test your changes?
`shopify app deploy`

### Measuring impac
How do we know this change was effective? Please choose one:
- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
