### PR TITLE
Fixed problem with theme app extension server in spin

### DIFF
--- a/.changeset/curvy-papayas-travel.md
+++ b/.changeset/curvy-papayas-travel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fixed problem with theme app extension server in spin

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -184,7 +184,8 @@ module ShopifyCLI
           # (Taken from Rack::Proxy)
           response_headers.reject! { |k| HOP_BY_HOP_HEADERS.include?(k.downcase) }
 
-          if response_headers["location"]&.include?("myshopify.com") || response_headers["location"]&.include?("spin.dev")
+          if response_headers["location"]&.include?("myshopify.com")
+            || response_headers["location"]&.include?("spin.dev")
             response_headers["location"].gsub!(%r{(https://#{shop})}, "http://#{host(env)}")
           end
 

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -184,8 +184,8 @@ module ShopifyCLI
           # (Taken from Rack::Proxy)
           response_headers.reject! { |k| HOP_BY_HOP_HEADERS.include?(k.downcase) }
 
-          if response_headers["location"]&.include?("myshopify.com")
-            || response_headers["location"]&.include?("spin.dev")
+          if response_headers["location"]&.include?("myshopify.com") ||
+            response_headers["location"]&.include?("spin.dev")
             response_headers["location"].gsub!(%r{(https://#{shop})}, "http://#{host(env)}")
           end
 

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -184,7 +184,7 @@ module ShopifyCLI
           # (Taken from Rack::Proxy)
           response_headers.reject! { |k| HOP_BY_HOP_HEADERS.include?(k.downcase) }
 
-          if response_headers["location"]&.include?("myshopify.com")
+          if response_headers["location"]&.include?("myshopify.com") || response_headers["location"]&.include?("spin.dev")
             response_headers["location"].gsub!(%r{(https://#{shop})}, "http://#{host(env)}")
           end
 


### PR DESCRIPTION
### WHY are these changes introduced?
When you run the `dev` command with a `theme app extension` the cli is running the ruby-cli `extension serve` command. This command is running a http server that allows the user to preview the content of the extension. 
This feature is working when you run the command against `shopify.com` but not when the command uses a `spin` environment.
These are the verbose messages of the proxy when it's working properly
![image](https://user-images.githubusercontent.com/105213827/219419751-4c687a9d-db90-45d9-b9bd-e7253f5fab21.png)

These ones are when it run against `spin`
![image](https://user-images.githubusercontent.com/105213827/219419962-3d35f163-ed2b-4108-bb73-115726ea3ff3.png)


### WHAT is this pull request doing?
- Add support to the theme app extension server for spin domains

### How to test your changes?
- Run the following command `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name) yarn shopify app dev` with an app that includes a theme app extension

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
