### PR TITLE
Theme app extension server disabled in spin

### DIFF
--- a/.changeset/nine-moles-raise.md
+++ b/.changeset/nine-moles-raise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Theme app extension server disabled in spin

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -162,7 +162,7 @@ async function dev(options: DevOptions) {
 
   const additionalProcesses: OutputProcess[] = []
 
-  if (localApp.extensions.theme.length > 0) {
+  if (localApp.extensions.theme.length > 0 && !isSpinEnvironment()) {
     const adminSession = await ensureAuthenticatedAdmin(storeFqdn)
     const extension = localApp.extensions.theme[0]!
     let optionsToOverwrite = {}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Although theme app extension server is working properly in spin including the hot code reloading, the content of the theme app extensions is not shown in the storefront even after enabling it in the theme editor.

There ir an [open research](https://shopify.slack.com/archives/C01D7U7AJ5C/p1677526583011839) to solve this problem but in the meantime it's better to disable it in spin to avoid unexpected behaviours,

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Disabling theme app extension server when the app includes on extension of this type and it is run with spin
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Run the `dev` command in spin using an app with a theme  app extension
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
