### PR TITLE
Upgrade to TypeScript 4.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "tmp": "^0.2.1",
     "ts-node": "^10.7.0",
     "tslib": "^2.3.1",
-    "typescript": "4.8.4",
+    "typescript": "4.9.4",
     "@babel/core": "^7.11.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@shopify/eslint-plugin": "^41.3.0",
     "@shopify/typescript-configs": "^5.1.0",
     "@shopify/web-pixels-extension": "0.1.4",
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "@types/rimraf": "^3.0.2",
     "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.27.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -59,7 +59,7 @@
     "@types/diff": "^5.0.2",
     "@types/http-proxy": "^1.17.9",
     "@types/lodash-es": "^4.17.6",
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "@types/serve-static": "^1.15.0",
     "@types/ws": "^8.5.3",
     "graphql": "^16.0.0",

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -49,7 +49,7 @@
     "fs-extra": "11.1.0",
     "graphql-request": "4.3.0",
     "prettier": "2.6.1",
-    "typescript": "4.8.4",
+    "typescript": "4.9.4",
     "vite": "2.9.13"
   },
   "devDependencies": {

--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "9.0.13",
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "graphql": "^16.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -154,7 +154,7 @@
     "@types/fs-extra": "9.0.13",
     "@types/gradient-string": "^1.1.2",
     "@types/lodash": "4.14.191",
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "@types/react": "17.0.2",
     "@types/semver": "^7.3.9",
     "@vitest/coverage-istanbul": "^0.26.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -103,7 +103,7 @@
     "@shopify/app": "3.38.0",
     "@shopify/cli-hydrogen": "3.38.0",
     "@shopify/theme": "3.38.0",
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "@vitest/coverage-istanbul": "^0.26.3",
     "vite": "^2.9.13",
     "vitest": "^0.26.3"

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -53,7 +53,7 @@
     "@shopify/cli-kit": "3.38.0"
   },
   "devDependencies": {
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "vite": "^2.9.13",
     "vitest": "^0.26.3"
   },

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@types/download": "8.0.0",
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "vite": "^2.9.13",
     "vitest": "^0.26.3"
   },

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -29,7 +29,7 @@
     "@cucumber/pretty-formatter": "1.0.0",
     "@types/cucumber": "^7.0.0",
     "@types/fs-extra": "^9.0.13",
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "@types/rimraf": "^3.0.2",
     "ansi-colors": "^4.1.1",
     "execa": "^5.1.1",

--- a/packages/plugin-ngrok/package.json
+++ b/packages/plugin-ngrok/package.json
@@ -40,7 +40,7 @@
     "@shopify/ngrok": "4.3.2"
   },
   "devDependencies": {
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "vite": "^2.9.13",
     "vitest": "^0.26.3"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -37,7 +37,7 @@
     "@shopify/cli-kit": "3.38.0"
   },
   "devDependencies": {
-    "@types/node": "14.17.0",
+    "@types/node": "14.18.36",
     "vite": "^2.9.13",
     "vitest": "^0.26.3"
   },

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -62,7 +62,7 @@
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "sass": "^1.42.1",
     "ts-node": "^10.2.1",
-    "typescript": "4.8.4",
+    "typescript": "4.9.4",
     "vite": "^2.9.13",
     "vite-tsconfig-paths": "^3.3.14",
     "vitest": "^0.26.3"

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@shopify/react-testing": "^3.0.0",
     "@shopify/ui-extensions-test-utils": "3.25.0",
-    "@types/node": "^17.0.38",
+    "@types/node": "14.18.36",
     "@types/qrcode.react": "^1.0.2",
     "@types/react": "16.14.0",
     "@types/react-dom": "^16.9.11",

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@shopify/react-testing": "^3.0.0",
     "@shopify/ui-extensions-test-utils": "3.25.0",
-    "@types/node": "^17.0.38",
+    "@types/node": "14.18.36",
     "@types/react": "17.0.2",
     "@types/react-dom": "^16.9.11",
     "@vitejs/plugin-react-refresh": "^1.3.1",

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -59,7 +59,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "ts-node": "^10.2.1",
-    "typescript": "4.8.4",
+    "typescript": "4.9.4",
     "vi-fetch": "^0.8.0",
     "vite": "^2.9.13",
     "vite-tsconfig-paths": "^3.3.14",

--- a/packages/ui-extensions-test-utils/package.json
+++ b/packages/ui-extensions-test-utils/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@shopify/react-testing": "^3.0.0",
-    "@types/node": "^17.0.38",
+    "@types/node": "14.18.36",
     "@types/react": "16.14.0",
     "@types/react-dom": "^16.9.11",
     "mock-socket": "^9.0.5",

