### PR TITLE
Fix layout width for very narrow terminals

### DIFF
--- a/.changeset/great-guests-yell.md
+++ b/.changeset/great-guests-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix layout width for very narrow terminals

--- a/packages/cli-kit/src/private/node/ui/hooks/use-layout.test.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-layout.test.ts
@@ -6,6 +6,28 @@ import {useStdout} from 'ink'
 vi.mock('ink')
 
 describe('useLayout', async () => {
+  describe('fullWidth', async () => {
+    test('it returns 20 if the stdout width is less than 20', async () => {
+      vi.mocked(useStdout).mockReturnValue({
+        stdout: new OutputStream({columns: 10}) as any,
+        write: () => {},
+      })
+
+      const {fullWidth} = useLayout()
+      expect(fullWidth).toBe(20)
+    })
+
+    test('it returns the stdout width if that is more than 20', async () => {
+      vi.mocked(useStdout).mockReturnValue({
+        stdout: new OutputStream({columns: 200}) as any,
+        write: () => {},
+      })
+
+      const {fullWidth} = useLayout()
+      expect(fullWidth).toBe(200)
+    })
+  })
+
   describe('twoThirds', async () => {
     test('it returns 2/3rds of the width if that is more than the min width of 80', async () => {
       vi.mocked(useStdout).mockReturnValue({

--- a/packages/cli-kit/src/private/node/ui/hooks/use-layout.test.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-layout.test.ts
@@ -58,6 +58,16 @@ describe('useLayout', async () => {
       const {twoThirds} = useLayout()
       expect(twoThirds).toBe(80)
     })
+
+    test('it returns 20 if the stdout width is less than 20', async () => {
+      vi.mocked(useStdout).mockReturnValue({
+        stdout: new OutputStream({columns: 10}) as any,
+        write: () => {},
+      })
+
+      const {twoThirds} = useLayout()
+      expect(twoThirds).toBe(20)
+    })
   })
 
   describe('oneThird', async () => {
@@ -89,6 +99,16 @@ describe('useLayout', async () => {
 
       const {oneThird} = useLayout()
       expect(oneThird).toBe(100)
+    })
+
+    test('it returns 20 if the stdout width is less than 20', async () => {
+      vi.mocked(useStdout).mockReturnValue({
+        stdout: new OutputStream({columns: 10}) as any,
+        write: () => {},
+      })
+
+      const {oneThird} = useLayout()
+      expect(oneThird).toBe(20)
     })
   })
 })

--- a/packages/cli-kit/src/private/node/ui/hooks/use-layout.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-layout.ts
@@ -18,6 +18,8 @@ export default function useLayout(): Layout {
 
   if (fullWidth <= MIN_FULL_WIDTH) {
     fullWidth = MIN_FULL_WIDTH
+    oneThird = MIN_FULL_WIDTH
+    twoThirds = MIN_FULL_WIDTH
   } else if (fullWidth > MIN_FRACTION_WIDTH) {
     oneThird = column({fullWidth, fraction: [1, 3], minWidth: MIN_FRACTION_WIDTH})
     twoThirds = column({fullWidth, fraction: [2, 3], minWidth: MIN_FRACTION_WIDTH})

--- a/packages/cli-kit/src/private/node/ui/hooks/use-layout.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-layout.ts
@@ -1,6 +1,7 @@
 import {useStdout} from 'ink'
 
-const MIN_WIDTH = 80
+const MIN_FULL_WIDTH = 20
+const MIN_FRACTION_WIDTH = 80
 
 interface Layout {
   twoThirds: number
@@ -11,16 +12,15 @@ interface Layout {
 export default function useLayout(): Layout {
   const {stdout} = useStdout()
 
-  const fullWidth = stdout?.columns ?? MIN_WIDTH
-  let oneThird
-  let twoThirds
+  let fullWidth = stdout?.columns ?? MIN_FRACTION_WIDTH
+  let oneThird = fullWidth
+  let twoThirds = fullWidth
 
-  if (fullWidth <= MIN_WIDTH) {
-    oneThird = fullWidth
-    twoThirds = fullWidth
-  } else {
-    oneThird = column({fullWidth, fraction: [1, 3], minWidth: MIN_WIDTH})
-    twoThirds = column({fullWidth, fraction: [2, 3], minWidth: MIN_WIDTH})
+  if (fullWidth <= MIN_FULL_WIDTH) {
+    fullWidth = MIN_FULL_WIDTH
+  } else if (fullWidth > MIN_FRACTION_WIDTH) {
+    oneThird = column({fullWidth, fraction: [1, 3], minWidth: MIN_FRACTION_WIDTH})
+    twoThirds = column({fullWidth, fraction: [2, 3], minWidth: MIN_FRACTION_WIDTH})
   }
 
   return {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/internal-cli-foundations/issues/559

Buildkit has a very narrow stdout and was producing very weird squeezed logs.

### WHAT is this pull request doing?

For terminals narrower than 20 characters we want to force a minimum width of 20.

### How to test your changes?

Resize your terminal to less than 20 characters and run kitchen-sink. Boxes should look a bit broken unless you resize the terminal up.