### PR TITLE
Fix: The `Syncer::Uploader` should not report IO messages when the `--json` flag is passed

### DIFF
--- a/.changeset/slimy-cherries-smoke.md
+++ b/.changeset/slimy-cherries-smoke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Fix: The CLI should not report IO messages when the `--json` flag is passed

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/push.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/push.rb
@@ -67,6 +67,7 @@ module Theme
         begin
           syncer.start_threads
           if options.flags[:json]
+            syncer.standard_reporter.disable!
             syncer.upload_theme!(delete: delete)
           else
             CLI::UI::Frame.open(@ctx.message("theme.push.info.pushing", theme.name, theme.id, theme.shop)) do

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer.rb
@@ -33,7 +33,7 @@ module ShopifyCLI
         :union_merge, # - Union merges the local file content with the remote file content
       ]
 
-      attr_reader :ctx, :theme, :checksums, :error_checksums, :api_client, :pending
+      attr_reader :ctx, :theme, :checksums, :error_checksums, :api_client, :pending, :standard_reporter
       attr_accessor :include_filter, :ignore_filter
 
       def_delegators :@error_reporter, :has_any_error?

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer/standard_reporter.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer/standard_reporter.rb
@@ -24,7 +24,7 @@ module ShopifyCLI
         end
 
         def report(message)
-          ctx.puts(message) if @enabled
+          ctx.error(message) if @enabled
         end
       end
     end

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer/standard_reporter.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer/standard_reporter.rb
@@ -5,7 +5,7 @@ module ShopifyCLI
     class Syncer
       ##
       # ShopifyCLI::Theme::Syncer::StdReporter allows disabling/enabling
-      # messages reported in the standard output (ShopifyCLI::Context#puts).
+      # messages reported in the standard error output (ShopifyCLI::Context#puts).
       #
       class StandardReporter
         attr_reader :ctx

--- a/packages/cli-kit/assets/cli-ruby/test/project_types/theme/commands/push_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/project_types/theme/commands/push_test.rb
@@ -24,7 +24,7 @@ module Theme
           editor_url: "https://test.myshopify.io/",
           live?: false,
         )
-        @syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: false)
+        @syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: false, standard_reporter: mock)
         @ignore_filter = mock("IgnoreFilter")
         @include_filter = mock("IncludeFilter")
 
@@ -226,6 +226,7 @@ module Theme
         @syncer.expects(:start_threads)
         @syncer.expects(:shutdown)
 
+        @syncer.standard_reporter.expects(:disable!)
         @syncer.expects(:upload_theme!).with(delete: true)
         @command.expects(:puts).with("{\"theme\":{}}")
 
@@ -239,7 +240,7 @@ module Theme
       end
 
       def test_push_when_syncer_has_an_error_json
-        syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: true)
+        syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: true, standard_reporter: stub(disable!: nil))
 
         ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
           .with(@ctx, root: @root, identifier: 1234)

--- a/packages/cli-kit/assets/cli-ruby/test/project_types/theme/commands/push_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/project_types/theme/commands/push_test.rb
@@ -240,7 +240,8 @@ module Theme
       end
 
       def test_push_when_syncer_has_an_error_json
-        syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: true, standard_reporter: stub(disable!: nil))
+        syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: true,
+          standard_reporter: stub(disable!: nil))
 
         ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
           .with(@ctx, root: @root, identifier: 1234)

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/syncer_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/syncer_test.rb
@@ -573,7 +573,7 @@ module ShopifyCLI
         @syncer.start_threads
 
         # Assert a single synced message
-        @ctx.expects(:puts)
+        @ctx.expects(:error)
           .with("12:30:59 {{green:Synced}} {{>}} {{blue:update #{file_path}}}").once
 
         file.stubs(checksum: "initial")
@@ -637,7 +637,7 @@ module ShopifyCLI
         end
 
         # Assert a single fix message
-        @ctx.expects(:puts).with("12:30:59 {{cyan:Fixed }} {{>}} {{blue:update sections/footer.liquid}}").once
+        @ctx.expects(:error).with("12:30:59 {{cyan:Fixed }} {{>}} {{blue:update sections/footer.liquid}}").once
         file.stubs(checksum: "initial")
         time_freeze do
           @syncer.enqueue_updates([file])


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1377

### WHAT is this pull request doing?

When some bulk upload fails, the `Syncer::Uploader` relies on regular uploads as a fallback, however, regular uploads print success messages even when the `--json` flag is passed.

This PR fixes that by deactivating the `standard_reporter` when the `--json` flag is passed.

### How to test your changes?

- First of all, let's emulate the fallback scenario
- Open the `packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer/uploader.rb`
- Update the `bulk_upload!` method with this body:
  ```ruby
  def bulk_upload!
    update_progress_bar!

    enqueue_bulk_updates(liquid_files)
    enqueue_bulk_updates(json_files)
    enqueue_bulk_updates(config_files)

    # if delay_low_priority_files?
      # Process lower-priority files (assets) in the background, as they
      # are served locally
      enqueue_updates(static_asset_files)
    # else
      # enqueue_bulk_updates(static_asset_files)
    # end

    wait!(&@update_progress_bar_block) unless delay_low_priority_files?
  end
  ```
- Now, run `shopify-dev theme push --unpublished --ison --theme new-theme`
- Notice that success messages no longer appear

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
