### PR TITLE
Prettify oclif manifests

### DIFF
--- a/bin/prettify-manifests.js
+++ b/bin/prettify-manifests.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import glob from 'fast-glob';
+
+const manifestFiles = glob.sync(`packages/*/oclif.manifest.json`)
+for (const file of manifestFiles) {
+  console.log(`Prettifying ${file}...`)
+  const content = fs.readFileSync(file)
+  const prettyContent = JSON.stringify(JSON.parse(content),null,2)
+  fs.writeFileSync(file, prettyContent)
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "nx run-many --target=build --all --skip-nx-cache",
     "build:affected": "nx affected --target=build --all",
     "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache",
-    "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache",
+    "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache && bin/prettify-manifests.js",
     "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests && bin/update-cli-kit-version.js"
   },
   "devDependencies": {

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -1,1 +1,845 @@
-{"version":"3.43.0","commands":{"app:build":{"id":"app:build","description":"Build the app.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your app directory.","hidden":false,"multiple":false},"skip-dependencies-installation":{"name":"skip-dependencies-installation","type":"boolean","description":"Skips the installation of dependencies.","hidden":false,"allowNo":false},"api-key":{"name":"api-key","type":"option","description":"Application's API key that will be exposed at build time.","hidden":false,"multiple":false}},"args":[]},"app:deploy":{"id":"app:deploy","description":"Deploy your Shopify app.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your app directory.","hidden":false,"multiple":false},"api-key":{"name":"api-key","type":"option","description":"The API key of your app.","hidden":false,"multiple":false},"reset":{"name":"reset","type":"boolean","description":"Reset all your settings.","hidden":false,"allowNo":false},"force":{"name":"force","type":"boolean","char":"f","description":"Deploy without asking for confirmation.","hidden":false,"allowNo":false}},"args":[]},"app:dev":{"id":"app:dev","description":"Run the app.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your app directory.","hidden":false,"multiple":false},"api-key":{"name":"api-key","type":"option","description":"The API key of your app.","hidden":false,"multiple":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. Must be an existing development or Shopify Plus sandbox store.","hidden":false,"multiple":false},"reset":{"name":"reset","type":"boolean","description":"Reset all your settings.","hidden":false,"allowNo":false},"skip-dependencies-installation":{"name":"skip-dependencies-installation","type":"boolean","description":"Skips the installation of dependencies.","hidden":false,"allowNo":false},"no-update":{"name":"no-update","type":"boolean","description":"Skips the Partners Dashboard URL update step.","hidden":false,"allowNo":false},"subscription-product-url":{"name":"subscription-product-url","type":"option","description":"Resource URL for subscription UI extension. Format: \"/products/{productId}\"","hidden":false,"multiple":false},"checkout-cart-url":{"name":"checkout-cart-url","type":"option","description":"Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"","hidden":false,"multiple":false},"tunnel-url":{"name":"tunnel-url","type":"option","description":"Override the ngrok tunnel URL. Format: \"https://my-tunnel-url:port\"","hidden":false,"multiple":false,"exclusive":["no-tunnel","tunnel"]},"no-tunnel":{"name":"no-tunnel","type":"boolean","description":"Automatic creation of a tunnel is disabled. Service entry point will listen to localhost instead","hidden":true,"allowNo":false,"exclusive":["tunnel-url","tunnel"]},"tunnel":{"name":"tunnel","type":"boolean","description":"Use ngrok to create a tunnel to your service entry point","hidden":false,"allowNo":false,"exclusive":["tunnel-url","no-tunnel"]},"theme":{"name":"theme","type":"option","char":"t","description":"Theme ID or name of the theme app extension host theme.","hidden":false,"multiple":false},"theme-app-extension-port":{"name":"theme-app-extension-port","type":"option","description":"Local port of the theme app extension development server.","hidden":false,"multiple":false}},"args":[]},"app:info":{"id":"app:info","description":"Print basic information about your app and extensions.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your app directory.","hidden":false,"multiple":false},"json":{"name":"json","type":"boolean","description":"format output as JSON","hidden":false,"allowNo":false},"web-env":{"name":"web-env","type":"boolean","description":"Outputs environment variables necessary for running and deploying web/.","hidden":false,"allowNo":false}},"args":[]},"app:update-url":{"id":"app:update-url","description":"Update your app and redirect URLs in the Partners Dashboard.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"api-key":{"name":"api-key","type":"option","description":"The API key of your app.","hidden":false,"multiple":false},"app-url":{"name":"app-url","type":"option","description":"URL through which merchants will access your app.","hidden":false,"multiple":false},"redirect-urls":{"name":"redirect-urls","type":"option","description":"Comma separated list of allowed URLs where merchants are redirected after the app is installed","hidden":false,"multiple":false}},"args":[]},"webhook:trigger":{"id":"webhook:trigger","description":"Trigger delivery of a sample webhook topic payload to a designated address.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"help":{"name":"help","type":"boolean","description":"This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.","hidden":false,"required":false,"allowNo":false},"topic":{"name":"topic","type":"option","description":"The requested webhook topic.","hidden":false,"required":false,"multiple":false},"api-version":{"name":"api-version","type":"option","description":"The API Version of the webhook topic.","hidden":false,"required":false,"multiple":false},"delivery-method":{"name":"delivery-method","type":"option","description":"Method chosen to deliver the topic payload. If not passed, it's inferred from the address.","hidden":false,"required":false,"multiple":false,"options":["http","google-pub-sub","event-bridge"]},"shared-secret":{"name":"shared-secret","type":"option","description":"Deprecated. Please use client-secret.","hidden":false,"required":false,"multiple":false},"client-secret":{"name":"client-secret","type":"option","description":"Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.","hidden":false,"required":false,"multiple":false},"address":{"name":"address","type":"option","description":"The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:","hidden":false,"required":false,"multiple":false}},"args":[]},"app:env:pull":{"id":"app:env:pull","description":"Pull app and extensions environment variables.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your app directory.","hidden":false,"multiple":false},"env-file":{"name":"env-file","type":"option","description":"Specify an environment file to update if the update flag is set","hidden":false,"multiple":false,"default":".env"}},"args":[]},"app:env:show":{"id":"app:env:show","description":"Display app and extensions environment variables.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your app directory.","hidden":false,"multiple":false}},"args":[]},"app:function:build":{"id":"app:function:build","description":"Compile a Function to WASM.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your function directory.","hidden":false,"multiple":false}},"args":[]},"app:function:run":{"id":"app:function:run","description":"Run a Function locally for testing.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your function directory.","hidden":false,"multiple":false}},"args":[]},"app:function:schema":{"id":"app:function:schema","description":"Fetch the latest GraphQL schema for a Function.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your function directory.","hidden":false,"multiple":false},"api-key":{"name":"api-key","type":"option","description":"The API key to fetch the schema with.","required":false,"multiple":false}},"args":[]},"app:function:typegen":{"id":"app:function:typegen","description":"Generate GraphQL types for a JavaScript Function.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your function directory.","hidden":false,"multiple":false}},"args":[]},"app:generate:extension":{"id":"app:generate:extension","description":"Scaffold an Extension.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"examples":["<%= config.bin %> <%= command.id %>"],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your app directory.","hidden":false,"multiple":false},"type":{"name":"type","type":"option","char":"t","description":"Extension type","hidden":false,"multiple":false},"name":{"name":"name","type":"option","char":"n","description":"name of your Extension","hidden":false,"multiple":false},"clone-url":{"name":"clone-url","type":"option","char":"u","description":"The Git URL to clone the function extensions templates from. Defaults to: https://github.com/Shopify/function-examples","hidden":true,"multiple":false},"template":{"name":"template","type":"option","description":"Choose a starting template for your extension, where applicable","hidden":false,"multiple":false,"options":["vanilla-js","react","typescript","typescript-react","wasm","rust"]},"reset":{"name":"reset","type":"boolean","description":"Reset all your settings.","hidden":false,"allowNo":false},"api-key":{"name":"api-key","type":"option","description":"The API key of your app.","hidden":false,"multiple":false}},"args":[{"name":"file"}]},"app:generate:schema":{"id":"app:generate:schema","description":"Fetch the latest GraphQL schema for a Function.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your function directory.","hidden":false,"multiple":false},"api-key":{"name":"api-key","type":"option","description":"The API key to fetch the schema with.","required":false,"multiple":false}},"args":[]},"app:scaffold:extension":{"id":"app:scaffold:extension","description":"Scaffold an Extension.","strict":true,"pluginName":"@shopify/app","pluginAlias":"@shopify/app","pluginType":"core","hidden":true,"aliases":[],"examples":["<%= config.bin %> <%= command.id %>"],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your app directory.","hidden":false,"multiple":false},"type":{"name":"type","type":"option","char":"t","description":"Extension type","hidden":false,"multiple":false},"name":{"name":"name","type":"option","char":"n","description":"name of your Extension","hidden":false,"multiple":false},"clone-url":{"name":"clone-url","type":"option","char":"u","description":"The Git URL to clone the function extensions templates from. Defaults to: https://github.com/Shopify/function-examples","hidden":true,"multiple":false},"template":{"name":"template","type":"option","description":"Choose a starting template for your extension, where applicable","hidden":false,"multiple":false,"options":["vanilla-js","react","typescript","typescript-react","wasm","rust"]},"reset":{"name":"reset","type":"boolean","description":"Reset all your settings.","hidden":false,"allowNo":false},"api-key":{"name":"api-key","type":"option","description":"The API key of your app.","hidden":false,"multiple":false}},"args":[{"name":"file"}]}}}
+{
+  "version": "3.43.0",
+  "commands": {
+    "app:build": {
+      "id": "app:build",
+      "description": "Build the app.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your app directory.",
+          "hidden": false,
+          "multiple": false
+        },
+        "skip-dependencies-installation": {
+          "name": "skip-dependencies-installation",
+          "type": "boolean",
+          "description": "Skips the installation of dependencies.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "api-key": {
+          "name": "api-key",
+          "type": "option",
+          "description": "Application's API key that will be exposed at build time.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "app:deploy": {
+      "id": "app:deploy",
+      "description": "Deploy your Shopify app.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your app directory.",
+          "hidden": false,
+          "multiple": false
+        },
+        "api-key": {
+          "name": "api-key",
+          "type": "option",
+          "description": "The API key of your app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "reset": {
+          "name": "reset",
+          "type": "boolean",
+          "description": "Reset all your settings.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "Deploy without asking for confirmation.",
+          "hidden": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "app:dev": {
+      "id": "app:dev",
+      "description": "Run the app.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your app directory.",
+          "hidden": false,
+          "multiple": false
+        },
+        "api-key": {
+          "name": "api-key",
+          "type": "option",
+          "description": "The API key of your app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
+          "hidden": false,
+          "multiple": false
+        },
+        "reset": {
+          "name": "reset",
+          "type": "boolean",
+          "description": "Reset all your settings.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "skip-dependencies-installation": {
+          "name": "skip-dependencies-installation",
+          "type": "boolean",
+          "description": "Skips the installation of dependencies.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-update": {
+          "name": "no-update",
+          "type": "boolean",
+          "description": "Skips the Partners Dashboard URL update step.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "subscription-product-url": {
+          "name": "subscription-product-url",
+          "type": "option",
+          "description": "Resource URL for subscription UI extension. Format: \"/products/{productId}\"",
+          "hidden": false,
+          "multiple": false
+        },
+        "checkout-cart-url": {
+          "name": "checkout-cart-url",
+          "type": "option",
+          "description": "Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"",
+          "hidden": false,
+          "multiple": false
+        },
+        "tunnel-url": {
+          "name": "tunnel-url",
+          "type": "option",
+          "description": "Override the ngrok tunnel URL. Format: \"https://my-tunnel-url:port\"",
+          "hidden": false,
+          "multiple": false,
+          "exclusive": [
+            "no-tunnel",
+            "tunnel"
+          ]
+        },
+        "no-tunnel": {
+          "name": "no-tunnel",
+          "type": "boolean",
+          "description": "Automatic creation of a tunnel is disabled. Service entry point will listen to localhost instead",
+          "hidden": true,
+          "allowNo": false,
+          "exclusive": [
+            "tunnel-url",
+            "tunnel"
+          ]
+        },
+        "tunnel": {
+          "name": "tunnel",
+          "type": "boolean",
+          "description": "Use ngrok to create a tunnel to your service entry point",
+          "hidden": false,
+          "allowNo": false,
+          "exclusive": [
+            "tunnel-url",
+            "no-tunnel"
+          ]
+        },
+        "theme": {
+          "name": "theme",
+          "type": "option",
+          "char": "t",
+          "description": "Theme ID or name of the theme app extension host theme.",
+          "hidden": false,
+          "multiple": false
+        },
+        "theme-app-extension-port": {
+          "name": "theme-app-extension-port",
+          "type": "option",
+          "description": "Local port of the theme app extension development server.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "app:info": {
+      "id": "app:info",
+      "description": "Print basic information about your app and extensions.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your app directory.",
+          "hidden": false,
+          "multiple": false
+        },
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as JSON",
+          "hidden": false,
+          "allowNo": false
+        },
+        "web-env": {
+          "name": "web-env",
+          "type": "boolean",
+          "description": "Outputs environment variables necessary for running and deploying web/.",
+          "hidden": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "app:update-url": {
+      "id": "app:update-url",
+      "description": "Update your app and redirect URLs in the Partners Dashboard.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "api-key": {
+          "name": "api-key",
+          "type": "option",
+          "description": "The API key of your app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "app-url": {
+          "name": "app-url",
+          "type": "option",
+          "description": "URL through which merchants will access your app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "redirect-urls": {
+          "name": "redirect-urls",
+          "type": "option",
+          "description": "Comma separated list of allowed URLs where merchants are redirected after the app is installed",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "webhook:trigger": {
+      "id": "webhook:trigger",
+      "description": "Trigger delivery of a sample webhook topic payload to a designated address.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "help": {
+          "name": "help",
+          "type": "boolean",
+          "description": "This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.",
+          "hidden": false,
+          "required": false,
+          "allowNo": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "option",
+          "description": "The requested webhook topic.",
+          "hidden": false,
+          "required": false,
+          "multiple": false
+        },
+        "api-version": {
+          "name": "api-version",
+          "type": "option",
+          "description": "The API Version of the webhook topic.",
+          "hidden": false,
+          "required": false,
+          "multiple": false
+        },
+        "delivery-method": {
+          "name": "delivery-method",
+          "type": "option",
+          "description": "Method chosen to deliver the topic payload. If not passed, it's inferred from the address.",
+          "hidden": false,
+          "required": false,
+          "multiple": false,
+          "options": [
+            "http",
+            "google-pub-sub",
+            "event-bridge"
+          ]
+        },
+        "shared-secret": {
+          "name": "shared-secret",
+          "type": "option",
+          "description": "Deprecated. Please use client-secret.",
+          "hidden": false,
+          "required": false,
+          "multiple": false
+        },
+        "client-secret": {
+          "name": "client-secret",
+          "type": "option",
+          "description": "Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.",
+          "hidden": false,
+          "required": false,
+          "multiple": false
+        },
+        "address": {
+          "name": "address",
+          "type": "option",
+          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
+          "hidden": false,
+          "required": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "app:env:pull": {
+      "id": "app:env:pull",
+      "description": "Pull app and extensions environment variables.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your app directory.",
+          "hidden": false,
+          "multiple": false
+        },
+        "env-file": {
+          "name": "env-file",
+          "type": "option",
+          "description": "Specify an environment file to update if the update flag is set",
+          "hidden": false,
+          "multiple": false,
+          "default": ".env"
+        }
+      },
+      "args": []
+    },
+    "app:env:show": {
+      "id": "app:env:show",
+      "description": "Display app and extensions environment variables.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your app directory.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "app:function:build": {
+      "id": "app:function:build",
+      "description": "Compile a Function to WASM.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your function directory.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "app:function:run": {
+      "id": "app:function:run",
+      "description": "Run a Function locally for testing.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your function directory.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "app:function:schema": {
+      "id": "app:function:schema",
+      "description": "Fetch the latest GraphQL schema for a Function.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your function directory.",
+          "hidden": false,
+          "multiple": false
+        },
+        "api-key": {
+          "name": "api-key",
+          "type": "option",
+          "description": "The API key to fetch the schema with.",
+          "required": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "app:function:typegen": {
+      "id": "app:function:typegen",
+      "description": "Generate GraphQL types for a JavaScript Function.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your function directory.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "app:generate:extension": {
+      "id": "app:generate:extension",
+      "description": "Scaffold an Extension.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "<%= config.bin %> <%= command.id %>"
+      ],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your app directory.",
+          "hidden": false,
+          "multiple": false
+        },
+        "type": {
+          "name": "type",
+          "type": "option",
+          "char": "t",
+          "description": "Extension type",
+          "hidden": false,
+          "multiple": false
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "name of your Extension",
+          "hidden": false,
+          "multiple": false
+        },
+        "clone-url": {
+          "name": "clone-url",
+          "type": "option",
+          "char": "u",
+          "description": "The Git URL to clone the function extensions templates from. Defaults to: https://github.com/Shopify/function-examples",
+          "hidden": true,
+          "multiple": false
+        },
+        "template": {
+          "name": "template",
+          "type": "option",
+          "description": "Choose a starting template for your extension, where applicable",
+          "hidden": false,
+          "multiple": false,
+          "options": [
+            "vanilla-js",
+            "react",
+            "typescript",
+            "typescript-react",
+            "wasm",
+            "rust"
+          ]
+        },
+        "reset": {
+          "name": "reset",
+          "type": "boolean",
+          "description": "Reset all your settings.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "api-key": {
+          "name": "api-key",
+          "type": "option",
+          "description": "The API key of your app.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": [
+        {
+          "name": "file"
+        }
+      ]
+    },
+    "app:generate:schema": {
+      "id": "app:generate:schema",
+      "description": "Fetch the latest GraphQL schema for a Function.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your function directory.",
+          "hidden": false,
+          "multiple": false
+        },
+        "api-key": {
+          "name": "api-key",
+          "type": "option",
+          "description": "The API key to fetch the schema with.",
+          "required": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "app:scaffold:extension": {
+      "id": "app:scaffold:extension",
+      "description": "Scaffold an Extension.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "hidden": true,
+      "aliases": [],
+      "examples": [
+        "<%= config.bin %> <%= command.id %>"
+      ],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your app directory.",
+          "hidden": false,
+          "multiple": false
+        },
+        "type": {
+          "name": "type",
+          "type": "option",
+          "char": "t",
+          "description": "Extension type",
+          "hidden": false,
+          "multiple": false
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "name of your Extension",
+          "hidden": false,
+          "multiple": false
+        },
+        "clone-url": {
+          "name": "clone-url",
+          "type": "option",
+          "char": "u",
+          "description": "The Git URL to clone the function extensions templates from. Defaults to: https://github.com/Shopify/function-examples",
+          "hidden": true,
+          "multiple": false
+        },
+        "template": {
+          "name": "template",
+          "type": "option",
+          "description": "Choose a starting template for your extension, where applicable",
+          "hidden": false,
+          "multiple": false,
+          "options": [
+            "vanilla-js",
+            "react",
+            "typescript",
+            "typescript-react",
+            "wasm",
+            "rust"
+          ]
+        },
+        "reset": {
+          "name": "reset",
+          "type": "boolean",
+          "description": "Reset all your settings.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "api-key": {
+          "name": "api-key",
+          "type": "option",
+          "description": "The API key of your app.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": [
+        {
+          "name": "file"
+        }
+      ]
+    }
+  }
+}

--- a/packages/cli-hydrogen/oclif.manifest.json
+++ b/packages/cli-hydrogen/oclif.manifest.json
@@ -1,1 +1,408 @@
-{"version":"3.43.0","commands":{"hydrogen:build":{"id":"hydrogen:build","description":"Builds a Hydrogen storefront for production.","strict":true,"pluginName":"@shopify/cli-hydrogen","pluginAlias":"@shopify/cli-hydrogen","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"the path to your hydrogen storefront","hidden":true,"multiple":false},"base":{"name":"base","type":"option","description":" the public path when served in production","multiple":false},"client":{"name":"client","type":"boolean","description":"build the client code","allowNo":true},"target":{"name":"target","type":"option","char":"t","description":"the target platform to build for (worker or node)","multiple":false,"options":["node","worker"],"default":"worker"},"entry":{"name":"entry","type":"option","description":"produce Server Side Rendering (SSR) build for node environments","multiple":false}},"args":[]},"hydrogen:deploy":{"id":"hydrogen:deploy","description":"Deploy your Hydrogen app to Oxygen hosting","strict":true,"pluginName":"@shopify/cli-hydrogen","pluginAlias":"@shopify/cli-hydrogen","pluginType":"core","hidden":true,"aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"the path to your hydrogen storefront","hidden":true,"multiple":false},"install":{"name":"install","type":"boolean","description":"should install packages","hidden":true,"allowNo":true},"deploymentToken":{"name":"deploymentToken","type":"option","description":"Specify your Oxygen deployment token.","required":true,"multiple":false},"commitMessage":{"name":"commitMessage","type":"option","description":"Override the default Git commit message.","multiple":false},"commitAuthor":{"name":"commitAuthor","type":"option","description":"Override the default Git commit author.","multiple":false},"pathToBuild":{"name":"pathToBuild","type":"option","description":"Skip build process and use provided value as build","hidden":true,"multiple":false},"healthCheck":{"name":"healthCheck","type":"boolean","description":"Require a health check before the deployment succeeds.","allowNo":false},"assumeYes":{"name":"assumeYes","type":"boolean","char":"y","description":"Automatic yes to prompts. Assume \"yes\" as answer to all prompts and run non-interactively.","allowNo":false},"oxygenAddress":{"name":"oxygenAddress","type":"option","hidden":true,"multiple":false,"default":"oxygen-dms.shopifycloud.com"}},"args":[]},"hydrogen:dev":{"id":"hydrogen:dev","description":"Run a Hydrogen storefront locally for development.","strict":true,"pluginName":"@shopify/cli-hydrogen","pluginAlias":"@shopify/cli-hydrogen","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"the path to your hydrogen storefront","hidden":true,"multiple":false},"force":{"name":"force","type":"boolean","description":"force dependency pre-bundling.","allowNo":false},"host":{"name":"host","type":"boolean","description":"listen on all addresses, including LAN and public addresses.","allowNo":false},"open":{"name":"open","type":"boolean","description":"automatically open the app in the browser","allowNo":false}},"args":[]},"hydrogen:info":{"id":"hydrogen:info","description":"Print basic information about your hydrogen app.","strict":true,"pluginName":"@shopify/cli-hydrogen","pluginAlias":"@shopify/cli-hydrogen","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"the path to your hydrogen storefront","hidden":true,"multiple":false},"install":{"name":"install","type":"boolean","description":"should install packages","hidden":true,"allowNo":true},"showToken":{"name":"showToken","type":"boolean","description":"Show storefront API token","hidden":false,"allowNo":false}},"args":[]},"hydrogen:preview":{"id":"hydrogen:preview","description":"Run a Hydrogen storefront locally in a worker environment.","strict":true,"pluginName":"@shopify/cli-hydrogen","pluginAlias":"@shopify/cli-hydrogen","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"the path to your hydrogen storefront","hidden":true,"multiple":false},"port":{"name":"port","type":"option","char":"p","description":"the port to run the preview server on","hidden":true,"multiple":false,"default":"3000"},"env":{"name":"env","type":"option","char":"e","description":"the file path to your .env","multiple":false},"target":{"name":"target","type":"option","char":"t","description":"the target environment (worker or node)","multiple":false,"options":["node","worker"],"default":"worker"}},"args":[]},"hydrogen:add:eslint":{"id":"hydrogen:add:eslint","strict":true,"pluginName":"@shopify/cli-hydrogen","pluginAlias":"@shopify/cli-hydrogen","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"the path to your hydrogen storefront","hidden":true,"multiple":false},"install":{"name":"install","type":"boolean","description":"should install packages","hidden":true,"allowNo":true},"force":{"name":"force","type":"boolean","char":"f","description":"Overwrite existing configuration","hidden":false,"allowNo":false}},"args":[]},"hydrogen:add:tailwind":{"id":"hydrogen:add:tailwind","strict":true,"pluginName":"@shopify/cli-hydrogen","pluginAlias":"@shopify/cli-hydrogen","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"the path to your hydrogen storefront","hidden":true,"multiple":false},"install":{"name":"install","type":"boolean","description":"should install packages","hidden":true,"allowNo":true},"force":{"name":"force","type":"boolean","char":"f","description":"overwrite existing configuration","hidden":false,"allowNo":false}},"args":[]}}}
+{
+  "version": "3.43.0",
+  "commands": {
+    "hydrogen:build": {
+      "id": "hydrogen:build",
+      "description": "Builds a Hydrogen storefront for production.",
+      "strict": true,
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "the path to your hydrogen storefront",
+          "hidden": true,
+          "multiple": false
+        },
+        "base": {
+          "name": "base",
+          "type": "option",
+          "description": " the public path when served in production",
+          "multiple": false
+        },
+        "client": {
+          "name": "client",
+          "type": "boolean",
+          "description": "build the client code",
+          "allowNo": true
+        },
+        "target": {
+          "name": "target",
+          "type": "option",
+          "char": "t",
+          "description": "the target platform to build for (worker or node)",
+          "multiple": false,
+          "options": [
+            "node",
+            "worker"
+          ],
+          "default": "worker"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "option",
+          "description": "produce Server Side Rendering (SSR) build for node environments",
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "hydrogen:deploy": {
+      "id": "hydrogen:deploy",
+      "description": "Deploy your Hydrogen app to Oxygen hosting",
+      "strict": true,
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "hidden": true,
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "the path to your hydrogen storefront",
+          "hidden": true,
+          "multiple": false
+        },
+        "install": {
+          "name": "install",
+          "type": "boolean",
+          "description": "should install packages",
+          "hidden": true,
+          "allowNo": true
+        },
+        "deploymentToken": {
+          "name": "deploymentToken",
+          "type": "option",
+          "description": "Specify your Oxygen deployment token.",
+          "required": true,
+          "multiple": false
+        },
+        "commitMessage": {
+          "name": "commitMessage",
+          "type": "option",
+          "description": "Override the default Git commit message.",
+          "multiple": false
+        },
+        "commitAuthor": {
+          "name": "commitAuthor",
+          "type": "option",
+          "description": "Override the default Git commit author.",
+          "multiple": false
+        },
+        "pathToBuild": {
+          "name": "pathToBuild",
+          "type": "option",
+          "description": "Skip build process and use provided value as build",
+          "hidden": true,
+          "multiple": false
+        },
+        "healthCheck": {
+          "name": "healthCheck",
+          "type": "boolean",
+          "description": "Require a health check before the deployment succeeds.",
+          "allowNo": false
+        },
+        "assumeYes": {
+          "name": "assumeYes",
+          "type": "boolean",
+          "char": "y",
+          "description": "Automatic yes to prompts. Assume \"yes\" as answer to all prompts and run non-interactively.",
+          "allowNo": false
+        },
+        "oxygenAddress": {
+          "name": "oxygenAddress",
+          "type": "option",
+          "hidden": true,
+          "multiple": false,
+          "default": "oxygen-dms.shopifycloud.com"
+        }
+      },
+      "args": []
+    },
+    "hydrogen:dev": {
+      "id": "hydrogen:dev",
+      "description": "Run a Hydrogen storefront locally for development.",
+      "strict": true,
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "the path to your hydrogen storefront",
+          "hidden": true,
+          "multiple": false
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "description": "force dependency pre-bundling.",
+          "allowNo": false
+        },
+        "host": {
+          "name": "host",
+          "type": "boolean",
+          "description": "listen on all addresses, including LAN and public addresses.",
+          "allowNo": false
+        },
+        "open": {
+          "name": "open",
+          "type": "boolean",
+          "description": "automatically open the app in the browser",
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "hydrogen:info": {
+      "id": "hydrogen:info",
+      "description": "Print basic information about your hydrogen app.",
+      "strict": true,
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "the path to your hydrogen storefront",
+          "hidden": true,
+          "multiple": false
+        },
+        "install": {
+          "name": "install",
+          "type": "boolean",
+          "description": "should install packages",
+          "hidden": true,
+          "allowNo": true
+        },
+        "showToken": {
+          "name": "showToken",
+          "type": "boolean",
+          "description": "Show storefront API token",
+          "hidden": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "hydrogen:preview": {
+      "id": "hydrogen:preview",
+      "description": "Run a Hydrogen storefront locally in a worker environment.",
+      "strict": true,
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "the path to your hydrogen storefront",
+          "hidden": true,
+          "multiple": false
+        },
+        "port": {
+          "name": "port",
+          "type": "option",
+          "char": "p",
+          "description": "the port to run the preview server on",
+          "hidden": true,
+          "multiple": false,
+          "default": "3000"
+        },
+        "env": {
+          "name": "env",
+          "type": "option",
+          "char": "e",
+          "description": "the file path to your .env",
+          "multiple": false
+        },
+        "target": {
+          "name": "target",
+          "type": "option",
+          "char": "t",
+          "description": "the target environment (worker or node)",
+          "multiple": false,
+          "options": [
+            "node",
+            "worker"
+          ],
+          "default": "worker"
+        }
+      },
+      "args": []
+    },
+    "hydrogen:add:eslint": {
+      "id": "hydrogen:add:eslint",
+      "strict": true,
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "the path to your hydrogen storefront",
+          "hidden": true,
+          "multiple": false
+        },
+        "install": {
+          "name": "install",
+          "type": "boolean",
+          "description": "should install packages",
+          "hidden": true,
+          "allowNo": true
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "Overwrite existing configuration",
+          "hidden": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "hydrogen:add:tailwind": {
+      "id": "hydrogen:add:tailwind",
+      "strict": true,
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "the path to your hydrogen storefront",
+          "hidden": true,
+          "multiple": false
+        },
+        "install": {
+          "name": "install",
+          "type": "boolean",
+          "description": "should install packages",
+          "hidden": true,
+          "allowNo": true
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "overwrite existing configuration",
+          "hidden": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    }
+  }
+}

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1,1 +1,93 @@
-{"version":"3.43.0","commands":{"upgrade":{"id":"upgrade","description":"Upgrade the Shopify CLI.","strict":true,"pluginName":"@shopify/cli","pluginAlias":"@shopify/cli","pluginType":"core","aliases":[],"flags":{"path":{"name":"path","type":"option","description":"The path to your project directory.","hidden":false,"multiple":false}},"args":[]},"version":{"id":"version","description":"Shopify CLI version.","strict":true,"pluginName":"@shopify/cli","pluginAlias":"@shopify/cli","pluginType":"core","aliases":[],"flags":{},"args":[]},"auth:logout":{"id":"auth:logout","description":"Logout from Shopify.","strict":true,"pluginName":"@shopify/cli","pluginAlias":"@shopify/cli","pluginType":"core","aliases":[],"flags":{},"args":[]},"kitchen-sink:async":{"id":"kitchen-sink:async","description":"View the UI kit components that process async tasks","strict":true,"pluginName":"@shopify/cli","pluginAlias":"@shopify/cli","pluginType":"core","aliases":[],"flags":{},"args":[]},"kitchen-sink":{"id":"kitchen-sink","description":"View all the available UI kit components","strict":true,"pluginName":"@shopify/cli","pluginAlias":"@shopify/cli","pluginType":"core","hidden":true,"aliases":["kitchen-sink all"],"flags":{},"args":[]},"kitchen-sink:prompts":{"id":"kitchen-sink:prompts","description":"View the UI kit components prompts","strict":true,"pluginName":"@shopify/cli","pluginAlias":"@shopify/cli","pluginType":"core","aliases":[],"flags":{},"args":[]},"kitchen-sink:static":{"id":"kitchen-sink:static","description":"View the UI kit components that display static output","strict":true,"pluginName":"@shopify/cli","pluginAlias":"@shopify/cli","pluginType":"core","aliases":[],"flags":{},"args":[]}}}
+{
+  "version": "3.43.0",
+  "commands": {
+    "upgrade": {
+      "id": "upgrade",
+      "description": "Upgrade the Shopify CLI.",
+      "strict": true,
+      "pluginName": "@shopify/cli",
+      "pluginAlias": "@shopify/cli",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your project directory.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "version": {
+      "id": "version",
+      "description": "Shopify CLI version.",
+      "strict": true,
+      "pluginName": "@shopify/cli",
+      "pluginAlias": "@shopify/cli",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {},
+      "args": []
+    },
+    "auth:logout": {
+      "id": "auth:logout",
+      "description": "Logout from Shopify.",
+      "strict": true,
+      "pluginName": "@shopify/cli",
+      "pluginAlias": "@shopify/cli",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {},
+      "args": []
+    },
+    "kitchen-sink:async": {
+      "id": "kitchen-sink:async",
+      "description": "View the UI kit components that process async tasks",
+      "strict": true,
+      "pluginName": "@shopify/cli",
+      "pluginAlias": "@shopify/cli",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {},
+      "args": []
+    },
+    "kitchen-sink": {
+      "id": "kitchen-sink",
+      "description": "View all the available UI kit components",
+      "strict": true,
+      "pluginName": "@shopify/cli",
+      "pluginAlias": "@shopify/cli",
+      "pluginType": "core",
+      "hidden": true,
+      "aliases": [
+        "kitchen-sink all"
+      ],
+      "flags": {},
+      "args": []
+    },
+    "kitchen-sink:prompts": {
+      "id": "kitchen-sink:prompts",
+      "description": "View the UI kit components prompts",
+      "strict": true,
+      "pluginName": "@shopify/cli",
+      "pluginAlias": "@shopify/cli",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {},
+      "args": []
+    },
+    "kitchen-sink:static": {
+      "id": "kitchen-sink:static",
+      "description": "View the UI kit components that display static output",
+      "strict": true,
+      "pluginName": "@shopify/cli",
+      "pluginAlias": "@shopify/cli",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {},
+      "args": []
+    }
+  }
+}

--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -1,1 +1,71 @@
-{"version":"3.43.0","commands":{"init":{"id":"init","strict":true,"pluginName":"@shopify/create-app","pluginAlias":"@shopify/create-app","pluginType":"core","aliases":["create-app"],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"name":{"name":"name","type":"option","char":"n","hidden":false,"multiple":false},"path":{"name":"path","type":"option","char":"p","hidden":false,"multiple":false},"template":{"name":"template","type":"option","description":"The app template. Accepts one of the following:\n       - <node|php|ruby>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]","multiple":false},"package-manager":{"name":"package-manager","type":"option","char":"d","hidden":false,"multiple":false,"options":["npm","yarn","pnpm"]},"local":{"name":"local","type":"boolean","char":"l","hidden":true,"allowNo":false}},"args":[]}}}
+{
+  "version": "3.43.0",
+  "commands": {
+    "init": {
+      "id": "init",
+      "strict": true,
+      "pluginName": "@shopify/create-app",
+      "pluginAlias": "@shopify/create-app",
+      "pluginType": "core",
+      "aliases": [
+        "create-app"
+      ],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "hidden": false,
+          "multiple": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "char": "p",
+          "hidden": false,
+          "multiple": false
+        },
+        "template": {
+          "name": "template",
+          "type": "option",
+          "description": "The app template. Accepts one of the following:\n       - <node|php|ruby>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
+          "multiple": false
+        },
+        "package-manager": {
+          "name": "package-manager",
+          "type": "option",
+          "char": "d",
+          "hidden": false,
+          "multiple": false,
+          "options": [
+            "npm",
+            "yarn",
+            "pnpm"
+          ]
+        },
+        "local": {
+          "name": "local",
+          "type": "boolean",
+          "char": "l",
+          "hidden": true,
+          "allowNo": false
+        }
+      },
+      "args": []
+    }
+  }
+}

