### PR TITLE
Increase cloudflare timeout to 40 seconds

### DIFF
--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -13,7 +13,7 @@ export default startTunnel({provider: TUNNEL_PROVIDER, action: hookStart})
 export type ReturnType = Promise<Result<{url: string}, TunnelError>>
 
 // How much time to wait for a tunnel to be established. in seconds.
-const TUNNEL_TIMEOUT = isUnitTest() ? 0.2 : 20
+const TUNNEL_TIMEOUT = isUnitTest() ? 0.2 : 40
 
 export async function hookStart(port: number): ReturnType {
   try {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- @Arkham reported that in some slooow cases cloudflare might need more than 20s to connect to the tunnel.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Increase cloudflared timeout to 40 seconds.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
No way really, if cloudflare ever fails to connect for more than 40 seconds you'll see an error
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
