### PR TITLE
Add abortController to async ui function parameters

### DIFF
--- a/.changeset/lemon-feet-begin.md
+++ b/.changeset/lemon-feet-begin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add abortController to async ui function parameters

--- a/.changeset/lemon-feet-begin.md
+++ b/.changeset/lemon-feet-begin.md
@@ -2,4 +2,4 @@
 '@shopify/cli-kit': patch
 ---
 
-Add abortController to async ui function parameters
+Add abortSignal to async ui function parameters

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -114,7 +114,7 @@ ${outputToken.json(JSON.stringify(rules))}
 
   let renderConcurrentOptions: RenderConcurrentOptions = {
     processes: [...processes, ...additionalProcesses],
-    abortController,
+    abortSignal: abortController.signal,
   }
 
   if (previewUrl) {

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -734,7 +734,7 @@ describe('AutocompletePrompt', async () => {
             data: [],
           } as SearchResults<string>)
         }
-        abortController={abortController}
+        abortSignal={abortController.signal}
       />,
     )
     const promise = renderInstance.waitUntilExit()

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -8,6 +8,7 @@ import {
   render,
 } from '../../testing/ui.js'
 import {Stdout} from '../../ui.js'
+import {AbortController} from '../../../../public/node/abort.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import React from 'react'
 import {useStdout} from 'ink'
