### PR TITLE
Use utf8 encoding for log output

### DIFF
--- a/.changeset/dirty-spies-walk.md
+++ b/.changeset/dirty-spies-walk.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix issue with unicode characters not being displayed correctly in log output

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -79,7 +79,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
   const writableStream = (process: OutputProcess, index: number) => {
     return new Writable({
       write(chunk, _encoding, next) {
-        const lines = stripAnsi(chunk.toString('ascii').replace(/(\n)$/, '')).split(/\n/)
+        const lines = stripAnsi(chunk.toString('utf8').replace(/(\n)$/, '')).split(/\n/)
 
         setProcessOutput((previousProcessOutput) => [
           ...previousProcessOutput,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1400
Unicode characters were not being displayed correctly in logs.

### WHAT is this pull request doing?

Change the log encoding from `ascii` to `utf-8`

In this example I've added こんにちは (Japanese) to the server logs.

<img width="941" alt="Screenshot 2023-02-28 at 14 13 25" src="https://user-images.githubusercontent.com/151725/221760659-e0195c49-720f-4add-a6bf-5856ed7a985c.png">
