### PR TITLE
Enable navigating directly to the embedded app when the Dev Console is embedded inside Admin

### DIFF
--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/AppHomeRow/AppHomeRow.test.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/AppHomeRow/AppHomeRow.test.tsx
@@ -1,6 +1,6 @@
 import {AppHomeRow} from '.'
 import en from './translations/en.json'
-import {QRCodeModal} from '..'
+import {PreviewLink, QRCodeModal} from '..'
 import React from 'react'
 
 import {DefaultProviders} from 'tests/DefaultProviders'
@@ -52,5 +52,41 @@ describe('<AppHomeRow/>', () => {
     })
 
     expect(container).toContainReactComponent(QRCodeModal, {code: undefined})
+  })
+
+  test("renders a <PreviewLink/> with the resource url set to the app's handle if the surface has been set to 'admin'", () => {
+    const appState = {
+      app: {url: 'mock.url', title: 'Mock App Title', handle: 'my-app-handle'},
+    }
+    const container = render(<AppHomeRow />, withProviders(DefaultProviders), {
+      state: appState,
+      client: {options: {surface: 'admin'}},
+    })
+
+    expect(container).toContainReactComponent(PreviewLink, {resourceUrl: '/apps/my-app-handle'})
+  })
+
+  test("renders a <PreviewLink/> with the resource url set to the app's handle if the surface has been set to 'admin'", () => {
+    const appState = {
+      app: {url: 'mock.url', title: 'Mock App Title', handle: 'my-app-handle'},
+    }
+    const container = render(<AppHomeRow />, withProviders(DefaultProviders), {
+      state: appState,
+      client: {options: {surface: 'admin'}},
+    })
+
+    expect(container).toContainReactComponent(PreviewLink, {resourceUrl: '/admin/apps/my-app-handle'})
+  })
+
+  test("renders a <PreviewLink/> without a resource url if the surface has not been set to 'admin'", () => {
+    const appState = {
+      app: {url: 'mock.url', title: 'Mock App Title', handle: 'my-app-handle'},
+    }
+    const container = render(<AppHomeRow />, withProviders(DefaultProviders), {
+      state: appState,
+      client: {options: {surface: 'checkout'}},
+    })
+
+    expect(container).toContainReactComponent(PreviewLink, {resourceUrl: undefined})
   })
 })

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/AppHomeRow/AppHomeRow.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/AppHomeRow/AppHomeRow.tsx
@@ -3,8 +3,9 @@ import en from './translations/en.json'
 
 import {NotApplicable, PreviewLink, QRCodeModal, Row} from '..'
 import {useApp} from '../../hooks/useApp'
-import React, {useState} from 'react'
+import {useExtensionServerOptions} from '../../hooks/useExtensionServerOptions.js'
 import {useI18n} from '@shopify/react-i18n'
+import React, {useState} from 'react'
 import {Button} from '@/components'
 
 export function AppHomeRow() {
@@ -14,11 +15,14 @@ export function AppHomeRow() {
     fallback: en,
   })
 
+  const {surface} = useExtensionServerOptions()
   const {app} = useApp()
 
   if (!app) {
     return null
   }
+
+  const resourceUrl = surface === 'admin' && app.handle ? `/admin/apps/${app.handle}` : undefined
 
   return (
     <Row>
@@ -26,7 +30,7 @@ export function AppHomeRow() {
         <span className={styles.Title}>{app.title}</span>
       </td>
       <td>
-        <PreviewLink rootUrl={app.url} title={'App home'} />
+        <PreviewLink resourceUrl={resourceUrl} rootUrl={app.url} title={'App home'} />
       </td>
       <td>
         <Button type="button" onClick={() => setShowModal(true)}>


### PR DESCRIPTION
### WHY are these changes introduced?

Fix the navigation to App Home when the Dev Console is embedded inside Shopify Admin

https://user-images.githubusercontent.com/29458473/218873025-3c2caa87-7bee-41ab-9345-8b836b680ea3.mov

### WHAT is this pull request doing?

Populate the `resourceUrl` which will be used when sending the `navigate` event through the Dev Console when it's embedded as an iframe. The resource url is only populated when the Dev Console is embedded and the surface has been set to  "admin". I'm using the app's handle because only embedded apps have handles and can be opened inside of Admin.

### How to test your changes?

The unit tests should be sufficient.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
