### PR TITLE
Improve the message we display when installing deps

### DIFF
--- a/packages/app/src/cli/services/dependencies.ts
+++ b/packages/app/src/cli/services/dependencies.ts
@@ -12,7 +12,7 @@ import {renderTasks} from '@shopify/cli-kit/node/ui'
 export async function installAppDependencies(app: AppInterface) {
   const tasks = [
     {
-      title: 'Installing any necessary dependencies',
+      title: 'Installing dependencies',
       task: async () => {
         await installNPMDependenciesRecursively({
           packageManager: app.packageManager,

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -79,7 +79,7 @@ async function uiExtensionInit({
 }: UIExtensionInitOptions) {
   const tasks = [
     {
-      title: 'Installing additional dependencies',
+      title: 'Installing dependencies',
       task: async () => {
         await addResolutionOrOverrideIfNeeded(app.directory, extensionFlavor)
         const requiredDependencies = getRuntimeDependencies({specification, extensionFlavor})

--- a/packages/cli-hydrogen/src/cli/services/eslint.ts
+++ b/packages/cli-hydrogen/src/cli/services/eslint.ts
@@ -23,7 +23,7 @@ export async function addESLint({app, force, install}: AddESlintOptions) {
   const list = ui.newListr(
     [
       {
-        title: 'Installing additional dependencies',
+        title: 'Installing dependencies',
         skip: () => !install,
         task: async (_, task) => {
           const requiredDependencies = ['eslint', 'eslint-plugin-hydrogen', 'prettier', '@shopify/prettier-config']

--- a/packages/cli-hydrogen/src/cli/services/tailwind.ts
+++ b/packages/cli-hydrogen/src/cli/services/tailwind.ts
@@ -27,7 +27,7 @@ const tailwindImportsExist = (indexCSS: string) =>
 export async function addTailwind({app, force, install, directory}: AddTailwindOptions) {
   const list = ui.newListr([
     {
-      title: 'Installing additional dependencies',
+      title: 'Installing dependencies',
       skip: () => !install,
       task: async (_, task) => {
         const requiredDependencies = ['postcss', 'postcss-loader', 'tailwindcss', 'autoprefixer']

--- a/packages/create-app/src/utils/template/npm.test.ts
+++ b/packages/create-app/src/utils/template/npm.test.ts
@@ -128,49 +128,51 @@ describe('getDeepInstallNPMTasks', () => {
     didInstallEverything: () => {},
   }
 
-  it.each([
-    ['/', 0],
-    ['/web/', 1],
-    ['/web/frontend/', 2],
-  ])('returns a task for %s', async (folderPath, i) => {
+  it('returns a task for each folder with a package.json', async () => {
     await mockAppFolder(async (tmpDir) => {
       const tasks = await getDeepInstallNPMTasks({...defaultArgs, from: tmpDir})
-      const thisTask = tasks[i]
 
-      expect(thisTask).toStrictEqual({
-        title: `Installing dependencies in ${folderPath}`,
-        task: expect.any(Function),
-      })
+      expect(tasks).toStrictEqual([
+        {
+          title: `Installing dependencies`,
+          task: expect.any(Function),
+        },
+        {
+          title: `Installing dependencies in web/`,
+          task: expect.any(Function),
+        },
+        {
+          title: `Installing dependencies in web/frontend/`,
+          task: expect.any(Function),
+        },
+      ])
     })
   })
 
-  it.each([['darwin'], ['win32']])(
-    'each task.task installs dependencies when the os is %s',
-    async (operativeSystem) => {
-      await mockAppFolder(async (tmpDir) => {
-        const expectedArgs = operativeSystem === 'win32' ? ['--network-concurrency', '1'] : []
-        vi.mocked(platform).mockReturnValue(operativeSystem as NodeJS.Platform)
+  it.each([['darwin'], ['win32']])('each task installs dependencies when the os is %s', async (operativeSystem) => {
+    await mockAppFolder(async (tmpDir) => {
+      const expectedArgs = operativeSystem === 'win32' ? ['--network-concurrency', '1'] : []
+      vi.mocked(platform).mockReturnValue(operativeSystem as NodeJS.Platform)
 
-        const tasks = await getDeepInstallNPMTasks({...defaultArgs, packageManager: 'yarn', from: tmpDir})
+      const tasks = await getDeepInstallNPMTasks({...defaultArgs, packageManager: 'yarn', from: tmpDir})
 
-        await Promise.all(tasks.map(({task}) => task({})))
+      await Promise.all(tasks.map(({task}) => task({})))
 
-        expect(installNodeModules).toHaveBeenCalledWith({
-          directory: `${normalizePath(tmpDir)}/`,
-          packageManager: 'yarn',
-          args: expectedArgs,
-        })
-        expect(installNodeModules).toHaveBeenCalledWith({
-          directory: `${joinPath(tmpDir, 'web')}/`,
-          packageManager: 'yarn',
-          args: expectedArgs,
-        })
-        expect(installNodeModules).toHaveBeenCalledWith({
-          directory: `${joinPath(tmpDir, 'web', 'frontend')}/`,
-          packageManager: 'yarn',
-          args: expectedArgs,
-        })
+      expect(installNodeModules).toHaveBeenCalledWith({
+        directory: `${normalizePath(tmpDir)}/`,
+        packageManager: 'yarn',
+        args: expectedArgs,
       })
-    },
-  )
+      expect(installNodeModules).toHaveBeenCalledWith({
+        directory: `${joinPath(tmpDir, 'web')}/`,
+        packageManager: 'yarn',
+        args: expectedArgs,
+      })
+      expect(installNodeModules).toHaveBeenCalledWith({
+        directory: `${joinPath(tmpDir, 'web', 'frontend')}/`,
+        packageManager: 'yarn',
+        args: expectedArgs,
+      })
+    })
+  })
 })

--- a/packages/create-app/src/utils/template/npm.ts
+++ b/packages/create-app/src/utils/template/npm.ts
@@ -66,7 +66,7 @@ export async function getDeepInstallNPMTasks({
 
   return packageJSONFiles.map((filePath) => {
     const folderPath = filePath.replace('package.json', '')
-    const titlePath = folderPath.replace(root, '')
+    const titlePath = folderPath.replace(joinPath(root, '/'), '')
 
     /**
      * Installation of dependencies using Yarn on Windows might lead
@@ -78,8 +78,9 @@ export async function getDeepInstallNPMTasks({
      * Reported issue: https://github.com/yarnpkg/yarn/issues/7212
      */
     const args = platform() === 'win32' && packageManager === 'yarn' ? ['--network-concurrency', '1'] : []
+    const title = titlePath === '' ? 'Installing dependencies' : `Installing dependencies in ${titlePath}`
     return {
-      title: `Installing dependencies in ${titlePath}`,
+      title,
       task: async () => {
         await installNodeModules({directory: folderPath, packageManager, args})
       },


### PR DESCRIPTION
### WHY are these changes introduced?

When you create a node app, our task list is printing this messages:
- `Installing dependencies in / ...`
- `Installing dependencies in /web/ ...`
- `Installing dependencies in /web/frontend/ ...`

This is mildly alarming as it looks we are installing things at the root of the filesystem.

### WHAT is this pull request doing?

Change the above messages to:
- `Installing dependencies ...`
- `Installing dependencies in web/ ...`
- `Installing dependencies in web/frontend/ ...`

Also make sure we use 'Installing dependencies' messaging consistently.

### How to test your changes?

- Create a new node app

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
