### PR TITLE
Cache identity introspection endpoint

### DIFF
--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -64,7 +64,7 @@ describe('cacheFetch', () => {
 
       // Then
       // Uses the prior run to return the cached value
-      expect(got).toEqual('two')
+      expect(got).toEqual(2)
     })
   })
 
@@ -75,8 +75,7 @@ describe('cacheFetch', () => {
 
       // Then
       const got = await cacheFetch('two', async () => 3, 1000, config)
-      // Uses the prior run to return the cached value
-      expect(got).toEqual(2)
+      expect(got).toEqual(3)
     })
   })
 

--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -1,4 +1,4 @@
-import {ConfSchema, cacheFetch, getSession, removeSession, setSession} from './conf-store.js'
+import {ConfSchema, cacheRetrieveOrRepopulate, getSession, removeSession, setSession} from './conf-store.js'
 import {LocalStorage} from '../../public/node/local-storage.js'
 import {describe, expect, it} from 'vitest'
 import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
@@ -51,16 +51,16 @@ describe('removeSession', () => {
   })
 })
 
-describe('cacheFetch', () => {
+describe('cacheRetrieveOrRepopulate', () => {
   it('returns the cached contents when they exist', async () => {
     await inTemporaryDirectory(async (cwd) => {
       // Given
       const config = new LocalStorage<ConfSchema>({cwd})
       // populate the cache
-      await cacheFetch('identity-introspection-url', async () => 'URL1', 1000, config)
+      await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL1', 1000, config)
 
       // When
-      const got = await cacheFetch('identity-introspection-url', async () => 'URL2', 1000, config)
+      const got = await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL2', 1000, config)
 
       // Then
       // Uses the prior run to return the cached value
@@ -74,7 +74,7 @@ describe('cacheFetch', () => {
       const config = new LocalStorage<ConfSchema>({cwd})
 
       // Then
-      const got = await cacheFetch('identity-introspection-url', async () => 'URL1', 1000, config)
+      const got = await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL1', 1000, config)
       expect(got).toEqual('URL1')
     })
   })
@@ -86,10 +86,10 @@ describe('cacheFetch', () => {
 
       // When
       // populate the cache
-      await cacheFetch('identity-introspection-url', async () => 'URL1', 1000, config)
+      await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL1', 1000, config)
 
       // Then
-      const got = await cacheFetch('identity-introspection-url', async () => 'URL2', 0, config)
+      const got = await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL2', 0, config)
       // Fetches a new value because the old one is outdated per the current request
       expect(got).toEqual('URL2')
     })

--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -57,10 +57,15 @@ describe('cacheRetrieveOrRepopulate', () => {
       // Given
       const config = new LocalStorage<ConfSchema>({cwd})
       // populate the cache
-      await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL1', 1000, config)
+      await cacheRetrieveOrRepopulate('identity-introspection-url-IDENTITYURL', async () => 'URL1', 1000, config)
 
       // When
-      const got = await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL2', 1000, config)
+      const got = await cacheRetrieveOrRepopulate(
+        'identity-introspection-url-IDENTITYURL',
+        async () => 'URL2',
+        1000,
+        config,
+      )
 
       // Then
       // Uses the prior run to return the cached value
@@ -74,7 +79,12 @@ describe('cacheRetrieveOrRepopulate', () => {
       const config = new LocalStorage<ConfSchema>({cwd})
 
       // Then
-      const got = await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL1', 1000, config)
+      const got = await cacheRetrieveOrRepopulate(
+        'identity-introspection-url-IDENTITYURL',
+        async () => 'URL1',
+        1000,
+        config,
+      )
       expect(got).toEqual('URL1')
     })
   })
@@ -86,10 +96,15 @@ describe('cacheRetrieveOrRepopulate', () => {
 
       // When
       // populate the cache
-      await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL1', 1000, config)
+      await cacheRetrieveOrRepopulate('identity-introspection-url-IDENTITYURL', async () => 'URL1', 1000, config)
 
       // Then
-      const got = await cacheRetrieveOrRepopulate('identity-introspection-url', async () => 'URL2', 0, config)
+      const got = await cacheRetrieveOrRepopulate(
+        'identity-introspection-url-IDENTITYURL',
+        async () => 'URL2',
+        0,
+        config,
+      )
       // Fetches a new value because the old one is outdated per the current request
       expect(got).toEqual('URL2')
     })

--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -57,14 +57,14 @@ describe('cacheFetch', () => {
       // Given
       const config = new LocalStorage<ConfSchema>({cwd})
       // populate the cache
-      await cacheFetch('two', async () => 2, 1000, config)
+      await cacheFetch('identity-introspection-url', async () => 'URL1', 1000, config)
 
       // When
-      const got = await cacheFetch('two', async () => 3, 1000, config)
+      const got = await cacheFetch('identity-introspection-url', async () => 'URL2', 1000, config)
 
       // Then
       // Uses the prior run to return the cached value
-      expect(got).toEqual(2)
+      expect(got).toEqual('URL1')
     })
   })
 
@@ -74,8 +74,8 @@ describe('cacheFetch', () => {
       const config = new LocalStorage<ConfSchema>({cwd})
 
       // Then
-      const got = await cacheFetch('two', async () => 3, 1000, config)
-      expect(got).toEqual(3)
+      const got = await cacheFetch('identity-introspection-url', async () => 'URL1', 1000, config)
+      expect(got).toEqual('URL1')
     })
   })
 
@@ -86,12 +86,12 @@ describe('cacheFetch', () => {
 
       // When
       // populate the cache
-      await cacheFetch('two', async () => 2, 1000, config)
+      await cacheFetch('identity-introspection-url', async () => 'URL1', 1000, config)
 
       // Then
-      const got = await cacheFetch('two', async () => 3, 0, config)
+      const got = await cacheFetch('identity-introspection-url', async () => 'URL2', 0, config)
       // Fetches a new value because the old one is outdated per the current request
-      expect(got).toEqual(3)
+      expect(got).toEqual('URL2')
     })
   })
 })

