### PR TITLE
Allow passing deployment label to deploy command

### DIFF
--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -101,6 +101,13 @@
           "description": "Deploy without asking for confirmation.",
           "hidden": false,
           "allowNo": false
+        },
+        "label": {
+          "name": "label",
+          "type": "option",
+          "description": "The deployment label.",
+          "hidden": true,
+          "multiple": false
         }
       },
       "args": {}

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -105,7 +105,7 @@
         "label": {
           "name": "label",
           "type": "option",
-          "description": "The deployment label.",
+          "description": "The deployment label. Will be shown in the Partners Dashboard.",
           "hidden": true,
           "multiple": false
         }

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -32,6 +32,12 @@ export default class Deploy extends Command {
       char: 'f',
       default: false,
     }),
+    label: Flags.string({
+      // we can make this visible once we've rolled out unified deployments
+      hidden: true,
+      description: 'The deployment label.',
+      env: 'SHOPIFY_FLAG_LABEL',
+    }),
   }
 
   async run(): Promise<void> {
@@ -43,6 +49,6 @@ export default class Deploy extends Command {
 
     const specifications = await loadExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path})
-    await deploy({app, apiKey: flags['api-key'], reset: flags.reset, force: flags.force})
+    await deploy({app, apiKey: flags['api-key'], reset: flags.reset, force: flags.force, label: flags.label})
   }
 }

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -35,7 +35,7 @@ export default class Deploy extends Command {
     label: Flags.string({
       // we can make this visible once we've rolled out unified deployments
       hidden: true,
-      description: 'The deployment label.',
+      description: 'The deployment label. Will be shown in the Partners Dashboard.',
       env: 'SHOPIFY_FLAG_LABEL',
     }),
   }

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -104,6 +104,27 @@ describe('deploy', () => {
     )
   })
 
+  it('passes a label to the deployment mutation with a flag', async () => {
+    // Given
+    const uiExtension = await testUIExtension({type: 'web_pixel_extension'})
+    const app = testApp({extensions: {ui: [uiExtension], theme: [], function: []}})
+
+    // When
+    await testDeployBundle(
+      app,
+      {id: 'org-id', businessName: 'org-name', betas: {appUiDeployments: true}},
+      'Deployed from CLI with flag',
+    )
+
+    // Then
+    expect(renderTextPrompt).not.toHaveBeenCalled()
+    expect(uploadExtensionsBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'Deployed from CLI with flag',
+      }),
+    )
+  })
+
   it('shows a success message', async () => {
     // Given
     const uiExtension = await testUIExtension({type: 'web_pixel_extension'})
@@ -169,7 +190,7 @@ describe('deploy', () => {
   })
 })
 
-async function testDeployBundle(app: AppInterface, organization?: Organization) {
+async function testDeployBundle(app: AppInterface, organization?: Organization, label?: string) {
   // Given
   const extensionsPayload: {[key: string]: string} = {}
   for (const uiExtension of app.extensions.ui) {
@@ -198,6 +219,7 @@ async function testDeployBundle(app: AppInterface, organization?: Organization) 
     app,
     reset: false,
     force: true,
+    label,
   })
 
   // Then

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -34,6 +34,9 @@ interface DeployOptions {
 
   /** If true, proceed with deploy without asking for confirmation */
   force: boolean
+
+  /** The deployment label */
+  label?: string
 }
 
 interface TasksContext {
@@ -54,10 +57,12 @@ export async function deploy(options: DeployOptions) {
   let label: string | undefined
 
   if (organization.betas.appUiDeployments) {
-    label = await renderTextPrompt({
-      message: 'Deployment label',
-      allowEmpty: true,
-    })
+    label =
+      options.label ??
+      (await renderTextPrompt({
+        message: 'Deployment label',
+        allowEmpty: true,
+      }))
 
     if (label.length === 0) {
       label = undefined


### PR DESCRIPTION
### WHY are these changes introduced?

Users have to write the deployment label in the prompt at the moment, but we want to let them pass the `label` as a flag as well so that they can use it from CI environments.

### WHAT is this pull request doing?

Add the `label` flag to the deployment command.

### How to test your changes?

With the `appUiDeployments` beta flag enabled you can run `shopify app deploy --label myLabel` and verify that it's using it. You also shouldn't be asked to enter the label in a prompt.