### PR TITLE
Skip first run

### DIFF
--- a/workspace/src/benchmark.js
+++ b/workspace/src/benchmark.js
@@ -12,10 +12,10 @@ import {promises as fs, existsSync} from 'fs'
 import {cloneCLIRepository} from './utils/git.js'
 import {logMessage, logSection} from './utils/log.js'
 
-const TOTAL_RUNS = 5
+const TOTAL_TIMES = 5
 
 async function benchmark(directory, results = {}, time = 1, {name}) {
-  logSection(`Benchmarking ${name}. ${times} remaining`)
+  logSection(`Benchmarking ${name}. Time ${time}`)
 
   for (const pluginName of ['app', 'theme']) {
     const oclifManifestPath = path.join(directory, 'packages', pluginName, 'oclif.manifest.json')
@@ -46,8 +46,8 @@ async function benchmark(directory, results = {}, time = 1, {name}) {
     }
   }
 
-  if (times < TOTAL_RUNS) {
-    return benchmark(directory, results, times + 1, {name})
+  if (time < TOTAL_TIMES) {
+    return benchmark(directory, results, time + 1, {name})
   } else {
     return results
   }

--- a/workspace/src/benchmark.js
+++ b/workspace/src/benchmark.js
@@ -16,7 +16,7 @@ const TOTAL_TIMES = 5
 
 async function benchmark(directory, {name}) {
   const results = {}
-  for (let time = 1; time < 5; time++) {
+  for (let time = 1; time < TOTAL_TIMES; time++) {
     logSection(`Benchmarking ${name}. Time ${time}`)
 
     for (const pluginName of ['app', 'theme']) {


### PR DESCRIPTION
### WHY are these changes introduced?
The benchmarking workflow yields non-deterministic numbers in PRs. This PR is an attempt to reduce the non-determinism by ignoring the results of the first iteration assuming the engine does some optimizations that persist across runs.
This might not work as expected because GitHub Actions is most likely sharing the virtual environment in which the workflows run with other virtual environments and therefore the CPU and the Memory that's available is impacted by the load of other jobs running in the same host. The only way to achieve full determinism is running it in a more controlled environment like our laptops or a baremetal host.

### WHAT is this pull request doing?
I adjusted the `benchmark.js` script to ignore the first results.

### How to test your changes?
We should see the report in this PR.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
