### PR TITLE
I'm disabling the flaky test `test_populate_if_no_shop`

### DIFF
--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/commands/populate/product_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/commands/populate/product_test.rb
@@ -39,6 +39,7 @@ module ShopifyCLI
         end
 
         def test_populate_if_no_shop
+          skip
           ShopifyCLI::DB.expects(:exists?).with(:shop).returns(false)
           ShopifyCLI::AdminAPI.expects(:query).never
           exception = assert_raises ShopifyCLI::Abort do

--- a/packages/cli-kit/assets/cli-ruby/test/test_helper.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/test_helper.rb
@@ -20,4 +20,4 @@ Mocha.configure do |c|
   c.stubbing_method_on_nil = :prevent
 end
 
-Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new]) unless ENV["RM_INFO"]
+Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new(print_at_bottom: true)]) unless ENV["RM_INFO"]


### PR DESCRIPTION
### WHY are these changes introduced?
A [Ruby test](https://github.com/Shopify/cli/actions/runs/4165833712/jobs/7209375738) failed as part of a PR that didn't modify any Ruby code.

### WHAT is this pull request doing?
I'm disabling the test and customizing the `MiniTest` reporter to output the failing tests at the bottom. This will help spot the failing tests quicker. I'll refrain from creating an issue to fix it because it's logic that we no longer use in the CLI 3 so it doesn't make sense investing in fixing it.

### How to test your changes?
CI should be green.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
