### PR TITLE
Add a script to create a test app for releases

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Build the fixture app
-        run: pnpm run shopify app build --path ./fixtures/app --skip-dependencies-installation
+        run: pnpm fixtures:build
 
   main:
     name: Node ${{ matrix.node }} in ${{ matrix.os }}

--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import execa from 'execa'
+import { Readable } from 'stream'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const homeDir = os.homedir()
+const today = new Date().toISOString().split('T')[0]
+const appName = `nightly-app-${today}`
+const appPath = path.join(homeDir, 'Desktop', appName)
+
+// helpers
+function log(message) {
+  console.log(`🧪 ${message}`)
+}
+
+async function appExec(command, args, options = {}) {
+  const defaults = {cwd: appPath, stdio: 'inherit'}
+  await execa(command, args, {...defaults, ...options})
+}
+
+async function pnpmDev() {
+  try {
+    await appExec(`cd ${appPath} && pnpm run dev`, [], {shell: true})
+  } catch (error) {
+  }
+}
+
+// main script
+if (!fs.existsSync(appPath)) {
+  log("Creating a new app using nightly...")
+  await execa('pnpm', [
+    'create',
+    '@shopify/app@nightly',
+    '--template=node',
+    `--name=${appName}`,
+    `--path=${path.join(homeDir, 'Desktop')}`,
+  ], {stdio: 'inherit'})
+
+  log("Running the app...")
+  await appExec('pnpm', ['install'])
+  await pnpmDev()
+}
+
+if (!fs.existsSync(path.join(appPath, 'extensions', 'sub-ui-ext'))) {
+  log("Generating UI extension...")
+  await appExec('pnpm', ['generate', 'extension', '--type=subscription_ui', '--name=sub-ui-ext', '--template=vanilla-js'])
+  await pnpmDev()
+}
+
+if (!fs.existsSync(path.join(appPath, 'extensions', 'theme-app-ext'))) {
+  log("Generating Theme App extension...")
+  await appExec('pnpm', ['generate', 'extension', '--type=theme_app_extension', '--name=theme-app-ext'])
+  const fixtureAppTheme = path.join(__dirname, '..', 'fixtures', 'app', 'extensions', 'theme-extension')
+  const filesToCopy = [
+    path.join('blocks', 'star_rating.liquid'),
+    path.join('snippets', 'stars.liquid'),
+    path.join('assets', 'thumbs-up.png'),
+    path.join('locales', 'en.default.json'),
+  ]
+  filesToCopy.forEach((file) => {
+    fs.copyFileSync(
+      path.join(fixtureAppTheme, file),
+      path.join(appPath, 'extensions', 'theme-app-ext', file)
+    )
+  })
+  await pnpmDev()
+}
+
+if (!fs.existsSync(path.join(appPath, 'extensions', 'prod-discount-fun'))) {
+  log("Generating JS function...")
+  const functionDir = path.join(appPath, 'extensions', 'prod-discount-fun')
+  await appExec(
+    'pnpm',
+    ['generate', 'extension', '--type=product_discounts', '--name=prod-discount-fun', '--template=typescript'],
+    {env: {SHOPIFY_CLI_FUNCTIONS_JAVASCRIPT: '1'}}
+  )
+  await appExec('pnpm', ['build'], {cwd: functionDir})
+  const previewProcess = execa('pnpm', ['preview'], {cwd: functionDir, stdout: 'inherit'})
+  Readable.from(['{"discountNode":{"metafield":null}}']).pipe(previewProcess.stdin)
+  await previewProcess
+}

--- a/dev.yml
+++ b/dev.yml
@@ -23,7 +23,6 @@ up:
 env:
   SHOPIFY_CLI_ENV: development
   SHOPIFY_SERVICE_ENV: production
-  SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION: "1"
 
 open:
   app: http://localhost:3000

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "build:affected": "nx affected --target=build --all",
     "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache",
     "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache && bin/prettify-manifests.js",
-    "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests && bin/update-cli-kit-version.js && pnpm docs:generate"
+    "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests && bin/update-cli-kit-version.js && pnpm docs:generate",
+    "fixtures:build": "pnpm shopify app build --path fixtures/app --skip-dependencies-installation",
+    "fixtures:dev": "pnpm shopify app dev --path fixtures/app --skip-dependencies-installation",
+    "fixtures:deploy": "pnpm shopify app deploy --path fixtures/app"
   },
   "devDependencies": {
     "@apollo/client": "^3.4.8",


### PR DESCRIPTION
### WHY are these changes introduced?

Add a cross-env script to test releases

### How to test your changes?

- `node bin/create-test-app.js`
  - this command will create a new app on your Desktop called `nightly-app-{date}`
- open link with `p`, install app in your shop and verifies it loads
- press `q` to continue and test the UI extension in `extensions/sub-ui-ext`
  - use dev console to go to admin page, click “Add purchase option > Select existing option”, you’ll see a message
  - change the message inside `src/index.js`, you should see it hot reload
- press `q` to continue and test the theme extension in `extensions/theme-app-ext`
  - enable the theme extension in your app
  - in the theme editor, click “Add section” > choose your nightly app, then “Save”
  - make a change to the theme’s `blocks/star_rating.liquid`
  - open http://localhost:9292/ and verifies it appears
- press `q` to continue and test the JS function
  - you should see a colored Output section

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
