### PR TITLE
Clean wpm errors on theme dev

### DIFF
--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -28,7 +28,12 @@ module ShopifyCLI
         SESSION_COOKIE_NAME = "_secure_session_id"
         SESSION_COOKIE_REGEXP = /#{SESSION_COOKIE_NAME}=(\h+)/
         SESSION_COOKIE_MAX_AGE = 60 * 60 * 23 # 1 day - leeway of 1h
-        IGNORED_ENDPOINTS = ["shopify/monorail", "mini-profiler-resources", "web-pixels-manager"]
+        IGNORED_ENDPOINTS = %w[
+          shopify/monorail
+          mini-profiler-resources
+          web-pixels-manager
+          wpm
+        ]
 
         def initialize(ctx, theme, param_builder)
           @ctx = ctx

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -82,6 +82,19 @@ module ShopifyCLI
             times: 0)
         end
 
+        def test_new_webpixels_requests_are_ignored
+          path = "cli/sfr/wpm@0.0.264@24271aa3w5f39399apdce3a888m968cefc2/sandbox/worker.modern.js"
+          stub_session_id_request
+
+          request.get(path)
+
+          assert_requested(
+            :get,
+            "https://dev-theme-server-store.myshopify.com#{path}",
+            times: 0
+          )
+        end
+
         def test_get_is_proxied_to_theme_access_api_when_password_is_provided
           Environment.stubs(:theme_access_password?).returns(true)
           Environment.stubs(:store).returns("https://dev-theme-server-store.myshopify.com")


### PR DESCRIPTION
### WHY are these changes introduced?

Continuation of https://github.com/Shopify/cli/pull/1484

As @Poitrin mentioned [here](https://github.com/Shopify/cli/issues/1675#issuecomment-1486965718), there's a new Web Pixels Manager endpoint we are not ignoring when running `theme dev` with a password.

### WHAT is this pull request doing?

Ignore requests containing `wpm` as well.

### How to test your changes?

`shopify theme dev --password XXX --verbose`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
