### PR TITLE
Increase AutocompletePrompt test search response time

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -440,7 +440,7 @@ describe('AutocompletePrompt', async () => {
     const onEnter = vi.fn()
 
     const search = async (term: string) => {
-      await new Promise((resolve) => setTimeout(resolve, 300))
+      await new Promise((resolve) => setTimeout(resolve, 500))
       return {
         data: DATABASE.filter((item) => item.label.includes(term)),
       }


### PR DESCRIPTION
AutocompletePrompt test can be flakey as the window to wait for `Loading...` is very narrow. I've increased that window of time.

Fixes https://github.com/Shopify/internal-cli-foundations/issues/551