### PR TITLE
fix sizing and alignment of tooltip

### DIFF
--- a/packages/ui-extensions-dev-console/src/components/Tooltip/TooltipPopover.module.css
+++ b/packages/ui-extensions-dev-console/src/components/Tooltip/TooltipPopover.module.css
@@ -9,14 +9,12 @@
   font-weight: 400;
   padding: 1rem;
   border-radius: 4px;
+  width: max-content;
   max-width: var(--tooltip-popover-max-width);
-  white-space: initial;
-
+  white-space: pre-wrap;
+  word-break: break-word;
+  word-wrap: break-word;
   z-index: 9999;
   box-shadow: 0px 3px 6px -3px rgba(23, 24, 24, 0.08),
     0px 8px 20px -4px rgba(23, 24, 24, 0.12);
-}
-
-.LongText {
-  width: var(--tooltip-popover-max-width);
 }

--- a/packages/ui-extensions-dev-console/src/components/Tooltip/TooltipPopover.tsx
+++ b/packages/ui-extensions-dev-console/src/components/Tooltip/TooltipPopover.tsx
@@ -1,6 +1,5 @@
 import styles from './TooltipPopover.module.css'
 import React, {useLayoutEffect, useRef} from 'react'
-import {classNames} from '@/utilities/css'
 
 export interface Position {
   x: number
@@ -12,7 +11,6 @@ export interface TooltipPopoverProps {
   targetRef: React.RefObject<HTMLElement>
 }
 
-const TOOLTIP_MAX_CHAR_WIDTH = 30
 const TOOLTIP_VERTICAL_OFFSET = 10
 
 export function TooltipPopover({targetRef, text}: TooltipPopoverProps) {
@@ -52,11 +50,7 @@ export function TooltipPopover({targetRef, text}: TooltipPopoverProps) {
   }, [])
 
   return (
-    <div
-      className={classNames(styles.Popover, text.length > TOOLTIP_MAX_CHAR_WIDTH && styles.LongText)}
-      role="tooltip"
-      ref={ref}
-    >
+    <div className={styles.Popover} role="tooltip" ref={ref}>
       {text}
     </div>
   )


### PR DESCRIPTION
Tooltip component had a temporary sizing/positioning solution in place to address some weird visual issues.

This PR cleans that up and replaces it with a pure css fix.

![image](https://user-images.githubusercontent.com/103125965/218183969-23401872-6351-4631-9ab9-f713eaea0c19.png)

Previously this tooltip would have additional space at the end, or if the text was longer it suffered from weird breaking.