### PR TITLE
Clean Nx cache before deploying

### DIFF
--- a/shipit.nightly.yml
+++ b/shipit.nightly.yml
@@ -15,6 +15,7 @@ deploy:
   override:
     - |-
       bash -i -c 'echo -e "---\n'"'@shopify/cli'"': patch\n---" > .changeset/force-nightly-build.md'
+    - bash -i -c "npm_config_loglevel=verbose pnpm clean"
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset version --snapshot nightly"
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset-manifests"
     - bash -i -c "npm_config_loglevel=verbose pnpm nx run cli-kit:build"

--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -11,6 +11,7 @@ dependencies:
     - bash -i -c "pnpm install"
 deploy:
   override:
+    - bash -i -c "npm_config_loglevel=verbose pnpm clean"
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset publish"
     - bash -i -c "./bin/package.js"
   post:


### PR DESCRIPTION
### WHY are these changes introduced?

When cutting a new release, I witnessed this flake:
```
🦋  error an error occurred while publishing @shopify/theme: ELIFECYCLE undefined 
🦋  error 
🦋  error > @shopify/theme@3.39.0 prepack /app/data/stacks/shopify/cli/production/deploys/1992998/packages/theme
🦋  error > cross-env NODE_ENV=production pnpm nx build && cp ../../README.md README.md
🦋  error 
🦋  error 
🦋  error  >  NX   ENOENT: no such file or directory, open '/app/data/stacks/shopify/cli/production/deploys/1992998/node_modules/.cache/nx/d/server-process.json'
🦋  error 
🦋  error 
🦋  error {
🦋  error   "error": {
🦋  error     "code": "ELIFECYCLE",
🦋  error     "message": "@shopify/theme@3.39.0 prepack: `cross-env NODE_ENV=production pnpm nx build && cp ../../README.md README.md`\nExit status 1"
🦋  error   }
🦋  error }
🦋  error 
```

Retrying the deploy succeeded, but it made me sweat a little bit.

### WHAT is this pull request doing?

- Run `pnpm clean` before attempting to publish changesets

### How to test your changes?

- Run `pnpm build`
- Verify the your local `node_modules/.cache` has been populated by nx
- Run `pnpm clean`
- Verify that `node_modules/.cache` is now empty


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
