### PR TITLE
Fix regression caused by using function instead of variable

### DIFF
--- a/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
@@ -6,7 +6,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 import {describe, expect, test} from 'vitest'
 
 describe('themeExtensionConfig', () => {
-  test('throws an error if the request to return the url errors', async () => {
+  test('builds a base64 encoded payload containing all theme files', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const themeExtension = new ThemeExtensionInstance({

--- a/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
@@ -1,0 +1,37 @@
+import {themeExtensionConfig} from './theme-extension-config.js'
+import themeSpec from '../../models/extensions/theme-specifications/theme.js'
+import {ThemeExtensionInstance} from '../../models/extensions/theme.js'
+import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {describe, expect, test} from 'vitest'
+
+describe('themeExtensionConfig', () => {
+  test('throws an error if the request to return the url errors', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const themeExtension = new ThemeExtensionInstance({
+        configuration: {
+          name: 'theme extension name',
+          type: 'theme' as const,
+        },
+        configurationPath: '',
+        directory: tmpDir,
+        remoteSpecification: undefined,
+        specification: themeSpec,
+        outputBundlePath: tmpDir,
+      })
+
+      await mkdir(joinPath(tmpDir, 'blocks'))
+      await writeFile(joinPath(tmpDir, 'blocks', 'test.liquid'), 'test content')
+
+      // Then
+      await expect(themeExtensionConfig(themeExtension)).resolves.toStrictEqual({
+        theme_extension: {
+          files: {
+            'blocks/test.liquid': Buffer.from('test content').toString('base64'),
+          },
+        },
+      })
+    })
+  })
+})

--- a/packages/app/src/cli/services/deploy/theme-extension-config.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.ts
@@ -17,7 +17,7 @@ export async function themeExtensionConfig(themeExtension: ThemeExtension): Prom
       const directoryName = dirname(relativePathName)
       const encoding = directoryName === 'assets' ? 'binary' : 'utf8'
       const fileContents = await readFile(filepath, {encoding})
-      files[relativePath] = Buffer.from(fileContents, encoding).toString('base64')
+      files[relativePathName] = Buffer.from(fileContents, encoding).toString('base64')
     }),
   )
   return {theme_extension: {files}}


### PR DESCRIPTION
### WHY are these changes introduced?

Theme app extensions could not be deployed any longer

### WHAT is this pull request doing?

Use correct variable instead of function. Also adds test to verify correct behaviour.

### How to test your changes?

- Create new app
- Add theme app extension
- Deploy

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
