### PR TITLE
Remove invalid reference in the workspace `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
       {"path": "./packages/ui-extensions-server-kit"},
       {"path": "./packages/ui-extensions-test-utils"},
       {"path": "./packages/plugin-ngrok"},
-      {"path": "./packages/plugin-did-you-mean"},
-      {"path": "./workspace"}
+      {"path": "./packages/plugin-did-you-mean"}
     ]
 }


### PR DESCRIPTION
### WHY are these changes introduced?
@nikijiandani noticed that Typescript was complaining about the reference to `./workspace` from the root `tsconfig.json`. 

### WHAT is this pull request doing?
The reference is not necessary. The `./workspace` directory doesn't have a `tsconfig.json`
