### PR TITLE
Fix embedded CLI (remove Gemfile.lock)

### DIFF
--- a/.changeset/clever-paws-double.md
+++ b/.changeset/clever-paws-double.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix embedded Ruby CLI (remove Gemfile.lock)

--- a/packages/cli-kit/assets/cli-ruby/.npmignore
+++ b/packages/cli-kit/assets/cli-ruby/.npmignore
@@ -39,3 +39,4 @@ ext/javy/bin
 .console_history
 TODO.md
 .ruby-version
+Gemfile.lock


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1320

The Gemfile.lock was forcing to use bundler 2.3.20, but we are not ensuring it is present

### WHAT is this pull request doing?

Remove useless Gemfile.lock from the NPM package

### How to test your changes?

- `brew install shopify-cli`
- Temporarily remove `/opt/homebrew/lib/ruby/gems/3.2.0/gems/bundler-2.3.20/exe/bundle`
- `shopify theme dev` should raise an error about bundler not being found
- `rm /opt/homebrew/Cellar/shopify-cli/3.42.0/libexec/lib/node_modules/@shopify/theme/node_modules/@shopify/cli-kit/assets/cli-ruby/Gemfile.lock`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
