### PR TITLE
Improve how we handle the `path` flag

### DIFF
--- a/bin/prettify-manifests.js
+++ b/bin/prettify-manifests.js
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import glob from 'fast-glob';
+import fs from 'fs'
+import {fileURLToPath} from 'url'
+import glob from 'fast-glob'
+import path from 'path'
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(path.join(__dirname, '..'))
 const manifestFiles = glob.sync(`packages/*/oclif.manifest.json`)
+
 for (const file of manifestFiles) {
   console.log(`Prettifying ${file}...`)
   const content = fs.readFileSync(file)
-  const prettyContent = JSON.stringify(JSON.parse(content),null,2)
+  const prettyContent = JSON.stringify(JSON.parse(content),null,2).replaceAll(root, '.')
   fs.writeFileSync(file, prettyContent)
 }

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -29,7 +29,8 @@
           "type": "option",
           "description": "The path to your app directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "skip-dependencies-installation": {
           "name": "skip-dependencies-installation",
@@ -76,7 +77,8 @@
           "type": "option",
           "description": "The path to your app directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "api-key": {
           "name": "api-key",
@@ -131,7 +133,8 @@
           "type": "option",
           "description": "The path to your app directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "api-key": {
           "name": "api-key",
@@ -262,7 +265,8 @@
           "type": "option",
           "description": "The path to your app directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "json": {
           "name": "json",
@@ -429,7 +433,8 @@
           "type": "option",
           "description": "The path to your app directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "env-file": {
           "name": "env-file",
@@ -470,7 +475,8 @@
           "type": "option",
           "description": "The path to your app directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         }
       },
       "args": {}
@@ -503,7 +509,8 @@
           "type": "option",
           "description": "The path to your function directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         }
       },
       "args": {}
@@ -536,7 +543,8 @@
           "type": "option",
           "description": "The path to your function directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         }
       },
       "args": {}
@@ -569,7 +577,8 @@
           "type": "option",
           "description": "The path to your function directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "api-key": {
           "name": "api-key",
@@ -609,7 +618,8 @@
           "type": "option",
           "description": "The path to your function directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         }
       },
       "args": {}
@@ -645,7 +655,8 @@
           "type": "option",
           "description": "The path to your app directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "type": {
           "name": "type",
@@ -735,7 +746,8 @@
           "type": "option",
           "description": "The path to your function directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "api-key": {
           "name": "api-key",
@@ -779,7 +791,8 @@
           "type": "option",
           "description": "The path to your app directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "type": {
           "name": "type",

--- a/packages/app/src/cli/commands/app/build.ts
+++ b/packages/app/src/cli/commands/app/build.ts
@@ -6,7 +6,6 @@ import Command from '../../utilities/app-command.js'
 import {loadExtensionsSpecifications} from '../../models/extensions/specifications.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
 export default class Build extends Command {
@@ -35,9 +34,8 @@ export default class Build extends Command {
       cmd_app_dependency_installation_skipped: flags['skip-dependencies-installation'],
     }))
 
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
     const specifications = await loadExtensionsSpecifications(this.config)
-    const app: AppInterface = await loadApp({directory, specifications})
+    const app: AppInterface = await loadApp({specifications, directory: flags.path})
     await build({app, skipDependenciesInstallation: flags['skip-dependencies-installation'], apiKey: flags['api-key']})
   }
 }

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -6,7 +6,6 @@ import Command from '../../utilities/app-command.js'
 import {loadExtensionsSpecifications} from '../../models/extensions/specifications.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
 export default class Deploy extends Command {
@@ -42,9 +41,8 @@ export default class Deploy extends Command {
       cmd_app_reset_used: flags.reset,
     }))
 
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
     const specifications = await loadExtensionsSpecifications(this.config)
