### PR TITLE
Not release Hydrogen

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,9 +6,7 @@
   "fixed": [[
     "@shopify/cli",
     "@shopify/app",
-    "@shopify/cli-hydrogen",
     "@shopify/create-app",
-    "@shopify/create-hydrogen",
     "@shopify/cli-kit",
     "@shopify/fixtures-app",
     "@shopify/theme",
@@ -18,7 +16,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
+  "ignore": ["@shopify/create-hydrogen", "@shopify/cli-hydrogen"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
### WHY are these changes introduced?
Hydrogen packages are being developed and published to the NPM registry from the https://github.com/shopify/h2 and therefore we should stop publishing them from here.

### WHAT is this pull request doing?
I'm adjusting the changesets configuration to untie the versioning of the packages from the rest of the packages in the monorepo.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
