### PR TITLE
Enable Dev Server to handle updates to extension points payload and support resource.url per extension point

### DIFF
--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -133,7 +133,7 @@ describe('getUIExtensionPayload', () => {
     })
   })
 
-  test('adds root.url and surface to extensionPoints[n] when extensionPoints[n] is an object', async () => {
+  test('adds root.url, resource.url and surface to extensionPoints[n] when extensionPoints[n] is an object', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const uiExtension = await testUIExtension({
@@ -179,6 +179,9 @@ describe('getUIExtensionPayload', () => {
           root: {
             url: 'http://tunnel-url.com/extensions/devUUID/Admin::Checkout::Editor::Settings',
           },
+          resource: {
+            url: '',
+          },
         },
         {
           target: 'Checkout::ShippingMethods::RenderAfter',
@@ -186,6 +189,9 @@ describe('getUIExtensionPayload', () => {
           surface: 'checkout',
           root: {
             url: 'http://tunnel-url.com/extensions/devUUID/Checkout::ShippingMethods::RenderAfter',
+          },
+          resource: {
+            url: '',
           },
         },
       ])

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -26,8 +26,11 @@ export interface ExtensionsEndpointPayload extends ExtensionsPayloadInterface {
   }
 }
 
-interface NewExtensionPointSchema extends NewExtensionPointSchemaType {
-  main: {
+export interface DevNewExtensionPointSchema extends NewExtensionPointSchemaType {
+  root: {
+    url: string
+  }
+  resource: {
     url: string
   }
 }
@@ -51,7 +54,7 @@ export interface UIExtensionPayload {
     status: ExtensionAssetBuildStatus
     localizationStatus: ExtensionAssetBuildStatus
   }
-  extensionPoints: string[] | null | NewExtensionPointSchema[]
+  extensionPoints: string[] | null | DevNewExtensionPointSchema[]
   localization: Localization | null
   categories: string[] | null
   authenticatedRedirectStartUrl?: string

--- a/packages/app/src/cli/services/dev/extension/payload/store.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.test.ts
@@ -172,6 +172,47 @@ describe('ExtensionsPayloadStore()', () => {
       expect(extensionsPayloadStore.getRawPayload().extensions[0]?.test).toEqual('value')
     })
 
+    it('deep merge extension points with incoming payload when the target matches', () => {
+      // Given
+      const payload = {
+        extensions: [
+          {
+            uuid: '123',
+            extensionPoints: [
+              {target: 'First::Extension::Point', extraProp: '1', resource: {url: ''}},
+              {target: 'Second::Extension::Point', extraProp: '2', resource: {url: ''}},
+              {target: 'Third::Extension::Point', extraProp: '3', resource: {url: ''}},
+            ],
+          },
+        ],
+      } as unknown as ExtensionsEndpointPayload
+
+      const extensionsPayloadStore = new ExtensionsPayloadStore(payload, mockOptions)
+
+      // When
+      extensionsPayloadStore.updateExtensions([
+        {
+          uuid: '123',
+          extensionPoints: [
+            {target: 'First::Extension::Point', resource: {url: '/first-extension-point-url'}},
+            {target: 'Second::Extension::Point', resource: {url: '/second-extension-point-url'}},
+          ],
+        },
+      ] as unknown as UIExtensionPayload[])
+
+      // Then
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      expect(extensionsPayloadStore.getRawPayload().extensions[0]).toMatchObject({
+        uuid: '123',
+        extensionPoints: [
+          {target: 'First::Extension::Point', extraProp: '1', resource: {url: '/first-extension-point-url'}},
+          {target: 'Second::Extension::Point', extraProp: '2', resource: {url: '/second-extension-point-url'}},
+          {target: 'Third::Extension::Point', extraProp: '3', resource: {url: ''}},
+        ],
+      })
+    })
+
     it('informs event listeners of updated extensions', () => {
       // Given
       const payload = {
@@ -304,7 +345,7 @@ describe('ExtensionsPayloadStore()', () => {
       expect(onUpdateSpy).toHaveBeenCalledWith(['123'])
     })
 
-    test('Does not update or inform event listeners if the extension does not exist', async () => {
+    test('does not update or inform event listeners if the extension does not exist', async () => {
       // Given
       const mockPayload = {
         extensions: [{uuid: '123'}],

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/PreviewLinks.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/components/PreviewLinks/PreviewLinks.tsx
@@ -35,9 +35,9 @@ export function PreviewLinks({extension}: Props) {
               return null
             }
 
-            const {root, target} = extensionPoint
+            const {root, target, resource} = extensionPoint
 
-            return <PreviewLink rootUrl={root.url} title={target} key={target} />
+            return <PreviewLink rootUrl={root.url} title={target} key={target} resourceUrl={resource.url} />
           })}
         </span>
       </>

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -86,7 +86,7 @@ export interface ExtensionPoint {
   target: string
   surface: Surface
   metafields?: Metafield[]
-  resource?: ResourceURL
+  resource: ResourceURL
   root: ResourceURL
 }
 


### PR DESCRIPTION
Enable support for resource.url per extension point.

### WHY are these changes introduced?

Currently the extension points array creates a union when the update payload comes in because it doesn't account for objects. For example, when the current payload is `[{target: 'A', {target: 'B'}]` and the update payload is  `[{target: 'A', {target: 'B', foo: 'bar'}]`  we get a combined array of `[{target: 'A', {target: 'B'}, {target: 'A', {target: 'B', foo: 'bar'}] `

### WHAT is this pull request doing?

Add special logic to merge extension points when the array contain extension points objects.

### How to test your changes?

The unit tests should cover the changes

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
