### PR TITLE
Remove the dependency of tests on build

### DIFF
--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -99,7 +99,6 @@
       },
       "test:js": {
         "executor": "nx:run-commands",
-        "dependsOn": ["build"],
         "options": {
           "command": "pnpm vitest run",
           "cwd": "packages/cli-kit"
@@ -115,7 +114,6 @@
       },
       "test:watch": {
         "executor": "nx:run-commands",
-        "dependsOn": ["build"],
         "options": {
           "command": "pnpm vitest watch",
           "cwd": "packages/cli-kit"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/internal-cli-foundations/issues/475
In https://github.com/Shopify/cli/pull/633 I made tests depend on build so that we'd be able to execute some transpiled code during tests, but these tests no longer exist and we can remove this dependency.

### WHAT is this pull request doing?

What the title says