### PR TITLE
Upgrade graphql-request (ESM)

### DIFF
--- a/fixtures/app/web/frontend/package.json
+++ b/fixtures/app/web/frontend/package.json
@@ -20,7 +20,7 @@
     "cross-env": "^7.0.3",
     "express": "^4.17.3",
     "graphql": "^16.3.0",
-    "graphql-request": "next",
+    "graphql-request": "5.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-query": "^3.34.19",

--- a/fixtures/app/web/frontend/package.json
+++ b/fixtures/app/web/frontend/package.json
@@ -20,7 +20,7 @@
     "cross-env": "^7.0.3",
     "express": "^4.17.3",
     "graphql": "^16.3.0",
-    "graphql-request": "^4.2.0",
+    "graphql-request": "next",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-query": "^3.34.19",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -50,7 +50,7 @@
     "diff": "5.1.0",
     "esbuild": "0.15.16",
     "function-runner": "4.0.2",
-    "graphql-request": "next",
+    "graphql-request": "5.2.0",
     "http-proxy": "1.18.1",
     "javy-cli": "0.1.2",
     "serve-static": "1.15.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -50,7 +50,7 @@
     "diff": "5.1.0",
     "esbuild": "0.15.16",
     "function-runner": "4.0.2",
-    "graphql-request": "4.3.0",
+    "graphql-request": "next",
     "http-proxy": "1.18.1",
     "javy-cli": "0.1.2",
     "serve-static": "1.15.0",

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -123,7 +123,7 @@
     "get-port-please": "3.0.1",
     "gradient-string": "2.0.2",
     "graphql": "16.4.0",
-    "graphql-request": "4.3.0",
+    "graphql-request": "next",
     "h3": "0.7.21",
     "ink": "3.2.0",
     "is-interactive": "2.0.0",

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -123,7 +123,7 @@
     "get-port-please": "3.0.1",
     "gradient-string": "2.0.2",
     "graphql": "16.4.0",
-    "graphql-request": "next",
+    "graphql-request": "5.2.0",
     "h3": "0.7.21",
     "ink": "3.2.0",
     "is-interactive": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,7 +200,7 @@ importers:
       cross-env: ^7.0.3
       express: ^4.17.3
       graphql: ^16.3.0
-      graphql-request: next
+      graphql-request: 5.2.0
       prettier: ^2.6.1
       react: ^17.0.2
       react-dom: ^17.0.2
@@ -216,7 +216,7 @@ importers:
       cross-env: 7.0.3
       express: 4.18.2
       graphql: 16.6.0
-      graphql-request: 5.2.0-next.4_graphql@16.6.0
+      graphql-request: 5.2.0_graphql@16.6.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-query: 3.39.2_sfoxds7t5ydpegc3knd667wn6m
@@ -243,7 +243,7 @@ importers:
       esbuild: 0.15.16
       function-runner: 4.0.2
       graphql: ^16.0.0
-      graphql-request: next
+      graphql-request: 5.2.0
       graphql-tag: ^2.11.0
       http-proxy: 1.18.1
       javy-cli: 0.1.2
@@ -261,7 +261,7 @@ importers:
       diff: 5.1.0
       esbuild: 0.15.16
       function-runner: 4.0.2
-      graphql-request: 5.2.0-next.4_graphql@16.6.0
+      graphql-request: 5.2.0_graphql@16.6.0
       http-proxy: 1.18.1
       javy-cli: 0.1.2
       serve-static: 1.15.0
@@ -348,7 +348,7 @@ importers:
       get-port-please: 3.0.1
       gradient-string: 2.0.2
       graphql: 16.4.0
-      graphql-request: next
+      graphql-request: 5.2.0
       h3: 0.7.21
       ink: 3.2.0
       ink-testing-library: ^2.1.0
@@ -411,7 +411,7 @@ importers:
       get-port-please: 3.0.1
       gradient-string: 2.0.2
       graphql: 16.4.0
-      graphql-request: 5.2.0-next.4_graphql@16.4.0
+      graphql-request: 5.2.0_graphql@16.4.0
       h3: 0.7.21
       ink: 3.2.0_hw3ykagcixqw57etxpo4kpffqq
       is-interactive: 2.0.0
