### PR TITLE
Remove colon in AutocompletePrompt

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -214,7 +214,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWait(renderInstance, 100, ENTER)
 
     expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36ma[7m [27m[39m
+      "?  Associate your project with the org Castile Ventures?   [36ma[7m [27m[39m
 
          [2mNo results found.[22m
       "
@@ -248,7 +248,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWait(renderInstance, 100, ENTER)
 
     expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36ma[7m [27m[39m
+      "?  Associate your project with the org Castile Ventures?   [36ma[7m [27m[39m
 
          [2mLoading...[22m
       "
@@ -274,7 +274,7 @@ describe('AutocompletePrompt', async () => {
     )
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36m[7mT[27m[2mype to search...[22m[39m
+      "?  Associate your project with the org Castile Ventures?   [36m[7mT[27m[2mype to search...[22m[39m
 
       [36m>[39m  [36mfirst[39m
          second
@@ -310,7 +310,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWaitForContent(renderInstance, 'th[1mi[22mrty-sixth', 'i')
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36mi[7m [27m[39m
+      "?  Associate your project with the org Castile Ventures?   [36mi[7m [27m[39m
 
       [36m>[39m  [36mf[1mi[22mrst[39m
          th[1mi[22mrd
@@ -345,7 +345,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWaitForChange(renderInstance, DELETE)
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36m[7mT[27m[2mype to search...[22m[39m
+      "?  Associate your project with the org Castile Ventures?   [36m[7mT[27m[2mype to search...[22m[39m
 
       [36m>[39m  [36mfirst[39m
          second
@@ -382,7 +382,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWaitForChange(renderInstance, ARROW_DOWN)
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36mi[7m [27m[39m
+      "?  Associate your project with the org Castile Ventures?   [36mi[7m [27m[39m
 
          f[1mi[22mrst
          th[1mi[22mrd
@@ -447,7 +447,7 @@ describe('AutocompletePrompt', async () => {
     await waitForContent(renderInstance, 'Press ↑↓ arrows to select, enter to confirm')
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36me[7m [27m[39m
+      "?  Associate your project with the org Castile Ventures?   [36me[7m [27m[39m
 
       [36m>[39m  [36ms[1me[22mcond[39m
          s[1me[22mventh
@@ -508,7 +508,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWaitForContent(renderInstance, 'There has been an error', 'i')
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36mi[7m [27m[39m
+      "?  Associate your project with the org Castile Ventures?   [36mi[7m [27m[39m
 
          [31mThere has been an error while searching. Please try again later.[39m
       "
@@ -533,7 +533,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWaitForContent(renderInstance, 'th[1mi[22mrty-sixth', 'i')
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36mi[7m [27m[39m
+      "?  Associate your project with the org Castile Ventures?   [36mi[7m [27m[39m
 
       [36m>[39m  [36mf[1mi[22mrst[39m
          th[1mi[22mrd
@@ -568,7 +568,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWaitForChange(renderInstance, DELETE)
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?: [36m[7mT[27m[2mype to search...[22m[39m
+      "?  Associate your project with the org Castile Ventures?   [36m[7mT[27m[2mype to search...[22m[39m
 
       [36m>[39m  [36mfirst[39m
          second

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -2,6 +2,7 @@ import SelectInput, {Props as SelectProps, Item as SelectItem, Item} from './Sel
 import InfoTable, {Props as InfoTableProps} from './Prompts/InfoTable.js'
 import {TextInput} from './TextInput.js'
 import {handleCtrlC} from '../../ui.js'
+import {messageWithPunctuation} from '../utilities.js'
 import React, {ReactElement, useCallback, useRef, useState} from 'react'
 import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
 import figures from 'figures'
@@ -118,27 +119,24 @@ function AutocompletePrompt<T>({
         <Box marginRight={2}>
           <Text>?</Text>
         </Box>
-        <Text>{message}</Text>
+        <Text>{messageWithPunctuation(message)}</Text>
         {promptState !== PromptState.Submitted && canSearch && (
-          <Box>
-            <Text>: </Text>
-            <Box>
-              <TextInput
-                value={searchTerm}
-                onChange={(term) => {
-                  setSearchTerm(term)
+          <Box marginLeft={3}>
+            <TextInput
+              value={searchTerm}
+              onChange={(term) => {
+                setSearchTerm(term)
 
-                  if (term.length > 0) {
-                    debounceSearch(term)
-                  } else {
-                    debounceSearch.cancel()
-                    setPromptState(PromptState.Idle)
-                    setSearchResults(paginatedInitialChoices)
-                  }
-                }}
-                placeholder="Type to search..."
-              />
-            </Box>
+                if (term.length > 0) {
+                  debounceSearch(term)
+                } else {
+                  debounceSearch.cancel()
+                  setPromptState(PromptState.Idle)
+                  setSearchResults(paginatedInitialChoices)
+                }
+              }}
+              placeholder="Type to search..."
+            />
           </Box>
         )}
       </Box>

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -1,7 +1,8 @@
 import SelectInput, {Props as SelectProps, Item as SelectItem, Item} from './SelectInput.js'
 import InfoTable, {Props as InfoTableProps} from './Prompts/InfoTable.js'
-import {appendToTokenItem, TokenItem, tokenItemToString, TokenizedText} from './TokenizedText.js'
+import {TokenItem, TokenizedText} from './TokenizedText.js'
 import {handleCtrlC} from '../../ui.js'
+import {messageWithPunctuation} from '../utilities.js'
 import React, {ReactElement, useCallback, useState} from 'react'
 import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
 import figures from 'figures'
@@ -57,17 +58,13 @@ function SelectPrompt<T>({
     ),
   )
 
-  const messageToString = tokenItemToString(message)
-  const messageWithPunctuation =
-    messageToString.endsWith('?') || messageToString.endsWith(':') ? message : appendToTokenItem(message, ':')
-
   return (
     <Box flexDirection="column" marginBottom={1} ref={measuredRef}>
       <Box>
         <Box marginRight={2}>
           <Text>?</Text>
         </Box>
-        <TokenizedText item={messageWithPunctuation} />
+        <TokenizedText item={messageWithPunctuation(message)} />
       </Box>
       {infoTable && !submitted && (
         <Box marginLeft={7} marginTop={1}>

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -1,6 +1,7 @@
 import {TextInput} from './TextInput.js'
 import {handleCtrlC} from '../../ui.js'
 import useLayout from '../hooks/use-layout.js'
+import {messageWithPunctuation} from '../utilities.js'
 import React, {useCallback, useState} from 'react'
 import {Box, useApp, useInput, Text} from 'ink'
 import figures from 'figures'
@@ -57,15 +58,13 @@ const TextPrompt: React.FC<Props> = ({message, onSubmit, validate, defaultValue 
     ),
   )
 
-  const messageWithPunctuation = message.endsWith('?') || message.endsWith(':') ? message : `${message}:`
-
   return (
     <Box flexDirection="column" marginBottom={1} width={oneThird}>
       <Box>
         <Box marginRight={2}>
           <Text>?</Text>
         </Box>
-        <Text>{messageWithPunctuation}</Text>
+        <Text>{messageWithPunctuation(message)}</Text>
       </Box>
       {submitted && !error ? (
         <Box>

--- a/packages/cli-kit/src/private/node/ui/utilities.ts
+++ b/packages/cli-kit/src/private/node/ui/utilities.ts
@@ -1,0 +1,6 @@
+import {appendToTokenItem, TokenItem, tokenItemToString} from './components/TokenizedText.js'
+
+export function messageWithPunctuation(message: TokenItem) {
+  const messageToString = tokenItemToString(message)
+  return messageToString.endsWith('?') || messageToString.endsWith(':') ? message : appendToTokenItem(message, ':')
+}


### PR DESCRIPTION
### WHY are these changes introduced?

As mentioned [here](https://github.com/Shopify/cli/issues/1147) we want to remove the colon in the AutocompletePrompt text.

### WHAT is this pull request doing?

This PR removes the colon.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
