### PR TITLE
Not upgrade the global Homebrew-managed installation of the CLI on `shopify upgrade`

### DIFF
--- a/.changeset/shaggy-lizards-grow.md
+++ b/.changeset/shaggy-lizards-grow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Not upgrade the global Homebrew installation of the CLI on 'shopify upgrade'


### PR DESCRIPTION
### WHY are these changes introduced?
When a Homebrew-managed installation of the CLI tries to upgrade itself via Homebrew, it leads to [an error](https://shopify.slack.com/archives/C030LHFCA5T/p1680618843167109) because Homebrew deletes modules of the current version that OCLIF fails to load dynamically.

### WHAT is this pull request doing?
Upgrades and installation should be managed from a process other than the CLI's, otherwise we'll continue to find race conditions like this one where the package manager has replaced modules that are needed for the CLI process that initiates the upgrade. Because installing and upgrading packages is the package managers' responsibility, we should not have that responsibility in the CLI.

**Note:** If the issue is that `package.json` have two packages that need to be in sync, for example `@shopify/app` and `@shopify/cli`, we should investigate how to reduce that to one package such that a simply `npm update` does the job.

### Post-release steps
We need to [merge the PR](https://github.com/Shopify/shopify-dev/pull/32617) that updates the docs.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
