### PR TITLE
Add eslint rule to warn users with certain prompt messages

### DIFF
--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -100,7 +100,7 @@ export async function reuseDevConfigPrompt(): Promise<boolean> {
 
 export function updateURLsPrompt(currentAppUrl: string, currentRedirectUrls: string[]): Promise<string> {
   return renderSelectPrompt({
-    message: `Have Shopify automatically update your app's URL in order to create a preview experience?`,
+    message: "Have Shopify automatically update your app's URL in order to create a preview experience?",
     choices: [
       {label: 'Always by default', value: 'always'},
       {label: 'Yes, this time', value: 'yes'},

--- a/packages/cli/src/cli/services/kitchen-sink/prompts.ts
+++ b/packages/cli/src/cli/services/kitchen-sink/prompts.ts
@@ -88,7 +88,7 @@ export async function prompts() {
   ]
 
   await renderAutocompletePrompt({
-    message: 'Select a template',
+    message: 'Template',
     choices: database,
     search(term: string) {
       return Promise.resolve({data: database.filter((item) => item.label.includes(term))})

--- a/packages/eslint-plugin-cli/config.js
+++ b/packages/eslint-plugin-cli/config.js
@@ -119,7 +119,7 @@ module.exports = {
     '@shopify/cli/no-trailing-js-in-cli-kit-imports': 'error',
     '@shopify/cli/no-vi-manual-mock-clear': 'error',
     '@shopify/cli/no-vi-mock-in-callbacks': 'error',
-    '@shopify/cli/no-choose-select-message-prompts': 'warn',
+    '@shopify/cli/prompt-message-format': 'warn',
     'no-restricted-syntax': [
       'error',
       {

--- a/packages/eslint-plugin-cli/config.js
+++ b/packages/eslint-plugin-cli/config.js
@@ -119,6 +119,7 @@ module.exports = {
     '@shopify/cli/no-trailing-js-in-cli-kit-imports': 'error',
     '@shopify/cli/no-vi-manual-mock-clear': 'error',
     '@shopify/cli/no-vi-mock-in-callbacks': 'error',
+    '@shopify/cli/no-choose-select-message-prompts': 'warn',
     'no-restricted-syntax': [
       'error',
       {

--- a/packages/eslint-plugin-cli/index.js
+++ b/packages/eslint-plugin-cli/index.js
@@ -8,8 +8,8 @@ module.exports = {
     'no-trailing-js-in-cli-kit-imports': require('./rules/no-trailing-js-in-cli-kit-imports'),
     'no-vi-manual-mock-clear': require('./rules/no-vi-manual-mock-clear'),
     'no-vi-mock-in-callbacks': require('./rules/no-vi-mock-in-callbacks'),
-    'specific-imports-in-bootstrap-code': require('./rules/specific-imports-in-bootstrap-code'),
     'prompt-message-format': require('./rules/prompt-message-format'),
+    'specific-imports-in-bootstrap-code': require('./rules/specific-imports-in-bootstrap-code'),
   },
 
   configs: {

--- a/packages/eslint-plugin-cli/index.js
+++ b/packages/eslint-plugin-cli/index.js
@@ -9,7 +9,7 @@ module.exports = {
     'no-vi-manual-mock-clear': require('./rules/no-vi-manual-mock-clear'),
     'no-vi-mock-in-callbacks': require('./rules/no-vi-mock-in-callbacks'),
     'specific-imports-in-bootstrap-code': require('./rules/specific-imports-in-bootstrap-code'),
-    'no-choose-select-message-prompts': require('./rules/no-choose-select-message-prompts'),
+    'prompt-message-format': require('./rules/prompt-message-format'),
   },
 
   configs: {

--- a/packages/eslint-plugin-cli/index.js
+++ b/packages/eslint-plugin-cli/index.js
@@ -9,6 +9,7 @@ module.exports = {
     'no-vi-manual-mock-clear': require('./rules/no-vi-manual-mock-clear'),
     'no-vi-mock-in-callbacks': require('./rules/no-vi-mock-in-callbacks'),
     'specific-imports-in-bootstrap-code': require('./rules/specific-imports-in-bootstrap-code'),
+    'no-choose-select-message-prompts': require('./rules/no-choose-select-message-prompts'),
   },
 
   configs: {

--- a/packages/eslint-plugin-cli/rules/no-choose-select-message-prompts.js
+++ b/packages/eslint-plugin-cli/rules/no-choose-select-message-prompts.js
@@ -1,0 +1,52 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow "choose" or "select" in the message attribute of renderSelectPrompt and renderAutocompletePrompt',
+      category: 'Possible Errors',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      chooseSelectDisallowed: 'The message attribute should not contain the words "choose" or "select".',
+    },
+  },
+
+  create: function (context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee
+        const functionName = callee.name
+
+        if (
+          functionName === 'renderSelectPrompt' ||
+          functionName === 'renderAutocompletePrompt' ||
+          functionName === 'renderConfirmationPrompt' ||
+          functionName === 'renderTextPrompt'
+        ) {
+          const firstArgument = node.arguments[0]
+
+          if (firstArgument.type === 'ObjectExpression') {
+            const messageProperty = firstArgument.properties.find((property) => property.key.name === 'message')
+
+            if (messageProperty) {
+              let messageValue = messageProperty.value.value
+
+              if (typeof messageValue === 'string') {
+                messageValue = messageValue.toLowerCase()
+
+                if (messageValue.includes('choose') || messageValue.includes('select')) {
+                  context.report({
+                    node: messageProperty,
+                    messageId: 'chooseSelectDisallowed',
+                  })
+                }
+              }
+            }
+          }
+        }
+      },
+    }
+  },
+}

--- a/packages/eslint-plugin-cli/rules/no-choose-select-message-prompts.js
+++ b/packages/eslint-plugin-cli/rules/no-choose-select-message-prompts.js
@@ -2,14 +2,13 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description:
-        'Disallow "choose" or "select" in the message attribute of renderSelectPrompt and renderAutocompletePrompt',
+      description: 'Disallow "choose" or "select" in the message attribute of prompts',
       category: 'Possible Errors',
       recommended: false,
     },
     schema: [],
     messages: {
-      chooseSelectDisallowed: 'The message attribute should not contain the words "choose" or "select".',
+      chooseSelectDisallowed: 'Message should not contain the words "choose" or "select".',
     },
   },
 

--- a/packages/eslint-plugin-cli/rules/prompt-message-format.js
+++ b/packages/eslint-plugin-cli/rules/prompt-message-format.js
@@ -36,7 +36,11 @@ module.exports = {
               if (typeof messageValue === 'string') {
                 messageValue = messageValue.toLowerCase()
 
-                if (messageValue.includes('choose') || messageValue.includes('select')) {
+                if (
+                  messageValue.includes('choose') ||
+                  messageValue.includes('select') ||
+                  messageValue.includes('pick')
+                ) {
                   context.report({
                     node: messageProperty,
                     messageId: 'chooseSelectDisallowed',

--- a/packages/eslint-plugin-cli/rules/prompt-message-format.js
+++ b/packages/eslint-plugin-cli/rules/prompt-message-format.js
@@ -2,13 +2,14 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow "choose" or "select" in the message attribute of prompts',
+      description: 'Disallow certain characters to appear in the message attribute of prompts',
       category: 'Possible Errors',
       recommended: false,
     },
     schema: [],
     messages: {
       chooseSelectDisallowed: 'Message should not contain the words "choose" or "select".',
+      invalidPunctuation: 'The message attribute should not end with any punctuation except "?" and ":".',
     },
   },
 
@@ -39,6 +40,16 @@ module.exports = {
                   context.report({
                     node: messageProperty,
                     messageId: 'chooseSelectDisallowed',
+                  })
+                }
+
+                const lastChar = messageValue.slice(-1)
+                const invalidPunctuation = /[!.,;]/
+
+                if (lastChar.match(invalidPunctuation)) {
+                  context.report({
+                    node: messageProperty,
+                    messageId: 'invalidPunctuation',
                   })
                 }
               }

--- a/packages/plugin-ngrok/src/tunnel.ts
+++ b/packages/plugin-ngrok/src/tunnel.ts
@@ -52,7 +52,7 @@ async function tokenPrompt(showExplanation = true): Promise<string> {
 
   return renderTextPrompt({
     password: true,
-    message: 'Enter your ngrok token.',
+    message: 'Enter your ngrok token',
     validate: (value) => {
       if (value.length === 0) {
         return "Token can't be empty"


### PR DESCRIPTION
We had been discussing with @MeredithCastile the option of encouraging people to not use words like "choose" or "select" in prompt messages as it can conflict with the wording used in the footer of the prompt. Also these words are simply redundant.

This PR introduces a rule that will simply warn users if they include these words.