### PR TITLE
remove line jsdoc description

### DIFF
--- a/packages/cli-kit/src/public/node/api/graphql.ts
+++ b/packages/cli-kit/src/public/node/api/graphql.ts
@@ -28,7 +28,6 @@ export interface GraphQLResponseOptions<T> {
 /**
  * Executes a GraphQL query to an endpoint.
  *
- *
  * @param options - GraphQL request options.
  * @returns The response of the query of generic type <T>.
  */


### PR DESCRIPTION
osbolete extra line in jsdoc description introduced in #1688 caused an error in the workflow

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/59287019/229117992-1e647fc4-599b-4022-bd7d-90d3942d6617.png">
