### PR TITLE
update script size limit to 128kb

### DIFF
--- a/packages/app/src/cli/models/extensions/ui-specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/web_pixel_extension.ts
@@ -6,7 +6,7 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {fileSize} from '@shopify/cli-kit/node/fs'
 
 const kilobytes = 1024
-const BUNDLE_SIZE_LIMIT_KB = 64
+const BUNDLE_SIZE_LIMIT_KB = 128
 const BUNDLE_SIZE_LIMIT = BUNDLE_SIZE_LIMIT_KB * kilobytes
 
 const dependency = {name: '@shopify/web-pixels-extension', version: '^0.1.1'}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Quick update to increase our bundle size update restriction to 128KB instead of 64KB now that our LHM migration has finished running.

### WHAT is this pull request doing?

Just increasing our `web_pixel_extension` build validation to set the size limit at 128KB instead of 64KB.

### How to test your changes?

You can deploy an web pixels app with this CLI with a script size of 128KB or higher!

128KB Script now:

<img width="816" alt="Screenshot 2023-05-02 at 11 27 04 AM" src="https://user-images.githubusercontent.com/19720593/235712488-f0aef7cd-c310-436b-a270-b2882fc8be20.png">


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
