### PR TITLE
Fix theme issues with bundler and Ruby version managers

### DIFF
--- a/.changeset/long-melons-burn.md
+++ b/.changeset/long-melons-burn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix theme issues with bundler and ruby version managers

--- a/.github/workflows/cli-ruby.yml
+++ b/.github/workflows/cli-ruby.yml
@@ -40,6 +40,7 @@ jobs:
         uses: ruby/setup-ruby@8df78e55761745aad83acaf3ff12976382356e6d # pin@v1
         with:
           ruby-version: ${{ matrix.version }}
+          bundler: 'latest'
           bundler-cache: true
 
       - name: Install Dependencies
@@ -64,6 +65,7 @@ jobs:
         uses: ruby/setup-ruby@8df78e55761745aad83acaf3ff12976382356e6d # pin@v1
         with:
           ruby-version: ${{ matrix.version }}
+          bundler: 'latest'
           bundler-cache: true
 
       - name: Install Dependencies

--- a/packages/cli-kit/assets/cli-ruby/.npmignore
+++ b/packages/cli-kit/assets/cli-ruby/.npmignore
@@ -38,3 +38,4 @@ ext/shopify-extensions/shopify-extensions
 ext/javy/bin
 .console_history
 TODO.md
+.ruby-version

--- a/packages/cli-kit/assets/cli-ruby/shopify-cli.gemspec
+++ b/packages/cli-kit/assets/cli-ruby/shopify-cli.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib", "vendor"]
   spec.executables << "shopify"
 
-  spec.add_development_dependency("bundler", "~> 2.3.11")
+  spec.add_development_dependency("bundler", ">= 2.3.11")
   spec.add_development_dependency("rake", "~> 12.3", ">= 12.3.3")
   spec.add_development_dependency("minitest", "~> 5.0")
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1308
Fixes https://github.com/Shopify/cli/issues/1320

### WHAT is this pull request doing?

- Exclude `.ruby-version` from cli-kit NPM package
- Relax bundler version requirements for bundled CLI

### How to test your changes?

- Install bundler 2.4 and run `shopify theme dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
