### PR TITLE
Remove h3 from cli-kit

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -55,7 +55,8 @@
     "http-proxy": "1.18.1",
     "javy-cli": "0.1.2",
     "serve-static": "1.15.0",
-    "ws": "8.12.1"
+    "ws": "8.12.1",
+    "h3": "0.7.21"
   },
   "devDependencies": {
     "@types/diff": "^5.0.2",

--- a/packages/app/src/cli/services/dev/extension/server.ts
+++ b/packages/app/src/cli/services/dev/extension/server.ts
@@ -12,7 +12,7 @@ import {
 } from './server/middlewares.js'
 import {ExtensionsPayloadStore} from './payload/store.js'
 import {ExtensionDevOptions} from '../extension.js'
-import {createApp, createRouter} from '@shopify/cli-kit/node/http'
+import {createApp, createRouter} from 'h3'
 import {createServer} from 'http'
 
 interface SetupHTTPServerOptions {

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
@@ -15,7 +15,7 @@ import {UIExtensionPayload} from '../payload/models.js'
 import {testUIExtension} from '../../../../models/app/app.test-data.js'
 import {describe, expect, it, vi} from 'vitest'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
-import * as http from '@shopify/cli-kit/node/http'
+import * as http from 'h3'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
 function getMockRequest({context = {}, headers = {}}) {

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -3,7 +3,7 @@ import {GetExtensionsMiddlewareOptions} from './models.js'
 import {getUIExtensionPayload} from '../payload.js'
 import {getHTML} from '../templates.js'
 import {fileExists, isDirectory, readFile, findPathUp} from '@shopify/cli-kit/node/fs'
-import {IncomingMessage, ServerResponse, sendRedirect, send} from '@shopify/cli-kit/node/http'
+import {IncomingMessage, ServerResponse, sendRedirect, send} from 'h3'
 import {joinPath, extname, moduleDirectory} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 

--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -2,7 +2,7 @@ import {UIExtension} from '../../../../models/app/extensions.js'
 import {getUIExtensionResourceURL} from '../../../../utilities/extensions/configuration.js'
 import {ExtensionDevOptions} from '../../extension.js'
 import {getExtensionPointTargetSurface} from '../utilities.js'
-import * as http from '@shopify/cli-kit/node/http'
+import {createError, H3Error, ServerResponse, sendError as h3SendError} from 'h3'
 
 export function getRedirectUrl(extension: UIExtension, options: ExtensionDevOptions): string {
   const {url: resourceUrl} = getUIExtensionResourceURL(extension.configuration.type, options)
@@ -65,6 +65,6 @@ export function getExtensionUrl(extension: UIExtension, options: ExtensionDevOpt
   return extensionUrl.toString()
 }
 
-export function sendError(response: http.ServerResponse, error: Partial<http.H3Error>) {
-  http.sendError(response.event, http.createError(error))
+export function sendError(response: ServerResponse, error: Partial<H3Error>) {
+  h3SendError(response.event, createError(error))
 }

--- a/packages/app/src/cli/services/dev/extension/websocket/handlers.test.ts
+++ b/packages/app/src/cli/services/dev/extension/websocket/handlers.test.ts
@@ -8,7 +8,7 @@ import {SetupWebSocketConnectionOptions} from './models.js'
 import {ExtensionsEndpointPayload} from '../payload/models.js'
 import {vi, describe, test, expect} from 'vitest'
 import WebSocket, {RawData, WebSocketServer} from 'ws'
-import {IncomingMessage} from '@shopify/cli-kit/node/http'
+import {IncomingMessage} from 'h3'
 import {Duplex} from 'stream'
 
 function getMockRequest() {

--- a/packages/app/src/cli/services/dev/extension/websocket/handlers.ts
+++ b/packages/app/src/cli/services/dev/extension/websocket/handlers.ts
@@ -6,8 +6,8 @@ import {
   SetupWebSocketConnectionOptions,
 } from './models.js'
 import {RawData, WebSocket, WebSocketServer} from 'ws'
-import {IncomingMessage} from '@shopify/cli-kit/node/http'
 import {outputDebug, outputContent, outputToken} from '@shopify/cli-kit/node/output'
+import {IncomingMessage} from 'http'
 import {Duplex} from 'stream'
 
 export function websocketUpgradeHandler(

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -125,7 +125,6 @@
     "gradient-string": "2.0.2",
     "graphql": "16.4.0",
     "graphql-request": "5.2.0",
-    "h3": "0.7.21",
     "ink": "3.2.0",
     "is-interactive": "2.0.0",
     "js-yaml": "4.1.0",

--- a/packages/cli-kit/src/private/node/session/redirect-listener.ts
+++ b/packages/cli-kit/src/private/node/session/redirect-listener.ts
@@ -12,9 +12,8 @@ import {
 } from './post-auth.js'
 import {AbortError, BugError} from '../../../public/node/error.js'
 import {outputContent, outputInfo, outputToken} from '../../../public/node/output.js'
-import {createApp, IncomingMessage, ServerResponse} from 'h3'
 import url from 'url'
-import {createServer, Server} from 'http'
+import {createServer, Server, IncomingMessage, ServerResponse} from 'http'
 
 const ResponseTimeoutSeconds = 10
 const ServerStopDelaySeconds = 0.5
@@ -42,7 +41,7 @@ interface RedirectListenerOptions {
  */
 export class RedirectListener {
   private static createServer(callback: RedirectCallback): Server {
-    const app = createApp().use('*', async (request: IncomingMessage, response: ServerResponse) => {
+    const app = async (request: IncomingMessage, response: ServerResponse) => {
       const requestUrl = request.url
       if (requestUrl?.includes('favicon')) {
         const faviconFile = await getFavicon()
@@ -97,7 +96,7 @@ export class RedirectListener {
 
       const file = await getSuccessHTML()
       return respond(file, undefined, `${queryObject.code}`, `${queryObject.state}`)
-    })
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     return createServer(app)

--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -6,19 +6,6 @@ import {debugLogResponseInfo} from '../../private/node/api.js'
 import FormData from 'form-data'
 import nodeFetch, {RequestInfo, RequestInit} from 'node-fetch'
 
-export {
-  createApp,
-  createRouter,
-  IncomingMessage,
-  ServerResponse,
-  CompatibilityEvent,
-  createError,
-  send,
-  sendError,
-  sendRedirect,
-  H3Error,
-} from 'h3'
-
 export {FetchError} from 'node-fetch'
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,7 @@ importers:
       graphql: ^16.0.0
       graphql-request: 5.2.0
       graphql-tag: ^2.12.6
+      h3: 0.7.21
       http-proxy: 1.18.1
       javy-cli: 0.1.2
       serve-static: 1.15.0
@@ -234,6 +235,7 @@ importers:
       esbuild: 0.15.16
       function-runner: 4.0.2
       graphql-request: 5.2.0_graphql@16.6.0
+      h3: 0.7.21
       http-proxy: 1.18.1
       javy-cli: 0.1.2
       serve-static: 1.15.0
@@ -321,7 +323,6 @@ importers:
       gradient-string: 2.0.2
       graphql: 16.4.0
       graphql-request: 5.2.0
-      h3: 0.7.21
       ink: 3.2.0
       ink-testing-library: ^2.1.0
       is-interactive: 2.0.0
@@ -347,9 +348,9 @@ importers:
       terminal-link: 3.0.0
       tree-kill: 1.2.2
       ts-error: 1.0.6
+      ts-morph: ^17.0.1
       typedoc: ^0.23.26
       typescript: 4.9.5
-      ts-morph: ^17.0.1
       unique-string: 3.0.0
       vite: 2.9.12
       vitest: ^0.28.5
@@ -385,7 +386,6 @@ importers:
       gradient-string: 2.0.2
       graphql: 16.4.0
       graphql-request: 5.2.0_graphql@16.4.0
-      h3: 0.7.21
       ink: 3.2.0_hw3ykagcixqw57etxpo4kpffqq
       is-interactive: 2.0.0
       js-yaml: 4.1.0
@@ -424,9 +424,9 @@ importers:
       '@vitest/coverage-istanbul': 0.28.5
       ink-testing-library: 2.1.0_@types+react@16.14.0
       node-stream-zip: 1.15.0
+      ts-morph: 17.0.1
       typedoc: 0.23.26_typescript@4.9.5
       typescript: 4.9.5
-      ts-morph: 17.0.1
       vite: 2.9.12
       vitest: 0.28.5
 
@@ -6175,8 +6175,8 @@ packages:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
     dev: true
 
-  /destr/1.2.1:
-    resolution: {integrity: sha512-ud8w0qMLlci6iFG7CNgeRr8OcbUWMsbfjtWft1eJ5Luqrz/M8Ebqk/KCzne8rKUlIQWWfLv0wD6QHrqOf4GshA==}
+  /destr/1.2.2:
+    resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
     dev: false
 
   /destroy/1.2.0:
@@ -8262,7 +8262,7 @@ packages:
     resolution: {integrity: sha512-F/qdr3JKh8zBLiZyiprH5kuzG6vjoTK3nFnIYFUIQPLsw755GI5JezAFc3HJxbgYlzawcGeJlmsw4xu2t/0n/Q==}
     dependencies:
       cookie-es: 0.5.0
-      destr: 1.2.1
+      destr: 1.2.2
       radix3: 0.1.2
       ufo: 0.8.6
     dev: false
@@ -13206,7 +13206,7 @@ packages:
       globrex: 0.1.2
       recrawl-sync: 2.2.3
       tsconfig-paths: 4.1.1
-      vite: 2.9.12_sass@1.56.1
+      vite: 2.9.12
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
H3 is an http server package that is used only in two places:
- The auth redirect listener
- The app dev console / extensions server

For the redirect listener we can use the default node's http server which allows us to remove h3 as a dependency from cli-kit and move it to `app`. Cli-kit shouldn't have dependencies just to re-export them.

<!--
  Context about the problem that’s being addressed.
-->


<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Try to logout/login
- Try to dev an app with extensions
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->


<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
