### PR TITLE
Run cwd test only if env var is defined

### DIFF
--- a/packages/cli-kit/src/public/node/path.test.ts
+++ b/packages/cli-kit/src/public/node/path.test.ts
@@ -1,4 +1,4 @@
-import {relativizePath, cwd} from './path.js'
+import {relativizePath, normalizePath, cwd} from './path.js'
 import {describe, test, expect} from 'vitest'
 
 describe('relativize', () => {
@@ -16,12 +16,11 @@ describe('relativize', () => {
 })
 
 describe('cwd', () => {
-  test('returns the initial cwd where the command has been called', () => {
+  test.runIf(process.env.INIT_CWD)('returns the initial cwd where the command has been called', () => {
     // Given
     const path = cwd()
 
     // Then
-    // eslint-disable-next-line rulesdir/no-process-cwd
-    expect(path).toStrictEqual(process.cwd())
+    expect(path).toStrictEqual(normalizePath(process.env.INIT_CWD!))
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Cwd tests would fail if ran through a node script, such as `pnpm test`

### WHAT is this pull request doing?

Only run path.cwd test if executed from a node script

### How to test your changes?

- `pnpm test`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
