### PR TITLE
Fix issue with CLI2 process printing tasks inside concurrent output

### DIFF
--- a/.changeset/many-zoos-care.md
+++ b/.changeset/many-zoos-care.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix issue with CLI2 task output not being rendered correctly inside the output from the dev command

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -8,6 +8,7 @@ import {AbortError, AbortSilentError} from './error.js'
 import {pathConstants} from '../../private/node/constants.js'
 import {AdminSession} from '../../public/node/session.js'
 import {content, token} from '../../output.js'
+import {isTruthy} from '../../private/node/environment/utilities.js'
 import {Writable} from 'stream'
 
 const RubyCLIVersion = '2.34.0'
@@ -144,7 +145,7 @@ async function installCLIDependencies(stdout: Writable) {
   const exists = await file.fileExists(shopifyCLIDirectory())
 
   if (!exists) stdout.write('Installing theme dependencies...')
-  const usingLocalCLI2 = Boolean(process.env.SHOPIFY_CLI_2_0_DIRECTORY)
+  const usingLocalCLI2 = isTruthy(process.env.SHOPIFY_CLI_2_0_DIRECTORY)
   await validateRubyEnv()
   if (usingLocalCLI2) {
     await bundleInstallLocalShopifyCLI()

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -1,5 +1,4 @@
 import {coerceSemverVersion} from './semver.js'
-import {renderTasks} from './ui.js'
 import {AbortSignal} from './abort.js'
 import {platformAndArch} from './os.js'
 import {captureOutput, exec} from './system.js'
@@ -27,6 +26,8 @@ interface ExecCLI2Options {
   directory?: string
   // A signal to stop the process execution.
   signal?: AbortSignal
+  // Stream to pipe the command's stdout to.
+  stdout?: Writable
 }
 /**
  * Execute CLI 2.0 commands.
@@ -37,7 +38,7 @@ interface ExecCLI2Options {
  * @param options - Options to customize the execution of cli2.
  */
 export async function execCLI2(args: string[], options: ExecCLI2Options = {}): Promise<void> {
-  await installCLIDependencies()
+  await installCLIDependencies(options.stdout ?? process.stdout)
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     SHOPIFY_CLI_STOREFRONT_RENDERER_AUTH_TOKEN: options.storefrontToken,
@@ -136,31 +137,24 @@ async function installThemeCheckCLIDependencies(stdout: Writable) {
  * Install RubyCLI and its dependencies
  * Shows a loading spinner if it's the first time installing dependencies
  * or if we are installing a new version of RubyCLI.
+ *
+ * @param stdout - The Writable stream on which to write the standard output.
  */
-async function installCLIDependencies() {
+async function installCLIDependencies(stdout: Writable) {
   const exists = await file.fileExists(shopifyCLIDirectory())
-  const tasks = [
-    {
-      title: 'Installing theme dependencies',
-      task: async () => {
-        const usingLocalCLI2 = Boolean(process.env.SHOPIFY_CLI_2_0_DIRECTORY)
-        await validateRubyEnv()
-        if (usingLocalCLI2) {
-          await bundleInstallLocalShopifyCLI()
-        } else {
-          await createShopifyCLIWorkingDirectory()
-          await createShopifyCLIGemfile()
-          await bundleInstallShopifyCLI()
-        }
-      },
-    },
-  ]
 
-  if (exists) {
-    await tasks[0]!.task()
+  if (!exists) stdout.write('Installing theme dependencies...')
+  const usingLocalCLI2 = Boolean(process.env.SHOPIFY_CLI_2_0_DIRECTORY)
+  await validateRubyEnv()
+  if (usingLocalCLI2) {
+    await bundleInstallLocalShopifyCLI()
   } else {
-    await renderTasks(tasks)
+    await createShopifyCLIWorkingDirectory()
+    await createShopifyCLIGemfile()
+    await bundleInstallShopifyCLI()
   }
+
+  if (!exists) stdout.write('Installed theme dependencies!')
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

I've extracted this fix from https://github.com/Shopify/cli/pull/1185

### WHAT is this pull request doing?

Fix execCLI2 running tasks inside renderConcurrent. Previously renderTasks was trying to be rendered inside renderConcurrent, but that's not possible.

### How to test your changes?

- Run `pnpm shopify app dev --path fixtures/app`
- Output shouldn't break

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
