### PR TITLE
Fix introspection URL cache

### DIFF
--- a/.changeset/hip-boats-sin.md
+++ b/.changeset/hip-boats-sin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix introspection URL cache

--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -52,19 +52,20 @@ describe('removeSession', () => {
 })
 
 describe('cacheRetrieveOrRepopulate', () => {
-  // flaky test
-  test.skip('returns the cached contents when they exist', async () => {
+  test('returns the cached contents when they exist', async () => {
     await inTemporaryDirectory(async (cwd) => {
       // Given
       const config = new LocalStorage<ConfSchema>({cwd})
-      // populate the cache
-      await cacheRetrieveOrRepopulate('identity-introspection-url-IDENTITYURL', async () => 'URL1', 1000, config)
+      const cacheValue = {
+        'identity-introspection-url-IDENTITYURL': {value: 'URL1', timestamp: Date.now()},
+      }
+      config.set('cache', cacheValue)
 
       // When
       const got = await cacheRetrieveOrRepopulate(
         'identity-introspection-url-IDENTITYURL',
         async () => 'URL2',
-        1000,
+        60 * 1000,
         config,
       )
 
@@ -83,7 +84,7 @@ describe('cacheRetrieveOrRepopulate', () => {
       const got = await cacheRetrieveOrRepopulate(
         'identity-introspection-url-IDENTITYURL',
         async () => 'URL1',
-        1000,
+        60 * 1000,
         config,
       )
 
@@ -97,7 +98,7 @@ describe('cacheRetrieveOrRepopulate', () => {
       // Given
       const config = new LocalStorage<ConfSchema>({cwd})
       const cacheValue = {
-        'identity-introspection-url-IDENTITYURL': {value: 'URL1', timestamp: Date.now() - 3600 * 1000},
+        'identity-introspection-url-IDENTITYURL': {value: 'URL1', timestamp: Date.now() - 60 * 1000},
       }
       config.set('cache', cacheValue)
 
@@ -126,7 +127,7 @@ describe('cacheRetrieveOrRepopulate', () => {
       const got = await cacheRetrieveOrRepopulate(
         'identity-introspection-url-IDENTITYURL',
         async () => 'URL2',
-        3600 * 1000,
+        60 * 1000,
         config,
       )
 

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -65,7 +65,8 @@ type CacheValueForKey<TKey extends keyof Cache> = NonNullable<Cache[TKey]>['valu
  * before returning it.
  * @param key - The key to use for the cache.
  * @param fn - The function to run to get the value to cache, if a cache miss occurs.
- * @param timeout - The maximum valid age of a cached value, in milliseconds. If the cached value is older than this, it will be refreshed.
+ * @param timeout - The maximum valid age of a cached value, in milliseconds.
+ * If the cached value is older than this, it will be refreshed.
  * @returns The value from the cache or the result of the function.
  */
 export async function cacheRetrieveOrRepopulate(
@@ -77,7 +78,7 @@ export async function cacheRetrieveOrRepopulate(
   const cache: Cache = config.get('cache') || {}
   const cached = cache[key]
 
-  if (cached && (timeout === undefined || Date.now() - cached.timestamp < timeout)) {
+  if (cached?.value && (timeout === undefined || Date.now() - cached.timestamp < timeout)) {
     return cached.value
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1664

Some users apparently got an invalid cache (missing the `value` field):

```
"cache": {
	"identity-introspection-url-accounts.shopify.com": {
		"timestamp": 1679500965290
	}
}
```

### WHAT is this pull request doing?

Ignore the cache when the value is not present

### How to test your changes?

- Open `~/Library/Preferences/shopify-cli-kit-nodejs/config.json` and remove the value field
- `shopify app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
