### PR TITLE
Fix AutocompletePrompt resetting the SelectInput state

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -287,7 +287,7 @@ describe('AutocompletePrompt', async () => {
       />,
     )
 
-    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?: [36m[7mT[27m[2mype to search...[22m[39m
 
       [36m>[39m  [36mfirst[39m
@@ -324,7 +324,7 @@ describe('AutocompletePrompt', async () => {
     // there is a debounce of 300ms before the search is triggered
     await sendInputAndWait(renderInstance, 400, 'i')
 
-    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?: [36mi[7m [27m[39m
 
       [36m>[39m  [36mf[1mi[22mrst[39m
@@ -359,7 +359,7 @@ describe('AutocompletePrompt', async () => {
 
     await sendInputAndWaitForChange(renderInstance, DELETE)
 
-    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?: [36m[7mT[27m[2mype to search...[22m[39m
 
       [36m>[39m  [36mfirst[39m
@@ -396,7 +396,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWaitForChange(renderInstance, ARROW_DOWN)
     await sendInputAndWaitForChange(renderInstance, ARROW_DOWN)
 
-    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?: [36mi[7m [27m[39m
 
          f[1mi[22mrst
@@ -462,7 +462,7 @@ describe('AutocompletePrompt', async () => {
     // there is a debounce of 300ms before the search is triggered + 300ms for the search to complete
     await sendInputAndWait(renderInstance, 700, 'e')
 
-    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?: [36me[7m [27m[39m
 
       [36m>[39m  [36ms[1me[22mcond[39m
@@ -523,7 +523,7 @@ describe('AutocompletePrompt', async () => {
     await waitForInputsToBeReady()
     await sendInputAndWaitForContent(renderInstance, 'There has been an error', 'i')
 
-    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?: [36mi[7m [27m[39m
 
          [31mThere has been an error while searching. Please try again later.[39m
@@ -559,7 +559,7 @@ describe('AutocompletePrompt', async () => {
     // there is a debounce of 300ms before the search is triggered
     await sendInputAndWait(renderInstance, 400, 'i')
 
-    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?: [36mi[7m [27m[39m
 
       [36m>[39m  [36mf[1mi[22mrst[39m
@@ -571,7 +571,7 @@ describe('AutocompletePrompt', async () => {
 
     await sendInputAndWaitForChange(renderInstance, DELETE)
 
-    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?: [36m[7mT[27m[2mype to search...[22m[39m
 
       [36m>[39m  [36mfirst[39m

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -15,6 +15,59 @@ const ARROW_DOWN = '\u001B[B'
 const ENTER = '\r'
 const DELETE = '\u007F'
 
+const DATABASE = [
+  {label: 'first', value: 'first'},
+  {label: 'second', value: 'second'},
+  {label: 'third', value: 'third'},
+  {label: 'fourth', value: 'fourth'},
+  {label: 'fifth', value: 'fifth'},
+  {label: 'sixth', value: 'sixth'},
+  {label: 'seventh', value: 'seventh'},
+  {label: 'eighth', value: 'eighth'},
+  {label: 'ninth', value: 'ninth'},
+  {label: 'tenth', value: 'tenth'},
+  {label: 'eleventh', value: 'eleventh'},
+  {label: 'twelfth', value: 'twelfth'},
+  {label: 'thirteenth', value: 'thirteenth'},
+  {label: 'fourteenth', value: 'fourteenth'},
+  {label: 'fifteenth', value: 'fifteenth'},
+  {label: 'sixteenth', value: 'sixteenth'},
+  {label: 'seventeenth', value: 'seventeenth'},
+  {label: 'eighteenth', value: 'eighteenth'},
+  {label: 'nineteenth', value: 'nineteenth'},
+  {label: 'twentieth', value: 'twentieth'},
+  {label: 'twenty-first', value: 'twenty-first'},
+  {label: 'twenty-second', value: 'twenty-second'},
+  {label: 'twenty-third', value: 'twenty-third'},
+  {label: 'twenty-fourth', value: 'twenty-fourth'},
+  {label: 'twenty-fifth', value: 'twenty-fifth'},
+  {label: 'twenty-sixth', value: 'twenty-sixth'},
+  {label: 'twenty-seventh', value: 'twenty-seventh'},
+  {label: 'twenty-eighth', value: 'twenty-eighth'},
+  {label: 'twenty-ninth', value: 'twenty-ninth'},
+  {label: 'thirtieth', value: 'thirtieth'},
+  {label: 'thirty-first', value: 'thirty-first'},
+  {label: 'thirty-second', value: 'thirty-second'},
+  {label: 'thirty-third', value: 'thirty-third'},
+  {label: 'thirty-fourth', value: 'thirty-fourth'},
+  {label: 'thirty-fifth', value: 'thirty-fifth'},
+  {label: 'thirty-sixth', value: 'thirty-sixth'},
+  {label: 'thirty-seventh', value: 'thirty-seventh'},
+  {label: 'thirty-eighth', value: 'thirty-eighth'},
+  {label: 'thirty-ninth', value: 'thirty-ninth'},
+  {label: 'fortieth', value: 'fortieth'},
+  {label: 'forty-first', value: 'forty-first'},
+  {label: 'forty-second', value: 'forty-second'},
+  {label: 'forty-third', value: 'forty-third'},
+  {label: 'forty-fourth', value: 'forty-fourth'},
+  {label: 'forty-fifth', value: 'forty-fifth'},
+  {label: 'forty-sixth', value: 'forty-sixth'},
+  {label: 'forty-seventh', value: 'forty-seventh'},
+  {label: 'forty-eighth', value: 'forty-eighth'},
+  {label: 'forty-ninth', value: 'forty-ninth'},
+  {label: 'fiftieth', value: 'fiftieth'},
+]
+
 describe('AutocompletePrompt', async () => {
   test('choose an answer', async () => {
     const onEnter = vi.fn()
@@ -33,6 +86,7 @@ describe('AutocompletePrompt', async () => {
         choices={items}
         infoTable={infoTable}
         onSubmit={onEnter}
+        search={() => Promise.resolve([] as Item<string>[])}
       />,
     )
 
@@ -68,6 +122,7 @@ describe('AutocompletePrompt', async () => {
         message="Associate your project with the org Castile Ventures?"
         choices={items}
         onSubmit={() => {}}
+        search={() => Promise.resolve([] as Item<string>[])}
       />,
     )
 
@@ -114,6 +169,7 @@ describe('AutocompletePrompt', async () => {
         choices={items}
         infoTable={infoTable}
         onSubmit={() => {}}
+        search={() => Promise.resolve([] as Item<string>[])}
       />,
     )
 
@@ -214,28 +270,55 @@ describe('AutocompletePrompt', async () => {
     expect(onEnter).not.toHaveBeenCalled()
   })
 
-  test('highlights the search term', async () => {
-    const database = [
-      {label: 'first', value: 'first'},
-      {label: 'second', value: 'second'},
-      {label: 'third', value: 'third'},
-      {label: 'fourth', value: 'fourth'},
-    ]
+  test('allows searching with pagination', async () => {
+    const onEnter = vi.fn()
+    const items = DATABASE.slice(0, 27)
 
-    const items = database.slice(0, 2)
-
-    const search = (term: string) => {
-      return Promise.resolve(database.filter((item) => item.label.includes(term)))
+    const search = async (term: string) => {
+      return DATABASE.filter((item) => item.label.includes(term))
     }
 
     const renderInstance = render(
       <AutocompletePrompt
         message="Associate your project with the org Castile Ventures?"
         choices={items}
-        onSubmit={() => {}}
+        onSubmit={onEnter}
         search={search}
       />,
     )
+
+    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?: [36m[7mT[27m[2mype to search...[22m[39m
+
+      [36m>[39m  [36mfirst[39m
+         second
+         third
+         fourth
+         fifth
+         sixth
+         seventh
+         eighth
+         ninth
+         tenth
+         eleventh
+         twelfth
+         thirteenth
+         fourteenth
+         fifteenth
+         sixteenth
+         seventeenth
+         eighteenth
+         nineteenth
+         twentieth
+         twenty-first
+         twenty-second
+         twenty-third
+         twenty-fourth
+         twenty-fifth
+
+         [2mnavigate with arrows, enter to select[22m
+      "
+    `)
 
     await waitForInputsToBeReady()
     // there is a debounce of 300ms before the search is triggered
@@ -246,30 +329,192 @@ describe('AutocompletePrompt', async () => {
 
       [36m>[39m  [36mf[1mi[22mrst[39m
          th[1mi[22mrd
+         f[1mi[22mfth
+         s[1mi[22mxth
+         e[1mi[22mghth
+         n[1mi[22mnth
+         th[1mi[22mrteenth
+         f[1mi[22mfteenth
+         s[1mi[22mxteenth
+         e[1mi[22mghteenth
+         n[1mi[22mneteenth
+         twent[1mi[22meth
+         twenty-f[1mi[22mrst
+         twenty-th[1mi[22mrd
+         twenty-f[1mi[22mfth
+         twenty-s[1mi[22mxth
+         twenty-e[1mi[22mghth
+         twenty-n[1mi[22mnth
+         th[1mi[22mrtieth
+         th[1mi[22mrty-first
+         th[1mi[22mrty-second
+         th[1mi[22mrty-third
+         th[1mi[22mrty-fourth
+         th[1mi[22mrty-fifth
+         th[1mi[22mrty-sixth
 
          [2mnavigate with arrows, enter to select[22m
       "
     `)
+
+    await sendInputAndWaitForChange(renderInstance, DELETE)
+
+    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?: [36m[7mT[27m[2mype to search...[22m[39m
+
+      [36m>[39m  [36mfirst[39m
+         second
+         third
+         fourth
+         fifth
+         sixth
+         seventh
+         eighth
+         ninth
+         tenth
+         eleventh
+         twelfth
+         thirteenth
+         fourteenth
+         fifteenth
+         sixteenth
+         seventeenth
+         eighteenth
+         nineteenth
+         twentieth
+         twenty-first
+         twenty-second
+         twenty-third
+         twenty-fourth
+         twenty-fifth
+
+         [2mnavigate with arrows, enter to select[22m
+      "
+    `)
+
+    await sendInputAndWait(renderInstance, 400, 'i')
+    await sendInputAndWaitForChange(renderInstance, ARROW_DOWN)
+    await sendInputAndWaitForChange(renderInstance, ARROW_DOWN)
+
+    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?: [36mi[7m [27m[39m
+
+         f[1mi[22mrst
+         th[1mi[22mrd
+      [36m>[39m  [36mf[1mi[22mfth[39m
+         s[1mi[22mxth
+         e[1mi[22mghth
+         n[1mi[22mnth
+         th[1mi[22mrteenth
+         f[1mi[22mfteenth
+         s[1mi[22mxteenth
+         e[1mi[22mghteenth
+         n[1mi[22mneteenth
+         twent[1mi[22meth
+         twenty-f[1mi[22mrst
+         twenty-th[1mi[22mrd
+         twenty-f[1mi[22mfth
+         twenty-s[1mi[22mxth
+         twenty-e[1mi[22mghth
+         twenty-n[1mi[22mnth
+         th[1mi[22mrtieth
+         th[1mi[22mrty-first
+         th[1mi[22mrty-second
+         th[1mi[22mrty-third
+         th[1mi[22mrty-fourth
+         th[1mi[22mrty-fifth
+         th[1mi[22mrty-sixth
+
+         [2mnavigate with arrows, enter to select[22m
+      "
+    `)
+
+    await sendInputAndWaitForChange(renderInstance, ENTER)
+
+    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?
+      [36m✔[39m  [36mfifth[39m
+      "
+    `)
+
+    expect(onEnter).toHaveBeenCalledWith('fifth')
   })
 
-  test('displays an error message if the search fails', async () => {
-    const database = [
-      {label: 'first', value: 'first'},
-      {label: 'second', value: 'second'},
-      {label: 'third', value: 'third'},
-      {label: 'fourth', value: 'fourth'},
-    ]
+  test('allows selecting the first item after searching and triggering the loading state', async () => {
+    const onEnter = vi.fn()
+    const items = DATABASE.slice(0, 27)
 
-    const items = database.slice(0, 2)
-
-    const search = (term: string) => {
-      return Promise.reject(new Error('Something went wrong'))
+    const search = async (term: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      return DATABASE.filter((item) => item.label.includes(term))
     }
 
     const renderInstance = render(
       <AutocompletePrompt
         message="Associate your project with the org Castile Ventures?"
         choices={items}
+        onSubmit={onEnter}
+        search={search}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+    // there is a debounce of 300ms before the search is triggered + 300ms for the search to complete
+    await sendInputAndWait(renderInstance, 700, 'e')
+
+    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?: [36me[7m [27m[39m
+
+      [36m>[39m  [36ms[1me[22mcond[39m
+         s[1me[22mventh
+         [1me[22mighth
+         t[1me[22mnth
+         [1me[22mleventh
+         tw[1me[22mlfth
+         thirt[1me[22menth
+         fourt[1me[22menth
+         fift[1me[22menth
+         sixt[1me[22menth
+         s[1me[22mventeenth
+         [1me[22mighteenth
+         nin[1me[22mteenth
+         tw[1me[22mntieth
+         tw[1me[22mnty-first
+         tw[1me[22mnty-second
+         tw[1me[22mnty-third
+         tw[1me[22mnty-fourth
+         tw[1me[22mnty-fifth
+         tw[1me[22mnty-sixth
+         tw[1me[22mnty-seventh
+         tw[1me[22mnty-eighth
+         tw[1me[22mnty-ninth
+         thirti[1me[22mth
+         thirty-s[1me[22mcond
+
+         [2mnavigate with arrows, enter to select[22m
+      "
+    `)
+
+    await sendInputAndWaitForChange(renderInstance, ENTER)
+
+    expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?
+      [36m✔[39m  [36msecond[39m
+      "
+    `)
+
+    expect(onEnter).toHaveBeenCalledWith('second')
+  })
+
+  test('displays an error message if the search fails', async () => {
+    const search = (_term: string) => {
+      return Promise.reject(new Error('Something went wrong'))
+    }
+
+    const renderInstance = render(
+      <AutocompletePrompt
+        message="Associate your project with the org Castile Ventures?"
+        choices={DATABASE}
         onSubmit={() => {}}
         search={search}
       />,

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -11,10 +11,9 @@ import Table, {TableProps} from '../../private/node/ui/components/Table/Table.js
 import {SelectPrompt, Props as SelectPromptProps} from '../../private/node/ui/components/SelectPrompt.js'
 import {Tasks, Task} from '../../private/node/ui/components/Tasks.js'
 import {TextPrompt, Props as TextPromptProps} from '../../private/node/ui/components/TextPrompt.js'
-import {
-  AutocompletePrompt,
-  Props as AutocompletePromptProps,
-} from '../../private/node/ui/components/AutocompletePrompt.js'
+import {Item as SelectItem, Props as SelectProps} from '../../private/node/ui/components/SelectInput.js'
+import {Props as InfoTableProps} from '../../private/node/ui/components/Prompts/InfoTable.js'
+import {AutocompletePrompt} from '../../private/node/ui/components/AutocompletePrompt.js'
 import React from 'react'
 import {RenderOptions} from 'ink'
 import {AbortController} from '@shopify/cli-kit/node/abort'
@@ -262,6 +261,13 @@ export function renderConfirmationPrompt({
   })
 }
 
+interface RenderAutocompletePromptProps<T> {
+  message: string
+  choices: SelectProps<T>['items']
+  infoTable?: InfoTableProps['table']
+  search?: (term: string) => Promise<SelectItem<T>[]>
+}
+
 /**
  * Renders an autocomplete prompt to the console.
  * ```
@@ -274,7 +280,7 @@ export function renderConfirmationPrompt({
  *  navigate with arrows, enter to select
  * ```
  */
-export function renderAutocompletePrompt<T>(props: Omit<AutocompletePromptProps<T>, 'onSubmit'>): Promise<T> {
+export function renderAutocompletePrompt<T>(props: RenderAutocompletePromptProps<T>): Promise<T> {
   const newProps = {
     search(term: string) {
       return Promise.resolve(props.choices.filter((item) => item.label.toLowerCase().includes(term.toLowerCase())))


### PR DESCRIPTION
### WHY are these changes introduced?

@isaacroldan reported the a bug with the autocomplete select in the app selection, where if you selected the first result after searching for an app it wouldn't select that, but instead it would select the first item of the initial list.

### WHAT is this pull request doing?

The core of the issue is that the `AutocompletePrompt` was removing and hence unmounting the `SelectInput` component when the state changed, but that would mean the internal state of `SelectInput` wouldn't be preserved and we rely on that to trigger `onChange` when the items change.

I've then moved the helper messages logic to `SelectInput` itself so that it can stay in the tree.

I've also fixed an issue with pagination. Items were being reset to the original not sliced list when the input was cleared.

### How to test your changes?

- Run `shopify app dev --reset`
- Try searching for an app and without using the arrows immediately hit enter
- The selected result should be correct

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
