### PR TITLE
Removed the hat on retail ui

### DIFF
--- a/packages/app/src/cli/models/extensions/ui-specifications/pos_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/pos_ui_extension.ts
@@ -3,7 +3,7 @@ import {createUIExtensionSpecification} from '../ui.js'
 import {BaseUIExtensionSchema} from '../schemas.js'
 import {BugError} from '@shopify/cli-kit/node/error'
 
-const dependency = {name: '@shopify/retail-ui-extensions-react', version: '^1.0.0'}
+const dependency = {name: '@shopify/retail-ui-extensions-react', version: '1.0.0'}
 
 const spec = createUIExtensionSpecification({
   identifier: 'pos_ui_extension',


### PR DESCRIPTION
### WHY are these changes introduced?

POS will only support the last minor version released, as it takes time to create support for a new version and release it to the app store. We are making this change so that when a template is generated, it can support only the specified latest version.

For example, if we release 1.1.0 now (which we will), we need a few weeks to implement the changes required on the POS side, before partners can actually use it. We do document this in our [change log](https://shopify.dev/beta/pos-ui-extensions/changelog).

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
