### PR TITLE
support new extension point names format

### DIFF
--- a/.changeset/neat-avocados-peel.md
+++ b/.changeset/neat-avocados-peel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Adding support for the new naming convention of extension points

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -153,6 +153,10 @@ describe('getUIExtensionPayload', () => {
               module: './src/AdminCheckoutEditorSettings.js',
             },
             {
+              target: 'admin.checkout.editor.settings',
+              module: './src/AdminCheckoutEditorSettings.js',
+            },
+            {
               target: 'Checkout::ShippingMethods::RenderAfter',
               module: './src/CheckoutShippingMethodsRenderAfter.js',
             },
@@ -178,6 +182,17 @@ describe('getUIExtensionPayload', () => {
           surface: 'admin',
           root: {
             url: 'http://tunnel-url.com/extensions/devUUID/Admin::Checkout::Editor::Settings',
+          },
+          resource: {
+            url: '',
+          },
+        },
+        {
+          target: 'admin.checkout.editor.settings',
+          module: './src/AdminCheckoutEditorSettings.js',
+          surface: 'admin',
+          root: {
+            url: 'http://tunnel-url.com/extensions/devUUID/admin.checkout.editor.settings',
           },
           resource: {
             url: '',

--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -41,22 +41,27 @@ describe('getRedirectURL()', () => {
 })
 
 describe('getExtensionPointRedirectUrl()', () => {
-  it('returns Admin dev server URL if the extension point targets Admin', () => {
-    const extension = {
-      devUUID: '123abc',
-    } as UIExtension
+  it.each(['Admin::CheckoutEditor::RenderSettings', 'admin.checkout-editor.render-settings'])(
+    'returns Admin dev server URL if the extension point targets Admin using naming convention: %s',
+    (extensionPoint: string) => {
+      const extension = {
+        devUUID: '123abc',
+      } as UIExtension
 
-    const options = {
-      storeFqdn: 'example.myshopify.com',
-      url: 'https://localhost:8081',
-    } as unknown as ExtensionDevOptions
+      const options = {
+        storeFqdn: 'example.myshopify.com',
+        url: 'https://localhost:8081',
+      } as unknown as ExtensionDevOptions
 
-    const result = getExtensionPointRedirectUrl('Admin::CheckoutEditor::RenderSettings', extension, options)
+      const result = getExtensionPointRedirectUrl(extensionPoint, extension, options)
 
-    expect(result).toBe(
-      'https://example.myshopify.com/admin/extensions-dev?url=https%3A%2F%2Flocalhost%3A8081%2Fextensions%2F123abc&target=Admin%3A%3ACheckoutEditor%3A%3ARenderSettings',
-    )
-  })
+      expect(result).toBe(
+        `https://example.myshopify.com/admin/extensions-dev?url=https%3A%2F%2Flocalhost%3A8081%2Fextensions%2F123abc&target=${encodeURIComponent(
+          extensionPoint,
+        )}`,
+      )
+    },
+  )
 
   it('returns Checkout dev server URL if the extension point targets Checkout', () => {
     const extension = {

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -19,5 +19,5 @@ export async function getCartPathFromExtensions(extensions: UIExtension[], store
  * Returns the surface for UI extension from an extension point target
  */
 export function getExtensionPointTargetSurface(extensionPointTarget: string) {
-  return extensionPointTarget.toLowerCase().replace(/::.+$/, '')
+  return extensionPointTarget.toLowerCase().replace(/(::|\.).+$/, '')
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Adds support for both the `Admin::XX::XX` syntax and the `admin.x.x` syntax when extracting the surface of an extension. This will allow to fix the issue where `No extensions found for the surface: admin` is returned in the embedded admin console.

### WHAT is this pull request doing?

Just  changing the regex to support both `::` or `.` as delimiter. (Can current extension points use a `.` that would influence this?)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
