### PR TITLE
Add link to success UI screen to app deploy

### DIFF
--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -18,6 +18,7 @@ import {AllAppExtensionRegistrationsQuerySchema} from '../api/graphql/all_app_ex
 import {path, output} from '@shopify/cli-kit'
 import {useThemeBundling} from '@shopify/cli-kit/node/environment/local'
 import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs'
+import {renderSuccess} from '@shopify/cli-kit/node/ui'
 
 interface DeployOptions {
   /** The app to be built and uploaded */
@@ -144,10 +145,19 @@ async function outputCompletionMessage({
   registrations: AllAppExtensionRegistrationsQuerySchema
   validationErrors: UploadExtensionValidationError[]
 }) {
-  output.newline()
-  output.info('  Summary:')
   const outputDeployedButNotLiveMessage = (extension: Extension) => {
-    output.info(output.content`    • ${extension.localIdentifier} is deployed to Shopify but not yet live`)
+    renderSuccess({
+      headline: 'Deployment successful.',
+      body: 'Your extensions have been uploaded to your Shopify Partners Dashboard.',
+      nextSteps: [
+        {
+          link: {
+            label: 'See your deployment and set it live',
+            url: `https://partners.shopify.com/${partnersOrganizationId}/apps/${partnersApp.id}/deployments`,
+          },
+        },
+      ],
+    })
     const uuid = identifiers.extensions[extension.localIdentifier]
     const validationError = validationErrors.find((error) => error.uuid === uuid)
 

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -160,7 +160,6 @@ async function outputCompletionMessage({
     })
     const uuid = identifiers.extensions[extension.localIdentifier]
     const validationError = validationErrors.find((error) => error.uuid === uuid)
-
     if (validationError) {
       const title = output.token.errorText('Validation errors found in your extension toml file')
       output.info(output.content`       - ${title} `)
@@ -170,7 +169,18 @@ async function outputCompletionMessage({
     }
   }
   const outputDeployedAndLivedMessage = (extension: Extension) => {
-    output.info(output.content`    · ${extension.localIdentifier} is live`)
+    renderSuccess({
+      headline: 'Deployment successful.',
+      body: 'Your extensions have been uploaded to your Shopify Partners Dashboard.',
+      nextSteps: [
+        {
+          link: {
+            label: 'See your live deployment.',
+            url: `https://partners.shopify.com/${partnersOrganizationId}/apps/${partnersApp.id}/deployments`,
+          },
+        },
+      ],
+    })
   }
   app.extensions.ui.forEach(outputDeployedButNotLiveMessage)
   app.extensions.theme.forEach(outputDeployedButNotLiveMessage)

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -182,6 +182,7 @@ async function outputCompletionMessage({
       ],
     })
   }
+
   app.extensions.ui.forEach(outputDeployedButNotLiveMessage)
   app.extensions.theme.forEach(outputDeployedButNotLiveMessage)
   app.extensions.function.forEach(outputDeployedAndLivedMessage)


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes [#87](https://github.com/Shopify/app-deploys/issues/87)

### WHAT is this pull request doing?
Adding a URL on the deployment success screen that takes you to the partners dashboard.

### How to test your changes?
`shopify app deploy`

### Measuring impact
How do we know this change was effective? Please choose one:
- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
