### PR TITLE
Fix bug with SelectInput and non existent keys

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/SelectInput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectInput.test.tsx
@@ -107,6 +107,39 @@ describe('SelectInput', async () => {
     expect(onChange).toHaveBeenCalledWith(items[2]!)
   })
 
+  test('handles pressing non existing keys', async () => {
+    const onChange = vi.fn()
+    const items = [
+      {
+        label: 'First',
+        value: 'first',
+      },
+      {
+        label: 'Second',
+        value: 'second',
+      },
+      {
+        label: 'Tenth',
+        value: 'tenth',
+      },
+    ]
+
+    const renderInstance = render(<SelectInput items={items} onChange={onChange} />)
+
+    await waitForInputsToBeReady()
+    // nothing changes when pressing a key that doesn't exist
+    await sendInputAndWait(renderInstance, 100, '4')
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "[36m>[39m  [36m(1) First[39m
+         (2) Second
+         (3) Tenth
+
+         [2mnavigate with arrows, enter to select[22m"
+    `)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   test('handles custom keys', async () => {
     const onChange = vi.fn()
     const items = [

--- a/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
@@ -26,6 +26,7 @@ export interface Item<T> {
 }
 
 interface ItemWithIndex<T> extends Item<T> {
+  key: string
   index: number
 }
 
@@ -117,9 +118,9 @@ export default function SelectInput<T>({
   const initialIndex = defaultValueIndex === -1 ? 0 : defaultValueIndex
   const inputStack = useRef<string | null>(null)
   const [selectedIndex, setSelectedIndex] = useState(initialIndex)
-  const keys = useRef(new Set(items.map((item) => item.key)))
   const [groupedItems, ungroupedItems] = groupItems(items)
   const groupedItemsValues = [...Object.values(groupedItems).flat(), ...ungroupedItems]
+  const keys = groupedItemsValues.map((item) => item.key)
   const groupTitles = Object.keys(groupedItems)
   const previousItems = useRef<Item<T>[]>(items)
 
@@ -164,11 +165,7 @@ export default function SelectInput<T>({
 
   const handleShortcuts = useCallback(
     (input: string) => {
-      const parsedInput = parseInt(input, 10)
-
-      if (parsedInput !== 0 && parsedInput <= items.length + 1) {
-        changeSelection(parsedInput - 1)
-      } else if (keys.current.has(input)) {
+      if (keys.includes(input)) {
         const groupedItem = groupedItemsValues.find((item) => item.key === input)
         if (groupedItem !== undefined) {
           changeSelection(groupedItem.index)


### PR DESCRIPTION
### WHY are these changes introduced?

@pacocastrotech reported an issue with `SelectInput` throwing error if non existent keys were being pressed.

### WHAT is this pull request doing?

I've fixed the issue by ignoring non existent keys.

### How to test your changes?

- Run `shopify kitchen-sink prompts`
- In the first select try pressing `11`
- Nothing should happen

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
