### PR TITLE
Use `figures.lineVertical` instead of `|`

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
@@ -71,15 +71,15 @@ describe('ConcurrentOutput', () => {
 
     // Then
     expect(unstyled(getLastFrameAfterUnmount(renderInstance)!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
-      "0000-00-00 00:00:00 | backend  | first backend message
-      0000-00-00 00:00:00 | backend  | second backend message
-      0000-00-00 00:00:00 | backend  | third backend message
-      0000-00-00 00:00:00 | frontend | first frontend message
-      0000-00-00 00:00:00 | frontend | second frontend message
-      0000-00-00 00:00:00 | frontend | third frontend message
+      "0000-00-00 00:00:00 │ backend  │ first backend message
+      0000-00-00 00:00:00 │ backend  │ second backend message
+      0000-00-00 00:00:00 │ backend  │ third backend message
+      0000-00-00 00:00:00 │ frontend │ first frontend message
+      0000-00-00 00:00:00 │ frontend │ second frontend message
+      0000-00-00 00:00:00 │ frontend │ third frontend message
 
-      › Press p | open your browser
-      › Press q | quit
+      › Press p │ open your browser
+      › Press q │ quit
 
       Preview URL: https://shopify.com
       "

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -138,7 +138,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
                       </Box>
 
                       <Text bold color={chunk.color}>
-                        |
+                        {figures.lineVertical}
                       </Text>
                     </Box>
                   ) : null}
@@ -148,7 +148,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
                   </Box>
 
                   <Text bold color={chunk.color}>
-                    |
+                    {figures.lineVertical}
                   </Text>
 
                   <Box flexGrow={1} paddingLeft={1}>
@@ -165,7 +165,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
           <Box flexDirection="column">
             {footer.shortcuts.map((shortcut, index) => (
               <Text key={index}>
-                {figures.pointerSmall} Press <Text bold>{shortcut.key}</Text> | {shortcut.action}
+                {figures.pointerSmall} Press <Text bold>{shortcut.key}</Text> {figures.lineVertical} {shortcut.action}
               </Text>
             ))}
           </Box>

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -27,15 +27,15 @@ export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps
 /**
  * Renders output from concurrent processes to the terminal with {@link ConcurrentOutput}.
  * @example
- * 0000-00-00 00:00:00 | backend  | first backend message
- * 0000-00-00 00:00:00 | backend  | second backend message
- * 0000-00-00 00:00:00 | backend  | third backend message
- * 0000-00-00 00:00:00 | frontend | first frontend message
- * 0000-00-00 00:00:00 | frontend | second frontend message
- * 0000-00-00 00:00:00 | frontend | third frontend message
+ * 0000-00-00 00:00:00 │ backend  │ first backend message
+ * 0000-00-00 00:00:00 │ backend  │ second backend message
+ * 0000-00-00 00:00:00 │ backend  │ third backend message
+ * 0000-00-00 00:00:00 │ frontend │ first frontend message
+ * 0000-00-00 00:00:00 │ frontend │ second frontend message
+ * 0000-00-00 00:00:00 │ frontend │ third frontend message
  *
- * › Press p | open your browser
- * › Press q | quit.
+ * › Press p │ open your browser
+ * › Press q │ quit.
  *
  * Preview URL: https://shopify.com
  *


### PR DESCRIPTION
A small detail that was bothering me is that the vertical lines weren't solid in the `ConcurrentOutput` component. This PR uses the `figures.lineVertical` to display them. Check out the updated docs and tests to see how the change looks visually.