### PR TITLE
[WIP] Migrate checkout UI extension

### DIFF
--- a/packages/app/src/cli/api/graphql/extension_migrate_to_ui_extension.ts
+++ b/packages/app/src/cli/api/graphql/extension_migrate_to_ui_extension.ts
@@ -1,0 +1,28 @@
+import {gql} from 'graphql-request'
+
+export const ExtensionMigrateToUiExtensionQuery = gql`
+  mutation MigrateToUiExtension($apiKey: String!, $registrationId: String!) {
+    migrateToUiExtension(input: {apiKey: $apiKey, registrationId: $registrationId}) {
+      migratedToUiExtension
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`
+
+export interface ExtensionMigrateToUiExtensionVariables {
+  apiKey: string
+  registrationId: string
+}
+
+export interface ExtensionMigrateToUiExtensionSchema {
+  migrateToUiExtension: {
+    migratedToUiExtension: boolean
+    userErrors: {
+      field: string[]
+      message: string
+    }[]
+  }
+}

--- a/packages/app/src/cli/api/graphql/extension_migrate_to_ui_extension.ts
+++ b/packages/app/src/cli/api/graphql/extension_migrate_to_ui_extension.ts
@@ -1,7 +1,7 @@
 import {gql} from 'graphql-request'
 
 export const ExtensionMigrateToUiExtensionQuery = gql`
-  mutation MigrateToUiExtension($apiKey: String!, $registrationId: String!) {
+  mutation MigrateToUiExtension($apiKey: String!, $registrationId: ID!) {
     migrateToUiExtension(input: {apiKey: $apiKey, registrationId: $registrationId}) {
       migratedToUiExtension
       userErrors {

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.test.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.test.ts
@@ -1,0 +1,179 @@
+import {getExtensionsToMigrate, migrateExtensionsToUIExtension} from './migrate-to-ui-extension.js'
+import {LocalSource, RemoteSource} from '../environment/identifiers.js'
+import {ExtensionMigrateToUiExtensionQuery} from '../../api/graphql/extension_migrate_to_ui_extension.js'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+
+beforeEach(() => {
+  vi.mock('@shopify/cli-kit/node/api/partners')
+  vi.mock('@shopify/cli-kit/node/session')
+})
+
+function getLocalExtension(attributes: Partial<LocalSource> = {}) {
+  return {
+    type: 'ui_extension',
+    localIdentifier: 'my-extension',
+    configuration: {
+      name: 'my-extension',
+    },
+    ...attributes,
+  } as unknown as LocalSource
+}
+
+function getRemoteExtension(attributes: Partial<RemoteSource> = {}) {
+  return {
+    uuid: '1234',
+    type: 'CHECKOUT_UI_EXTENSION',
+    title: 'a-different-extension',
+    ...attributes,
+  } as unknown as RemoteSource
+}
+
+describe('getExtensionsToMigrate()', () => {
+  const defaultIds = {
+    'my-extension': '1234',
+  }
+
+  describe('if local.id matches remote.id', () => {
+    it('returns extensions where local.type is ui_extension but remote.type is CHECKOUT_UI_EXTENSION', () => {
+      // Given
+      const localExtension = getLocalExtension({type: 'ui_extension'})
+      const remoteExtension = getRemoteExtension({type: 'CHECKOUT_UI_EXTENSION'})
+
+      // When
+      const toMigrate = getExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+      // Then
+      expect(toMigrate).toStrictEqual([{local: localExtension, remote: remoteExtension}])
+    })
+
+    it('does not return extensions where local.type is not ui_extension', () => {
+      // Given
+      const localExtension = getLocalExtension({type: 'checkout_ui_extension'})
+      const remoteExtension = getRemoteExtension({type: 'CHECKOUT_UI_EXTENSION'})
+
+      // When
+      const toMigrate = getExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+      // Then
+      expect(toMigrate).toStrictEqual([])
+    })
+
+    it('does not return extensions where remote.type is not CHECKOUT_UI_EXTENSION', () => {
+      // Given
+      const localExtension = {...getLocalExtension(), type: 'ui_extension'}
+      const remoteExtension = {...getRemoteExtension(), type: 'PRODUCT_SUBSCRIPTION_UI_EXTENSION'}
+
+      // When
+      const toMigrate = getExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+      // Then
+      expect(toMigrate).toStrictEqual([])
+    })
+  })
+
+  describe('if local.configuration.name matches remote.title', () => {
+    it('returns extensions where local.type is ui_extension but remote.type is CHECKOUT_UI_EXTENSION', () => {
+      // Given
+      const localExtension = getLocalExtension({type: 'ui_extension'})
+      const remoteExtension = getRemoteExtension({type: 'CHECKOUT_UI_EXTENSION', title: 'my-extension'})
+
+      // When
+      const toMigrate = getExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+      // Then
+      expect(toMigrate).toStrictEqual([{local: localExtension, remote: remoteExtension}])
+    })
+
+    it('does not return extensions where local.type is not ui_extension', () => {
+      // Given
+      const localExtension = getLocalExtension({type: 'checkout_ui_extension'})
+      const remoteExtension = getRemoteExtension({type: 'CHECKOUT_UI_EXTENSION', title: 'my-extension'})
+
+      // When
+      const toMigrate = getExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+      // Then
+      expect(toMigrate).toStrictEqual([])
+    })
+
+    it('does not return extensions where remote.type is not CHECKOUT_UI_EXTENSION', () => {
+      // Given
+      const localExtension = getLocalExtension({type: 'ui_extension'})
+      const remoteExtension = getRemoteExtension({type: 'PRODUCT_SUBSCRIPTION_UI_EXTENSION', title: 'my-extension'})
+
+      // When
+      const toMigrate = getExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+      // Then
+      expect(toMigrate).toStrictEqual([])
+    })
+  })
+
+  describe('if neither title/name or ids match', () => {
+    it('does not return any extensions', () => {
+      // Given
+      const localExtension = getLocalExtension({
+        type: 'ui_extension',
+        configuration: {name: 'a-different-extension'},
+      })
+      const remoteExtension = getRemoteExtension({type: 'CHECKOUT_UI_EXTENSION', title: 'does-not-match', uuid: '5678'})
+
+      // When
+      const toMigrate = getExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+      // Then
+      expect(toMigrate).toStrictEqual([])
+    })
+  })
+})
+
+describe('migrateExtensions()', () => {
+  beforeEach(() => {
+    vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('mockToken')
+    vi.mocked(partnersRequest).mockResolvedValue({
+      migrateToUiExtension: {userErrors: null, migratedToUiExtension: true},
+    })
+  })
+
+  it('performs a graphQL mutation for each extension', async () => {
+    // Given
+    const extensionsToMigrate = [
+      {local: getLocalExtension(), remote: getRemoteExtension()},
+      {local: getLocalExtension(), remote: getRemoteExtension()},
+    ]
+    const appId = '123abc'
+    const remoteExtensions = extensionsToMigrate.map(({remote}) => ({...remote, type: 'CHECKOUT_UI_EXTENSION'}))
+
+    // When
+    await migrateExtensionsToUIExtension(extensionsToMigrate, appId, remoteExtensions)
+
+    // Then
+    expect(partnersRequest).toHaveBeenCalledTimes(extensionsToMigrate.length)
+    expect(partnersRequest).toHaveBeenCalledWith(ExtensionMigrateToUiExtensionQuery, 'mockToken', {
+      apiKey: appId,
+      registrationId: extensionsToMigrate[0]!.remote.id,
+    })
+    expect(partnersRequest).toHaveBeenCalledWith(ExtensionMigrateToUiExtensionQuery, 'mockToken', {
+      apiKey: appId,
+      registrationId: extensionsToMigrate[1]!.remote.id,
+    })
+  })
+
+  it('Returns updated remoteExensions', async () => {
+    // Given
+    const extensionsToMigrate = [
+      {local: getLocalExtension(), remote: getRemoteExtension()},
+      {local: getLocalExtension(), remote: getRemoteExtension()},
+    ]
+    const appId = '123abc'
+    const remoteExtensions = extensionsToMigrate.map(({remote}) => ({...remote, type: 'CHECKOUT_UI_EXTENSION'}))
+
+    // When
+    const result = await migrateExtensionsToUIExtension(extensionsToMigrate, appId, remoteExtensions)
+
+    // Then
+    expect(result).toStrictEqual(remoteExtensions.map((remote) => ({...remote, type: 'UI_EXTENSION'})))
+  })
+})

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -3,9 +3,45 @@ import {
   ExtensionMigrateToUiExtensionSchema,
   ExtensionMigrateToUiExtensionVariables,
 } from '../../api/graphql/extension_migrate_to_ui_extension.js'
+import {LocalSource, RemoteSource} from '../environment/identifiers.js'
+import {IdentifiersExtensions} from '../../models/app/identifiers.js'
+import {getExtensionIds, LocalRemoteSource} from '../environment/id-matching.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {error} from '@shopify/cli-kit'
+
+export function getExtensionsToMigrate(
+  localSources: LocalSource[],
+  remoteSources: RemoteSource[],
+  identifiers: IdentifiersExtensions,
+) {
+  const ids = getExtensionIds(localSources, identifiers)
+  const remoteExtensionTypesToMigrate = ['CHECKOUT_UI_EXTENSION']
+
+  return localSources.reduce<LocalRemoteSource[]>((accumulator, localSource) => {
+    if (localSource.type === 'ui_extension') {
+      const remoteSource = remoteSources.find((source) => {
+        const matchesId = source.uuid === ids[localSource.configuration.name]
+        const matchesTitle = source.title === localSource.configuration.name
+
+        return matchesId || matchesTitle
+      })
+
+      if (!remoteSource) {
+        return accumulator
+      }
+
+      const typeMimatches = remoteSource.type !== localSource.type
+      const typeIsToMigrate = remoteExtensionTypesToMigrate.includes(remoteSource.type)
+
+      if (typeMimatches && typeIsToMigrate) {
+        accumulator.push({local: localSource, remote: remoteSource})
+      }
+    }
+
+    return accumulator
+  }, [])
+}
 
 export async function migrateToUiExtension(
   apiKey: ExtensionMigrateToUiExtensionVariables['apiKey'],

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -47,11 +47,7 @@ export async function migrateExtensionsToUIExtension(
   appId: string,
   remoteExtensions: RemoteSource[],
 ) {
-  await Promise.all(
-    extensionsToMigrate.map(async ({remote}) => {
-      await migrateExtensionToUIExtension(appId, remote.id)
-    }),
-  )
+  await Promise.all(extensionsToMigrate.map(({remote}) => migrateExtensionToUIExtension(appId, remote.id)))
 
   return remoteExtensions.map((extension) => {
     if (extensionsToMigrate.some(({remote}) => remote.id === extension.id)) {

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -1,0 +1,31 @@
+import {
+  ExtensionMigrateToUiExtensionQuery,
+  ExtensionMigrateToUiExtensionSchema,
+  ExtensionMigrateToUiExtensionVariables,
+} from '../../api/graphql/extension_migrate_to_ui_extension.js'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
+import {error} from '@shopify/cli-kit'
+
+export async function migrateToUiExtension(
+  apiKey: ExtensionMigrateToUiExtensionVariables['apiKey'],
+  registrationId: ExtensionMigrateToUiExtensionVariables['registrationId'],
+) {
+  const token = await ensureAuthenticatedPartners()
+  const query = ExtensionMigrateToUiExtensionQuery
+  const variables: ExtensionMigrateToUiExtensionVariables = {
+    apiKey,
+    registrationId,
+  }
+
+  const result: ExtensionMigrateToUiExtensionSchema = await partnersRequest(query, token, variables)
+
+  if (result?.migrateToUiExtension?.userErrors?.length > 0) {
+    const errors = result.migrateToUiExtension.userErrors.map((error) => error.message).join(', ')
+    throw new error.Abort(errors)
+  }
+
+  if (!result?.migrateToUiExtension?.migratedToUiExtension) {
+    throw new error.Abort("Couldn't migrate to UI extension")
+  }
+}

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -8,7 +8,7 @@ import {IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {getExtensionIds, LocalRemoteSource} from '../environment/id-matching.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
-import {error} from '@shopify/cli-kit'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 export function getExtensionsToMigrate(
   localSources: LocalSource[],
@@ -82,10 +82,10 @@ export async function migrateExtensionToUIExtension(
 
   if (result?.migrateToUiExtension?.userErrors?.length > 0) {
     const errors = result.migrateToUiExtension.userErrors.map((error) => error.message).join(', ')
-    throw new error.Abort(errors)
+    throw new AbortError(errors)
   }
 
   if (!result?.migrateToUiExtension?.migratedToUiExtension) {
-    throw new error.Abort("Couldn't migrate to UI extension")
+    throw new AbortError("Couldn't migrate to UI extension")
   }
 }

--- a/packages/app/src/cli/services/environment/id-matching.ts
+++ b/packages/app/src/cli/services/environment/id-matching.ts
@@ -5,11 +5,15 @@ import {uniqBy, difference} from '@shopify/cli-kit/common/array'
 import {pickBy} from '@shopify/cli-kit/common/object'
 import {slugify} from '@shopify/cli-kit/common/string'
 
+export interface LocalRemoteSource {
+  local: LocalSource
+  remote: RemoteSource
+}
+
 export interface MatchResult {
   identifiers: IdentifiersExtensions
-  toConfirm: {local: LocalSource; remote: RemoteSource}[]
+  toConfirm: LocalRemoteSource[]
   toCreate: LocalSource[]
-  toMigrate: {local: LocalSource; remote: RemoteSource}[]
   toManualMatch: {local: LocalSource[]; remote: RemoteSource[]}
 }
 
@@ -113,17 +117,13 @@ export async function automaticMatchmaking(
   identifiers: IdentifiersExtensions,
   remoteIdField: 'id' | 'uuid',
 ): Promise<MatchResult> {
-  const localSourcesIds = localSources.map((source) => source.localIdentifier)
-  const ids = pickBy(identifiers, (_, id) => localSourcesIds.includes(id))
+  const ids = getExtensionIds(localSources, identifiers)
   const localUUIDs = Object.values(ids)
 
-  const existsRemotely = (local: LocalSource) => {
-    return Boolean(
-      remoteSources.find(
-        (remote) => remote[remoteIdField] === ids[local.localIdentifier] && remote.type === local.graphQLType,
-      ),
+  const existsRemotely = (local: LocalSource) =>
+    remoteSources.some(
+      (remote) => remote[remoteIdField] === ids[local.localIdentifier] && remote.type === local.graphQLType,
     )
-  }
 
   // We try to automatically match sources if they have the same name and type,
   // by considering local sources which are missing on the remote side and
@@ -145,33 +145,14 @@ export async function automaticMatchmaking(
     toConfirm,
     toCreate,
     toManualMatch: pending,
-    toMigrate: getExtensionsToMigrate(localSources, remoteSources, ids),
   }
 }
 
-function getExtensionsToMigrate(
+export function getExtensionIds(
   localSources: LocalSource[],
-  remoteSources: RemoteSource[],
-  ids: {[key: string]: string},
-) {
-  const remoteExtensionTypesToMigrate = ['CHECKOUT_UI_EXTENSION']
+  identifiers: IdentifiersExtensions,
+): IdentifiersExtensions {
+  const localSourcesIds = localSources.map((source) => source.localIdentifier)
 
-  return localSources.reduce<MatchResult['toMigrate']>((accumulator, localSource) => {
-    if (localSource.type === 'ui_extension') {
-      const remoteSource = remoteSources.find((source) => source.uuid === ids[localSource.configuration.name])
-
-      if (!remoteSource) {
-        return accumulator
-      }
-
-      const typeMimatches = remoteSource.type !== localSource.type
-      const typeIsToMigrate = remoteExtensionTypesToMigrate.includes(remoteSource.type)
-
-      if (typeMimatches && typeIsToMigrate) {
-        accumulator.push({local: localSource, remote: remoteSource})
-      }
-    }
-
-    return accumulator
-  }, [])
+  return pickBy(identifiers, (_, id) => localSourcesIds.includes(id))
 }

--- a/packages/app/src/cli/services/environment/prompts.ts
+++ b/packages/app/src/cli/services/environment/prompts.ts
@@ -62,3 +62,19 @@ export async function deployConfirmationPrompt(summary: SourceSummary): Promise<
     cancellationMessage: 'No, cancel',
   })
 }
+
+export async function migratePrompt(local: LocalSource, remote: RemoteSource): Promise<boolean> {
+  const remoteType = remote.type.toLowerCase()
+  const localType = local.type
+  const localName = local.configuration.name
+
+  return renderConfirmationPrompt({
+    message: `You've changed ${localName} from ${remoteType} to ${localType}. Would you like to migrate it in Shopify Partners?`,
+    infoTable: {
+      'Old type': [remoteType],
+      'New type': [localType],
+    },
+    confirmationMessage: `Yes, update to ${localType}`,
+    cancellationMessage: 'No, cancel the deploy',
+  })
+}


