### PR TITLE
Add merge_group so that CI checks are run in the merge queue

### DIFF
--- a/.github/workflows/cli-ruby.yml
+++ b/.github/workflows/cli-ruby.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 concurrency:
   group: shopify-${{ github.head_ref }}

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -38,6 +38,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  merge_group:
 
 concurrency:
   group: shopify-cli-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
### WHY are these changes introduced?

What the title says. Change suggested in the Github tutorial: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions