### PR TITLE
Add support for Google Cloud Shell

### DIFF
--- a/.changeset/small-buses-build.md
+++ b/.changeset/small-buses-build.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Add support for Google Cloud Shell

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -28,6 +28,7 @@ export const environmentVariables = {
   codespaceName: 'CODESPACE_NAME',
   codespaces: 'CODESPACES',
   gitpod: 'GITPOD_WORKSPACE_URL',
+  cloudShell: 'CLOUD_SHELL',
   spin: 'SPIN',
   spinAppPort: 'SERVER_PORT',
   spinAppHost: 'SPIN_APP_HOST',

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -179,6 +179,17 @@ describe('useDeviceAuth', () => {
     expect(got).toBe(true)
   })
 
+  test('returns true if CLOUD_SHELL is truthy', () => {
+    // Given
+    const env = {CLOUD_SHELL: 'true'}
+
+    // When
+    const got = useDeviceAuth(env)
+
+    // Then
+    expect(got).toBe(true)
+  })
+
   test('returns false when SHOPIFY_CLI_DEVICE_AUTH, SPIN, CODESPACES or GITPOD_WORKSPACE_URL are missing', () => {
     // Given
     const env = {}

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -162,7 +162,7 @@ export function isCloudEnvironment(env: NodeJS.ProcessEnv = process.env): boolea
  * @returns Cloud platform information.
  */
 export function cloudEnvironment(env: NodeJS.ProcessEnv = process.env): {
-  platform: 'spin' | 'codespaces' | 'gitpod' | 'localhost'
+  platform: 'spin' | 'codespaces' | 'gitpod' | 'cloudShell' | 'localhost'
   editor: boolean
 } {
   if (isSet(env[environmentVariables.codespaces])) {
@@ -170,6 +170,9 @@ export function cloudEnvironment(env: NodeJS.ProcessEnv = process.env): {
   }
   if (isSet(env[environmentVariables.gitpod])) {
     return {platform: 'gitpod', editor: true}
+  }
+  if (isSet(env[environmentVariables.cloudShell])) {
+    return {platform: 'cloudShell', editor: true}
   }
   if (isSpin(env)) {
     return {platform: 'spin', editor: false}


### PR DESCRIPTION
### WHY are these changes introduced?

The default auth flow doesn't work in Google Cloud Shell

### WHAT is this pull request doing?

Auto-detect Cloud Shell environment to use device auth flow, as we do for Gitpod or Codespaces.

### How to test your changes?

- `p build`
- Copy the content of `packages/cli-kit/dist/public/node/context/local.js`
- https://ide.cloud.google.com/
- `npm init @shopify/app`
- `npm run dev` ❌ 
- Paste the content in `node_modules/@shopify/cli-kit/dist/public/node/context/local.js`
- Add `cloudShell: 'CLOUD_SHELL',` to `environmentVariables` in `node_modules/@shopify/cli-kit/dist/private/node/constants.js`
- `npm run dev` ✔️

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
