### PR TITLE
Add description to POS UI Extension

### DIFF
--- a/.changeset/stupid-kangaroos-suffer.md
+++ b/.changeset/stupid-kangaroos-suffer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Add description configuration to POS UI Extension

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -30,6 +30,7 @@ export const ExtensionPointSchema = schema.union([OldExtensionPointsSchema, NewE
 
 export const BaseUIExtensionSchema = schema.object({
   name: schema.string(),
+  description: schema.string().optional(),
   type: schema.string().default('ui_extension'),
   extensionPoints: schema.any().optional(),
   capabilities: CapabilitiesSchema.optional(),

--- a/packages/app/src/cli/models/extensions/ui-specifications/pos_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/pos_ui_extension.ts
@@ -13,10 +13,14 @@ const spec = createUIExtensionSpecification({
   dependency,
   partnersWebIdentifier: 'pos_ui_extension',
   schema: BaseUIExtensionSchema,
-  deployConfig: async (_, directory) => {
+  deployConfig: async (config, directory) => {
     const result = await getDependencyVersion(dependency.name, directory)
     if (result === 'not_found') throw new BugError(`Dependency ${dependency.name} not found`)
-    return {renderer_version: result?.version}
+    return {
+      name: config.name,
+      description: config.description,
+      renderer_version: result?.version,
+    }
   },
   previewMessage: () => undefined,
 })

--- a/packages/app/templates/ui-extensions/projects/pos_ui/shopify.ui.extension.toml.liquid
+++ b/packages/app/templates/ui-extensions/projects/pos_ui/shopify.ui.extension.toml.liquid
@@ -1,5 +1,6 @@
 type = "{{ type }}"
 name = "{{ name }}"
+description = "{{ name }}"
 
 extension_points = [
   'Retail::SmartGrid::Tile',


### PR DESCRIPTION
### WHY are these changes introduced?

Unblocks https://github.com/Shopify/shopify/pull/402073
Required to resolve https://github.com/Shopify/pos-next-react-native/issues/20351

For the [Native App Extensions for POS](https://vault.shopify.io/gsd/projects/21763) project we need to support merchants easily differentiating between extensions in a human-friendly manner.

### WHAT is this pull request doing?

The [registration title is consider internal and only viewable to the partner](https://github.com/Shopify/extensions-runtime/pull/285#issuecomment-1404131949), so instead we can put a "description" into the extension config and provide that to POS. Partners will specify this description via shopify.ui.extension.toml - which is what this PR enables.

### How to test your changes?

#### Generate a new extension

```bash
$ pnpm run generate extension

> my-app-1@1.0.0 generate /Users/me/my-app-1
> shopify app generate "extension"
...

   Discounts and checkout
   (1) Checkout UI
   (2) Function - Delivery customization
   (3) Function - Order discount
   (4) Function - Payment customization
   (5) Function - Product discount
   (6) Function - Shipping discount
   (7) Post-purchase UI

   Shopify private
   (8) Order routing location rule

   Point-of-Sale
>  (9) POS UI
```

#### Edit extensions/my-extension/shopify.ui.extension.toml

```toml
type = "pos_ui_extension"
name = "my-extension"
description = "Merchant-friendly Name For My Extension"

extension_points = [
  'Retail::SmartGrid::Tile',
  'Retail::SmartGrid::Modal'
]
```

#### Deploy

````bash
$ pnpm run deploy
````

#### [Verify database contains the new data](https://app.shopify.com/services/internal/queries/new?q=SELECT%20*%20FROM%20app_static_extension_configs%20C%0AINNER%20JOIN%20app_extension_registrations%20R%20ON%20R.id%20%3D%20C.registration_id%0AWHERE%20R.id%20%3D%2020348207105%3B&shard_by=master) in config

<img width="1170" alt="Screenshot 2023-01-25 at 4 51 22 PM" src="https://user-images.githubusercontent.com/388069/214709868-8df47112-35f2-485e-9cb3-73d44aa1d907.png">

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
