### PR TITLE
Remove references to hydrogen tools in changeset

### DIFF
--- a/.changeset/beige-experts-deliver.md
+++ b/.changeset/beige-experts-deliver.md
@@ -1,9 +1,7 @@
 ---
 '@shopify/app': minor
-'@shopify/cli-hydrogen': minor
 '@shopify/cli-kit': minor
 '@shopify/create-app': minor
-'@shopify/create-hydrogen': minor
 '@shopify/theme': minor
 ---
 


### PR DESCRIPTION
### WHY are these changes introduced?

We merged a PR that referenced hydrogen in the changeset, but hydrogen isn't part of the project any longer

### WHAT is this pull request doing?

Remove those references
