### PR TITLE
Fix generate command to delete folder when an error arises

### DIFF
--- a/.changeset/ninety-files-exercise.md
+++ b/.changeset/ninety-files-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Remove folder created when a new extension is being generated but an error arises during the execution

--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -393,6 +393,7 @@ describe('initialize a extension', async () => {
 
       // Then
       await expect(got).rejects.toThrowErrorMatchingInlineSnapshot('"No folder for selected flavor"')
+      expect(file.fileExistsSync(joinPath(tmpDir, 'extensions', name))).toBeFalsy()
     })
   })
 })

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -78,18 +78,23 @@ export async function generateExtension(extensionOptions: ExtensionInitOptions[]
   return Promise.all(
     extensionOptions.flatMap(async (options) => {
       const extensionDirectory = await ensureExtensionDirectoryExists({app: options.app, name: options.name})
-      switch (options.specification.category()) {
-        case 'theme':
-          await themeExtensionInit({...(options as ThemeExtensionInitOptions), extensionDirectory})
-          break
-        case 'function':
-          await functionExtensionInit({...(options as FunctionExtensionInitOptions), extensionDirectory})
-          break
-        case 'ui':
-          await uiExtensionInit({...(options as UIExtensionInitOptions), extensionDirectory})
-          break
+      try {
+        switch (options.specification.category()) {
+          case 'theme':
+            await themeExtensionInit({...(options as ThemeExtensionInitOptions), extensionDirectory})
+            break
+          case 'function':
+            await functionExtensionInit({...(options as FunctionExtensionInitOptions), extensionDirectory})
+            break
+          case 'ui':
+            await uiExtensionInit({...(options as UIExtensionInitOptions), extensionDirectory})
+            break
+        }
+        return {directory: relativizePath(extensionDirectory), specification: options.specification}
+      } catch (error) {
+        await removeFile(extensionDirectory)
+        throw error
       }
-      return {directory: relativizePath(extensionDirectory), specification: options.specification}
     }),
   )
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When you try to generate an extension the first step is creating a folder inside `extensions` with the name introduced by the user. In case the process finishes with an error, the folder is not deleted so if you try to generate a new extension with the same name you receive and error like this

![image](https://user-images.githubusercontent.com/105213827/235854686-e32a0d58-242b-4ea4-af14-615a69eec54d.png)

You need to delete it manually before trying to generate an extension with the same name. 

The final extension folder must bu deleted in case an error is produced when the user tries to generate an extension 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Catch the generate error, delete the folder and throw it again
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Generate one `Function - Cart transformer`, use a desired name, and select `Javascript` as flavor
- Generate another extension type and use the same name than above. No error should appears 

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
