### PR TITLE
Get webhook test to pass new eslint rules

### DIFF
--- a/packages/app/src/cli/services/webhook/send-app-uninstalled-webhook.test.ts
+++ b/packages/app/src/cli/services/webhook/send-app-uninstalled-webhook.test.ts
@@ -1,20 +1,13 @@
 import {sendUninstallWebhookToAppServer} from './send-app-uninstalled-webhook.js'
 import {triggerLocalWebhook} from './trigger-local-webhook.js'
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {FetchError} from '@shopify/cli-kit/node/http'
 import {Writable} from 'stream'
 
-beforeEach(async () => {
-  vi.mock('@shopify/cli-kit/node/api/partners')
-  vi.mock('./trigger-local-webhook.js')
-  // Stub out sleep so that we don't have to wait for the retries
-  vi.mock('@shopify/cli-kit/node/system')
-})
-
-afterEach(async () => {
-  vi.clearAllMocks()
-})
+vi.mock('@shopify/cli-kit/node/api/partners')
+vi.mock('./trigger-local-webhook.js')
+vi.mock('@shopify/cli-kit/node/system')
 
 const apiVersionsResponse = {
   publicApiVersions: ['2022', '2023', 'unstable'],


### PR DESCRIPTION
### WHY are these changes introduced?

I merged a couple new eslint rules [here](https://github.com/Shopify/cli/pull/1283), but my `main` branch was out of date.

### WHAT is this pull request doing?

Fix leftover test.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
