### PR TITLE
Fix `shopify theme share` description

### DIFF
--- a/.changeset/tall-mails-allow.md
+++ b/.changeset/tall-mails-allow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Fix `shopify theme share` description

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -1115,7 +1115,7 @@
     },
     "theme:share": {
       "id": "theme:share",
-      "description": "Creates a shareable, unpublished, and new theme on your theme library with a randomized name. Works like an alias to {{command:theme push -u -t=RANDOMIZED_NAME}}.",
+      "description": "Creates a shareable, unpublished, and new theme on your theme library with a randomized name. Works like an alias to `shopify theme push -u -t=RANDOMIZED_NAME`.",
       "strict": true,
       "pluginName": "@shopify/theme",
       "pluginAlias": "@shopify/theme",

--- a/packages/theme/src/cli/commands/theme/share.ts
+++ b/packages/theme/src/cli/commands/theme/share.ts
@@ -8,7 +8,7 @@ import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 
 export default class Share extends ThemeCommand {
   static description =
-    'Creates a shareable, unpublished, and new theme on your theme library with a randomized name. Works like an alias to {{command:theme push -u -t=RANDOMIZED_NAME}}.'
+    'Creates a shareable, unpublished, and new theme on your theme library with a randomized name. Works like an alias to `shopify theme push -u -t=RANDOMIZED_NAME`.'
 
   static flags = {
     ...globalFlags,


### PR DESCRIPTION
### WHY are these changes introduced?

The `shopify theme share` command description was following the CLI styling.

### WHAT is this pull request doing?

This PR fixes the description of the `shopify theme share` command.

### How to test your changes?

- Run `shopify theme share -h`

**Before**:
<img width="70%" src="https://user-images.githubusercontent.com/1079279/225668542-df2fd813-86ed-4c81-a543-a8fb65e96fa4.png">

**After**:
<img width="70%" src="https://user-images.githubusercontent.com/1079279/225668577-d28ecac1-c8e0-45fa-bcd4-73b1fd1bd19b.png">


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
