### PR TITLE
Do not inject hot-reload code into web-pixels-manager sandbox

### DIFF
--- a/.changeset/thick-trainers-rhyme.md
+++ b/.changeset/thick-trainers-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Do not inject hot-reload code into web-pixels-manager sandbox

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -327,4 +327,5 @@ module.exports = {
       },
     },
   ],
+  ignorePatterns: ['assets/cli-ruby/lib/shopify_cli/theme/dev_server/hot_reload/resources/*.js'],
 }

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/hot_reload/script_injector.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/hot_reload/script_injector.rb
@@ -25,7 +25,7 @@ module ShopifyCLI
               "</script>",
             ].join("\n")
 
-            body = body.join.gsub("</body>", "#{hot_reload_script}\n</body>")
+            body = body.join.sub("</body>", "#{hot_reload_script}\n</body>")
 
             [body]
           end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1119

When HMR code (`SSRClient` etc.) is injected into the HTML returned by `/`, no CORS error happens, and HMR is running. However, URL `http://127.0.0.1:9292/web-pixels-manager@0.0.219/sandbox/` is being requested too. This URL returns HTML, in which HMR code is injected and tried to be loaded a second time, “thankfully” leading to the CORS error, because the `Origin` is `null`.

### WHAT is this pull request doing?

Injects HMR code for all requests which return HTML **and** whose URL is not matching `web-pixels-manager…sandbox`.

### How to test your changes?

1. Serve your favorite theme with `shopify theme dev`
2. Open your browser’s Network tab and make sure that `/hot-reload` is only called **once**.
3. Open your browser’s console and make sure that no CORS errors appear anymore.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
