### PR TITLE
only replace font urls when content type is not present or it is a text

### DIFF
--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
@@ -21,8 +21,14 @@ module ShopifyCLI
 
           # Proxy the request, and replace the URLs in the response
           status, headers, body = @app.call(env)
-          body = replace_font_urls(body)
-          [status, headers, body]
+          # Use Rack::Response to get the content type header regardless of case
+          response = Rack::Response.new(nil, status, headers)
+          content_type = response.get_header("Content-Type")
+          if content_type.nil? || content_type == "" || content_type&.start_with?("text/")
+            Rack::Response.new(replace_font_urls(body), status, headers).finish
+          else
+            Rack::Response.new(body, status, headers).finish
+          end
         end
 
         private

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/cdn_fonts_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/cdn_fonts_test.rb
@@ -102,11 +102,21 @@ module ShopifyCLI
           assert_equal("Not found", response.body)
         end
 
+        def test_do_not_replace_when_content_type_does_not_match_text
+          CdnFonts.any_instance.expects(:replace_font_urls).never
+          response = serve(path: "/cdn/shop/products/tan-colored-hat-on-monochrome-background.jpg", content_type: "image/jpeg")
+        end
+
+        def test_replace_when_content_type_does_match_text
+          CdnFonts.any_instance.expects(:replace_font_urls).once
+          response = serve(path: "/cdn/shop/products/style.css", content_type: "text/css")
+        end
+
         private
 
-        def serve(response_body = "", path: "/")
+        def serve(response_body = "", path: "/", content_type: "text/html")
           app = lambda do |_env|
-            [200, {}, [response_body]]
+            [200, {"Content-Type" => content_type}, [response_body]]
           end
           stack = CdnFonts.new(app, theme: theme)
           request = Rack::MockRequest.new(stack)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/assets/issues/653

New vanity urls are breaking theme development

### WHAT is this pull request doing?

Ensure the fonts url replacement only happens on text assets (or when content type is not present)

### How to test your changes?

`bundle exec rake test TEST=test/shopify-cli/theme/dev_server/cdn_fonts_test.rb`

OR

- enable [storefront_vanity_assets_url](https://app.shopify.com/services/internal/betas/shops/storefront_vanity_assets_url) on your test shop
- ensure theme preview works properly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
