### PR TITLE
Fix hooks

### DIFF
--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -3,7 +3,7 @@ import {outputDebug} from '../../../public/node/output.js'
 import {Hook} from '@oclif/core'
 
 // This hook is called after each successful command run. More info: https://oclif.io/docs/hooks
-export const hookPost: Hook.Postrun = async ({config, Command}) => {
+export const hook: Hook.Postrun = async ({config, Command}) => {
   await reportAnalyticsEvent({config})
   const command = Command?.id?.replace(/:/g, ' ')
   outputDebug(`Completed command ${command}`)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -158,8 +158,8 @@
       "-h"
     ],
     "hooks": {
-      "prerun": "@shopify/cli-kit/node/hooks/prerun",
-      "postrun": "@shopify/cli-kit/node/hooks/postrun"
+      "prerun": "./dist/hooks/prerun.js",
+      "postrun": "./dist/hooks/postrun.js"
     }
   }
 }

--- a/packages/cli/src/hooks/postrun.ts
+++ b/packages/cli/src/hooks/postrun.ts
@@ -1,0 +1,1 @@
+export {hook as default} from '@shopify/cli-kit/node/hooks/postrun'

--- a/packages/cli/src/hooks/prerun.ts
+++ b/packages/cli/src/hooks/prerun.ts
@@ -1,0 +1,1 @@
+export {hook as default} from '@shopify/cli-kit/node/hooks/prerun'

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -77,8 +77,8 @@
       "-h"
     ],
     "hooks": {
-      "prerun": "@shopify/cli-kit/node/hooks/prerun",
-      "postrun": "@shopify/cli-kit/node/hooks/postrun"
+      "prerun": "./dist/hooks/prerun.js",
+      "postrun": "./dist/hooks/postrun.js"
     }
   }
 }

--- a/packages/create-app/src/hooks/postrun.ts
+++ b/packages/create-app/src/hooks/postrun.ts
@@ -1,0 +1,1 @@
+export {hook as default} from '@shopify/cli-kit/node/hooks/postrun'

--- a/packages/create-app/src/hooks/prerun.ts
+++ b/packages/create-app/src/hooks/prerun.ts
@@ -1,0 +1,1 @@
+export {hook as default} from '@shopify/cli-kit/node/hooks/prerun'

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -83,8 +83,8 @@
       "-h"
     ],
     "hooks": {
-      "prerun": "@shopify/cli-kit/node/hooks/prerun",
-      "postrun": "@shopify/cli-kit/node/hooks/postrun"
+      "prerun": "./dist/hooks/prerun.js",
+      "postrun": "./dist/hooks/postrun.js"
     }
   }
 }

--- a/packages/create-hydrogen/src/hooks/postrun.ts
+++ b/packages/create-hydrogen/src/hooks/postrun.ts
@@ -1,0 +1,1 @@
+export {hook as default} from '@shopify/cli-kit/node/hooks/postrun'

--- a/packages/create-hydrogen/src/hooks/prerun.ts
+++ b/packages/create-hydrogen/src/hooks/prerun.ts
@@ -1,0 +1,1 @@
+export {hook as default} from '@shopify/cli-kit/node/hooks/prerun'


### PR DESCRIPTION
### WHY are these changes introduced?
@gonzaloriestra reported that hooks were not running. If we run `DEBUG=* p shopify version` we can see an error that says that OCLIF can't resolve the hook modules:

```bash
shopify:@shopify/cli:hooks:prerun ModuleLoadError: [MODULE_NOT_FOUND] require failed to load /Users/gonzalo/src/github.com/Shopify/cli/packages/cli/@shopify/cli-kit/node/hooks/prerun: Cannot find module '/Users/gonzalo/src/github.com/Shopify/cli/packages/cli/@shopify/cli-kit/node/hooks/prerun'
```

### WHAT is this pull request doing?
OCLIF's [`ModuleLoader.resolvePath`](https://github.com/oclif/core/blob/f759fb1710eb1013a48fa04e817d43231553590a/src/module-loader.ts#L135) function which is the one in charge of resolving the module identifiers doesn't work with Node's module resolution for ESM (using the `exports` attribute in the `package.json`).

I added a `src/hooks` folder to `create-hydrogen`, `create-app` and `cli` re-exporting the hooks from `@shopify/cli-kit`. On the side, I'll open a PR on OCLIF to add support for resolving Node ESM modules.

### How to test your changes?

Any of the following commands should run without a "MODULE_NOT_FOUND" error for the hooks.

```
DEBUG=* pnpm run create-app
DEBUG=* pnpm run shopify
DEBUG=* pnpm run create-hydrogen
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
