### PR TITLE
Add `fulfillment_constraints` extension type

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -116,6 +116,7 @@
           "order_routing_location_rule",
           "cart_transform",
           "tax_calculation",
+          "fulfillment_constraints",
         ],
         "default": "checkout_ui_extension",
     },

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -72,6 +72,11 @@ export const extensionTypesGroups: {name: string; extensions: string[]}[] = [
   {name: 'Point-of-Sale', extensions: ['pos_ui_extension']},
   {
     name: 'Shopify private',
-    extensions: ['customer_accounts_ui_extension', 'ui_extension', 'order_routing_location_rule'],
+    extensions: [
+      'customer_accounts_ui_extension',
+      'ui_extension',
+      'order_routing_location_rule',
+      'fulfillment_constraints',
+    ],
   },
 ]

--- a/packages/app/src/cli/models/extensions/function-specifications/fulfillment_constraints.ts
+++ b/packages/app/src/cli/models/extensions/function-specifications/fulfillment_constraints.ts
@@ -1,0 +1,11 @@
+import {createFunctionSpecification} from '../functions.js'
+
+const spec = createFunctionSpecification({
+  identifier: 'fulfillment_constraints',
+  externalIdentifier: 'fulfillment_constraints',
+  externalName: 'Fulfillment constraints',
+  supportedFlavors: [{name: 'Rust', value: 'rust'}],
+  templatePath: (lang) => `order-routing/${lang}/fulfillment-constraints/default`,
+})
+
+export default spec


### PR DESCRIPTION
### WHY are these changes introduced?

These changes will allow us to stop using the [corresponding `internal-cli-plugin`](https://github.com/Shopify/internal-cli-plugins/blob/main/packages/fulfillment-constraints/src/hooks/function_specs.ts), and instead use the main `cli` repo to deploy `fulfillment_constraint` functions.

### WHAT is this pull request doing?

Exposes the `fulfillment_constraints` extension type and allows us to deploy `fulfillment_constraints` functions. I copied the `order_routing_location_rule` config.

### How to test your changes?

Was able to deploy a function to spin with these changes on my branch.

### Post-release steps

N/A, `shopify.dev` documentation for this extension type is live behind a betaflag.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
