### PR TITLE
[Feature] Add `--no-input` flag to disable input prompts for development

### DIFF
--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -66,6 +66,13 @@ export default class Dev extends Command {
       default: false,
       exclusive: ['tunnel-url', 'tunnel'],
     }),
+    'no-input': Flags.boolean({
+      hidden: false,
+      description: 'Disables input prompts. Requires setting up your app first before use.',
+      env: 'SHOPIFY_FLAG_NO_INPUT',
+      default: false,
+      exclusive: ['reset'],
+    }),
     tunnel: Flags.boolean({
       hidden: false,
       description: 'Use ngrok to create a tunnel to your service entry point',
@@ -112,6 +119,7 @@ export default class Dev extends Command {
       noTunnel: flags['no-tunnel'],
       theme: flags.theme,
       themeExtensionPort: flags['theme-app-extension-port'],
+      noInput: flags['no-input'],
     })
   }
 }

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -40,6 +40,7 @@ export interface DevContextOptions {
   apiKey?: string
   storeFqdn?: string
   reset: boolean
+  noInput: boolean
 }
 
 interface DevContextOutput {
@@ -129,6 +130,10 @@ export async function ensureDevContext(options: DevContextOptions, token: string
   })
 
   if (cachedInfo === undefined && !options.reset) {
+    if (options.noInput) {
+      throw new AbortError('--no-input flag may not be used until the app has been setup')
+    }
+
     const explanation =
       `\nLooks like this is the first time you're running dev for this project.\n` +
       'Configure your preferences by answering a few questions.\n'

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -50,6 +50,7 @@ export interface DevOptions {
   tunnelUrl?: string
   tunnel: boolean
   noTunnel: boolean
+  noInput: boolean
   theme?: string
   themeExtensionPort?: number
 }
@@ -214,6 +215,7 @@ async function dev(options: DevOptions) {
       portNumber: proxyPort,
       proxyTargets,
       additionalProcesses,
+      noInput: options.noInput,
     })
   }
 }

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -126,7 +126,7 @@ ${outputToken.json(JSON.stringify(rules))}
     }
   }
 
-  await Promise.all([renderConcurrent({...renderConcurrentOptions}), server.listen(availablePort)])
+  await Promise.all([renderConcurrent(renderConcurrentOptions), server.listen(availablePort)])
 }
 
 function match(rules: {[key: string]: string}, req: http.IncomingMessage) {

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -30,6 +30,7 @@ interface Options {
   portNumber: number | undefined
   proxyTargets: ReverseHTTPProxyTarget[]
   additionalProcesses: OutputProcess[]
+  noInput?: boolean
 }
 
 /**
@@ -46,6 +47,7 @@ export async function runConcurrentHTTPProcessesAndPathForwardTraffic({
   portNumber = undefined,
   proxyTargets,
   additionalProcesses,
+  noInput,
 }: Options): Promise<void> {
   // Lazy-importing it because it's CJS and we don't want it
   // to block the loading of the ESM module graph.
@@ -106,7 +108,7 @@ ${outputToken.json(JSON.stringify(rules))}
     abortController,
   }
 
-  if (previewUrl) {
+  if (previewUrl && !noInput) {
     renderConcurrentOptions = {
       ...renderConcurrentOptions,
       onInput: (input, _key, exit) => {
@@ -124,7 +126,7 @@ ${outputToken.json(JSON.stringify(rules))}
     }
   }
 
-  await Promise.all([renderConcurrent(renderConcurrentOptions), server.listen(availablePort)])
+  await Promise.all([renderConcurrent({...renderConcurrentOptions}), server.listen(availablePort)])
 }
 
 function match(rules: {[key: string]: string}, req: http.IncomingMessage) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #1341 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

As stated in the original issue, when running `shopify app dev` with Vercel's turborepo (or any parent proccess that uses `stdin` i would image) the cli crashes with the following error `ERROR Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default.`.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR adds the optional `--no-input` flag to `shopify app dev` to essentially disable `stdin` from being required. The primary use case is usage within a monorepo/parent process that might have its own `stdin` handling. This flag requires the app to first be set up/configured before using. Additionally, it is restricted from being used along side of `--reset` since that is a process that does require prompts (if there are additional commands/flags I missed please let me know!)

I'm not sure that this is the "correct" fix since it doesn't deal with `stdin` directly really, but personally felt this flag would be more friendly for developers in the less common scenario of a monorepo/parent context. Totally open to suggestions/ideas though!

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

**Note: **If this change is wanted I can totally make a reproducible repo!

1. Setup a new app with `shopify app dev`
2. Run `shopify app dev --no-input` from any parent process that uses `stdin`, (ie. turbo, others) and the app will still run

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

I imagine there's documentation to be updated on the docs page which I am happy to do assuming this change is desired.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
