### PR TITLE
checkout-ui-extensions 0.26.0 update

### DIFF
--- a/packages/app/src/cli/models/extensions/ui-specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/checkout_ui_extension.ts
@@ -3,7 +3,7 @@ import {BaseUIExtensionSchema} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const dependency = {name: '@shopify/checkout-ui-extensions-react', version: '^0.24.0'}
+const dependency = {name: '@shopify/checkout-ui-extensions-react', version: '^0.26.0'}
 
 const CheckoutSchema = BaseUIExtensionSchema.extend({
   extensionPoints: zod.array(zod.string()).optional(),

--- a/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
@@ -9,7 +9,7 @@ import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 
-const dependency = {name: '@shopify/checkout-ui-extensions-react', version: '^0.24.0'}
+const dependency = {name: '@shopify/checkout-ui-extensions-react', version: '^0.26.0'}
 
 const UIExtensionSchema = BaseUIExtensionSchema.extend({
   settings: zod


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Follow-up to https://github.com/Shopify/ui-extensions/pull/902. This PR updates the dependancies for `@shopify/checkout-ui-extensions` and `@shopify/checkout-ui-extensions-react` to the latest version **0.26.0**. This ensures scaffolded extensions will be on the latest version.

### WHAT is this pull request doing?

Updates the checkout ui extensions version.

### How to test your changes?

Create a new app and scaffold a Checkout UI extension. It should use the `0.26.0` versions for both a React or a JavaScript extension.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
