### PR TITLE
Pass api-key for Event-Bridge validation

### DIFF
--- a/packages/app/src/cli/services/webhook/request-sample.test.ts
+++ b/packages/app/src/cli/services/webhook/request-sample.test.ts
@@ -8,34 +8,35 @@ const sampleHeaders = '{ "header": "Header Value" }'
 vi.mock('@shopify/cli-kit/node/api/partners')
 
 const aToken = 'A_TOKEN'
+const anApiKey = 'AN_API_KEY'
+const inputValues = {
+  topic: 'A_TOPIC',
+  apiVersion: 'A_VERSION',
+  value: 'A_DELIVERY_METHOD',
+  address: 'https://example.org',
+  clientSecret: 'A_SECRET',
+}
+const graphQLResult = {
+  sendSampleWebhook: {
+    samplePayload,
+    headers: sampleHeaders,
+    success: false,
+    userErrors: [
+      {message: 'Error 1', fields: ['field1']},
+      {message: 'Error 2', fields: ['field1']},
+    ],
+  },
+}
 
 describe('getWebhookSample', () => {
-  it('calls partners to request data', async () => {
+  it('calls partners to request data without api-key', async () => {
     // Given
-    const inputValues = {
-      topic: 'A_TOPIC',
-      apiVersion: 'A_VERSION',
-      value: 'A_DELIVERY_METHOD',
-      address: 'https://example.org',
-      clientSecret: 'A_SECRET',
-    }
     const requestValues = {
       topic: inputValues.topic,
       api_version: inputValues.apiVersion,
       address: inputValues.address,
       delivery_method: inputValues.value,
       shared_secret: inputValues.clientSecret,
-    }
-    const graphQLResult = {
-      sendSampleWebhook: {
-        samplePayload,
-        headers: sampleHeaders,
-        success: false,
-        userErrors: [
-          {message: 'Error 1', fields: ['field1']},
-          {message: 'Error 2', fields: ['field1']},
-        ],
-      },
     }
     vi.mocked(partnersRequest).mockResolvedValue(graphQLResult)
 
@@ -47,6 +48,37 @@ describe('getWebhookSample', () => {
       inputValues.value,
       inputValues.address,
       inputValues.clientSecret,
+    )
+
+    // Then
+    expect(partnersRequest).toHaveBeenCalledWith(expect.any(String), 'A_TOKEN', requestValues)
+    expect(got.samplePayload).toEqual(samplePayload)
+    expect(got.headers).toEqual(sampleHeaders)
+    expect(got.success).toEqual(graphQLResult.sendSampleWebhook.success)
+    expect(got.userErrors).toEqual(graphQLResult.sendSampleWebhook.userErrors)
+  })
+
+  it('calls partners to request data with api-key', async () => {
+    // Given
+    const requestValues = {
+      topic: inputValues.topic,
+      api_version: inputValues.apiVersion,
+      address: inputValues.address,
+      delivery_method: inputValues.value,
+      shared_secret: inputValues.clientSecret,
+      api_key: anApiKey,
+    }
+    vi.mocked(partnersRequest).mockResolvedValue(graphQLResult)
+
+    // When
+    const got = await getWebhookSample(
+      aToken,
+      inputValues.topic,
+      inputValues.apiVersion,
+      inputValues.value,
+      inputValues.address,
+      inputValues.clientSecret,
+      anApiKey,
     )
 
     // Then

--- a/packages/app/src/cli/services/webhook/request-sample.ts
+++ b/packages/app/src/cli/services/webhook/request-sample.ts
@@ -16,8 +16,8 @@ export interface UserErrors {
 }
 
 const sendSampleWebhookMutation = `
-  mutation samplePayload($topic: String!, $api_version: String!, $address: String!, $delivery_method: String!, $shared_secret: String!) {
-    sendSampleWebhook(input: {topic: $topic, apiVersion: $api_version, address: $address, deliveryMethod: $delivery_method, sharedSecret: $shared_secret}) {
+  mutation samplePayload($topic: String!, $api_version: String!, $address: String!, $delivery_method: String!, $shared_secret: String!, $api_key: String) {
+    sendSampleWebhook(input: {topic: $topic, apiVersion: $api_version, address: $address, deliveryMethod: $delivery_method, sharedSecret: $shared_secret, apiKey: $api_key}) {
         samplePayload
         success
         headers
@@ -41,6 +41,7 @@ const sendSampleWebhookMutation = `
  * @param deliveryMethod - one of DELIVERY_METHOD
  * @param address - A destination for the webhook notification
  * @param clientSecret - A secret to generate the HMAC header apps can use to validate the origin
+ * @param apiKey - Client Api Key required to validate Event-Bridge addresses
  * @returns Empty if a remote delivery was requested, payload data if a local delivery was requested
  */
 export async function getWebhookSample(
@@ -50,6 +51,7 @@ export async function getWebhookSample(
   deliveryMethod: string,
   address: string,
   clientSecret: string,
+  apiKey?: string,
 ): Promise<SampleWebhook> {
   const variables = {
     topic,
@@ -57,6 +59,7 @@ export async function getWebhookSample(
     address,
     delivery_method: deliveryMethod,
     shared_secret: clientSecret,
+    api_key: apiKey,
   }
 
   const {sendSampleWebhook: result}: SamplePayloadSchema = await partnersRequest(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Because we want to validate that the event-bridge arn is owned by a known app.
See:
* https://github.com/Shopify/shopify/pull/411020
* https://github.com/Shopify/partners/pull/45998

**IMPORTANT:** this PR has to be deployed after those two

### WHAT is this pull request doing?

Making sure that we have an api-key if event-bridge is used and passing it to Partners
No UI changes, only prompted for app (if you belong to more than one org) if secret not set manually

### How to test your changes?

See the PRs above for testing instructions.
With that spin setup:
* execute the command with a non even-bridge url: Check the logs of partners and core to see that api_key is not sent ✅ 
* execute the command with an event-bridge url and set secret manually: api-key will be get from .env or partners and sent ✅ 
* execute the command with an event-bridge url and set secret automatically: api-key will be get from .env or partners during that step (only once) and then be sent ✅ 

### Post-release steps

Nothing yet: The parameter is just passed, but not validated to prevent breaking the flow during the rollout

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).

This would be totally safe to rollback