### PR TITLE
Fix to include customer JSON templates in `theme package`

### DIFF
--- a/.changeset/cuddly-papayas-own.md
+++ b/.changeset/cuddly-papayas-own.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix to include customer JSON templates in `theme package`

--- a/packages/theme/src/cli/services/package.test.ts
+++ b/packages/theme/src/cli/services/package.test.ts
@@ -50,10 +50,16 @@ describe('packageTheme', () => {
       const themeRelativePaths = [
         'assets/base.css',
         'config/settings_schema.json',
+        'config/unsupported_dir/settings_schema.json',
+        'templates/customers/account.json',
         'invalid-file.md',
         'invalid/file.liquid',
       ]
-      const expectedThemeRelativePaths = ['assets/base.css', 'config/settings_schema.json']
+      const expectedThemeRelativePaths = [
+        'assets/base.css',
+        'config/settings_schema.json',
+        'templates/customers/account.json',
+      ]
       await createFiles(themeRelativePaths, inputDirectory)
       await createSettingsSchema(
         '[{"name": "theme_info", "theme_name": "Dawn", "theme_version": "7.0.2"}]',

--- a/packages/theme/src/cli/services/package.ts
+++ b/packages/theme/src/cli/services/package.ts
@@ -12,6 +12,7 @@ const themeDirectoriesPattern = [
   'sections',
   'snippets',
   'templates',
+  'templates/customers',
   'release-notes.md',
 ].join('/**|')
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1249

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Fix to add template/customers sub directory to be added to zip file when matching directories

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

- Checkout branch 
- `pnpm shopify theme init` or use existing Dawn theme
- `pnpm shopify theme package --path /path/to/package`
- Open zip file and navigate to templates directory, confirm customers sub directory included

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
