### PR TITLE
Allow to select spin instance

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -2,6 +2,6 @@
 
 export NODE_TLS_REJECT_UNAUTHORIZED="${NODE_TLS_REJECT_UNAUTHORIZED:=0}"
 export SHOPIFY_SERVICE_ENV="spin"
-export SPIN_INSTANCE="${SPIN_INSTANCE:=$(spin show --latest --json | jq -r '.name')}"
+export SPIN_INSTANCE="${SPIN_INSTANCE:=$(spin show --output=name)}"
 
 "$@"


### PR DESCRIPTION
### WHY are these changes introduced?

While testing on spin, it's not convenient to force to use the latest spin instance. This PR changes that behavior which allows developer to select which spin instance to use. 

### WHAT is this pull request doing?

Change spin command

### How to test your changes?

Run `./bin/spin`. Expect spin instances selector shows up. 

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
