### PR TITLE
Make sure that the preview banner is shown when there is no web folder

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -103,7 +103,7 @@ async function dev(options: DevOptions) {
   const proxyPort = usingLocalhost ? await getAvailableTCPPort() : frontendPort
   const proxyUrl = usingLocalhost ? `${frontendUrl}:${proxyPort}` : frontendUrl
 
-  let previewUrl
+  let previewUrl = localApp.extensions.ui.length > 0 ? `${proxyUrl}/extensions/dev-console` : undefined
 
   if ((frontendConfig || backendConfig) && options.update) {
     const currentURLs = await getURLs(apiKey, token)
@@ -116,12 +116,7 @@ async function dev(options: DevOptions) {
     })
     if (shouldUpdateURLs) await updateURLs(newURLs, apiKey, token)
     await outputUpdateURLsResult(shouldUpdateURLs, newURLs, remoteApp)
-
-    if (localApp.extensions.ui.length > 0) {
-      previewUrl = `${proxyUrl}/extensions/dev-console`
-    } else {
-      previewUrl = buildAppURLForWeb(storeFqdn, exposedUrl)
-    }
+    previewUrl = buildAppURLForWeb(storeFqdn, exposedUrl)
   }
 
   // If we have a real UUID for an extension, use that instead of a random one


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/internal-cli-foundations/issues/550

We weren't showing the footer with the preview url in `dev` if there was no web folder and only UI extensions

### WHAT is this pull request doing?

This PR makes sure that the `previewUrl` is initialized outside the check for `web` or backend. Note that if we had function or theme extensions only, we would still not show the banner, but this is temporary while we're moving the instructions for both to the dev console.

### How to test your changes?

- Delete the web folder in the fixture app
- Run dev
- A footer with the dev console URL should appear

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
