### PR TITLE
Enable javy dynamic linking for function build

### DIFF
--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -133,7 +133,16 @@ describe('runJavy', () => {
     await expect(got).resolves.toBeUndefined()
     expect(exec).toHaveBeenCalledWith(
       'npm',
-      ['exec', '--', 'javy', 'compile', '-o', joinPath(ourFunction.directory, 'dist/index.wasm'), 'dist/function.js'],
+      [
+        'exec',
+        '--',
+        'javy',
+        'compile',
+        '-d',
+        '-o',
+        joinPath(ourFunction.directory, 'dist/index.wasm'),
+        'dist/function.js',
+      ],
       {
         cwd: ourFunction.directory,
         stderr,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -107,7 +107,7 @@ function getESBuildOptions(directory: string, entryPoint: string, userFunction: 
 }
 
 export async function runJavy(fun: FunctionExtension, options: JSFunctionBuildOptions) {
-  return exec('npm', ['exec', '--', 'javy', 'compile', '-o', fun.buildWasmPath, 'dist/function.js'], {
+  return exec('npm', ['exec', '--', 'javy', 'compile', '-d', '-o', fun.buildWasmPath, 'dist/function.js'], {
     cwd: fun.directory,
     stdout: options.stdout,
     stderr: options.stderr,


### PR DESCRIPTION
### WHY are these changes introduced?

So that functions can deploy to Shopify!