### PR TITLE
Fix the partnersWebIdentifier for ui_extension specification

### DIFF
--- a/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
@@ -26,7 +26,7 @@ const spec = createUIExtensionSpecification({
   externalName: 'UI Extension',
   surface: 'all',
   dependency,
-  partnersWebIdentifier: 'checkout_ui_extension',
+  partnersWebIdentifier: 'ui_extension',
   singleEntryPath: false,
   schema: UIExtensionSchema,
   validate: async (config, directory) => {


### PR DESCRIPTION
### WHY are these changes introduced?

The Partner's dashboard publish url for the ui_extension specification is incorrectly set to `checkout_ui_extension`

![image](https://user-images.githubusercontent.com/29458473/215611309-1f930677-d9ba-45ed-a37f-e18b7af5c397.png)

### WHAT is this pull request doing?

Set the correct `partnersWebIdentifier`

### How to test your changes?

@elanalynn can you please test with Shopcodes?

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
