### PR TITLE
Fix changeset config for Hydrogen packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,9 @@
     "@shopify/fixtures-app",
     "@shopify/theme",
     "@shopify/ui-extensions-dev-console-app",
-    "@shopify/plugin-ngrok"
+    "@shopify/plugin-ngrok",
+    "@shopify/cli-hydrogen",
+    "@shopify/create-hydrogen"
   ]],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
### WHY are these changes introduced?

Continuation of https://github.com/Shopify/cli/pull/1295

Hydrogen packages are not released anymore from this repository and https://github.com/Shopify/cli/pull/1246 was not generating the expected versions.

### WHAT is this pull request doing?

Fix `cli-hydrogen` and `create-hydrogen` versions in changeset config

### How to test your changes?

`pnpm changeset version`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
