### PR TITLE
Pin all unofficial github actions

### DIFF
--- a/.github/actions/download-and-publish-test-coverage/action.yml
+++ b/.github/actions/download-and-publish-test-coverage/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Clean base ref name
       shell: bash
       env:
-          SAFE_BASE_REF_NAME: "${{ inputs.base-branch-name }}"
+        SAFE_BASE_REF_NAME: "${{ inputs.base-branch-name }}"
       run: |
         SAFE_BASE_REF_NAME=${{ env.SAFE_BASE_REF_NAME }}
         SAFE_BASE_REF_NAME=${SAFE_BASE_REF_NAME//[\/.]/}
@@ -20,14 +20,14 @@ runs:
       continue-on-error: true
       id: download-artifact
       # We use this action and not Github's default, due to https://github.com/actions/download-artifact/issues/3
-      uses: dawidd6/action-download-artifact@v2.24.2
+      uses: dawidd6/action-download-artifact@e6e25ac3a2b93187502a8be1ef9e9603afc34925 # pin@v2.24.2
       with:
         workflow: shopify-cli.yml
         workflow_conclusion: success
         branch: ${{ inputs.base-branch-name }}
         name: ${{ env.SAFE_BASE_REF_NAME }}--coverage-report
         if_no_artifact_found: ignore
-    - uses: ArtiomTr/jest-coverage-report-action@v2.1.2
+    - uses: ArtiomTr/jest-coverage-report-action@9f733792c44d05327cb371766bf78a5261e43936 # pin@v2.1.2
       id: coverage
       with:
         annotations: none
@@ -35,6 +35,6 @@ runs:
         coverage-file: "./report.json"
         base-coverage-file: "./baseline-report.json"
         threshold: 0
-    - uses: marocchino/sticky-pull-request-comment@v2.3.1
+    - uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # pin@v2.3.1
       with:
         message: ${{ steps.coverage.outputs.report }}

--- a/.github/actions/run-and-save-test-coverage/action.yml
+++ b/.github/actions/run-and-save-test-coverage/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Clean ref name
       shell: bash
       env:
-          SAFE_REF_NAME: "${{ inputs.branch-name }}"
+        SAFE_REF_NAME: "${{ inputs.branch-name }}"
       run: |
         SAFE_REF_NAME=${{ env.SAFE_REF_NAME }}
         SAFE_REF_NAME=${SAFE_REF_NAME//[\/.]/}

--- a/.github/actions/setup-cli-deps/action.yml
+++ b/.github/actions/setup-cli-deps/action.yml
@@ -13,7 +13,7 @@ runs:
         git config --global user.name "CLI Foundations"
       shell: bash
     - name: Set Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2 # pin@v1
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
         bundler-cache: false
@@ -25,9 +25,9 @@ runs:
       run: bundle install
       shell: bash
     - name: Install pnpm
-      uses: pnpm/action-setup@v2.2.2
+      uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d # pin@v2.2.2
       with:
-        version:  ${{ env.PNPM_VERSION }}
+        version: ${{ env.PNPM_VERSION }}
     - name: Set Node.js
       uses: actions/setup-node@master
       with:
@@ -43,4 +43,4 @@ runs:
       run: pnpm install
       shell: bash
     - name: Derive appropriate SHAs for base and head for `nx affected` commands
-      uses: nrwl/nx-set-shas@v2.2.5
+      uses: nrwl/nx-set-shas@526caa9cb6b172df606cd33b7a3544bf1bc49c2e # pin@v2.2.5

--- a/.github/actions/setup-cli-deps/action.yml
+++ b/.github/actions/setup-cli-deps/action.yml
@@ -13,7 +13,7 @@ runs:
         git config --global user.name "CLI Foundations"
       shell: bash
     - name: Set Ruby
-      uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2 # pin@v1
+      uses: ruby/setup-ruby@8df78e55761745aad83acaf3ff12976382356e6d # pin@v1
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
         bundler-cache: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,8 +22,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: ['ubuntu-latest']
-        node: ['18.7.0']
+        os: [ 'ubuntu-latest' ]
+        node: [ '18.7.0' ]
     steps:
       - uses: actions/checkout@v2
         name: Checkout [main]
@@ -39,7 +39,7 @@ jobs:
         working-directory: workspace
         id: benchmark
         run: pnpm nx run benchmark
-      - uses: marocchino/sticky-pull-request-comment@v2.3.1
+      - uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # pin@v2.3.1
         with:
           header: Benchmark
           message: ${{ steps.benchmark.outputs.report }}

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -1,7 +1,11 @@
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths: ["packages/*/src/**", "packages/cli-kit/assets/cli-ruby/**"]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+    paths:
+      [
+        "packages/*/src/**",
+        "packages/cli-kit/assets/cli-ruby/**"
+      ]
 name: Changelog Reminder
 jobs:
   remind:
@@ -10,7 +14,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v2
-      - uses: mskelton/changelog-reminder-action@v2
+      - uses: mskelton/changelog-reminder-action@7039cd14fb784c0a2b37f6e7a6ade2c9148c2245 # pin@v2
         with:
           changelogRegex: \.changeset
           message: |

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,9 +2,9 @@ name: Contributor License Agreement (CLA)
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
   issue_comment:
-    types: [created]
+    types: [ created ]
 
 jobs:
   cla:
@@ -16,7 +16,7 @@ jobs:
       ) 
       || (github.event.pull_request && !github.event.pull_request.merged)
     steps:
-      - uses: Shopify/shopify-cla-action@v1
+      - uses: Shopify/shopify-cla-action@c6bc827f3c22da647ed72a556b0b30b8641786eb # pin@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cla-token: ${{ secrets.CLA_TOKEN }}

--- a/.github/workflows/cli-ruby.yml
+++ b/.github/workflows/cli-ruby.yml
@@ -6,13 +6,14 @@ on:
       - main
   pull_request:
 
+
 concurrency:
   group: shopify-${{ github.head_ref }}
   cancel-in-progress: true
 
 defaults:
- run:
-  working-directory: ./packages/cli-kit/assets/cli-ruby
+  run:
+    working-directory: ./packages/cli-kit/assets/cli-ruby
 
 jobs:
   test:
@@ -36,7 +37,7 @@ jobs:
           git config --global user.name "Development Lifecycle"
 
       - name: Set up Ruby ${{ matrix.version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2 # pin@v1
         with:
           ruby-version: ${{ matrix.version }}
           bundler-cache: true
@@ -60,7 +61,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Ruby ${{ matrix.version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2 # pin@v1
         with:
           ruby-version: ${{ matrix.version }}
           bundler-cache: true

--- a/.github/workflows/cli-ruby.yml
+++ b/.github/workflows/cli-ruby.yml
@@ -37,7 +37,7 @@ jobs:
           git config --global user.name "Development Lifecycle"
 
       - name: Set up Ruby ${{ matrix.version }}
-        uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2 # pin@v1
+        uses: ruby/setup-ruby@8df78e55761745aad83acaf3ff12976382356e6d # pin@v1
         with:
           ruby-version: ${{ matrix.version }}
           bundler-cache: true
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Ruby ${{ matrix.version }}
-        uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2 # pin@v1
+        uses: ruby/setup-ruby@8df78e55761745aad83acaf3ff12976382356e6d # pin@v1
         with:
           ruby-version: ${{ matrix.version }}
           bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@646cdf48217256a3d0b80361c5a50727664284f2 # pin@v2.0.1
         with:
           version: ${{ env.PNPM_VERSION }}
       - name: Set Node.js
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Create Release Pull Request
-        uses: changesets/action@v1
+        uses: changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a # pin@v1
         with:
           version: pnpm changeset-manifests
         env:

--- a/.github/workflows/reviewers-reminder.yml
+++ b/.github/workflows/reviewers-reminder.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: comment PR
-        uses: unsplash/comment-on-pr@v1.3.0
+        uses: unsplash/comment-on-pr@ffe8f97ccc63ce12c3c23c6885b169db67958d3b # pin@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -77,8 +77,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        node: ['14.20.0', '16.17.0', '18.7.0']
+        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
+        node: [ '14.20.0', '16.17.0', '18.7.0' ]
     steps:
       - uses: actions/checkout@v2
         name: Checkout [main]
@@ -115,9 +115,9 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: ['ubuntu-latest']
-        node: ["18.7.0"]
-        target: ['build', 'type-check', 'lint']
+        os: [ 'ubuntu-latest' ]
+        node: [ "18.7.0" ]
+        target: [ 'build', 'type-check', 'lint' ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -161,8 +161,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        node: ['14.20.0', '16.17.0', '18.7.0']
+        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
+        node: [ '14.20.0', '16.17.0', '18.7.0' ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -209,6 +209,6 @@ jobs:
         run: pnpm nx run features:test
       - name: Setup tmate session
         if: ${{ failure() && inputs.debug-enabled }}
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@1005f9c9db5f1b055a495e72c6e589764984baf6 # pin@v3
         with:
           limit-access-to-actor: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,8 +7,9 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '31 3 * * *' # randomly chosen time of day
+    - cron: '31 3 * * *' # randomly chosen time of day
   workflow_dispatch:
+
 
 jobs:
   stale:
@@ -19,24 +20,24 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v4
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-issue-stale: 21
-        days-before-pr-stale: 30
-        days-before-close: 7
-        stale-issue-message: |-
-          This issue seems inactive. If it's still relevant, please add a comment saying so. Otherwise, take no action.
-          → If there's no activity within a week, then a bot will automatically close this.
-          Thanks for helping to improve Shopify's dev tooling and experience.
-        stale-pr-message: |-
-          This PR seems inactive. If it's still relevant, please add a comment saying so. Otherwise, take no action.
-          → If there's no activity within a week, then a bot will automatically close this.
-          Thanks for helping to improve Shopify's dev tooling and experience.
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
-        ascending: true
-        # The math seems a bit fuzzy, but this should amount to a max of 50 issues daily.
-        # But then the same issues get checked first so we don't end up progressing too quickly until we can close what we started.
-        # Hopefully https://github.com/actions/stale/issues/692 will be closed and fix some of this mess.
-        operations-per-run: 200
+      - uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 21
+          days-before-pr-stale: 30
+          days-before-close: 7
+          stale-issue-message: |-
+            This issue seems inactive. If it's still relevant, please add a comment saying so. Otherwise, take no action.
+            → If there's no activity within a week, then a bot will automatically close this.
+            Thanks for helping to improve Shopify's dev tooling and experience.
+          stale-pr-message: |-
+            This PR seems inactive. If it's still relevant, please add a comment saying so. Otherwise, take no action.
+            → If there's no activity within a week, then a bot will automatically close this.
+            Thanks for helping to improve Shopify's dev tooling and experience.
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'
+          ascending: true
+          # The math seems a bit fuzzy, but this should amount to a max of 50 issues daily.
+          # But then the same issues get checked first so we don't end up progressing too quickly until we can close what we started.
+          # Hopefully https://github.com/actions/stale/issues/692 will be closed and fix some of this mess.
+          operations-per-run: 200

--- a/.github/workflows/workflow-cleaner.yml
+++ b/.github/workflows/workflow-cleaner.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
+        uses: Mattraks/delete-workflow-runs@5ebc537fc6b4f5c1634865f0030271fb6776b28d # pin@v2
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/bin/pin-github-actions.js
+++ b/bin/pin-github-actions.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import glob from 'fast-glob'
+import { fileURLToPath } from 'url'
+import path from 'node:path'
+import utils from 'util'
+import { exec } from 'child_process'
+
+export const execute = utils.promisify(exec);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const args = process.argv;
+if (args.length !== 3) {
+  console.log(`Usage: bin/${path.basename(__filename)} <GITHUB_ACCESS_TOKEN>.\n\nThis script needs a Github access token to avoid hitting rate limits.\nYou can create one at https://github.com/settings/tokens.`)
+  process.exit(1)
+}
+const githubAccessToken = args[2]
+
+async function doIt() {
+  const githubYmls = glob.sync(`${__dirname}/../.github/{actions,workflows}/**/*.yml`)
+  const pinGithubAction = `${__dirname}/../node_modules/.bin/pin-github-action`
+  for (const githubYml of githubYmls) {
+    await execute(`GH_ADMIN_TOKEN=${githubAccessToken} ${pinGithubAction} ${githubYml} --allow="actions/*" --allow-empty`)
+    process.stdout.write(".");
+  }
+  console.log(" Done!")
+}
+
+doIt()

--- a/bin/pin-github-actions.js
+++ b/bin/pin-github-actions.js
@@ -1,19 +1,25 @@
-#!/usr/bin/env node
+#! /usr/bin/env node
 
 import glob from 'fast-glob'
-import { fileURLToPath } from 'url'
+import {fileURLToPath} from 'url'
 import path from 'node:path'
 import utils from 'util'
-import { exec } from 'child_process'
+import {exec} from 'child_process'
 
-export const execute = utils.promisify(exec);
+export const execute = utils.promisify(exec)
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
-const args = process.argv;
+const args = process.argv
 if (args.length !== 3) {
-  console.log(`Usage: bin/${path.basename(__filename)} <GITHUB_ACCESS_TOKEN>.\n\nThis script needs a Github access token to avoid hitting rate limits.\nYou can create one at https://github.com/settings/tokens.`)
+  console.log(
+    [
+      `Usage: bin/${path.basename(__filename)} <GITHUB_ACCESS_TOKEN>\n`,
+      'This script needs a Github access token to avoid hitting rate limits.',
+      'You can grab your existing one by running `dev github print-auth`.',
+    ].join('\n'),
+  )
   process.exit(1)
 }
 const githubAccessToken = args[2]
@@ -22,10 +28,12 @@ async function doIt() {
   const githubYmls = glob.sync(`${__dirname}/../.github/{actions,workflows}/**/*.yml`)
   const pinGithubAction = `${__dirname}/../node_modules/.bin/pin-github-action`
   for (const githubYml of githubYmls) {
-    await execute(`GH_ADMIN_TOKEN=${githubAccessToken} ${pinGithubAction} ${githubYml} --allow="actions/*" --allow-empty`)
-    process.stdout.write(".");
+    await execute(
+      `GH_ADMIN_TOKEN=${githubAccessToken} ${pinGithubAction} ${githubYml} --allow="actions/*" --allow-empty`,
+    )
+    process.stdout.write('.')
   }
-  console.log(" Done!")
+  console.log(' Done!')
 }
 
 doIt()

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "oclif": "^3.4.2",
     "octokit-plugin-create-pull-request": "^3.12.2",
     "pathe": "1.0.0",
+    "pin-github-action": "^1.8.0",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.6.1",
     "react": "17.0.2",

--- a/packages/features/features/github-actions.feature
+++ b/packages/features/features/github-actions.feature
@@ -1,0 +1,5 @@
+Feature: Github Actions
+
+Scenario: All non-official github actions are pinned
+   When I look at the github actions we use
+   Then I see all non-official actions being pinned

--- a/packages/features/steps/github-actions.steps.ts
+++ b/packages/features/steps/github-actions.steps.ts
@@ -1,0 +1,29 @@
+import {exec} from '../lib/system'
+import {When, Then} from '@cucumber/cucumber'
+import * as path from 'pathe'
+import {strict as assert} from 'assert'
+
+When(/I look at the github actions we use/, async function () {
+  const {stdout} = await exec('grep', ['-Roh', 'uses: \\S*', '.'], {cwd: path.join(__dirname, '../../../.github')})
+  this.githubActions = stdout.split('\n').map((line: string) => line.split(' ')[1])
+})
+
+Then(/I see all non-official actions being pinned/, async function () {
+  const remaining: string[] = this.githubActions.filter(
+    // we skip the ones from github or from the repo
+    (action: string) => !action.startsWith('actions/') && !action.startsWith('./'),
+  )
+  const unpinned = remaining.filter(
+    (action: string) =>
+      // an example of pinned package:
+      // pnpm/action-setup@646cdf48217256a3d0b80361c5a50727664284f2
+      !action.match(/^[^@]+@[0-9a-f]+/),
+  )
+  const errorMessage = `The following unofficial github actions have not been pinned:\n\n${unpinned
+    .map((el: string) => `  - ${el}`)
+    .join(
+      '\n',
+    )}\n\nRun the bin/pin-github-actions.js script, verify that the action is not doing anything malicious, then commit your changes.`
+
+  assert.equal(unpinned.length, 0, errorMessage)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,7 @@ importers:
       oclif: ^3.4.2
       octokit-plugin-create-pull-request: ^3.12.2
       pathe: 1.0.0
+      pin-github-action: ^1.8.0
       postinstall-postinstall: ^2.1.0
       prettier: ^2.6.1
       react: 17.0.2
@@ -120,6 +121,7 @@ importers:
       oclif: 3.4.2
       octokit-plugin-create-pull-request: 3.13.1
       pathe: 1.0.0
+      pin-github-action: 1.8.0
       postinstall-postinstall: 2.1.0
       prettier: 2.8.0
       react: 17.0.2
@@ -10462,6 +10464,13 @@ packages:
       remove-accents: 0.4.2
     dev: false
 
+  /matcher/4.0.0:
+    resolution: {integrity: sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      escape-string-regexp: 4.0.0
+    dev: true
+
   /media-typer/0.3.0:
     resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
     engines: {node: '>= 0.6'}
@@ -11836,6 +11845,20 @@ packages:
   /pify/4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  /pin-github-action/1.8.0:
+    resolution: {integrity: sha512-8QMKGbDUmMLFSyeV7hDIVmlI8B3ThJed1uFYuhcCBLi/w8xHPbrPhnCvJndYdugNc8aj1FrijrOMDLQ93ATc7A==}
+    hasBin: true
+    dependencies:
+      '@octokit/rest': 18.12.0
+      commander: 9.4.1
+      debug: 4.3.4
+      matcher: 4.0.0
+      yaml: 2.2.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
 
   /pinkie-promise/2.0.1:
     resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==}
@@ -15015,6 +15038,11 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+
+  /yaml/2.2.1:
+    resolution: {integrity: sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==}
+    engines: {node: '>= 14'}
+    dev: true
 
   /yargs-parser/18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}


### PR DESCRIPTION
### WHY are these changes introduced?

We use quite a lot of open source Github actions, which are inherently vulnerable to supply chain attacks.

### WHAT is this pull request doing?

- Pin all unofficial Github actions to a specific sha
- add a feature test to verify that all unofficial github actions are pinned

### How to test your changes?

- unpin any OSS github action
- run `cd packages/features`
- run `FEATURE=features/github-actions.feature pnpm test`
- you should see this test failing
```
1) Scenario: All non-official github actions are pinned # features/github-actions.feature:3
   ✔ When I look at the github actions we use # steps/github-actions.steps.ts:6
   ✖ Then I see all non-official actions being pinned # steps/github-actions.steps.ts:11
       AssertionError [ERR_ASSERTION]: The following unofficial github actions have not been pinned:

         - mxschmitt/action-tmate@v3

       Run the bin/pin-github-actions.js script, verify that the action is not doing anything malicious, then commit your changes.
           + expected - actual

           -1
           +0

           at World.<anonymous> (/Users/arkham/src/github.com/Shopify/cli/packages/features/steps/github-actions.steps.ts:28:10)
   ✔ After # steps/environment.steps.ts:38
   ```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
