### PR TITLE
Skip benchmark and coverage steps on forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,6 +18,7 @@ jobs:
   benchmark:
     name: benchmark with Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: github.repository_owner == 'Shopify'
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -179,12 +179,12 @@ jobs:
         run: pnpm nx run features:test
       - name: Run and save test coverage
         uses: ./.github/actions/run-and-save-test-coverage
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
+        if: ${{ github.repository_owner == 'Shopify' && matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
         with:
           branch-name: "${{ github.head_ref }}"
       - name: Download and publish test coverage
         uses: ./.github/actions/download-and-publish-test-coverage
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
+        if: ${{ github.repository_owner == 'Shopify' && matrix.os == 'ubuntu-latest' && matrix.node == '18.7.0' }}
         with:
           base-branch-name: "${{ github.base_ref }}"
 


### PR DESCRIPTION
### WHY are these changes introduced?

Some GitHub Actions are not working on forks (like [here](https://github.com/Shopify/cli/pull/1035)) because of missing permissions. 

![25-28-k7xrk-nld2h](https://user-images.githubusercontent.com/14979109/214514942-f5b27a89-62dd-47d5-963e-105a86d7a0ae.png)

Specifically, the failing steps are benchmark and coverage because both use an action to comment on the PR.

We could use the [pull_request_target event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target), but it's not recommended for security reasons in our case, as we build and run code. More details [here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests).

### WHAT is this pull request doing?

Skip the benchmark and coverage steps on forks, as it's not essential.

### How to test your changes?

We have to merge 🤷 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
