### PR TITLE
Include update docs in changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,6 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-        # Updated documentation should be generated with each release
-      - name: Generate documentation
-        run: pnpm docs:generate
       - name: Create Release Pull Request
         uses: changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a # pin@v1
         with:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:affected": "nx affected --target=build --all",
     "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache",
     "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache && bin/prettify-manifests.js",
-    "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests && bin/update-cli-kit-version.js"
+    "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests && bin/update-cli-kit-version.js && pnpm docs:generate"
   },
   "devDependencies": {
     "@apollo/client": "^3.4.8",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Based on output [here](https://github.com/Shopify/cli/actions/runs/4224935717/jobs/7336537499), it seems the generated docs aren't being committed.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Adds to the (already poorly named) `changeset-manifests` script to include doc generation, so that changesets should include them in the generated PR.

(As an aside, it should be renamed, but only after [releases](https://github.com/Shopify/cli/pull/1237) are released, as that also depends on the same job name.)

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Gotta merge and run!

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
