### PR TITLE
[cli-kit] add export mime type functions using "mrmime"

### DIFF
--- a/.changeset/rotten-bears-trade.md
+++ b/.changeset/rotten-bears-trade.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+lookupMimeType and setMimeTypes using mrmime

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -133,6 +133,7 @@
     "liquidjs": "10.6.0",
     "lodash": "4.17.21",
     "macaddress": "0.5.3",
+    "mrmime": "1.0.1",
     "node-abort-controller": "3.0.1",
     "node-fetch": "3.2.4",
     "open": "8.4.2",

--- a/packages/cli-kit/src/public/node/mimes.test.ts
+++ b/packages/cli-kit/src/public/node/mimes.test.ts
@@ -1,0 +1,19 @@
+import {lookupMimeType, setMimeTypes} from './mimes.js'
+import {describe, expect, test} from 'vitest'
+
+describe('mimes', () => {
+  test('gets mime types for filenames and extensions', async () => {
+    const examples = ['file.txt', 'png', '.jpeg', 'file.tar.gz', 'noextension']
+    const expected = ['text/plain', 'image/png', 'image/jpeg', 'application/gzip', 'application/octet-stream']
+    examples.forEach((example, index) => expect(lookupMimeType(example)).toEqual(expected[index]))
+  })
+
+  test('sets mime types for extensions', async () => {
+    const newMimeExamples = {
+      bar: 'bar/foo',
+      foo: 'foo/bar',
+    }
+    setMimeTypes(newMimeExamples)
+    Object.entries(newMimeExamples).forEach(([extension, value]) => expect(lookupMimeType(extension)).toEqual(value))
+  })
+})

--- a/packages/cli-kit/src/public/node/mimes.ts
+++ b/packages/cli-kit/src/public/node/mimes.ts
@@ -1,0 +1,23 @@
+// import * as mimeTypes from 'mrmime'
+import {lookup, mimes} from 'mrmime'
+
+/**
+ * Returns the MIME type for a filename.
+ *
+ * @param fileName - Filename.
+ * @returns The mime type.
+ */
+export function lookupMimeType(fileName: string): string {
+  return lookup(fileName) || 'application/octet-stream'
+}
+
+/**
+ * Adds MIME type(s) to the dictionary.
+ *
+ * @param newTypes - Object of key-values where key is extension and value is mime type.
+ */
+export function setMimeTypes(newTypes: {[key: string]: string}): void {
+  Object.entries(newTypes).forEach(([extension, mimeType]) => {
+    mimes[extension] = mimeType
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,7 @@ importers:
       liquidjs: 10.6.0
       lodash: 4.17.21
       macaddress: 0.5.3
+      mrmime: 1.0.1
       node-abort-controller: 3.0.1
       node-fetch: 3.2.4
       node-stream-zip: ^1.15.0
@@ -303,6 +304,7 @@ importers:
       liquidjs: 10.6.0
       lodash: 4.17.21
       macaddress: 0.5.3
+      mrmime: 1.0.1
       node-abort-controller: 3.0.1
       node-fetch: 3.2.4
       open: 8.4.2
@@ -9203,6 +9205,11 @@ packages:
     resolution: {integrity: sha512-3DeNIcsQixWHHKk6NdoBhWI4t1VMj5/HzfnI1rE/pLl5qKx7+gd4DNA07ehTaZ6MoUU053si6Hd+YtiM/tQZfg==}
     engines: {node: '>= 8'}
     dev: true
+
+  /mrmime/1.0.1:
+    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+    engines: {node: '>=10'}
+    dev: false
 
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

exports functions to retrieve a mime type from a string (filename) and to add an extension to the mime type dictionary. Uses [mrmime](https://www.npmjs.com/package/mrmime).

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