@@ -713,5 +714,34 @@ describe('AutocompletePrompt', async () => {
          [2mPress ↑↓ arrows to select, enter to confirm[22m
       "
     `)
+  })
+
+  test('abortController can be used to exit the prompt from outside', async () => {
+    const items = [
+      {label: 'a', value: 'a'},
+      {label: 'b', value: 'b'},
+    ]
+
+    const abortController = new AbortController()
+
+    const renderInstance = render(
+      <AutocompletePrompt
+        message="Associate your project with the org Castile Ventures?"
+        choices={items}
+        onSubmit={() => {}}
+        search={() =>
+          Promise.resolve({
+            data: [],
+          } as SearchResults<string>)
+        }
+        abortController={abortController}
+      />,
+    )
+    const promise = renderInstance.waitUntilExit()
+
+    abortController.abort()
+
+    expect(getLastFrameAfterUnmount(renderInstance)).toEqual('')
+    await expect(promise).resolves.toEqual(undefined)
   })
 })

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -5,7 +5,7 @@ import {TokenizedText} from './TokenizedText.js'
 import {handleCtrlC} from '../../ui.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {debounce} from '../../../../public/common/function.js'
-import {AbortController} from '../../../../public/node/abort.js'
+import {AbortSignal} from '../../../../public/node/abort.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
 import React, {ReactElement, useCallback, useLayoutEffect, useRef, useState} from 'react'
 import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
@@ -27,7 +27,7 @@ export interface AutocompletePromptProps<T> {
   infoTable?: InfoTableProps['table']
   hasMorePages?: boolean
   search: (term: string) => Promise<SearchResults<T>>
-  abortController?: AbortController
+  abortSignal?: AbortSignal
 }
 
 enum PromptState {
@@ -47,7 +47,7 @@ function AutocompletePrompt<T>({
   onSubmit,
   search,
   hasMorePages: initialHasMorePages = false,
-  abortController,
+  abortSignal,
 }: React.PropsWithChildren<AutocompletePromptProps<T>>): ReactElement | null {
   const paginatedInitialChoices = initialChoices.slice(0, PAGE_SIZE)
   const [answer, setAnswer] = useState<SelectItem<T> | undefined>(paginatedInitialChoices[0])
@@ -110,7 +110,7 @@ function AutocompletePrompt<T>({
     }
   }, [wrapperHeight, selectInputHeight, searchResults.length, stdout, limit, numberOfGroups])
 
-  const {isAborted} = useAbortSignal(abortController?.signal)
+  const {isAborted} = useAbortSignal(abortSignal)
 
   useInput((input, key) => {
     handleCtrlC(input, key)

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -5,6 +5,8 @@ import {TokenizedText} from './TokenizedText.js'
 import {handleCtrlC} from '../../ui.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {debounce} from '../../../../public/common/function.js'
+import {AbortController} from '../../../../public/node/abort.js'
+import useAbortSignal from '../hooks/use-abort-signal.js'
 import React, {ReactElement, useCallback, useLayoutEffect, useRef, useState} from 'react'
 import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
 import figures from 'figures'
@@ -25,6 +27,7 @@ export interface AutocompletePromptProps<T> {
   infoTable?: InfoTableProps['table']
   hasMorePages?: boolean
   search: (term: string) => Promise<SearchResults<T>>
+  abortController?: AbortController
 }
 
 enum PromptState {
@@ -44,6 +47,7 @@ function AutocompletePrompt<T>({
   onSubmit,
   search,
   hasMorePages: initialHasMorePages = false,
+  abortController,
 }: React.PropsWithChildren<AutocompletePromptProps<T>>): ReactElement | null {
   const paginatedInitialChoices = initialChoices.slice(0, PAGE_SIZE)
   const [answer, setAnswer] = useState<SelectItem<T> | undefined>(paginatedInitialChoices[0])
@@ -106,6 +110,8 @@ function AutocompletePrompt<T>({
     }
   }, [wrapperHeight, selectInputHeight, searchResults.length, stdout, limit, numberOfGroups])
 
+  const {isAborted} = useAbortSignal(abortController?.signal)
+
   useInput((input, key) => {
     handleCtrlC(input, key)
 
@@ -160,7 +166,7 @@ function AutocompletePrompt<T>({
     [initialHasMorePages, paginatedInitialChoices, paginatedSearch],
   )
 
-  return (
+  return isAborted ? null : (
     <Box flexDirection="column" marginBottom={1} ref={wrapperRef}>
       <Box>
         <Box marginRight={2}>

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
@@ -51,7 +51,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess, frontendProcess]}
-        abortController={new AbortController()}
+        abortSignal={new AbortController().signal}
         footer={{
           shortcuts: [
             {
@@ -131,7 +131,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess, frontendProcess]}
-        abortController={new AbortController()}
+        abortSignal={new AbortController().signal}
         footer={{
           shortcuts: [
             {
@@ -180,8 +180,8 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[neverEndingProcess]}
-        abortController={new AbortController()}
         onInput={(input, key) => onInput(input, key)}
+        abortSignal={new AbortController().signal}
       />,
     )
 
@@ -214,7 +214,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortController={abortController}
+        abortSignal={abortController.signal}
         footer={{
           shortcuts: [
             {
@@ -263,7 +263,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortController={new AbortController()}
+        abortSignal={new AbortController().signal}
         footer={{
           shortcuts: [
             {
@@ -306,7 +306,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortController={new AbortController()}
+        abortSignal={new AbortController().signal}
         footer={{
           shortcuts: [
             {

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -4,6 +4,7 @@ import {AbortController} from '../../../../public/node/abort.js'
 import {handleCtrlC} from '../../ui.js'
 import {addOrUpdateConcurrentUIEventOutput} from '../../demo-recorder.js'
 import {treeKill} from '../../tree-kill.js'
+import useAbortSignal from '../hooks/use-abort-signal.js'
 import React, {FunctionComponent, useState} from 'react'
 import {Box, Key, Static, Text, useInput, TextProps, useStdin} from 'ink'
 import stripAnsi from 'strip-ansi'
@@ -124,7 +125,8 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
     {isActive: typeof onInput !== 'undefined' && Boolean(isRawModeSupported)},
   )
 
-  useAsyncAndUnmount(runProcesses, {onRejected: () => abortController.abort()})
+  useAsyncAndUnmount(runProcesses)
+  const {isAborted} = useAbortSignal(abortController.signal)
 
   return (
     <>
@@ -165,7 +167,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
           )
         }}
       </Static>
-      {footer ? (
+      {!isAborted && footer ? (
         <Box marginY={1} flexDirection="column" flexGrow={1}>
           {isRawModeSupported ? (
             <Box flexDirection="column">

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -1,6 +1,6 @@
 import {OutputProcess} from '../../../../public/node/output.js'
 import useAsyncAndUnmount from '../hooks/use-async-and-unmount.js'
-import {AbortController} from '../../../../public/node/abort.js'
+import {AbortSignal} from '../../../../public/node/abort.js'
 import {handleCtrlC} from '../../ui.js'
 import {addOrUpdateConcurrentUIEventOutput} from '../../demo-recorder.js'
 import {treeKill} from '../../tree-kill.js'
@@ -19,7 +19,7 @@ interface Shortcut {
 }
 export interface ConcurrentOutputProps {
   processes: OutputProcess[]
-  abortController: AbortController
+  abortSignal: AbortSignal
   showTimestamps?: boolean
   onInput?: (input: string, key: Key, exit: () => void) => void
   footer?: {
@@ -73,7 +73,7 @@ enum ConcurrentOutputState {
  */
 const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
   processes,
-  abortController,
+  abortSignal,
   showTimestamps = true,
   onInput,
   footer,
@@ -115,7 +115,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
         const stdout = writableStream(process, index)
         const stderr = writableStream(process, index)
 
-        await process.action(stdout, stderr, abortController.signal)
+        await process.action(stdout, stderr, abortSignal)
       }),
     )
   }
@@ -140,7 +140,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
     },
   })
 
-  const {isAborted} = useAbortSignal(abortController.signal)
+  const {isAborted} = useAbortSignal(abortSignal)
 
   return (
     <>

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
@@ -2,6 +2,7 @@ import {SelectPrompt} from './SelectPrompt.js'
 import {getLastFrameAfterUnmount, sendInputAndWaitForChange, waitForInputsToBeReady, render} from '../../testing/ui.js'
 import {unstyled} from '../../../../public/node/output.js'
 import {Stdout} from '../../ui.js'
+import {AbortController} from '../../../../public/node/abort.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import React from 'react'
 import {useStdout} from 'ink'
@@ -342,5 +343,35 @@ describe('SelectPrompt', async () => {
          [2mPress ↑↓ arrows to select, enter to confirm[22m
       "
     `)
+  })
+
+  test('abortController can be used to exit the prompt from outside', async () => {
+    const items = [
+      {label: 'a', value: 'a'},
+      {label: 'b', value: 'b'},
+    ]
+
+    const abortController = new AbortController()
+
+    const renderInstance = render(
+      <SelectPrompt choices={items} onSubmit={() => {}} message="Test question?" abortController={abortController} />,
+    )
+
+    const promise = renderInstance.waitUntilExit()
+
+    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
+    "?  Test question?
+
+    >  (1) a
+       (2) b
+
+       Press ↑↓ arrows to select, enter to confirm
+    "
+  `)
+
+    abortController.abort()
+
+    expect(getLastFrameAfterUnmount(renderInstance)).toEqual('')
+    await expect(promise).resolves.toEqual(undefined)
   })
 })

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
@@ -354,7 +354,12 @@ describe('SelectPrompt', async () => {
     const abortController = new AbortController()
 
     const renderInstance = render(
-      <SelectPrompt choices={items} onSubmit={() => {}} message="Test question?" abortController={abortController} />,
+      <SelectPrompt
+        choices={items}
+        onSubmit={() => {}}
+        message="Test question?"
+        abortSignal={abortController.signal}
+      />,
     )
 
     const promise = renderInstance.waitUntilExit()

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -4,7 +4,7 @@ import {InlineToken, LinkToken, TokenItem, TokenizedText} from './TokenizedText.
 import {handleCtrlC} from '../../ui.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {uniqBy} from '../../../../public/common/array.js'
-import {AbortController} from '../../../../public/node/abort.js'
+import {AbortSignal} from '../../../../public/node/abort.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
 import React, {ReactElement, useCallback, useLayoutEffect, useState} from 'react'
 import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
@@ -18,7 +18,7 @@ export interface SelectPromptProps<T> {
   infoTable?: InfoTableProps['table']
   defaultValue?: T
   submitWithShortcuts?: boolean
-  abortController?: AbortController
+  abortSignal?: AbortSignal
 }
 
 // eslint-disable-next-line react/function-component-definition
@@ -29,7 +29,7 @@ function SelectPrompt<T>({
   onSubmit,
   defaultValue,
   submitWithShortcuts = false,
-  abortController,
+  abortSignal,
 }: React.PropsWithChildren<SelectPromptProps<T>>): ReactElement | null {
   if (choices.length === 0) {
     throw new Error('SelectPrompt requires at least one choice')
@@ -95,7 +95,7 @@ function SelectPrompt<T>({
     [stdout, wrapperHeight, unmountInk, onSubmit],
   )
 
-  const {isAborted} = useAbortSignal(abortController?.signal)
+  const {isAborted} = useAbortSignal(abortSignal)
 
   useInput((input, key) => {
     handleCtrlC(input, key)

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -4,6 +4,8 @@ import {InlineToken, LinkToken, TokenItem, TokenizedText} from './TokenizedText.
 import {handleCtrlC} from '../../ui.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {uniqBy} from '../../../../public/common/array.js'
+import {AbortController} from '../../../../public/node/abort.js'
+import useAbortSignal from '../hooks/use-abort-signal.js'
 import React, {ReactElement, useCallback, useLayoutEffect, useState} from 'react'
 import {Box, measureElement, Text, useApp, useInput, useStdout} from 'ink'
 import figures from 'figures'
@@ -16,6 +18,7 @@ export interface SelectPromptProps<T> {
   infoTable?: InfoTableProps['table']
   defaultValue?: T
   submitWithShortcuts?: boolean
+  abortController?: AbortController
 }
 
 // eslint-disable-next-line react/function-component-definition
@@ -26,6 +29,7 @@ function SelectPrompt<T>({
   onSubmit,
   defaultValue,
   submitWithShortcuts = false,
+  abortController,
 }: React.PropsWithChildren<SelectPromptProps<T>>): ReactElement | null {
   if (choices.length === 0) {
     throw new Error('SelectPrompt requires at least one choice')
@@ -91,6 +95,8 @@ function SelectPrompt<T>({
     [stdout, wrapperHeight, unmountInk, onSubmit],
   )
 
+  const {isAborted} = useAbortSignal(abortController?.signal)
+
   useInput((input, key) => {
     handleCtrlC(input, key)
 
@@ -99,7 +105,7 @@ function SelectPrompt<T>({
     }
   })
 
-  return (
+  return isAborted ? null : (
     <Box flexDirection="column" marginBottom={1} ref={wrapperRef}>
       <Box>
         <Box marginRight={2}>

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
@@ -71,7 +71,7 @@ describe('Tasks', () => {
 
     // When
     const renderInstance = render(
-      <Tasks tasks={[firstTask, secondTask]} silent={false} abortController={abortController} />,
+      <Tasks tasks={[firstTask, secondTask]} silent={false} abortSignal={abortController.signal} />,
     )
 
     // Then
@@ -415,7 +415,7 @@ describe('Tasks', () => {
     }
 
     // When
-    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} abortController={abortController} />)
+    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} abortSignal={abortController.signal} />)
     await taskHasRendered()
     const promise = renderInstance.waitUntilExit()
 

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
@@ -422,7 +422,7 @@ describe('Tasks', () => {
     abortController.abort()
 
     // Then
-    expect(unstyled(renderInstance.lastFrame()!)).toEqual('')
+    expect(unstyled(getLastFrameAfterUnmount(renderInstance)!)).toEqual('')
     await expect(promise).resolves.toEqual(undefined)
   })
 })

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
@@ -3,7 +3,7 @@ import useLayout from '../hooks/use-layout.js'
 import useAsyncAndUnmount from '../hooks/use-async-and-unmount.js'
 import {isUnitTest} from '../../../../public/node/context/local.js'
 import {handleCtrlC} from '../../ui.js'
-import {AbortController} from '../../../../public/node/abort.js'
+import {AbortSignal} from '../../../../public/node/abort.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
 import {Box, Text, useInput, useStdin} from 'ink'
 import React, {useRef, useState} from 'react'
@@ -23,7 +23,7 @@ export interface TasksProps<TContext> {
   tasks: Task<TContext>[]
   silent?: boolean
   onComplete?: (ctx: TContext) => void
-  abortController?: AbortController
+  abortSignal?: AbortSignal
 }
 
 enum TasksState {
@@ -63,7 +63,7 @@ function Tasks<TContext>({
   tasks,
   silent = isUnitTest(),
   onComplete = noop,
-  abortController,
+  abortSignal,
 }: React.PropsWithChildren<TasksProps<TContext>>) {
   const {twoThirds} = useLayout()
   const loadingBar = new Array(twoThirds).fill(loadingBarChar).join('')
@@ -111,7 +111,7 @@ function Tasks<TContext>({
     {isActive: Boolean(isRawModeSupported)},
   )
 
-  const {isAborted} = useAbortSignal(abortController?.signal)
+  const {isAborted} = useAbortSignal(abortSignal)
 
   if (silent) {
     return null

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
@@ -193,7 +193,7 @@ describe('TextPrompt', () => {
         onSubmit={() => {}}
         message="Test question"
         defaultValue="Placeholder"
-        abortController={abortController}
+        abortSignal={abortController.signal}
       />,
     )
     const promise = renderInstance.waitUntilExit()

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
@@ -1,6 +1,7 @@
 import {TextPrompt} from './TextPrompt.js'
 import {getLastFrameAfterUnmount, sendInputAndWaitForChange, waitForInputsToBeReady, render} from '../../testing/ui.js'
 import {unstyled} from '../../../../public/node/output.js'
+import {AbortController} from '../../../../public/node/abort.js'
 import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 
@@ -182,5 +183,24 @@ describe('TextPrompt', () => {
     const renderInstance = render(<TextPrompt onSubmit={() => {}} message="Test question" password defaultValue="A" />)
 
     expect(unstyled(getLastFrameAfterUnmount(renderInstance)!)).toContain("ERROR  Can't use defaultValue with password")
+  })
+
+  test('abortController can be used to exit the prompt from outside', async () => {
+    const abortController = new AbortController()
+
+    const renderInstance = render(
+      <TextPrompt
+        onSubmit={() => {}}
+        message="Test question"
+        defaultValue="Placeholder"
+        abortController={abortController}
+      />,
+    )
+    const promise = renderInstance.waitUntilExit()
+
+    abortController.abort()
+
+    expect(getLastFrameAfterUnmount(renderInstance)).toEqual('')
+    await expect(promise).resolves.toEqual(undefined)
   })
 })

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -3,7 +3,7 @@ import {TokenizedText} from './TokenizedText.js'
 import {handleCtrlC} from '../../ui.js'
 import useLayout from '../hooks/use-layout.js'
 import {messageWithPunctuation} from '../utilities.js'
-import {AbortController} from '../../../../public/node/abort.js'
+import {AbortSignal} from '../../../../public/node/abort.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
 import React, {FunctionComponent, useCallback, useState} from 'react'
 import {Box, useApp, useInput, Text} from 'ink'
@@ -17,7 +17,7 @@ export interface TextPromptProps {
   validate?: (value: string) => string | undefined
   allowEmpty?: boolean
   emptyDisplayedValue?: string
-  abortController?: AbortController
+  abortSignal?: AbortSignal
 }
 
 const TextPrompt: FunctionComponent<TextPromptProps> = ({
@@ -28,7 +28,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   password = false,
   allowEmpty = false,
   emptyDisplayedValue = '(empty)',
-  abortController,
+  abortSignal,
 }) => {
   if (password && defaultValue) {
     throw new Error("Can't use defaultValue with password")
@@ -58,7 +58,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   const shouldShowError = submitted && error
   const color = shouldShowError ? 'red' : 'cyan'
   const underline = new Array(oneThird - 3).fill('▔')
-  const {isAborted} = useAbortSignal(abortController?.signal)
+  const {isAborted} = useAbortSignal(abortSignal)
 
   useInput((input, key) => {
     handleCtrlC(input, key)

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -3,6 +3,8 @@ import {TokenizedText} from './TokenizedText.js'
 import {handleCtrlC} from '../../ui.js'
 import useLayout from '../hooks/use-layout.js'
 import {messageWithPunctuation} from '../utilities.js'
+import {AbortController} from '../../../../public/node/abort.js'
+import useAbortSignal from '../hooks/use-abort-signal.js'
 import React, {FunctionComponent, useCallback, useState} from 'react'
 import {Box, useApp, useInput, Text} from 'ink'
 import figures from 'figures'
@@ -15,6 +17,7 @@ export interface TextPromptProps {
   validate?: (value: string) => string | undefined
   allowEmpty?: boolean
   emptyDisplayedValue?: string
+  abortController?: AbortController
 }
 
 const TextPrompt: FunctionComponent<TextPromptProps> = ({
@@ -25,6 +28,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   password = false,
   allowEmpty = false,
   emptyDisplayedValue = '(empty)',
+  abortController,
 }) => {
   if (password && defaultValue) {
     throw new Error("Can't use defaultValue with password")
@@ -54,6 +58,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   const shouldShowError = submitted && error
   const color = shouldShowError ? 'red' : 'cyan'
   const underline = new Array(oneThird - 3).fill('▔')
+  const {isAborted} = useAbortSignal(abortController?.signal)
 
   useInput((input, key) => {
     handleCtrlC(input, key)
@@ -70,7 +75,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
     }
   })
 
-  return (
+  return isAborted ? null : (
     <Box flexDirection="column" marginBottom={1} width={oneThird}>
       <Box>
         <Box marginRight={2}>

--- a/packages/cli-kit/src/private/node/ui/hooks/use-abort-signal.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-abort-signal.ts
@@ -1,0 +1,17 @@
+import {AbortSignal} from '../../../../public/node/abort.js'
+import {useApp} from 'ink'
+import {useLayoutEffect, useState} from 'react'
+
+export default function useAbortSignal(abortSignal?: AbortSignal) {
+  const {exit: unmountInk} = useApp()
+  const [isAborted, setIsAborted] = useState(false)
+
+  useLayoutEffect(() => {
+    abortSignal?.addEventListener('abort', () => {
+      setIsAborted(true)
+      unmountInk()
+    })
+  }, [])
+
+  return {isAborted}
+}

--- a/packages/cli-kit/src/private/node/ui/hooks/use-async-and-unmount.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-async-and-unmount.ts
@@ -8,7 +8,7 @@ interface Options {
 
 export default function useAsyncAndUnmount(
   asyncFunction: () => Promise<unknown>,
-  {onFulfilled = () => {}, onRejected = () => {}}: Options,
+  {onFulfilled = () => {}, onRejected = () => {}}: Options = {},
 ) {
   const {exit: unmountInk} = useApp()
 

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -47,7 +47,7 @@ export async function renderConcurrent({renderOptions, ...props}: RenderConcurre
   const abortSignal = props.abortSignal ?? new AbortController().signal
 
   if (terminalSupportsRawMode(renderOptions?.stdin)) {
-    await render(<ConcurrentOutput {...props} abortSignal={abortSignal} />, {
+    return render(<ConcurrentOutput {...props} abortSignal={abortSignal} />, {
       ...renderOptions,
       exitOnCtrlC: typeof props.onInput === 'undefined',
     })

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -49,15 +49,10 @@ export async function renderConcurrent({renderOptions, ...props}: RenderConcurre
     ...props,
   }
   if (terminalSupportsRawMode(renderOptions?.stdin)) {
-    try {
-      await render(<ConcurrentOutput {...newProps} />, {
-        ...renderOptions,
-        exitOnCtrlC: typeof props.onInput === 'undefined',
-      })
-    } catch (error) {
-      newProps.abortController.abort()
-      throw error
-    }
+    await render(<ConcurrentOutput {...newProps} />, {
+      ...renderOptions,
+      exitOnCtrlC: typeof props.onInput === 'undefined',
+    })
   } else {
     return Promise.all(
       newProps.processes.map(async (concurrentProcess) => {


### PR DESCRIPTION
### WHY are these changes introduced?

At the moment there is no way for async processes to make the async prompts quit. For example in this scenario, the prompt would still remain in the terminal:

```
const templatesPromise = getLatestTemplates()
    .catch((error) => {
      renderFatalError(error);
      process.exit(1);
    });

await renderXPrompt(...);
```

![image (6)](https://user-images.githubusercontent.com/151725/234042022-868dfabc-8bc4-4913-be10-7fc4fb19ef6c.png)

### WHAT is this pull request doing?

This PR adds the ability to pass an abort controller from outside. Prompts and `Tasks` will clear the output before quitting when the abort controller signal receives the `abort` event.
`ConcurrentOutput` will clear only the dynamic part, currently the preview URL and the shortcuts, but will preserve the logs.

### How to test your changes?

I've tested it modifying `kitchen-sink prompts` and replacing the first prompt with this code

```
  const controller = new AbortController()

  // after 2 seconds call abort
  setTimeout(() => {
    controller.abort()
  }, 2000)

  // renderSelectPrompt
  await renderSelectPrompt({
    message: 'Associate your project with the org Castile Ventures?',
    choices: [
      {label: 'first', value: 'first', key: 'f'},
      {label: 'second', value: 'second', key: 's'},
      {label: 'third', value: 'third'},
      {label: 'fourth', value: 'fourth'},
      {label: 'fifth', value: 'fifth', group: 'Automations', key: 'a'},
      {label: 'sixth', value: 'sixth', group: 'Automations'},
      {label: 'seventh', value: 'seventh'},
      {label: 'eighth', value: 'eighth', group: 'Merchant Admin'},
      {label: 'ninth', value: 'ninth', group: 'Merchant Admin'},
      {label: 'tenth', value: 'tenth'},
    ],
    infoTable: {add: ['new-ext'], remove: ['integrated-demand-ext', 'order-discount']},
    abortController: controller,
  })
```

The prompt should disappear.