### PR TITLE
Use unifiedAppDeployment flag instead of appUiDeployments

### DIFF
--- a/packages/app/src/cli/api/graphql/all_orgs.ts
+++ b/packages/app/src/cli/api/graphql/all_orgs.ts
@@ -4,9 +4,6 @@ export interface AllOrganizationsQuerySchemaOrganization {
   id: string
   businessName: string
   website?: string
-  betas: {
-    cliTunnelAlternative?: boolean
-  }
 }
 
 export interface AllOrganizationsQuerySchema {
@@ -22,9 +19,6 @@ export const AllOrganizationsQuery = gql`
         id
         businessName
         website
-        betas {
-          cliTunnelAlternative
-        }
       }
     }
   }

--- a/packages/app/src/cli/api/graphql/all_orgs.ts
+++ b/packages/app/src/cli/api/graphql/all_orgs.ts
@@ -5,7 +5,7 @@ export interface AllOrganizationsQuerySchemaOrganization {
   businessName: string
   website?: string
   betas: {
-    appUiDeployments?: boolean
+    cliTunnelAlternative?: boolean
   }
 }
 
@@ -23,7 +23,7 @@ export const AllOrganizationsQuery = gql`
         businessName
         website
         betas {
-          appUiDeployments
+          cliTunnelAlternative
         }
       }
     }

--- a/packages/app/src/cli/api/graphql/find_app.ts
+++ b/packages/app/src/cli/api/graphql/find_app.ts
@@ -12,6 +12,9 @@ export const FindAppQuery = gql`
       }
       appType
       grantedScopes
+      betas {
+        unifiedAppDeployment
+      }
     }
   }
 `
@@ -27,5 +30,8 @@ export interface FindAppQuerySchema {
     }[]
     appType: string
     grantedScopes: string[]
+    betas?: {
+      unifiedAppDeployment: boolean
+    }
   }
 }

--- a/packages/app/src/cli/api/graphql/find_app.ts
+++ b/packages/app/src/cli/api/graphql/find_app.ts
@@ -31,7 +31,7 @@ export interface FindAppQuerySchema {
     appType: string
     grantedScopes: string[]
     betas?: {
-      unifiedAppDeployment: boolean
+      unifiedAppDeployment?: boolean
     }
   }
 }

--- a/packages/app/src/cli/api/graphql/find_org.ts
+++ b/packages/app/src/cli/api/graphql/find_org.ts
@@ -8,7 +8,7 @@ export const FindOrganizationQuery = gql`
         businessName
         website
         betas {
-          appUiDeployments
+          cliTunnelAlternative
         }
         apps(first: 25, title: $title) {
           pageInfo {
@@ -32,7 +32,7 @@ export interface FindOrganizationQuerySchema {
       businessName: string
       website: string
       betas: {
-        appUiDeployments?: boolean
+        cliTunnelAlternative?: boolean
       }
       apps: {
         pageInfo: {

--- a/packages/app/src/cli/api/graphql/find_org.ts
+++ b/packages/app/src/cli/api/graphql/find_org.ts
@@ -7,9 +7,6 @@ export const FindOrganizationQuery = gql`
         id
         businessName
         website