@@ -8285,8 +8285,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-request/5.2.0-next.4_graphql@16.4.0:
-    resolution: {integrity: sha512-Nylg6X3QO6ecOkhXV6O9ZO8djOjvV0aNTmRm2dSDg83KeEX8/s3c9j+ojVdmIora81sNeL3KtXXHOPzXhOTRAQ==}
+  /graphql-request/5.2.0_graphql@16.4.0:
+    resolution: {integrity: sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
@@ -8299,8 +8299,8 @@ packages:
       - encoding
     dev: false
 
-  /graphql-request/5.2.0-next.4_graphql@16.6.0:
-    resolution: {integrity: sha512-Nylg6X3QO6ecOkhXV6O9ZO8djOjvV0aNTmRm2dSDg83KeEX8/s3c9j+ojVdmIora81sNeL3KtXXHOPzXhOTRAQ==}
+  /graphql-request/5.2.0_graphql@16.6.0:
+    resolution: {integrity: sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
       tempy: 3.0.0
       tmp: 0.2.1
       ts-node: 10.9.1_ocil65wecyuhsmrrocoajouipe
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.9.4
 
   fixtures/app:
@@ -243,7 +243,7 @@ importers:
       esbuild: 0.15.16
       function-runner: 4.0.2
       graphql: ^16.0.0
-      graphql-request: 4.3.0
+      graphql-request: next
       graphql-tag: ^2.11.0
       http-proxy: 1.18.1
       javy-cli: 0.1.2
@@ -261,7 +261,7 @@ importers:
       diff: 5.1.0
       esbuild: 0.15.16
       function-runner: 4.0.2
-      graphql-request: 4.3.0_graphql@16.6.0
+      graphql-request: 5.2.0-next.4_graphql@16.6.0
       http-proxy: 1.18.1
       javy-cli: 0.1.2
       serve-static: 1.15.0
@@ -348,7 +348,7 @@ importers:
       get-port-please: 3.0.1
       gradient-string: 2.0.2
       graphql: 16.4.0
-      graphql-request: 4.3.0
+      graphql-request: next
       h3: 0.7.21
       ink: 3.2.0
       ink-testing-library: ^2.1.0
@@ -411,7 +411,7 @@ importers:
       get-port-please: 3.0.1
       gradient-string: 2.0.2
       graphql: 16.4.0
-      graphql-request: 4.3.0_graphql@16.4.0
+      graphql-request: 5.2.0-next.4_graphql@16.4.0
       h3: 0.7.21
       ink: 3.2.0_hw3ykagcixqw57etxpo4kpffqq
       is-interactive: 2.0.0
@@ -734,7 +734,7 @@ packages:
       response-iterator: 0.2.6
       symbol-observable: 4.0.0
       ts-invariant: 0.10.3
-      tslib: 2.4.1
+      tslib: 2.5.0
       zen-observable-ts: 1.2.5
     dev: true
 
@@ -2470,6 +2470,22 @@ packages:
       graphql: 15.8.0
     dev: true
 
+  /@graphql-typed-document-node/core/3.1.1_graphql@16.4.0:
+    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 16.4.0
+    dev: false
+
+  /@graphql-typed-document-node/core/3.1.1_graphql@16.6.0:
+    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 16.6.0
+    dev: false
+
   /@humanwhocodes/config-array/0.11.7:
     resolution: {integrity: sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==}
     engines: {node: '>=10.10.0'}
@@ -2941,7 +2957,7 @@ packages:
       rxjs: 6.6.7
       semver: 7.3.4
       tmp: 0.2.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       yargs: 17.6.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -3718,7 +3734,7 @@ packages:
       pg: 8.8.0
       redis: 4.5.1
       sqlite3: 5.1.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - aws-crt
@@ -8269,11 +8285,25 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-request/4.3.0_graphql@16.4.0:
+  /graphql-request/4.3.0_graphql@16.6.0:
     resolution: {integrity: sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
+      cross-fetch: 3.1.5
+      extract-files: 9.0.0
+      form-data: 3.0.1
+      graphql: 16.6.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /graphql-request/5.2.0-next.4_graphql@16.4.0:
+    resolution: {integrity: sha512-Nylg6X3QO6ecOkhXV6O9ZO8djOjvV0aNTmRm2dSDg83KeEX8/s3c9j+ojVdmIora81sNeL3KtXXHOPzXhOTRAQ==}
+    peerDependencies:
+      graphql: 14 - 16
+    dependencies:
+      '@graphql-typed-document-node/core': 3.1.1_graphql@16.4.0
       cross-fetch: 3.1.5
       extract-files: 9.0.0
       form-data: 3.0.1
@@ -8282,11 +8312,12 @@ packages:
       - encoding
     dev: false
 
-  /graphql-request/4.3.0_graphql@16.6.0:
-    resolution: {integrity: sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==}
+  /graphql-request/5.2.0-next.4_graphql@16.6.0:
+    resolution: {integrity: sha512-Nylg6X3QO6ecOkhXV6O9ZO8djOjvV0aNTmRm2dSDg83KeEX8/s3c9j+ojVdmIora81sNeL3KtXXHOPzXhOTRAQ==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
+      '@graphql-typed-document-node/core': 3.1.1_graphql@16.6.0
       cross-fetch: 3.1.5
       extract-files: 9.0.0
       form-data: 3.0.1
@@ -8302,7 +8333,7 @@ packages:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /graphql-tag/2.12.6_graphql@16.6.0:
@@ -8312,7 +8343,7 @@ packages:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
 
   /graphql-ws/4.9.0_graphql@15.8.0:
     resolution: {integrity: sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==}
@@ -10455,7 +10486,7 @@ packages:
       tar-stream: 2.2.0
       tmp: 0.2.1
       tsconfig-paths: 3.14.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       v8-compile-cache: 2.3.0
       yargs: 17.6.2
       yargs-parser: 21.1.1
@@ -11077,8 +11108,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /postcss/8.4.19:
-    resolution: {integrity: sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==}
+  /postcss/8.4.21:
+    resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.4
@@ -12925,9 +12956,6 @@ packages:
     resolution: {integrity: sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==}
     dev: true
 
-  /tslib/2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
-
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
@@ -13407,7 +13435,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.14.54
-      postcss: 8.4.19
+      postcss: 8.4.21
       resolve: 1.22.1
       rollup: 2.79.1
     optionalDependencies:
@@ -13430,7 +13458,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.14.54
-      postcss: 8.4.19
+      postcss: 8.4.21
       resolve: 1.22.1
       rollup: 2.79.1
       sass: 1.56.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,7 +200,7 @@ importers:
       cross-env: ^7.0.3
       express: ^4.17.3
       graphql: ^16.3.0
-      graphql-request: ^4.2.0
+      graphql-request: next
       prettier: ^2.6.1
       react: ^17.0.2
       react-dom: ^17.0.2
@@ -216,7 +216,7 @@ importers:
       cross-env: 7.0.3
       express: 4.18.2
       graphql: 16.6.0
-      graphql-request: 4.3.0_graphql@16.6.0
+      graphql-request: 5.2.0-next.4_graphql@16.6.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-query: 3.39.2_sfoxds7t5ydpegc3knd667wn6m
@@ -8284,19 +8284,6 @@ packages:
       - typescript
       - utf-8-validate
     dev: true
-
-  /graphql-request/4.3.0_graphql@16.6.0:
-    resolution: {integrity: sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==}
-    peerDependencies:
-      graphql: 14 - 16
-    dependencies:
-      cross-fetch: 3.1.5
-      extract-files: 9.0.0
-      form-data: 3.0.1
-      graphql: 16.6.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
 
   /graphql-request/5.2.0-next.4_graphql@16.4.0:
     resolution: {integrity: sha512-Nylg6X3QO6ecOkhXV6O9ZO8djOjvV0aNTmRm2dSDg83KeEX8/s3c9j+ojVdmIora81sNeL3KtXXHOPzXhOTRAQ==}


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/internal-cli-foundations/issues/502

Our current `graphql-request` version is a CommonJS dependency, so it's not loaded concurrently with the rest of ESM modules. 

### WHAT is this pull request doing?

Upgrades `graphql-request` to the latest version, which [supports ESM](https://github.com/jasonkuhrt/graphql-request/releases/tag/5.2.0).

### How to test your changes?

`shopify app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