--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -57,10 +57,10 @@ describe('cacheFetch', () => {
       // Given
       const config = new LocalStorage<ConfSchema>({cwd})
       // populate the cache
-      await cacheFetch('two', (async () => 2), 1000, config)
+      await cacheFetch('two', async () => 2, 1000, config)
 
       // When
-      const got = await cacheFetch('two', (async () => 3), 1000, config)
+      const got = await cacheFetch('two', async () => 3, 1000, config)
 
       // Then
       // Uses the prior run to return the cached value
@@ -74,7 +74,7 @@ describe('cacheFetch', () => {
       const config = new LocalStorage<ConfSchema>({cwd})
 
       // Then
-      const got = await cacheFetch('two', (async () => 3), 1000, config)
+      const got = await cacheFetch('two', async () => 3, 1000, config)
       // Uses the prior run to return the cached value
       expect(got).toEqual(2)
     })
@@ -87,10 +87,10 @@ describe('cacheFetch', () => {
 
       // When
       // populate the cache
-      await cacheFetch('two', (async () => 2), 1000, config)
+      await cacheFetch('two', async () => 2, 1000, config)
 
       // Then
-      const got = await cacheFetch('two', (async () => 3), 0, config)
+      const got = await cacheFetch('two', async () => 3, 0, config)
       // Fetches a new value because the old one is outdated per the current request
       expect(got).toEqual(3)
     })

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -57,20 +57,21 @@ export function removeSession(config: LocalStorage<ConfSchema> = cliKitStore()):
   config.delete('sessionStore')
 }
 
+type CacheValueForKey<TKey extends keyof Cache> = NonNullable<Cache[TKey]>['value']
 /**
  * Fetch from cache, or run the provided function to get the value, and cache it
  * before returning it.
  * @param key - The key to use for the cache.
- * @param fn - The function to run to get the value to cache.
- * @param timeout - The number of milliseconds to cache the value for.
+ * @param fn - The function to run to get the value to cache, if a cache miss occurs.
+ * @param timeout - The maximum valid age of a cached value, in milliseconds. If the cached value is older than this, it will be refreshed.
  * @returns The value from the cache or the result of the function.
  */
-export async function cacheFetch(
+export async function cacheRetrieveOrRepopulate(
   key: keyof Cache,
-  fn: () => Promise<NonNullable<Cache[typeof key]>['value']>,
+  fn: () => Promise<CacheValueForKey<typeof key>>,
   timeout?: number,
   config = cliKitStore(),
-): Promise<NonNullable<Cache[typeof key]>['value']> {
+): Promise<CacheValueForKey<typeof key>> {
   const cache: Cache = config.get('cache') || {}
   const cached = cache[key]
 

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -1,16 +1,18 @@
 import {LocalStorage} from '../../public/node/local-storage.js'
 import {outputContent, outputDebug} from '@shopify/cli-kit/node/output'
 
+interface CacheValue<T> {
+  value: T
+  timestamp: number
+}
+
 interface Cache {
-  [key: string]: {
-    value: unknown
-    timestamp: number
-  }
+  'identity-introspection-url'?: CacheValue<string>
 }
 
 export interface ConfSchema {
   sessionStore: string
-  cache: Cache
+  cache?: Cache
 }
 
 let _instance: LocalStorage<ConfSchema> | undefined
@@ -63,17 +65,17 @@ export function removeSession(config: LocalStorage<ConfSchema> = cliKitStore()):
  * @param timeout - The number of milliseconds to cache the value for.
  * @returns The value from the cache or the result of the function.
  */
-export async function cacheFetch<T>(
-  key: string,
-  fn: () => Promise<T>,
+export async function cacheFetch(
+  key: keyof Cache,
+  fn: () => Promise<NonNullable<Cache[typeof key]>['value']>,
   timeout?: number,
   config = cliKitStore(),
-): Promise<T> {
+): Promise<NonNullable<Cache[typeof key]>['value']> {
   const cache: Cache = config.get('cache') || {}
   const cached = cache[key]
 
   if (cached && (timeout === undefined || Date.now() - cached.timestamp < timeout)) {
-    return cached.value as T
+    return cached.value
   }
 
   const value = await fn()

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -1,8 +1,16 @@
 import {LocalStorage} from '../../public/node/local-storage.js'
 import {outputContent, outputDebug} from '@shopify/cli-kit/node/output'
 
+interface Cache {
+  [key: string]: {
+    value: any
+    timestamp: number
+  }
+}
+
 export interface ConfSchema {
   sessionStore: string
+  cache: Cache
 }
 
 let _instance: LocalStorage<ConfSchema> | undefined
@@ -45,4 +53,27 @@ export function setSession(session: string, config: LocalStorage<ConfSchema> = c
 export function removeSession(config: LocalStorage<ConfSchema> = cliKitStore()): void {
   outputDebug(outputContent`Removing session store...`)
   config.delete('sessionStore')
+}
+
+/**
+ * Fetch from cache, or run the provided function to get the value, and cache it
+ * before returning it.
+ * @param key - The key to use for the cache.
+ * @param fn - The function to run to get the value to cache.
+ * @param timeout - The number of milliseconds to cache the value for.
+ * @returns The value from the cache or the result of the function.
+ */
+export async function cacheFetch<T>(key: string, fn: () => Promise<T>, timeout?: number, config = cliKitStore()): Promise<T> {
+  config = config || cliKitStore()
+  const cache: Cache = config.get("cache") || {}
+  const cached = cache[key]
+
+  if (cached && (!timeout || Date.now() - cached.timestamp < timeout)) {
+    return cached.value as T
+  }
+
+  const value = await fn()
+  cache[key] = {value, timestamp: Date.now()}
+  cliKitStore().set("cache", cache)
+  return value
 }

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -6,8 +6,10 @@ interface CacheValue<T> {
   timestamp: number
 }
 
+export type IntrospectionUrlKey = `identity-introspection-url-${string}`
+
 interface Cache {
-  'identity-introspection-url'?: CacheValue<string>
+  [introspectionUrlKey: IntrospectionUrlKey]: CacheValue<string>
 }
 
 export interface ConfSchema {

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -3,7 +3,7 @@ import {outputContent, outputDebug} from '@shopify/cli-kit/node/output'
 
 interface Cache {
   [key: string]: {
-    value: any
+    value: unknown
     timestamp: number
   }
 }
@@ -63,9 +63,13 @@ export function removeSession(config: LocalStorage<ConfSchema> = cliKitStore()):
  * @param timeout - The number of milliseconds to cache the value for.
  * @returns The value from the cache or the result of the function.
  */
-export async function cacheFetch<T>(key: string, fn: () => Promise<T>, timeout?: number, config = cliKitStore()): Promise<T> {
-  config = config || cliKitStore()
-  const cache: Cache = config.get("cache") || {}
+export async function cacheFetch<T>(
+  key: string,
+  fn: () => Promise<T>,
+  timeout?: number,
+  config = cliKitStore(),
+): Promise<T> {
+  const cache: Cache = config.get('cache') || {}
   const cached = cache[key]
 
   if (cached && (!timeout || Date.now() - cached.timestamp < timeout)) {
@@ -74,6 +78,6 @@ export async function cacheFetch<T>(key: string, fn: () => Promise<T>, timeout?:
 
   const value = await fn()
   cache[key] = {value, timestamp: Date.now()}
-  cliKitStore().set("cache", cache)
+  cliKitStore().set('cache', cache)
   return value
 }

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -72,12 +72,12 @@ export async function cacheFetch<T>(
   const cache: Cache = config.get('cache') || {}
   const cached = cache[key]
 
-  if (cached && (!timeout || Date.now() - cached.timestamp < timeout)) {
+  if (cached && (timeout === undefined || Date.now() - cached.timestamp < timeout)) {
     return cached.value as T
   }
 
   const value = await fn()
   cache[key] = {value, timestamp: Date.now()}
-  cliKitStore().set('cache', cache)
+  config.set('cache', cache)
   return value
 }

--- a/packages/cli-kit/src/private/node/session/identity-token-validation.ts
+++ b/packages/cli-kit/src/private/node/session/identity-token-validation.ts
@@ -4,7 +4,7 @@ import {shopifyFetch} from '../../../public/node/http.js'
 
 export async function validateIdentityToken(token: string) {
   try {
-    const instrospectionURL = await getInstrospectionEndpoint()
+    const instrospectionURL = await getIntrospectionEndpoint()
     const options = {
       method: 'POST',
       headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
@@ -34,7 +34,7 @@ export async function validateIdentityToken(token: string) {
   }
 }
 
-async function getInstrospectionEndpoint(): Promise<string> {
+async function getIntrospectionEndpoint(): Promise<string> {
   const response = await shopifyFetch(`https://${await identityFqdn()}/.well-known/openid-configuration.json`)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const json: any = await response.json()

--- a/packages/cli-kit/src/private/node/session/identity-token-validation.ts
+++ b/packages/cli-kit/src/private/node/session/identity-token-validation.ts
@@ -15,7 +15,8 @@ export async function validateIdentityToken(token: string): Promise<boolean> {
     return withIntrospectionURL<boolean>(async (introspectionURL: string) => {
       const options = {
         method: 'POST',
-        headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'}, body: JSON.stringify({token}),
+        headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
+        body: JSON.stringify({token}),
       }
       outputDebug(`Sending Identity Introspection request to URL: ${introspectionURL}`)
 

--- a/packages/cli-kit/src/private/node/session/identity-token-validation.ts
+++ b/packages/cli-kit/src/private/node/session/identity-token-validation.ts
@@ -1,7 +1,7 @@
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {outputDebug} from '../../../public/node/output.js'
 import {shopifyFetch} from '../../../public/node/http.js'
-import {cacheFetch} from '../conf-store.js'
+import {cacheRetrieveOrRepopulate} from '../conf-store.js'
 import {err, ok, Result} from '../../../public/node/result.js'
 import {AbortError} from '../../../public/node/error.js'
 
@@ -42,10 +42,10 @@ export async function validateIdentityToken(token: string): Promise<boolean> {
 
 async function withIntrospectionURL<T>(fn: (introspectionUrl: string) => Promise<Result<T, AbortError>>): Promise<T> {
   const week = 7 * 24 * 60 * 60 * 1000
-  const introspectionURL = await cacheFetch('identity-introspection-url', getIntrospectionURL, week)
+  const introspectionURL = await cacheRetrieveOrRepopulate('identity-introspection-url', getIntrospectionURL, week)
   let result: Result<T, AbortError> = await fn(introspectionURL)
   if (result.isErr()) {
-    await cacheFetch('identity-introspection-url', getIntrospectionURL, 0)
+    await cacheRetrieveOrRepopulate('identity-introspection-url', getIntrospectionURL, 0)
     result = await fn(introspectionURL)
   }
   if (result.isErr()) {

--- a/packages/cli-kit/src/private/node/session/identity-token-validation.ts
+++ b/packages/cli-kit/src/private/node/session/identity-token-validation.ts
@@ -1,7 +1,7 @@
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {outputDebug} from '../../../public/node/output.js'
 import {shopifyFetch} from '../../../public/node/http.js'
-import {cacheRetrieveOrRepopulate} from '../conf-store.js'
+import {cacheRetrieveOrRepopulate, IntrospectionUrlKey} from '../conf-store.js'
 import {err, ok, Result} from '../../../public/node/result.js'
 import {AbortError} from '../../../public/node/error.js'
 
@@ -42,10 +42,11 @@ export async function validateIdentityToken(token: string): Promise<boolean> {
 
 async function withIntrospectionURL<T>(fn: (introspectionUrl: string) => Promise<Result<T, AbortError>>): Promise<T> {
   const week = 7 * 24 * 60 * 60 * 1000
-  const introspectionURL = await cacheRetrieveOrRepopulate('identity-introspection-url', getIntrospectionURL, week)
+  const cacheKey: IntrospectionUrlKey = `identity-introspection-url-${await identityFqdn()}`
+  let introspectionURL = await cacheRetrieveOrRepopulate(cacheKey, getIntrospectionURL, week)
   let result: Result<T, AbortError> = await fn(introspectionURL)
   if (result.isErr()) {
-    await cacheRetrieveOrRepopulate('identity-introspection-url', getIntrospectionURL, 0)
+    introspectionURL = await cacheRetrieveOrRepopulate(cacheKey, getIntrospectionURL, 0)
     result = await fn(introspectionURL)
   }
   if (result.isErr()) {

--- a/packages/cli-kit/src/private/node/session/identity-token-validation.ts
+++ b/packages/cli-kit/src/private/node/session/identity-token-validation.ts
@@ -1,32 +1,42 @@
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {outputDebug} from '../../../public/node/output.js'
 import {shopifyFetch} from '../../../public/node/http.js'
+import {cacheFetch} from '../conf-store.js'
 
-export async function validateIdentityToken(token: string) {
+class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}
+
+export async function validateIdentityToken(token: string): Promise<boolean> {
   try {
-    const instrospectionURL = await getIntrospectionEndpoint()
-    const options = {
-      method: 'POST',
-      headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
-      body: JSON.stringify({token}),
-    }
-    outputDebug(`Sending Identity Introspection request to URL: ${instrospectionURL}`)
+    return withIntrospectionURL<boolean>(async (introspectionURL: string) => {
+      const options = {
+        method: 'POST',
+        headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'}, body: JSON.stringify({token}),
+      }
+      outputDebug(`Sending Identity Introspection request to URL: ${introspectionURL}`)
 
-    const response = await shopifyFetch(instrospectionURL, options)
+      const response = await shopifyFetch(introspectionURL, options)
 
-    if (response.ok && response.headers.get('content-type')?.includes('json')) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const json: any = await response.json()
-      outputDebug(`The identity token is valid: ${json.valid}`)
-      return json.valid
-    } else {
-      const text = await response.text()
-      outputDebug(`The Introspection request failed with:
+      if (response.ok && response.headers.get('content-type')?.includes('json')) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const json: any = await response.json()
+        outputDebug(`The identity token is valid: ${json.valid}`)
+        return json.valid
+      } else if (response.status === 404) {
+        throw new NotFoundError('Identity Introspection endpoint not found')
+      } else {
+        const text = await response.text()
+        outputDebug(`The Introspection request failed with:
  - status: ${response.status}
  - www-authenticate header: ${JSON.stringify(response.headers.get('www-authenticate'))}
  - body: ${JSON.stringify(text)}`)
-      return false
-    }
+        return false
+      }
+    })
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
     outputDebug(`The identity token is invalid: ${error}`)
@@ -34,7 +44,23 @@ export async function validateIdentityToken(token: string) {
   }
 }
 
-async function getIntrospectionEndpoint(): Promise<string> {
+async function withIntrospectionURL<T>(fn: (introspectionUrl: string) => Promise<T>): Promise<T> {
+  const week = 7 * 24 * 60 * 60 * 1000
+  const introspectionURL = await cacheFetch('identity-introspection-url', getIntrospectionURL, week)
+  try {
+    return fn(introspectionURL)
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      // If the introspection URL is invalid, clear the cache and try again
+      await cacheFetch('identity-introspection-url', getIntrospectionURL, 0)
+      return fn(introspectionURL)
+    } else {
+      throw error
+    }
+  }
+}
+
+async function getIntrospectionURL(): Promise<string> {
   const response = await shopifyFetch(`https://${await identityFqdn()}/.well-known/openid-configuration.json`)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const json: any = await response.json()

--- a/packages/cli-kit/src/private/node/session/identity-token-validation.ts
+++ b/packages/cli-kit/src/private/node/session/identity-token-validation.ts
@@ -22,8 +22,10 @@ export async function validateIdentityToken(token: string): Promise<boolean> {
         const json: any = await response.json()
         outputDebug(`The identity token is valid: ${json.valid}`)
         return ok(json.valid)
-      } else if (response.status === 404) {
-        return err(new AbortError(`The introspection endpoint returned a 404: ${introspectionURL}`))
+      } else if (response.status === 404 || response.status > 500) {
+        // If the status is 404 or 5xx, most likely the introspection endpoint
+        // has changed. We should invalidate the cache and try again.
+        return err(new AbortError(`The introspection endpoint returned a ${response.status}: ${introspectionURL}`))
       } else {
         const text = await response.text()
         outputDebug(`The Introspection request failed with:

--- a/packages/cli-kit/src/private/node/session/identity-token-validation.ts
+++ b/packages/cli-kit/src/private/node/session/identity-token-validation.ts
@@ -2,13 +2,8 @@ import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {outputDebug} from '../../../public/node/output.js'
 import {shopifyFetch} from '../../../public/node/http.js'
 import {cacheFetch} from '../conf-store.js'
-
-class NotFoundError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'NotFoundError'
-  }
-}
+import {err, ok, Result} from '../../../public/node/result.js'
+import {AbortError} from '../../../public/node/error.js'
 
 export async function validateIdentityToken(token: string): Promise<boolean> {
   try {
@@ -26,16 +21,16 @@ export async function validateIdentityToken(token: string): Promise<boolean> {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const json: any = await response.json()
         outputDebug(`The identity token is valid: ${json.valid}`)
-        return json.valid
+        return ok(json.valid)
       } else if (response.status === 404) {
-        throw new NotFoundError('Identity Introspection endpoint not found')
+        return err(new AbortError(`The introspection endpoint returned a 404: ${introspectionURL}`))
       } else {
         const text = await response.text()
         outputDebug(`The Introspection request failed with:
  - status: ${response.status}
  - www-authenticate header: ${JSON.stringify(response.headers.get('www-authenticate'))}
  - body: ${JSON.stringify(text)}`)
-        return false
+        return ok(false)
       }
     })
     // eslint-disable-next-line no-catch-all/no-catch-all
@@ -45,19 +40,18 @@ export async function validateIdentityToken(token: string): Promise<boolean> {
   }
 }
 
-async function withIntrospectionURL<T>(fn: (introspectionUrl: string) => Promise<T>): Promise<T> {
+async function withIntrospectionURL<T>(fn: (introspectionUrl: string) => Promise<Result<T, AbortError>>): Promise<T> {
   const week = 7 * 24 * 60 * 60 * 1000
   const introspectionURL = await cacheFetch('identity-introspection-url', getIntrospectionURL, week)
-  try {
-    return fn(introspectionURL)
-  } catch (error) {
-    if (error instanceof NotFoundError) {
-      // If the introspection URL is invalid, clear the cache and try again
-      await cacheFetch('identity-introspection-url', getIntrospectionURL, 0)
-      return fn(introspectionURL)
-    } else {
-      throw error
-    }
+  let result: Result<T, AbortError> = await fn(introspectionURL)
+  if (result.isErr()) {
+    await cacheFetch('identity-introspection-url', getIntrospectionURL, 0)
+    result = await fn(introspectionURL)
+  }
+  if (result.isErr()) {
+    throw result.error
+  } else {
+    return result.value
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Replaces https://github.com/Shopify/cli/pull/712
Fixes https://github.com/Shopify/internal-cli-foundations/issues/489 with the blessing of the identity team

The identity introspection endpoint is supposed to be fetched dynamically, BUT that makes less sense for the CLI which launches a new process frequently while a user sits there, vs. servers spinning up which can take a half-second hit.

This small change will make most command runs up to 0.5s faster on average (since most frequently-used commands require authentication).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Caches the identity introspection endpoint for a period of 1 week. If the existing endpoint 404s, we can retry with fetching the correct endpoint first, as we do now.

It's technically slower in the rare case of the endpoint changing, but honestly I don't think it's changed in the last year, and it's unlikely to change more than once every few months.

**BEFORE: 556ms total**

```
2023-02-12T14:29:28.254Z: Validating existing session against the scopes:
[
  "openid",
  "https://api.shopify.com/auth/shop.admin.graphql",
  "https://api.shopify.com/auth/shop.admin.themes",
  "https://api.shopify.com/auth/partners.collaborator-relationships.readonly",
  "https://api.shopify.com/auth/shop.storefront-renderer.devtools",
  "https://api.shopify.com/auth/partners.app.cli.access"
]
For applications:
{
  "partnersApi": {
    "scopes": []
  }
}

2023-02-12T14:29:28.254Z: 
Sending GET request to URL https://accounts.shopify.com/.well-known/openid-configuration.json and headers:
 - User-Agent: Shopify CLI; v=3.43.0
 - Sec-CH-UA-PLATFORM: darwin
 - X-Request-Id: e98a988f-4150-483e-8142-a360b80fe49f
 - Content-Type: application/json

2023-02-12T14:29:28.801Z: Request to https://accounts.shopify.com/.well-known/openid-configuration.json completed with status 200 in 547 ms
2023-02-12T14:29:28.810Z: Sending Identity Introspection request to URL: https://accounts.shopify.com/oauth/introspection
```

**AFTER: 1ms total**

```
2023-02-12T14:27:57.772Z: Validating existing session against the scopes:
[
  "openid",
  "https://api.shopify.com/auth/shop.admin.graphql",
  "https://api.shopify.com/auth/shop.admin.themes",
  "https://api.shopify.com/auth/partners.collaborator-relationships.readonly",
  "https://api.shopify.com/auth/shop.storefront-renderer.devtools",
  "https://api.shopify.com/auth/partners.app.cli.access"
]
For applications:
{
  "partnersApi": {
    "scopes": []
  }
}

2023-02-12T14:27:57.773Z: Sending Identity Introspection request to URL: https://accounts.shopify.com/oauth/introspection
```

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run any authenticated command in `--verbose` mode. (NOTE: Run it twice to see the caching actually working!)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
