### PR TITLE
Adding app_setup as extension management experience

### DIFF
--- a/.changeset/strange-vans-flow.md
+++ b/.changeset/strange-vans-flow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Adding app_setup as an option for management experience on Extension Specifications.

--- a/packages/app/src/cli/api/graphql/extension_specifications.ts
+++ b/packages/app/src/cli/api/graphql/extension_specifications.ts
@@ -32,7 +32,7 @@ export interface RemoteSpecification {
   gated: boolean
   externalIdentifier: string
   options: {
-    managementExperience: 'cli' | 'custom' | 'dashboard'
+    managementExperience: 'app_setup' | 'cli' | 'custom' | 'dashboard'
     registrationLimit: number
   }
   features?: {

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -203,6 +203,17 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     },
   },
   {
+    name: 'Application URLs',
+    externalName: 'Application URLs',
+    identifier: 'app_urls',
+    externalIdentifier: 'app_urls',
+    gated: false,
+    options: {
+      managementExperience: 'app_setup',
+      registrationLimit: 1,
+    },
+  },
+  {
     name: 'Product Subscription',
     externalName: 'Subscription UI',
     // we are going to replace this to 'product_subscription' because we


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes part of https://github.com/Shopify/shopify/issues/413960.

Related to the project "Deployable app configurations" and to support versioning of app configurations which currently are unique and not versionable.

### WHAT is this pull request doing?

Core now can send `app_setup` as an option for extension management experiences. If the CLI does not recognize it could crash.

### How to test your changes?

Created a new extension in the cli and it completed the process correctly.

> Note: I had to remove the source code for the `tax-ext-cli` extension since it complained that it was empty when I tried to deploy. The `subs-ui-ext` extension was correctly deployed though.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/14079734/228973559-2cb5307d-2d32-46ae-85b6-da837f635a54.png">

Deployment ran correctly.

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/14079734/228976762-961cd5ac-6b46-4e81-88ac-23acb6548ebb.png">

Extension shows up correctly in [partners](https://partners.ext-spin-app-setup.sinuhe-guerra.us.spin.dev/1/apps/905743398577/extensions).

<img width="980" alt="image" src="https://user-images.githubusercontent.com/14079734/228976961-61e27ee6-b543-4175-82e3-efd0741c3ff7.png">

While debugging in core I can see the new extension specification being served to the cli.

<img width="835" alt="image" src="https://user-images.githubusercontent.com/14079734/229219339-e6318419-c696-4e18-90ee-f86a8a7f5f5e.png">

Correct extensions are shown as options.

<img width="652" alt="image" src="https://user-images.githubusercontent.com/14079734/229219574-0eb39839-5809-4729-b642-cf7f311a0e55.png">



### Post-release steps

No Post-release steps as this change should be transparent for users.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
