### PR TITLE
Improve README - add tap for brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To work with themes, the CLI needs to be installed globally with:
 
 - `npm install -g @shopify/cli @shopify/theme`
 
-You can also use do it through Homebrew on macOS: `brew install shopify-cli`
+You can also use do it through Homebrew on macOS: `brew tap shopify/shopify && brew install shopify-cli`
 
 Learn more in the docs: [Shopify CLI for themes](https://shopify.dev/docs/themes/tools/cli)
 


### PR DESCRIPTION
### WHY are these changes introduced?

The README's Mac homebrew installation instruction is incomplete.

Can't brew the install without the tap.

The dev docs list both commands, and this document links to that, but if you're going to provide a copy/paste one-liner it should probably have the whole thing.

### WHAT is this pull request doing?

Adding a tap to get the brew.

### How to test your changes?

(On a Mac, in a terminal)
```
# install home-brew if needed - from https://brew.sh
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

# reset your env if needed
brew uninstall shopify-cli
brew untap shopify/shopify

# try to install with the current README's command
brew install shopify-cli
# see failure

# try to install with proposed command
brew tap shopify/shopify && brew install shopify-cli
# see success

# repeat with the tap already tapped
# this shows it still works if someone already has it tapped / installed
brew tap shopify/shopify && brew install shopify-cli
# see success again and again in your life
```

### Post-release steps

Sit back and enjoy knowing your users are happier.

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [?] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
