### PR TITLE
Get redirect URL for customer-accounts-ui-extension

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -38,6 +38,23 @@ describe('getRedirectURL()', () => {
 
     expect(result).toBe('https://example.myshopify.com/mock/cart/url?dev=https%3A%2F%2Flocalhost%3A8081%2Fextensions')
   })
+
+  it('returns a URL with a origin param if the surface is customer_accounts', async () => {
+    const extension = await testUIExtension({
+      configuration: {type: 'customer_accounts_ui_extension', name: 'test', metafields: []},
+    })
+
+    const options = {
+      storeFqdn: 'example.myshopify.com',
+      url: 'https://localhost:8081',
+    } as unknown as ExtensionDevOptions
+
+    const result = getRedirectUrl(extension, options)
+
+    expect(result).toBe(
+      'https://example.account.myshopify.com/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=test-ui-extension-uuid',
+    )
+  })
 })
 
 describe('getExtensionPointRedirectUrl()', () => {

--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -13,6 +13,16 @@ export function getRedirectUrl(extension: UIExtension, options: ExtensionDevOpti
     rawUrl.searchParams.append('dev', `${options.url}/extensions`)
 
     return rawUrl.toString()
+  } else if (extension.surface === 'customer_accounts') {
+    const [storeName, ...storeDomainParts] = options.storeFqdn.split('.')
+    const accountsUrl = `${storeName}.account.${storeDomainParts.join('.')}`
+    const origin = `${options.url}/extensions`
+
+    const rawUrl = new URL(`https://${accountsUrl}/extensions-development`)
+    rawUrl.searchParams.append('origin', origin)
+    rawUrl.searchParams.append('extensionId', extension.devUUID)
+
+    return rawUrl.toString()
   } else {
     const rawUrl = new URL(`https://${options.storeFqdn}/`)
     rawUrl.pathname = 'admin/extensions-dev'


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/core-issues/issues/51780

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR constructs a redirect url for `customer_accounts_ui_extenion` so that the preview link in the dev console gets redirected to customer account page instead of going to admin. 

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Go to [dev-console](https://a20a-142-188-90-53.ngrok.io/extensions/dev-console)
- Click the preview link of customer accounts ui extension

You should be redirected to the customer account log in page 
<img width="1601" alt="Screenshot 2023-02-28 at 16 00 03" src="https://user-images.githubusercontent.com/26579337/221979023-210c7082-7034-434b-8548-fd77be103a9d.png">

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
