### PR TITLE
Embedded cli-ruby opt-in by default

### DIFF
--- a/.changeset/rude-geckos-raise.md
+++ b/.changeset/rude-geckos-raise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Embedded cli-ruby opt-in by default. Use SHOPIFY_CLI_BUNDLED_THEME_CLI=1 in case of problems with the embedded version.

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -1,0 +1,13 @@
+/**
+ * It returns the environment variables of the environment
+ * where the Node process is running.
+ *
+ * This function exists to prevent the access of the process
+ * global variable which is discouraged via the no-process-env
+ * ESLint rule.
+ *
+ * @returns Current process environment variables.
+ */
+export function getEnvironmentVariables(): NodeJS.ProcessEnv {
+  return {...process.env}
+}

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -9,5 +9,5 @@
  * @returns Current process environment variables.
  */
 export function getEnvironmentVariables(): NodeJS.ProcessEnv {
-  return {...process.env}
+  return process.env
 }

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -5,7 +5,7 @@ import {captureOutput, exec} from './system.js'
 import * as file from './fs.js'
 import {joinPath, dirname, cwd} from './path.js'
 import {AbortError, AbortSilentError} from './error.js'
-import {isShopify} from './context/local.js'
+import {getEnvironmentVariables} from './environment.js'
 import {pathConstants} from '../../private/node/constants.js'
 import {AdminSession} from '../../public/node/session.js'
 import {outputContent, outputToken} from '../../public/node/output.js'
@@ -42,11 +42,12 @@ interface ExecCLI2Options {
  * @param options - Options to customize the execution of cli2.
  */
 export async function execCLI2(args: string[], options: ExecCLI2Options = {}): Promise<void> {
-  const embedded = (await isShopify()) || isTruthy(process.env.SHOPIFY_CLI_EMBEDDED_THEME_CLI)
+  const currentEnv = getEnvironmentVariables()
+  const embedded = !isTruthy(currentEnv.SHOPIFY_CLI_BUNDLED_THEME_CLI) && !currentEnv.SHOPIFY_CLI_2_0_DIRECTORY
 
   await installCLIDependencies(options.stdout ?? process.stdout, embedded)
   const env: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...currentEnv,
     SHOPIFY_CLI_STOREFRONT_RENDERER_AUTH_TOKEN: options.storefrontToken,
     SHOPIFY_CLI_ADMIN_AUTH_TOKEN: options.adminSession?.token,
     SHOPIFY_SHOP: options.adminSession?.storeFqdn,
@@ -156,7 +157,7 @@ async function installCLIDependencies(stdout: Writable, embedded = false) {
   const exists = await file.fileExists(localCLI)
 
   if (!exists) stdout.write('Installing theme dependencies...')
-  const usingLocalCLI2 = embedded || isTruthy(process.env.SHOPIFY_CLI_2_0_DIRECTORY)
+  const usingLocalCLI2 = embedded || isTruthy(getEnvironmentVariables().SHOPIFY_CLI_2_0_DIRECTORY)
   await validateRubyEnv()
   if (usingLocalCLI2) {
     await bundleInstallLocalShopifyCLI(localCLI)
@@ -350,7 +351,7 @@ async function shopifyCLIDirectory(embedded = false): Promise<string> {
   })) as string
   const bundledDirectory = joinPath(pathConstants.directories.cache.vendor.path(), 'ruby-cli', RubyCLIVersion)
 
-  return embedded ? embeddedDirectory : process.env.SHOPIFY_CLI_2_0_DIRECTORY ?? bundledDirectory
+  return embedded ? embeddedDirectory : getEnvironmentVariables().SHOPIFY_CLI_2_0_DIRECTORY ?? bundledDirectory
 }
 
 /**
@@ -380,7 +381,7 @@ export async function version(): Promise<string | undefined> {
  * @returns The value of the environment variable.
  */
 function getRubyBinDir(): string | undefined {
-  return process.env.SHOPIFY_RUBY_BINDIR
+  return getEnvironmentVariables().SHOPIFY_RUBY_BINDIR
 }
 
 /**


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
In the first try to use the `embedded cli-ruby` some problems arise so we had to [revert the activation ](https://github.com/Shopify/cli/pull/1346) and opt-it by default only for `shopifolk` users.

There were three main problems:
* Running the Ruby `shopify-cli` bin script using the `env` Ruby version. Solution [PR](https://github.com/Shopify/cli/pull/1304)
* Running `bundler` with a fixed version because of the `Gemfile.lock` presence. Solution PR](https://github.com/Shopify/cli/pull/1347)
* Missed the installation of specific gems in Windows for `theme-app-extension`. Solution [PR](https://github.com/Shopify/cli/pull/1350)



<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Modify the check condition that evaluates when the `embedded cli-ruby` must be used. Now is opted-in by default and the environment variable `SHOPIFY_CLI_BUNDLED_THEME_CLI`  should be set to use the `bundled` version
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Run any theme command using `--verbose` flag and check the exec message of the CLI2. It should be similar to this
```
Running system process:
  · Command: /Users/alvarogutierrez/src/github.com/Shopify/cli/packages/cli-kit/assets/cli-sources/bin/shopify theme check /Users/alvarogutierrez/cli-themes/first-theme --output text
  · Working directory: /Users/alvarogutierrez/cli-themes/first-theme
```

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
