### PR TITLE
[Feature] add localization to deployment (customer_accounts_ui)

### DIFF
--- a/packages/app/src/cli/models/extensions/ui-specifications/customer_accounts_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/customer_accounts_ui_extension.ts
@@ -1,5 +1,6 @@
 import {createUIExtensionSpecification} from '../ui.js'
 import {BaseUIExtensionSchema} from '../schemas.js'
+import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {schema} from '@shopify/cli-kit/node/schema'
 import {outputContent} from '@shopify/cli-kit/node/output'
 
@@ -41,6 +42,7 @@ const spec = createUIExtensionSpecification({
       extension_points: config.extensionPoints,
       name: config.name,
       categories: config.categories,
+      localization: await loadLocalesConfig(directory, 'customer_accounts_ui'),
       authenticated_redirect_start_url: config.authenticatedRedirectStartUrl,
       authenticated_redirect_redirect_urls: config.authenticatedRedirectRedirectUrls,
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Adds localization to the deployment of customer accounts extensions. This PR basically reverts the changes we had to do in this [old PR here](https://github.com/Shopify/cli/pull/725).

**Depends on:**
- https://github.com/Shopify/shopify/pull/403936

### WHAT is this pull request doing?

- adds `localization` to the deployment of customer accounts extensions

### How to test your changes?

- [Instance](https://development-store-1.account.shopify.localization.filipe-correa.eu.spin.dev/e/ea089092-1013-47b8-83ed-7321e74e50d6)
- [Identity Mailer](https://identity.localization.filipe-correa.eu.spin.dev/services/mail/)
- The instance contains a deployed customer accounts extension with locales.

1. Navigate to [self-serve hub](https://development-store-1.account.shopify.localization.filipe-correa.eu.spin.dev/e/ea089092-1013-47b8-83ed-7321e74e50d6)
2. Sign in with any account
3. Open dev-tools
4. Find the element with `data-serialized-id="extensions-data"
5. You should see `translations` inside array

<img width="1505" alt="Screenshot 2023-02-01 at 12 57 24" src="https://user-images.githubusercontent.com/3514796/216036376-35948c56-13e7-4412-a5af-339bb07591b2.png">

**Manual deployment?**

If you also want to manually deploy an extension w/ locales by yourself, please let me know an I will add those detailed steps instructions here as well, although the setup to tophat might take a bit...


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes

