### PR TITLE
Deployment warning

### DIFF
--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -300,7 +300,7 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
     force: options.force,
     token,
     envIdentifiers,
-    organization,
+    partnersApp,
   })
 
   // eslint-disable-next-line no-param-reassign

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -300,6 +300,7 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
     force: options.force,
     token,
     envIdentifiers,
+    organization,
   })
 
   // eslint-disable-next-line no-param-reassign

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -8,6 +8,7 @@ import {AppInterface} from '../../models/app/app.js'
 import {FunctionExtension, UIExtension} from '../../models/app/extensions.js'
 import {testApp} from '../../models/app/app.test-data.js'
 import {getExtensionsToMigrate, migrateExtensionsToUIExtension} from '../dev/migrate-to-ui-extension.js'
+import {OrganizationApp} from '../../models/organization.js'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {err, ok} from '@shopify/cli-kit/node/result'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
@@ -134,10 +135,14 @@ const LOCAL_APP = (uiExtensions: UIExtension[], functionExtensions: FunctionExte
   })
 }
 
-const ORGANIZATION = {
-  id: '1',
-  businessName: 'org1',
-  betas: {appUiDeployments: true},
+const PARTNERS_APP: OrganizationApp = {
+  id: 'app-id',
+  organizationId: 'org-id',
+  title: 'app-title',
+  grantedScopes: [],
+  betas: {unifiedAppDeployment: true},
+  apiKey: 'api-key',
+  apiSecretKeys: [],
 }
 
 const options = (uiExtensions: UIExtension[], identifiers: any = {}) => {
@@ -148,7 +153,7 @@ const options = (uiExtensions: UIExtension[], identifiers: any = {}) => {
     appName: 'appName',
     envIdentifiers: {extensions: identifiers},
     force: false,
-    organization: ORGANIZATION,
+    partnersApp: PARTNERS_APP,
   }
 }
 
@@ -422,7 +427,7 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
         onlyRemote: [],
         toCreate: [],
       },
-      ORGANIZATION,
+      PARTNERS_APP,
     )
   })
 

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -134,6 +134,12 @@ const LOCAL_APP = (uiExtensions: UIExtension[], functionExtensions: FunctionExte
   })
 }
 
+const ORGANIZATION = {
+  id: '1',
+  businessName: 'org1',
+  betas: {appUiDeployments: true},
+}
+
 const options = (uiExtensions: UIExtension[], identifiers: any = {}) => {
   return {
     app: LOCAL_APP(uiExtensions),
@@ -142,6 +148,7 @@ const options = (uiExtensions: UIExtension[], identifiers: any = {}) => {
     appName: 'appName',
     envIdentifiers: {extensions: identifiers},
     force: false,
+    organization: ORGANIZATION,
   }
 }
 
@@ -405,15 +412,18 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
     const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), [REGISTRATION_A, REGISTRATION_A_2])
 
     // Then
-    expect(deployConfirmationPrompt).toBeCalledWith({
-      question: 'Make the following changes to your extensions in Shopify Partners?',
-      identifiers: {
-        EXTENSION_A: 'UUID_A',
-        EXTENSION_A_2: 'UUID_A_2',
+    expect(deployConfirmationPrompt).toBeCalledWith(
+      {
+        question: 'Make the following changes to your extensions in Shopify Partners?',
+        identifiers: {
+          EXTENSION_A: 'UUID_A',
+          EXTENSION_A_2: 'UUID_A_2',
+        },
+        onlyRemote: [],
+        toCreate: [],
       },
-      onlyRemote: [],
-      toCreate: [],
-    })
+      ORGANIZATION,
+    )
   })
 
   test('skips confirmation prompt if --force is passed', async () => {

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -58,7 +58,7 @@ export async function ensureExtensionsIds(
         toCreate: extensionsToCreate,
         onlyRemote: onlyRemoteExtensions,
       },
-      options.organization,
+      options.partnersApp,
     )
     if (!confirmed) return err('user-cancelled')
   }

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -51,12 +51,15 @@ export async function ensureExtensionsIds(
   }
 
   if (!options.force) {
-    const confirmed = await deployConfirmationPrompt({
-      question: 'Make the following changes to your extensions in Shopify Partners?',
-      identifiers: validMatches,
-      toCreate: extensionsToCreate,
-      onlyRemote: onlyRemoteExtensions,
-    })
+    const confirmed = await deployConfirmationPrompt(
+      {
+        question: 'Make the following changes to your extensions in Shopify Partners?',
+        identifiers: validMatches,
+        toCreate: extensionsToCreate,
+        onlyRemote: onlyRemoteExtensions,
+      },
+      options.organization,
+    )
     if (!confirmed) return err('user-cancelled')
   }
 

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -3,6 +3,7 @@ import {ensureExtensionsIds} from './identifiers-extensions.js'
 import {AppInterface} from '../../models/app/app.js'
 import {Identifiers, IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
+import {Organization} from '../../models/organization.js'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
@@ -14,6 +15,7 @@ export interface EnsureDeploymentIdsPresenceOptions {
   appName: string
   envIdentifiers: Partial<Identifiers>
   force: boolean
+  organization?: Organization
 }
 
 export interface RemoteSource {

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -3,7 +3,7 @@ import {ensureExtensionsIds} from './identifiers-extensions.js'
 import {AppInterface} from '../../models/app/app.js'
 import {Identifiers, IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
-import {Organization} from '../../models/organization.js'
+import {OrganizationApp} from '../../models/organization.js'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
@@ -15,7 +15,7 @@ export interface EnsureDeploymentIdsPresenceOptions {
   appName: string
   envIdentifiers: Partial<Identifiers>
   force: boolean
-  organization?: Organization
+  partnersApp?: OrganizationApp
 }
 
 export interface RemoteSource {

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -1,7 +1,12 @@
 import {LocalSource, RemoteSource} from './identifiers.js'
 import {LocalRemoteSource} from './id-matching.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
-import {renderAutocompletePrompt, renderConfirmationPrompt, renderInfo} from '@shopify/cli-kit/node/ui'
+import {
+  InfoTableSection,
+  renderAutocompletePrompt,
+  renderConfirmationPrompt,
+  renderInfo,
+} from '@shopify/cli-kit/node/ui'
 
 export async function matchConfirmationPrompt(local: LocalSource, remote: RemoteSource) {
   return renderConfirmationPrompt({
@@ -36,24 +41,24 @@ interface SourceSummary {
 }
 
 export async function deployConfirmationPrompt(summary: SourceSummary): Promise<boolean> {
-  const infoTable = []
+  const infoTable: InfoTableSection[] = []
 
   if (summary.toCreate.length > 0) {
-    infoTable.push({header: 'add', items: summary.toCreate.map((source) => source.localIdentifier)})
+    infoTable.push({header: 'Add', items: summary.toCreate.map((source) => source.localIdentifier)})
   }
 
   const toUpdate = Object.keys(summary.identifiers)
 
   if (toUpdate.length > 0) {
-    infoTable.push({header: 'update', items: toUpdate})
+    infoTable.push({header: 'Update', items: toUpdate})
   }
 
   if (summary.onlyRemote.length > 0) {
     infoTable.push({
-      header: 'missing locally',
+      header: 'Missing locally',
       items: summary.onlyRemote.map((source) => source.title),
       color: 'red',
-      helperText: 'These extensions will be deleted from the app.',
+      helperMessage: 'These extensions will be deleted from the app',
     })
   }
 

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -58,7 +58,7 @@ export async function deployConfirmationPrompt(summary: SourceSummary): Promise<
       header: 'Missing locally',
       items: summary.onlyRemote.map((source) => source.title),
       color: 'red',
-      helperMessage: 'These extensions will be deleted from the app',
+      helperMessage: 'Extensions missing locally will be deleted when you publish this deployment',
     })
   }
 

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -36,20 +36,25 @@ interface SourceSummary {
 }
 
 export async function deployConfirmationPrompt(summary: SourceSummary): Promise<boolean> {
-  const infoTable: {[key: string]: string[]} = {}
+  const infoTable = []
 
   if (summary.toCreate.length > 0) {
-    infoTable.add = summary.toCreate.map((source) => source.localIdentifier)
+    infoTable.push({header: 'add', items: summary.toCreate.map((source) => source.localIdentifier)})
   }
 
   const toUpdate = Object.keys(summary.identifiers)
 
   if (toUpdate.length > 0) {
-    infoTable.update = toUpdate
+    infoTable.push({header: 'update', items: toUpdate})
   }
 
   if (summary.onlyRemote.length > 0) {
-    infoTable['missing locally'] = summary.onlyRemote.map((source) => source.title)
+    infoTable.push({
+      header: 'missing locally',
+      items: summary.onlyRemote.map((source) => source.title),
+      color: 'red',
+      helperText: 'These extensions will be deleted from the app.',
+    })
   }
 
   if (Object.keys(infoTable).length === 0) {

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -1,7 +1,7 @@
 import {LocalSource, RemoteSource} from './identifiers.js'
 import {LocalRemoteSource} from './id-matching.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
-import {Organization} from '../../models/organization.js'
+import {OrganizationApp} from '../../models/organization.js'
 import {
   InfoTableSection,
   renderAutocompletePrompt,
@@ -41,7 +41,10 @@ interface SourceSummary {
   onlyRemote: RemoteSource[]
 }
 
-export async function deployConfirmationPrompt(summary: SourceSummary, organization?: Organization): Promise<boolean> {
+export async function deployConfirmationPrompt(
+  summary: SourceSummary,
+  partnersApp?: OrganizationApp,
+): Promise<boolean> {
   const infoTable: InfoTableSection[] = []
 
   if (summary.toCreate.length > 0) {
@@ -60,7 +63,7 @@ export async function deployConfirmationPrompt(summary: SourceSummary, organizat
       items: summary.onlyRemote.map((source) => source.title),
     }
 
-    if (organization?.betas.appUiDeployments) {
+    if (partnersApp?.betas?.unifiedAppDeployment) {
       missingLocallySection = {
         ...missingLocallySection,
         color: 'red',

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -58,7 +58,7 @@ export async function deployConfirmationPrompt(summary: SourceSummary): Promise<
       header: 'Missing locally',
       items: summary.onlyRemote.map((source) => source.title),
       color: 'red',
-      helperMessage: 'Extensions missing locally will be deleted when you publish this deployment',
+      helperText: 'Extensions missing locally will be deleted when you publish this deployment',
     })
   }
 

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -1,6 +1,7 @@
 import {LocalSource, RemoteSource} from './identifiers.js'
 import {LocalRemoteSource} from './id-matching.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
+import {Organization} from '../../models/organization.js'
 import {
   InfoTableSection,
   renderAutocompletePrompt,
@@ -40,7 +41,7 @@ interface SourceSummary {
   onlyRemote: RemoteSource[]
 }
 
-export async function deployConfirmationPrompt(summary: SourceSummary): Promise<boolean> {
+export async function deployConfirmationPrompt(summary: SourceSummary, organization?: Organization): Promise<boolean> {
   const infoTable: InfoTableSection[] = []
 
   if (summary.toCreate.length > 0) {
@@ -54,12 +55,20 @@ export async function deployConfirmationPrompt(summary: SourceSummary): Promise<
   }
 
   if (summary.onlyRemote.length > 0) {
-    infoTable.push({
+    let missingLocallySection: InfoTableSection = {
       header: 'Missing locally',
       items: summary.onlyRemote.map((source) => source.title),
-      color: 'red',
-      helperText: 'Extensions missing locally will be deleted when you publish this deployment',
-    })
+    }
+
+    if (organization?.betas.appUiDeployments) {
+      missingLocallySection = {
+        ...missingLocallySection,
+        color: 'red',
+        helperText: 'Extensions missing locally will be removed for users when you publish this deployment',
+      }
+    }
+
+    infoTable.push(missingLocallySection)
   }
 
   if (Object.keys(infoTable).length === 0) {

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -3,7 +3,7 @@ import useAsyncAndUnmount from '../hooks/use-async-and-unmount.js'
 import {AbortController} from '../../../../public/node/abort.js'
 import {handleCtrlC} from '../../ui.js'
 import React, {FunctionComponent, useState} from 'react'
-import {Box, Key, Static, Text, useInput} from 'ink'
+import {Box, Key, Static, Text, useInput, TextProps} from 'ink'
 import stripAnsi from 'strip-ansi'
 import treeKill from 'tree-kill'
 import figures from 'figures'
@@ -26,7 +26,7 @@ export interface ConcurrentOutputProps {
   }
 }
 interface Chunk {
-  color: string
+  color: TextProps['color']
   prefix: string
   lines: string[]
 }
@@ -72,7 +72,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
   footer,
 }) => {
   const [processOutput, setProcessOutput] = useState<Chunk[]>([])
-  const concurrentColors = ['yellow', 'cyan', 'magenta', 'green', 'blue']
+  const concurrentColors: TextProps['color'][] = ['yellow', 'cyan', 'magenta', 'green', 'blue']
   const prefixColumnSize = Math.max(...processes.map((process) => process.prefix.length))
 
   function lineColor(index: number) {

--- a/packages/cli-kit/src/private/node/ui/components/List.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/List.tsx
@@ -1,5 +1,5 @@
 import {InlineToken, TokenItem, TokenizedText} from './TokenizedText.js'
-import {Box, Text} from 'ink'
+import {Box, Text, TextProps} from 'ink'
 import React, {FunctionComponent} from 'react'
 
 interface ListProps {
@@ -7,6 +7,7 @@ interface ListProps {
   items: TokenItem<InlineToken>[]
   ordered?: boolean
   margin?: boolean
+  color?: TextProps['color']
 }
 
 const DOT = '•'
@@ -15,19 +16,25 @@ const DOT = '•'
  * `List` displays an unordered or ordered list with text aligned with the bullet point
  * and wrapped to the container width.
  */
-const List: FunctionComponent<ListProps> = ({title, items, margin = true, ordered = false}): JSX.Element => {
+const List: FunctionComponent<ListProps> = ({title, items, margin = true, ordered = false, color}): JSX.Element => {
   return (
     <Box flexDirection="column">
-      {title ? <Text bold>{title}</Text> : null}
+      {title ? (
+        <Text bold color={color}>
+          {title}
+        </Text>
+      ) : null}
       {items.map((item, index) => (
         <Box key={index}>
           <Box>
             {margin ? <Text>{'  '}</Text> : null}
-            <Text>{`${ordered ? `${index + 1}.` : DOT}`}</Text>
+            <Text color={color}>{`${ordered ? `${index + 1}.` : DOT}`}</Text>
           </Box>
 
           <Box flexGrow={1} marginLeft={1}>
-            <TokenizedText item={item} />
+            <Text color={color}>
+              <TokenizedText item={item} />
+            </Text>
           </Box>
         </Box>
       ))}

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
@@ -30,22 +30,20 @@ const InfoTable: FunctionComponent<InfoTableProps> = ({table}) => {
   return (
     <Box flexDirection="column">
       {sections.map((section, index) => (
-        <Box key={index} marginBottom={index === sections.length - 1 ? 0 : 1} flexDirection="column">
-          <Box>
-            {section.header.length > 0 && (
-              <Box width={headerColumnWidth + 1}>
-                <Text color={section.color}>{capitalize(section.header)}:</Text>
+        <Box key={index} marginBottom={index === sections.length - 1 ? 0 : 1}>
+          {section.header.length > 0 && (
+            <Box width={headerColumnWidth + 1}>
+              <Text color={section.color}>{capitalize(section.header)}:</Text>
+            </Box>
+          )}
+          <Box marginLeft={section.header.length > 0 ? 2 : 0} flexGrow={1} flexDirection="column">
+            <List margin={false} items={section.items} color={section.color} />
+            {section.helperMessage ? (
+              <Box marginTop={1}>
+                <Text color={section.color}>{section.helperMessage}</Text>
               </Box>
-            )}
-            <Box marginLeft={section.header.length > 0 ? 2 : 0} flexGrow={1}>
-              <List margin={false} items={section.items} color={section.color} />
-            </Box>
+            ) : null}
           </Box>
-          {section.helperMessage ? (
-            <Box marginTop={1}>
-              <Text color={section.color}>{section.helperMessage}</Text>
-            </Box>
-          ) : null}
         </Box>
       ))}
     </Box>

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
@@ -6,7 +6,7 @@ import React, {FunctionComponent} from 'react'
 
 type Items = TokenItem<InlineToken>[]
 
-interface TableSection {
+export interface InfoTableSection {
   color?: TextProps['color']
   header: string
   helperMessage?: string
@@ -18,7 +18,7 @@ export interface InfoTableProps {
     | {
         [header: string]: Items
       }
-    | TableSection[]
+    | InfoTableSection[]
 }
 
 const InfoTable: FunctionComponent<InfoTableProps> = ({table}) => {
@@ -30,16 +30,22 @@ const InfoTable: FunctionComponent<InfoTableProps> = ({table}) => {
   return (
     <Box flexDirection="column">
       {sections.map((section, index) => (
-        <Box key={index} marginBottom={index === sections.length - 1 ? 0 : 1}>
-          {section.header.length > 0 && (
-            <Box width={headerColumnWidth + 1} flexDirection="column">
-              <Text color={section.color}>{capitalize(section.header)}:</Text>
-              {section.helperMessage ? <Text color={section.color}>{section.helperMessage}</Text> : null}
+        <Box key={index} marginBottom={index === sections.length - 1 ? 0 : 1} flexDirection="column">
+          <Box>
+            {section.header.length > 0 && (
+              <Box width={headerColumnWidth + 1}>
+                <Text color={section.color}>{capitalize(section.header)}:</Text>
+              </Box>
+            )}
+            <Box marginLeft={section.header.length > 0 ? 2 : 0} flexGrow={1}>
+              <List margin={false} items={section.items} color={section.color} />
             </Box>
-          )}
-          <Box marginLeft={sections.length > 0 ? 2 : 0} flexGrow={1}>
-            <List margin={false} items={section.items} color={section.color} />
           </Box>
+          {section.helperMessage ? (
+            <Box marginTop={1}>
+              <Text color={section.color}>{section.helperMessage}</Text>
+            </Box>
+          ) : null}
         </Box>
       ))}
     </Box>

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
@@ -1,30 +1,44 @@
 import {List} from '../List.js'
 import {capitalize} from '../../../../../public/common/string.js'
 import {InlineToken, TokenItem} from '../TokenizedText.js'
-import {Box, Text} from 'ink'
+import {Box, Text, TextProps} from 'ink'
 import React, {FunctionComponent} from 'react'
 
+type Items = TokenItem<InlineToken>[]
+
+interface TableSection {
+  color?: TextProps['color']
+  header: string
+  helperMessage?: string
+  items: Items
+}
+
 export interface InfoTableProps {
-  table: {
-    [header: string]: TokenItem<InlineToken>[]
-  }
+  table:
+    | {
+        [header: string]: Items
+      }
+    | TableSection[]
 }
 
 const InfoTable: FunctionComponent<InfoTableProps> = ({table}) => {
-  const headers = Object.keys(table)
-  const headerColumnWidth = Math.max(...headers.map((header) => header.length))
+  const sections = Array.isArray(table)
+    ? table
+    : Object.keys(table).map((header) => ({header, items: table[header]!, color: undefined, helperMessage: undefined}))
+  const headerColumnWidth = Math.max(...sections.map((section) => section.header.length))
 
   return (
     <Box flexDirection="column">
-      {headers.map((header, index) => (
-        <Box key={index} marginBottom={index === headers.length - 1 ? 0 : 1}>
-          {header.length > 0 && (
-            <Box width={headerColumnWidth + 1}>
-              <Text>{capitalize(header)}:</Text>
+      {sections.map((section, index) => (
+        <Box key={index} marginBottom={index === sections.length - 1 ? 0 : 1}>
+          {section.header.length > 0 && (
+            <Box width={headerColumnWidth + 1} flexDirection="column">
+              <Text color={section.color}>{capitalize(section.header)}:</Text>
+              {section.helperMessage ? <Text color={section.color}>{section.helperMessage}</Text> : null}
             </Box>
           )}
-          <Box marginLeft={header.length > 0 ? 2 : 0} flexGrow={1}>
-            <List margin={false} items={table[header]!} />
+          <Box marginLeft={sections.length > 0 ? 2 : 0} flexGrow={1}>
+            <List margin={false} items={section.items} color={section.color} />
           </Box>
         </Box>
       ))}

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
@@ -9,7 +9,7 @@ type Items = TokenItem<InlineToken>[]
 export interface InfoTableSection {
   color?: TextProps['color']
   header: string
-  helperMessage?: string
+  helperText?: string
   items: Items
 }
 
@@ -24,7 +24,7 @@ export interface InfoTableProps {
 const InfoTable: FunctionComponent<InfoTableProps> = ({table}) => {
   const sections = Array.isArray(table)
     ? table
-    : Object.keys(table).map((header) => ({header, items: table[header]!, color: undefined, helperMessage: undefined}))
+    : Object.keys(table).map((header) => ({header, items: table[header]!, color: undefined, helperText: undefined}))
   const headerColumnWidth = Math.max(...sections.map((section) => section.header.length))
 
   return (
@@ -38,9 +38,9 @@ const InfoTable: FunctionComponent<InfoTableProps> = ({table}) => {
           )}
           <Box marginLeft={section.header.length > 0 ? 2 : 0} flexGrow={1} flexDirection="column">
             <List margin={false} items={section.items} color={section.color} />
-            {section.helperMessage ? (
+            {section.helperText ? (
               <Box marginTop={1}>
-                <Text color={section.color}>{section.helperMessage}</Text>
+                <Text color={section.color}>{section.helperText}</Text>
               </Box>
             ) : null}
           </Box>

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -15,6 +15,7 @@ import {Tasks, Task} from '../../private/node/ui/components/Tasks.js'
 import {TextPrompt, TextPromptProps} from '../../private/node/ui/components/TextPrompt.js'
 import {AutocompletePromptProps, AutocompletePrompt} from '../../private/node/ui/components/AutocompletePrompt.js'
 import {InlineToken, LinkToken, TokenItem} from '../../private/node/ui/components/TokenizedText.js'
+import {InfoTableSection} from '../../private/node/ui/components/Prompts/InfoTable.js'
 import React from 'react'
 import {Key as InkKey, RenderOptions} from 'ink'
 
@@ -460,4 +461,4 @@ export const keypress = async () => {
 }
 
 export type Key = InkKey
-export {Task, TokenItem, InlineToken, LinkToken, TableColumn}
+export {Task, TokenItem, InlineToken, LinkToken, TableColumn, InfoTableSection}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/274

We want to show a warning that, with the unified deployments flow, publishing a deployment after having deleted extensions will result in such extensions being removed for app users.

### WHAT is this pull request doing?

I've added a warning message only if the beta flag is set that explains the above.
Example:
<img width="743" alt="Screenshot 2023-03-30 at 11 59 57" src="https://user-images.githubusercontent.com/151725/228816564-e7885580-d276-4ca3-8b51-05cd415bf33f.png">

### How to test your changes?

- Deploy an app with some extensions
- Delete the extension
- Deploy again, you should see the message
