### PR TITLE
Exclude system files in theme extensions

### DIFF
--- a/.changeset/cold-points-provide.md
+++ b/.changeset/cold-points-provide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Exclude system files from theme app extensions

--- a/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
@@ -51,11 +51,13 @@ describe('themeExtensionConfig', () => {
       await mkdir(joinPath(tmpDir, 'blocks'))
       // Testing standard filenames, files with leading dots, ignored directories.
       const ignoredFiles = ['Thumbs.db', '.DS_Store', '.sublime-project', 'node_modules/foo/package.json']
-      await Promise.all(['test.liquid', ...ignoredFiles].map(async (filename) => {
-        const fullpath = joinPath(tmpDir, 'blocks', filename)
-        await mkdir(dirname(fullpath))
-        await writeFile(fullpath, 'test content')
-      }))
+      await Promise.all(
+        ['test.liquid', ...ignoredFiles].map(async (filename) => {
+          const fullpath = joinPath(tmpDir, 'blocks', filename)
+          await mkdir(dirname(fullpath))
+          await writeFile(fullpath, 'test content')
+        }),
+      )
 
       // Then
       await expect(themeExtensionConfig(themeExtension)).resolves.toStrictEqual({

--- a/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
@@ -2,7 +2,7 @@ import {themeExtensionConfig} from './theme-extension-config.js'
 import themeSpec from '../../models/extensions/theme-specifications/theme.js'
 import {ThemeExtensionInstance} from '../../models/extensions/theme.js'
 import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
-import {joinPath} from '@shopify/cli-kit/node/path'
+import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {describe, expect, test} from 'vitest'
 
 describe('themeExtensionConfig', () => {
@@ -22,6 +22,40 @@ describe('themeExtensionConfig', () => {
 
       await mkdir(joinPath(tmpDir, 'blocks'))
       await writeFile(joinPath(tmpDir, 'blocks', 'test.liquid'), 'test content')
+
+      // Then
+      await expect(themeExtensionConfig(themeExtension)).resolves.toStrictEqual({
+        theme_extension: {
+          files: {
+            'blocks/test.liquid': Buffer.from('test content').toString('base64'),
+          },
+        },
+      })
+    })
+  })
+
+  test('excludes system files', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const themeExtension = new ThemeExtensionInstance({
+        configuration: {
+          name: 'theme extension name',
+          type: 'theme' as const,
+        },
+        configurationPath: '',
+        directory: tmpDir,
+        specification: themeSpec,
+        outputBundlePath: tmpDir,
+      })
+
+      await mkdir(joinPath(tmpDir, 'blocks'))
+      // Testing standard filenames, files with leading dots, ignored directories.
+      const ignoredFiles = ['Thumbs.db', '.DS_Store', '.sublime-project', 'node_modules/foo/package.json']
+      await Promise.all(['test.liquid', ...ignoredFiles].map(async (filename) => {
+        const fullpath = joinPath(tmpDir, 'blocks', filename)
+        await mkdir(dirname(fullpath))
+        await writeFile(fullpath, 'test content')
+      }))
 
       // Then
       await expect(themeExtensionConfig(themeExtension)).resolves.toStrictEqual({

--- a/packages/app/src/cli/services/deploy/theme-extension-config.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.ts
@@ -2,6 +2,22 @@ import {ThemeExtension} from '../../models/app/extensions.js'
 import {readFile, glob} from '@shopify/cli-kit/node/fs'
 import {joinPath, relativePath, dirname} from '@shopify/cli-kit/node/path'
 
+const ignoredFilePatterns = [
+  '.git',
+  '.hg',
+  '.bzr',
+  '.svn',
+  '_darcs',
+  'CVS',
+  '.sublime-(project|workspace)',
+  '.DS_Store',
+  '.sass-cache',
+  'Thumbs.db',
+  'desktop.ini',
+  'config.yml',
+  'node_modules',
+]
+
 export interface ThemeExtensionConfig {
   theme_extension: {
     files: {[key: string]: string}
@@ -10,7 +26,7 @@ export interface ThemeExtensionConfig {
 
 export async function themeExtensionConfig(themeExtension: ThemeExtension): Promise<ThemeExtensionConfig> {
   const files: {[key: string]: string} = {}
-  const themeFiles = await glob(joinPath(themeExtension.directory, '*/*'))
+  const themeFiles = await glob(joinPath(themeExtension.directory, '*/*'), {ignore: ignoredFilePatterns.map((pattern) => joinPath(themeExtension.directory, '*', pattern))})
   await Promise.all(
     themeFiles.map(async (filepath) => {
       const relativePathName = relativePath(themeExtension.directory, filepath)

--- a/packages/app/src/cli/services/deploy/theme-extension-config.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.ts
@@ -1,22 +1,7 @@
 import {ThemeExtension} from '../../models/app/extensions.js'
-import {readFile, glob} from '@shopify/cli-kit/node/fs'
-import {joinPath, relativePath, dirname} from '@shopify/cli-kit/node/path'
-
-const ignoredFilePatterns = [
-  '.git',
-  '.hg',
-  '.bzr',
-  '.svn',
-  '_darcs',
-  'CVS',
-  '.sublime-(project|workspace)',
-  '.DS_Store',
-  '.sass-cache',
-  'Thumbs.db',
-  'desktop.ini',
-  'config.yml',
-  'node_modules',
-]
+import {themeExtensionFiles} from '../../utilities/extensions/theme.js'
+import {readFile} from '@shopify/cli-kit/node/fs'
+import {relativePath, dirname} from '@shopify/cli-kit/node/path'
 
 export interface ThemeExtensionConfig {
   theme_extension: {
@@ -26,7 +11,7 @@ export interface ThemeExtensionConfig {
 
 export async function themeExtensionConfig(themeExtension: ThemeExtension): Promise<ThemeExtensionConfig> {
   const files: {[key: string]: string} = {}
-  const themeFiles = await glob(joinPath(themeExtension.directory, '*/*'), {ignore: ignoredFilePatterns.map((pattern) => joinPath(themeExtension.directory, '*', pattern))})
+  const themeFiles = await themeExtensionFiles(themeExtension)
   await Promise.all(
     themeFiles.map(async (filepath) => {
       const relativePathName = relativePath(themeExtension.directory, filepath)

--- a/packages/app/src/cli/utilities/extensions/theme.test.ts
+++ b/packages/app/src/cli/utilities/extensions/theme.test.ts
@@ -1,0 +1,37 @@
+import {themeExtensionFiles} from './theme.js'
+import themeSpec from '../../models/extensions/theme-specifications/theme.js'
+import {ThemeExtensionInstance} from '../../models/extensions/theme.js'
+import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
+import {dirname, joinPath} from '@shopify/cli-kit/node/path'
+import {describe, expect, test} from 'vitest'
+
+describe('themeExtensionConfig', () => {
+  test('excludes system files', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const themeExtension = new ThemeExtensionInstance({
+        configuration: {
+          name: 'theme extension name',
+          type: 'theme' as const,
+        },
+        configurationPath: '',
+        directory: tmpDir,
+        specification: themeSpec,
+        outputBundlePath: tmpDir,
+      })
+
+      await mkdir(joinPath(tmpDir, 'blocks'))
+      // Testing standard filenames, files with leading dots, ignored directories.
+      const ignoredFiles = ['Thumbs.db', '.DS_Store', '.sublime-project', 'node_modules/foo/package.json']
+      await Promise.all(['test.liquid', ...ignoredFiles].map(async (filename) => {
+        const fullpath = joinPath(tmpDir, 'blocks', filename)
+        await mkdir(dirname(fullpath))
+        await writeFile(fullpath, 'test content')
+      }))
+
+      // Then
+      await expect(themeExtensionFiles(themeExtension)).resolves.toStrictEqual(['blocks/test.liquid'])
+    })
+  })
+})
+

--- a/packages/app/src/cli/utilities/extensions/theme.test.ts
+++ b/packages/app/src/cli/utilities/extensions/theme.test.ts
@@ -23,15 +23,16 @@ describe('themeExtensionConfig', () => {
       await mkdir(joinPath(tmpDir, 'blocks'))
       // Testing standard filenames, files with leading dots, ignored directories.
       const ignoredFiles = ['Thumbs.db', '.DS_Store', '.sublime-project', 'node_modules/foo/package.json']
-      await Promise.all(['test.liquid', ...ignoredFiles].map(async (filename) => {
-        const fullpath = joinPath(tmpDir, 'blocks', filename)
-        await mkdir(dirname(fullpath))
-        await writeFile(fullpath, 'test content')
-      }))
+      await Promise.all(
+        ['test.liquid', ...ignoredFiles].map(async (filename) => {
+          const fullpath = joinPath(tmpDir, 'blocks', filename)
+          await mkdir(dirname(fullpath))
+          await writeFile(fullpath, 'test content')
+        }),
+      )
 
       // Then
-      await expect(themeExtensionFiles(themeExtension)).resolves.toStrictEqual(['blocks/test.liquid'])
+      await expect(themeExtensionFiles(themeExtension)).resolves.toStrictEqual([joinPath(tmpDir, 'blocks/test.liquid')])
     })
   })
 })
-

--- a/packages/app/src/cli/utilities/extensions/theme.ts
+++ b/packages/app/src/cli/utilities/extensions/theme.ts
@@ -20,7 +20,6 @@ const ignoredFilePatterns = [
 
 export async function themeExtensionFiles(themeExtension: ThemeExtension): Promise<string[]> {
   return glob(joinPath(themeExtension.directory, '*/*'), {
-    ignore: ignoredFilePatterns.map((pattern) => joinPath(themeExtension.directory, '*', pattern))
+    ignore: ignoredFilePatterns.map((pattern) => joinPath(themeExtension.directory, '*', pattern)),
   })
 }
-

--- a/packages/app/src/cli/utilities/extensions/theme.ts
+++ b/packages/app/src/cli/utilities/extensions/theme.ts
@@ -1,0 +1,26 @@
+import {ThemeExtension} from '../../models/app/extensions.js'
+import {glob} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+
+const ignoredFilePatterns = [
+  '.git',
+  '.hg',
+  '.bzr',
+  '.svn',
+  '_darcs',
+  'CVS',
+  '.sublime-(project|workspace)',
+  '.DS_Store',
+  '.sass-cache',
+  'Thumbs.db',
+  'desktop.ini',
+  'config.yml',
+  'node_modules',
+]
+
+export async function themeExtensionFiles(themeExtension: ThemeExtension): Promise<string[]> {
+  return glob(joinPath(themeExtension.directory, '*/*'), {
+    ignore: ignoredFilePatterns.map((pattern) => joinPath(themeExtension.directory, '*', pattern))
+  })
+}
+

--- a/packages/app/src/cli/utilities/extensions/theme.ts
+++ b/packages/app/src/cli/utilities/extensions/theme.ts
@@ -16,6 +16,7 @@ const ignoredFilePatterns = [
   'desktop.ini',
   'config.yml',
   'node_modules',
+  '.gitkeep',
 ]
 
 export async function themeExtensionFiles(themeExtension: ThemeExtension): Promise<string[]> {

--- a/packages/app/src/cli/validators/extensions/theme.ts
+++ b/packages/app/src/cli/validators/extensions/theme.ts
@@ -1,4 +1,5 @@
 import {ThemeExtension} from '../../models/app/extensions.js'
+import {themeExtensionFiles} from '../../utilities/extensions/theme.js'
 import {fileSize, glob} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname, relativePath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -46,7 +47,7 @@ export async function validateThemeExtensions(extensions: ThemeExtension[]) {
 }
 
 async function validateThemeExtension(extension: ThemeExtension): Promise<void> {
-  const themeFiles = await glob(joinPath(extension.directory, '*/*'))
+  const themeFiles = await themeExtensionFiles(extension)
   const liquidBytes: number[] = []
   const extensionBytes: number[] = []
   await Promise.all(

--- a/packages/app/src/cli/validators/extensions/theme.ts
+++ b/packages/app/src/cli/validators/extensions/theme.ts
@@ -1,7 +1,7 @@
 import {ThemeExtension} from '../../models/app/extensions.js'
 import {themeExtensionFiles} from '../../utilities/extensions/theme.js'
-import {fileSize, glob} from '@shopify/cli-kit/node/fs'
-import {joinPath, dirname, relativePath} from '@shopify/cli-kit/node/path'
+import {fileSize} from '@shopify/cli-kit/node/fs'
+import {dirname, relativePath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 

--- a/release_notes_draft.md
+++ b/release_notes_draft.md
@@ -26,6 +26,9 @@ frontend or backend processes of the app.
 appear in a separate area and conflict with other logs or the preview/quit bar.
 Instead, they will be integrated with the other logs. Progress bars have been
 replaced with static output to accommodate this placement.
+* ***Theme app extension excluding system files.*** System files like `Thumbs.db`
+or `.DS_STORE` will now be excluded from theme app extension builds, just like
+they are excluded from themes.
 * ***Customer accounts UI extension preview.*** The link from the dev console for
 Customer Accounts UI Extensions will now redirect to the customer account page.
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2171#issuecomment-1479087268 noting we don't filter out `.DS_STORE`

All kinds of invalid system files get included in theme extension uploads.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Filters system files from theme extensions, similar to what we already do in themes: https://github.com/Shopify/cli/blob/6735253e6f6055b7f79093e409574dcda28f378a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/ignore_filter.rb#L12-L26).

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Create a `.DS_STORE` in one of the directories of `fixtures/app/extensions/theme-extension`
2. `dev shopify app deploy --path=fixtures/app`

This works on the branch, but fails on `main`.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
