### PR TITLE
add tests for tooltip

### DIFF
--- a/packages/ui-extensions-dev-console/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/packages/ui-extensions-dev-console/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -1,0 +1,50 @@
+import {Tooltip} from '../Tooltip'
+import React from 'react'
+import {mount} from '@shopify/react-testing'
+import {vi} from 'vitest'
+
+const handleClick = vi.fn()
+
+const TextChildComponent = () => <Tooltip text="test">test</Tooltip>
+const ComponentChildComponent = () => (
+  <Tooltip text="test">
+    <button onClick={handleClick} id="btn">
+      Button
+    </button>
+  </Tooltip>
+)
+
+describe('<Tooltip />', () => {
+  test.each([
+    ['onMouseEnter', 'onMouseLeave'],
+    ['onFocus', 'onBlur'],
+  ])('appears if hovered/focused/etc, hidden otherwise', (showEvent: any, hideEvent: any) => {
+    const wrapper = mount(<TextChildComponent />)
+
+    wrapper.act(() => {
+      wrapper.find('div')?.trigger(showEvent)
+    })
+
+    let tooltip = wrapper.find('div', {role: 'tooltip'})
+
+    expect(tooltip).not.toBeNull()
+
+    wrapper.act(() => {
+      wrapper.find('div')?.trigger(hideEvent)
+    })
+
+    tooltip = wrapper.find('div', {role: 'tooltip'})
+
+    expect(tooltip).toBeNull()
+  })
+
+  test('hitting enter triggers content onClick', () => {
+    const wrapper = mount(<ComponentChildComponent />)
+
+    wrapper.act(() => {
+      wrapper.find('div')?.trigger('onKeyUp', {key: 'Enter'})
+    })
+
+    expect(handleClick).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Tooltips presently have no tests so I added some, albeit basic tests that cover:

- component visibility when hovered/focused and when not
- verify ENTER key forwarding to interactable component child