### PR TITLE
Use ESM version of Lodash

### DIFF
--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -131,7 +131,7 @@
     "kill-port-process": "3.1.0",
     "latest-version": "7.0.0",
     "liquidjs": "10.5.0",
-    "lodash": "4.17.21",
+    "lodash-es": "4.17.21",
     "macaddress": "0.5.3",
     "node-abort-controller": "3.0.1",
     "node-fetch": "3.2.4",

--- a/packages/cli-kit/src/public/common/function.ts
+++ b/packages/cli-kit/src/public/common/function.ts
@@ -1,7 +1,5 @@
-import {createRequire} from 'module'
+import {memoize as lodashMemoize, debounce as lodashDebounce} from 'lodash'
 import type {DebouncedFunc, DebounceSettings} from 'lodash'
-
-const require = createRequire(import.meta.url)
 
 /**
  * Creates a function that memoizes the result of func. If resolver is provided it determines the cache key for
@@ -15,8 +13,7 @@ const require = createRequire(import.meta.url)
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function memoize<T extends (...args: any) => any>(func: T, resolver?: (...args: Parameters<T>) => unknown): T {
-  const memoize = require('lodash/memoize')
-  return memoize(func, resolver)
+  return lodashMemoize(func, resolver)
 }
 
 /**
@@ -42,6 +39,5 @@ export function debounce<T extends (...args: any) => any>(
   wait?: number,
   options?: DebounceSettings,
 ): DebouncedFunc<T> {
-  const lodashDebounce = require('lodash/debounce')
   return lodashDebounce(func, wait, options)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
       tempy: 3.0.0
       tmp: 0.2.1
       ts-node: 10.9.1_ocil65wecyuhsmrrocoajouipe
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.9.4
 
   fixtures/app:
@@ -677,7 +677,7 @@ importers:
       execa: 6.1.0
       fast-glob: 3.2.12
       git-diff: 2.0.6
-      pathe: 1.0.0
+      pathe: 1.1.0
       simple-git: 3.5.0
       tempy: 3.0.0
 
@@ -734,7 +734,7 @@ packages:
       response-iterator: 0.2.6
       symbol-observable: 4.0.0
       ts-invariant: 0.10.3
-      tslib: 2.4.1
+      tslib: 2.5.0
       zen-observable-ts: 1.2.5
     dev: true
 
@@ -2941,7 +2941,7 @@ packages:
       rxjs: 6.6.7
       semver: 7.3.4
       tmp: 0.2.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       yargs: 17.6.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -3718,7 +3718,7 @@ packages:
       pg: 8.8.0
       redis: 4.5.1
       sqlite3: 5.1.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - aws-crt
@@ -4438,27 +4438,21 @@ packages:
   /acorn-globals/7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
     dev: true
 
-  /acorn-jsx/5.3.2_acorn@8.8.1:
+  /acorn-jsx/5.3.2_acorn@8.8.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.2
     dev: true
 
   /acorn-walk/8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
-    dev: true
-
-  /acorn/8.8.1:
-    resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
     dev: true
 
   /acorn/8.8.2:
@@ -7391,8 +7385,8 @@ packages:
     resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.1
-      acorn-jsx: 5.3.2_acorn@8.8.1
+      acorn: 8.8.2
+      acorn-jsx: 5.3.2_acorn@8.8.2
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -8361,7 +8355,7 @@ packages:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /graphql-tag/2.12.6_graphql@16.6.0:
@@ -8371,7 +8365,7 @@ packages:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
 
   /graphql-ws/4.9.0_graphql@15.8.0:
     resolution: {integrity: sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==}
@@ -9276,7 +9270,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-globals: 7.0.1
       cssom: 0.5.0
       cssstyle: 2.3.0
@@ -10518,7 +10512,7 @@ packages:
       tar-stream: 2.2.0
       tmp: 0.2.1
       tsconfig-paths: 3.14.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       v8-compile-cache: 2.3.0
       yargs: 17.6.2
       yargs-parser: 21.1.1
@@ -11140,8 +11134,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /postcss/8.4.19:
-    resolution: {integrity: sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==}
+  /postcss/8.4.21:
+    resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.4
@@ -12564,7 +12558,7 @@ packages:
   /strip-literal/1.0.0:
     resolution: {integrity: sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==}
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.2
     dev: true
 
   /strnum/1.0.5:
@@ -12965,7 +12959,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 14.18.36
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -13024,9 +13018,6 @@ packages:
   /tslib/2.2.0:
     resolution: {integrity: sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==}
     dev: true
-
-  /tslib/2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
@@ -13511,7 +13502,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.14.54
-      postcss: 8.4.19
+      postcss: 8.4.21
       resolve: 1.22.1
       rollup: 2.79.1
     optionalDependencies:
@@ -13534,7 +13525,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.14.54
-      postcss: 8.4.19
+      postcss: 8.4.21
       resolve: 1.22.1
       rollup: 2.79.1
       sass: 1.56.1
@@ -13571,7 +13562,7 @@ packages:
       '@vitest/runner': 0.28.5
       '@vitest/spy': 0.28.5
       '@vitest/utils': 0.28.5
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
@@ -13624,7 +13615,7 @@ packages:
       '@vitest/runner': 0.28.5
       '@vitest/spy': 0.28.5
       '@vitest/utils': 0.28.5
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
@@ -13678,7 +13669,7 @@ packages:
       '@vitest/runner': 0.28.5
       '@vitest/spy': 0.28.5
       '@vitest/utils': 0.28.5
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,7 +357,7 @@ importers:
       kill-port-process: 3.1.0
       latest-version: 7.0.0
       liquidjs: 10.5.0
-      lodash: 4.17.21
+      lodash-es: 4.17.21
       macaddress: 0.5.3
       node-abort-controller: 3.0.1
       node-fetch: 3.2.4
@@ -419,7 +419,7 @@ importers:
       kill-port-process: 3.1.0
       latest-version: 7.0.0
       liquidjs: 10.5.0
-      lodash: 4.17.21
+      lodash-es: 4.17.21
       macaddress: 0.5.3
       node-abort-controller: 3.0.1
       node-fetch: 3.2.4
@@ -9559,7 +9559,6 @@ packages:
 
   /lodash-es/4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-    dev: true
 
   /lodash.camelcase/4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}


### PR DESCRIPTION
### WHY are these changes introduced?

We were using the [CommonJS version of Lodash](https://www.npmjs.com/package/lodash), but there's another official [package exported as ESM](https://www.npmjs.com/package/lodash-es).

The ESM version is much lighter (636kB vs 1.41MB) and it will load faster.

### WHAT is this pull request doing?

- Replaces `lodash` with `lodash-es` in cli-kit
- Deduplicates dependencies

### How to test your changes?

CI

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
