### PR TITLE
Add timeouts to ruby jobs

### DIFF
--- a/.github/workflows/cli-ruby.yml
+++ b/.github/workflows/cli-ruby.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     name: Tests with Ruby ${{ matrix.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         version:
@@ -51,6 +52,7 @@ jobs:
   rubocop:
     name: Rubocop
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         version:


### PR DESCRIPTION
### WHY are these changes introduced?

I've noticed a couple of ruby CI builds getting stuck for a long period of time.

### WHAT is this pull request doing?

Add a 15 minute timeout to each ruby step