### PR TITLE
Validating function flavor existence

### DIFF
--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -28,7 +28,6 @@ export const blocks = {
   },
   functions: {
     defaultUrl: 'https://github.com/Shopify/function-examples',
-    defaultLanguage: 'wasm',
     defaultRegistrationLimit: 10,
   },
   web: {

--- a/packages/app/src/cli/services/function/common.ts
+++ b/packages/app/src/cli/services/function/common.ts
@@ -2,10 +2,13 @@ import {FunctionExtension} from '../../models/app/extensions.js'
 import {App, AppInterface} from '../../models/app/app.js'
 import {load as loadApp} from '../../models/app/loader.js'
 import {loadExtensionsSpecifications} from '../../models/extensions/specifications.js'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
+import {FunctionSpec} from '../../models/extensions/functions.js'
+import {ExtensionFlavor, TemplateFlavor} from '../generate/extension.js'
+import {resolvePath, cwd, joinPath} from '@shopify/cli-kit/node/path'
 import {renderFatalError} from '@shopify/cli-kit/node/ui'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {Config, Flags} from '@oclif/core'
+import {fileExists} from '@shopify/cli-kit/node/fs'
 
 export const functionFlags = {
   path: Flags.string({
@@ -33,4 +36,18 @@ export async function inFunctionContext(
       new AbortError('Run this command from a function directory or use `--path` to specify a function directory.'),
     )
   }
+}
+
+export async function ensureFunctionExtensionFlavorExists(
+  specification: FunctionSpec,
+  extensionFlavor: ExtensionFlavor,
+  templateFlavor: TemplateFlavor,
+  templateDownloadDir: string,
+): Promise<string> {
+  const templatePath = specification.templatePath(templateFlavor)
+  const origin = joinPath(templateDownloadDir, templatePath)
+  if (!(await fileExists(origin))) {
+    throw new AbortError(`\nExtension '${specification.externalName}' is not available for ${extensionFlavor}`)
+  }
+  return origin
 }

--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -12,6 +12,7 @@ import {
   loadLocalUIExtensionsSpecifications,
 } from '../../models/extensions/specifications.js'
 import * as functionBuild from '../function/build.js'
+import * as functionCommon from '../function/common.js'
 import {describe, it, expect, vi} from 'vitest'
 import * as output from '@shopify/cli-kit/node/output'
 import {addNPMDependenciesIfNeeded, addResolutionOrOverride} from '@shopify/cli-kit/node/node-package-manager'
@@ -260,6 +261,7 @@ describe('initialize a extension', async () => {
     await withTemporaryApp(async (tmpDir) => {
       // Given
       vi.spyOn(git, 'downloadGitRepository').mockResolvedValue()
+      vi.spyOn(functionCommon, 'ensureFunctionExtensionFlavorExists').mockImplementationOnce(async () => tmpDir)
 
       const name = 'my-ext-1'
       const specification = allFunctionSpecs.find((spec) => spec.identifier === 'order_discounts')!
@@ -286,6 +288,7 @@ describe('initialize a extension', async () => {
       const extensionFlavor = 'rust'
 
       vi.spyOn(git, 'downloadGitRepository').mockResolvedValue()
+      vi.spyOn(functionCommon, 'ensureFunctionExtensionFlavorExists').mockImplementationOnce(async () => tmpDir)
       vi.spyOn(template, 'recursiveLiquidTemplateCopy').mockImplementationOnce(async (_origin, destination) => {
         await file.writeFile(
           joinPath(destination, 'shopify.function.extension.toml'),
@@ -324,6 +327,7 @@ describe('initialize a extension', async () => {
       const extensionFlavor = 'vanilla-js'
 
       vi.spyOn(git, 'downloadGitRepository').mockResolvedValue()
+      vi.spyOn(functionCommon, 'ensureFunctionExtensionFlavorExists').mockImplementationOnce(async () => tmpDir)
       vi.spyOn(template, 'recursiveLiquidTemplateCopy').mockImplementationOnce(async (_origin, destination) => {
         await file.writeFile(
           joinPath(destination, 'shopify.function.extension.toml'),

--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -363,6 +363,32 @@ describe('initialize a extension', async () => {
       expect(buildGraphqlTypesSpy).toHaveBeenCalledOnce()
     })
   })
+
+  it('throws an error if there is no folder for selected flavor', async () => {
+    await withTemporaryApp(async (tmpDir) => {
+      // Given
+      const name = 'my-fun-1'
+      const specification = allFunctionSpecs.find((spec) => spec.identifier === 'order_discounts')!
+      const extensionFlavor = 'vanilla-js'
+
+      vi.spyOn(git, 'downloadGitRepository').mockResolvedValue()
+      vi.spyOn(functionCommon, 'ensureFunctionExtensionFlavorExists').mockImplementationOnce(async () => {
+        throw new Error('No folder for selected flavor')
+      })
+
+      // When
+      const got = createFromTemplate({
+        name,
+        specification,
+        extensionFlavor,
+        appDirectory: tmpDir,
+        specifications,
+      })
+
+      // Then
+      await expect(got).rejects.toThrowErrorMatchingInlineSnapshot('"No folder for selected flavor"')
+    })
+  })
 })
 
 describe('getExtensionRuntimeDependencies', () => {

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -5,6 +5,7 @@ import {GenericSpecification} from '../../models/app/extensions.js'
 import {UIExtensionSpec} from '../../models/extensions/ui.js'
 import {ThemeExtensionSpec} from '../../models/extensions/theme.js'
 import {buildGraphqlTypes} from '../function/build.js'
+import {ensureFunctionExtensionFlavorExists} from '../function/common.js'
 import {
   addNPMDependenciesIfNeeded,
   addResolutionOrOverride,
@@ -202,7 +203,7 @@ async function functionExtensionInit(options: FunctionExtensionInitOptions) {
 
   await inTemporaryDirectory(async (tmpDir) => {
     const templateDownloadDir = joinPath(tmpDir, 'download')
-    const extensionFlavor = options.extensionFlavor
+    const extensionFlavor = options.extensionFlavor ?? blocks.functions.defaultLanguage
     const templateFlavor = extensionFlavor && getTemplateFlavor(extensionFlavor)
     const taskList = []
 
@@ -229,8 +230,13 @@ async function functionExtensionInit(options: FunctionExtensionInitOptions) {
           destination: templateDownloadDir,
           shallow: true,
         })
-        const templatePath = specification.templatePath(templateFlavor ?? blocks.functions.defaultLanguage)
-        const origin = joinPath(templateDownloadDir, templatePath)
+        const origin = await ensureFunctionExtensionFlavorExists(
+          specification,
+          extensionFlavor,
+          templateFlavor,
+          templateDownloadDir,
+        )
+
         await recursiveLiquidTemplateCopy(origin, options.extensionDirectory, {
           flavor: extensionFlavor ?? '',
           ...options,

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -45,9 +45,13 @@ interface ExtensionDirectory {
   extensionDirectory: string
 }
 
+interface FunctionFlavor {
+  extensionFlavor: ExtensionFlavor
+}
+
 export type ExtensionFlavor = 'vanilla-js' | 'react' | 'typescript' | 'typescript-react' | 'rust' | 'wasm'
 
-type FunctionExtensionInitOptions = ExtensionInitOptions<FunctionSpec> & ExtensionDirectory
+type FunctionExtensionInitOptions = ExtensionInitOptions<FunctionSpec> & ExtensionDirectory & FunctionFlavor
 type UIExtensionInitOptions = ExtensionInitOptions<UIExtensionSpec> & ExtensionDirectory
 type ThemeExtensionInitOptions = ExtensionInitOptions<ThemeExtensionSpec> & ExtensionDirectory
 
@@ -203,8 +207,8 @@ async function functionExtensionInit(options: FunctionExtensionInitOptions) {
 
   await inTemporaryDirectory(async (tmpDir) => {
     const templateDownloadDir = joinPath(tmpDir, 'download')
-    const extensionFlavor = options.extensionFlavor ?? blocks.functions.defaultLanguage
-    const templateFlavor = extensionFlavor && getTemplateFlavor(extensionFlavor)
+    const extensionFlavor = options.extensionFlavor
+    const templateFlavor = getTemplateFlavor(extensionFlavor)
     const taskList = []
 
     if (templateFlavor === 'javascript') {
@@ -238,15 +242,13 @@ async function functionExtensionInit(options: FunctionExtensionInitOptions) {
         )
 
         await recursiveLiquidTemplateCopy(origin, options.extensionDirectory, {
-          flavor: extensionFlavor ?? '',
+          flavor: extensionFlavor,
           ...options,
         })
 
         if (templateFlavor === 'javascript') {
-          const srcFileExtension = getSrcFileExtension(extensionFlavor ?? 'vanilla-js')
-          if (extensionFlavor) {
-            await changeIndexFileExtension(options.extensionDirectory, srcFileExtension)
-          }
+          const srcFileExtension = getSrcFileExtension(extensionFlavor)
+          await changeIndexFileExtension(options.extensionDirectory, srcFileExtension)
         }
 
         const configYamlPath = joinPath(options.extensionDirectory, 'script.config.yml')


### PR DESCRIPTION

### WHY are these changes introduced?

Function teams will likely be adding JavaScript templates over the course of our dev preview, before GA. If a certain function type doesn't have JS yet, the current error message is:

```
Building Function - Payment customization graphql types ...
Unable to find Codegen config file! 


── external error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Error coming from `npm exec -- graphql-code-generator`

Command failed with exit code 1: npm exec -- graphql-code-generator
Unable to find Codegen config file!

        Please make sure that you have a configuration file under the current directory!


────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

### WHAT is this pull request doing?

Throws a more helpful error message if the function is missing a flavor.