### PR TITLE
Cut long host names for development theme naming

### DIFF
--- a/.changeset/spicy-icons-protect.md
+++ b/.changeset/spicy-icons-protect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Cut long host names for development theme naming

--- a/packages/cli-kit/src/private/node/themes/generate-theme-name.test.ts
+++ b/packages/cli-kit/src/private/node/themes/generate-theme-name.test.ts
@@ -1,4 +1,4 @@
-import {generateThemeName} from './generate-theme-name.js'
+import {API_NAME_LIMIT, generateThemeName} from './generate-theme-name.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {hostname} from 'os'
 import {randomBytes} from 'crypto'
@@ -20,6 +20,8 @@ describe('generateThemeName', () => {
 
   it('should truncate if the theme name is above the API limit', () => {
     vi.mocked(hostname).mockReturnValue('theme-dev-lan-very-long-name-that-will-be-truncated')
-    expect(generateThemeName(context)).toEqual('Development (010203-theme-dev-lan-very-long-name-t)')
+    const themeName = generateThemeName(context)
+    expect(themeName.length).toBe(API_NAME_LIMIT)
+    expect(themeName).toEqual('Development (010203-theme-dev-lan-very-long-name-)')
   })
 })

--- a/packages/cli-kit/src/private/node/themes/generate-theme-name.ts
+++ b/packages/cli-kit/src/private/node/themes/generate-theme-name.ts
@@ -2,14 +2,14 @@ import {replaceInvalidCharacters} from './replace-invalid-characters.js'
 import {randomBytes} from 'crypto'
 import {hostname} from 'os'
 
-const API_NAME_LIMIT = 50
+export const API_NAME_LIMIT = 50
 
 export function generateThemeName(context: string): string {
   const hostNameWithoutDomain = hostname().split('.')[0]!
   const hash = randomBytes(3).toString('hex')
 
   const name = `${context} ()`
-  const hostNameCharacterLimit = API_NAME_LIMIT - name.length - hash.length
+  const hostNameCharacterLimit = API_NAME_LIMIT - name.length - hash.length - 1
   const identifier = replaceInvalidCharacters(`${hash}-${hostNameWithoutDomain.substring(0, hostNameCharacterLimit)}`)
   return `${context} (${identifier})`
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1589

### WHAT is this pull request doing?

Removes one additional character from host name, so that development theme name is ≤ 50 characters long.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
