### PR TITLE
Fix flakey test in AutocompletePrompt.test.tsx

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -241,7 +241,6 @@ describe('AutocompletePrompt', async () => {
     await waitForInputsToBeReady()
     await sendInputAndWaitForContent(renderInstance, 'No results found', 'a')
     // prompt doesn't change when enter is pressed
-    await new Promise((resolve) => setTimeout(resolve, 100))
     await sendInputAndWait(renderInstance, 100, ENTER)
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
@@ -256,12 +255,13 @@ describe('AutocompletePrompt', async () => {
 
   test('has a loading state', async () => {
     const onEnter = vi.fn()
-    const searchPromise = new Promise<SearchResults<string>>((resolve) => {
-      setTimeout(() => resolve({data: [{label: 'a', value: 'b'}]}), 2000)
-    })
 
     const search = () => {
-      return searchPromise
+      return new Promise<SearchResults<string>>((resolve) => {
+        setTimeout(() => {
+          resolve({data: [{label: 'a', value: 'b'}]})
+        }, 2000)
+      })
     }
 
     const renderInstance = render(


### PR DESCRIPTION
### WHY are these changes introduced?

A test in `AutocompletePrompt.test.tsx` was flakey.

### WHAT is this pull request doing?

I've moved the `setTimeout` inside the `search` function definition instead of letting it start immediately from the outside which sometimes would cause the function to resolve before the end of the test.

### How to test your changes?

I've tried this 100 times with a script and couldn't reproduce the issue after the fix. Before the fix the issue would appear ~1/20 times.