### PR TITLE
Remove `-n` alias for `--notify`

### DIFF
--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -269,7 +269,6 @@
         "notify": {
           "name": "notify",
           "type": "option",
-          "char": "n",
           "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
           "multiple": false
         }

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -85,7 +85,6 @@ export default class Dev extends Command {
       env: 'SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT',
     }),
     notify: Flags.string({
-      char: 'n',
       description:
         'The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.',
       env: 'SHOPIFY_FLAG_NOTIFY',

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -393,7 +393,6 @@
         "notify": {
           "name": "notify",
           "type": "option",
-          "char": "n",
           "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
           "multiple": false
         }
@@ -1181,7 +1180,6 @@
         "notify": {
           "name": "notify",
           "type": "option",
-          "char": "n",
           "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
           "multiple": false
         }

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -81,7 +81,6 @@ export default class Dev extends ThemeCommand {
     password: themeFlags.password,
     environment: themeFlags.environment,
     notify: Flags.string({
-      char: 'n',
       description:
         'The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.',
       env: 'SHOPIFY_FLAG_NOTIFY',


### PR DESCRIPTION
### WHY are these changes introduced?

This PR is a minor followup regarding the https://github.com/Shopify/cli/pull/1821 effort to remove `-n` aliases, following [this guideline](https://github.com/Shopify/cli/blob/main/docs/cli-kit/command-guidelines.md#aliases--shortcuts-for-flags).

### WHAT is this pull request doing?

This PR removes `-n` aliases.

### How to test your changes?

- Run `shopify theme dev -h`
- Run `shopify app dev -h`

### Post-release steps

After the release, merge this PR: https://github.com/Shopify/shopify-dev/pull/33036.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
