### PR TITLE
Make Hydrogen packages private

### DIFF
--- a/packages/cli-hydrogen/package.json
+++ b/packages/cli-hydrogen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/cli-hydrogen",
   "version": "3.39.0",
-  "private": false,
+  "private": true,
   "description": "Commands for building Hydrogen storefronts",
   "homepage": "https://github.com/shopify/cli#readme",
   "bugs": {

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/create-hydrogen",
   "version": "3.39.0",
-  "private": false,
+  "private": true,
   "description": "A CLI tool to create a new Shopify hydrogen app.",
   "keywords": [
     "shopify",


### PR DESCRIPTION
### WHY are these changes introduced?

Hydrogen packages are not released anymore from this repository and [Version Packages PR](https://github.com/Shopify/cli/pull/1246) was not generating the expected versions.

### WHAT is this pull request doing?

Make the packages private

### How to test your changes?

`p changeset version`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
