### PR TITLE
Reverting theme-bundling on by default

### DIFF
--- a/.changeset/silent-bats-invite.md
+++ b/.changeset/silent-bats-invite.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': minor
+'@shopify/cli-kit': minor
+---
+
+Theme bundling is now an opt-in feature

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -14,6 +14,7 @@ vi.mock('./deploy/upload.js')
 vi.mock('./deploy/bundle.js')
 vi.mock('./dev/fetch.js')
 vi.mock('../models/app/identifiers.js')
+vi.mock('@shopify/cli-kit/node/context/local')
 
 describe('deploy', () => {
   it('uploads the extension bundle with 1 UI extension', async () => {
@@ -90,7 +91,6 @@ async function testDeployBundle(app: AppInterface) {
     partnersOrganizationId: '',
     token: 'api-token',
   })
-  vi.mock('@shopify/cli-kit/node/context/local')
   vi.mocked(useThemebundling).mockReturnValue(true)
   vi.mocked(uploadFunctionExtensions).mockResolvedValue(identifiers)
   vi.mocked(uploadExtensionsBundle).mockResolvedValue([])

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -90,6 +90,7 @@ async function testDeployBundle(app: AppInterface) {
     partnersOrganizationId: '',
     token: 'api-token',
   })
+  vi.mock('@shopify/cli-kit/node/context/local')
   vi.mocked(useThemebundling).mockReturnValue(true)
   vi.mocked(uploadFunctionExtensions).mockResolvedValue(identifiers)
   vi.mocked(uploadExtensionsBundle).mockResolvedValue([])

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -7,7 +7,7 @@ import {testApp, testThemeExtensions, testUIExtension} from '../models/app/app.t
 import {updateAppIdentifiers} from '../models/app/identifiers.js'
 import {AppInterface} from '../models/app/app.js'
 import {describe, expect, it, vi} from 'vitest'
-import {themeBundling} from '@shopify/cli-kit/node/context/local'
+import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 
 vi.mock('./context.js')
 vi.mock('./deploy/upload.js')
@@ -90,7 +90,7 @@ async function testDeployBundle(app: AppInterface) {
     partnersOrganizationId: '',
     token: 'api-token',
   })
-  vi.mocked(themeBundling).mockReturnValue(true)
+  vi.mocked(useThemebundling).mockReturnValue(true)
   vi.mocked(uploadFunctionExtensions).mockResolvedValue(identifiers)
   vi.mocked(uploadExtensionsBundle).mockResolvedValue([])
   vi.mocked(updateAppIdentifiers).mockResolvedValue(app)

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -7,6 +7,7 @@ import {testApp, testThemeExtensions, testUIExtension} from '../models/app/app.t
 import {updateAppIdentifiers} from '../models/app/identifiers.js'
 import {AppInterface} from '../models/app/app.js'
 import {describe, expect, it, vi} from 'vitest'
+import {themeBundling} from '@shopify/cli-kit/node/context/local'
 
 vi.mock('./context.js')
 vi.mock('./deploy/upload.js')
@@ -89,6 +90,7 @@ async function testDeployBundle(app: AppInterface) {
     partnersOrganizationId: '',
     token: 'api-token',
   })
+  vi.mocked(themeBundling).mockReturnValue(true)
   vi.mocked(uploadFunctionExtensions).mockResolvedValue(identifiers)
   vi.mocked(uploadExtensionsBundle).mockResolvedValue([])
   vi.mocked(updateAppIdentifiers).mockResolvedValue(app)

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -19,7 +19,7 @@ import {renderInfo, renderSuccess, renderTasks} from '@shopify/cli-kit/node/ui'
 import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
 import {outputNewline, outputInfo} from '@shopify/cli-kit/node/output'
-import {useThemebundling} from '@shopify/cli-kit/node/context/local.js'
+import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import type {AlertCustomSection, Task} from '@shopify/cli-kit/node/ui'
 
 interface DeployOptions {

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -15,11 +15,11 @@ import {Extension} from '../models/app/extensions.js'
 import {OrganizationApp} from '../models/organization.js'
 import {validateExtensions} from '../validators/extensions.js'
 import {AllAppExtensionRegistrationsQuerySchema} from '../api/graphql/all_app_extension_registrations.js'
-import {themeBundlingDisabled} from '@shopify/cli-kit/node/context/local'
 import {renderInfo, renderSuccess, renderTasks} from '@shopify/cli-kit/node/ui'
 import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
 import {outputNewline, outputInfo} from '@shopify/cli-kit/node/output'
+import {useThemebundling} from '@shopify/cli-kit/node/context/local.js'
 import type {AlertCustomSection, Task} from '@shopify/cli-kit/node/ui'
 
 interface DeployOptions {
@@ -64,7 +64,7 @@ export async function deploy(options: DeployOptions) {
       }
     }),
   )
