### PR TITLE
Don't use Bearer in header when shpat token

### DIFF
--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -52,6 +52,26 @@ describe('common API methods', () => {
     })
   })
 
+  test('when using a custom app token, omit Bearer from auth headers', () => {
+    // Given
+    vi.mocked(randomUUID).mockReturnValue('random-uuid')
+    vi.mocked(firstPartyDev).mockReturnValue(false)
+    const token = 'shpat_my_token'
+    // When
+    const headers = buildHeaders(token)
+
+    // Then
+    const version = CLI_KIT_VERSION
+    expect(headers).toEqual({
+      'Content-Type': 'application/json',
+      'X-Shopify-Access-Token': token,
+      'X-Request-Id': 'random-uuid',
+      'User-Agent': `Shopify CLI; v=${version}`,
+      authorization: token,
+      'Sec-CH-UA-PLATFORM': process.platform,
+    })
+  })
+
   test('sanitizedHeadersOutput removes the headers that include the token', () => {
     // Given
     const headers = {

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -45,9 +45,10 @@ export function buildHeaders(token?: string): {[key: string]: string} {
     ...(firstPartyDev() && {'X-Shopify-Cli-Employee': '1'}),
   }
   if (token) {
+    const authString = token.startsWith('shpat') ? token : `Bearer ${token}`
     // eslint-disable-next-line dot-notation
-    headers['authorization'] = `Bearer ${token}`
-    headers['X-Shopify-Access-Token'] = `Bearer ${token}`
+    headers['authorization'] = authString
+    headers['X-Shopify-Access-Token'] = authString
   }
 
   return headers


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Something I noticed when using cli-kit for my hackdays project. For some reason, `Bearer` needs to be left out of the headers when using a custom app access token. This is preventing us from leveraging the existing `adminRequest` using a pseudo AdminSession.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Removes `Bearer` from the header when using a `shpat` token (i.e. custom token from the store dashboard)

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Generate a custom access token
2.
    ```js
    const query = "{ shop { name }}"
    const adminSession = {
      storeFqdn: "MY_STORE.myshopify.com",
      token: "shpat_whatever"
    }
    await adminRequest(query, adminSession)
    ```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