--- a/packages/ui-extensions-test-utils/package.json
+++ b/packages/ui-extensions-test-utils/package.json
@@ -35,7 +35,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "ts-node": "^10.2.1",
-    "typescript": "4.8.4"
+    "typescript": "4.9.4"
   },
   "peerDependencies": {
     "react": "^17.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
       '@shopify/eslint-plugin': ^41.3.0
       '@shopify/typescript-configs': ^5.1.0
       '@shopify/web-pixels-extension': 0.1.4
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@types/rimraf': ^3.0.2
       '@types/tmp': ^0.2.3
       '@typescript-eslint/eslint-plugin': ^5.27.0
@@ -68,26 +68,26 @@ importers:
       tmp: ^0.2.1
       ts-node: ^10.7.0
       tslib: ^2.3.1
-      typescript: 4.8.4
+      typescript: 4.9.4
     devDependencies:
       '@apollo/client': 3.7.1_77h5kg6422vos5a7c32osaaxh4
       '@babel/core': 7.20.5
       '@bugsnag/source-maps': 2.3.1
       '@changesets/cli': 2.25.2
-      '@nrwl/eslint-plugin-nx': 15.3.0_f5sgilseslzokx4rl2cbqiuvfm
-      '@nrwl/js': 15.3.0_fxeh3qq5g7mre3t472uwf6qa7q
+      '@nrwl/eslint-plugin-nx': 15.3.0_khwqonkpxvizx5gfphwz6mdodm
+      '@nrwl/js': 15.3.0_pi7ctgt3apakr6ixdq3msrhkyy
       '@nrwl/tao': 15.3.0
-      '@nrwl/workspace': 15.3.0_n6qshekvp4yqndkuu5fuozz5ni
+      '@nrwl/workspace': 15.3.0_pbhkxitjplcbleyi5jfqwqdsju
       '@octokit/core': 4.1.0
       '@octokit/rest': 19.0.5
-      '@shopify/eslint-plugin': 41.3.1_em2gb7xybgqjsdu6qumqqdiike
+      '@shopify/eslint-plugin': 41.3.1_m6slonagemwjv2qkfsz2bojzbm
       '@shopify/typescript-configs': 5.1.0
       '@shopify/web-pixels-extension': 0.1.4
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@types/rimraf': 3.0.2
       '@types/tmp': 0.2.3
-      '@typescript-eslint/eslint-plugin': 5.45.0_psz44bhp76u27vmulntnlx26h4
-      '@typescript-eslint/parser': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/eslint-plugin': 5.45.0_wke4plxjew2ogjxrdwvzd2srfq
+      '@typescript-eslint/parser': 5.45.0_wy4udjehnvkneqnogzx5kughki
       ansi-colors: 4.1.3
       bugsnag-build-reporter: 2.0.0
       commander: 9.4.1
@@ -97,7 +97,7 @@ importers:
       eslint-config-airbnb: 19.0.4_vt5pco6i6xyxmp2zptq3cuddue
       eslint-config-prettier: 8.5.0_eslint@8.28.0
       eslint-plugin-import: 2.26.0_vbnhqcxlbs7ynbxw44hu2vq7eq
-      eslint-plugin-jest: 26.9.0_brvvscwiof5cmspgfht34o7vqq
+      eslint-plugin-jest: 26.9.0_f2vz4uylpwx7vkkuf4vs26ih3q
       eslint-plugin-jsdoc: 39.6.4_eslint@8.28.0
       eslint-plugin-jsx-a11y: 6.6.1_eslint@8.28.0
       eslint-plugin-no-catch-all: 1.1.0_eslint@8.28.0
@@ -127,9 +127,9 @@ importers:
       shx: 0.3.4
       tempy: 3.0.0
       tmp: 0.2.1
-      ts-node: 10.9.1_76zcixmkjnbphw74ddtkdwldva
+      ts-node: 10.9.1_ocil65wecyuhsmrrocoajouipe
       tslib: 2.4.1
-      typescript: 4.8.4
+      typescript: 4.9.4
 
   fixtures/app:
     specifiers:
@@ -231,7 +231,7 @@ importers:
       '@types/diff': ^5.0.2
       '@types/http-proxy': ^1.17.9
       '@types/lodash-es': ^4.17.6
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@types/serve-static': ^1.15.0
       '@types/ws': ^8.5.3
       abort-controller: 3.0.0
@@ -264,7 +264,7 @@ importers:
       '@types/diff': 5.0.2
       '@types/http-proxy': 1.17.9
       '@types/lodash-es': 4.17.6
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@types/serve-static': 1.15.0
       '@types/ws': 8.5.3
       graphql: 16.6.0
@@ -282,7 +282,7 @@ importers:
       '@shopify/cli-hydrogen': 3.38.0
       '@shopify/cli-kit': 3.38.0
       '@shopify/theme': 3.38.0
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@vitest/coverage-istanbul': ^0.26.3
       vite: 2.9.12
       vitest: ^0.26.3
@@ -296,7 +296,7 @@ importers:
       '@shopify/app': link:../app
       '@shopify/cli-hydrogen': link:../cli-hydrogen
       '@shopify/theme': link:../theme
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@vitest/coverage-istanbul': 0.26.3
       vite: 2.9.12
       vitest: 0.26.3
@@ -309,7 +309,7 @@ importers:
       '@shopify/mini-oxygen': 0.2.0
       '@shopify/prettier-config': 1.1.2
       '@types/fs-extra': 9.0.13
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@types/prettier': 2.6.3
       fast-glob: 3.2.11
       fs-extra: 11.1.0
@@ -318,7 +318,7 @@ importers:
       prettier: 2.6.1
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: 4.8.4
+      typescript: 4.9.4
       vite: 2.9.12
       vitest: ^0.26.3
     dependencies:
@@ -332,11 +332,11 @@ importers:
       fs-extra: 11.1.0
       graphql-request: 4.3.0_graphql@16.6.0
       prettier: 2.6.1
-      typescript: 4.8.4
+      typescript: 4.9.4
       vite: 2.9.12
     devDependencies:
       '@types/fs-extra': 9.0.13
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       graphql: 16.6.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -354,7 +354,7 @@ importers:
       '@types/fs-extra': 9.0.13
       '@types/gradient-string': ^1.1.2
       '@types/lodash': 4.14.191
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@types/react': 16.14.0
       '@types/semver': ^7.3.9
       '@vitest/coverage-istanbul': ^0.26.3
@@ -486,7 +486,7 @@ importers:
       '@types/fs-extra': 9.0.13
       '@types/gradient-string': 1.1.2
       '@types/lodash': 4.14.191
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@types/react': 16.14.0
       '@types/semver': 7.3.13
       '@vitest/coverage-istanbul': 0.26.3
@@ -499,14 +499,14 @@ importers:
     specifiers:
       '@oclif/core': 1.21.0
       '@shopify/cli-kit': 3.38.0
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       vite: 2.9.12
       vitest: ^0.26.3
     dependencies:
       '@oclif/core': 1.21.0
       '@shopify/cli-kit': link:../cli-kit
     devDependencies:
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       vite: 2.9.12
       vitest: 0.26.3
 
@@ -515,7 +515,7 @@ importers:
       '@oclif/core': 1.21.0
       '@shopify/cli-kit': 3.38.0
       '@types/download': 8.0.0
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       download: 8.0.0
       vite: 2.9.12
       vitest: ^0.26.3
@@ -525,7 +525,7 @@ importers:
       download: 8.0.0
     devDependencies:
       '@types/download': 8.0.0
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       vite: 2.9.12
       vitest: 0.26.3
 
@@ -536,7 +536,7 @@ importers:
       '@cucumber/pretty-formatter': 1.0.0
       '@types/cucumber': ^7.0.0
       '@types/fs-extra': ^9.0.13
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@types/rimraf': ^3.0.2
       ansi-colors: ^4.1.1
       execa: ^5.1.1
@@ -550,7 +550,7 @@ importers:
       '@cucumber/pretty-formatter': 1.0.0_hydn4najtrvg6qst6ilzadj5xa
       '@types/cucumber': 7.0.0
       '@types/fs-extra': 9.0.13
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       '@types/rimraf': 3.0.2
       ansi-colors: 4.1.3
       execa: 5.1.1
@@ -564,7 +564,7 @@ importers:
       '@oclif/core': 1.21.0
       '@shopify/cli-kit': 3.38.0
       '@shopify/ngrok': 4.3.2
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       vite: 2.9.12
       vitest: ^0.26.3
     dependencies:
@@ -572,7 +572,7 @@ importers:
       '@shopify/cli-kit': link:../cli-kit
       '@shopify/ngrok': 4.3.2
     devDependencies:
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       vite: 2.9.12
       vitest: 0.26.3
 
@@ -580,14 +580,14 @@ importers:
     specifiers:
       '@oclif/core': 1.21.0
       '@shopify/cli-kit': 3.38.0
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       vite: 2.9.12
       vitest: ^0.26.3
     dependencies:
       '@oclif/core': 1.21.0
       '@shopify/cli-kit': link:../cli-kit
     devDependencies:
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       vite: 2.9.12
       vitest: 0.26.3
 
@@ -598,7 +598,7 @@ importers:
       '@shopify/react-testing': ^3.0.0
       '@shopify/ui-extensions-server-kit': 4.1.0
       '@shopify/ui-extensions-test-utils': 3.25.0
-      '@types/node': ^17.0.38
+      '@types/node': 14.18.36
       '@types/qrcode.react': ^1.0.2
       '@types/react': 16.14.0
       '@types/react-dom': ^16.9.11
@@ -613,7 +613,7 @@ importers:
       react-transition-group: ^4.4.5
       sass: ^1.42.1
       ts-node: ^10.2.1
-      typescript: 4.8.4
+      typescript: 4.9.4
       vite: 2.9.12
       vite-tsconfig-paths: ^3.3.14
       vitest: ^0.26.3
@@ -632,14 +632,14 @@ importers:
     devDependencies:
       '@shopify/react-testing': 3.3.10_sfoxds7t5ydpegc3knd667wn6m
       '@shopify/ui-extensions-test-utils': link:../ui-extensions-test-utils
-      '@types/node': 17.0.45
+      '@types/node': 14.18.36
       '@types/qrcode.react': 1.0.2
       '@types/react': 16.14.0
       '@types/react-dom': 16.9.17
       '@vitejs/plugin-react-refresh': 1.3.6
       sass: 1.56.1
-      ts-node: 10.9.1_ksn4eycaeggbrckn3ykh37hwf4
-      typescript: 4.8.4
+      ts-node: 10.9.1_ocil65wecyuhsmrrocoajouipe
+      typescript: 4.9.4
       vite: 2.9.12_sass@1.56.1
       vite-tsconfig-paths: 3.6.0_vite@2.9.12
       vitest: 0.26.3_sass@1.56.1
@@ -648,7 +648,7 @@ importers:
     specifiers:
       '@shopify/react-testing': ^3.0.0
       '@shopify/ui-extensions-test-utils': 3.25.0
-      '@types/node': ^17.0.38
+      '@types/node': 14.18.36
       '@types/react': 16.14.0
       '@types/react-dom': ^16.9.11
       '@vitejs/plugin-react-refresh': ^1.3.1
@@ -658,7 +658,7 @@ importers:
       react: ^17.0.2
       react-dom: ^17.0.2
       ts-node: ^10.2.1
-      typescript: 4.8.4
+      typescript: 4.9.4
       vi-fetch: ^0.8.0
       vite: 2.9.12
       vite-tsconfig-paths: ^3.3.14
@@ -666,7 +666,7 @@ importers:
     devDependencies:
       '@shopify/react-testing': 3.3.10_sfoxds7t5ydpegc3knd667wn6m
       '@shopify/ui-extensions-test-utils': link:../ui-extensions-test-utils
-      '@types/node': 17.0.45
+      '@types/node': 14.18.36
       '@types/react': 16.14.0
       '@types/react-dom': 16.9.17
       '@vitejs/plugin-react-refresh': 1.3.6
@@ -675,8 +675,8 @@ importers:
       mock-socket: 9.1.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      ts-node: 10.9.1_ksn4eycaeggbrckn3ykh37hwf4
-      typescript: 4.8.4
+      ts-node: 10.9.1_ocil65wecyuhsmrrocoajouipe
+      typescript: 4.9.4
       vi-fetch: 0.8.0
       vite: 2.9.12
       vite-tsconfig-paths: 3.6.0_vite@2.9.12
@@ -685,24 +685,24 @@ importers:
   packages/ui-extensions-test-utils:
     specifiers:
       '@shopify/react-testing': ^3.0.0
-      '@types/node': ^17.0.38
+      '@types/node': 14.18.36
       '@types/react': 16.14.0
       '@types/react-dom': ^16.9.11
       mock-socket: ^9.0.5
       react: ^17.0.2
       react-dom: ^17.0.2
       ts-node: ^10.2.1
-      typescript: 4.8.4
+      typescript: 4.9.4
     devDependencies:
       '@shopify/react-testing': 3.3.10_sfoxds7t5ydpegc3knd667wn6m
-      '@types/node': 17.0.45
+      '@types/node': 14.18.36
       '@types/react': 16.14.0
       '@types/react-dom': 16.9.17
       mock-socket: 9.1.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      ts-node: 10.9.1_ksn4eycaeggbrckn3ykh37hwf4
-      typescript: 4.8.4
+      ts-node: 10.9.1_ocil65wecyuhsmrrocoajouipe
+      typescript: 4.9.4
 
   workspace:
     specifiers:
@@ -2268,7 +2268,7 @@ packages:
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
     dev: true
 
-  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_nms4vp24lf2t67koyek5br3g5a:
+  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_zujpnpxkl4z7yqcjoyqfwgzdgu:
     resolution: {integrity: sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -2277,7 +2277,7 @@ packages:
       cosmiconfig: 7.0.0
       lodash.get: 4.4.2
       make-error: 1.3.6
-      ts-node: 9.1.1_typescript@4.8.4
+      ts-node: 9.1.1_typescript@4.9.4
       tslib: 2.4.1
     transitivePeerDependencies:
       - typescript
@@ -2427,7 +2427,7 @@ packages:
       value-or-promise: 1.0.6
     dev: true
 
-  /@graphql-tools/url-loader/6.10.1_uiex7h67ci7ddskfqq7pk5lwym:
+  /@graphql-tools/url-loader/6.10.1_qajhxsyh4z27ur52xwwod6iuj4:
     resolution: {integrity: sha512-DSDrbhQIv7fheQ60pfDpGD256ixUQIR6Hhf9Z5bRjVkXOCvO5XrkwoWLiU7iHL81GB1r0Ba31bf+sl+D4nyyfw==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
@@ -2446,7 +2446,7 @@ packages:
       is-promise: 4.0.0
       isomorphic-ws: 4.0.1_ws@7.4.5
       lodash: 4.17.21
-      meros: 1.1.4_@types+node@14.17.0
+      meros: 1.1.4_@types+node@14.18.36
       subscriptions-transport-ws: 0.9.19_graphql@15.8.0
       sync-fetch: 0.3.0
       tslib: 2.2.0
@@ -2545,7 +2545,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
       '@types/yargs': 15.0.14
       chalk: 4.1.2
     dev: true
@@ -2975,12 +2975,12 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/devkit/15.3.0_nx@15.3.0+typescript@4.8.4:
+  /@nrwl/devkit/15.3.0_nx@15.3.0+typescript@4.9.4:
     resolution: {integrity: sha512-1O9QLB/eYS6ddw4MZnV4yj4CEqLIbpleZZiG/9w1TaiVO/jfNfXVaxc8EA87XSzMpk2W+/4Qggmabt6gAQaabA==}
     peerDependencies:
       nx: '>= 14 <= 16'
     dependencies:
-      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.8.4
+      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.9.4
       ejs: 3.1.8
       ignore: 5.2.1
       nx: 15.3.0
@@ -2990,7 +2990,7 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/eslint-plugin-nx/15.3.0_f5sgilseslzokx4rl2cbqiuvfm:
+  /@nrwl/eslint-plugin-nx/15.3.0_khwqonkpxvizx5gfphwz6mdodm:
     resolution: {integrity: sha512-PWBzLIUddfO3wLTFZhcle0R1IA4RO9pyPO/a3yNP+ao8LQqWcE1kknsXgBdDOdlI7vATJvB0BGnPxT5eCu0ZXw==}
     peerDependencies:
       '@typescript-eslint/parser': ^5.29.0
@@ -2999,9 +2999,9 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      '@nrwl/devkit': 15.3.0_nx@15.3.0+typescript@4.8.4
-      '@typescript-eslint/parser': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
-      '@typescript-eslint/utils': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@nrwl/devkit': 15.3.0_nx@15.3.0+typescript@4.9.4
+      '@typescript-eslint/parser': 5.45.0_wy4udjehnvkneqnogzx5kughki
+      '@typescript-eslint/utils': 5.45.0_wy4udjehnvkneqnogzx5kughki
       chalk: 4.1.0
       confusing-browser-globals: 1.0.11
       eslint-config-prettier: 8.5.0_eslint@8.28.0
@@ -3013,12 +3013,12 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/js/15.3.0_fxeh3qq5g7mre3t472uwf6qa7q:
+  /@nrwl/js/15.3.0_pi7ctgt3apakr6ixdq3msrhkyy:
     resolution: {integrity: sha512-BeYmXsKWbrER5TdtSzgOdi6zue1hpMzfqS7XYqszOq7Pw121ewGiDDDo5KPhBAJvLfQ7Qa2YyqyIg/YLtr4MWA==}
     dependencies:
-      '@nrwl/devkit': 15.3.0_nx@15.3.0+typescript@4.8.4
-      '@nrwl/linter': 15.3.0_oihys2rbsohdb5hudxfp3i4gai
-      '@nrwl/workspace': 15.3.0_n6qshekvp4yqndkuu5fuozz5ni
+      '@nrwl/devkit': 15.3.0_nx@15.3.0+typescript@4.9.4
+      '@nrwl/linter': 15.3.0_uynf6tzc2ulgejke7a5cxylfbi
+      '@nrwl/workspace': 15.3.0_pbhkxitjplcbleyi5jfqwqdsju
       chalk: 4.1.0
       fast-glob: 3.2.7
       fs-extra: 10.1.0
@@ -3037,7 +3037,7 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/linter/15.3.0_oihys2rbsohdb5hudxfp3i4gai:
+  /@nrwl/linter/15.3.0_uynf6tzc2ulgejke7a5cxylfbi:
     resolution: {integrity: sha512-pxmL9taYRjKsQC3/XAD9JJCoIRGiuAs+xW4798kD/SFCRQEs5CddA3J4M1y9YoyPjiocNDfUE2AvVMOuM2qbDw==}
     peerDependencies:
       eslint: ^8.0.0
@@ -3045,8 +3045,8 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@nrwl/devkit': 15.3.0_nx@15.3.0+typescript@4.8.4
-      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.8.4
+      '@nrwl/devkit': 15.3.0_nx@15.3.0+typescript@4.9.4
+      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.9.4
       eslint: 8.28.0
       tmp: 0.2.1
       tslib: 2.4.1
@@ -3066,7 +3066,7 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/workspace/15.3.0_n6qshekvp4yqndkuu5fuozz5ni:
+  /@nrwl/workspace/15.3.0_pbhkxitjplcbleyi5jfqwqdsju:
     resolution: {integrity: sha512-MjDRzDZLke3A44FeMjaV9Zyc3XcgbZJlrvFe0nDj7lo3/aLP/SvltE30kfkTwlg7EwvyCSv61lt9zz2NMxpHQw==}
     peerDependencies:
       prettier: ^2.6.2
@@ -3074,8 +3074,8 @@ packages:
       prettier:
         optional: true
     dependencies:
-      '@nrwl/devkit': 15.3.0_nx@15.3.0+typescript@4.8.4
-      '@nrwl/linter': 15.3.0_oihys2rbsohdb5hudxfp3i4gai
+      '@nrwl/devkit': 15.3.0_nx@15.3.0+typescript@4.9.4
+      '@nrwl/linter': 15.3.0_uynf6tzc2ulgejke7a5cxylfbi
       '@parcel/watcher': 2.0.4
       chalk: 4.1.0
       chokidar: 3.5.3
@@ -3455,13 +3455,13 @@ packages:
       node-gyp-build: 4.5.0
     dev: true
 
-  /@phenomnomnominal/tsquery/4.1.1_typescript@4.8.4:
+  /@phenomnomnominal/tsquery/4.1.1_typescript@4.9.4:
     resolution: {integrity: sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==}
     peerDependencies:
       typescript: ^3 || ^4
     dependencies:
       esquery: 1.4.0
-      typescript: 4.8.4
+      typescript: 4.9.4
     dev: true
 
   /@pnpm/network.ca-file/1.0.2:
@@ -3657,6 +3657,9 @@ packages:
 
   /@shopify/checkout-ui-extensions/0.23.0:
     resolution: {integrity: sha512-7pBbZqeDbIQ9nBdY6gmyQWuUkijHyT2vR9HpRhYHVI2VKo7uOVhweuOdmbG7WtQ9P3Pmz47ODGupvVcQCtsHNA==}
+    dependencies:
+      '@remote-ui/async-subscription': 2.1.13
+      '@remote-ui/core': 2.1.16
     dev: false
 
   /@shopify/customer-account-ui-extensions-react/0.0.8_react@17.0.2:
@@ -3691,15 +3694,15 @@ packages:
       '@shopify/function-enhancers': 2.0.8
     dev: false
 
-  /@shopify/eslint-plugin/41.3.1_em2gb7xybgqjsdu6qumqqdiike:
+  /@shopify/eslint-plugin/41.3.1_m6slonagemwjv2qkfsz2bojzbm:
     resolution: {integrity: sha512-d30Ox8AW1H324rs/eFSx1GFt71vcAu4srSXWPVxkbOqTIhHTjaMBpJXFDTvtjTsLPw9YwJSta8jJnkL+lHkIPA==}
     peerDependencies:
       eslint: ^8.3.0
     dependencies:
       '@babel/eslint-parser': 7.19.1_ajivmgign6qnltueqq3ekylg5a
       '@babel/eslint-plugin': 7.19.1_qo7nbvejrlukndoriyrzp32xfy
-      '@typescript-eslint/eslint-plugin': 5.45.0_psz44bhp76u27vmulntnlx26h4
-      '@typescript-eslint/parser': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/eslint-plugin': 5.45.0_wke4plxjew2ogjxrdwvzd2srfq
+      '@typescript-eslint/parser': 5.45.0_wy4udjehnvkneqnogzx5kughki
       change-case: 4.1.2
       common-tags: 1.8.2
       doctrine: 2.1.0
@@ -3707,9 +3710,9 @@ packages:
       eslint-config-prettier: 8.5.0_eslint@8.28.0
       eslint-module-utils: 2.7.4_vbnhqcxlbs7ynbxw44hu2vq7eq
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.28.0
-      eslint-plugin-graphql: 4.0.0_epjn35yhk6fzvqlqoih5vk7bkm
+      eslint-plugin-graphql: 4.0.0_f5f33advzlsfhshr7usu3gvosi
       eslint-plugin-import: 2.26.0_vbnhqcxlbs7ynbxw44hu2vq7eq
-      eslint-plugin-jest: 25.7.0_brvvscwiof5cmspgfht34o7vqq
+      eslint-plugin-jest: 25.7.0_f2vz4uylpwx7vkkuf4vs26ih3q
       eslint-plugin-jest-formatting: 3.1.0_eslint@8.28.0
       eslint-plugin-jsx-a11y: 6.6.1_eslint@8.28.0
       eslint-plugin-node: 11.1.0_eslint@8.28.0
@@ -3813,7 +3816,7 @@ packages:
       inquirer: 9.1.4
       mime: 3.0.0
       semiver: 1.1.0
-      typescript: 4.8.4
+      typescript: 4.9.4
       vitest: 0.22.1
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -4098,7 +4101,7 @@ packages:
   /@types/better-sqlite3/7.6.2:
     resolution: {integrity: sha512-RgmaapusqTq6IMAr4McMyAsC6RshYTCjXCnzwVV59WctUxC8bNPyUfT9t5F81lKcU41lLurhjqjoMHfauzfqGg==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: false
 
   /@types/cacheable-request/6.0.3:
@@ -4106,7 +4109,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
       '@types/responselike': 1.0.0
 
   /@types/chai-subset/1.3.3:
@@ -4124,7 +4127,7 @@ packages:
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: false
 
   /@types/cookiejar/2.1.2:
@@ -4145,7 +4148,7 @@ packages:
   /@types/decompress/4.2.4:
     resolution: {integrity: sha512-/C8kTMRTNiNuWGl5nEyKbPiMv6HA+0RbEXzFhFBEzASM6+oa4tJro9b8nj7eRlOFfuLdzUU+DS/GPDlvvzMOhA==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/diff/5.0.2:
@@ -4157,7 +4160,7 @@ packages:
     dependencies:
       '@types/decompress': 4.2.4
       '@types/got': 8.3.6
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/expect/1.20.4:
@@ -4167,19 +4170,19 @@ packages:
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/glob/8.0.0:
     resolution: {integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
 
   /@types/got/8.3.6:
     resolution: {integrity: sha512-nvLlj+831dhdm4LR2Ly+HTpdLyBaMynoOr6wpIxS19d/bPeHQxFU5XQ6Gp6ohBpxvCWZM1uHQIC2+ySRH1rGrQ==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/gradient-string/1.1.2:
@@ -4201,7 +4204,7 @@ packages:
   /@types/http-proxy/1.17.9:
     resolution: {integrity: sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/is-ci/3.0.0:
@@ -4237,13 +4240,13 @@ packages:
   /@types/jsonwebtoken/8.5.9:
     resolution: {integrity: sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: false
 
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
 
   /@types/lodash-es/4.17.6:
     resolution: {integrity: sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==}
@@ -4272,7 +4275,7 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
       form-data: 3.0.1
     dev: false
 
@@ -4280,20 +4283,16 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node/14.17.0:
-    resolution: {integrity: sha512-w8VZUN/f7SSbvVReb9SWp6cJFevxb4/nkG65yLAya//98WgocKm5PLDAtSs5CtJJJM+kHmJjO/6mmYW4MHShZA==}
+  /@types/node/14.18.36:
+    resolution: {integrity: sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==}
     dev: true
 
   /@types/node/15.14.9:
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
     dev: true
 
-  /@types/node/17.0.45:
-    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-    dev: true
-
-  /@types/node/18.11.10:
-    resolution: {integrity: sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==}
+  /@types/node/18.11.18:
+    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
 
   /@types/node/8.10.66:
     resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
@@ -4353,13 +4352,13 @@ packages:
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
 
   /@types/rimraf/3.0.2:
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
     dependencies:
       '@types/glob': 8.0.0
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/semver/6.2.3:
@@ -4374,14 +4373,14 @@ packages:
     resolution: {integrity: sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/superagent/4.1.16:
     resolution: {integrity: sha512-tLfnlJf6A5mB6ddqF159GqcDizfzbMUB1/DeT59/wBNqzRTNNKsaw79A/1TZ84X+f/EwWH8FeuSkjlCLyqS/zQ==}
     dependencies:
       '@types/cookiejar': 2.1.2
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: false
 
   /@types/supertest/2.0.12:
@@ -4405,7 +4404,7 @@ packages:
     resolution: {integrity: sha512-4UqPv+2567NhMQuMLdKAyK4yzrfCqwaTt6bLhHEs8PFcxbHILsrxaY63n4wgE/BRLDWDQeI+WcTmkXKExh9hQg==}
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/webidl-conversions/7.0.0:
@@ -4415,20 +4414,20 @@ packages:
   /@types/websocket/1.0.2:
     resolution: {integrity: sha512-B5m9aq7cbbD/5/jThEr33nUY8WEfVi6A2YKCTOvw5Ldy7mtsOkqRvGjnzy6g7iMMDsgu7xREuCzqATLDLQVKcQ==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/whatwg-url/8.2.2:
     resolution: {integrity: sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
       '@types/webidl-conversions': 7.0.0
     dev: false
 
   /@types/ws/8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: true
 
   /@types/yargs-parser/21.0.0:
@@ -4445,7 +4444,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: false
     optional: true
 
@@ -4453,7 +4452,7 @@ packages:
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.45.0_psz44bhp76u27vmulntnlx26h4:
+  /@typescript-eslint/eslint-plugin/5.45.0_wke4plxjew2ogjxrdwvzd2srfq:
     resolution: {integrity: sha512-CXXHNlf0oL+Yg021cxgOdMHNTXD17rHkq7iW6RFHoybdFgQBjU3yIXhhcPpGwr1CjZlo6ET8C6tzX5juQoXeGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4464,36 +4463,36 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/parser': 5.45.0_wy4udjehnvkneqnogzx5kughki
       '@typescript-eslint/scope-manager': 5.45.0
-      '@typescript-eslint/type-utils': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
-      '@typescript-eslint/utils': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/type-utils': 5.45.0_wy4udjehnvkneqnogzx5kughki
+      '@typescript-eslint/utils': 5.45.0_wy4udjehnvkneqnogzx5kughki
       debug: 4.3.4
       eslint: 8.28.0
       ignore: 5.2.1
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.45.0_zksrc6ykdxhogxjbhb5axiabwi:
+  /@typescript-eslint/experimental-utils/5.45.0_wy4udjehnvkneqnogzx5kughki:
     resolution: {integrity: sha512-DnRQg5+3uHHt/gaifTjwg9OKbg9/TWehfJzYHQIDJboPEbF897BKDE/qoqMhW7nf0jWRV1mwVXTaUvtB1/9Gwg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/utils': 5.45.0_wy4udjehnvkneqnogzx5kughki
       eslint: 8.28.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.45.0_zksrc6ykdxhogxjbhb5axiabwi:
+  /@typescript-eslint/parser/5.45.0_wy4udjehnvkneqnogzx5kughki:
     resolution: {integrity: sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4505,10 +4504,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.45.0
       '@typescript-eslint/types': 5.45.0
-      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.4
       debug: 4.3.4
       eslint: 8.28.0
-      typescript: 4.8.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4521,7 +4520,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.45.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.45.0_zksrc6ykdxhogxjbhb5axiabwi:
+  /@typescript-eslint/type-utils/5.45.0_wy4udjehnvkneqnogzx5kughki:
     resolution: {integrity: sha512-DY7BXVFSIGRGFZ574hTEyLPRiQIvI/9oGcN8t1A7f6zIs6ftbrU0nhyV26ZW//6f85avkwrLag424n+fkuoJ1Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4531,12 +4530,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.8.4
-      '@typescript-eslint/utils': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.4
+      '@typescript-eslint/utils': 5.45.0_wy4udjehnvkneqnogzx5kughki
       debug: 4.3.4
       eslint: 8.28.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4546,7 +4545,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.45.0_typescript@4.8.4:
+  /@typescript-eslint/typescript-estree/5.45.0_typescript@4.9.4:
     resolution: {integrity: sha512-maRhLGSzqUpFcZgXxg1qc/+H0bT36lHK4APhp0AEUVrpSwXiRAomm/JGjSG+kNUio5kAa3uekCYu/47cnGn5EQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4561,13 +4560,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.45.0_zksrc6ykdxhogxjbhb5axiabwi:
+  /@typescript-eslint/utils/5.45.0_wy4udjehnvkneqnogzx5kughki:
     resolution: {integrity: sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4577,7 +4576,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.45.0
       '@typescript-eslint/types': 5.45.0
-      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.4
       eslint: 8.28.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.28.0
@@ -7414,7 +7413,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/parser': 5.45.0_wy4udjehnvkneqnogzx5kughki
       debug: 3.2.7
       eslint: 8.28.0
       eslint-import-resolver-node: 0.3.6
@@ -7443,7 +7442,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/parser': 5.45.0_wy4udjehnvkneqnogzx5kughki
       debug: 3.2.7
       eslint: 8.28.0
     transitivePeerDependencies:
@@ -7472,7 +7471,7 @@ packages:
       ignore: 5.2.1
     dev: true
 
-  /eslint-plugin-graphql/4.0.0_epjn35yhk6fzvqlqoih5vk7bkm:
+  /eslint-plugin-graphql/4.0.0_f5f33advzlsfhshr7usu3gvosi:
     resolution: {integrity: sha512-d5tQm24YkVvCEk29ZR5ScsgXqAGCjKlMS8lx3mS7FS/EKsWbkvXQImpvic03EpMIvNTBW5e+2xnHzXB/VHNZJw==}
     engines: {node: '>=10.0'}
     peerDependencies:
@@ -7480,7 +7479,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.6
       graphql: 15.8.0
-      graphql-config: 3.4.1_epjn35yhk6fzvqlqoih5vk7bkm
+      graphql-config: 3.4.1_f5f33advzlsfhshr7usu3gvosi
       lodash.flatten: 4.4.0
       lodash.without: 4.4.0
     transitivePeerDependencies:
@@ -7501,7 +7500,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/parser': 5.45.0_wy4udjehnvkneqnogzx5kughki
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
@@ -7531,7 +7530,7 @@ packages:
       eslint: 8.28.0
     dev: true
 
-  /eslint-plugin-jest/25.7.0_brvvscwiof5cmspgfht34o7vqq:
+  /eslint-plugin-jest/25.7.0_f2vz4uylpwx7vkkuf4vs26ih3q:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -7544,15 +7543,15 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.45.0_psz44bhp76u27vmulntnlx26h4
-      '@typescript-eslint/experimental-utils': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/eslint-plugin': 5.45.0_wke4plxjew2ogjxrdwvzd2srfq
+      '@typescript-eslint/experimental-utils': 5.45.0_wy4udjehnvkneqnogzx5kughki
       eslint: 8.28.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jest/26.9.0_brvvscwiof5cmspgfht34o7vqq:
+  /eslint-plugin-jest/26.9.0_f2vz4uylpwx7vkkuf4vs26ih3q:
     resolution: {integrity: sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7565,8 +7564,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.45.0_psz44bhp76u27vmulntnlx26h4
-      '@typescript-eslint/utils': 5.45.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/eslint-plugin': 5.45.0_wke4plxjew2ogjxrdwvzd2srfq
+      '@typescript-eslint/utils': 5.45.0_wy4udjehnvkneqnogzx5kughki
       eslint: 8.28.0
     transitivePeerDependencies:
       - supports-color
@@ -7749,7 +7748,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.45.0_psz44bhp76u27vmulntnlx26h4
+      '@typescript-eslint/eslint-plugin': 5.45.0_wke4plxjew2ogjxrdwvzd2srfq
       eslint: 8.28.0
       eslint-rule-composer: 0.3.0
     dev: true
@@ -8872,18 +8871,18 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
-  /graphql-config/3.4.1_epjn35yhk6fzvqlqoih5vk7bkm:
+  /graphql-config/3.4.1_f5f33advzlsfhshr7usu3gvosi:
     resolution: {integrity: sha512-g9WyK4JZl1Ko++FSyE5Ir2g66njfxGzrDDhBOwnkoWf/t3TnnZG6BBkWP+pkqVJ5pqMJGPKHNrbew8jRxStjhw==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_nms4vp24lf2t67koyek5br3g5a
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_zujpnpxkl4z7yqcjoyqfwgzdgu
       '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
       '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
       '@graphql-tools/load': 6.2.8_graphql@15.8.0
       '@graphql-tools/merge': 6.2.14_graphql@15.8.0
-      '@graphql-tools/url-loader': 6.10.1_uiex7h67ci7ddskfqq7pk5lwym
+      '@graphql-tools/url-loader': 6.10.1_qajhxsyh4z27ur52xwwod6iuj4
       '@graphql-tools/utils': 7.10.0_graphql@15.8.0
       cosmiconfig: 7.0.0
       cosmiconfig-toml-loader: 1.0.0
@@ -10558,7 +10557,7 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  /meros/1.1.4_@types+node@14.17.0:
+  /meros/1.1.4_@types+node@14.18.36:
     resolution: {integrity: sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -10567,7 +10566,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
     dev: true
 
   /methods/1.1.2:
@@ -13954,7 +13953,7 @@ packages:
       tslib: 2.4.1
     dev: true
 
-  /ts-node/10.9.1_76zcixmkjnbphw74ddtkdwldva:
+  /ts-node/10.9.1_ocil65wecyuhsmrrocoajouipe:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -13973,50 +13972,19 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 14.17.0
+      '@types/node': 14.18.36
       acorn: 8.8.1
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.8.4
+      typescript: 4.9.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
 
-  /ts-node/10.9.1_ksn4eycaeggbrckn3ykh37hwf4:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 17.0.45
-      acorn: 8.8.1
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.8.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
-  /ts-node/9.1.1_typescript@4.8.4:
+  /ts-node/9.1.1_typescript@4.9.4:
     resolution: {integrity: sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==}
     engines: {node: '>=10.0.0'}
     hasBin: true
@@ -14028,7 +13996,7 @@ packages:
       diff: 4.0.2
       make-error: 1.3.6
       source-map-support: 0.5.21
-      typescript: 4.8.4
+      typescript: 4.9.4
       yn: 3.1.1
     dev: true
 
@@ -14073,14 +14041,14 @@ packages:
     engines: {node: '>=0.6.x'}
     dev: false
 
-  /tsutils/3.21.0_typescript@4.8.4:
+  /tsutils/3.21.0_typescript@4.9.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.8.4
+      typescript: 4.9.4
     dev: true
 
   /tty-table/4.1.6:
@@ -14197,8 +14165,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript/4.8.4:
-    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+  /typescript/4.9.4:
+    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 
@@ -14645,7 +14613,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
       chai: 4.3.7
       debug: 4.3.4
       local-pkg: 0.4.2
@@ -14683,7 +14651,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
       acorn: 8.8.1
       acorn-walk: 8.2.0
       chai: 4.3.7
@@ -14727,7 +14695,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
       acorn: 8.8.1
       acorn-walk: 8.2.0
       chai: 4.3.7
@@ -14772,7 +14740,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
       acorn: 8.8.1
       acorn-walk: 8.2.0
       chai: 4.3.7


### PR DESCRIPTION
### WHY are these changes introduced?

We recently had a bug https://github.com/Shopify/cli/pull/1156 that would have been caught by the latest TS compiler.

### WHAT is this pull request doing?

- Upgrade to latest TypeScript.
- Fix version of `@types/node` everywhere to latest version available for node 14 (which is the oldest we support).

### How to test your changes?

- Edit `packages/app/src/cli/services/deploy/theme-extension-config.ts`
- Change `files[relativePathName]` to `files[relativePath]`
- You should see the TS compiler complaining about it with
`type '(from: string, to: string) => string' cannot be used as an index type`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
