### PR TITLE
Remove leftover mentions to fixtures

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,6 @@
     "@shopify/app",
     "@shopify/create-app",
     "@shopify/cli-kit",
-    "@shopify/fixtures-app",
     "@shopify/theme",
     "@shopify/ui-extensions-dev-console-app",
     "@shopify/plugin-ngrok",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,7 +2,6 @@
   "mode": "pre",
   "tag": "pre",
   "initialVersions": {
-    "@shopify/fixtures-app": "3.44.0",
     "shopify-app-template-node": "0.1.0",
     "starter-react-frontend-app": "0.1.0",
     "@shopify/app": "3.44.0",

--- a/.nxignore
+++ b/.nxignore
@@ -1,3 +1,2 @@
 **/templates/**
 docs/**
-fixtures/**


### PR DESCRIPTION
### WHY are these changes introduced?

I removed the fixtures but both `changeset` and `nx` still had some references to them.

### WHAT is this pull request doing?

Remove them

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
