### PR TITLE
Remove the dev dependency between `@shopify/cli` and `@shopify/cli-hydrogen`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -101,7 +101,6 @@
   },
   "devDependencies": {
     "@shopify/app": "3.39.0",
-    "@shopify/cli-hydrogen": "3.39.0",
     "@shopify/theme": "3.39.0",
     "@types/node": "14.18.36",
     "@vitest/coverage-istanbul": "^0.26.3",

--- a/packages/features/snapshots/commands.txt
+++ b/packages/features/snapshots/commands.txt
@@ -10,12 +10,6 @@
  auth logout            @shopify/cli           
  commands               @oclif/plugin-commands 
  help                   @oclif/plugin-help     
- hydrogen add eslint    @shopify/cli-hydrogen  
- hydrogen add tailwind  @shopify/cli-hydrogen  
- hydrogen build         @shopify/cli-hydrogen  
- hydrogen dev           @shopify/cli-hydrogen  
- hydrogen info          @shopify/cli-hydrogen  
- hydrogen preview       @shopify/cli-hydrogen  
  kitchen-sink async     @shopify/cli           
  kitchen-sink banners   @shopify/cli           
  kitchen-sink prompts   @shopify/cli           

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,7 +279,6 @@ importers:
       '@oclif/plugin-help': 5.1.12
       '@oclif/plugin-plugins': 2.1.0
       '@shopify/app': 3.39.0
-      '@shopify/cli-hydrogen': 3.39.0
       '@shopify/cli-kit': 3.39.0
       '@shopify/theme': 3.39.0
       '@types/node': 14.18.36
@@ -294,7 +293,6 @@ importers:
       '@shopify/cli-kit': link:../cli-kit
     devDependencies:
       '@shopify/app': link:../app
-      '@shopify/cli-hydrogen': link:../cli-hydrogen
       '@shopify/theme': link:../theme
       '@types/node': 14.18.36
       '@vitest/coverage-istanbul': 0.26.3
@@ -14509,7 +14507,7 @@ packages:
       globrex: 0.1.2
       recrawl-sync: 2.2.3
       tsconfig-paths: 4.1.1
-      vite: 2.9.12
+      vite: 2.9.12_sass@1.56.1
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
### WHY are these changes introduced?
The workflow that bumps the versions [is failing](https://github.com/Shopify/cli/actions/runs/4084144314/jobs/7040497134) because `@shopify/cli-hydrogen` is ignored but `@shopify/cli` depends on it as a `devDependency`.

### WHAT is this pull request doing?
I'm removing `@shopify/cli-hydrogen` as a dev dependency of `@shopify/cli`.

### How to test your changes?
You can checkout this branch, change [this pipeline](https://github.com/Shopify/cli/blob/main/.github/workflows/release.yml#L7) to run on your branch, and push it upstream.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
