### PR TITLE
Reword preview label

### DIFF
--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -132,7 +132,7 @@ ${outputToken.json(JSON.stringify(rules))}
         shortcuts: [
           {
             key: 'p',
-            action: 'open your browser',
+            action: 'preview in your browser',
           },
           {
             key: 'q',

--- a/packages/cli-kit/bin/documentation/examples.ts
+++ b/packages/cli-kit/bin/documentation/examples.ts
@@ -68,7 +68,7 @@ export const examples: {[key in string]: Example} = {
         footer: {
           shortcuts: [{
             key: 'p',
-            action: 'open your browser'
+            action: 'preview in your browser'
           }, {
             key: 'q',
             action: 'quit.',

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
@@ -54,7 +54,7 @@ describe('ConcurrentOutput', () => {
           shortcuts: [
             {
               key: 'p',
-              action: 'open your browser',
+              action: 'preview in your browser',
             },
             {
               key: 'q',
@@ -78,7 +78,7 @@ describe('ConcurrentOutput', () => {
       0000-00-00 00:00:00 │ frontend │ second frontend message
       0000-00-00 00:00:00 │ frontend │ third frontend message
 
-      › Press p │ open your browser
+      › Press p │ preview in your browser
       › Press q │ quit
 
       Preview URL: https://shopify.com

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -35,7 +35,7 @@ export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps
  * 0000-00-00 00:00:00 │ frontend │ second frontend message
  * 0000-00-00 00:00:00 │ frontend │ third frontend message
  *
- * › Press p │ open your browser
+ * › Press p │ preview in your browser
  * › Press q │ quit.
  *
  * Preview URL: https://shopify.com

--- a/packages/cli/src/cli/services/kitchen-sink/async.ts
+++ b/packages/cli/src/cli/services/kitchen-sink/async.ts
@@ -43,7 +43,7 @@ export async function asyncTasks() {
       shortcuts: [
         {
           key: 'p',
-          action: 'open your browser',
+          action: 'preview in your browser',
         },
         {
           key: 'q',


### PR DESCRIPTION
### WHY are these changes introduced?

The dev command is now showing these shortcuts:

```
Press p | open your browser
Press q | quit
```

But it's a bit weird to use `p` for `open your browser`.

### WHAT is this pull request doing?

Reword it to use `preview`:

```
Press p | preview in your browser
Press q | quit
```

### How to test your changes?

`pnpm shopify app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
