### PR TITLE
Fix theme extensions not being bundled when there are no other ui extensions

### DIFF
--- a/.changeset/blue-dots-build.md
+++ b/.changeset/blue-dots-build.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix bug when deploying apps that contain only theme app extensions

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -41,7 +41,7 @@ export async function testUIExtension(uiExtension: Partial<UIExtension> = {}): P
 
   const configuration = uiExtension?.configuration ?? {
     name: uiExtension?.configuration?.name ?? 'test-ui-extension',
-    type: uiExtension?.configuration?.type ?? 'product_subscription',
+    type: uiExtension?.configuration?.type ?? uiExtension?.type ?? 'product_subscription',
     metafields: [],
     capabilities: {
       block_progress: false,

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -1,0 +1,108 @@
+import {ensureDeployContext} from './context.js'
+import {deploy} from './deploy.js'
+import {uploadExtensionsBundle, uploadFunctionExtensions} from './deploy/upload.js'
+import {bundleAndBuildExtensions} from './deploy/bundle.js'
+import {fetchAppExtensionRegistrations} from './dev/fetch.js'
+import {testApp, testThemeExtensions, testUIExtension} from '../models/app/app.test-data.js'
+import {updateAppIdentifiers} from '../models/app/identifiers.js'
+import {AppInterface} from '../models/app/app.js'
+import {describe, expect, it, vi} from 'vitest'
+
+vi.mock('./context.js')
+vi.mock('./deploy/upload.js')
+vi.mock('./deploy/bundle.js')
+vi.mock('./dev/fetch.js')
+vi.mock('../models/app/identifiers.js')
+
+describe('deploy', () => {
+  it('uploads the extension bundle with 1 UI extension', async () => {
+    // Given
+    const uiExtension = await testUIExtension({type: 'web_pixel_extension'})
+    const app = testApp({extensions: {ui: [uiExtension], theme: [], function: []}})
+
+    // When
+    await testDeployBundle(app)
+
+    // Then
+    expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      apiKey: 'app-id',
+      bundlePath: expect.stringMatching(/bundle.zip$/),
+      extensions: [{uuid: uiExtension.localIdentifier, config: '{}', context: ''}],
+      token: 'api-token',
+    })
+  })
+
+  it('uploads the extension bundle with 1 theme extension', async () => {
+    // Given
+    const themeExtension = await testThemeExtensions()
+    const app = testApp({extensions: {ui: [], theme: [themeExtension], function: []}})
+
+    // When
+    await testDeployBundle(app)
+
+    // Then
+    expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      apiKey: 'app-id',
+      bundlePath: expect.stringMatching(/bundle.zip$/),
+      extensions: [{uuid: themeExtension.localIdentifier, config: '{"theme_extension": {"files": {}}}', context: ''}],
+      token: 'api-token',
+    })
+  })
+
+  it('uploads the extension bundle with 1 UI and 1 theme extension', async () => {
+    // Given
+    const uiExtension = await testUIExtension({type: 'web_pixel_extension'})
+    const themeExtension = await testThemeExtensions()
+    const app = testApp({extensions: {ui: [uiExtension], theme: [themeExtension], function: []}})
+
+    // When
+    await testDeployBundle(app)
+
+    // Then
+    expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      apiKey: 'app-id',
+      bundlePath: expect.stringMatching(/bundle.zip$/),
+      extensions: [
+        {uuid: uiExtension.localIdentifier, config: '{}', context: ''},
+        {uuid: themeExtension.localIdentifier, config: '{"theme_extension": {"files": {}}}', context: ''},
+      ],
+      token: 'api-token',
+    })
+  })
+})
+
+async function testDeployBundle(app: AppInterface) {
+  // Given
+  const extensionsPayload: {[key: string]: string} = {}
+  for (const uiExtension of app.extensions.ui) {
+    extensionsPayload[uiExtension.localIdentifier] = uiExtension.localIdentifier
+  }
+  for (const themeExtension of app.extensions.theme) {
+    extensionsPayload[themeExtension.localIdentifier] = themeExtension.localIdentifier
+  }
+  const identifiers = {app: 'app-id', extensions: extensionsPayload, extensionIds: {}}
+
+  vi.mocked(ensureDeployContext).mockResolvedValue({
+    app,
+    identifiers,
+    partnersApp: {id: 'app-id', organizationId: 'org-id', title: 'app-title', grantedScopes: []},
+    partnersOrganizationId: '',
+    token: 'api-token',
+  })
+  vi.mocked(uploadFunctionExtensions).mockResolvedValue(identifiers)
+  vi.mocked(uploadExtensionsBundle).mockResolvedValue([])
+  vi.mocked(updateAppIdentifiers).mockResolvedValue(app)
+  vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({app: {extensionRegistrations: [], functions: []}})
+
+  // When
+  await deploy({
+    app,
+    reset: false,
+    force: true,
+  })
+
+  // Then
+  expect(bundleAndBuildExtensions).toHaveBeenCalledOnce()
+  expect(updateAppIdentifiers).toHaveBeenCalledOnce()
+  expect(fetchAppExtensionRegistrations).toHaveBeenCalledOnce()
+}

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -3,11 +3,11 @@ import {
   UploadExtensionValidationError,
   uploadFunctionExtensions,
   uploadThemeExtensions,
-  uploadUIExtensionsBundle,
+  uploadExtensionsBundle,
 } from './deploy/upload.js'
 
 import {ensureDeployContext} from './context.js'