-  if (!themeBundlingDisabled()) {
+  if (useThemebundling()) {
     const themeExtensions = await Promise.all(
       options.app.extensions.theme.map(async (extension) => {
         return {
@@ -84,7 +84,7 @@ export async function deploy(options: DeployOptions) {
     try {
       const bundlePath = joinPath(tmpDir, `bundle.zip`)
       await mkdir(dirname(bundlePath))
-      const bundleTheme = !themeBundlingDisabled() && app.extensions.theme.length !== 0
+      const bundleTheme = useThemebundling() && app.extensions.theme.length !== 0
       const bundleUI = app.extensions.ui.length !== 0
       const bundle = bundleTheme || bundleUI
       await bundleAndBuildExtensions({app, bundlePath, identifiers, bundle})
@@ -108,7 +108,7 @@ export async function deploy(options: DeployOptions) {
               })
             }
 
-            if (themeBundlingDisabled()) {
+            if (!useThemebundling()) {
               await uploadThemeExtensions(options.app.extensions.theme, {apiKey, identifiers, token})
             }
 

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -1,9 +1,9 @@
 import {buildThemeExtensions, ThemeExtensionBuildOptions} from '../build/extension.js'
 import {build as esBuild, BuildFailure, BuildResult, formatMessagesSync} from 'esbuild'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
-import {themeBundlingDisabled} from '@shopify/cli-kit/node/context/local'
 import {copyFile, glob} from '@shopify/cli-kit/node/fs'
 import {joinPath, relativePath} from '@shopify/cli-kit/node/path'
+import {useThemebundling} from '@shopify/cli-kit/node/context/local.js'
 import {Writable} from 'stream'
 import {createRequire} from 'module'
 import type {StdinOptions} from 'esbuild'
@@ -64,7 +64,7 @@ export async function bundleThemeExtensions(options: ThemeExtensionBuildOptions)
 
   await buildThemeExtensions(options)
 
-  if (!themeBundlingDisabled()) {
+  if (useThemebundling()) {
     await Promise.all(
       options.extensions.map(async (extension) => {
         options.stdout.write(`Bundling theme extension ${extension.localIdentifier}...`)

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -3,7 +3,7 @@ import {build as esBuild, BuildFailure, BuildResult, formatMessagesSync} from 'e
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {copyFile, glob} from '@shopify/cli-kit/node/fs'
 import {joinPath, relativePath} from '@shopify/cli-kit/node/path'
-import {useThemebundling} from '@shopify/cli-kit/node/context/local.js'
+import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import {Writable} from 'stream'
 import {createRequire} from 'module'
 import type {StdinOptions} from 'esbuild'

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -23,7 +23,7 @@ export const environmentVariables = {
   themeToken: 'SHOPIFY_CLI_THEME_TOKEN',
   unitTest: 'SHOPIFY_UNIT_TEST',
   verbose: 'SHOPIFY_FLAG_VERBOSE',
-  noThemeBundling: 'SHOPIFY_CLI_NO_THEME_BUNDLING',
+  themeBundling: 'SHOPIFY_CLI_THEME_BUNDLING',
   javascriptFunctions: 'SHOPIFY_CLI_FUNCTIONS_JAVASCRIPT',
   // Variables to detect if the CLI is running in a cloud environment
   codespaceName: 'CODESPACE_NAME',

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -113,13 +113,13 @@ export function useDeviceAuth(env = process.env): boolean {
 }
 
 /**
- * Returns true if the CLI should not use theme bundling.
+ * Returns true if the CLI should use theme bundling.
  *
  * @param env - The environment variables from the environment of the current process.
  * @returns True if SHOPIFY_NO_THEME_BUNDLING is truthy.
  */
-export function themeBundlingDisabled(env = process.env): boolean {
-  return isTruthy(env[environmentVariables.noThemeBundling])
+export function useThemebundling(env = process.env): boolean {
+  return isTruthy(env[environmentVariables.themeBundling])
 }
 
 /**


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Theme bundling was turned on by default and resulted in a lot of deployment errors popping up for partners. We want to revert this change to give us more time to investigate the issue before turning it back on. 

Fixes https://github.com/Shopify/cli/issues/1325

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Changing the environment variable to be opt-in usage instead of opt-out. 

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
