### PR TITLE
We need to update brew before upgrading the cli

### DIFF
--- a/packages/cli/src/cli/services/upgrade.test.ts
+++ b/packages/cli/src/cli/services/upgrade.test.ts
@@ -87,6 +87,9 @@ describe('upgrade global CLI', () => {
         await upgrade(tmpDir, oldCliVersion)
 
         // Then
+        expect(vi.mocked(exec)).toHaveBeenCalledWith('brew', ['update'], {
+          stdio: 'inherit',
+        })
         expect(vi.mocked(exec)).toHaveBeenCalledWith('brew', ['upgrade', homebrewPackageName], {
           stdio: 'inherit',
         })

--- a/packages/cli/src/cli/services/upgrade.ts
+++ b/packages/cli/src/cli/services/upgrade.ts
@@ -93,6 +93,7 @@ async function upgradeGlobalViaHomebrew(homebrewPackage: HomebrewPackageName): P
       'brew upgrade',
     )}...`,
   )
+  await exec('brew', ['update'], {stdio: 'inherit'})
   await exec('brew', ['upgrade', homebrewPackage], {stdio: 'inherit'})
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Currently running `shopify upgrade` on a homebrew executable does not update the homebrew executable. Instead it says:
```
$ shopify upgrade
Upgrading CLI from 3.44.0 to 3.44.1...
Homebrew installation detected. Attempting to upgrade via brew upgrade...
Warning: shopify/shopify/shopify-cli 3.44.0 already installed
✅ Success! Upgraded Shopify CLI to version 3.44.1.
```

but the version remains unchanged:
```
$ shopify --version
@shopify/cli/3.44.0 darwin-arm64 node-v19.7.0
```

this is because we fetch the latest version from npm, but we are not updating the brew sources.

### WHAT is this pull request doing?

Run `brew update` before `brew upgrade shopify-cli`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
