### PR TITLE
Add a new Remix template to the CLI

### DIFF
--- a/packages/create-app/src/commands/init.ts
+++ b/packages/create-app/src/commands/init.ts
@@ -1,4 +1,4 @@
-import initPrompt, {templateURLMap} from '../prompts/init.js'
+import initPrompt, {getTemplateURLMap, templateURLMap} from '../prompts/init.js'
 import initService from '../services/init.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -49,7 +49,7 @@ export default class Init extends Command {
   async run(): Promise<void> {
     const {flags} = await this.parse(Init)
 
-    this.validateTemplateValue(flags.template)
+    await this.validateTemplateValue(flags.template)
 
     const promptAnswers = await initPrompt({
       name: flags.name,
@@ -66,7 +66,7 @@ export default class Init extends Command {
     })
   }
 
-  validateTemplateValue(template: string | undefined) {
+  async validateTemplateValue(template: string | undefined) {
     if (!template) {
       return
     }
@@ -77,12 +77,16 @@ export default class Init extends Command {
         'Only GitHub repository references are supported, ' +
           'e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]',
       )
-    if (!url && !Object.keys(templateURLMap).includes(template))
+
+    const templateURLMap = await getTemplateURLMap()
+
+    if (!url && !Object.keys(templateURLMap).includes(template)) {
       throw new AbortError(
         outputContent`Only ${Object.keys(templateURLMap)
           .map((alias) => outputContent`${outputToken.yellow(alias)}`.value)
           .join(', ')} template aliases are supported`,
       )
+    }
   }
 
   parseURL(url: string): URL | undefined {

--- a/packages/create-app/src/prompts/init.test.ts
+++ b/packages/create-app/src/prompts/init.test.ts
@@ -4,7 +4,7 @@ import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 vi.mock('@shopify/cli-kit/node/ui')
 
-describe('init', () => {
+describe('init prompt', () => {
   test('when name is not passed', async () => {
     const answers = {
       name: 'app',

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -1,5 +1,6 @@
 import {generateRandomNameForSubdirectory} from '@shopify/cli-kit/node/fs'
 import {renderText, renderSelectPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
+import {isShopify} from '@shopify/cli-kit/node/context/local'
 
 interface InitOptions {
   name?: string
@@ -12,17 +13,26 @@ interface InitOutput {
   template: string
 }
 
-// Eventually this list should be taken from a remote location
-// That way we don't have to update the CLI every time we add a template
 export const templateURLMap = {
   node: 'https://github.com/Shopify/shopify-app-template-node',
   php: 'https://github.com/Shopify/shopify-app-template-php',
   ruby: 'https://github.com/Shopify/shopify-app-template-ruby',
 } as const
 
+export const templateURLMapForShopifolk = {
+  ...templateURLMap,
+  remix: 'https://github.com/Shopify/shopify-app-template-remix',
+} as const
+
+export async function getTemplateURLMap(): Promise<typeof templateURLMap | typeof templateURLMapForShopifolk> {
+  const isShopifolk = await isShopify()
+  return isShopifolk ? templateURLMapForShopifolk : templateURLMap
+}
+
 const init = async (options: InitOptions): Promise<InitOutput> => {
   let name = options.name
   let template = options.template
+  const templateURLMap = await getTemplateURLMap()
 
   const defaults = {
     name: await generateRandomNameForSubdirectory({suffix: 'app', directory: options.directory}),

--- a/packages/create-app/src/services/init.ts
+++ b/packages/create-app/src/services/init.ts
@@ -11,7 +11,6 @@ import {renderSuccess, renderTasks, Task} from '@shopify/cli-kit/node/ui'
 import {parseGitHubRepositoryReference} from '@shopify/cli-kit/node/github'
 import {hyphenate} from '@shopify/cli-kit/common/string'
 import {recursiveLiquidTemplateCopy} from '@shopify/cli-kit/node/liquid'
-import {isShopify} from '@shopify/cli-kit/node/context/local'
 import {downloadGitRepository, initializeGitRepository} from '@shopify/cli-kit/node/git'
 import {appendFile, fileExists, inTemporaryDirectory, mkdir, moveFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -85,17 +84,6 @@ async function init(options: InitOptions) {
         },
       },
     )
-
-    if (await isShopify()) {
-      tasks.push({
-        title: "[Shopifolks-only] Configuring the project's NPM registry",
-        task: async () => {
-          const npmrcPath = joinPath(templateScaffoldDir, '.npmrc')
-          const npmrcContent = `@shopify:registry=https://registry.npmjs.org\n`
-          await appendFile(npmrcPath, npmrcContent)
-        },
-      })
-    }
 
     tasks.push(
       {


### PR DESCRIPTION
### WHY are these changes introduced?

We want shopifolk to be able to create a new Remix app using the CLI.  Right now, the template that is checked out doesn't fully work since it's waiting on https://github.com/Shopify/cli/pull/1789

### WHAT is this pull request doing?

Add a new Remix templateto the available templates.  If you work for Shopify this allows you to run `yarn create @shopify/app` and select Remix.  Or, shopifolk can use `yarn create @shopify/app --template=remix`.

Non shopifolk do not get access to this template.

### How to test your changes?
As a shopify employee:

1. `pnpm create-app --template=remix`
2. `pnpm create-app --template=node`
3. `pnpm create-app` and select remix`
4. `pnpm create-app` and select node` 

Now fake not working for Shopify (the horror!) by changing `isShopify` to return false.  Re-run the above commands and check:

1. `pnpm create-app` should not present remix as an option in the choice list.
2.`pnpm create-app --template=remix` should throw an error.
3. `pnpm create-app --template=node` should still work.

### Post-release steps

Since this is only available to shopifolk I don't think there are any.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
