### PR TITLE
Add missing api_version in ui-extension template

### DIFF
--- a/.changeset/pretty-dryers-drop.md
+++ b/.changeset/pretty-dryers-drop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Add default api_version to the TOML for the ui-extension template

--- a/packages/app/templates/ui-extensions/projects/ui_extension/shopify.ui.extension.toml.liquid
+++ b/packages/app/templates/ui-extensions/projects/ui_extension/shopify.ui.extension.toml.liquid
@@ -1,5 +1,7 @@
 name = "{{ name }}"
 
+api_version = "2022-10"
+
 [capabilities]
 api_access = true
 network_access = true


### PR DESCRIPTION
The existing template for `ui_extension` is missing the require `api_version` in the TOML. I've set this to the default `2022-10` version. 

NOTE: There will be further changes to the template when this [PR](https://github.com/Shopify/cli/pull/1275) is revived