### PR TITLE
Added windows gem depencies to embedded cli-ruby

### DIFF
--- a/.changeset/five-books-wave.md
+++ b/.changeset/five-books-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Added windows gem depencies to embedded cli-ruby

--- a/packages/cli-kit/src/public/node/ruby.test.ts
+++ b/packages/cli-kit/src/public/node/ruby.test.ts
@@ -1,4 +1,4 @@
-import {execCLI2, RubyCLIVersion} from './ruby.js'
+import {execCLI2, MinWdmWindowsVersion, RubyCLIVersion} from './ruby.js'
 import {captureOutput} from './system.js'
 import * as system from './system.js'
 import * as file from './fs.js'
@@ -191,7 +191,7 @@ function mockPlatformAndArch({windows}: {windows: boolean}) {
 async function createGemFile(cli2Directory: string, existingWindowsDependency: boolean) {
   const gemfilePath = joinPath(cli2Directory, 'Gemfile')
   let content = "source 'https://rubygems.org'\n"
-  if (existingWindowsDependency) content = content.concat("gem 'wdm', '>= 0.1.0'")
+  if (existingWindowsDependency) content = content.concat(`gem 'wdm', '>= ${MinWdmWindowsVersion}'`)
   await file.touchFile(gemfilePath)
   await file.appendFile(gemfilePath, content.concat('\n'))
 }
@@ -217,7 +217,7 @@ async function validateGemFileContent(gemfilePath: string, {bundled, windows}: {
   const gemContent = await file.readFile(gemfilePath, {encoding: 'utf8'})
   expect(gemContent).toContain("source 'https://rubygems.org'")
   if (bundled) expect(gemContent).toContain(`gem 'shopify-cli', '${RubyCLIVersion}'`)
-  const windowsDepency = "gem 'wdm', '>= 0.1.0'"
+  const windowsDepency = `gem 'wdm', '>= ${MinWdmWindowsVersion}'`
   if (windows) {
     expect(gemContent).toContain(windowsDepency)
     const notDuplicated = gemContent.indexOf(windowsDepency) === gemContent.lastIndexOf(windowsDepency)

--- a/packages/cli-kit/src/public/node/ruby.test.ts
+++ b/packages/cli-kit/src/public/node/ruby.test.ts
@@ -159,7 +159,7 @@ function mockBundledCLI2(cli2Directory: string, {windows}: {windows: boolean}) {
   vi.spyOn(local, 'isShopify').mockResolvedValue(false)
   vi.spyOn(pathConstants.directories.cache.vendor, 'path').mockReturnValue(cli2Directory)
   mockRubyEnvironment()
-  mockPlatformAndArch(windows)
+  mockPlatformAndArch({windows})
   return vi.spyOn(system, 'exec')
 }
 
@@ -170,7 +170,7 @@ async function mockEmbeddedCLI2(
   vi.spyOn(local, 'isShopify').mockResolvedValue(true)
   vi.spyOn(file, 'findPathUp').mockResolvedValue(cli2Directory)
   mockRubyEnvironment()
-  mockPlatformAndArch(windows)
+  mockPlatformAndArch({windows})
   await createGemFile(cli2Directory, existingWindowsDependency)
   return vi.spyOn(system, 'exec')
 }
@@ -180,7 +180,7 @@ function mockRubyEnvironment() {
   vi.mocked(captureOutput).mockResolvedValueOnce('2.4.0')
 }
 
-function mockPlatformAndArch(windows: boolean) {
+function mockPlatformAndArch({windows}: {windows: boolean}) {
   if (windows) {
     vi.mocked(platformAndArch).mockReturnValue({platform: 'windows', arch: 'x64'})
   } else {

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -41,7 +41,9 @@ interface ExecCLI2Options {
  * @param options - Options to customize the execution of cli2.
  */
 export async function execCLI2(args: string[], options: ExecCLI2Options = {}): Promise<void> {
-  const embedded = (await isShopify()) || isTruthy(process.env.SHOPIFY_CLI_EMBEDDED_THEME_CLI)
+  const embedded =
+    ((await isShopify()) && process.env.SHOPIFY_CLI_EMBEDDED_THEME_CLI === undefined) ||
+    isTruthy(process.env.SHOPIFY_CLI_EMBEDDED_THEME_CLI)
 
   await installCLIDependencies(options.stdout ?? process.stdout, embedded)
   const env: NodeJS.ProcessEnv = {
@@ -254,14 +256,10 @@ async function createThemeCheckCLIWorkingDirectory(): Promise<void> {
  * It creates the Gemfile to install The Ruby CLI and the dependencies.
  */
 async function createShopifyCLIGemfile(): Promise<void> {
-  const gemPath = joinPath(await shopifyCLIDirectory(), 'Gemfile')
-  const gemFileContent = ["source 'https://rubygems.org'", `gem 'shopify-cli', '${RubyCLIVersion}'`]
-  const {platform} = platformAndArch()
-  if (platform === 'windows') {
-    // 'wdm' is required by 'listen', see https://github.com/Shopify/cli/issues/780
-    gemFileContent.push("gem 'wdm', '>= 0.1.0'")
-  }
-  await file.writeFile(gemPath, gemFileContent.join('\n'))
+  const directory = await shopifyCLIDirectory()
+  await addContentToGemfile(directory, "source 'https://rubygems.org'")
+  await addContentToGemfile(directory, `gem 'shopify-cli', '${RubyCLIVersion}'`)
+  await addWindowsDependencies(directory)
 }
 
 /**
@@ -278,7 +276,35 @@ async function createThemeCheckGemfile(): Promise<void> {
  * @param directory - Directory where CLI2 Gemfile is located.
  */
 async function bundleInstallLocalShopifyCLI(directory: string): Promise<void> {
+  await addWindowsDependencies(directory)
   await exec(bundleExecutable(), ['install'], {cwd: directory})
+}
+
+/**
+ * Add Windows dependencies to Gemfile.
+ *
+ * @param directory - Directory where Gemfile is located.
+ */
+async function addWindowsDependencies(directory: string) {
+  if (platformAndArch().platform === 'windows') {
+    // 'wdm' is required by 'listen', see https://github.com/Shopify/cli/issues/780
+    await addContentToGemfile(directory, "gem 'wdm', '>= 0.1.0'")
+  }
+}
+
+/**
+ * Append contente to a Gemfile located in the given directory.
+ *
+ * @param gemfileDirectory - Directory where Gemfile is located.
+ * @param content - Content to append to the Gemfile.
+ */
+async function addContentToGemfile(gemfileDirectory: string, content: string) {
+  const gemfilePath = joinPath(gemfileDirectory, 'Gemfile')
+  if (!(await file.fileExists(gemfilePath))) await file.touchFile(gemfilePath)
+  const gemContent = await file.readFile(gemfilePath, {encoding: 'utf8'})
+  if (!gemContent.includes(content)) {
+    await file.appendFile(gemfilePath, `${content}\n`)
+  }
 }
 
 /**

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -295,6 +295,8 @@ function getBaseGemfileContent() {
 function getWindowsDependencies() {
   if (platformAndArch().platform === 'windows') {
     // 'wdm' is required by 'listen', see https://github.com/Shopify/cli/issues/780
+    // Because it's a Windows-only dependency, it's not included in the `.gemspec`.
+    // Otherwise it'd install it in non-Windows environments, which is not needed.
     return [`gem 'wdm', '>= ${MinWdmWindowsVersion}'`]
   }
   return []

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -17,6 +17,7 @@ export const RubyCLIVersion = '2.34.0'
 const ThemeCheckVersion = '1.14.0'
 const MinBundlerVersion = '2.3.8'
 const MinRubyVersion = '2.7.5'
+export const MinWdmWindowsVersion = '0.1.0'
 
 interface ExecCLI2Options {
   // Contains token and store to pass to CLI 2.0, which will be set as environment variables
@@ -294,7 +295,7 @@ function getBaseGemfileContent() {
 function getWindowsDependencies() {
   if (platformAndArch().platform === 'windows') {
     // 'wdm' is required by 'listen', see https://github.com/Shopify/cli/issues/780
-    return ["gem 'wdm', '>= 0.1.0'"]
+    return [`gem 'wdm', '>= ${MinWdmWindowsVersion}'`]
   }
   return []
 }

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -255,10 +255,8 @@ async function createThemeCheckCLIWorkingDirectory(): Promise<void> {
  */
 async function createShopifyCLIGemfile(): Promise<void> {
   const directory = await shopifyCLIDirectory()
-  const content = ["source 'https://rubygems.org'", `gem 'shopify-cli', '${RubyCLIVersion}'`].concat(
-    buildWindowsDependencies(),
-  )
-  await addContentToGemfile(directory, content)
+  const gemfileContent = getBaseGemfileContent().concat(getWindowsDependencies())
+  await addContentToGemfile(directory, gemfileContent)
 }
 
 /**
@@ -275,8 +273,17 @@ async function createThemeCheckGemfile(): Promise<void> {
  * @param directory - Directory where CLI2 Gemfile is located.
  */
 async function bundleInstallLocalShopifyCLI(directory: string): Promise<void> {
-  await addContentToGemfile(directory, buildWindowsDependencies())
+  await addContentToGemfile(directory, getWindowsDependencies())
   await exec(bundleExecutable(), ['install'], {cwd: directory})
+}
+
+/**
+ * Build the list of lines with the base content of the Gemfile.
+ *
+ * @returns List of lines with base content.
+ */
+function getBaseGemfileContent() {
+  return ["source 'https://rubygems.org'", `gem 'shopify-cli', '${RubyCLIVersion}'`]
 }
 
 /**
@@ -284,7 +291,7 @@ async function bundleInstallLocalShopifyCLI(directory: string): Promise<void> {
  *
  * @returns List of Windows dependencies.
  */
-function buildWindowsDependencies() {
+function getWindowsDependencies() {
   if (platformAndArch().platform === 'windows') {
     // 'wdm' is required by 'listen', see https://github.com/Shopify/cli/issues/780
     return ["gem 'wdm', '>= 0.1.0'"]


### PR DESCRIPTION
### WHY are these changes introduced?
Related to https://github.com/Shopify/cli/issues/1314

Windows gem dependencies needed for the `theme-app-extension` are not installed when the embedded `cli-ruby` version is used so this error is displayed

<img src="https://user-images.githubusercontent.com/105213827/218144212-93bb8968-f9fd-4668-9139-190de0f297d8.png" width="500" >

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Added windows gem dependencies when the embedded `cli-ruby` is used
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Run a `dev` command for an app with `theme-app-extension` in windows.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
