### PR TITLE
Fix customer_account_ui extension identifier

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -170,7 +170,7 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     name: 'Customer Accounts',
     externalName: 'Customer Accounts',
     identifier: 'customer_accounts_ui_extension',
-    externalIdentifier: 'customer_accounts_ui_extension',
+    externalIdentifier: 'customer_accounts_ui',
     gated: false,
     options: {
       managementExperience: 'cli',


### PR DESCRIPTION
### WHY are these changes introduced?

@robin-drexler reported that it's no longer possible to generate customer account ui extensions from the CLI.

### WHAT is this pull request doing?

The problem was that the external identifier ended with `extension`, but the template folder didn't. All UI extensions seem to be exceptions to the rule of ending with `_extension` so I've removed this suffix.

### How to test your changes?

- Run `pnpm generate extension` in the fixture app
- It works

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
