### PR TITLE
Add try/cach to extension bundle

### DIFF
--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -56,6 +56,14 @@ export async function bundleExtension(options: BundleOptions) {
       }
     })
   }
+
+  // TEMPORARY - hack the built javascript bundle by adding a try/catch around the entire script.
+  // This ensures that any unexpected error that may occur gets output to console log and not
+  // swallowed by our web worker.
+  const fs = require('fs');
+  const mainJs = fs.readFileSync(esbuildOptions.outfile, 'utf8')
+  const safeJs = `try{${mainJs}}catch(e){console.log('Unexpected Error Loading Script',e,e.stack)}`
+  fs.writeFileSync(esbuildOptions.outfile, safeJs, { encoding: 'utf8' })
   onResult(result, options)
 }
 


### PR DESCRIPTION
Temporarily hack the built javascript bundle for extensions by adding a try/catch around the entire script.  This ensures that any unexpected error that may occur gets output to console log and not swallowed by our web worker.

### WHY are these changes introduced?

When developing native UI extensions for POS, it is possible to get into a state where the extension fails to load. The Smart Grid tile just says "Error loading extension," but there is no further information available. Trying to use chrome://inspect shows no console error messages whatsoever, leaving a partner with no good avenue to debug.

### WHAT is this pull request doing?

This PR is a possible short-term solution that ensures that the extension bundle that we build is wrapped in a try/catch so that any error is properly caught and output to the console. Long-term, we should consider modifying the web worker which calls `importScript` to either do a try/catch or ensure that errors are properly reported.

### How to test your changes?

One easy way of getting into this state is to create a new POS UI extension and then to make the following change to your src/index.js file:

```javascript
throw new Error("Simulate a catastrophic error");
render('Retail::SmartGrid::Tile', () => <SmartGridTile />);
render('Retail::SmartGrid::Modal', () => <SmartGridModal />);
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
