### PR TITLE
Support json output when running function locally

### DIFF
--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -535,6 +535,14 @@
           "hidden": false,
           "multiple": false,
           "default": "."
+        },
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "char": "j",
+          "description": "Log the run result as a JSON object.",
+          "hidden": false,
+          "allowNo": false
         }
       },
       "args": {}

--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -2,6 +2,7 @@ import {functionFlags, inFunctionContext} from '../../../services/function/commo
 import {runFunctionRunner} from '../../../services/function/build.js'
 import Command from '@shopify/cli-kit/node/base-command'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {Flags} from '@oclif/core'
 
 export default class FunctionRun extends Command {
   static description = 'Run a Function locally for testing.'
@@ -9,12 +10,18 @@ export default class FunctionRun extends Command {
   static flags = {
     ...globalFlags,
     ...functionFlags,
+    json: Flags.boolean({
+      char: 'j',
+      hidden: false,
+      description: 'Log the run result as a JSON object.',
+      env: 'SHOPIFY_FLAG_JSON',
+    }),
   }
 
   public async run() {
     const {flags} = await this.parse(FunctionRun)
     await inFunctionContext(this.config, flags.path, async (_app, ourFunction) => {
-      await runFunctionRunner(ourFunction)
+      await runFunctionRunner(ourFunction, {json: flags.json})
     })
   }
 }

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -1,4 +1,4 @@
-import {buildGraphqlTypes, bundleExtension, runJavy} from './build.js'
+import {buildGraphqlTypes, bundleExtension, runFunctionRunner, runJavy} from './build.js'
 import {testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
@@ -148,6 +148,50 @@ describe('runJavy', () => {
         stderr,
         stdout,
         signal,
+      },
+    )
+  })
+})
+
+describe('runFunctionRunner', () => {
+  test('calls function runner to execute function locally', async () => {
+    // Given
+    const ourFunction = await testFunctionExtension()
+
+    // When
+    const got = runFunctionRunner(ourFunction, {json: false})
+
+    // Then
+    await expect(got).resolves.toBeUndefined()
+    expect(exec).toHaveBeenCalledWith(
+      'npm',
+      ['exec', '--', 'function-runner', '-f', joinPath(ourFunction.directory, 'dist/index.wasm')],
+      {
+        cwd: ourFunction.directory,
+        stderr: 'inherit',
+        stdin: 'inherit',
+        stdout: 'inherit',
+      },
+    )
+  })
+
+  test('calls function runner to execute function locally and return json', async () => {
+    // Given
+    const ourFunction = await testFunctionExtension()
+
+    // When
+    const got = runFunctionRunner(ourFunction, {json: true})
+
+    // Then
+    await expect(got).resolves.toBeUndefined()
+    expect(exec).toHaveBeenCalledWith(
+      'npm',
+      ['exec', '--', 'function-runner', '-f', joinPath(ourFunction.directory, 'dist/index.wasm'), '--json'],
+      {
+        cwd: ourFunction.directory,
+        stderr: 'inherit',
+        stdin: 'inherit',
+        stdout: 'inherit',
       },
     )
   })

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -115,8 +115,13 @@ export async function runJavy(fun: FunctionExtension, options: JSFunctionBuildOp
   })
 }
 
-export async function runFunctionRunner(fun: FunctionExtension) {
-  return exec('npm', ['exec', '--', 'function-runner', '-f', fun.buildWasmPath], {
+interface FunctionRunnerOptions {
+  json: boolean
+}
+
+export async function runFunctionRunner(fun: FunctionExtension, options: FunctionRunnerOptions) {
+  const outputAsJson = options.json ? ['--json'] : []
+  return exec('npm', ['exec', '--', 'function-runner', '-f', fun.buildWasmPath, ...outputAsJson], {
     cwd: fun.directory,
     stdin: 'inherit',
     stdout: 'inherit',


### PR DESCRIPTION
### WHY are these changes introduced?

`function-runner` now supports emitting JSON

Fixes https://github.com/Shopify/internal-cli-foundations/issues/613

### WHAT is this pull request doing?

Add a `-j, --json` flag to `app function run`

### How to test your changes?

- `bin/create-test-app.js -e function`
- `cd ~/Desktop/nightly-app-*/extensions/prod-discount-fun`
- `echo '{"discountNode":{"metafield":null}}' | npm run preview`
- `echo '{"discountNode":{"metafield":null}}' | npm run preview -- --json`

### Post-release steps

Update shopify.dev page and add new flag

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
