### PR TITLE
Remove outdated reference to shopify login

### DIFF
--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/messages/messages.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/messages/messages.rb
@@ -485,7 +485,7 @@ module ShopifyCLI
           error: {
             timeout: "Timed out while waiting for response from Shopify",
             local_identity_not_running: "Identity needs to be running locally in order to proceed.",
-            reauthenticate: "Please login again with {{command:shopify login}}",
+            reauthenticate: "Please login again",
             invalid_destination: "The store %s doesn't exist. Please log out and try again.",
           },
 


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify login` doesn't exist as a command anymore.

### WHAT is this pull request doing?

Removes it