### PR TITLE
Only report benchmark results if there are commands with high deviation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,9 +40,9 @@ jobs:
         id: benchmark
         run: pnpm nx run benchmark
       - uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # pin@v2.3.1
+        if: steps.benchmark.outputs.report != ''
         with:
           header: Benchmark
-          if: steps.benchmark.outputs.report != ''
           message: ${{ steps.benchmark.outputs.report }}
           recreate: true
   type-diff:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # pin@v2.3.1
         with:
           header: Benchmark
+          if: steps.benchmark.outputs.report != ''
           message: ${{ steps.benchmark.outputs.report }}
           recreate: true
   type-diff:

--- a/workspace/src/benchmark.js
+++ b/workspace/src/benchmark.js
@@ -66,33 +66,32 @@ async function report(currentBenchmark, baselineBenchmark) {
 
       const diff = round((currentAverageTime / baselineAverageTime - 1) * 100)
       let icon = '⚪️'
-      if (diff < 8) {
-        icon = '🟢'
-      } else if (diff < 10) {
-        icon = '🟡'
-      } else {
-        icon = '🔴'
+      if (diff > 10) {
+        rows.push([
+          '🔴',
+          `\`${command}\``,
+          `${round(baselineAverageTime)} ms`,
+          `${round(currentAverageTime)} ms`,
+          `${diff} %`,
+        ])
       }
-      rows.push([
-        icon,
-        `\`${command}\``,
-        `${round(baselineAverageTime)} ms`,
-        `${round(currentAverageTime)} ms`,
-        `${diff} %`,
-      ])
     }
   }
-  const markdownTable = `| Status | Command | Baseline (avg) | Current (avg) | Diff |
+  if (rows.length !== 0) {
+    const markdownTable = `| Status | Command | Baseline (avg) | Current (avg) | Diff |
 | ------- | -------- | ------- | ----- | ---- |
 ${rows.map((row) => `| ${row.join(' | ')} |`).join('\n')}
 `
-  setOutput(
-    'report',
-    `## Benchmark report
-The following table contains a summary of the startup time for all commands.
+    setOutput(
+      'report',
+      `## Benchmark report
+We detected a significant variation of startup time in the following commands.
+Note that it might be related to external factors that influence the benchmarking.
+If you believe that's the case, feel free to ignore the table below.
 ${markdownTable}
 `,
-  )
+    )
+  }
 }
 
 await temporaryDirectoryTask(async (tmpDir) => {


### PR DESCRIPTION
### WHY are these changes introduced?
The comment that posts the benchmark results in PRs adds a lot of noise.

### WHAT is this pull request doing?
I adjusted the logic to only report the results if there are commands with a high deviation in startup time. Only those commands are listed on the table. 

### How to test your changes?
We shouldn't see the table posted in this PR.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
