### PR TITLE
Set TypeScript parser explicitly when formatting .ts and .tsx files

### DIFF
--- a/.changeset/warm-tools-wash.md
+++ b/.changeset/warm-tools-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add better TypeScript support when formating files with the fs module by explicitly setting the parser to "typescript" in the prettier config. Fixes issues where the babel parser was not able to process JSX in TypeScript files.

--- a/packages/cli-kit/src/public/node/fs.test.ts
+++ b/packages/cli-kit/src/public/node/fs.test.ts
@@ -203,6 +203,17 @@ describe('format', () => {
     await expect(formattedContent).toEqual("const array: string[] = ['bar', 'baz'];\n")
   })
 
+  it('formats TypeScript file content with JSX', async () => {
+    // Given
+    const unformatedContent = 'const C = (p: any) => <>{ p.foo }</>'
+
+    // When
+    const formattedContent = await fileContentPrettyFormat(unformatedContent, {path: 'someFile.tsx'})
+
+    // Then
+    await expect(formattedContent).toEqual('const C = (p: any) => <>{p.foo}</>;\n')
+  })
+
   it('formats CSS file content', async () => {
     // Given
     const unformatedContent = 'body { color: red; }'

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -418,6 +418,10 @@ export async function fileContentPrettyFormat(content: string, options: FileOpti
     case '.css':
       prettierConfig.parser = ext.slice(1)
       break
+    case '.ts':
+    case '.tsx':
+      prettierConfig.parser = 'typescript'
+      break
   }
 
   const formattedContent = await prettier.format(content, prettierConfig)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We found some issues when formatting large typescript files using the babel parser in hydrogen. This PR specifically uncovered [the issue](https://github.com/Shopify/h2/pull/365) and found that adding that specifying the `typescript` parser resolved this issue. 

### WHAT is this pull request doing?

Sets the 'typescript' parser explicitly for typescript extensions (.tsx and .ts)

### How to test your changes?

I've added tests to demonstrate the desired behaviour.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
