### PR TITLE
Improve error handling in proxy 

### DIFF
--- a/.changeset/spicy-parrots-do.md
+++ b/.changeset/spicy-parrots-do.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix proxy crashing with ECONNREFUSED/ECONNRESET when a process isn't ready to receive packets.

--- a/fixtures/app/web/package.json
+++ b/fixtures/app/web/package.json
@@ -23,7 +23,7 @@
     "serve-static": "^1.14.1"
   },
   "devDependencies": {
-    "nodemon": "^2.0.15",
+    "nodemon": "2.0.20",
     "prettier": "^2.6.1",
     "pretty-quick": "^3.1.3",
     "supertest": "^6.2.2",

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
@@ -59,21 +59,4 @@ describe('runConcurrentHTTPProcessesAndPathForwardTraffic', () => {
     expect(concurrentProcesses[1].prefix).toEqual('web')
     expect(server.close).not.toHaveBeenCalled()
   })
-
-  test('uses a random port when no port is passed', async () => {
-    // Given
-    const server: any = {register: vi.fn(), listen: vi.fn(), close: vi.fn()}
-    vi.mocked(getAvailableTCPPort).mockResolvedValueOnce(4000)
-
-    // When
-    const got = await runConcurrentHTTPProcessesAndPathForwardTraffic({
-      previewUrl: '',
-      portNumber: undefined,
-      proxyTargets: [],
-      additionalProcesses: [],
-    })
-
-    // Then
-    expect(server.close).not.toHaveBeenCalled()
-  })
 })

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -27,7 +27,7 @@ export interface ReverseHTTPProxyTarget {
 
 interface Options {
   previewUrl: string | undefined
-  portNumber: number | undefined
+  portNumber: number
   proxyTargets: ReverseHTTPProxyTarget[]
   additionalProcesses: OutputProcess[]
 }
@@ -43,7 +43,7 @@ interface Options {
  */
 export async function runConcurrentHTTPProcessesAndPathForwardTraffic({
   previewUrl,
-  portNumber = undefined,
+  portNumber,
   proxyTargets,
   additionalProcesses,
 }: Options): Promise<void> {
@@ -66,10 +66,8 @@ export async function runConcurrentHTTPProcessesAndPathForwardTraffic({
     }),
   )
 
-  const availablePort = portNumber ?? (await getAvailableTCPPort())
-
   outputDebug(outputContent`
-Starting reverse HTTP proxy on port ${outputToken.raw(availablePort.toString())}
+Starting reverse HTTP proxy on port ${outputToken.raw(portNumber.toString())}
 Routing traffic rules:
 ${outputToken.json(JSON.stringify(rules))}
 `)
@@ -124,7 +122,7 @@ ${outputToken.json(JSON.stringify(rules))}
     }
   }
 
-  await Promise.all([renderConcurrent(renderConcurrentOptions), server.listen(availablePort)])
+  await Promise.all([renderConcurrent(renderConcurrentOptions), server.listen(portNumber)])
 }
 
 function match(rules: {[key: string]: string}, req: http.IncomingMessage) {

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -51,7 +51,6 @@ interface Chunk {
  * 2022-10-10 13:11:03 | frontend   | > cross-env NODE_ENV=development node vite-server.js
  * 2022-10-10 13:11:03 | frontend   |
  * 2022-10-10 13:11:03 | frontend   |
- * 2022-10-10 13:11:03 | backend    | [nodemon] 2.0.19
  * 2022-10-10 13:11:03 | backend    |
  * 2022-10-10 13:11:03 | backend    | [nodemon] to restart at any time, enter `rs`
  * 2022-10-10 13:11:03 | backend    | [nodemon] watching path(s): backend/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,7 +166,7 @@ importers:
       cookie-parser: ^1.4.6
       cross-env: ^7.0.3
       express: ^4.17.3
-      nodemon: ^2.0.15
+      nodemon: 2.0.20
       prettier: ^2.6.1
       pretty-quick: ^3.1.3
       serve-static: ^1.14.1


### PR DESCRIPTION
### WHY are these changes introduced?

Whenever one of the processes connected to the proxy crashes, the CLI crashes as well.

### WHAT is this pull request doing?

Add error handling to the proxy we use for web requests and websockets.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
