### PR TITLE
Always run pnpm install when running dev up

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -13,9 +13,10 @@ up:
         version: 7.18.1
   - custom:
       name: 'Install PNPM dependencies'
-      met?: test -d node_modules
-      meet: pnpm install
-
+      # we flip these two conditions to always run `pnpm install`
+      # whenever we run dev up.
+      met?: pnpm install
+      meet: 'true'
 
 env:
   SHOPIFY_CLI_ENV: development


### PR DESCRIPTION
### WHY are these changes introduced?

Whenever we change `package.json` we tell shopifolks to run `dev up`, but it doesn't rerun `pnpm install`

### WHAT is this pull request doing?

Hack a bit around the custom task syntax to ensure that every time we run `dev up` we also run `pnpm install`.
Basically the way dev works is:
- it checks `met?`
- if it returns false, it crashes
- if it returns true, it runs the `meet` callback

In this change, we set `met?` to `pnpm install` and `meet` to true (a unix command that always returns true)

### How to test your changes?

- Add a dependency in the package.json
- Notice dev telling you to run `dev up`
- Running `dev up` should install the new dep (there is no output, check with `git status`)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
