### PR TITLE
Only display each extension type once

### DIFF
--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -120,7 +120,7 @@ class AppInfo {
       extensions: TExtension[],
       outputFormatter: (extension: TExtension) => string,
     ) {
-      const types = extensions.map((ext) => ext.type)
+      const types = new Set(extensions.map((ext) => ext.type))
       types.forEach((extensionType: string) => {
         const relevantExtensions = extensions.filter((extension: TExtension) => extension.type === extensionType)
         if (relevantExtensions[0]) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/internal-cli-foundations/issues/611 <!-- link to issue if one exists -->

If there are multiple of the same extension type, they are all printed multiple times.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Unique-ifies the list of types, so we only display each extension type once, instead of once per extension.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Create an app with multiple `product_discount` functions. After this change, they are only displayed once.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
