### PR TITLE
Resolve renderTasks with context

### DIFF
--- a/.changeset/quiet-turkeys-hope.md
+++ b/.changeset/quiet-turkeys-hope.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Resolve renderTasks with the value of context

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
@@ -406,4 +406,24 @@ describe('Tasks', () => {
     `)
     expect(thirdTaskFunction).toHaveBeenCalled()
   })
+
+  test('has an onComplete function that is called with the context', async () => {
+    // Given
+    const firstTaskFunction = vi.fn(async (ctx) => {
+      ctx.foo = 'bar'
+    })
+
+    const firstTask: Task<{foo: string}> = {
+      title: 'task 1',
+      task: firstTaskFunction,
+    }
+
+    // When
+    const context = await new Promise((resolve, _reject) => {
+      render(<Tasks tasks={[firstTask]} silent={false} onComplete={resolve} />)
+    })
+
+    // Then
+    expect(context).toEqual({foo: 'bar'})
+  })
 })

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
@@ -20,6 +20,7 @@ export interface Task<TContext = unknown> {
 export interface TasksProps<TContext> {
   tasks: Task<TContext>[]
   silent?: boolean
+  onComplete?: (ctx: TContext) => void
 }
 
 enum TasksState {
@@ -52,8 +53,14 @@ async function runTask<TContext>(task: Task<TContext>, ctx: TContext) {
   }
 }
 
+const noop = () => {}
+
 // eslint-disable-next-line react/function-component-definition
-function Tasks<TContext>({tasks, silent = isUnitTest()}: React.PropsWithChildren<TasksProps<TContext>>) {
+function Tasks<TContext>({
+  tasks,
+  silent = isUnitTest(),
+  onComplete = noop,
+}: React.PropsWithChildren<TasksProps<TContext>>) {
   const {twoThirds} = useLayout()
   const loadingBar = new Array(twoThirds).fill(loadingBarChar).join('')
   const [currentTask, setCurrentTask] = useState<Task<TContext>>(tasks[0]!)
@@ -80,7 +87,10 @@ function Tasks<TContext>({tasks, silent = isUnitTest()}: React.PropsWithChildren
   }
 
   useAsyncAndUnmount(runTasks, {
-    onFulfilled: () => setState(TasksState.Success),
+    onFulfilled: () => {
+      onComplete(ctx.current)
+      setState(TasksState.Success)
+    },
     onRejected: () => setState(TasksState.Failure),
   })
 

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -373,9 +373,12 @@ interface RenderTasksOptions {
  */
 // eslint-disable-next-line max-params
 export async function renderTasks<TContext>(tasks: Task<TContext>[], {renderOptions}: RenderTasksOptions = {}) {
-  return render(<Tasks tasks={tasks} />, {
-    ...renderOptions,
-    exitOnCtrlC: false,
+  // eslint-disable-next-line max-params
+  return new Promise<TContext>((resolve, reject) => {
+    render(<Tasks tasks={tasks} onComplete={resolve} />, {
+      ...renderOptions,
+      exitOnCtrlC: false,
+    }).catch(reject)
   })
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

We've got feedback that it would be useful to resolve `renderTasks` with the value of `ctx` instead of `void`

### WHAT is this pull request doing?

This PR makes `renderTask` resolve with the value of context.