### PR TITLE
Add uncaughtException handler so that the exit handler is always called

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,8 +9,14 @@ import fs from 'fs'
 // the error stack and manually call exit so that the cleanup code is called. This
 // makes sure that there are no lingering ngrok processes.
 process.on('uncaughtException', (err) => {
-  fs.writeSync(process.stderr.fd, `${err.stack}\n\n`)
+  fs.writeSync(process.stderr.fd, `${err.stack}\n`)
   process.exit(1)
+})
+const signals = ['SIGINT', 'SIGTERM', 'SIGQUIT']
+signals.forEach((signal) => {
+  process.on(signal, () => {
+    process.exit(1)
+  })
 })
 
 interface RunShopifyCLIOptions {


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed that if the proxy process crashes, the ngrok plugin is left running in the background.

### WHAT is this pull request doing?

Adds a `uncaughtException` handler that prints the stack and calls `process.exit` manually. Also handle common quit signals, like `SIGTERM`, `SIGQUIT` and `SIGINT`.

### How to test your changes?

**SIGTERM**

Try these steps on `main`
- now create a new app: `pnpm create-app --local --path ~/Desktop --name=test-error-handling`
- now run `pnpm shopify app dev --path ~/Desktop/test-error-handling`
- after everything is booted run `ps aux | grep app dev` and kill the process using `kill <pid>` (don't use -9 as it will skip cleanup code)
- if you run `ps aux | grep ngrok` you will see a lingering ngrok process in the background

Now change onto this branch:
- run `pnpm clean && pnpm shopify app dev --path ~/Desktop/test-error-handling`
- after everything is booted run `ps aux | grep app dev` and kill the process using `kill <pid>` (don't use -9 as it will skip cleanup code)
- if you run `ps aux | grep ngrok` you will see NO lingering ngrok

**uncaughtException**

Try these steps on `main`
- in `packages/app/src/cli/services/dev.ts` replace the line `const proxyPort = usingLocalhost ? await getAvailableTCPPort() : frontendPort` with `const proxyPort = 8000`
- run a python server on port 8000: `python3 -m http.server`
- now create a new app: `pnpm create-app --local --path ~/Desktop --name=test-error-handling`
- now run `pnpm shopify app dev --path ~/Desktop/test-error-handling`
- you should see the CLI crash because the proxy tries to connect to a port that's already in use
- if you run `ps aux | grep ngrok` you will see a lingering ngrok process in the background

Now change onto this branch:
- run `pnpm clean && pnpm shopify app dev --path ~/Desktop/test-error-handling`
- you will see the crash again, but this time `ps aux | grep ngrok` should have NO lingering ngrok process



### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
