### PR TITLE
Always populate host theme

### DIFF
--- a/.changeset/shy-windows-poke.md
+++ b/.changeset/shy-windows-poke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Always populate host theme

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -170,7 +170,7 @@ async function dev(options: DevOptions) {
       const theme = await new HostThemeManager(adminSession).findOrCreate()
       optionsToOverwrite = {
         theme: theme.id.toString(),
-        generateTmpTheme: theme.createdAtRuntime,
+        generateTmpTheme: true,
       }
     }
     const [storefrontToken, args] = await Promise.all([


### PR DESCRIPTION
### WHY are these changes introduced?

In order to avoid [non-populated host themes](https://github.com/Shopify/cli/pull/1264#pullrequestreview-1295240819), they should be populated _every time_, until Ruby CLI dependency has been removed.

### WHAT is this pull request doing?

Treats a host theme as always `createdAtRuntime`, so that `--generate-tmp-theme` is always passed to CLI 2.

### How to test your changes?

- `shopify app dev` in your favorite app directory.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
