### PR TITLE
Use useLayoutEffect where appropriate

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -84,7 +84,7 @@ function AutocompletePrompt<T>({
     function onResize() {
       const availableSpace = stdout.rows - (wrapperHeight - selectInputHeight)
       // rough estimate of the limit needed based on the space available
-      const newLimit = Math.max(2, availableSpace - 6)
+      const newLimit = Math.max(2, availableSpace - 4)
 
       if (newLimit < limit) {
         stdout.write(ansiEscapes.clearTerminal)

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -5,7 +5,7 @@ import {TokenizedText} from './TokenizedText.js'
 import {handleCtrlC} from '../../ui.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {debounce} from '../../../../public/common/function.js'
-import React, {ReactElement, useCallback, useEffect, useRef, useState} from 'react'
+import React, {ReactElement, useCallback, useLayoutEffect, useRef, useState} from 'react'
 import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
 import figures from 'figures'
 import ansiEscapes from 'ansi-escapes'
@@ -80,7 +80,7 @@ function AutocompletePrompt<T>({
     }
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     function onResize() {
       const availableSpace = stdout.rows - (wrapperHeight - selectInputHeight)
       // rough estimate of the limit needed based on the space available

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -4,7 +4,7 @@ import {InlineToken, LinkToken, TokenItem, TokenizedText} from './TokenizedText.
 import {handleCtrlC} from '../../ui.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {uniqBy} from '../../../../public/common/array.js'
-import React, {ReactElement, useCallback, useEffect, useState} from 'react'
+import React, {ReactElement, useCallback, useLayoutEffect, useState} from 'react'
 import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
 import figures from 'figures'
 import ansiEscapes from 'ansi-escapes'
@@ -58,7 +58,7 @@ function SelectPrompt<T>({
     }
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     function onResize() {
       const availableSpace = stdout.rows - (wrapperHeight - selectInputHeight)
       // rough estimate of the limit needed based on the space available

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -62,7 +62,7 @@ function SelectPrompt<T>({
     function onResize() {
       const availableSpace = stdout.rows - (wrapperHeight - selectInputHeight)
       // rough estimate of the limit needed based on the space available
-      const newLimit = Math.max(2, availableSpace - numberOfGroups * 2 - 6)
+      const newLimit = Math.max(2, availableSpace - numberOfGroups * 2 - 4)
 
       if (newLimit < limit) {
         stdout.write(ansiEscapes.clearTerminal)

--- a/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable id-length */
 import {Text} from 'ink'
-import React, {FunctionComponent, useCallback, useEffect, useRef, useState} from 'react'
+import React, {FunctionComponent, useCallback, useLayoutEffect, useRef, useState} from 'react'
 import gradient from 'gradient-string'
 
 interface TextAnimationProps {
@@ -33,7 +33,7 @@ const TextAnimation: FunctionComponent<TextAnimationProps> = ({text}): JSX.Eleme
     }, 35)
   }, [text])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     renderAnimation()
 
     return () => {

--- a/packages/cli-kit/src/private/node/ui/hooks/use-layout.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-layout.ts
@@ -1,5 +1,5 @@
 import {useStdout} from 'ink'
-import {useEffect, useState} from 'react'
+import {useLayoutEffect, useState} from 'react'
 
 const MIN_FULL_WIDTH = 20
 const MIN_FRACTION_WIDTH = 80
@@ -14,7 +14,7 @@ export default function useLayout(): Layout {
   const {stdout} = useStdout()
   const [layout, setLayout] = useState(calculateLayout(stdout))
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!stdout) {
       return
     }


### PR DESCRIPTION
In certain cases we were using `useEffect` where we should have been using `useLayoutEffect`. The difference is that `useLayoutEffect` will block painting until its effect has been processed, wether with `useEffect` the component would first render and paint to the screen and then the function would be called.

This means that in certain cases we were showing a first non-processed frame that would be immediately corrected by `useEffect`. With `useLayoutEffect` this first frame won't even show as its function is run synchronously with render.