### PR TITLE
Unhide JavaScript functions flavors and commands

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -79,7 +79,6 @@ if (!fs.existsSync(path.join(appPath, 'extensions', 'prod-discount-fun'))) {
   await appExec(
     'pnpm',
     ['generate', 'extension', '--type=product_discounts', '--name=prod-discount-fun', '--template=typescript'],
-    {env: {SHOPIFY_CLI_FUNCTIONS_JAVASCRIPT: '1'}}
   )
   await appExec('pnpm', ['build'], {cwd: functionDir})
   const previewProcess = execa('pnpm', ['preview'], {cwd: functionDir, stdout: 'inherit'})

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -37,13 +37,8 @@ export const blocks = {
 } as const
 
 export const defaultFunctionsFlavors: {name: string; value: ExtensionFlavor}[] = [
-  {name: 'Wasm', value: 'wasm'},
-  {name: 'Rust', value: 'rust'},
-]
-
-export const withJavaScriptFunctionsFlavors: {name: string; value: ExtensionFlavor}[] = [
-  {name: 'JavaScript', value: 'vanilla-js'},
-  {name: 'TypeScript', value: 'typescript'},
+  {name: 'JavaScript (developer preview)', value: 'vanilla-js'},
+  {name: 'TypeScript (developer preview)', value: 'typescript'},
   {name: 'Rust', value: 'rust'},
   {name: 'Wasm', value: 'wasm'},
 ]

--- a/packages/app/src/cli/models/extensions/functions.ts
+++ b/packages/app/src/cli/models/extensions/functions.ts
@@ -1,10 +1,9 @@
 import {BaseFunctionConfigurationSchema, ZodSchemaType} from './schemas.js'
 import {ExtensionCategory, GenericSpecification, FunctionExtension} from '../app/extensions.js'
-import {blocks, defaultFunctionsFlavors, withJavaScriptFunctionsFlavors} from '../../constants.js'
+import {blocks, defaultFunctionsFlavors} from '../../constants.js'
 import {ExtensionFlavor} from '../../services/generate/extension.js'
 import {constantize} from '@shopify/cli-kit/common/string'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {areJavaScriptFunctionsEnabled} from '@shopify/cli-kit/node/context/local'
 import {joinPath, basename} from '@shopify/cli-kit/node/path'
 import {schema} from '@shopify/cli-kit/node/schema'
 
@@ -137,7 +136,7 @@ export function createFunctionSpecification<TConfiguration extends FunctionConfi
     templateURL: 'https://github.com/Shopify/function-examples',
     externalIdentifier: spec.identifier,
     externalName: spec.identifier,
-    supportedFlavors: areJavaScriptFunctionsEnabled() ? withJavaScriptFunctionsFlavors : defaultFunctionsFlavors,
+    supportedFlavors: defaultFunctionsFlavors,
     configSchema: BaseFunctionConfigurationSchema,
     gated: false,
     registrationLimit: spec.registrationLimit ?? blocks.functions.defaultRegistrationLimit,

--- a/packages/app/src/cli/prompts/generate/extension.test.ts
+++ b/packages/app/src/cli/prompts/generate/extension.test.ts
@@ -6,7 +6,7 @@ import {
   loadLocalExtensionsSpecifications,
 } from '../../models/extensions/specifications.js'
 import {describe, it, expect, vi, beforeEach} from 'vitest'
-import {areJavaScriptFunctionsEnabled, isShopify, isUnitTest} from '@shopify/cli-kit/node/context/local'
+import {isShopify, isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {renderSelectPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 vi.mock('@shopify/cli-kit/node/context/local')
@@ -15,7 +15,6 @@ vi.mock('@shopify/cli-kit/node/ui')
 beforeEach(() => {
   vi.mocked(isShopify).mockResolvedValue(true)
   vi.mocked(isUnitTest).mockResolvedValue(true)
-  vi.mocked(areJavaScriptFunctionsEnabled).mockResolvedValue(false)
 })
 
 describe('extension prompt', async () => {

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -24,7 +24,6 @@ export const environmentVariables = {
   unitTest: 'SHOPIFY_UNIT_TEST',
   verbose: 'SHOPIFY_FLAG_VERBOSE',
   themeBundling: 'SHOPIFY_CLI_THEME_BUNDLING',
-  javascriptFunctions: 'SHOPIFY_CLI_FUNCTIONS_JAVASCRIPT',
   // Variables to detect if the CLI is running in a cloud environment
   codespaceName: 'CODESPACE_NAME',
   codespaces: 'CODESPACES',

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -123,16 +123,6 @@ export function useThemebundling(env = process.env): boolean {
 }
 
 /**
- * Returns true if the CLI enable JavaScript functions.
- *
- * @param env - The environment variables from the environment of the current process.
- * @returns True if SHOPIFY_CLI_FUNCTIONS_JAVASCRIPT is truthy.
- */
-export function areJavaScriptFunctionsEnabled(env = process.env): boolean {
-  return isTruthy(env[environmentVariables.javascriptFunctions])
-}
-
-/**
  * Return gitpodURL if we are running in gitpod.
  * Https://www.gitpod.io/docs/environment-variables#default-environment-variables.
  *

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -146,8 +146,7 @@
         "description": "Manage environment variables."
       },
       "app:function": {
-        "description": "Manage Shopify Functions.",
-        "hidden": true
+        "description": "Manage Shopify Functions."
       },
       "auth": {
         "description": "Auth operations."


### PR DESCRIPTION
### WHY are these changes introduced?

JavaScript functions are releasing to dev preview, but will still require use of the `@pre` release tag. We don't want the further step of enabling a feature flag to be required.

### WHAT is this pull request doing?

* Displays JS and TS flavors by default, with a `(developer preview)` description
* Unhides `shopify app function` topic

### How to test your changes?

Against a local build:
* `yarn shopify app generate extension --path <my app>`

![image](https://user-images.githubusercontent.com/27013789/223183561-3f036732-a392-4b3a-96fc-393861a68889.png)

* `yarn shopify app --help --path <my app>`

![image](https://user-images.githubusercontent.com/27013789/223183720-c827417d-18b0-4e22-8c96-31c707688ce3.png)