### PR DESCRIPTION
WIP PR to confirm this is the experience we want.

### WHY are these changes introduced?

Partially implements https://github.com/Shopify/shopify/issues/398990 

### WHAT is this pull request doing?

Deploy now checks for extensions that changed type from 'checkout_ui` to `ui_extension`.  If it finds any, it prompts the user to migrate the extension.  If they cancel deploy is cancelled.  If they accept the CLI performs a graphQL mutation.  Right now the GraphQL mutation is not in prod, but can be seen here: https://github.com/Shopify/partners/pull/44865

### How to test your changes?

1. `pnpm clean && pnpm install && pnpm build`
2. `pnpm shopify app deploy --path ./fixtures/app --verbose` to deploy the existing extensions.
3. Edit `shopify.ui.extension.toml` to migrate the checkout_ui extension. It should be like this:

```
name = "checkout-ui"

[capabilities]
api_access = true
network_access = true
block_progress = true

[[extension_points]]
target = "Checkout::Dynamic::Render"
module = "./src/index.jsx"
```

4. `pnpm shopify app deploy --path ./fixtures/app --verbose` to deploy your app again.
5. It should prompt you to migrate the extension.  Select no.  The deploy should stop
6. Now try step 5 & 6 again but accept the migration.  It will fail due to a GraphQL error (mutation is not deployed yet)

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
