### PR TITLE
Dev console banner

### DIFF
--- a/packages/app/src/cli/services/dev/output.test.ts
+++ b/packages/app/src/cli/services/dev/output.test.ts
@@ -1,43 +1,99 @@
-import {outputExtensionsMessages} from './output.js'
-import {testApp, testUIExtension} from '../../models/app/app.test-data.js'
+import {outputExtensionsMessages, outputPreviewUrl} from './output.js'
+import {testApp, testFunctionExtension, testThemeExtensions, testUIExtension} from '../../models/app/app.test-data.js'
 import {AppInterface} from '../../models/app/app.js'
-import {describe, expect, it} from 'vitest'
+import {afterEach, describe, expect, it} from 'vitest'
 import {outputMocker} from '@shopify/cli-kit'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
+afterEach(() => {
+  outputMocker.mockAndCaptureOutput().clear()
+})
+
 describe('output', () => {
-  it('logs the correct output extension message when the given app contains a customer-accounts-ui-extension', async () => {
-    const outputMock = outputMocker.mockAndCaptureOutput()
-    const appMock = await mockApp()
+  describe('outputExtensionsMessages', () => {
+    it('logs the correct output extension message when the given app contains a customer-accounts-ui-extension', async () => {
+      const outputMock = outputMocker.mockAndCaptureOutput()
+      const appMock = await mockApp({uiExtensions: false})
 
-    outputExtensionsMessages(appMock, 'shop1010', 'https://f97b-95-91-224-153.eu.ngrok.io')
+      outputExtensionsMessages(appMock)
 
-    expect(outputMock.output()).toMatchInlineSnapshot(`
-      "Shopify extension dev console URL
+      expect(outputMock.output()).toMatchInlineSnapshot(`
+        "test function extension
+        These extensions need to be deployed to be manually tested.
+        One testing option is to use a separate app dedicated to staging.
 
-        https://f97b-95-91-224-153.eu.ngrok.io/extensions/dev-console
+        theme extension name (Theme app extension)
+        Follow the dev doc instructions ( https://shopify.dev/apps/online-store/theme-app-extensions/getting-started#step-3-test-your-changes ) by deploying your work as a draft
+        "
+      `)
+    })
+  })
 
-      customer-accounts-ui-extension (Customer accounts UI)
-      Please open https://f97b-95-91-224-153.eu.ngrok.io and click on 'Visit Site' and then close the tab to allow connections.
-      Preview link: https://shop1010.account./extensions-development?origin=https%3A%2F%2Ff97b-95-91-224-153.eu.ngrok.io%2Fextensions&extensionId=dev-94b5f0a6-1264-461d-8f78-08db4565b044
-      "
-    `)
+  describe('outputPreviewUrl', () => {
+    it('renders a banner with a link to the dev console if there are ui extensions', async () => {
+      const outputMock = outputMocker.mockAndCaptureOutput()
+      const appMock = await mockApp({uiExtensions: true})
+
+      outputPreviewUrl({
+        app: appMock,
+        storeFqdn: 'my-store.myshopify.com',
+        exposedUrl: 'https://my-store.myshopify.com',
+        proxyUrl: 'https://my-store.myshopify.com',
+        appPreviewAvailable: true,
+      })
+
+      expect(outputMock.output()).toMatchInlineSnapshot(`
+        "╭─ success ────────────────────────────────────────────────────────────────────╮
+        │                                                                              │
+        │  Preview ready! Press any key to open your browser                           │
+        │                                                                              │
+        │  https://my-store.myshopify.com/extensions/dev-console                       │
+        │                                                                              │
+        │  Keep in mind that some Shopify extensions - like Functions and web pixel -  │
+        │   aren't yet available for dev previews.                                     │
+        │                                                                              │
+        ╰──────────────────────────────────────────────────────────────────────────────╯
+        "
+      `)
+    })
+
+    it('renders a banner with a link to the app if there are no ui extensions', async () => {
+      const outputMock = outputMocker.mockAndCaptureOutput()
+      const appMock = await mockApp({uiExtensions: false})
+
+      outputPreviewUrl({
+        app: appMock,
+        storeFqdn: 'my-store.myshopify.com',
+        exposedUrl: 'https://my-store.myshopify.com',
+        proxyUrl: 'https://my-store.myshopify.com',
+        appPreviewAvailable: true,
+      })
+
+      expect(outputMock.output()).toMatchInlineSnapshot(`
+        "╭─ success ────────────────────────────────────────────────────────────────────╮
+        │                                                                              │
+        │  Preview ready! Press any key to open your browser                           │
+        │                                                                              │
+        │  https://my-store.myshopify.com?shop=my-store.myshopify.com&host=bXktc3Rvcm  │
+        │  UubXlzaG9waWZ5LmNvbS9hZG1pbg                                                │
+        │                                                                              │
+        │  Keep in mind that some Shopify extensions - like Functions and web pixel -  │
+        │   aren't yet available for dev previews.                                     │
+        │                                                                              │
+        ╰──────────────────────────────────────────────────────────────────────────────╯
+        "
+      `)
+    })
   })
 })
 
-async function mockApp(currentVersion = '2.2.2'): Promise<AppInterface> {
+async function mockApp({uiExtensions}: {uiExtensions: boolean}): Promise<AppInterface> {
   const nodeDependencies: {[key: string]: string} = {}
-  nodeDependencies['@shopify/cli'] = currentVersion
+  nodeDependencies['@shopify/cli'] = '2.2.2'
 
-  const extension = await testUIExtension({
-    configuration: {
-      type: 'customer_accounts_ui_extension',
-      name: 'customer-accounts-ui-extension',
-      metafields: [{key: '', namespace: ''}],
-      categories: ['returns'],
-    },
-    devUUID: 'dev-94b5f0a6-1264-461d-8f78-08db4565b044',
-  })
+  const functionExtension = await testFunctionExtension()
+  const themeExtension = await testThemeExtensions()
+  const uiExtension = await testUIExtension()
 
   return testApp({
     name: 'my-super-customer-accounts-app',
@@ -48,9 +104,9 @@ async function mockApp(currentVersion = '2.2.2'): Promise<AppInterface> {
     },
     nodeDependencies,
     extensions: {
-      ui: [extension],
-      theme: [],
-      function: [],
+      ui: uiExtensions ? [uiExtension] : [],
+      theme: [themeExtension],
+      function: [functionExtension],
     },
   })
 }

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
@@ -37,6 +37,7 @@ describe('runConcurrentHTTPProcessesAndPathForwardTraffic', () => {
 
     // When
     const got = await runConcurrentHTTPProcessesAndPathForwardTraffic(
+      '',
       3000,
       [
         {
@@ -69,7 +70,7 @@ describe('runConcurrentHTTPProcessesAndPathForwardTraffic', () => {
     vi.mocked(getAvailableTCPPort).mockResolvedValueOnce(4000)
 
     // When
-    const got = await runConcurrentHTTPProcessesAndPathForwardTraffic(undefined, [], [])
+    const got = await runConcurrentHTTPProcessesAndPathForwardTraffic('', undefined, [], [])
 
     // Then
     expect(server.close).not.toHaveBeenCalled()

--- a/packages/cli-kit/src/private/node/ui/components/Alert.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Alert.tsx
@@ -6,7 +6,7 @@ import {Box, Text} from 'ink'
 import React from 'react'
 
 export interface CustomSection {
-  title: string
+  title?: string
   body: TokenItem
 }
 
@@ -68,7 +68,7 @@ const Alert: React.FC<AlertProps> = ({
         <Box flexDirection="column">
           {customSections.map((section, index) => (
             <Box key={index} flexDirection="column" marginTop={1}>
-              <Text bold>{section.title}</Text>
+              {section.title && <Text bold>{section.title}</Text>}
               <TokenizedText item={section.body} />
             </Box>
           ))}

--- a/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
@@ -42,7 +42,20 @@ interface ListToken {
   }
 }
 
-type Token = string | CommandToken | LinkToken | CharToken | UserInputToken | SubduedToken | FilePathToken | ListToken
+interface BoldToken {
+  bold: string
+}
+
+type Token =
+  | string
+  | CommandToken
+  | LinkToken
+  | CharToken
+  | UserInputToken
+  | SubduedToken
+  | FilePathToken
+  | ListToken
+  | BoldToken
 export type TokenItem = Token | Token[]
 
 type DisplayType = 'block' | 'inline'
@@ -75,6 +88,8 @@ export function tokenItemToString(token: TokenItem): string {
     return token.filePath
   } else if ('list' in token) {
     return token.list.items.map(tokenItemToString).join(' ')
+  } else if ('bold' in token) {
+    return token.bold
   } else {
     return token.map(tokenItemToString).join(' ')
   }
@@ -123,6 +138,8 @@ const TokenizedText: React.FC<Props> = ({item}) => {
     return <FilePath filePath={item.filePath} />
   } else if ('list' in item) {
     return <List {...item.list} />
+  } else if ('bold' in item) {
+    return <Text bold>{item.bold}</Text>
   } else {
     const groupedItems = item.map(tokenToBlock).reduce(splitByDisplayType, [])
 


### PR DESCRIPTION
### WHY are these changes introduced?

Now that we have a new dev console capable of showing different types of UI extensions together with the app link, we want to point to that directly if we can.

### WHAT is this pull request doing?

I've added a success banner to `dev` that displays either the app url if there are no ui extensions or the dev console url if there are. Pressing any key will now open that url.
<img width="883" alt="Screenshot 2023-01-23 at 15 56 14" src="https://user-images.githubusercontent.com/151725/213982027-1a12691b-81f4-4937-b211-98995a32a237.png">

I've also adde some minor fixes:
- Fix `execCLI2` running tasks inside `renderConcurrent`. Previously `renderTasks` was trying to be rendered inside `renderConcurrent`, but that's not possible.
- Add bold text token to UI kit
- Banner custom sections can now have no title

### How to test your changes?

- Run `pnpm shopify app dev --path fixtures/app`
- Press any key
- Get to the new dev console

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
