### PR TITLE
Fix: conf store not saving some values on windows

### DIFF
--- a/.changeset/forty-cobras-warn.md
+++ b/.changeset/forty-cobras-warn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix windows not storing dev selected values correctly

--- a/packages/app/src/cli/services/conf.test.ts
+++ b/packages/app/src/cli/services/conf.test.ts
@@ -65,6 +65,20 @@ describe('setAppInfo', async () => {
       expect(got).toEqual(APP2)
     })
   })
+
+  it('creates new info normalizing the path', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const conf = new Conf<AppConfSchema>({cwd})
+
+      // When
+      setAppInfo({appId: 'app2', directory: '\\app2\\something', storeFqdn: APP2.storeFqdn, orgId: APP2.orgId}, conf)
+      const got = conf.get('/app2/something')
+
+      // Then
+      expect(got.appId).toEqual(APP2.appId)
+    })
+  })
 })
 
 describe('clearAppInfo', async () => {

--- a/packages/app/src/cli/services/conf.ts
+++ b/packages/app/src/cli/services/conf.ts
@@ -1,5 +1,6 @@
 import {Conf} from '@shopify/cli-kit/node/conf'
 import {outputDebug, outputContent, outputToken} from '@shopify/cli-kit/node/output'
+import {normalizePath} from '@shopify/cli-kit/node/path'
 
 export interface CachedAppInfo {
   directory: string
@@ -26,13 +27,15 @@ function appConf() {
 }
 
 export function getAppInfo(directory: string, config: Conf<AppConfSchema> = appConf()): CachedAppInfo | undefined {
-  outputDebug(outputContent`Reading cached app information for directory ${outputToken.path(directory)}...`)
-  return config.get(directory)
+  const normalized = normalizePath(directory)
+  outputDebug(outputContent`Reading cached app information for directory ${outputToken.path(normalized)}...`)
+  return config.get(normalized)
 }
 
 export function clearAppInfo(directory: string, config: Conf<AppConfSchema> = appConf()): void {
-  outputDebug(outputContent`Clearing app information for directory ${outputToken.path(directory)}...`)
-  config.delete(directory)
+  const normalized = normalizePath(directory)
+  outputDebug(outputContent`Clearing app information for directory ${outputToken.path(normalized)}...`)
+  config.delete(normalized)
 }
 
 export function clearAllAppInfo(config: Conf<AppConfSchema> = appConf()): void {
@@ -41,15 +44,14 @@ export function clearAllAppInfo(config: Conf<AppConfSchema> = appConf()): void {
 }
 
 export function setAppInfo(options: CachedAppInfo, config: Conf<AppConfSchema> = appConf()): void {
+  const normalized = normalizePath(options.directory)
   outputDebug(
-    outputContent`Storing app information for directory ${outputToken.path(options.directory)}:${outputToken.json(
-      options,
-    )}`,
+    outputContent`Storing app information for directory ${outputToken.path(normalized)}:${outputToken.json(options)}`,
   )
-  const savedApp = config.get(options.directory)
+  const savedApp = config.get(normalized)
   if (savedApp) {
-    config.set(options.directory, {
-      directory: options.directory,
+    config.set(normalized, {
+      directory: normalized,
       appId: options.appId ?? savedApp.appId,
       title: options.title ?? savedApp.title,
       storeFqdn: options.storeFqdn ?? savedApp.storeFqdn,
@@ -58,6 +60,6 @@ export function setAppInfo(options: CachedAppInfo, config: Conf<AppConfSchema> =
       tunnelPlugin: options.tunnelPlugin ?? savedApp.tunnelPlugin,
     })
   } else {
-    config.set(options.directory, options)
+    config.set(normalized, options)
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Paths are weird. At some points in the CLI execution, when working on windows, a directory path might use `/` or `\`. 
Since we use the the directory as the key to store local information about the app, this led to inconsistencies reading the cached values.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Normalize the directory path before getting/setting values
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- `yarn dev` caches any selected value and a 2nd run should load those values.
- `yarn run info` should read the same values
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
