### PR TITLE
Improve theme selector component by grouping themes by role

### DIFF
--- a/.changeset/silent-dancers-tan.md
+++ b/.changeset/silent-dancers-tan.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Improve theme selector component by grouping themes by role

--- a/packages/theme/src/cli/utilities/theme-selector.test.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.test.ts
@@ -1,10 +1,12 @@
 import {fetchStoreThemes} from './theme-selector/fetch.js'
 import {findOrSelectTheme, findThemes} from './theme-selector.js'
+import {getDevelopmentTheme} from '../services/local-storage.js'
 import {Theme} from '@shopify/cli-kit/node/themes/models/theme'
 import {test, describe, vi, expect} from 'vitest'
 import {renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 
 vi.mock('./theme-selector/fetch.js')
+vi.mock('../services/local-storage.js')
 vi.mock('@shopify/cli-kit/node/ui')
 
 const session = {
@@ -46,6 +48,7 @@ describe('findOrSelectTheme', () => {
     const themes = [theme(7, 'development'), theme(8, 'development')]
     vi.mocked(fetchStoreThemes).mockResolvedValue(themes)
     vi.mocked(renderSelectPrompt).mockResolvedValue(themes[0])
+    vi.mocked(getDevelopmentTheme).mockReturnValue('7')
 
     // When
     await findOrSelectTheme(session, {
@@ -58,8 +61,8 @@ describe('findOrSelectTheme', () => {
     expect(renderSelectPrompt).toHaveBeenCalledWith({
       message: header,
       choices: [
-        {label: 'theme 7 [development] [yours]', value: themes[0]},
-        {label: 'theme 8 [development]', value: themes[1]},
+        {group: 'Development', label: 'theme 7 [yours]', value: themes[0]},
+        {group: 'Development', label: 'theme 8', value: themes[1]},
       ],
     })
   })

--- a/packages/theme/src/cli/utilities/theme-selector.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.ts
@@ -1,7 +1,9 @@
 import {fetchStoreThemes} from './theme-selector/fetch.js'
 import {Filter, FilterProps, filterThemes} from './theme-selector/filter.js'
+import {getDevelopmentTheme} from '../services/local-storage.js'
 import {renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 import {AdminSession} from '@shopify/cli-kit/node/session'
+import {capitalize} from '@shopify/cli-kit/common/string'
 
 /**
  * Finds or selects a theme in the store.
@@ -30,10 +32,12 @@ export async function findOrSelectTheme(
   return renderSelectPrompt({
     message: options.header,
     choices: themes.map((theme) => {
-      const yoursLabel = theme.id === options.developmentTheme ? ' [yours]' : ''
+      const yoursLabel = theme.id.toString() === getDevelopmentTheme() ? ' [yours]' : ''
+
       return {
         value: theme,
-        label: `${theme.name} [${theme.role}]${yoursLabel}`,
+        label: `${theme.name}${yoursLabel}`,
+        group: capitalize(theme.role),
       }
     }),
   })


### PR DESCRIPTION
### WHY are these changes introduced?

Improve theme selector component to group themes by role (following DX feedback).

### WHAT is this pull request doing?

This PR improves the `[theme-selector.ts](https://github.com/Shopify/cli/compare/fix-572?expand=1#diff-7633fa15fdce1b666ec9e64add1637d9a51d681f0ea67bfbda93a396198b4b8d)` to group themes by role and to properly apply the `[yours]` label

### How to test your changes?

- Run `shopify theme delete`

![Screenshot 2023-03-24 at 17 05 35](https://user-images.githubusercontent.com/1079279/227580229-c7326e1f-02b1-4279-81ac-9b734a8e9d42.png)



### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
