### PR TITLE
Clean errors on theme dev

### DIFF
--- a/.changeset/blue-jokes-worry.md
+++ b/.changeset/blue-jokes-worry.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+Clean errors related to metrics requests on theme dev

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -28,6 +28,7 @@ module ShopifyCLI
         SESSION_COOKIE_NAME = "_secure_session_id"
         SESSION_COOKIE_REGEXP = /#{SESSION_COOKIE_NAME}=(\h+)/
         SESSION_COOKIE_MAX_AGE = 60 * 60 * 23 # 1 day - leeway of 1h
+        IGNORED_ENDPOINTS = ['shopify/monorail', 'mini-profiler-resources', 'web-pixels-manager']
 
         def initialize(ctx, theme, param_builder)
           @ctx = ctx
@@ -40,6 +41,8 @@ module ShopifyCLI
         end
 
         def call(env)
+          return [204, {}, []] if IGNORED_ENDPOINTS.any? { |endpoint| env["PATH_INFO"].include?(endpoint) }
+
           headers = extract_http_request_headers(env)
           headers["Host"] = shop
           headers["Cookie"] = add_session_cookie(headers["Cookie"])

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -28,7 +28,7 @@ module ShopifyCLI
         SESSION_COOKIE_NAME = "_secure_session_id"
         SESSION_COOKIE_REGEXP = /#{SESSION_COOKIE_NAME}=(\h+)/
         SESSION_COOKIE_MAX_AGE = 60 * 60 * 23 # 1 day - leeway of 1h
-        IGNORED_ENDPOINTS = ['shopify/monorail', 'mini-profiler-resources', 'web-pixels-manager']
+        IGNORED_ENDPOINTS = ["shopify/monorail", "mini-profiler-resources", "web-pixels-manager"]
 
         def initialize(ctx, theme, param_builder)
           @ctx = ctx

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -49,6 +49,39 @@ module ShopifyCLI
           request.get("/")
         end
 
+        def test_monorail_requests_are_ignored
+          path = "/cli/sfr/.well-known/shopify/monorail/unstable/produce_batch?_fd=0&pb=0"
+          stub_session_id_request
+
+          request.post(path)
+
+          assert_requested(:post,
+            "https://dev-theme-server-store.myshopify.com#{path}",
+            times: 0)
+        end
+
+        def test_miniprofiler_requests_are_ignored
+          path = "cli/sfr/mini-profiler-resources/includes.js"
+          stub_session_id_request
+
+          request.get(path)
+
+          assert_requested(:get,
+            "https://dev-theme-server-store.myshopify.com#{path}",
+            times: 0)
+        end
+
+        def test_webpixels_requests_are_ignored
+          path = "cli/sfr/web-pixels-manager@0.0.225@487839awab38cc13pfd6bd3d2m9a3137/sandbox/?_fd=0&pb=0"
+          stub_session_id_request
+
+          request.get(path)
+
+          assert_requested(:get,
+            "https://dev-theme-server-store.myshopify.com#{path}",
+            times: 0)
+        end
+
         def test_get_is_proxied_to_theme_access_api_when_password_is_provided
           Environment.stubs(:theme_access_password?).returns(true)
           Environment.stubs(:store).returns("https://dev-theme-server-store.myshopify.com")


### PR DESCRIPTION
### WHY are these changes introduced?

While previewing a theme, both the CLI and Chrome consoles show a lot of errors related to analytics requests that are not needed:

![console-errors](https://user-images.githubusercontent.com/14979109/222135505-e406fb82-5284-447e-a685-f6a81db5aa7e.png)
![chrome-errors](https://user-images.githubusercontent.com/14979109/222135496-4fb967af-020f-45f9-98a6-5e5799bdba48.png)

### WHAT is this pull request doing?

Ignore requests to monorail, mini-profiler or web pixels, so that the consoles are clean:

![console-after](https://user-images.githubusercontent.com/14979109/222135918-1efa4660-6196-429f-b466-f86b42c07665.png)
![chrome-after](https://user-images.githubusercontent.com/14979109/222135914-f23fcf13-17e7-4186-8219-2cfbd39056d8.png)

### How to test your changes?

`shopify theme dev --verbose`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
