### PR TITLE
Use system cache folder to store embedded ruby gems

### DIFF
--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -444,7 +444,7 @@ async function getSpinEnvironmentVariables() {
  */
 async function shopifyBundleInstall(directory: string): Promise<void> {
   const bundle = bundleExecutable()
-  const shopifyGemsPath = shopifyGems.data
+  const shopifyGemsPath = shopifyGems.cache
 
   await exec(bundle, ['config', 'set', '--local', 'path', shopifyGemsPath], {
     cwd: directory,


### PR DESCRIPTION
### WHY are these changes introduced?

Steph reported this error when trying out a nightly release:
```
Error: Command failed with exit code 5: /usr/local/opt/ruby/bin/bundle install
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory: /Users/steph/Library/Application
Support/shopify-gems-nodejs/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c
/usr/local/opt/ruby/bin/ruby -I /usr/local/Cellar/ruby/3.2.1/lib/ruby/3.2.0
extconf.rb
checking for ffi_prep_closure_loc() in -lffi... no
checking for ffi_prep_closure_loc() in -llibffi... no
checking for ffi_prep_closure_loc() in -llibffi-8... no
checking for whether -Wl,--exclude-libs,ALL is accepted as LDFLAGS... no
checking for whether -pthread is accepted as LDFLAGS... yes
creating extconf.h
creating Makefile

current directory: /Users/steph/Library/Application
Support/shopify-gems-nodejs/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c
make DESTDIR\= sitearchdir\=./.gem.20230324-30768-grzqmp
sitelibdir\=./.gem.20230324-30768-grzqmp clean

current directory: /Users/steph/Library/Application
Support/shopify-gems-nodejs/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c
make DESTDIR\= sitearchdir\=./.gem.20230324-30768-grzqmp
sitelibdir\=./.gem.20230324-30768-grzqmp
/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 1: syntax error: unexpected end of file
make: *** ["/Users/steph/Library/Application] Error 2
```

I found [this ffi issue](https://github.com/ffi/ffi/issues/623) which seems to confirm that there can be issues when the path where we try to install `ffi` contains a space.

### WHAT is this pull request doing?

Use [paths.cache](https://github.com/sindresorhus/env-paths#pathscache) to store embedded Ruby gems instead. That path doesn't contain any spaces in any of the supported platforms.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
