### PR TITLE
More improvements to test scripts

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -32,6 +32,11 @@ program
     extensionTypes.join(",")
   )
   .option(
+    "--bare",
+    "don't create any extensions. Overrides --extensions",
+    false
+  )
+  .option(
     "--name <name>",
     "name of your app. It will be placed on your Desktop",
     `nightly-app-${today}`
@@ -66,7 +71,7 @@ program
     // main
     let shopifyExec
     let defaultOpts = { stdio: "inherit" }
-    let extensions = new Set(options.extensions.split(","))
+    let extensions = options.bare ? new Set() : new Set(options.extensions.split(","))
 
     const appName = options.name
     const appPath = path.join(homeDir, "Desktop", appName)

--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+import * as readline from 'node:readline/promises'
+import { stdin as input, stdout as output } from 'node:process'
 import { createRequire } from "module"
 import { fileURLToPath } from "url"
 import { Readable } from "stream"
@@ -80,6 +82,19 @@ program
       case "local":
         log("Building latest release...")
         await execa("pnpm", ["build"])
+
+        if (fs.existsSync(appPath)) {
+          const rl = readline.createInterface({ input, output })
+          const answer = await rl.question(`\r\n🙋‍♀️ I've found an app in ${appPath}. Should I remove it and keep going? (Y/n)`);
+          rl.close();
+
+          if (answer.toLowerCase() === 'y' || answer === '') {
+            log(`Removing app in '${appPath}'...`)
+            fs.rmSync(appPath, { recursive: true })
+          } else {
+            process.exit(0)
+          }
+        }
 
         log(`Creating new app in ${appPath}...`)
         await execa(

--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -99,7 +99,7 @@ program
         if (os.platform() == "win32") {
           fs.rmSync(path.join(appPath, "pnpm-lock.yaml"))
         }
-        await appExec("pnpm", ["install"])
+
         break
       case "nightly":
         log(`Creating new app in ${appPath}...`)
@@ -120,6 +120,10 @@ program
         log(`Invalid installation type: ${options.install}. Must be one of ${installationTypes.join(", ")}.`)
         process.exit(1)
     }
+
+    // on windows pnpm sets the wrong paths, rerunning install fixes it
+    log("Making sure pnpm is setup correctly")
+    await appExec("pnpm", ["install"])
 
     if (extensions.has("ui")) {
       log("Generating UI extension...")

--- a/bin/create-test-theme.js
+++ b/bin/create-test-theme.js
@@ -14,8 +14,6 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const homeDir = os.homedir()
 const today = new Date().toISOString().split("T")[0]
-const themeName = `nightly-theme-${today}`
-const themePath = path.join(homeDir, "Desktop", themeName)
 
 const installationTypes = os.platform() == "darwin" ? ["homebrew", "local", "npm"] : ["local", "npm"]
 
@@ -31,13 +29,27 @@ program
     `your dev store's name (e.g. my-awesome-dev-store)`
   )
   .option(
+    "--name <name>",
+    "name of your theme. It will be placed on your Desktop",
+    `nightly-theme-${today}`
+  )
+  .option(
     "--cleanup",
     "delete temp theme and nightly dependencies afterwards",
     false
   )
   .action(async (options) => {
+    // helpers
+    const log = (message) => {
+      console.log(`\r\n🧪 ${message}`)
+    }
+
+    // main
     let shopifyExec
     let defaultOpts = { stdio: "inherit" }
+
+    const themeName = options.name
+    const themePath = path.join(homeDir, "Desktop", themeName)
 
     delete process.env.GEM_HOME
     delete process.env.GEM_PATH
@@ -147,8 +159,3 @@ program
 
 // run it
 program.parse()
-
-// helpers
-function log(message) {
-  console.log(`\r\n🧪 ${message}`)
-}

--- a/bin/create-test-theme.js
+++ b/bin/create-test-theme.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+import * as readline from 'node:readline/promises'
+import { stdin as input, stdout as output } from 'node:process'
 import { createRequire } from "module"
 import { fileURLToPath } from "url"
 import execa from "execa"
@@ -99,6 +101,19 @@ program
       default:
         log(`Invalid installation type: ${options.install}. Must be one of ${installationTypes.join(", ")}.`)
         process.exit(1)
+    }
+
+    if (fs.existsSync(themePath)) {
+      const rl = readline.createInterface({ input, output })
+      const answer = await rl.question(`\r\n🙋‍♀️ I've found a theme in ${themePath}. Should I remove it and keep going? (Y/n)`);
+      rl.close();
+
+      if (answer.toLowerCase() === 'y' || answer === '') {
+        log(`Removing theme in '${themePath}'...`)
+        fs.rmSync(themePath, { recursive: true })
+      } else {
+        process.exit(0)
+      }
     }
 
     log(`Creating new theme '${themeName}'...`)


### PR DESCRIPTION
### WHY are these changes introduced?

It was a bit annoying to have to remember to delete your test app or theme when you forgot about it.

### WHAT is this pull request doing?

- Prompt the user to delete the test app or theme if it already exists
- Add `--bare` option to `create-test-app.js` when user doesn't want any extension
- Add `--name` option if you want to customize the name of your app or theme

### How to test your changes?

- `bin/create-test-app.js --bare`
- rerun the command, it should prompt and ask if you want to remove the folder
- `bin/create-test-app.js --bare --name foobar-1234` and it should create a new app on your desktop

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
