### PR TITLE
Port shopify-cli#2724 and shopify-cli#2721 to CLI3

### DIFF
--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/serve.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/serve.rb
@@ -35,6 +35,7 @@ module Theme
           flags[:ignores] |= pattern
         end
         parser.on("-f", "--force") { flags[:force] = true }
+        parser.on("--overwrite-json") { flags[:overwrite_json] = true }
       end
 
       def call(_args, name)

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server.rb
@@ -41,6 +41,7 @@ module ShopifyCLI
           port: 9292,
           poll: false,
           editor_sync: false,
+          overwrite_json: false,
           stable: false,
           mode: ReloadMode.default,
           includes: nil,
@@ -55,6 +56,7 @@ module ShopifyCLI
             port,
             poll,
             editor_sync,
+            overwrite_json,
             stable,
             mode,
             includes,
@@ -78,6 +80,7 @@ module ShopifyCLI
         port,
         poll,
         editor_sync,
+        overwrite_json,
         stable,
         mode,
         includes,
@@ -91,6 +94,7 @@ module ShopifyCLI
         @port = port
         @poll = poll
         @editor_sync = editor_sync
+        @overwrite_json = overwrite_json
         @stable = stable
         @mode = mode
         @includes = includes
@@ -199,7 +203,7 @@ module ShopifyCLI
           theme: theme,
           include_filter: include_filter,
           ignore_filter: ignore_filter,
-          overwrite_json: !editor_sync,
+          overwrite_json: !editor_sync || @overwrite_json,
           stable: stable
         )
       end

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server_test.rb
@@ -118,9 +118,10 @@ module ShopifyCLI
       private
 
       def dev_server(identifier: nil, ignores: nil, includes: nil)
-        host, port, poll, editor_sync, stable, mode = nil
+        host, port, poll, editor_sync, overwrite_json, stable, mode = nil
         server = DevServer.instance
-        server.setup(ctx, root, host, identifier, port, poll, editor_sync, stable, mode, includes, ignores)
+        server.setup(ctx, root, host, identifier, port, poll, editor_sync, overwrite_json, stable, mode, includes,
+          ignores)
         server
       end
 

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server_test.rb
@@ -147,9 +147,10 @@ module ShopifyCLI
         private
 
         def dev_server(identifier: nil)
-          host, port, poll, editor_sync, stable, mode, ignores, includes = nil
+          host, port, poll, editor_sync, overwrite_json, stable, mode, ignores, includes = nil
           server = Extension::DevServer.instance
-          server.setup(ctx, root, host, identifier, port, poll, editor_sync, stable, mode, ignores, includes)
+          server.setup(ctx, root, host, identifier, port, poll, editor_sync, overwrite_json, stable, mode, ignores,
+            includes)
           server.project = project
           server.specification_handler = specification_handler
           server


### PR DESCRIPTION
### WHY are these changes introduced?

Following https://github.com/Shopify/cli/pull/1173, this PR ports https://github.com/Shopify/shopify-cli/pull/2721 and https://github.com/Shopify/shopify-cli/pull/2724 to CLI3.

### WHAT is this pull request doing?

Thus, now themes in the CLI3 is updated with the latest CLI2 changes.

### How to test your changes?

N/A

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
