### PR TITLE
Text prompt displays an specific empty value when no input is entered

### DIFF
--- a/.changeset/clean-feet-judge.md
+++ b/.changeset/clean-feet-judge.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add support to display an empty value when the input in configured to allow empty values

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
@@ -92,6 +92,44 @@ describe('TextPrompt', () => {
     `)
   })
 
+  test('display the empty value when no input is entered and there is no default value', async () => {
+    const onSubmit = vi.fn()
+    const renderInstance = render(
+      <TextPrompt onSubmit={onSubmit} message="Test question" allowEmpty emptyDisplayedValue="empty" />,
+    )
+
+    await waitForInputsToBeReady()
+    await sendInputAndWaitForChange(renderInstance, ENTER)
+    expect(onSubmit).toHaveBeenCalledWith('')
+    expect(unstyled(getLastFrameAfterUnmount(renderInstance)!)).toMatchInlineSnapshot(`
+      "?  Test question:
+      ✔  empty
+      "
+    `)
+  })
+
+  test("display the default value when allow empty is enabled but the user don't modify it", async () => {
+    const onSubmit = vi.fn()
+    const renderInstance = render(
+      <TextPrompt
+        onSubmit={onSubmit}
+        message="Test question"
+        allowEmpty
+        emptyDisplayedValue="empty"
+        defaultValue="A"
+      />,
+    )
+
+    await waitForInputsToBeReady()
+    await sendInputAndWaitForChange(renderInstance, ENTER)
+    expect(onSubmit).toHaveBeenCalledWith('A')
+    expect(unstyled(getLastFrameAfterUnmount(renderInstance)!)).toMatchInlineSnapshot(`
+      "?  Test question:
+      ✔  A
+      "
+    `)
+  })
+
   test('text wrapping', async () => {
     // component width is 80 characters wide in tests but because of the question mark and
     // spaces before the question, we only have 77 characters to work with

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -14,6 +14,7 @@ export interface TextPromptProps {
   password?: boolean
   validate?: (value: string) => string | undefined
   allowEmpty?: boolean
+  emptyDisplayedValue?: string
 }
 
 const TextPrompt: FunctionComponent<TextPromptProps> = ({
@@ -23,6 +24,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   defaultValue = '',
   password = false,
   allowEmpty = false,
+  emptyDisplayedValue = '(empty)',
 }) => {
   if (password && defaultValue) {
     throw new Error("Can't use defaultValue with password")
@@ -44,6 +46,8 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   const {oneThird} = useLayout()
   const [answer, setAnswer] = useState<string>('')
   const answerOrDefault = answer.length > 0 ? answer : defaultValue
+  const useEmptyValue = answerOrDefault === ''
+  const answerWithEmptyOrDefault = useEmptyValue ? emptyDisplayedValue : answerOrDefault
   const {exit: unmountInk} = useApp()
   const [submitted, setSubmitted] = useState(false)
   const [error, setError] = useState<string | undefined>(undefined)
@@ -81,7 +85,9 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
           </Box>
 
           <Box flexGrow={1}>
-            <Text color="cyan">{password ? '*'.repeat(answer.length) : answerOrDefault}</Text>
+            <Text color="cyan" dimColor={useEmptyValue}>
+              {password ? '*'.repeat(answer.length) : answerWithEmptyOrDefault}
+            </Text>
           </Box>
         </Box>
       ) : (

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -46,8 +46,8 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   const {oneThird} = useLayout()
   const [answer, setAnswer] = useState<string>('')
   const answerOrDefault = answer.length > 0 ? answer : defaultValue
-  const useEmptyValue = answerOrDefault === ''
-  const answerWithEmptyOrDefault = useEmptyValue ? emptyDisplayedValue : answerOrDefault
+  const displayEmptyValue = answerOrDefault === ''
+  const displayedAnswer = displayEmptyValue ? emptyDisplayedValue : answerOrDefault
   const {exit: unmountInk} = useApp()
   const [submitted, setSubmitted] = useState(false)
   const [error, setError] = useState<string | undefined>(undefined)
@@ -85,8 +85,8 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
           </Box>
 
           <Box flexGrow={1}>
-            <Text color="cyan" dimColor={useEmptyValue}>
-              {password ? '*'.repeat(answer.length) : answerWithEmptyOrDefault}
+            <Text color="cyan" dimColor={displayEmptyValue}>
+              {password ? '*'.repeat(answer.length) : displayedAnswer}
             </Text>
           </Box>
         </Box>


### PR DESCRIPTION
### WHY are these changes introduced?
When you deploy an app using the new unified deployment system you could add a label value to the deployment. This input is optional so if the user does not enter a value the text prompt displays nothing which looks a bit weird

![image](https://user-images.githubusercontent.com/105213827/234843099-80cc6377-4071-4334-8577-304150690aae.png)

In that case we would want to add the option of displaying en empty message

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add an new optional parameter to the `TextPrompt` component with a default value `(empty)`. In case you don't want to display an empty message you could set it to empty in the call
- In case the user submit an empty value the empty message will be displayed with a dimmed style

![label_empty](https://user-images.githubusercontent.com/105213827/234847495-5b267f85-3d7b-4d3f-b184-0b8dab53d0b1.gif)

- The value submitted should be an empty string regardless the empty value is displayed



<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Activate the `unified deployment beta flag` in your app
- Run the `deploy` command and leave empty the `Deployment label` prompt

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