-import {bundleUIAndBuildFunctionExtensions} from './deploy/bundle.js'
+import {bundleAndBuildExtensions} from './deploy/bundle.js'
 import {fetchAppExtensionRegistrations} from './dev/fetch.js'
 import {AppInterface} from '../models/app/app.js'
 import {Identifiers, updateAppIdentifiers} from '../models/app/identifiers.js'
@@ -41,7 +41,7 @@ interface TasksContext {
   bundle?: boolean
 }
 
-export const deploy = async (options: DeployOptions) => {
+export async function deploy(options: DeployOptions) {
   if (!options.app.hasExtensions()) {
     renderInfo({headline: 'No extensions to deploy to Shopify Partners yet.'})
     return
@@ -87,7 +87,7 @@ export const deploy = async (options: DeployOptions) => {
       const bundleTheme = !themeBundlingDisabled() && app.extensions.theme.length !== 0
       const bundleUI = app.extensions.ui.length !== 0
       const bundle = bundleTheme || bundleUI
-      await bundleUIAndBuildFunctionExtensions({app, bundlePath, identifiers, bundle})
+      await bundleAndBuildExtensions({app, bundlePath, identifiers, bundle})
 
       const tasks: Task<TasksContext>[] = [
         {
@@ -100,11 +100,7 @@ export const deploy = async (options: DeployOptions) => {
           title: 'Pushing your code to Shopify',
           task: async () => {
             if (bundle) {
-              /**
-               * The bundles only support UI extensions for now so we only need bundle and upload
-               * the bundle if the app has UI extensions.
-               */
-              validationErrors = await uploadUIExtensionsBundle({
+              validationErrors = await uploadExtensionsBundle({
                 apiKey,
                 bundlePath,
                 extensions,

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -84,7 +84,9 @@ export const deploy = async (options: DeployOptions) => {
     try {
       const bundlePath = joinPath(tmpDir, `bundle.zip`)
       await mkdir(dirname(bundlePath))
-      const bundle = app.extensions.ui.length !== 0
+      const bundleTheme = !themeBundlingDisabled() && app.extensions.theme.length !== 0
+      const bundleUI = app.extensions.ui.length !== 0
+      const bundle = bundleTheme || bundleUI
       await bundleUIAndBuildFunctionExtensions({app, bundlePath, identifiers, bundle})
 
       const tasks: Task<TasksContext>[] = [

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -16,7 +16,7 @@ interface BundleOptions {
   bundle: boolean
 }
 
-export async function bundleUIAndBuildFunctionExtensions(options: BundleOptions) {
+export async function bundleAndBuildExtensions(options: BundleOptions) {
   await inTemporaryDirectory(async (tmpDir) => {
     const bundleDirectory = joinPath(tmpDir, 'bundle')
     await mkdirSync(bundleDirectory)

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -74,7 +74,7 @@ export async function uploadThemeExtensions(
   )
 }
 
-interface UploadUIExtensionsBundleOptions {
+interface UploadExtensionsBundleOptions {
   /** The application API key */
   apiKey: string
 
@@ -100,11 +100,11 @@ export interface UploadExtensionValidationError {
  * Uploads a bundle.
  * @param options - The upload options
  */
-export async function uploadUIExtensionsBundle(
-  options: UploadUIExtensionsBundleOptions,
+export async function uploadExtensionsBundle(
+  options: UploadExtensionsBundleOptions,
 ): Promise<UploadExtensionValidationError[]> {
   const deploymentUUID = randomUUID()
-  const signedURL = await getUIExtensionUploadURL(options.apiKey, deploymentUUID)
+  const signedURL = await getExtensionUploadURL(options.apiKey, deploymentUUID)
 
   const form = formData()
   const buffer = readFileSync(options.bundlePath)
@@ -144,7 +144,7 @@ export async function uploadUIExtensionsBundle(
  * @param apiKey - The application API key
  * @param deploymentUUID - The unique identifier of the deployment.
  */
-export async function getUIExtensionUploadURL(apiKey: string, deploymentUUID: string) {
+export async function getExtensionUploadURL(apiKey: string, deploymentUUID: string) {
   const mutation = GenerateSignedUploadUrl
   const token = await ensureAuthenticatedPartners()
   const variables: GenerateSignedUploadUrlVariables = {


### PR DESCRIPTION
### WHY are these changes introduced?
A bug was reported that theme extensions were not being uploaded. It's true in the case where you don't have other UI extensions.

Fixes https://github.com/Shopify/cli/issues/1311
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Enable bundling if there are any `ui` OR `theme` extensions.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new project with just a theme app extension and try to deploy, you should see a new version in your partners dashboard
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
