### PR TITLE
Move `fulfillment_constraints` to public extension type group

### DIFF
--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -65,6 +65,7 @@ export const extensionTypesGroups: {name: string; extensions: string[]}[] = [
       'cart_checkout_validation',
       'checkout_post_purchase',
       'cart_transform',
+      'fulfillment_constraints',
     ],
   },
   {name: 'Analytics', extensions: ['web_pixel_extension']},
@@ -72,11 +73,6 @@ export const extensionTypesGroups: {name: string; extensions: string[]}[] = [
   {name: 'Point-of-Sale', extensions: ['pos_ui_extension']},
   {
     name: 'Shopify private',
-    extensions: [
-      'customer_accounts_ui_extension',
-      'ui_extension',
-      'order_routing_location_rule',
-      'fulfillment_constraints',
-    ],
+    extensions: ['customer_accounts_ui_extension', 'ui_extension', 'order_routing_location_rule'],
   },
 ]


### PR DESCRIPTION
### WHY are these changes introduced?

In reference to https://github.com/Shopify/partners/pull/46274#discussion_r1146028024.

Changing the extension type group here to reflect that this API is now public for 3p use via a private beta.

### WHAT is this pull request doing?

Changing the extension type group.

### How to test your changes?

N/A

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