-        betas {
-          cliTunnelAlternative
-        }
         apps(first: 25, title: $title) {
           pageInfo {
             hasNextPage
@@ -31,9 +28,6 @@ export interface FindOrganizationQuerySchema {
       id: string
       businessName: string
       website: string
-      betas: {
-        cliTunnelAlternative?: boolean
-      }
       apps: {
         pageInfo: {
           hasNextPage: boolean

--- a/packages/app/src/cli/api/graphql/find_org_basic.ts
+++ b/packages/app/src/cli/api/graphql/find_org_basic.ts
@@ -8,7 +8,6 @@ export const FindOrganizationBasicQuery = gql`
         businessName
         website
         betas {
-          appUiDeployments
           cliTunnelAlternative
         }
       }
@@ -23,7 +22,6 @@ export interface FindOrganizationBasicQuerySchema {
       businessName: string
       website: string
       betas: {
-        appUiDeployments?: boolean
         cliTunnelAlternative?: boolean
       }
     }[]

--- a/packages/app/src/cli/api/graphql/find_store_by_domain.ts
+++ b/packages/app/src/cli/api/graphql/find_store_by_domain.ts
@@ -8,7 +8,7 @@ export const FindStoreByDomainQuery = gql`
         businessName
         website
         betas {
-          appUiDeployments
+          cliTunnelAlternative
         }
         stores(shopDomain: $shopDomain, first: 1, archived: false) {
           nodes {
@@ -32,7 +32,7 @@ export interface FindStoreByDomainSchema {
       businessName: string
       website: string
       betas: {
-        appUiDeployments?: boolean
+        cliTunnelAlternative?: boolean
       }
       stores: {
         nodes: {

--- a/packages/app/src/cli/api/graphql/find_store_by_domain.ts
+++ b/packages/app/src/cli/api/graphql/find_store_by_domain.ts
@@ -7,9 +7,6 @@ export const FindStoreByDomainQuery = gql`
         id
         businessName
         website
-        betas {
-          cliTunnelAlternative
-        }
         stores(shopDomain: $shopDomain, first: 1, archived: false) {
           nodes {
             shopId
@@ -31,9 +28,6 @@ export interface FindStoreByDomainSchema {
       id: string
       businessName: string
       website: string
-      betas: {
-        cliTunnelAlternative?: boolean
-      }
       stores: {
         nodes: {
           shopId: string

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -3,7 +3,6 @@ export interface Organization {
   businessName: string
   website?: string
   betas: {
-    appUiDeployments?: boolean
     cliTunnelAlternative?: boolean
   }
 }
@@ -22,6 +21,9 @@ export type OrganizationApp = MinimalOrganizationApp & {
   appType?: string
   newApp?: boolean
   grantedScopes: string[]
+  betas?: {
+    unifiedAppDeployment?: boolean
+  }
 }
 
 export interface OrganizationStore {

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -2,7 +2,7 @@ export interface Organization {
   id: string
   businessName: string
   website?: string
-  betas: {
+  betas?: {
     cliTunnelAlternative?: boolean
   }
 }

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -57,6 +57,9 @@ const APP1: OrganizationApp = {
   organizationId: '1',
   apiSecretKeys: [{secret: 'secret1'}],
   grantedScopes: [],
+  betas: {
+    unifiedAppDeployment: false,
+  },
 }
 const APP2: OrganizationApp = {
   id: '2',
@@ -65,18 +68,21 @@ const APP2: OrganizationApp = {
   organizationId: '1',
   apiSecretKeys: [{secret: 'secret2'}],
   grantedScopes: [],
+  betas: {
+    unifiedAppDeployment: false,
+  },
 }
 
 const ORG1: Organization = {
   id: '1',
   businessName: 'org1',
-  betas: {appUiDeployments: false, cliTunnelAlternative: false},
+  betas: {cliTunnelAlternative: false},
   website: '',
 }
 const ORG2: Organization = {
   id: '2',
   businessName: 'org2',
-  betas: {appUiDeployments: false, cliTunnelAlternative: true},
+  betas: {cliTunnelAlternative: true},
   website: '',
 }
 
@@ -372,12 +378,10 @@ describe('ensureDeployContext', () => {
 
     // Then
     expect(selectOrCreateApp).not.toHaveBeenCalled()
-    expect(fetchOrgFromId).toHaveBeenCalledWith(ORG1.id, 'token')
     expect(got.partnersApp.id).toEqual(APP2.id)
     expect(got.partnersApp.title).toEqual(APP2.title)
     expect(got.partnersApp.appType).toEqual(APP2.appType)
     expect(got.identifiers).toEqual(identifiers)
-    expect(got.organization?.id).toEqual(ORG1.id)
 
     expect(metadata.getAllPublicMetadata()).toMatchObject({api_key: APP2.apiKey, partner_id: 1})
   })
@@ -395,7 +399,6 @@ describe('ensureDeployContext', () => {
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
     vi.mocked(reuseDevConfigPrompt).mockResolvedValueOnce(true)
-    vi.mocked(fetchOrgFromId).mockResolvedValueOnce(ORG1)
 
     // When
     const got = await ensureDeployContext(options(app))
@@ -403,12 +406,10 @@ describe('ensureDeployContext', () => {
     // Then
     expect(selectOrCreateApp).not.toHaveBeenCalled()
     expect(reuseDevConfigPrompt).toHaveBeenCalled()
-    expect(fetchOrgFromId).toHaveBeenCalledWith(ORG1.id, 'token')
     expect(got.partnersApp.id).toEqual(APP2.id)
     expect(got.partnersApp.title).toEqual(APP2.title)
     expect(got.partnersApp.appType).toEqual(APP2.appType)
     expect(got.identifiers).toEqual(identifiers)
-    expect(got.organization?.id).toEqual(ORG1.id)
   })
 
   test('prompts the user to create or select an app and returns it with its id when the app has no extensions', async () => {
@@ -438,12 +439,10 @@ describe('ensureDeployContext', () => {
       identifiers,
       command: 'deploy',
     })
-    expect(fetchOrgFromId).not.toHaveBeenCalled()
     expect(got.partnersApp.id).toEqual(APP1.id)
     expect(got.partnersApp.title).toEqual(APP1.title)
     expect(got.partnersApp.appType).toEqual(APP1.appType)
     expect(got.identifiers).toEqual({app: APP1.apiKey, extensions: {}, extensionIds: {}})
-    expect(got.organization?.id).toEqual(ORG1.id)
   })
 
   test("throws an app not found error if the app with the API key doesn't exist", async () => {
@@ -493,7 +492,6 @@ describe('ensureDeployContext', () => {
     expect(got.partnersApp.title).toEqual(APP1.title)
     expect(got.partnersApp.appType).toEqual(APP1.appType)
     expect(got.identifiers).toEqual({app: APP1.apiKey, extensions: {}, extensionIds: {}})
-    expect(got.organization?.id).toEqual(ORG1.id)
   })
 })
 

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -139,7 +139,7 @@ export async function ensureDevContext(options: DevContextOptions, token: string
 
   let {app: selectedApp, store: selectedStore} = await fetchDevDataFromOptions(options, orgId, token)
   const organization = await fetchOrgFromId(orgId, token)
-  const useCloudflareTunnels = organization.betas.cliTunnelAlternative !== true
+  const useCloudflareTunnels = organization.betas?.cliTunnelAlternative !== true
 
   if (selectedApp && selectedStore) {
     setAppInfo({

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -325,7 +325,7 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
   return result
 }
 
-export async function fetchOrganizationAndFetchOrCreateApp(app: AppInterface, token: string): Promise<OrganizationApp> {
+export async function fetchOrCreateOrganizationApp(app: AppInterface, token: string): Promise<OrganizationApp> {
   const orgId = await selectOrg(token)
   const {organization, apps} = await fetchOrgsAppsAndStores(orgId, token)
   const partnersApp = await selectOrCreateApp(app.name, apps, organization, token)
@@ -362,7 +362,7 @@ export async function fetchAppAndIdentifiers(
   }
 
   if (!partnersApp) {
-    partnersApp = await fetchOrganizationAndFetchOrCreateApp(options.app, token)
+    partnersApp = await fetchOrCreateOrganizationApp(options.app, token)
   }
 
   return [partnersApp, envIdentifiers]

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -27,7 +27,6 @@ import {renderInfo, renderTasks} from '@shopify/cli-kit/node/ui'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputInfo, outputToken, formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
-import {usePartnersToken} from '@shopify/cli-kit/node/environment'
 
 export const InvalidApiKeyErrorMessage = (apiKey: string) => {
   return {
@@ -245,7 +244,6 @@ interface DeployContextOutput {
   token: string
   partnersApp: Omit<OrganizationApp, 'apiSecretKeys' | 'apiKey'>
   identifiers: Identifiers
-  organization: Organization | undefined
 }
 
 /**
@@ -291,7 +289,7 @@ export async function ensureThemeExtensionDevContext(
 
 export async function ensureDeployContext(options: DeployContextOptions): Promise<DeployContextOutput> {
   const token = await ensureAuthenticatedPartners()
-  const [partnersApp, envIdentifiers, organization] = await fetchAppAndIdentifiers(options, token)
+  const [partnersApp, envIdentifiers] = await fetchAppAndIdentifiers(options, token)
 
   let identifiers: Identifiers = envIdentifiers as Identifiers
 
@@ -317,24 +315,21 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
       appType: partnersApp.appType,
       organizationId: partnersApp.organizationId,
       grantedScopes: partnersApp.grantedScopes,
+      betas: partnersApp.betas,
     },
     identifiers,
     token,
-    organization,
   }
 
   await logMetadataForLoadedDeployContext(result)
   return result
 }
 
-export async function fetchOrganizationAndFetchOrCreateApp(
-  app: AppInterface,
-  token: string,
-): Promise<{partnersApp: OrganizationApp; organization: Organization}> {
+export async function fetchOrganizationAndFetchOrCreateApp(app: AppInterface, token: string): Promise<OrganizationApp> {
   const orgId = await selectOrg(token)
   const {organization, apps} = await fetchOrgsAppsAndStores(orgId, token)
   const partnersApp = await selectOrCreateApp(app.name, apps, organization, token)
-  return {organization, partnersApp}
+  return partnersApp
 }
 
 export async function fetchAppAndIdentifiers(
@@ -345,10 +340,9 @@ export async function fetchAppAndIdentifiers(
     apiKey?: string
   },
   token: string,
-): Promise<[OrganizationApp, Partial<UuidOnlyIdentifiers>, Organization | undefined]> {
+): Promise<[OrganizationApp, Partial<UuidOnlyIdentifiers>]> {
   let envIdentifiers = getAppIdentifiers({app: options.app})
   let partnersApp: OrganizationApp | undefined
-  let organization: Organization | undefined
 
   if (options.reset) {
     envIdentifiers = {app: undefined, extensions: {}}
@@ -368,18 +362,10 @@ export async function fetchAppAndIdentifiers(
   }
 
   if (!partnersApp) {
-    const result = await fetchOrganizationAndFetchOrCreateApp(options.app, token)
-    partnersApp = result.partnersApp
-    organization = result.organization
+    partnersApp = await fetchOrganizationAndFetchOrCreateApp(options.app, token)
   }
 
-  // if the command is run using a partnersToken then it is not possible to fetch the organization information because
-  // that token has not enough permissions and the command break at this point with a not found organizations error.
-  if (!usePartnersToken() && !organization) {
-    organization = await fetchOrgFromId(partnersApp.organizationId, token)
-  }
-
-  return [partnersApp, envIdentifiers, organization]
+  return [partnersApp, envIdentifiers]
 }
 
 async function fetchOrgsAppsAndStores(orgId: string, token: string): Promise<FetchResponse> {

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -284,7 +284,7 @@ async function testDeployBundle(
   await deploy({
     app,
     reset: false,
-    force: options?.force ?? false,
+    force: Boolean(options?.force),
     label: options?.label,
   })
 

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -6,7 +6,7 @@ import {fetchAppExtensionRegistrations} from './dev/fetch.js'
 import {testApp, testThemeExtensions, testUIExtension} from '../models/app/app.test-data.js'
 import {updateAppIdentifiers} from '../models/app/identifiers.js'
 import {AppInterface} from '../models/app/app.js'
-import {Organization} from '../models/organization.js'
+import {OrganizationApp} from '../models/organization.js'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import {renderSuccess, renderTasks, renderTextPrompt, Task} from '@shopify/cli-kit/node/ui'
@@ -90,14 +90,18 @@ describe('deploy', () => {
   test('passes a label to the deployment mutation', async () => {
     // Given
     const uiExtension = await testUIExtension({type: 'web_pixel_extension'})
-    const app = testApp({extensions: {ui: [uiExtension], theme: [], function: []}})
+    const app = testApp({
+      extensions: {ui: [uiExtension], theme: [], function: []},
+    })
     vi.mocked(renderTextPrompt).mockResolvedValue('Deployed from CLI')
 
     // When
     await testDeployBundle(app, {
-      id: 'org-id',
-      businessName: 'org-name',
-      betas: {appUiDeployments: true},
+      id: 'app-id',
+      organizationId: 'org-id',
+      title: 'app-title',
+      grantedScopes: [],
+      betas: {unifiedAppDeployment: true},
     })
 
     // Then
@@ -108,16 +112,57 @@ describe('deploy', () => {
     )
   })
 
-  test('passes a label to the deployment mutation with a flag', async () => {
+  test("doesn't ask for a label if force is used", async () => {
     // Given
     const uiExtension = await testUIExtension({type: 'web_pixel_extension'})
-    const app = testApp({extensions: {ui: [uiExtension], theme: [], function: []}})
+    const app = testApp({
+      extensions: {ui: [uiExtension], theme: [], function: []},
+    })
 
     // When
     await testDeployBundle(
       app,
-      {id: 'org-id', businessName: 'org-name', betas: {appUiDeployments: true}},
-      'Deployed from CLI with flag',
+      {
+        id: 'app-id',
+        organizationId: 'org-id',
+        title: 'app-title',
+        grantedScopes: [],
+        betas: {unifiedAppDeployment: true},
+      },
+      {
+        force: true,
+      },
+    )
+
+    // Then
+    expect(vi.mocked(renderTextPrompt)).not.toHaveBeenCalled()
+    expect(uploadExtensionsBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: undefined,
+      }),
+    )
+  })
+
+  test('passes a label to the deployment mutation with a flag', async () => {
+    // Given
+    const uiExtension = await testUIExtension({type: 'web_pixel_extension'})
+    const app = testApp({
+      extensions: {ui: [uiExtension], theme: [], function: []},
+    })
+
+    // When
+    await testDeployBundle(
+      app,
+      {
+        id: 'app-id',
+        organizationId: 'org-id',
+        title: 'app-title',
+        grantedScopes: [],
+        betas: {unifiedAppDeployment: true},
+      },
+      {
+        label: 'Deployed from CLI with flag',
+      },
     )
 
     // Then
@@ -135,11 +180,7 @@ describe('deploy', () => {
     const app = testApp({extensions: {ui: [uiExtension], theme: [], function: []}})
 
     // When
-    await testDeployBundle(app, {
-      id: 'org-id',
-      businessName: 'org-name',
-      betas: {appUiDeployments: false},
-    })
+    await testDeployBundle(app)
 
     // Then
     expect(renderSuccess).toHaveBeenCalledWith({
@@ -183,9 +224,11 @@ describe('deploy', () => {
 
     // When
     await testDeployBundle(app, {
-      id: 'org-id',
-      businessName: 'org-name',
-      betas: {appUiDeployments: true},
+      id: 'app-id',
+      organizationId: 'org-id',
+      title: 'app-title',
+      grantedScopes: [],
+      betas: {unifiedAppDeployment: true},
     })
 
     // Then
@@ -202,7 +245,14 @@ describe('deploy', () => {
   })
 })
 
-async function testDeployBundle(app: AppInterface, organization?: Organization, label?: string) {
+async function testDeployBundle(
+  app: AppInterface,
+  partnersApp?: Omit<OrganizationApp, 'apiSecretKeys' | 'apiKey'>,
+  options?: {
+    label?: string
+    force?: boolean
+  },
+) {
   // Given
   const extensionsPayload: {[key: string]: string} = {}
   for (const uiExtension of app.extensions.ui) {
@@ -216,13 +266,13 @@ async function testDeployBundle(app: AppInterface, organization?: Organization, 
   vi.mocked(ensureDeployContext).mockResolvedValue({
     app,
     identifiers,
-    partnersApp: {id: 'app-id', organizationId: 'org-id', title: 'app-title', grantedScopes: []},
-    token: 'api-token',
-    organization: organization ?? {
-      id: 'org-id',
-      businessName: 'org-name',
-      betas: {appUiDeployments: false},
+    partnersApp: partnersApp ?? {
+      id: 'app-id',
+      organizationId: 'org-id',
+      title: 'app-title',
+      grantedScopes: [],
     },
+    token: 'api-token',
   })
   vi.mocked(useThemebundling).mockReturnValue(true)
   vi.mocked(uploadFunctionExtensions).mockResolvedValue(identifiers)
@@ -234,8 +284,8 @@ async function testDeployBundle(app: AppInterface, organization?: Organization, 
   await deploy({
     app,
     reset: false,
-    force: true,
-    label,
+    force: options?.force ?? false,
+    label: options?.label,
   })
 
   // Then

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -150,7 +150,7 @@ export async function deploy(options: DeployOptions) {
         registrations,
         validationErrors,
         deploymentId,
-        unifiedDeployment: Boolean(partnersApp.betas?.unifiedAppDeployment) ?? false,
+        unifiedDeployment: Boolean(partnersApp.betas?.unifiedAppDeployment),
       })
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -20,12 +20,10 @@ import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 const ORG1: Organization = {
   id: '1',
   businessName: 'org1',
-  betas: {},
 }
 const ORG2: Organization = {
   id: '2',
   businessName: 'org2',
-  betas: {},
 }
 const APP1: OrganizationApp = {
   id: '1',

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -102,7 +102,7 @@ export async function fetchOrgAndApps(orgId: string, token: string, title?: stri
   const result: FindOrganizationQuerySchema = await partnersRequest(query, token, params)
   const org = result.organizations.nodes[0]
   if (!org) throw NoOrgError(orgId)
-  const parsedOrg = {id: org.id, businessName: org.businessName, betas: org.betas}
+  const parsedOrg = {id: org.id, businessName: org.businessName}
   return {organization: parsedOrg, apps: org.apps, stores: []}
 }
 
@@ -155,7 +155,7 @@ export async function fetchStoreByDomain(
     return undefined
   }
 
-  const parsedOrg = {id: org.id, businessName: org.businessName, betas: org.betas}
+  const parsedOrg = {id: org.id, businessName: org.businessName}
   const store = org.stores.nodes[0]
 
   return {organization: parsedOrg, store}

--- a/packages/app/src/cli/services/generate-schema.test.ts
+++ b/packages/app/src/cli/services/generate-schema.test.ts
@@ -78,19 +78,12 @@ describe('generateSchemaService', () => {
     beforeEach(async () => {
       getAppIdentifiers.mockReturnValue({app: identifiersApiKey})
       fetchOrganizationAndFetchOrCreateApp.mockResolvedValue({
-        partnersApp: {
-          id: 'id',
-          title: 'title',
-          apiKey: promptApiKey,
-          organizationId: '1',
-          apiSecretKeys: [],
-          grantedScopes: [],
-        },
-        organization: {
-          id: '1',
-          businessName: 'businessName',
-          betas: {},
-        },
+        id: 'id',
+        title: 'title',
+        apiKey: promptApiKey,
+        organizationId: '1',
+        apiSecretKeys: [],
+        grantedScopes: [],
       })
       vi.mocked(isTerminalInteractive).mockReturnValue(true)
     })

--- a/packages/app/src/cli/services/generate-schema.test.ts
+++ b/packages/app/src/cli/services/generate-schema.test.ts
@@ -24,7 +24,7 @@ vi.mock('./context.js', async () => {
   const context: any = await vi.importActual('./context.js')
   return {
     ...context,
-    fetchOrganizationAndFetchOrCreateApp: vi.fn(),
+    fetchOrCreateOrganizationApp: vi.fn(),
   }
 })
 
@@ -70,14 +70,13 @@ describe('generateSchemaService', () => {
     const promptApiKey = 'prompt-api-key'
 
     const getAppIdentifiers = identifiers.getAppIdentifiers as MockedFunction<typeof identifiers.getAppIdentifiers>
-    const fetchOrganizationAndFetchOrCreateApp =
-      localEnvironment.fetchOrganizationAndFetchOrCreateApp as MockedFunction<
-        typeof localEnvironment.fetchOrganizationAndFetchOrCreateApp
-      >
+    const fetchOrCreateOrganizationApp = localEnvironment.fetchOrCreateOrganizationApp as MockedFunction<
+      typeof localEnvironment.fetchOrCreateOrganizationApp
+    >
 
     beforeEach(async () => {
       getAppIdentifiers.mockReturnValue({app: identifiersApiKey})
-      fetchOrganizationAndFetchOrCreateApp.mockResolvedValue({
+      fetchOrCreateOrganizationApp.mockResolvedValue({
         id: 'id',
         title: 'title',
         apiKey: promptApiKey,

--- a/packages/app/src/cli/services/generate-schema.ts
+++ b/packages/app/src/cli/services/generate-schema.ts
@@ -33,7 +33,7 @@ export async function generateSchemaService(options: GenerateSchemaOptions) {
       )
     }
 
-    apiKey = (await fetchOrganizationAndFetchOrCreateApp(app, token)).partnersApp.apiKey
+    apiKey = (await fetchOrganizationAndFetchOrCreateApp(app, token)).apiKey
   }
 
   const query = ApiSchemaDefinitionQuery

--- a/packages/app/src/cli/services/generate-schema.ts
+++ b/packages/app/src/cli/services/generate-schema.ts
@@ -1,4 +1,4 @@
-import {fetchOrganizationAndFetchOrCreateApp} from './context.js'
+import {fetchOrCreateOrganizationApp} from './context.js'
 import {AppInterface} from '../models/app/app.js'
 import {FunctionExtension} from '../models/app/extensions.js'
 import {getAppIdentifiers} from '../models/app/identifiers.js'
@@ -33,7 +33,7 @@ export async function generateSchemaService(options: GenerateSchemaOptions) {
       )
     }
 
-    apiKey = (await fetchOrganizationAndFetchOrCreateApp(app, token)).apiKey
+    apiKey = (await fetchOrCreateOrganizationApp(app, token)).apiKey
   }
 
   const query = ApiSchemaDefinitionQuery


### PR DESCRIPTION
### WHY are these changes introduced?

We want to move the beta flag for unified deployments to the org level because we're getting rid of the org level one and also because the partners token doesn't have permission to fetch organizations, so the `deploy` command couldn't make use of such flags.

### WHAT is this pull request doing?

I've removed `appUiDeployments` from organizations and added `unifiedAppDeployment` to apps.

### How to test your changes?

- Enable the `unified_app_deployment` beta flag in partners
- The new flow should be active when deploying