### PR TITLE
Default to frontend in the web configuration file

### DIFF
--- a/.changeset/red-countries-sit.md
+++ b/.changeset/red-countries-sit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Default to type frontend in the web configuration file

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -22,7 +22,7 @@ const ensurePathStartsWithSlash = (arg: unknown) => (typeof arg === 'string' && 
 const WebConfigurationAuthCallbackPathSchema = zod.preprocess(ensurePathStartsWithSlash, zod.string())
 
 export const WebConfigurationSchema = zod.object({
-  type: zod.enum([WebType.Frontend, WebType.Backend]),
+  type: zod.enum([WebType.Frontend, WebType.Backend]).default(WebType.Frontend),
   authCallbackPath: zod
     .union([WebConfigurationAuthCallbackPathSchema, WebConfigurationAuthCallbackPathSchema.array()])
     .optional(),


### PR DESCRIPTION
### WHY are these changes introduced?
The mental model of having the "frontend" and "backend" web types, the first of which is expected to be a proxy to the latter, is **confusing** and couples the design to our templates. 

### WHAT is this pull request doing?
I'm removing part of the confusion without introducing breaking changes by defaulting the type to `frontend`. For single-process apps, like Rails or Remix, we can only configure the process that the CLI needs to run.

### How to test your changes?
You can create a new project and remove the `type: frontend` from the frontend `shopify.web.toml`.

### Post-release steps
We need to merge [the PR](https://github.com/Shopify/shopify-dev/pull/32623) with documentation changes.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
