### PR TITLE
Explicitly use package.json for functions typegen

### DIFF
--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -36,7 +36,7 @@ describe('buildGraphqlTypes', () => {
 
     // Then
     await expect(got).resolves.toBeUndefined()
-    expect(exec).toHaveBeenCalledWith('npm', ['exec', '--', 'graphql-code-generator'], {
+    expect(exec).toHaveBeenCalledWith('npm', ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
       cwd: ourFunction.directory,
       stderr,
       signal,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -65,7 +65,7 @@ export async function buildGraphqlTypes(
     throw new Error('GraphQL types can only be built for JavaScript functions')
   }
 
-  return exec('npm', ['exec', '--', 'graphql-code-generator'], {
+  return exec('npm', ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
     cwd: fun.directory,
     stderr: options.stderr,
     signal: options.signal,


### PR DESCRIPTION
### WHY are these changes introduced?

Workaround for [unexpected behavior](https://github.com/kamilkisiela/graphql-config/issues/1266) in graphql-config.

If a developer has a root `.graphqlrc` or similar in their app, typegen fails with an error such as

```
ENOENT: no such file or directory, scandir './sample-apps/discounts/extensions'
```

### WHAT is this pull request doing?

Explicitly pass `--config package.json` to `graphql-code-generator`. This makes us more opinionated but matches the structure of our boilerplate. I don't have a known use case at the moment which would require customizing this.

### How to test your changes?

* Attempt typegen against a JavaScript function in our examples repo, e.g. [product-discount-js](https://github.com/Shopify/function-examples/tree/sample-apps-javascript/sample-apps/discounts/extensions/product-discount-js)

![image](https://user-images.githubusercontent.com/27013789/223187497-b13359f6-0ac1-45eb-81eb-bb92fe6226f2.png)

* The same is successful using a local build of this PR

```
pnpm shopify app function typegen --path ~/src/function-examples/sample-apps/discounts/extensions/product-discount-js
```

![image](https://user-images.githubusercontent.com/27013789/223187957-061e9d56-abe3-4af4-bba2-6ef82edf1cc2.png)
