### PR TITLE
Fix log logic in api responses for node version that do not support Header type

### DIFF
--- a/.changeset/great-games-remain.md
+++ b/.changeset/great-games-remain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix log from api responses for node version that donnot support Headers type


### PR DESCRIPTION
…eaders type

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
After including this [PR](https://github.com/Shopify/cli/pull/1565) in the last `pre` version, users using node v16 reported this error:

```
╭─ error ──────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Headers is not defined                                                      │
│                                                                              │
│  To investigate the issue, examine this stack trace:                         │
│    at debugLogResponseInfo (@shopify/cli-kit/src/private/node/api.ts:22)     │
│      let headers: Headers = new Headers()                                    │
│    at shopifyFetch (@shopify/cli-kit/src/public/node/http.ts:73)             │
│      return debugLogResponseInfo({url: url.toString(), request:              │
```

The problem is that the `Headers` type does not exist in previous node versions. 
The debug log logic in api responses should work in all supported node version

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- The logic that gets the value of either the success or failure responses should be generic using primitive types.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Use any node version switcher to change between v16 and higher versions and run the dev command with each version using a wrong api-key with the --verbose flag
`yarn shopify app dev --api-key 1234 --verbose`

you should see that the correct responses and the error response should show the execution time and the desired headers
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
