### PR TITLE
Add default value option to renderConfirmation prompt

### DIFF
--- a/.changeset/rare-windows-obey.md
+++ b/.changeset/rare-windows-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add default value option to renderConfirmation prompt

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
@@ -318,4 +318,30 @@ describe('SelectPrompt', async () => {
       "
     `)
   })
+
+  test('allows passing false as the default value', async () => {
+    const items = [
+      {label: 'yes', value: true},
+      {label: 'no', value: false},
+    ]
+
+    const renderInstance = render(
+      <SelectPrompt
+        message="Associate your project with the org Castile Ventures?"
+        choices={items}
+        onSubmit={() => {}}
+        defaultValue={false}
+      />,
+    )
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?
+
+         (1) yes
+      [36m>[39m  [36m(2) no[39m
+
+         [2mPress ↑↓ arrows to select, enter to confirm[22m
+      "
+    `)
+  })
 })

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -30,7 +30,8 @@ function SelectPrompt<T>({
   if (choices.length === 0) {
     throw new Error('SelectPrompt requires at least one choice')
   }
-  const initialValue = defaultValue ? choices.find((choice) => choice.value === defaultValue) : undefined
+  const initialValue =
+    typeof defaultValue === 'undefined' ? undefined : choices.find((choice) => choice.value === defaultValue)
   const [answer, setAnswer] = useState<SelectItem<T> | undefined>(undefined)
   const {exit: unmountInk} = useApp()
   const [submitted, setSubmitted] = useState(false)

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -249,6 +249,7 @@ export interface RenderConfirmationPromptOptions extends Pick<SelectPromptProps<
   confirmationMessage?: string
   cancellationMessage?: string
   renderOptions?: RenderOptions
+  defaultValue?: boolean
 }
 
 /**
@@ -271,6 +272,7 @@ export function renderConfirmationPrompt({
   confirmationMessage = 'Yes, confirm',
   cancellationMessage = 'No, cancel',
   renderOptions,
+  defaultValue = true,
 }: RenderConfirmationPromptOptions): Promise<boolean> {
   const choices = [
     {
@@ -291,6 +293,7 @@ export function renderConfirmationPrompt({
     infoTable,
     submitWithShortcuts: true,
     renderOptions,
+    defaultValue,
   })
 }
 

--- a/packages/cli/src/cli/services/kitchen-sink/prompts.ts
+++ b/packages/cli/src/cli/services/kitchen-sink/prompts.ts
@@ -110,12 +110,23 @@ export async function prompts() {
     ],
   ]
 
+  // renderConfirmationPrompt
   const options = {
-    message: `Delete the following themes from the store?`,
+    message: `Add the following themes to the store?`,
     infoTable: {'': themes},
-    confirmationMessage: 'Yes, confirm changes',
+    confirmationMessage: 'Yes, add them',
     cancellationMessage: 'Cancel',
   }
 
   await renderConfirmationPrompt(options)
+
+  const dangerousPromptOptions = {
+    message: `Delete the following themes from the store?`,
+    infoTable: {'': themes},
+    confirmationMessage: 'Yes, delete them',
+    cancellationMessage: 'Cancel',
+    defaultValue: false,
+  }
+
+  await renderConfirmationPrompt(dangerousPromptOptions)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We want to allow developers to specify if the default value should be true or false in confirmation prompts. This can be useful for dangerous type of actions

### WHAT is this pull request doing?

Implement the above requirement.

### How to test your changes?

Run `kitchen-sink prompt` and the last prompt will be a "dangerous" prompt with `Cancel` preselected.