### PR TITLE
[Bug Fix] only retrieve published products

### DIFF
--- a/.changeset/wise-fans-rest.md
+++ b/.changeset/wise-fans-rest.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+
+Fix graphql query for products to only retrieve published products

--- a/packages/app/src/cli/api/graphql/get_variant_id.ts
+++ b/packages/app/src/cli/api/graphql/get_variant_id.ts
@@ -2,7 +2,7 @@ import {gql} from 'graphql-request'
 
 export const FindProductVariantQuery = gql`
   query {
-    products(first: 1) {
+    products(first: 1, query: "published_status:published") {
       edges {
         node {
           id

--- a/packages/cli-kit/assets/cli-ruby/lib/graphql/get_variant_id.graphql
+++ b/packages/cli-kit/assets/cli-ruby/lib/graphql/get_variant_id.graphql
@@ -1,5 +1,5 @@
 query {
-  products(first: 1) {
+  products(first: 1, query:"published_status:published") {
     edges {
       node {
         id


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/build-learn-dev-tools-issues/issues/199

Development stores with generated test data have products that are not published. When a non-published product is the first product, the CLI checkout extensions test will still put it in the cart and then have a no inventory error.

[Video demonstration](https://videobin.shopify.io/v/pgQdLq)

### WHAT is this pull request doing?

This PR adds a query filter to the GraphQL calls to only fetch the first published product.

Before:
https://screenshot.click/28-28-504w1-bgf8u.png

After:
https://screenshot.click/28-27-itq1j-o8myj.png

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
