### PR TITLE
Add support for 1P app with theme app extensions in Spin

### DIFF
--- a/.changeset/four-adults-flash.md
+++ b/.changeset/four-adults-flash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add support for theme app extensions in Spin

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/messages/messages.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/messages/messages.rb
@@ -126,6 +126,19 @@ module Extension
           Preview your theme app extension:
           {{green:%s}}
         PREVIEW_MESSAGE
+        preview_message_1p: <<~PREVIEW_MESSAGE,
+          Access Shopify Organization:
+            {{green:%s}}
+
+          Enable your theme app extension:
+          {{green:%s}}
+
+          Setup your theme app extension in the host theme:
+          {{green:%s}}
+
+          Preview your theme app extension:
+          {{green:%s}}
+        PREVIEW_MESSAGE
       },
       tunnel: {
         duplicate_session: <<~MESSAGE,

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/shopifolk.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/shopifolk.rb
@@ -32,7 +32,8 @@ module ShopifyCLI
 
       def acting_as_shopify_organization?
         !!(DB.get(:acting_as_shopify_organization) ||
-        (Project.has_current? && Project.current.config["shopify_organization"]))
+        (Project.has_current? && Project.current.config["shopify_organization"])) ||
+        ENV.fetch("SHOPIFY_CLI_1P_DEV", "0") == "1"
       end
 
       def reset

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/extension/dev_server.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/extension/dev_server.rb
@@ -145,7 +145,13 @@ module ShopifyCLI
         end
 
         def preview_message
-          ctx.message("serve.preview_message", extension.location, theme.editor_url, address)
+          if Shopifolk.acting_as_shopify_organization?
+            parsed_uri = URI.parse(extension.location)
+            shopify_org_url = "#{parsed_uri.scheme}://#{parsed_uri.host}/9082/impersonate"
+            ctx.message("serve.preview_message_1p", shopify_org_url, extension.location, theme.editor_url, address)
+          else
+            ctx.message("serve.preview_message", extension.location, theme.editor_url, address)
+          end
         end
       end
     end

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -6,6 +6,7 @@ import {joinPath, dirname, cwd} from './path.js'
 import {AbortError, AbortSilentError} from './error.js'
 import {getEnvironmentVariables} from './environment.js'
 import {isSpinEnvironment, spinFqdn} from './context/spin.js'
+import {firstPartyDev} from './context/local.js'
 import {pathConstants} from '../../private/node/constants.js'
 import {AdminSession} from '../../public/node/session.js'
 import {outputContent, outputToken} from '../../public/node/output.js'
@@ -64,6 +65,7 @@ export async function execCLI2(args: string[], options: ExecCLI2Options = {}): P
     // outside the user's project directory.
     BUNDLE_GEMFILE: joinPath(await shopifyCLIDirectory(embedded), 'Gemfile'),
     ...(await getSpinEnvironmentVariables()),
+    SHOPIFY_CLI_1P_DEV: firstPartyDev() ? '1' : '0',
   }
 
   try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,13 @@ signals.forEach((signal) => {
   })
 })
 
+// Sometimes we want to specify a precise amount of stdout columns, for example in
+// CI or on a cloud environment.
+const columns = Number(process.env.SHOPIFY_CLI_COLUMNS)
+if (!isNaN(columns)) {
+  process.stdout.columns = columns
+}
+
 interface RunShopifyCLIOptions {
   development: boolean
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Right now, there is a [demo app](https://shopify.workplace.com/groups/1207479046824983/permalink/1262249938014560/) that includes a patched CLI version that make it to be run as a service.

After generating a theme app extension, some problem arose after running the dev command:
- Extension specs partners API operation returns an empty response if the request is made as an employee
- One of the instructions displayed to preview the TAE requires to access to the details of the extension in the partners dashboard. It's not possible to access to Shopify Organization partners dashboard using a partners account session. You need to login as an employee
- The TEA preview urls are cut so user have to modified them previous to paste them in the browser

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
The modifications that are included in those patches should be moved to the cli repo:
- A new env variable is passed to the `cli-ruby` embed code to indicate if the command is being run as an employee
- Added a previous step to the TAE preview instructions to access the Shopify organization partners dashboard as an employee
- Add a new env variable `SHOPIFY_CLI_COLUMNS` that allows to modify the max length of cli outputs depending on the environments (CD pipeline, cloud envs,...)
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Added a patch with these changes to the repo https://github.com/Shopify/app-with-cli-as-service
- `spin up app-with-cli-as-service`
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->


<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
