### PR TITLE
[cli-kit] add options argument to createFileReadStream

### DIFF
--- a/packages/cli-kit/src/public/node/fs.test.ts
+++ b/packages/cli-kit/src/public/node/fs.test.ts
@@ -1,4 +1,5 @@
 import {
+  createFileReadStream,
   copyFile,
   mkdir,
   fileHasExecutablePermissions,
@@ -224,6 +225,43 @@ describe('readFileSync', () => {
       await touchFile(filePath)
       await appendFile(filePath, content)
       await expect(readFileSync(filePath).toString()).toContain(content)
+    })
+  })
+})
+
+describe('createFileReadStream', () => {
+  test('creates a readable stream for a file', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const filePath = joinPath(tmpDir, 'test-file')
+      const content = 'test-content'
+      await touchFile(filePath)
+      await appendFile(filePath, content)
+      const stream = createFileReadStream(filePath)
+      let data = ''
+      stream.on('data', (chunk) => {
+        data += chunk
+      })
+      stream.on('end', () => {
+        expect(data).toBe(content)
+      })
+    })
+  })
+
+  test('creates a readable stream for a chunk of a file', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const filePath = joinPath(tmpDir, 'test-file')
+      const content = 'test-content'
+      await touchFile(filePath)
+      await appendFile(filePath, content)
+
+      const stream = createFileReadStream(filePath, {start: 1, end: 7})
+      let data = ''
+      stream.on('data', (chunk) => {
+        data += chunk
+      })
+      stream.on('end', () => {
+        expect(data).toBe('est-con')
+      })
     })
   })
 })

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -319,13 +319,17 @@ export function unlinkFileSync(path: string): void {
 }
 
 /**
- * Create a read stream for a file.
+ * Create a read stream for a file with optional options.
  *
  * @param path - Path to the file.
+ * @param options - Options for the read stream.
  * @returns A read stream for the file.
  */
-export function createFileReadStream(path: string): ReadStream {
-  return fsCreateReadStream(path)
+export function createFileReadStream(
+  path: string,
+  options?: {encoding?: BufferEncoding; start?: number; end?: number},
+): ReadStream {
+  return fsCreateReadStream(path, options)
 }
 
 /**


### PR DESCRIPTION

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

cli-kit exports `createFileReadStream` (from `filehandle.createReadStream`) but doesn't expose its `options` argument. We'd like this available so we can set a `start` and `end` to read a range of bytes in our plugin.

This PR adds an optional `options` parameter exposing `start`, `end` and `encoding`. I also added a test.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
