### PR TITLE
Disable flaky test

### DIFF
--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/syncer/uploader/bulk_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/syncer/uploader/bulk_test.rb
@@ -79,6 +79,7 @@ module ShopifyCLI
           end
 
           def test_batch_num_files_upper_bound_with_multiple_threads
+            skip # flaky
             bulk = bulk_instance(pool_size: 2)
 
             expect_job_request(10, 100).twice


### PR DESCRIPTION
### WHY are these changes introduced?
The Ruby test `test_batch_num_files_upper_bound_with_multiple_threads` is flaky so I'm disabling it.


