### PR TITLE
Update cart_transform templatePath

### DIFF
--- a/packages/app/src/cli/models/extensions/function-specifications/cart_transform.ts
+++ b/packages/app/src/cli/models/extensions/function-specifications/cart_transform.ts
@@ -3,10 +3,10 @@ import {createFunctionSpecification} from '../functions.js'
 const spec = createFunctionSpecification({
   identifier: 'cart_transform',
   externalIdentifier: 'cart_transform',
-  externalName: 'Function - Cart transformer',
+  externalName: 'Function - Cart transform',
   gated: false,
   registrationLimit: 1,
-  templatePath: (lang) => `checkout/${lang}/cart-transform/bundles`,
+  templatePath: (lang) => `checkout/${lang}/cart-transform/default`,
 })
 
 export default spec


### PR DESCRIPTION
### WHY are these changes introduced?

The `cart_transform` [example-functions template](https://github.com/Shopify/function-examples/tree/main/checkout/rust/cart-transform/default) has been updated to match the pattern of the other function templates. This includes removing the directory `bundles/` and adding the directory `default`.

### WHAT is this pull request doing?

This updates the `templatePath` to use the new `default` directory.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
