### PR TITLE
Allow running deploy without extensions

### DIFF
--- a/packages/app/src/cli/api/graphql/create_deployment.ts
+++ b/packages/app/src/cli/api/graphql/create_deployment.ts
@@ -4,8 +4,8 @@ export const CreateDeployment = gql`
   mutation CreateDeployment(
     $apiKey: String!
     $uuid: String!
-    $bundleUrl: String!
-    $extensions: [ExtensionSettings!]!
+    $bundleUrl: String
+    $extensions: [ExtensionSettings!]
     $label: String
   ) {
     deploymentCreate(
@@ -42,8 +42,8 @@ export interface ExtensionSettings {
 export interface CreateDeploymentVariables {
   apiKey: string
   uuid: string
-  bundleUrl: string
-  extensions: ExtensionSettings[]
+  bundleUrl?: string
+  extensions?: ExtensionSettings[]
   label?: string
 }
 

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -49,7 +49,7 @@ export async function deploy(options: DeployOptions) {
   let {app, identifiers, partnersApp, token} = await ensureDeployContext(options)
   const apiKey = identifiers.app
 
-  if (!options.app.hasExtensions() && !organization?.betas.appUiDeployments) {
+  if (!options.app.hasExtensions() && !partnersApp.betas?.unifiedAppDeployment) {
     renderInfo({headline: 'No extensions to deploy to Shopify Partners yet.'})
     return
   }

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -45,14 +45,14 @@ interface TasksContext {
 }
 
 export async function deploy(options: DeployOptions) {
-  if (!options.app.hasExtensions()) {
-    renderInfo({headline: 'No extensions to deploy to Shopify Partners yet.'})
-    return
-  }
-
   // eslint-disable-next-line prefer-const
   let {app, identifiers, partnersApp, token} = await ensureDeployContext(options)
   const apiKey = identifiers.app
+
+  if (!options.app.hasExtensions() && !organization?.betas.appUiDeployments) {
+    renderInfo({headline: 'No extensions to deploy to Shopify Partners yet.'})
+    return
+  }
 
   let label: string | undefined
 
@@ -102,12 +102,16 @@ export async function deploy(options: DeployOptions) {
 
   await inTemporaryDirectory(async (tmpDir) => {
     try {
-      const bundlePath = joinPath(tmpDir, `bundle.zip`)
-      await mkdir(dirname(bundlePath))
       const bundleTheme = useThemebundling() && app.extensions.theme.length !== 0
       const bundleUI = app.extensions.ui.length !== 0
       const bundle = bundleTheme || bundleUI
-      await bundleAndBuildExtensions({app, bundlePath, identifiers, bundle})
+      let bundlePath: string | undefined
+
+      if (bundle) {
+        bundlePath = joinPath(tmpDir, `bundle.zip`)
+        await mkdir(dirname(bundlePath))
+        await bundleAndBuildExtensions({app, bundlePath, identifiers, bundle})
+      }
 
       const tasks: Task<TasksContext>[] = [
         {
@@ -119,15 +123,13 @@ export async function deploy(options: DeployOptions) {
         {
           title: partnersApp.betas?.unifiedAppDeployment ? 'Creating deployment' : 'Pushing your code to Shopify',
           task: async () => {
-            if (bundle) {
-              ;({validationErrors, deploymentId} = await uploadExtensionsBundle({
-                apiKey,
-                bundlePath,
-                extensions,
-                token,
-                label,
-              }))
-            }
+            ;({validationErrors, deploymentId} = await uploadExtensionsBundle({
+              apiKey,
+              bundlePath,
+              extensions,
+              token,
+              label,
+            }))
 
             if (!useThemebundling()) {
               await uploadThemeExtensions(options.app.extensions.theme, {apiKey, identifiers, token})

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -752,4 +752,35 @@ describe('uploadExtensionsBundle', () => {
       })
     })
   })
+
+  test('calls a mutation on partners when there are no extensions', async () => {
+    vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('api-token')
+    vi.mocked(partnersRequest).mockResolvedValueOnce({
+      deploymentCreate: {
+        deployment: {
+          deployedVersions: [],
+        },
+        id: '2',
+      },
+    })
+    const mockedFormData = {append: vi.fn(), getHeaders: vi.fn()}
+    vi.mocked<any>(formData).mockReturnValue(mockedFormData)
+    vi.mocked(randomUUID).mockReturnValue('random-uuid')
+    // When
+    await uploadExtensionsBundle({
+      apiKey: 'app-id',
+      bundlePath: undefined,
+      extensions: [],
+      token: 'api-token',
+      label: 'Deployed with CLI',
+    })
+
+    // Then
+    expect(vi.mocked(partnersRequest).mock.calls[0]![2]!).toEqual({
+      apiKey: 'app-id',
+      label: 'Deployed with CLI',
+      uuid: 'random-uuid',
+    })
+    expect(partnersRequest).toHaveBeenCalledOnce()
+  })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/349

### WHAT is this pull request doing?

Following up the work done [here](https://github.com/Shopify/partners/pull/46209) we want to enable deployments without extensions if you have the beta flag.

### How to test your changes?

- Enable the `appUiDeployments` beta flag
- Try deploying in an app with no extensions
- It should work
- It shouldn't work if you don't have the beta flag