-    const app: AppInterface = await loadApp({directory, specifications})
+    const app: AppInterface = await loadApp({specifications, directory: flags.path})
     await deploy({app, apiKey: flags['api-key'], reset: flags.reset, force: flags.force})
   }
 }

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -4,7 +4,6 @@ import Command from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
 export default class Dev extends Command {
@@ -94,11 +93,10 @@ export default class Dev extends Command {
       cmd_app_reset_used: flags.reset,
     }))
 
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
     const commandConfig = this.config
 
     await dev({
-      directory,
+      directory: flags.path,
       apiKey: flags['api-key'],
       storeFqdn: flags.store,
       reset: flags.reset,

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -22,7 +22,7 @@ export default class Dev extends Command {
       char: 's',
       description: 'Store URL. Must be an existing development or Shopify Plus sandbox store.',
       env: 'SHOPIFY_FLAG_STORE',
-      parse: (input, _) => Promise.resolve(normalizeStoreFqdn(input)),
+      parse: async (input) => normalizeStoreFqdn(input),
     }),
     reset: Flags.boolean({
       hidden: false,

--- a/packages/app/src/cli/commands/app/env/pull.ts
+++ b/packages/app/src/cli/commands/app/env/pull.ts
@@ -7,7 +7,7 @@ import {loadExtensionsSpecifications} from '../../../models/extensions/specifica
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
+import {joinPath} from '@shopify/cli-kit/node/path'
 
 export default class EnvPull extends Command {
   static description = 'Pull app and extensions environment variables.'
@@ -25,10 +25,9 @@ export default class EnvPull extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(EnvPull)
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
-    const envFile = resolvePath(directory, flags['env-file'])
+    const envFile = joinPath(flags.path, flags['env-file'])
     const specifications = await loadExtensionsSpecifications(this.config)
-    const app: AppInterface = await loadApp({directory, specifications, mode: 'report'})
+    const app: AppInterface = await loadApp({specifications, directory: flags.path, mode: 'report'})
     outputInfo(await pullEnv(app, {envFile}))
   }
 }

--- a/packages/app/src/cli/commands/app/env/show.ts
+++ b/packages/app/src/cli/commands/app/env/show.ts
@@ -5,7 +5,6 @@ import {showEnv} from '../../../services/app/env/show.js'
 import Command from '../../../utilities/app-command.js'
 import {loadExtensionsSpecifications} from '../../../models/extensions/specifications.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 
 export default class EnvShow extends Command {
@@ -18,9 +17,8 @@ export default class EnvShow extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(EnvShow)
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
     const specifications = await loadExtensionsSpecifications(this.config)
-    const app: AppInterface = await loadApp({directory, specifications, mode: 'report'})
+    const app: AppInterface = await loadApp({specifications, directory: flags.path, mode: 'report'})
     outputInfo(await showEnv(app))
   }
 }

--- a/packages/app/src/cli/commands/app/function/schema.ts
+++ b/packages/app/src/cli/commands/app/function/schema.ts
@@ -21,9 +21,8 @@ export default class FetchSchema extends Command {
 
   public async run(): Promise<void> {
     const {flags, args} = await this.parse(FetchSchema)
-    const apiKey = flags['api-key']
     await inFunctionContext(this.config, flags.path, async (app, ourFunction) => {
-      outputInfo(await generateSchemaService({app, extension: ourFunction, apiKey}))
+      outputInfo(await generateSchemaService({app, extension: ourFunction, apiKey: flags['api-key']}))
     })
   }
 }

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -4,7 +4,6 @@ import Command from '../../../utilities/app-command.js'
 import generate from '../../../services/generate.js'
 import {Args, Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 
 export default class AppGenerateExtension extends Command {
   static description = 'Scaffold an Extension.'
@@ -68,10 +67,8 @@ export default class AppGenerateExtension extends Command {
       cmd_scaffold_type_owner: '@shopify/app',
     }))
 
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
-
     await generate({
-      directory,
+      directory: flags.path,
       reset: flags.reset,
       apiKey: flags['api-key'],
       type: flags.type,

--- a/packages/app/src/cli/commands/app/info.ts
+++ b/packages/app/src/cli/commands/app/info.ts
@@ -7,7 +7,6 @@ import {loadExtensionsSpecifications} from '../../models/extensions/specificatio
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 
 export default class AppInfo extends Command {
   static description = 'Print basic information about your app and extensions.'
@@ -30,9 +29,8 @@ export default class AppInfo extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(AppInfo)
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
     const specifications = await loadExtensionsSpecifications(this.config)
-    const app: AppInterface = await loadApp({directory, specifications, mode: 'report'})
+    const app: AppInterface = await loadApp({specifications, directory: flags.path, mode: 'report'})
     outputInfo(await info(app, {format: (flags.json ? 'json' : 'text') as Format, webEnv: flags['web-env']}))
     if (app.errors) process.exit(2)
   }

--- a/packages/app/src/cli/flags.ts
+++ b/packages/app/src/cli/flags.ts
@@ -1,5 +1,5 @@
 import {Flags} from '@oclif/core'
-import {resolvePath} from '@shopify/cli-kit/node/path'
+import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 
 /**
  * An object that contains the flags that
@@ -9,7 +9,8 @@ export const appFlags = {
   path: Flags.string({
     hidden: false,
     description: 'The path to your app directory.',
-    parse: (input, _) => Promise.resolve(resolvePath(input)),
+    parse: async (input) => resolvePath(input),
+    default: async () => cwd(),
     env: 'SHOPIFY_FLAG_PATH',
   }),
 }

--- a/packages/app/src/cli/services/function/common.ts
+++ b/packages/app/src/cli/services/function/common.ts
@@ -11,22 +11,21 @@ export const functionFlags = {
   path: Flags.string({
     hidden: false,
     description: 'The path to your function directory.',
-    parse: (input, _) => Promise.resolve(resolvePath(input)),
+    parse: async (input) => resolvePath(input),
+    default: async () => cwd(),
     env: 'SHOPIFY_FLAG_PATH',
   }),
 }
 
 export async function inFunctionContext(
   config: Config,
-  path: string | undefined,
+  path: string,
   callback: (app: App, ourFunction: FunctionExtension) => Promise<void>,
 ) {
-  const directory = path ? resolvePath(path) : cwd()
-
   const specifications = await loadExtensionsSpecifications(config)
-  const app: AppInterface = await loadApp({directory, specifications})
+  const app: AppInterface = await loadApp({specifications, directory: path})
 
-  const ourFunction = app.extensions.function.find((fun) => fun.directory === directory)
+  const ourFunction = app.extensions.function.find((fun) => fun.directory === path)
   if (ourFunction) {
     return callback(app, ourFunction)
   } else {

--- a/packages/cli-kit/src/public/node/base-command.test.ts
+++ b/packages/cli-kit/src/public/node/base-command.test.ts
@@ -3,7 +3,7 @@ import {Environments, environmentsFilename} from './environments.js'
 import {encodeToml as encodeTOML} from './toml.js'
 import {globalFlags} from './cli.js'
 import {inTemporaryDirectory, mkdir, writeFile} from './fs.js'
-import {joinPath, resolvePath} from './path.js'
+import {joinPath, resolvePath, cwd} from './path.js'
 import {mockAndCaptureOutput} from './testing/output.js'
 import {describe, expect, test} from 'vitest'
 import {Flags} from '@oclif/core'
@@ -17,8 +17,8 @@ class MockCommand extends Command {
   static flags = {
     ...globalFlags,
     path: Flags.string({
-      parse: (input, _) => Promise.resolve(resolvePath(input)),
-      default: '.',
+      parse: async (input) => resolvePath(input),
+      default: async () => cwd(),
     }),
     someString: Flags.string({}),
     someInteger: Flags.integer({}),

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -15,7 +15,8 @@
           "type": "option",
           "description": "The path to your project directory.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         }
       },
       "args": {}

--- a/packages/cli/src/cli/commands/upgrade.ts
+++ b/packages/cli/src/cli/commands/upgrade.ts
@@ -11,15 +11,14 @@ export default class Upgrade extends Command {
     path: Flags.string({
       hidden: false,
       description: 'The path to your project directory.',
-      parse: (input, _) => Promise.resolve(resolvePath(input)),
       env: 'SHOPIFY_FLAG_PATH',
+      parse: async (input) => resolvePath(input),
+      default: async () => cwd(),
     }),
   }
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Upgrade)
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
-    const currentVersion = CLI_KIT_VERSION
-    await upgrade(directory, currentVersion)
+    await upgrade(flags.path, CLI_KIT_VERSION)
   }
 }

--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -37,7 +37,8 @@
           "type": "option",
           "char": "p",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "default": "."
         },
         "template": {
           "name": "template",

--- a/packages/create-app/src/commands/init.ts
+++ b/packages/create-app/src/commands/init.ts
@@ -22,7 +22,8 @@ export default class Init extends Command {
     path: Flags.string({
       char: 'p',
       env: 'SHOPIFY_FLAG_PATH',
-      parse: (input, _) => Promise.resolve(resolvePath(input)),
+      parse: async (input) => resolvePath(input),
+      default: async () => cwd(),
       hidden: false,
     }),
     template: Flags.string({
@@ -47,14 +48,13 @@ export default class Init extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Init)
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
 
     this.validateTemplateValue(flags.template)
 
     const promptAnswers = await initPrompt({
       name: flags.name,
       template: flags.template,
-      directory,
+      directory: flags.path,
     })
 
     await initService({
@@ -62,7 +62,7 @@ export default class Init extends Command {
       packageManager: flags['package-manager'],
       template: promptAnswers.template,
       local: flags.local,
-      directory,
+      directory: flags.path,
     })
   }
 

--- a/packages/theme/src/cli/commands/theme/init.ts
+++ b/packages/theme/src/cli/commands/theme/init.ts
@@ -4,8 +4,8 @@ import {cloneRepoAndCheckoutLatestTag, cloneRepo} from '../../services/init.js'
 import {Args, Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {generateRandomNameForSubdirectory} from '@shopify/cli-kit/node/fs'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
+import {joinPath} from '@shopify/cli-kit/node/path'
 
 export default class Init extends ThemeCommand {
   static description = 'Clones a Git repository to use as a starting point for building a new theme.'
@@ -37,10 +37,9 @@ export default class Init extends ThemeCommand {
 
   async run(): Promise<void> {
     const {args, flags} = await this.parse(Init)
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
-    const name = args.name || (await this.promptName(directory))
-    const destination = resolvePath(flags.path, name)
+    const name = args.name || (await this.promptName(flags.path))
     const repoUrl = flags['clone-url']
+    const destination = joinPath(flags.path, name)
 
     if (flags.latest) {
       await cloneRepoAndCheckoutLatestTag(repoUrl, destination)

--- a/packages/theme/src/cli/commands/theme/package.ts
+++ b/packages/theme/src/cli/commands/theme/package.ts
@@ -2,7 +2,6 @@ import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {packageTheme} from '../../services/package.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 
 export default class Package extends ThemeCommand {
   static description = 'Package your theme into a .zip file, ready to upload to the Online Store.'
@@ -14,8 +13,6 @@ export default class Package extends ThemeCommand {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Package)
-    const inputDirectory = flags.path ? resolvePath(flags.path) : cwd()
-
-    await packageTheme(inputDirectory)
+    await packageTheme(flags.path)
   }
 }

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -6,7 +6,6 @@ import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
-import {isAbsolutePath, resolvePath} from '@shopify/cli-kit/node/path'
 
 export default class Pull extends ThemeCommand {
   static description = 'Download your remote theme files locally.'
@@ -70,14 +69,8 @@ export default class Pull extends ThemeCommand {
       }
     }
 
-    let validPath = flags.path
-    if (!isAbsolutePath(validPath)) {
-      validPath = resolvePath(flags.path)
-    }
-
     const flagsToPass = this.passThroughFlags(flags, {allowedFlags: Pull.cli2Flags})
-
-    const command = ['theme', 'pull', validPath, ...flagsToPass]
+    const command = ['theme', 'pull', flags.path, ...flagsToPass]
 
     await execCLI2(command, {adminSession})
   }

--- a/packages/theme/src/cli/commands/theme/share.ts
+++ b/packages/theme/src/cli/commands/theme/share.ts
@@ -5,7 +5,6 @@ import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 
 export default class Share extends ThemeCommand {
   static description =
@@ -26,12 +25,11 @@ export default class Share extends ThemeCommand {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Share)
-    const directory = flags.path ? resolvePath(flags.path) : cwd()
     const flagsToPass = this.passThroughFlags(flags, {allowedFlags: Share.cli2Flags})
 
     const store = ensureThemeStore(flags)
     const adminSession = await ensureAuthenticatedThemes(store, flags.password)
 
-    await execCLI2(['theme', 'share', directory, ...flagsToPass], {adminSession})
+    await execCLI2(['theme', 'share', flags.path, ...flagsToPass], {adminSession})
   }
 }

--- a/packages/theme/src/cli/flags.ts
+++ b/packages/theme/src/cli/flags.ts
@@ -1,6 +1,6 @@
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {resolvePath} from '@shopify/cli-kit/node/path'
+import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 
 /**
  * An object that contains the flags that
@@ -10,9 +10,9 @@ export const themeFlags = {
   path: Flags.string({
     hidden: false,
     description: 'The path to your theme directory.',
-    parse: (input, _) => Promise.resolve(resolvePath(input)),
     env: 'SHOPIFY_FLAG_PATH',
-    default: '.',
+    parse: async (input) => resolvePath(input),
+    default: async () => cwd(),
   }),
   password: Flags.string({
     hidden: false,
@@ -25,6 +25,6 @@ export const themeFlags = {
       'Store URL. It can be the store prefix (johns-apparel)' +
       ' or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).',
     env: 'SHOPIFY_FLAG_STORE',
-    parse: (input, _) => Promise.resolve(normalizeStoreFqdn(input)),
+    parse: async (input) => normalizeStoreFqdn(input),
   }),
 }


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed that theme commands didn't work well handling the local folder as the root of the commands

### WHAT is this pull request doing?

- Unify how we handle `path` flags everywhere
- Move parsing and defaulting logic inside the definition of the flag itself
- Switch to `async` style when defining custom `parse` functions

### How to test your changes?

- from the cli repo
- `pnpm shopify theme init "theme-preview-2023-03-01" && cd theme-preview-2023-03-01`
- `pnpm shopify theme check` should work
  - before this PR you would have to write `pnpm shopify theme check --path theme-preview-2023-03-01` and pass the path again

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
