### PR TITLE
Adds new git methods `isClean` and `ensureIsClean`

### DIFF
--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -266,3 +266,27 @@ export async function ensureInsideGitDirectory(directory?: string): Promise<void
     throw new OutsideGitDirectoryError(`${outputToken.path(directory || cwd())} is not a Git directory`)
   }
 }
+
+export class GitDirectoryNotCleanError extends AbortError {}
+/**
+ * If the .git directory tree is not clean (has uncommitted changes)
+ * it throws an abort error.
+ *
+ * @param directory - The directory to check.
+ */
+export async function ensureIsClean(directory?: string): Promise<void> {
+  if (!(await isClean(directory))) {
+    throw new GitDirectoryNotCleanError(`${outputToken.path(directory || cwd())} is not a clean Git directory`)
+  }
+}
+
+/**
+ * Returns true if the .git directory tree is clean (no uncommitted changes).
+ *
+ * @param directory - The directory to check.
+ */
+export async function isClean(directory?: string): Promise<boolean> {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return (await git({baseDir: directory}).status()).isClean
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHAT is this pull request doing?
This PR adds 2 new methods for introspecting the clean status of a given directory. These were motivated by [this use-case](https://github.com/Shopify/hydrogen/pull/560) in hydrogen.

- **`git.ensureIsClean(directory?: string): Promise<void>`**: If the .git directory tree is not clean (has uncommitted changes) it throws an abort error.
- **`git.isClean(directory?: string): Promise<boolean>`**: Returns true if the .git directory tree is clean (no uncommitted changes).


