### PR TITLE
Drop hyphenated random name

### DIFF
--- a/packages/cli-kit/src/public/common/string.ts
+++ b/packages/cli-kit/src/public/common/string.ts
@@ -34,7 +34,7 @@ const SAFE_RANDOM_BUSINESS_ADJECTIVES = [
   'innovative',
   'regional',
   'specialized',
-  'client-focused',
+  'focused',
   'pragmatic',
   'ethical',
   'flexible',


### PR DESCRIPTION
We have a test that expects a certain folder name structure, and the extra hyphen is throwing it off.