### PR TITLE
Fix: allow ORDERS_CREATE-like topics again

### DIFF
--- a/packages/app/src/cli/prompts/webhook/options-prompt.test.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.test.ts
@@ -149,6 +149,26 @@ describe('optionsPrompt', () => {
       })
     })
 
+    describe('collectTopic', async () => {
+      const availableTopics = ['products/update', 'orders/create', 'shop/redact']
+
+      it('accepts and transforms an ORDERS_CREATE-like topic name into orders/create-like', async () => {
+        // When
+        const topic = await collectTopic('ORDERS_CREATE', aVersion, availableTopics)
+
+        // Then
+        expect(topic).toEqual('orders/create')
+      })
+
+      it('rejects case insensitive versions', async () => {
+        // When
+        await expect(collectTopic('OrdERS_Create', aVersion, availableTopics)).rejects.toThrow(AbortError)
+        await expect(collectTopic('orders_create', aVersion, availableTopics)).rejects.toThrow(AbortError)
+        await expect(collectTopic('OrdERS/CreaTE', aVersion, availableTopics)).rejects.toThrow(AbortError)
+        await expect(collectTopic('ORDERS/CREATE', aVersion, availableTopics)).rejects.toThrow(AbortError)
+      })
+    })
+
     function expectNoPrompts() {
       expect(topicPrompt).toHaveBeenCalledTimes(0)
       expect(apiVersionPrompt).toHaveBeenCalledTimes(0)

--- a/packages/app/src/cli/prompts/webhook/options-prompt.ts
+++ b/packages/app/src/cli/prompts/webhook/options-prompt.ts
@@ -52,15 +52,17 @@ export async function collectTopic(
   const topicPassed = flagPassed(topic)
 
   if (topicPassed) {
-    const passedTopic = (topic as string).trim()
-    if (availableTopics.includes(passedTopic)) {
-      return passedTopic
+    const passedTopic = equivalentTopic((topic as string).trim(), availableTopics)
+
+    if (passedTopic === undefined) {
+      throw new AbortError(
+        `Topic '${passedTopic}' does not exist for ApiVersion '${apiVersion}'`,
+        `Allowed values: ${availableTopics.join(', ')}`,
+        ['Try again with a valid api-version - topic pair'],
+      )
     }
-    throw new AbortError(
-      `Topic '${passedTopic}' does not exist for ApiVersion '${apiVersion}'`,
-      `Allowed values: ${availableTopics.join(', ')}`,
-      ['Try again with a valid api-version - topic pair'],
-    )
+
+    return passedTopic
   }
 
   if (availableTopics.length === 0) {
@@ -154,4 +156,12 @@ function inferMethodFromAddress(address: string): string {
   }
 
   return method
+}
+
+function equivalentTopic(passedTopic: string, availableTopics: string[]): string | undefined {
+  if (availableTopics.includes(passedTopic)) {
+    return passedTopic
+  }
+
+  return availableTopics.find((elm) => elm.toUpperCase().replace('/', '_') === passedTopic)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When I added the topics autocomplete feature, I validated the topic flag against the list of available topics coming from core. This list contains topics in the style of *products/update*. 
By doing this, I caused the tool to fail on topic names such as *PRODUCTS_UPDATE*. These names were allowed in the previous version and are documented as possible values here https://shopify.dev/apps/tools/cli/commands#webhook-trigger.

### WHAT is this pull request doing?

This PR recovers that functionality. It converts upper case - underscored names into REST lowercase - slash names.

Previously:
```
$ pnpm shopify webhook trigger --topic="ORDERS_CREATE" --api-version="2023-01" --address="http://localhost:55072/api/webhooks" --shared-secret="xxx"

Topic 'ORDERS_CREATE' does not exist for ApiVersion '2023-01'   
```

Now it works

### How to test your changes?

$ pnpm shopify webhook trigger --topic="ORDERS_CREATE" --api-version="2023-01" --address="something" --shared-secret="xxx"

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
