### PR TITLE
Fix regression introduced by file refactor

### DIFF
--- a/packages/cli-kit/src/public/node/fs.test.ts
+++ b/packages/cli-kit/src/public/node/fs.test.ts
@@ -14,6 +14,7 @@ import {
   touchFile,
   appendFile,
   generateRandomNameForSubdirectory,
+  readSync,
 } from './fs.js'
 import {join} from '../../path.js'
 import {takeRandomFromArray} from '../common/array.js'
@@ -262,6 +263,18 @@ describe('makeDirectoryWithRandomName', () => {
       // Then
       expect(got).toEqual('free-directory-app')
       expect(takeRandomFromArray).toHaveBeenCalledTimes(4)
+    })
+  })
+})
+
+describe('readSync', () => {
+  test('synchronously reads content of file', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const filePath = join(tmpDir, 'test-file')
+      const content = 'test-content'
+      await touchFile(filePath)
+      await appendFile(filePath, content)
+      await expect(readSync(filePath).toString()).toContain(content)
     })
   })
 })

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -100,16 +100,14 @@ export async function readFile(path: string, options: ReadOptions = {encoding: '
 }
 
 /**
- * Synchronously reads a file and returns its content as a string.
+ * Synchronously reads a file and returns its content as a buffer.
  *
  * @param path - Path to the file to read.
- * @param options - Options to read the file with (defaults to utf-8 encoding).
  * @returns The content of the file.
  */
-export function readSync(path: string, options: object = {encoding: 'utf-8'}): string {
+export function readSync(path: string): Buffer {
   debug(outputContent`Sync-reading the content of file at ${token.path(path)}...`)
-  const content = fsReadFileSync(path, options)
-  return content.toString()
+  return fsReadFileSync(path)
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes issue while deploying

### WHAT is this pull request doing?

In the case of deploys we use `readSync` to read a zip file, so we don't want to read it as a string nor interpret it as utf8.

### How to test your changes?

- Create a new app
- Add an extension
- Deploy it

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
