### PR TITLE
Use authCallbackPath in frontend configuration

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -111,7 +111,10 @@ async function dev(options: DevOptions) {
   let previewUrl
 
   if (initiateUpdateUrls) {
-    const newURLs = generatePartnersURLs(exposedUrl, backendConfig?.configuration.authCallbackPath)
+    const newURLs = generatePartnersURLs(
+      exposedUrl,
+      backendConfig?.configuration.authCallbackPath ?? frontendConfig?.configuration.authCallbackPath,
+    )
     shouldUpdateURLs = await shouldOrPromptUpdateURLs({
       currentURLs,
       appDirectory: localApp.directory,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1818

As mentioned in the [docs](https://shopify.dev/docs/apps/tools/cli/structure#shopify-web-toml) it should be possible to set `auth_callback_path` in the frontend config and have the app urls be updated accordingly when running `dev`. The frontend configuration is also of type `WebConfigurationSchema` and contains that property.

### WHAT is this pull request doing?

I've made it so we check both frontend and backend configurations for `authCallbackPath`, giving priority to the backend.

### How to test your changes?

- Generate an app
- Update the frontend toml `auth_callback_path` with a custom array of urls
- Run `dev`
- The app urls should be updated