### PR TITLE
Exit prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "pre",
   "initialVersions": {
     "shopify-app-template-node": "0.1.0",


### PR DESCRIPTION
### WHY are these changes introduced?
I'm doing a new minor release of the CLI and therefore I need to exit the pre-release mode of changeset.