--- a/packages/create-hydrogen/oclif.manifest.json
+++ b/packages/create-hydrogen/oclif.manifest.json
@@ -1,1 +1,98 @@
-{"version":"3.43.0","commands":{"init":{"id":"init","strict":true,"pluginName":"@shopify/create-hydrogen","pluginAlias":"@shopify/create-hydrogen","pluginType":"core","aliases":["create-hydrogen"],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"name":{"name":"name","type":"option","char":"n","description":"The name of the Hydrogen app.","hidden":false,"multiple":false},"template":{"name":"template","type":"option","char":"t","description":"The template to use. Can either be a Shopify template name (hello-world or demo-store) or a custom URL to any template.","hidden":false,"multiple":false},"ts":{"name":"ts","type":"boolean","description":"Set the language of the template to TypeScript instead of JavaScript.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","char":"p","description":"The path to the directory where the Hydrogen app will be created.","hidden":false,"multiple":false},"package-manager":{"name":"package-manager","type":"option","char":"d","hidden":false,"multiple":false,"options":["npm","yarn","pnpm"]},"shopify-cli-version":{"name":"shopify-cli-version","type":"option","char":"s","description":"The version of the Shopify CLI to use.","hidden":false,"multiple":false},"hydrogen-version":{"name":"hydrogen-version","type":"option","char":"h","description":"The version of Hydrogen to use.","hidden":false,"multiple":false},"local":{"name":"local","type":"boolean","char":"l","hidden":true,"allowNo":false}},"args":[]}}}
+{
+  "version": "3.43.0",
+  "commands": {
+    "init": {
+      "id": "init",
+      "strict": true,
+      "pluginName": "@shopify/create-hydrogen",
+      "pluginAlias": "@shopify/create-hydrogen",
+      "pluginType": "core",
+      "aliases": [
+        "create-hydrogen"
+      ],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "The name of the Hydrogen app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "template": {
+          "name": "template",
+          "type": "option",
+          "char": "t",
+          "description": "The template to use. Can either be a Shopify template name (hello-world or demo-store) or a custom URL to any template.",
+          "hidden": false,
+          "multiple": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "boolean",
+          "description": "Set the language of the template to TypeScript instead of JavaScript.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "char": "p",
+          "description": "The path to the directory where the Hydrogen app will be created.",
+          "hidden": false,
+          "multiple": false
+        },
+        "package-manager": {
+          "name": "package-manager",
+          "type": "option",
+          "char": "d",
+          "hidden": false,
+          "multiple": false,
+          "options": [
+            "npm",
+            "yarn",
+            "pnpm"
+          ]
+        },
+        "shopify-cli-version": {
+          "name": "shopify-cli-version",
+          "type": "option",
+          "char": "s",
+          "description": "The version of the Shopify CLI to use.",
+          "hidden": false,
+          "multiple": false
+        },
+        "hydrogen-version": {
+          "name": "hydrogen-version",
+          "type": "option",
+          "char": "h",
+          "description": "The version of Hydrogen to use.",
+          "hidden": false,
+          "multiple": false
+        },
+        "local": {
+          "name": "local",
+          "type": "boolean",
+          "char": "l",
+          "hidden": true,
+          "allowNo": false
+        }
+      },
+      "args": []
+    }
+  }
+}

