### PR TITLE
Set a custom BUNDLE_USER_HOME env var on Windows

### DIFF
--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -1,6 +1,6 @@
 import {AbortSignal} from './abort.js'
 import {platformAndArch} from './os.js'
-import {captureOutput, exec} from './system.js'
+import {captureOutput, exec, ExecOptions} from './system.js'
 import * as file from './fs.js'
 import {joinPath, dirname, cwd} from './path.js'
 import {AbortError, AbortSilentError} from './error.js'
@@ -68,7 +68,7 @@ export async function execCLI2(args: string[], options: ExecCLI2Options = {}): P
 
   try {
     const shopifyExecutable = embedded ? [rubyExecutable(), await embeddedCLIExecutable()] : ['shopify']
-    await exec(bundleExecutable(), ['exec', ...shopifyExecutable, ...args], {
+    await runBundler(['exec', ...shopifyExecutable, ...args], {
       ...(options.stdout === undefined && {stdio: 'inherit'}),
       cwd: options.directory ?? cwd(),
       env,
@@ -120,7 +120,7 @@ export async function execThemeCheckCLI(options: ExecThemeCheckCLIOptions): Prom
         }
       },
     })
-    await exec(bundleExecutable(), ['exec', 'theme-check'].concat([directory, ...(options.args || [])]), {
+    await runBundler(['exec', 'theme-check'].concat([directory, ...(options.args || [])]), {
       stdout: options.stdout,
       stderr: customStderr,
       cwd: themeCheckDirectory(),
@@ -221,7 +221,7 @@ async function validateRuby() {
 async function validateBundler() {
   let version
   try {
-    const stdout = await captureOutput(bundleExecutable(), ['-v'])
+    const stdout = await captureOutput(bundleExecutable(), ['-v'], {env: {BUNDLE_USER_HOME: bundleUserHome()}})
     version = coerceSemverVersion(stdout)
   } catch {
     throw new AbortError(
@@ -443,15 +443,35 @@ async function getSpinEnvironmentVariables() {
  * @param directory - Directory where the Gemfile is located.
  */
 async function shopifyBundleInstall(directory: string): Promise<void> {
-  const bundle = bundleExecutable()
-  const shopifyGemsPath = shopifyGems.cache
-
-  await exec(bundle, ['config', 'set', '--local', 'path', shopifyGemsPath], {
+  await runBundler(['config', 'set', '--local', 'path', shopifyGems.cache], {
     cwd: directory,
   })
-
-  await exec(bundle, ['config', 'set', '--local', 'without', 'development:test'], {
+  await runBundler(['config', 'set', '--local', 'without', 'development:test'], {
     cwd: directory,
   })
-  await exec(bundle, ['install'], {cwd: directory})
+  await runBundler(['install'], {cwd: directory})
+}
+
+/**
+ * It returns a custom BUNDLE_USER_HOME. This is required in Windows because
+ * bundler will instead crash if the username contains UTF-8 characters.
+ *
+ * @returns The value of the environment variable.
+ */
+export function bundleUserHome(): string | undefined {
+  if (platformAndArch().platform === 'windows' && process.env.PUBLIC) {
+    return joinPath(process.env.PUBLIC, 'AppData', 'Local', 'shopify-bundler-nodejs', 'Cache')
+  } else {
+    return undefined
+  }
+}
+
+/**
+ * It runs bundler commands by setting the correct BUNDLE_USER_HOME env var.
+ *
+ * @param args - Arguments to pass to the bundle command.
+ * @param options - Options to pass to the exec function.
+ */
+async function runBundler(args: string[], options: ExecOptions) {
+  return exec(bundleExecutable(), args, {...options, env: {...options.env, BUNDLE_USER_HOME: bundleUserHome()}})
 }

--- a/packages/plugin-cloudflare/scripts/postinstall.js
+++ b/packages/plugin-cloudflare/scripts/postinstall.js
@@ -3,7 +3,7 @@ import * as path from 'path'
 import {fileURLToPath} from 'url'
 import util from 'util'
 import {pipeline} from 'stream'
-import {execSync} from 'child_process'
+import {execSync, execFileSync} from 'child_process'
 import {createHash} from 'node:crypto'
 import {chmodSync, existsSync, mkdirSync, renameSync, unlinkSync, createWriteStream, readFileSync} from 'fs'
 import fetch from 'node-fetch'
@@ -91,7 +91,7 @@ export default async function install() {
 
   if (existsSync(binTarget)) {
     // --version returns an string like "cloudflared version 2023.3.1 (built 2023-03-13-1444 UTC)"
-    const versionArray = execSync(`${binTarget} --version`, {encoding: 'utf8'}).split(' ')
+    const versionArray = execFileSync(binTarget, ['--version'], {encoding: 'utf8'}).split(' ')
     const versionNumber = versionArray.length > 2 ? versionArray[2] : '0.0.0'
     const needsUpdate = semver.gt(CLOUDFLARE_VERSION, versionNumber)
     if (!needsUpdate) {


### PR DESCRIPTION
### WHY are these changes introduced?

If the username contains a UTF8 character, bundler will crash with this error:
```
PS C:\Users\Jöhnny Ärkhåm> bundle --version
C:/Ruby30-x64-utf8/lib/ruby/3.0.0/pathname.rb:50:in `match?': invalid byte sequence in UTF-8 (ArgumentError)
        from C:/Ruby30-x64-utf8/lib/ruby/3.0.0/pathname.rb:50:in `chop_basename'
        from C:/Ruby30-x64-utf8/lib/ruby/3.0.0/pathname.rb:374:in `plus'
        from C:/Ruby30-x64-utf8/lib/ruby/3.0.0/pathname.rb:354:in `+'
        from C:/Ruby30-x64-utf8/lib/ruby/3.0.0/pathname.rb:420:in `join'
```

Fixes https://github.com/Shopify/cli/issues/868 and https://github.com/Shopify/cli/issues/1634

### WHAT is this pull request doing?

Set a custom `BUNDLE_USER_HOME` var on Windows so that instead of using the user home folder we use `C:\Users\Public\AppData\Local\shopify-bundler-nodejs\Cache` as the Bundler user home.

### How to test your changes?

- On Windows, create a new user with UTF8 characters
- Make it an administrator
- Search for "environment variables", click edit env vars, and add `C:\Ruby30-x64\bin` (or whatever is your installed ruby) to the `PATH`
- `git clone https://github.com/Shopify/cli.git`
- `node bin/create-test-app.js -e theme`
- Witness it crashing
- Remove the app folder
- Change the branch from `main` to `fix-windows-uft8-bundler-bug`
- `node bin/create-test-app.js -e theme`and you should see it work now

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
