### PR TITLE
Add links to footnotes if terminal doesn't support hyperlinks

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -123,7 +123,6 @@ module.exports = {
       files: ['src/private/node/ui/components/**/*.tsx'],
       extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
       rules: {
-        'react/destructuring-assignment': 2,
         'react/function-component-definition': [
           'error',
           {

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -204,15 +204,16 @@ describe('NoOrgError', () => {
       │  No Organization found                                                       │
       │                                                                              │
       │  Next steps                                                                  │
-      │    • Have you created a Shopify Partners organization (                      │
-      │      https://partners.shopify.com/signup )?                                  │
+      │    • Have you created a Shopify Partners organization [1]?                   │
       │    • Have you confirmed your accounts from the emails you received?          │
       │    • Need to connect to a different App or organization? Run the command     │
       │      again with \`--reset\`                                                    │
       │    • Do you have access to the right Shopify Partners organization? The CLI  │
-      │       is loading this organization ( https://partner.shopify.com/3 )         │
+      │       is loading this organization [2]                                       │
       │                                                                              │
       ╰──────────────────────────────────────────────────────────────────────────────╯
+      [1] https://partners.shopify.com/signup
+      [2] https://partner.shopify.com/3
       "
     `)
   })

--- a/packages/app/src/cli/services/generate.test.ts
+++ b/packages/app/src/cli/services/generate.test.ts
@@ -89,10 +89,10 @@ describe('after extension command finishes correctly', () => {
       │  Your extension was created in extensions/name.                              │
       │                                                                              │
       │  Reference                                                                   │
-      │    • For more details, see the docs (                                        │
-      │      https://shopify.dev/docs/apps/discounts )                               │
+      │    • For more details, see the docs [1]                                      │
       │                                                                              │
       ╰──────────────────────────────────────────────────────────────────────────────╯
+      [1] https://shopify.dev/docs/apps/discounts
       "
     `)
   })

--- a/packages/cli-kit/bin/documentation/examples.ts
+++ b/packages/cli-kit/bin/documentation/examples.ts
@@ -144,7 +144,7 @@ export const examples: {[key in string]: Example} = {
             title: 'Custom section',
             body: {
               list: {
-                items: ['Item 1', 'Item 2', 'Item 3'],
+                items: [{link: {label: 'Item 1', url: 'https://www.google.com/search?q=jh56t9l34kpo35tw8s28hn7s9s2xvzla01d8cn6j7yq&rlz=1C1GCEU_enUS832US832&oq=jh56t9l34kpo35tw8s28hn7s9s2xvzla01d8cn6j7yq&aqs=chrome.0.35i39l2j0l4j46j69i60.2711j0j7&sourceid=chrome&ie=UTF-8'}}, 'Item 2', {link: {label: 'Item 3', url: 'https://shopify.com'}}],
               },
             },
           },

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -143,6 +143,7 @@
     "source-map-support": "0.5.21",
     "stacktracey": "2.1.8",
     "strip-ansi": "7.0.1",
+    "supports-hyperlinks": "^3.0.0",
     "tempy": "3.0.0",
     "term-size": "3.0.2",
     "terminal-link": "3.0.0",
@@ -164,9 +165,9 @@
     "@vitest/coverage-istanbul": "0.28.5",
     "ink-testing-library": "^2.1.0",
     "node-stream-zip": "^1.15.0",
+    "ts-morph": "^17.0.1",
     "typedoc": "^0.23.26",
     "typescript": "4.9.5",
-    "ts-morph": "^17.0.1",
     "vite": "^2.9.13",
     "vitest": "^0.28.5"
   },

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -143,7 +143,7 @@
     "source-map-support": "0.5.21",
     "stacktracey": "2.1.8",
     "strip-ansi": "7.0.1",
-    "supports-hyperlinks": "^3.0.0",
+    "supports-hyperlinks": "3.0.0",
     "tempy": "3.0.0",
     "term-size": "3.0.2",
     "terminal-link": "3.0.0",

--- a/packages/cli-kit/src/private/node/ui/components/Alert.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Alert.test.tsx
@@ -49,7 +49,7 @@ describe('Alert', async () => {
       ],
       link: {
         label: 'Link',
-        url: 'https://shopify.com',
+        url: 'https://www.google.com/search?q=jh56t9l34kpo35tw8s28hn7s9s2xvzla01d8cn6j7yq&rlz=1C1GCEU_enUS832US832&oq=jh56t9l34kpo35tw8s28hn7s9s2xvzla01d8cn6j7yq&aqs=chrome.0.35i39l2j0l4j46j69i60.2711j0j7&sourceid=chrome&ie=UTF-8',
       },
       customSections: [
         {
@@ -87,10 +87,9 @@ describe('Alert', async () => {
       │                                                                              │
       │  Reference                                                                   │
       │    • Run \`npm shopify help\`                                                  │
-      │    • Press 'return' to open the really amazing and clean dev docs (          │
-      │      https://shopify.dev )                                                   │
+      │    • Press 'return' to open the really amazing and clean dev docs [1]        │
       │                                                                              │
-      │  Link ( https://shopify.com )                                                │
+      │  Link [2]                                                                    │
       │                                                                              │
       │  Custom section                                                              │
       │    • Item 1                                                                  │
@@ -103,6 +102,10 @@ describe('Alert', async () => {
       │    • Item 3                                                                  │
       │                                                                              │
       ╰──────────────────────────────────────────────────────────────────────────────╯
+      [1] https://shopify.dev
+      [2] https://www.google.com/search?q=jh56t9l34kpo35tw8s28hn7s9s2xvzla01d8cn6j7yq&rlz=1C1GCEU_enUS832U
+      S832&oq=jh56t9l34kpo35tw8s28hn7s9s2xvzla01d8cn6j7yq&aqs=chrome.0.35i39l2j0l4j46j69i60.2711j0j7&sourc
+      eid=chrome&ie=UTF-8
       "
     `)
   })

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.test.tsx
@@ -90,8 +90,7 @@ describe('FatalError', async () => {
       │  Unexpected error                                                            │
       │                                                                              │
       │  Next steps                                                                  │
-      │    • Have you created a Shopify Partners organization (                      │
-      │      https://partners.shopify.com/signup )?                                  │
+      │    • Have you created a Shopify Partners organization [1]?                   │
       │    • Have you confirmed your accounts from the emails you received?          │
       │    • Need to connect to a different App or organization? Run the command     │
       │      again with \`--reset\`                                                    │
@@ -103,6 +102,7 @@ describe('FatalError', async () => {
       │    at _load (internal/modules/cjs/loader.js:878)                             │
       │                                                                              │
       ╰──────────────────────────────────────────────────────────────────────────────╯
+      [1] https://partners.shopify.com/signup
       "
     `)
   })

--- a/packages/cli-kit/src/private/node/ui/contexts/LinksContext.ts
+++ b/packages/cli-kit/src/private/node/ui/contexts/LinksContext.ts
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export interface Link {
+  label: string | undefined
+  url: string
+}
+
+export interface ContextValue {
+  links: React.RefObject<{[key: string]: Link}>
+  addLink: (label: string | undefined, url: string) => string
+}
+
+export const LinksContext = React.createContext<ContextValue | null>(null)

--- a/packages/cli-kit/src/public/node/ui.test.ts
+++ b/packages/cli-kit/src/public/node/ui.test.ts
@@ -95,10 +95,9 @@ describe('renderInfo', async () => {
       │                                                                              │
       │  Reference                                                                   │
       │    • Run \`npm shopify help\`                                                  │
-      │    • Press 'return' to open the really amazing and clean dev docs (          │
-      │      https://shopify.dev )                                                   │
+      │    • Press 'return' to open the really amazing and clean dev docs [1]        │
       │                                                                              │
-      │  Link ( https://shopify.com )                                                │
+      │  Link [2]                                                                    │
       │                                                                              │
       │  Custom section                                                              │
       │    • Item 1                                                                  │
@@ -111,6 +110,8 @@ describe('renderInfo', async () => {
       │    • Item 3                                                                  │
       │                                                                              │
       ╰──────────────────────────────────────────────────────────────────────────────╯
+      [1] https://shopify.dev
+      [2] https://shopify.com
       "
     `)
   })
@@ -275,13 +276,13 @@ describe('renderFatalError', async () => {
       │  No Organization found                                                       │
       │                                                                              │
       │  Next steps                                                                  │
-      │    • Have you created a Shopify Partners organization (                      │
-      │      https://partners.shopify.com/signup )?                                  │
+      │    • Have you created a Shopify Partners organization [1]?                   │
       │    • Have you confirmed your accounts from the emails you received?          │
       │    • Need to connect to a different App or organization? Run the command     │
       │      again with \`--reset\`                                                    │
       │                                                                              │
       ╰──────────────────────────────────────────────────────────────────────────────╯
+      [1] https://partners.shopify.com/signup
       "
     `)
   })

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -78,14 +78,20 @@ export type RenderAlertOptions = Omit<AlertOptions, 'type'>
  * │                                                          │
  * │  Reference                                               │
  * │    • Run `npm shopify help`                              │
- * │    • Dev docs ( https://shopify.dev )                    │
+ * │    • Dev docs [1]                                        │
  * │                                                          │
  * │  Custom section                                          │
- * │    • Item 1                                              │
+ * │    • Item 1 [2]                                          │
  * │    • Item 2                                              │
- * │    • Item 3                                              │
+ * │    • Item 3 [3]                                          │
  * │                                                          │
  * ╰──────────────────────────────────────────────────────────╯
+ * [1] https://shopify.dev
+ * [2] https://www.google.com/search?q=jh56t9l34kpo35tw8s28hn7s
+ * 9s2xvzla01d8cn6j7yq&rlz=1C1GCEU_enUS832US832&oq=jh56t9l34kpo
+ * 35tw8s28hn7s9s2xvzla01d8cn6j7yq&aqs=chrome.0.35i39l2j0l4j46j
+ * 69i60.2711j0j7&sourceid=chrome&ie=UTF-8
+ * [3] https://shopify.com
  *
  */
 export function renderInfo(options: RenderAlertOptions) {
@@ -112,11 +118,11 @@ export function renderInfo(options: RenderAlertOptions) {
  * │  Partners Dashboard.                                     │
  * │                                                          │
  * │  Next steps                                              │
- * │    • See your deployment and set it live ( https://part  │
- * │      ners.shopify.com/1797046/apps/4523695/deployments   │
- * │      )                                                   │
+ * │    • See your deployment and set it live [1]             │
  * │                                                          │
  * ╰──────────────────────────────────────────────────────────╯
+ * [1] https://partners.shopify.com/1797046/apps/4523695/deploy
+ * ments
  *
  */
 export function renderSuccess(options: RenderAlertOptions) {
@@ -145,9 +151,10 @@ export function renderSuccess(options: RenderAlertOptions) {
  * │  1, 2022.                                                │
  * │                                                          │
  * │  Reference                                               │
- * │    • Dev docs ( https://shopify.dev/app/scopes )         │
+ * │    • Dev docs [1]                                        │
  * │                                                          │
  * ╰──────────────────────────────────────────────────────────╯
+ * [1] https://shopify.dev/app/scopes
  *
  */
 export function renderWarning(options: RenderAlertOptions) {
@@ -179,14 +186,15 @@ interface RenderFatalErrorOptions {
  * │  No Organization found                                   │
  * │                                                          │
  * │  Next steps                                              │
- * │    • Have you created a Shopify Partners organization (  │
- * │       https://partners.shopify.com/signup )?             │
+ * │    • Have you created a Shopify Partners organization    │
+ * │      [1]?                                                │
  * │    • Have you confirmed your accounts from the emails    │
  * │      you received?                                       │
  * │    • Need to connect to a different App or               │
  * │      organization? Run the command again with `--reset`  │
  * │                                                          │
  * ╰──────────────────────────────────────────────────────────╯
+ * [1] https://partners.shopify.com/signup
  *
  */
 // eslint-disable-next-line max-params

--- a/packages/cli/src/cli/services/kitchen-sink/static.ts
+++ b/packages/cli/src/cli/services/kitchen-sink/static.ts
@@ -64,7 +64,7 @@ export async function staticService() {
         title: 'Custom section',
         body: {
           list: {
-            items: ['Item 1', 'Item 2', 'Item 3'],
+            items: [{link: {label: 'Item 1', url: 'https://shopify.com'}}, 'Item 2'],
           },
         },
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,7 @@ importers:
       source-map-support: 0.5.21
       stacktracey: 2.1.8
       strip-ansi: 7.0.1
+      supports-hyperlinks: ^3.0.0
       tempy: 3.0.0
       term-size: 3.0.2
       terminal-link: 3.0.0
@@ -404,6 +405,7 @@ importers:
       source-map-support: 0.5.21
       stacktracey: 2.1.8
       strip-ansi: 7.0.1
+      supports-hyperlinks: 3.0.0
       tempy: 3.0.0
       term-size: 3.0.2
       terminal-link: 3.0.0
@@ -13774,6 +13776,14 @@ packages:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
+
+  /supports-hyperlinks/3.0.0:
+    resolution: {integrity: sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==}
+    engines: {node: '>=14.18'}
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+    dev: false
 
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,7 +343,7 @@ importers:
       source-map-support: 0.5.21
       stacktracey: 2.1.8
       strip-ansi: 7.0.1
-      supports-hyperlinks: ^3.0.0
+      supports-hyperlinks: 3.0.0
       tempy: 3.0.0
       term-size: 3.0.2
       terminal-link: 3.0.0
@@ -14588,7 +14588,7 @@ packages:
       globrex: 0.1.2
       recrawl-sync: 2.2.3
       tsconfig-paths: 4.1.1
-      vite: 2.9.12
+      vite: 2.9.12_sass@1.56.1
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/internal-cli-foundations/issues/520
Links could wrap inside boxes and be hard to copy and paste

### WHAT is this pull request doing?

I've added some footnotes below the boxes that display all the links so that they can be easily copy and pasted. Here's an example.

<img width="786" alt="Screenshot 2023-03-17 at 14 18 00" src="https://user-images.githubusercontent.com/151725/225930753-26de7f1c-ddc7-463d-bca6-87a236de1d2e.png">

### How to test your changes?

Run `kitchen-sink static` and see the changes