### PR TITLE
Adjust deprecation warning copy

### DIFF
--- a/packages/cli-kit/src/public/node/hooks/deprecations.ts
+++ b/packages/cli-kit/src/public/node/hooks/deprecations.ts
@@ -31,7 +31,7 @@ function renderUpgradeWarning(upgradeByDate: Date, forThemes?: boolean): void {
   const formattedDate = dateFormat.format(upgradeByDate)
 
   const headline = `Upgrade to the latest CLI version by ${formattedDate}.`
-  const body = 'This command is using internal APIs that will no longer be supported.'
+  const body = 'This command requires an upgrade to continue working as intended.'
   const upgradeLink = {
     link: {
       label: 'upgrade Shopify CLI',


### PR DESCRIPTION
### WHY are these changes introduced?

#gsd:33165

Address [Vault project comments](https://vault.shopify.io/gsd/reviews/23365#comments)

- Express that the command will stop working, but avoid explaining why
- Imply (but don't guarantee) that upgrading to the latest version will resolve the issue. The latest version could use the same command, a different command, or remove the feature.

### WHAT is this pull request doing?

Adjust warning banner messages to @MeredithCastile's suggestion

<img width="735" alt="Warning: Upgrade to the latest CLI version by July 2, 2023. This command requires an upgrade to continue working as intended. Next steps: Run upgrade to upgrade Shopify CLI" src="https://user-images.githubusercontent.com/1707217/228911208-253af895-b2ac-430f-b077-7fa3c3ea1057.png">

### How to test your changes?

https://github.com/Shopify/cli/pull/1597

### Post-release steps

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