--- a/packages/plugin-ngrok/oclif.manifest.json
+++ b/packages/plugin-ngrok/oclif.manifest.json
@@ -1,1 +1,20 @@
-{"version":"3.43.0","commands":{"ngrok:auth":{"id":"ngrok:auth","description":"Saves a token to authenticate against ngrok. Visit https://dashboard.ngrok.com/signup to create an account.","strict":true,"pluginName":"@shopify/plugin-ngrok","pluginAlias":"@shopify/plugin-ngrok","pluginType":"core","aliases":[],"flags":{},"args":[{"name":"token"}]}}}
+{
+  "version": "3.43.0",
+  "commands": {
+    "ngrok:auth": {
+      "id": "ngrok:auth",
+      "description": "Saves a token to authenticate against ngrok. Visit https://dashboard.ngrok.com/signup to create an account.",
+      "strict": true,
+      "pluginName": "@shopify/plugin-ngrok",
+      "pluginAlias": "@shopify/plugin-ngrok",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {},
+      "args": [
+        {
+          "name": "token"
+        }
+      ]
+    }
+  }
+}

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -1,1 +1,1175 @@
-{"version":"3.43.0","commands":{"theme:check":{"id":"theme:check","description":"Validate the theme.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your theme directory.","hidden":false,"multiple":false,"default":"."},"auto-correct":{"name":"auto-correct","type":"boolean","char":"a","description":"Automatically fix offenses","required":false,"allowNo":false},"category":{"name":"category","type":"option","char":"c","description":"Only run this category of checks\nRuns checks matching all categories when specified more than once","required":false,"multiple":false},"config":{"name":"config","type":"option","char":"C","description":"Use the config provided, overriding .theme-check.yml if present\nUse :theme_app_extension to use default checks for theme app extensions","required":false,"multiple":false},"exclude-category":{"name":"exclude-category","type":"option","char":"x","description":"Exclude this category of checks\nExcludes checks matching any category when specified more than once","required":false,"multiple":false},"fail-level":{"name":"fail-level","type":"option","description":"Minimum severity for exit with error code","required":false,"multiple":false,"options":["error","suggestion","style"]},"init":{"name":"init","type":"boolean","description":"Generate a .theme-check.yml file","required":false,"allowNo":false},"list":{"name":"list","type":"boolean","description":"List enabled checks","required":false,"allowNo":false},"output":{"name":"output","type":"option","char":"o","description":"The output format to use","required":false,"multiple":false,"options":["text","json"],"default":"text"},"print":{"name":"print","type":"boolean","description":"Output active config to STDOUT","required":false,"allowNo":false},"version":{"name":"version","type":"boolean","char":"v","description":"Print Theme Check version","required":false,"allowNo":false}},"args":[],"cli2Flags":["auto-correct","category","config","exclude-category","fail-level","init","list","output","print","version"]},"theme:console":{"id":"theme:console","description":"Early access feature: Shopify Liquid REPL","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","hidden":true,"aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false}},"args":[]},"theme:delete":{"id":"theme:delete","description":"Delete remote themes from the connected store. This command can't be undone.","strict":false,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false},"development":{"name":"development","type":"boolean","char":"d","description":"Delete your development theme.","allowNo":false},"show-all":{"name":"show-all","type":"boolean","char":"a","description":"Include others development themes in theme list.","allowNo":false},"force":{"name":"force","type":"boolean","char":"f","description":"Skip confirmation.","allowNo":false},"theme":{"name":"theme","type":"option","char":"t","description":"Theme ID or name of the remote theme.","multiple":true},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false}},"args":[]},"theme:dev":{"id":"theme:dev","description":"Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your theme directory.","hidden":false,"multiple":false,"default":"."},"host":{"name":"host","type":"option","description":"Set which network interface the web server listens on. The default value is 127.0.0.1.","multiple":false},"live-reload":{"name":"live-reload","type":"option","description":"The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload","multiple":false,"options":["hot-reload","full-page","off"],"default":"hot-reload"},"poll":{"name":"poll","type":"boolean","description":"Force polling to detect file changes.","allowNo":false},"theme-editor-sync":{"name":"theme-editor-sync","type":"boolean","char":"e","description":"Synchronize Theme Editor updates in the local theme files.","allowNo":false},"port":{"name":"port","type":"option","description":"Local port to serve theme preview from.","multiple":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false},"theme":{"name":"theme","type":"option","char":"t","description":"Theme ID or name of the remote theme.","multiple":false},"only":{"name":"only","type":"option","char":"o","description":"Hot reload only files that match the specified pattern.","multiple":true},"ignore":{"name":"ignore","type":"option","char":"x","description":"Skip hot reloading any files that match the specified pattern.","multiple":true},"stable":{"name":"stable","type":"boolean","description":"Performs the upload by relying in the legacy upload approach (slower, but it might be more stable in some scenarios)","hidden":true,"allowNo":false},"force":{"name":"force","type":"boolean","char":"f","description":"Proceed without confirmation, if current directory does not seem to be theme directory.","hidden":true,"allowNo":false},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false}},"args":[],"cli2Flags":["host","live-reload","poll","theme-editor-sync","overwrite-json","port","theme","only","ignore","stable","force"]},"theme:help-old":{"id":"theme:help-old","description":"Show help from Ruby CLI","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","hidden":true,"aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"command":{"name":"command","type":"option","description":"The command for which to show CLI2 help.","multiple":false}},"args":[]},"theme:info":{"id":"theme:info","description":"Print basic information about your theme environment.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false}},"args":[]},"theme:init":{"id":"theme:init","description":"Clones a Git repository to use as a starting point for building a new theme.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your theme directory.","hidden":false,"multiple":false,"default":"."},"clone-url":{"name":"clone-url","type":"option","char":"u","description":"The Git URL to clone from. Defaults to Shopify's example theme, Dawn: https://github.com/Shopify/dawn.git","multiple":false,"default":"https://github.com/Shopify/dawn.git"},"latest":{"name":"latest","type":"boolean","char":"l","description":"Downloads the latest release of the `clone-url`","allowNo":false}},"args":[{"name":"name","description":"Name of the new theme","required":false}]},"theme:language-server":{"id":"theme:language-server","description":"Start a Language Server Protocol server.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false}},"args":[]},"theme:list":{"id":"theme:list","description":"Lists your remote themes.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false},"role":{"name":"role","type":"option","description":"Only list themes with the given role.","helpValue":"(live|unpublished|development)","multiple":false,"options":["live","unpublished","development"]},"name":{"name":"name","type":"option","description":"Only list themes that contain the given name.","multiple":false},"id":{"name":"id","type":"option","description":"Only list theme with the given ID.","multiple":false}},"args":[]},"theme:open":{"id":"theme:open","description":"Opens the preview of your remote theme.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false},"development":{"name":"development","type":"boolean","char":"d","description":"Delete your development theme.","allowNo":false},"editor":{"name":"editor","type":"boolean","char":"e","description":"Open the theme editor for the specified theme in the browser.","allowNo":false},"live":{"name":"live","type":"boolean","char":"l","description":"Pull theme files from your remote live theme.","allowNo":false},"theme":{"name":"theme","type":"option","char":"t","description":"Theme ID or name of the remote theme.","multiple":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false}},"args":[]},"theme:package":{"id":"theme:package","description":"Package your theme into a .zip file, ready to upload to the Online Store.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your theme directory.","hidden":false,"multiple":false,"default":"."}},"args":[]},"theme:publish":{"id":"theme:publish","description":"Set a remote theme as the live theme.","strict":false,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false},"force":{"name":"force","type":"boolean","char":"f","description":"Skip confirmation.","allowNo":false},"theme":{"name":"theme","type":"option","char":"t","description":"Theme ID or name of the remote theme.","multiple":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false}},"args":[]},"theme:pull":{"id":"theme:pull","description":"Download your remote theme files locally.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your theme directory.","hidden":false,"multiple":false,"default":"."},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false},"theme":{"name":"theme","type":"option","char":"t","description":"Theme ID or name of the remote theme.","multiple":false},"development":{"name":"development","type":"boolean","char":"d","description":"Pull theme files from your remote development theme.","allowNo":false},"live":{"name":"live","type":"boolean","char":"l","description":"Pull theme files from your remote live theme.","allowNo":false},"nodelete":{"name":"nodelete","type":"boolean","char":"n","description":"Runs the pull command without deleting local files.","allowNo":false},"only":{"name":"only","type":"option","char":"o","description":"Download only the specified files (Multiple flags allowed).","multiple":true},"ignore":{"name":"ignore","type":"option","char":"x","description":"Skip downloading the specified files (Multiple flags allowed).","multiple":true},"force":{"name":"force","type":"boolean","char":"f","description":"Proceed without confirmation, if current directory does not seem to be theme directory.","hidden":true,"allowNo":false}},"args":[],"cli2Flags":["theme","development","live","nodelete","only","ignore","force"]},"theme:push":{"id":"theme:push","description":"Uploads your local theme files to the connected store, overwriting the remote version if specified.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your theme directory.","hidden":false,"multiple":false,"default":"."},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false},"theme":{"name":"theme","type":"option","char":"t","description":"Theme ID or name of the remote theme.","multiple":false},"development":{"name":"development","type":"boolean","char":"d","description":"Push theme files from your remote development theme.","allowNo":false},"live":{"name":"live","type":"boolean","char":"l","description":"Push theme files from your remote live theme.","allowNo":false},"unpublished":{"name":"unpublished","type":"boolean","char":"u","description":"Create a new unpublished theme and push to it.","allowNo":false},"nodelete":{"name":"nodelete","type":"boolean","char":"n","description":"Runs the push command without deleting local files.","allowNo":false},"only":{"name":"only","type":"option","char":"o","description":"Download only the specified files (Multiple flags allowed).","multiple":true},"ignore":{"name":"ignore","type":"option","char":"x","description":"Skip downloading the specified files (Multiple flags allowed).","multiple":true},"json":{"name":"json","type":"boolean","char":"j","description":"Output JSON instead of a UI.","allowNo":false},"allow-live":{"name":"allow-live","type":"boolean","char":"a","description":"Allow push to a live theme.","allowNo":false},"publish":{"name":"publish","type":"boolean","char":"p","description":"Publish as the live theme after uploading.","allowNo":false},"stable":{"name":"stable","type":"boolean","description":"Performs the upload by relying in the legacy upload approach (slower, but it might be more stable in some scenarios)","hidden":true,"allowNo":false},"force":{"name":"force","type":"boolean","char":"f","description":"Proceed without confirmation, if current directory does not seem to be theme directory.","hidden":true,"allowNo":false}},"args":[],"cli2Flags":["theme","development","live","unpublished","nodelete","only","ignore","json","allow-live","publish","stable","force"]},"theme:serve":{"id":"theme:serve","description":"Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","hidden":true,"aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your theme directory.","hidden":false,"multiple":false,"default":"."},"host":{"name":"host","type":"option","description":"Set which network interface the web server listens on. The default value is 127.0.0.1.","multiple":false},"live-reload":{"name":"live-reload","type":"option","description":"The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload","multiple":false,"options":["hot-reload","full-page","off"],"default":"hot-reload"},"poll":{"name":"poll","type":"boolean","description":"Force polling to detect file changes.","allowNo":false},"theme-editor-sync":{"name":"theme-editor-sync","type":"boolean","char":"e","description":"Synchronize Theme Editor updates in the local theme files.","allowNo":false},"port":{"name":"port","type":"option","description":"Local port to serve theme preview from.","multiple":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false},"theme":{"name":"theme","type":"option","char":"t","description":"Theme ID or name of the remote theme.","multiple":false},"only":{"name":"only","type":"option","char":"o","description":"Hot reload only files that match the specified pattern.","multiple":true},"ignore":{"name":"ignore","type":"option","char":"x","description":"Skip hot reloading any files that match the specified pattern.","multiple":true},"stable":{"name":"stable","type":"boolean","description":"Performs the upload by relying in the legacy upload approach (slower, but it might be more stable in some scenarios)","hidden":true,"allowNo":false},"force":{"name":"force","type":"boolean","char":"f","description":"Proceed without confirmation, if current directory does not seem to be theme directory.","hidden":true,"allowNo":false},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false}},"args":[]},"theme:share":{"id":"theme:share","description":"Creates a shareable, unpublished, and new theme on your theme library with a randomized name. Works like an alias to {{command:theme push -u -t=RANDOMIZED_NAME}}.","strict":true,"pluginName":"@shopify/theme","pluginAlias":"@shopify/theme","pluginType":"core","aliases":[],"flags":{"environment":{"name":"environment","type":"option","description":"The environment to apply to the current command.","hidden":true,"multiple":false},"verbose":{"name":"verbose","type":"boolean","description":"Increase the verbosity of the logs.","hidden":false,"allowNo":false},"path":{"name":"path","type":"option","description":"The path to your theme directory.","hidden":false,"multiple":false,"default":"."},"password":{"name":"password","type":"option","description":"Password generated from the Theme Access app.","hidden":false,"multiple":false},"store":{"name":"store","type":"option","char":"s","description":"Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).","multiple":false},"force":{"name":"force","type":"boolean","char":"f","description":"Proceed without confirmation, if current directory does not seem to be theme directory.","hidden":true,"allowNo":false}},"args":[],"cli2Flags":["force"]}}}
+{
+  "version": "3.43.0",
+  "commands": {
+    "theme:check": {
+      "id": "theme:check",
+      "description": "Validate the theme.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your theme directory.",
+          "hidden": false,
+          "multiple": false,
+          "default": "."
+        },
+        "auto-correct": {
+          "name": "auto-correct",
+          "type": "boolean",
+          "char": "a",
+          "description": "Automatically fix offenses",
+          "required": false,
+          "allowNo": false
+        },
+        "category": {
+          "name": "category",
+          "type": "option",
+          "char": "c",
+          "description": "Only run this category of checks\nRuns checks matching all categories when specified more than once",
+          "required": false,
+          "multiple": false
+        },
+        "config": {
+          "name": "config",
+          "type": "option",
+          "char": "C",
+          "description": "Use the config provided, overriding .theme-check.yml if present\nUse :theme_app_extension to use default checks for theme app extensions",
+          "required": false,
+          "multiple": false
+        },
+        "exclude-category": {
+          "name": "exclude-category",
+          "type": "option",
+          "char": "x",
+          "description": "Exclude this category of checks\nExcludes checks matching any category when specified more than once",
+          "required": false,
+          "multiple": false
+        },
+        "fail-level": {
+          "name": "fail-level",
+          "type": "option",
+          "description": "Minimum severity for exit with error code",
+          "required": false,
+          "multiple": false,
+          "options": [
+            "error",
+            "suggestion",
+            "style"
+          ]
+        },
+        "init": {
+          "name": "init",
+          "type": "boolean",
+          "description": "Generate a .theme-check.yml file",
+          "required": false,
+          "allowNo": false
+        },
+        "list": {
+          "name": "list",
+          "type": "boolean",
+          "description": "List enabled checks",
+          "required": false,
+          "allowNo": false
+        },
+        "output": {
+          "name": "output",
+          "type": "option",
+          "char": "o",
+          "description": "The output format to use",
+          "required": false,
+          "multiple": false,
+          "options": [
+            "text",
+            "json"
+          ],
+          "default": "text"
+        },
+        "print": {
+          "name": "print",
+          "type": "boolean",
+          "description": "Output active config to STDOUT",
+          "required": false,
+          "allowNo": false
+        },
+        "version": {
+          "name": "version",
+          "type": "boolean",
+          "char": "v",
+          "description": "Print Theme Check version",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": [],
+      "cli2Flags": [
+        "auto-correct",
+        "category",
+        "config",
+        "exclude-category",
+        "fail-level",
+        "init",
+        "list",
+        "output",
+        "print",
+        "version"
+      ]
+    },
+    "theme:console": {
+      "id": "theme:console",
+      "description": "Early access feature: Shopify Liquid REPL",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "hidden": true,
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "theme:delete": {
+      "id": "theme:delete",
+      "description": "Delete remote themes from the connected store. This command can't be undone.",
+      "strict": false,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "development": {
+          "name": "development",
+          "type": "boolean",
+          "char": "d",
+          "description": "Delete your development theme.",
+          "allowNo": false
+        },
+        "show-all": {
+          "name": "show-all",
+          "type": "boolean",
+          "char": "a",
+          "description": "Include others development themes in theme list.",
+          "allowNo": false
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "Skip confirmation.",
+          "allowNo": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "option",
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "multiple": true
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "theme:dev": {
+      "id": "theme:dev",
+      "description": "Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your theme directory.",
+          "hidden": false,
+          "multiple": false,
+          "default": "."
+        },
+        "host": {
+          "name": "host",
+          "type": "option",
+          "description": "Set which network interface the web server listens on. The default value is 127.0.0.1.",
+          "multiple": false
+        },
+        "live-reload": {
+          "name": "live-reload",
+          "type": "option",
+          "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
+          "multiple": false,
+          "options": [
+            "hot-reload",
+            "full-page",
+            "off"
+          ],
+          "default": "hot-reload"
+        },
+        "poll": {
+          "name": "poll",
+          "type": "boolean",
+          "description": "Force polling to detect file changes.",
+          "allowNo": false
+        },
+        "theme-editor-sync": {
+          "name": "theme-editor-sync",
+          "type": "boolean",
+          "char": "e",
+          "description": "Synchronize Theme Editor updates in the local theme files.",
+          "allowNo": false
+        },
+        "port": {
+          "name": "port",
+          "type": "option",
+          "description": "Local port to serve theme preview from.",
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "option",
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "multiple": false
+        },
+        "only": {
+          "name": "only",
+          "type": "option",
+          "char": "o",
+          "description": "Hot reload only files that match the specified pattern.",
+          "multiple": true
+        },
+        "ignore": {
+          "name": "ignore",
+          "type": "option",
+          "char": "x",
+          "description": "Skip hot reloading any files that match the specified pattern.",
+          "multiple": true
+        },
+        "stable": {
+          "name": "stable",
+          "type": "boolean",
+          "description": "Performs the upload by relying in the legacy upload approach (slower, but it might be more stable in some scenarios)",
+          "hidden": true,
+          "allowNo": false
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "hidden": true,
+          "allowNo": false
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": [],
+      "cli2Flags": [
+        "host",
+        "live-reload",
+        "poll",
+        "theme-editor-sync",
+        "overwrite-json",
+        "port",
+        "theme",
+        "only",
+        "ignore",
+        "stable",
+        "force"
+      ]
+    },
+    "theme:help-old": {
+      "id": "theme:help-old",
+      "description": "Show help from Ruby CLI",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "hidden": true,
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "command": {
+          "name": "command",
+          "type": "option",
+          "description": "The command for which to show CLI2 help.",
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "theme:info": {
+      "id": "theme:info",
+      "description": "Print basic information about your theme environment.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "theme:init": {
+      "id": "theme:init",
+      "description": "Clones a Git repository to use as a starting point for building a new theme.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your theme directory.",
+          "hidden": false,
+          "multiple": false,
+          "default": "."
+        },
+        "clone-url": {
+          "name": "clone-url",
+          "type": "option",
+          "char": "u",
+          "description": "The Git URL to clone from. Defaults to Shopify's example theme, Dawn: https://github.com/Shopify/dawn.git",
+          "multiple": false,
+          "default": "https://github.com/Shopify/dawn.git"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "char": "l",
+          "description": "Downloads the latest release of the `clone-url`",
+          "allowNo": false
+        }
+      },
+      "args": [
+        {
+          "name": "name",
+          "description": "Name of the new theme",
+          "required": false
+        }
+      ]
+    },
+    "theme:language-server": {
+      "id": "theme:language-server",
+      "description": "Start a Language Server Protocol server.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "theme:list": {
+      "id": "theme:list",
+      "description": "Lists your remote themes.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        },
+        "role": {
+          "name": "role",
+          "type": "option",
+          "description": "Only list themes with the given role.",
+          "helpValue": "(live|unpublished|development)",
+          "multiple": false,
+          "options": [
+            "live",
+            "unpublished",
+            "development"
+          ]
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "description": "Only list themes that contain the given name.",
+          "multiple": false
+        },
+        "id": {
+          "name": "id",
+          "type": "option",
+          "description": "Only list theme with the given ID.",
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "theme:open": {
+      "id": "theme:open",
+      "description": "Opens the preview of your remote theme.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "development": {
+          "name": "development",
+          "type": "boolean",
+          "char": "d",
+          "description": "Delete your development theme.",
+          "allowNo": false
+        },
+        "editor": {
+          "name": "editor",
+          "type": "boolean",
+          "char": "e",
+          "description": "Open the theme editor for the specified theme in the browser.",
+          "allowNo": false
+        },
+        "live": {
+          "name": "live",
+          "type": "boolean",
+          "char": "l",
+          "description": "Pull theme files from your remote live theme.",
+          "allowNo": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "option",
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "theme:package": {
+      "id": "theme:package",
+      "description": "Package your theme into a .zip file, ready to upload to the Online Store.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your theme directory.",
+          "hidden": false,
+          "multiple": false,
+          "default": "."
+        }
+      },
+      "args": []
+    },
+    "theme:publish": {
+      "id": "theme:publish",
+      "description": "Set a remote theme as the live theme.",
+      "strict": false,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "Skip confirmation.",
+          "allowNo": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "option",
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "theme:pull": {
+      "id": "theme:pull",
+      "description": "Download your remote theme files locally.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your theme directory.",
+          "hidden": false,
+          "multiple": false,
+          "default": "."
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "option",
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "multiple": false
+        },
+        "development": {
+          "name": "development",
+          "type": "boolean",
+          "char": "d",
+          "description": "Pull theme files from your remote development theme.",
+          "allowNo": false
+        },
+        "live": {
+          "name": "live",
+          "type": "boolean",
+          "char": "l",
+          "description": "Pull theme files from your remote live theme.",
+          "allowNo": false
+        },
+        "nodelete": {
+          "name": "nodelete",
+          "type": "boolean",
+          "char": "n",
+          "description": "Runs the pull command without deleting local files.",
+          "allowNo": false
+        },
+        "only": {
+          "name": "only",
+          "type": "option",
+          "char": "o",
+          "description": "Download only the specified files (Multiple flags allowed).",
+          "multiple": true
+        },
+        "ignore": {
+          "name": "ignore",
+          "type": "option",
+          "char": "x",
+          "description": "Skip downloading the specified files (Multiple flags allowed).",
+          "multiple": true
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "hidden": true,
+          "allowNo": false
+        }
+      },
+      "args": [],
+      "cli2Flags": [
+        "theme",
+        "development",
+        "live",
+        "nodelete",
+        "only",
+        "ignore",
+        "force"
+      ]
+    },
+    "theme:push": {
+      "id": "theme:push",
+      "description": "Uploads your local theme files to the connected store, overwriting the remote version if specified.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your theme directory.",
+          "hidden": false,
+          "multiple": false,
+          "default": "."
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "option",
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "multiple": false
+        },
+        "development": {
+          "name": "development",
+          "type": "boolean",
+          "char": "d",
+          "description": "Push theme files from your remote development theme.",
+          "allowNo": false
+        },
+        "live": {
+          "name": "live",
+          "type": "boolean",
+          "char": "l",
+          "description": "Push theme files from your remote live theme.",
+          "allowNo": false
+        },
+        "unpublished": {
+          "name": "unpublished",
+          "type": "boolean",
+          "char": "u",
+          "description": "Create a new unpublished theme and push to it.",
+          "allowNo": false
+        },
+        "nodelete": {
+          "name": "nodelete",
+          "type": "boolean",
+          "char": "n",
+          "description": "Runs the push command without deleting local files.",
+          "allowNo": false
+        },
+        "only": {
+          "name": "only",
+          "type": "option",
+          "char": "o",
+          "description": "Download only the specified files (Multiple flags allowed).",
+          "multiple": true
+        },
+        "ignore": {
+          "name": "ignore",
+          "type": "option",
+          "char": "x",
+          "description": "Skip downloading the specified files (Multiple flags allowed).",
+          "multiple": true
+        },
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "char": "j",
+          "description": "Output JSON instead of a UI.",
+          "allowNo": false
+        },
+        "allow-live": {
+          "name": "allow-live",
+          "type": "boolean",
+          "char": "a",
+          "description": "Allow push to a live theme.",
+          "allowNo": false
+        },
+        "publish": {
+          "name": "publish",
+          "type": "boolean",
+          "char": "p",
+          "description": "Publish as the live theme after uploading.",
+          "allowNo": false
+        },
+        "stable": {
+          "name": "stable",
+          "type": "boolean",
+          "description": "Performs the upload by relying in the legacy upload approach (slower, but it might be more stable in some scenarios)",
+          "hidden": true,
+          "allowNo": false
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "hidden": true,
+          "allowNo": false
+        }
+      },
+      "args": [],
+      "cli2Flags": [
+        "theme",
+        "development",
+        "live",
+        "unpublished",
+        "nodelete",
+        "only",
+        "ignore",
+        "json",
+        "allow-live",
+        "publish",
+        "stable",
+        "force"
+      ]
+    },
+    "theme:serve": {
+      "id": "theme:serve",
+      "description": "Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "hidden": true,
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your theme directory.",
+          "hidden": false,
+          "multiple": false,
+          "default": "."
+        },
+        "host": {
+          "name": "host",
+          "type": "option",
+          "description": "Set which network interface the web server listens on. The default value is 127.0.0.1.",
+          "multiple": false
+        },
+        "live-reload": {
+          "name": "live-reload",
+          "type": "option",
+          "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
+          "multiple": false,
+          "options": [
+            "hot-reload",
+            "full-page",
+            "off"
+          ],
+          "default": "hot-reload"
+        },
+        "poll": {
+          "name": "poll",
+          "type": "boolean",
+          "description": "Force polling to detect file changes.",
+          "allowNo": false
+        },
+        "theme-editor-sync": {
+          "name": "theme-editor-sync",
+          "type": "boolean",
+          "char": "e",
+          "description": "Synchronize Theme Editor updates in the local theme files.",
+          "allowNo": false
+        },
+        "port": {
+          "name": "port",
+          "type": "option",
+          "description": "Local port to serve theme preview from.",
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "option",
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "multiple": false
+        },
+        "only": {
+          "name": "only",
+          "type": "option",
+          "char": "o",
+          "description": "Hot reload only files that match the specified pattern.",
+          "multiple": true
+        },
+        "ignore": {
+          "name": "ignore",
+          "type": "option",
+          "char": "x",
+          "description": "Skip hot reloading any files that match the specified pattern.",
+          "multiple": true
+        },
+        "stable": {
+          "name": "stable",
+          "type": "boolean",
+          "description": "Performs the upload by relying in the legacy upload approach (slower, but it might be more stable in some scenarios)",
+          "hidden": true,
+          "allowNo": false
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "hidden": true,
+          "allowNo": false
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": []
+    },
+    "theme:share": {
+      "id": "theme:share",
+      "description": "Creates a shareable, unpublished, and new theme on your theme library with a randomized name. Works like an alias to {{command:theme push -u -t=RANDOMIZED_NAME}}.",
+      "strict": true,
+      "pluginName": "@shopify/theme",
+      "pluginAlias": "@shopify/theme",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your theme directory.",
+          "hidden": false,
+          "multiple": false,
+          "default": "."
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "hidden": true,
+          "allowNo": false
+        }
+      },
+      "args": [],
+      "cli2Flags": [
+        "force"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Current oclif manifests are not human readable and when they are updated, it's impossible to understand the diffs

### WHAT is this pull request doing?

Prettify all the manifests after refreshing them

### How to test your changes?

`pnpm refresh-manifests`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
