### PR TITLE
Enable no color outputs

### DIFF
--- a/.changeset/short-wombats-kiss.md
+++ b/.changeset/short-wombats-kiss.md
@@ -1,0 +1,11 @@
+---
+'@shopify/app': minor
+'@shopify/cli': minor
+'@shopify/cli-hydrogen': minor
+'@shopify/cli-kit': minor
+'@shopify/create-app': minor
+'@shopify/create-hydrogen': minor
+'@shopify/theme': minor
+---
+
+Enable no color mode

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -24,6 +24,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -68,6 +75,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -123,6 +137,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -257,6 +278,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -301,6 +329,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -424,6 +459,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -465,6 +507,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -495,6 +544,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -531,6 +587,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -561,6 +624,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -604,6 +674,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -637,6 +714,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -730,6 +814,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -771,6 +862,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },

--- a/packages/cli-hydrogen/oclif.manifest.json
+++ b/packages/cli-hydrogen/oclif.manifest.json
@@ -24,6 +24,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -85,6 +92,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -174,6 +188,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -225,6 +246,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -269,6 +297,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -332,6 +367,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -376,6 +418,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -25,6 +25,10 @@ export const environmentVariables = {
   verbose: 'SHOPIFY_FLAG_VERBOSE',
   themeBundling: 'SHOPIFY_CLI_THEME_BUNDLING',
   javascriptFunctions: 'SHOPIFY_CLI_FUNCTIONS_JAVASCRIPT',
+  noColor: 'NO_COLOR',
+  shopifyNoColor: 'SHOPIFY_FLAG_NO_COLOR',
+  forceColor: 'FORCE_COLOR',
+  term: 'TERM',
   // Variables to detect if the CLI is running in a cloud environment
   codespaceName: 'CODESPACE_NAME',
   codespaces: 'CODESPACES',

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -9,6 +9,7 @@ import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
 import figures from 'figures'
 import {debounce} from '@shopify/cli-kit/common/function'
 import ansiEscapes from 'ansi-escapes'
+import {COLORS} from '@shopify/cli-kit/node/output'
 
 export interface SearchResults<T> {
   data: SelectItem<T>[]
@@ -165,10 +166,10 @@ function AutocompletePrompt<T>({
       {promptState === PromptState.Submitted ? (
         <Box>
           <Box marginRight={2}>
-            <Text color="cyan">{figures.tick}</Text>
+            <Text color={COLORS.cyan}>{figures.tick}</Text>
           </Box>
 
-          <Text color="cyan">{answer!.label}</Text>
+          <Text color={COLORS.cyan}>{answer!.label}</Text>
         </Box>
       ) : (
         <Box marginTop={1}>

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -1,5 +1,5 @@
 import {TextWithBackground} from './TextWithBackground.js'
-import {OutputProcess} from '../../../../public/node/output.js'
+import {OutputProcess, shouldDisplayColors} from '../../../../public/node/output.js'
 import useAsyncAndUnmount from '../hooks/use-async-and-unmount.js'
 import {AbortController} from '../../../../public/node/abort.js'
 import {handleCtrlC} from '../../ui.js'
@@ -72,6 +72,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
   const prefixColumnSize = Math.max(...processes.map((process) => process.prefix.length))
 
   function lineColor(index: number) {
+    if (!shouldDisplayColors()) return 'black'
     const colorIndex = index < concurrentColors.length ? index : index % concurrentColors.length
     return concurrentColors[colorIndex]!
   }

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
@@ -6,6 +6,7 @@ import {BugError, cleanSingleStackTracePath, ExternalError, FatalError as Fatal}
 import {Box, Text} from 'ink'
 import React, {FunctionComponent} from 'react'
 import StackTracey from 'stacktracey'
+import {COLORS} from '@shopify/cli-kit/node/output'
 
 export interface FatalErrorProps {
   error: Fatal
@@ -70,7 +71,7 @@ const FatalError: FunctionComponent<FatalErrorProps> = ({error}) => {
           {stack.items.map((item, index) => (
             <Box flexDirection="column" key={index} paddingLeft={2}>
               <Text>
-                at{item.calleeShort ? <Text color="yellow">{` ${item.calleeShort}`}</Text> : null}
+                at{item.calleeShort ? <Text color={COLORS.yellow}>{` ${item.calleeShort}`}</Text> : null}
                 {item.fileShort ? ` (${item.fileShort}:${item.line})` : null}
               </Text>
               <Box paddingLeft={2}>

--- a/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
@@ -6,6 +6,7 @@ import {Box, Key, useInput, Text} from 'ink'
 import {debounce} from '@shopify/cli-kit/common/function'
 import chalk from 'chalk'
 import figures from 'figures'
+import {COLORS} from '@shopify/cli-kit/node/output'
 
 interface OnChangeOptions<T> {
   item: Item<T> | undefined
@@ -102,9 +103,11 @@ function SelectItemsGroup<T>({
 
         return (
           <Box key={item.key}>
-            <Box marginRight={2}>{isSelected ? <Text color="cyan">{`>`}</Text> : <Text> </Text>}</Box>
+            <Box marginRight={2}>{isSelected ? <Text color={COLORS.cyan}>{`>`}</Text> : <Text> </Text>}</Box>
 
-            <Text color={isSelected ? 'cyan' : undefined}>{enableShortcuts ? `(${item.key}) ${label}` : label}</Text>
+            <Text color={isSelected ? COLORS.cyan : undefined}>
+              {enableShortcuts ? `(${item.key}) ${label}` : label}
+            </Text>
           </Box>
         )
       })}
@@ -230,7 +233,7 @@ function SelectInput<T>({
   } else if (errorMessage && errorMessage.length > 0) {
     return (
       <Box marginLeft={3}>
-        <Text color="red">{errorMessage}</Text>
+        <Text color={COLORS.red}>{errorMessage}</Text>
       </Box>
     )
   } else if (items.length === 0) {

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -7,6 +7,7 @@ import React, {ReactElement, useCallback, useState} from 'react'
 import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
 import figures from 'figures'
 import ansiEscapes from 'ansi-escapes'
+import {COLORS} from '@shopify/cli-kit/node/output'
 
 export interface SelectPromptProps<T> {
   message: TokenItem<Exclude<InlineToken, LinkToken>>
@@ -84,10 +85,10 @@ function SelectPrompt<T>({
       {submitted ? (
         <Box>
           <Box marginRight={2}>
-            <Text color="cyan">{figures.tick}</Text>
+            <Text color={COLORS.cyan}>{figures.tick}</Text>
           </Box>
 
-          <Text color="cyan">{answer!.label}</Text>
+          <Text color={COLORS.cyan}>{answer!.label}</Text>
         </Box>
       ) : (
         <Box marginTop={1}>

--- a/packages/cli-kit/src/private/node/ui/components/TextInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextInput.tsx
@@ -2,6 +2,7 @@
 import React, {useEffect, useState} from 'react'
 import {Text, useInput} from 'ink'
 import chalk from 'chalk'
+import {COLORS} from '@shopify/cli-kit/node/output'
 import type {FunctionComponent} from 'react'
 
 interface TextInputProps {
@@ -19,7 +20,7 @@ const TextInput: FunctionComponent<TextInputProps> = ({
   defaultValue = '',
   onChange,
   placeholder = '',
-  color = 'cyan',
+  color = COLORS.cyan,
   password = false,
   focus = true,
 }) => {

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -6,6 +6,7 @@ import {messageWithPunctuation} from '../utilities.js'
 import React, {FunctionComponent, useCallback, useState} from 'react'
 import {Box, useApp, useInput, Text} from 'ink'
 import figures from 'figures'
+import {COLORS} from '@shopify/cli-kit/node/output'
 
 export interface TextPromptProps {
   message: string
@@ -42,7 +43,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   const [submitted, setSubmitted] = useState(false)
   const [error, setError] = useState<string | undefined>(undefined)
   const shouldShowError = submitted && error
-  const color = shouldShowError ? 'red' : 'cyan'
+  const color = shouldShowError ? COLORS.red : COLORS.cyan
   const underline = new Array(oneThird - 3).fill('▔')
 
   useInput(
@@ -76,11 +77,11 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
       {submitted && !error ? (
         <Box>
           <Box marginRight={2}>
-            <Text color="cyan">{figures.tick}</Text>
+            <Text color={COLORS.cyan}>{figures.tick}</Text>
           </Box>
 
           <Box flexGrow={1}>
-            <Text color="cyan">{password ? '*'.repeat(answer.length) : answerOrDefault}</Text>
+            <Text color={COLORS.cyan}>{password ? '*'.repeat(answer.length) : answerOrDefault}</Text>
           </Box>
         </Box>
       ) : (

--- a/packages/cli-kit/src/private/node/ui/components/UserInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/UserInput.tsx
@@ -1,3 +1,4 @@
+import {COLORS} from '@shopify/cli-kit/node/output'
 import {Text} from 'ink'
 import React, {FunctionComponent} from 'react'
 
@@ -10,7 +11,7 @@ interface UserInputProps {
  * For example an answer to a selection prompt.
  */
 const UserInput: FunctionComponent<UserInputProps> = ({userInput}): JSX.Element => {
-  return <Text color="cyan">{userInput}</Text>
+  return <Text color={COLORS.cyan}>{userInput}</Text>
 }
 
 export {UserInput}

--- a/packages/cli-kit/src/public/node/cli.ts
+++ b/packages/cli-kit/src/public/node/cli.ts
@@ -150,6 +150,11 @@ export const globalFlags = {
     description: 'Increase the verbosity of the logs.',
     env: 'SHOPIFY_FLAG_VERBOSE',
   }),
+  'no-color': Flags.boolean({
+    hidden: false,
+    description: 'Disable color output.',
+    env: 'SHOPIFY_FLAG_NO_COLOR',
+  }),
 }
 
 export default runCLI

--- a/packages/cli-kit/src/public/node/output.test.ts
+++ b/packages/cli-kit/src/public/node/output.test.ts
@@ -1,5 +1,5 @@
-import {outputToken} from './output.js'
-import {describe, expect, it} from 'vitest'
+import {outputToken, shouldDisplayColors} from './output.js'
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 
 describe('Output helpers', () => {
   it('can format dependency manager commands with flags', () => {
@@ -11,5 +11,67 @@ describe('Output helpers', () => {
     expect(outputToken.packagejsonScript('yarn', 'dev').value).toEqual('yarn dev')
     expect(outputToken.packagejsonScript('npm', 'dev').value).toEqual('npm run dev')
     expect(outputToken.packagejsonScript('pnpm', 'dev').value).toEqual('pnpm dev')
+  })
+})
+
+describe('shouldDisplayColors', () => {
+  beforeEach(() => {
+    process.stdout.isTTY = true
+  })
+
+  afterEach(() => {
+    process.stdout.isTTY = false
+  })
+
+  it('returns true in TTY', () => {
+    // GIVEN
+    const env = {}
+
+    // WHEN/THEN
+    expect(shouldDisplayColors(env)).toBeTruthy()
+  })
+
+  it('returns true when FORCE_COLOR is set', () => {
+    // GIVEN
+    process.stdout.isTTY = false
+    const env = {FORCE_COLOR: '1'}
+
+    // WHEN/THEN
+    expect(shouldDisplayColors(env)).toBeTruthy()
+  })
+
+  it('returns false when NO_COLOR is set', () => {
+    // GIVEN
+    const env = {NO_COLOR: '1'}
+
+    // WHEN/THEN
+    expect(shouldDisplayColors(env)).toBeFalsy()
+  })
+
+  it('returns false when SHOPIFY_FLAG_NO_COLOR is set', () => {
+    // GIVEN
+    const env = {SHOPIFY_FLAG_NO_COLOR: '1'}
+
+    // WHEN/THEN
+    expect(shouldDisplayColors(env)).toBeFalsy()
+  })
+
+  it('returns false when --no-color is set', () => {
+    // GIVEN
+    const originalArgv = process.argv
+    process.argv = ['--no-color']
+    const env = {}
+
+    // WHEN/THEN
+    expect(shouldDisplayColors(env)).toBeFalsy()
+    process.argv = originalArgv
+  })
+
+  it('returns false when TERM is dumb', () => {
+    // GIVEN
+    const env = {TERM: 'dumb'}
+
+    // WHEN/THEN
+    expect(shouldDisplayColors(env)).toBeFalsy()
   })
 })

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -10,6 +10,27 @@
       "pluginType": "core",
       "aliases": [],
       "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -28,7 +49,29 @@
       "pluginAlias": "@shopify/cli",
       "pluginType": "core",
       "aliases": [],
-      "flags": {},
+      "flags": {
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        }
+      },
       "args": {}
     },
     "auth:logout": {

--- a/packages/cli/src/cli/commands/upgrade.ts
+++ b/packages/cli/src/cli/commands/upgrade.ts
@@ -3,11 +3,13 @@ import {Flags} from '@oclif/core'
 import Command from '@shopify/cli-kit/node/base-command'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
 
 export default class Upgrade extends Command {
   static description = 'Upgrade the Shopify CLI.'
 
   static flags = {
+    ...globalFlags,
     path: Flags.string({
       hidden: false,
       description: 'The path to your project directory.',

--- a/packages/cli/src/cli/commands/version.ts
+++ b/packages/cli/src/cli/commands/version.ts
@@ -1,8 +1,13 @@
 import {versionService} from '../services/commands/version.js'
 import Command from '@shopify/cli-kit/node/base-command'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
 
 export default class Version extends Command {
   static description = 'Shopify CLI version.'
+
+  static flags = {
+    ...globalFlags,
+  }
 
   async run(): Promise<void> {
     await versionService()

--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -25,6 +25,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "name": {
           "name": "name",
           "type": "option",

--- a/packages/create-hydrogen/oclif.manifest.json
+++ b/packages/create-hydrogen/oclif.manifest.json
@@ -25,6 +25,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "name": {
           "name": "name",
           "type": "option",

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -24,6 +24,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -157,6 +164,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "store": {
           "name": "store",
           "type": "option",
@@ -194,6 +208,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -262,6 +283,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -400,6 +428,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "command": {
           "name": "command",
           "type": "option",
@@ -431,6 +466,13 @@
           "description": "Increase the verbosity of the logs.",
           "hidden": false,
           "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
         }
       },
       "args": {}
@@ -455,6 +497,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -512,6 +561,13 @@
           "description": "Increase the verbosity of the logs.",
           "hidden": false,
           "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
         }
       },
       "args": {}
@@ -536,6 +592,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -599,6 +662,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -670,6 +740,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -701,6 +778,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -755,6 +839,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -862,6 +953,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },
@@ -1013,6 +1111,13 @@
           "hidden": false,
           "allowNo": false
         },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -1131,6 +1236,13 @@
           "name": "verbose",
           "type": "boolean",
           "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
           "hidden": false,
           "allowNo": false
         },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1161

### WHAT is this pull request doing?

Disables color outputs for dumb terminals or when `--no-color`, `NO_COLOR` or `SHOPIFY_FLAG_NO_COLOR` are provided

It does not work yet for theme commands or when running theme app extensions.

Based on previous work from @amcaplan 

### How to test your changes?

- `pnpm shopify app dev --no-color`
- `NO_COLOR=1 pnpm shopify app dev`
- `SHOPIFY_FLAG_NO_COLOR=1 pnpm shopify app dev`

### Post-release steps

Documentation

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
