### PR TITLE
Hide plugins commands

### DIFF
--- a/.changeset/heavy-flies-begin.md
+++ b/.changeset/heavy-flies-begin.md
@@ -1,0 +1,6 @@
+---
+'@shopify/features': minor
+'@shopify/cli': minor
+---
+
+Hide plugins commands

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -89,6 +89,17 @@
       "aliases": [],
       "flags": {},
       "args": {}
+    },
+    "plugins": {
+      "id": "plugins",
+      "strict": true,
+      "pluginName": "@shopify/cli",
+      "pluginAlias": "@shopify/cli",
+      "pluginType": "core",
+      "hidden": true,
+      "aliases": [],
+      "flags": {},
+      "args": {}
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -157,6 +157,9 @@
       },
       "webhook": {
         "description": "Manage webhooks."
+      },
+      "plugins": {
+        "hidden": true
       }
     },
     "additionalHelpFlags": [

--- a/packages/cli/src/cli/commands/plugins/index.ts
+++ b/packages/cli/src/cli/commands/plugins/index.ts
@@ -1,0 +1,10 @@
+import PluginsIndex from '@oclif/plugin-plugins/lib/commands/plugins/index.js'
+import Command from '@shopify/cli-kit/node/base-command'
+
+export default class Index extends Command {
+  static hidden = true
+
+  async run(): Promise<void> {
+    await PluginsIndex.default.run(this.argv)
+  }
+}

--- a/packages/features/snapshots/commands.txt
+++ b/packages/features/snapshots/commands.txt
@@ -20,7 +20,6 @@
  kitchen-sink async        @shopify/cli                 
  kitchen-sink prompts      @shopify/cli                 
  kitchen-sink static       @shopify/cli                 
- plugins                   @oclif/plugin-plugins        
  plugins add               @oclif/plugin-plugins        
  plugins inspect           @oclif/plugin-plugins        
  plugins install           @oclif/plugin-plugins        


### PR DESCRIPTION
### WHY are these changes introduced?

We don't want to show anything about plugins:

![19-56-q3dr6-q5tze](https://user-images.githubusercontent.com/14979109/233054265-d8ee5ece-1218-4daa-b385-75b601d4a70a.png)

### WHAT is this pull request doing?

- Hides the plugins topic by configuration
- Creates a wrapper for the plugin index command to hide it, as [there's no way to do it by configuration](https://github.com/oclif/oclif/issues/269)

![19-55-1qyxk-8wosm](https://user-images.githubusercontent.com/14979109/233053986-2fbbb04d-04f6-48e7-b015-ffd0bfff6685.png)

### How to test your changes?

- `pnpm shopify`
- `pnpm shopify plugins`
- `pnpm shopify plugins -h`
- `pnpm shopify plugins install @oclif/plugin-which`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
