### PR TITLE
Flush stdout after printing messages in Ruby CLI

### DIFF
--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/context.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/context.rb
@@ -47,12 +47,14 @@ module ShopifyCLI
         str ? str % params : key
       end
 
-      # a wrapper around Kernel.puts to allow for easy formatting
+      # a wrapper around $stdout.puts to allow for easy formatting
       #
       # #### Parameters
       # * `text` - a string message to output
       def puts(*args)
-        Kernel.puts(CLI::UI.fmt(*args))
+        $stdout.puts(CLI::UI.fmt(*args)).tap do
+          $stdout.flush
+        end
       end
 
       # aborts the current running command and outputs an error message:


### PR DESCRIPTION
### WHY are these changes introduced?

If we don't do this, in some operating systems the output will be buffered. For example, while serving theme app extensions this will cause the output to be only partially shown. This is very bad because we print out useful information such as links to enable the extension, edit your theme, or preview your extension.

### WHAT is this pull request doing?

- Flush stdout after printing ruby messages

**before**
<img width="1065" alt="Screenshot 2023-04-03 at 17 52 40" src="https://user-images.githubusercontent.com/62895/229578280-7191d13c-bdf2-4ac0-b1e4-bd5f75c6530d.png">

**after**
<img width="1205" alt="Screenshot 2023-04-03 at 17 55 21" src="https://user-images.githubusercontent.com/62895/229578297-ed6c74cd-472e-45f6-9390-7fa30a254c72.png">

### How to test your changes?

- Run `bin/create-test-app.js -e theme` on Linux

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
