### PR TITLE
Move embedded cli-ruby dependencies to Gemfile

### DIFF
--- a/.changeset/cuddly-months-draw.md
+++ b/.changeset/cuddly-months-draw.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+For the embedded cli-ruby the dependencies were moved from the gemspec to the Gemfile

--- a/packages/cli-kit/assets/cli-ruby/Gemfile
+++ b/packages/cli-kit/assets/cli-ruby/Gemfile
@@ -1,13 +1,14 @@
 # NOTE: These are development-only dependencies
 source "https://rubygems.org"
 
-gemspec
+gem "bugsnag", "~> 6.22"
+gem "listen", "~> 3.7.0"
+gem "theme-check", "~> 1.14.0"
 
 # None of these can actually be used in a development copy of dev
 # They are all for CI and tests
 # `dev` uses no gems
 group :development, :test do
-  gem "rake"
   gem "pry-byebug"
   gem "byebug"
   gem "rubocop-shopify", require: false
@@ -16,11 +17,13 @@ group :development, :test do
   gem "iniparse", "~> 1.5"
   gem "colorize", "~> 0.8.1"
   gem "octokit", "~> 4.0"
+  gem "bundler", ">= 2.3.11"
+  gem "rake", "~> 12.3", ">= 12.3.3"
+  gem "minitest", "~> 5.0"
 end
 
 group :test do
   gem "mocha", require: false
-  gem "minitest", ">= 5.0.0", require: false
   gem "minitest-reporters", require: false
   gem "minitest-fail-fast", require: false
   gem "fakefs", ">= 1.0", require: false

--- a/packages/cli-kit/assets/cli-ruby/Gemfile.lock
+++ b/packages/cli-kit/assets/cli-ruby/Gemfile.lock
@@ -1,11 +1,3 @@
-PATH
-  remote: .
-  specs:
-    shopify-cli (2.34.0)
-      bugsnag (~> 6.22)
-      listen (~> 3.7.0)
-      theme-check (~> 1.14.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -120,7 +112,7 @@ GEM
     racc (1.6.2)
     rack (2.2.3.1)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (12.3.3)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -165,24 +157,26 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bugsnag (~> 6.22)
   bundler (>= 2.3.11)
   byebug
   colorize (~> 0.8.1)
   cucumber (~> 7.0)
   fakefs (>= 1.0)
   iniparse (~> 1.5)
-  minitest (>= 5.0.0)
+  listen (~> 3.7.0)
+  minitest (~> 5.0)
   minitest-fail-fast
   minitest-reporters
   mocha
   octokit (~> 4.0)
   pry-byebug
   rack
-  rake
+  rake (~> 12.3, >= 12.3.3)
   rubocop-minitest
   rubocop-rake
   rubocop-shopify
-  shopify-cli!
+  theme-check (~> 1.14.0)
   timecop
   webmock
 

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -15,7 +15,7 @@ import {fileURLToPath} from 'url'
 
 export const RubyCLIVersion = '2.34.0'
 const ThemeCheckVersion = '1.14.0'
-const MinBundlerVersion = '2.3.8'
+const MinBundlerVersion = '2.3.11'
 const MinRubyVersion = '2.7.5'
 export const MinWdmWindowsVersion = '0.1.0'
 
@@ -295,7 +295,7 @@ function getBaseGemfileContent() {
 function getWindowsDependencies() {
   if (platformAndArch().platform === 'windows') {
     // 'wdm' is required by 'listen', see https://github.com/Shopify/cli/issues/780
-    // Because it's a Windows-only dependency, it's not included in the `.gemspec`.
+    // Because it's a Windows-only dependency, it's not included in the `.gemspec` or `Gemfile`.
     // Otherwise it'd install it in non-Windows environments, which is not needed.
     return [`gem 'wdm', '>= ${MinWdmWindowsVersion}'`]
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1327 

Older cli-ruby was using `gemspec` to run several configurations needed to registry the cli as a gem. Once we copied the whole content of the cli2 repo to the cli3 this script is not needed anymore and in fact it was causing an error message in Windows when the `gemspec` set the list of files that should be added to the gem using `git`.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Moving needed dependencies directly to `Gemfile` and remove the using of the `gemspec` file 
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Run any `theme` command in Windows enabling the embedded cli-ruby

```sh
$Env:SHOPIFY_CLI_EMBEDDED_THEME_CLI="1"
shopify theme dev
```
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
