### PR TITLE
Parallelize partners requests

### DIFF
--- a/.changeset/curvy-fishes-buy.md
+++ b/.changeset/curvy-fishes-buy.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': patch
+'@shopify/cli-kit': patch
+---
+
+Speed up app dev by running web requests in parallel

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -245,11 +245,6 @@ describe('ensureDevEnvironment', () => {
       directory: INPUT.directory,
       orgId: ORG1.id,
     })
-    expect(setAppInfo).toHaveBeenNthCalledWith(2, {
-      appId: APP1.apiKey,
-      directory: INPUT.directory,
-      storeFqdn: STORE1.shopDomain,
-    })
 
     expect(metadata.getAllPublicMetadata()).toMatchObject({
       api_key: APP1.apiKey,
@@ -283,11 +278,6 @@ describe('ensureDevEnvironment', () => {
       storeFqdn: STORE1.shopDomain,
       directory: INPUT.directory,
       orgId: ORG1.id,
-    })
-    expect(setAppInfo).toHaveBeenNthCalledWith(2, {
-      appId: APP1.apiKey,
-      directory: INPUT.directory,
-      storeFqdn: STORE1.shopDomain,
     })
     expect(outputMock.output()).toMatch(/Using your previous dev settings:/)
     expect(fetchOrgAndApps).not.toBeCalled()

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -241,6 +241,7 @@ describe('ensureDevEnvironment', () => {
     expect(setAppInfo).toHaveBeenNthCalledWith(1, {
       appId: APP1.apiKey,
       title: APP1.title,
+      storeFqdn: STORE1.shopDomain,
       directory: INPUT.directory,
       orgId: ORG1.id,
     })
@@ -279,6 +280,7 @@ describe('ensureDevEnvironment', () => {
     expect(setAppInfo).toHaveBeenNthCalledWith(1, {
       appId: APP1.apiKey,
       title: APP1.title,
+      storeFqdn: STORE1.shopDomain,
       directory: INPUT.directory,
       orgId: ORG1.id,
     })

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -152,7 +152,7 @@ export async function ensureDevContext(options: DevContextOptions, token: string
   const [organization, _selectedApp, _selectedStore] = await Promise.all([
     organizationFromId(orgId, token),
     selectedApp ? selectedApp : appFromId(cachedInfo?.appId, token),
-    selectedStore ? selectedStore : storeFromFqdn(cachedInfo?.storeFqdn, orgId, token)
+    selectedStore ? selectedStore : storeFromFqdn(cachedInfo?.storeFqdn, orgId, token),
   ])
 
   if (_selectedApp) {
@@ -160,14 +160,14 @@ export async function ensureDevContext(options: DevContextOptions, token: string
   } else {
     const {apps} = await fetchOrgAndApps(orgId, token)
     const localAppName = await loadAppName(options.directory)
-    selectedApp = await selectOrCreateApp(localAppName, apps, organization!, token)
+    selectedApp = await selectOrCreateApp(localAppName, apps, organization, token)
   }
 
   if (_selectedStore) {
     selectedStore = _selectedStore
   } else {
     const allStores = await fetchAllDevStores(orgId, token)
-    selectedStore = await selectStore(allStores, organization!, token)
+    selectedStore = await selectStore(allStores, organization, token)
   }
 
   setAppInfo({
@@ -201,7 +201,11 @@ const appFromId = async (appId: string | undefined, token: string): Promise<Orga
   return app
 }
 
-const storeFromFqdn = async (storeFqdn: string | undefined, orgId: string, token: string): Promise<OrganizationStore | undefined> => {
+const storeFromFqdn = async (
+  storeFqdn: string | undefined,
+  orgId: string,
+  token: string,
+): Promise<OrganizationStore | undefined> => {
   if (!storeFqdn) return
   const result = await fetchStoreByDomain(orgId, token, storeFqdn)
   if (result?.store) {

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -133,7 +133,7 @@ async function dev(options: DevOptions) {
   }
 
   // If we have a real UUID for an extension, use that instead of a random one
-  const prodEnvIdentifiers = await getAppIdentifiers({app: localApp})
+  const prodEnvIdentifiers = getAppIdentifiers({app: localApp})
   const envExtensionsIds = prodEnvIdentifiers.extensions || {}
   const extensionsIds = prodEnvIdentifiers.app === apiKey ? envExtensionsIds : {}
   localApp.extensions.ui.forEach((ext) => (ext.devUUID = extensionsIds[ext.localIdentifier] ?? ext.devUUID))

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -93,11 +93,7 @@ async function dev(options: DevOptions) {
   const initiateUpdateUrls = (frontendConfig || backendConfig) && options.update
   let shouldUpdateURLs = false
 
-  const [
-    {frontendUrl, frontendPort, usingLocalhost},
-    backendPort,
-    currentURLs
-  ] = await Promise.all([
+  const [{frontendUrl, frontendPort, usingLocalhost}, backendPort, currentURLs] = await Promise.all([
     generateFrontendURL({
       ...options,
       app: localApp,
@@ -179,7 +175,7 @@ async function dev(options: DevOptions) {
     }
     const [storefrontToken, args] = await Promise.all([
       ensureAuthenticatedStorefront(),
-      themeExtensionArgs(extension, apiKey, token, {...options, ...optionsToOverwrite})
+      themeExtensionArgs(extension, apiKey, token, {...options, ...optionsToOverwrite}),
     ])
     const devExt = devThemeExtensionTarget(args, adminSession, storefrontToken, token)
     additionalProcesses.push(devExt)

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -160,7 +160,6 @@ async function dev(options: DevOptions) {
 
   if (localApp.extensions.theme.length > 0) {
     const adminSession = await ensureAuthenticatedAdmin(storeFqdn)
-    const storefrontToken = await ensureAuthenticatedStorefront()
     const extension = localApp.extensions.theme[0]!
     let optionsToOverwrite = {}
     if (!options.theme) {
@@ -170,8 +169,11 @@ async function dev(options: DevOptions) {
         generateTmpTheme: theme.createdAtRuntime,
       }
     }
-    const args = await themeExtensionArgs(extension, apiKey, token, {...options, ...optionsToOverwrite})
-    const devExt = await devThemeExtensionTarget(args, adminSession, storefrontToken, token)
+    const [storefrontToken, args] = await Promise.all([
+      ensureAuthenticatedStorefront(),
+      themeExtensionArgs(extension, apiKey, token, {...options, ...optionsToOverwrite})
+    ])
+    const devExt = devThemeExtensionTarget(args, adminSession, storefrontToken, token)
     additionalProcesses.push(devExt)
   }
 

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -200,9 +200,9 @@ async function dev(options: DevOptions) {
     }
 
     if (usingLocalhost) {
-      additionalProcesses.push(await devFrontendNonProxyTarget(frontendOptions, frontendPort))
+      additionalProcesses.push(devFrontendNonProxyTarget(frontendOptions, frontendPort))
     } else {
-      proxyTargets.push(await devFrontendProxyTarget(frontendOptions))
+      proxyTargets.push(devFrontendProxyTarget(frontendOptions))
     }
   }
 
@@ -242,8 +242,8 @@ interface DevFrontendTargetOptions extends DevWebOptions {
   backendPort: number
 }
 
-async function devFrontendNonProxyTarget(options: DevFrontendTargetOptions, port: number): Promise<OutputProcess> {
-  const devFrontend = await devFrontendProxyTarget(options)
+function devFrontendNonProxyTarget(options: DevFrontendTargetOptions, port: number): OutputProcess {
+  const devFrontend = devFrontendProxyTarget(options)
   return {
     prefix: devFrontend.logPrefix,
     action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
@@ -266,7 +266,7 @@ function devThemeExtensionTarget(
   }
 }
 
-async function devFrontendProxyTarget(options: DevFrontendTargetOptions): Promise<ReverseHTTPProxyTarget> {
+function devFrontendProxyTarget(options: DevFrontendTargetOptions): ReverseHTTPProxyTarget {
   const {commands} = options.web.configuration
   const [cmd, ...args] = commands.dev.split(' ')
 

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -40,7 +40,7 @@ export async function selectStore(
 ): Promise<OrganizationStore> {
   const store = await selectStorePrompt(stores)
   if (store) {
-    await convertToTestStoreIfNeeded(store, org, token)
+    await convertToTestStoreIfNeeded(store, org.id, token)
     return store
   }
 
@@ -101,7 +101,7 @@ async function waitForCreatedStore(orgId: string, token: string): Promise<Organi
  */
 export async function convertToTestStoreIfNeeded(
   store: OrganizationStore,
-  org: Organization,
+  orgId: string,
   token: string,
 ): Promise<void> {
   /**
@@ -114,7 +114,7 @@ export async function convertToTestStoreIfNeeded(
       'Run dev --reset and select an eligible dev store.',
     )
   }
-  if (!store.transferDisabled) await convertStoreToTest(store, org.id, token)
+  if (!store.transferDisabled) await convertStoreToTest(store, orgId, token)
 }
 
 /**

--- a/packages/cli-kit/src/private/node/api/graphql.ts
+++ b/packages/cli-kit/src/private/node/api/graphql.ts
@@ -20,7 +20,7 @@ export function graphqlRequest<T>(
   const action = async () => {
     const headers = buildHeaders(token)
     debugLogRequest(api, query, variables, headers)
-    const clientOptions = {agent: await httpsAgent(), headers}
+    const clientOptions = {agent: await httpsAgent(api), headers}
     const client = new GraphQLClient(url, clientOptions)
     const t0 = performance.now()
     const response = await client.request<T>(query, variables)

--- a/packages/cli-kit/src/private/node/api/graphql.ts
+++ b/packages/cli-kit/src/private/node/api/graphql.ts
@@ -20,7 +20,7 @@ export function graphqlRequest<T>(
   const action = async () => {
     const headers = buildHeaders(token)
     debugLogRequest(api, query, variables, headers)
-    const clientOptions = {agent: await httpsAgent(api), headers}
+    const clientOptions = {agent: await httpsAgent(), headers}
     const client = new GraphQLClient(url, clientOptions)
     const t0 = performance.now()
     const response = await client.request<T>(query, variables)

--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -66,6 +66,7 @@ describe('common API methods', () => {
     const version = CLI_KIT_VERSION
     expect(headers).toEqual({
       'Content-Type': 'application/json',
+      'Keep-Alive': 'timeout=30',
       'X-Shopify-Access-Token': token,
       'X-Request-Id': 'random-uuid',
       'User-Agent': `Shopify CLI; v=${version}`,

--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -24,6 +24,7 @@ describe('common API methods', () => {
     const version = CLI_KIT_VERSION
     expect(headers).toEqual({
       'Content-Type': 'application/json',
+      'Keep-Alive': 'timeout=30',
       'X-Shopify-Access-Token': 'Bearer my-token',
       'X-Request-Id': 'random-uuid',
       'User-Agent': `Shopify CLI; v=${version}`,
@@ -44,6 +45,7 @@ describe('common API methods', () => {
     const version = CLI_KIT_VERSION
     expect(headers).toEqual({
       'Content-Type': 'application/json',
+      'Keep-Alive': 'timeout=30',
       'X-Shopify-Access-Token': 'Bearer my-token',
       'X-Request-Id': 'random-uuid',
       'User-Agent': `Shopify CLI; v=${version}`,
@@ -76,6 +78,7 @@ describe('common API methods', () => {
     // Given
     const headers = {
       'User-Agent': 'useragent',
+      'Keep-Alive': 'timeout=30',
       'X-Request-Id': 'uuid',
       Authorization: 'token',
       authorization: 'token',
@@ -89,6 +92,7 @@ describe('common API methods', () => {
     // Then
     expect(got).toMatchInlineSnapshot(`
       " - User-Agent: useragent
+       - Keep-Alive: timeout=30
        - X-Request-Id: uuid
        - Content-Type: application/json"
     `)

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -62,7 +62,7 @@ export function buildHeaders(token?: string): {[key: string]: string} {
  * if the service is running in a Spin environment, the attribute "rejectUnauthorized" is
  * set to false
  */
-async function _httpsAgent(_id: string = 'default'): Promise<https.Agent> {
+async function _httpsAgent(_id = 'default'): Promise<https.Agent> {
   return new https.Agent({
     rejectUnauthorized: await shouldRejectUnauthorizedRequests(),
     keepAlive: true,

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -3,7 +3,6 @@ import {firstPartyDev} from '../../../public/node/context/local.js'
 import {randomUUID} from '../../../public/node/crypto.js'
 import {Environment, serviceEnvironment} from '../context/service.js'
 import {ExtendableError} from '../../../public/node/error.js'
-import {memoize} from '../../../public/common/function.js'
 import https from 'https'
 
 export class RequestClientError extends ExtendableError {
@@ -62,13 +61,12 @@ export function buildHeaders(token?: string): {[key: string]: string} {
  * if the service is running in a Spin environment, the attribute "rejectUnauthorized" is
  * set to false
  */
-async function _httpsAgent(_id = 'default'): Promise<https.Agent> {
+export async function httpsAgent(): Promise<https.Agent> {
   return new https.Agent({
     rejectUnauthorized: await shouldRejectUnauthorizedRequests(),
     keepAlive: true,
   })
 }
-export const httpsAgent = memoize(_httpsAgent)
 
 /**
  * Spin stores the CA certificate in the keychain and it should be used when sending HTTP

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -173,7 +173,6 @@ describe('when existing session is valid', () => {
     expect(exchangeCodeForAccessToken).not.toBeCalled()
     expect(exchangeAccessForApplicationTokens).not.toBeCalled()
     expect(refreshAccessToken).not.toBeCalled()
-    expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(validTokens)
   })
 
@@ -192,7 +191,6 @@ describe('when existing session is valid', () => {
     expect(exchangeCodeForAccessToken).not.toBeCalled()
     expect(exchangeAccessForApplicationTokens).not.toBeCalled()
     expect(refreshAccessToken).not.toBeCalled()
-    expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(expected)
   })
 

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -134,7 +134,8 @@ ${outputToken.json(applications)}
   }
 
   const completeSession: Session = {...currentSession, ...newSession}
-  await secureStore.store(completeSession)
+  // Save the new session info if it has changed
+  if (Object.keys(newSession).length > 0) await secureStore.store(completeSession)
   const tokens = await tokensFor(applications, completeSession, fqdn)
 
   // Overwrite partners token if using a custom CLI Token

--- a/packages/cli-kit/src/public/node/api/admin.ts
+++ b/packages/cli-kit/src/public/node/api/admin.ts
@@ -1,10 +1,11 @@
 import {AdminSession} from '../session.js'
-import {outputContent, outputToken} from '../../../public/node/output.js'
+import {outputContent, outputDebug, outputToken} from '../../../public/node/output.js'
 import {BugError, AbortError} from '../error.js'
 import {graphqlRequest, GraphQLVariables} from '../../../private/node/api/graphql.js'
 import {restRequestBody, restRequestHeaders, restRequestUrl} from '../../../private/node/api/rest.js'
 import {fetch} from '../http.js'
 import {ClientError, gql} from 'graphql-request'
+import {performance} from 'perf_hooks'
 
 /**
  * Executes a GraphQL query against the Admin API.
@@ -108,6 +109,7 @@ export async function restRequest<T>(
   const body = restRequestBody<T>(requestBody)
 
   const headers = restRequestHeaders(session)
+  const t0 = performance.now()
   const response = await fetch(url, {
     headers,
     method,
@@ -115,6 +117,8 @@ export async function restRequest<T>(
   })
 
   const json = await response.json().catch(() => ({}))
+  const t1 = performance.now()
+  outputDebug(`Request to ${url.toString()} completed in ${Math.round(t1 - t0)} ms`)
 
   return {
     json,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Partners requests are the heaviest part of initiating the `app dev` command. By running some of them in parallel (plus a few other small optimizations), we can shave about 1.3 seconds off command startup in most cases. This makes for a much snappier CLI experience.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
1. Take Partners API GraphQL queries that can be run in parallel (i.e. they don't depend on each other) and make them parallel.
2. Use keepAlive to ensure we don't waste time re-establishing the connection to the Partners API each time
3. Eliminate waste. Don't save the session to secure storage (which takes about 20-30ms) if the session hasn't changed.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Make sure `app dev` still works in `--reset`, cached, and non-cached cases.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
