### PR TITLE
Fix an issue with CLI2 not printing to the right stdout

### DIFF
--- a/.changeset/modern-chefs-trade.md
+++ b/.changeset/modern-chefs-trade.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix an issue with CLI2 not printing to the right stdout

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -200,8 +200,8 @@ function devThemeExtensionTarget(
 ): OutputProcess {
   return {
     prefix: 'extensions',
-    action: async (_stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-      await execCLI2(['extension', 'serve', ...args], {adminSession, storefrontToken, token})
+    action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+      await execCLI2(['extension', 'serve', ...args], {adminSession, storefrontToken, token, stdout})
     },
   }
 }


### PR DESCRIPTION
In https://github.com/Shopify/cli/pull/1194 I forgot to include this change as well, so they fix didn't really go live.