### PR TITLE
Don't make users install dev or test gems when bundle installing

### DIFF
--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -441,5 +441,5 @@ async function localBundleInstall(directory: string): Promise<void> {
   await exec(bundle, ['config', 'set', '--local', 'path', directory], {
     cwd: directory,
   })
-  await exec(bundle, ['install'], {cwd: directory})
+  await exec(bundle, ['install', '--without', 'development', 'test'], {cwd: directory})
 }


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed that we're making users install development and test gems when they're installing CLI2. Those gems are only necessary while developing the library, but not at runtime. 

### WHAT is this pull request doing?

Skip development and test gems when installing CLI2

### How to test your changes?

On the `main` branch.
- Make sure to remove these local folders:
  - `rm -rf packages/cli-kit/assets/cli-ruby/{ruby,.bundle}`
- Now create a theme:
  - `pnpm shopify theme init "theme-fun-$(date '+%Y-%m-%d')" && cd theme-fun-$(date '+%Y-%m-%d')`
  - `pnpm shopify theme dev --store=<your-store>` should work
  - you can check live reload works on the theme
- If you run `ls -al ../packages/cli-kit/assets/cli-ruby/ruby/3.1.0/gems/ | wc -l` you should see **73 packages**

Now switch to this branch.
- Make sure to remove these local folders:
  - `rm -rf ../packages/cli-kit/assets/cli-ruby/{ruby,.bundle}`
- `pnpm shopify theme dev --store=<your-store>` should work
- you can check live reload works on the theme
- If you run `ls -al ../packages/cli-kit/assets/cli-ruby/ruby/3.1.0/gems/ | wc -l` you should see **12 packages**

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
