### PR TITLE
Improve pre-deploy validations for ui-extensions

### DIFF
--- a/packages/app/src/cli/models/extensions/ui-specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/web_pixel_extension.ts
@@ -26,8 +26,8 @@ const spec = createUIExtensionSpecification({
       runtime_configuration_definition: config.settings,
     }
   },
-  preDeployValidation: (config) => {
-    if (config.configuration) {
+  preDeployValidation: async (extension) => {
+    if (extension.configuration.configuration) {
       throw new AbortError(
         `The property configuration is deprecated and no longer supported.`,
         `It has been replaced by settings.`,

--- a/packages/app/src/cli/models/extensions/ui.ts
+++ b/packages/app/src/cli/models/extensions/ui.ts
@@ -28,7 +28,7 @@ export interface UIExtensionSpec<TConfiguration extends BaseConfigContents = Bas
   getBundleExtensionStdinContent?: (config: TConfiguration) => string
   deployConfig?: (config: TConfiguration, directory: string) => Promise<{[key: string]: unknown}>
   validate?: (config: TConfiguration, directory: string) => Promise<Result<unknown, string>>
-  preDeployValidation?: (config: TConfiguration) => Promise<void>
+  preDeployValidation?: (extension: UIExtensionInstance<TConfiguration>) => Promise<void>
   category: () => ExtensionCategory
   previewMessage?: (
     host: string,
@@ -125,9 +125,9 @@ export class UIExtensionInstance<TConfiguration extends BaseConfigContents = Bas
     return this.specification.validate(this.configuration, this.directory)
   }
 
-  preDeployValidation() {
+  preDeployValidation(): Promise<void> {
     if (!this.specification.preDeployValidation) return Promise.resolve()
-    return this.specification.preDeployValidation(this.configuration)
+    return this.specification.preDeployValidation(this)
   }
 
   async publishURL(options: {orgId: string; appId: string; extensionId?: string}) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- The web pixel team needs to add some extra validations on the pre-deploy step, but for that they need to access more information about the extension.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Modify the preDeployValidation function to receive the whole extension object and not only the configuration.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->


<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
