### PR TITLE
[Feature] Set firstPartyDev to true when env is Spin

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -7,6 +7,7 @@ import {
   useDeviceAuth,
   cloudEnvironment,
   macAddress,
+  firstPartyDev,
 } from './local.js'
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
@@ -244,5 +245,39 @@ describe('cloudEnvironment', () => {
 
     // Then
     expect(got.platform).toBe('localhost')
+  })
+})
+
+describe('firstPartyDev', () => {
+  it('returns true when in spin', () => {
+    // Given
+    const env = {SPIN: '1'}
+
+    // When
+    expect(firstPartyDev(env)).toBe(true)
+  })
+
+  it('returns true when the service environment is a spin environment', () => {
+    // Given
+    const env = {SHOPIFY_SERVICE_ENV: 'spin'}
+
+    // When
+    expect(firstPartyDev(env)).toBe(true)
+  })
+
+  it('returns true when the first party dev enviroment variable exists', () => {
+    // Given
+    const env = {SHOPIFY_CLI_1P_DEV: '1'}
+
+    // When
+    expect(firstPartyDev(env)).toBe(true)
+  })
+
+  it('returns false when no first party dev enviroment variable exists', () => {
+    // Given
+    const env = {}
+
+    // When
+    expect(firstPartyDev(env)).toBe(false)
   })
 })

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -1,4 +1,4 @@
-import {isSpin} from './spin.js'
+import {isSpin, isSpinEnvironment} from './spin.js'
 import {isTruthy, isSet} from '../../../private/node/context/utilities.js'
 import {environmentVariables, pathConstants} from '../../../private/node/constants.js'
 import {fileExists} from '../fs.js'
@@ -99,7 +99,7 @@ export function alwaysLogAnalytics(env = process.env): boolean {
  * @returns True if SHOPIFY_CLI_1P is truthy.
  */
 export function firstPartyDev(env = process.env): boolean {
-  return isTruthy(env[environmentVariables.firstPartyDev])
+  return isSpin(env) || isSpinEnvironment(env) || isTruthy(env[environmentVariables.firstPartyDev])
 }
 
 /**

--- a/packages/cli-kit/src/public/node/context/spin.ts
+++ b/packages/cli-kit/src/public/node/context/spin.ts
@@ -89,10 +89,10 @@ export function instance(env = process.env): string | undefined {
 }
 
 /**
- * Returns true if the CLI is running in a Spin environment.
+ * Returns true if the service environment is a Spin environment.
  *
  * @param env - Environment variables.
- * @returns True if the CLI is running in a Spin environment.
+ * @returns True if the service environment is a Spin environment.
  */
 export function isSpinEnvironment(env = process.env): boolean {
   return serviceEnvironment(env) === Environment.Spin


### PR DESCRIPTION
### WHY are these changes introduced?
Improves the internal Shopify developer experience by defaulting to the most common use case. 

This change could be merged on its own, but it should depend on https://github.com/Shopify/partners/pull/45140 which removes the binary choice between the Shopify or Italic apps org; instead both will be returned.

### WHAT is this pull request doing?
Enables `firstPartyDev` mode when in Spin.

### How to test your changes?
Run `yarn dev --reset` or `yarn deploy --reset` to see the list of partner organizations fetched.

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
