### PR TITLE
Remove ignored from changeset's configuration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@shopify/create-hydrogen", "@shopify/cli-hydrogen"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
### WHY are these changes introduced?
Changeset [doesn't like](https://github.com/Shopify/cli/actions/runs/4084690749/jobs/7041689317) having a mix of ignored and not-ignored packages and that's causing the release workflow to fail.

### WHAT is this pull request doing?
Removing the `ignored` list. Since they are removed from the `fixed` list and we are not including changesets for the `create-hydrogen` and `hydrogen` packages, the versioning will yield no updates for them.

### How to test your changes?
`pnpm changeset version` should run successfully

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
