### PR TITLE
Remove references to rack, which we don't need to use

### DIFF
--- a/.changeset/fluffy-peas-admire.md
+++ b/.changeset/fluffy-peas-admire.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+Fix unavailable constant reference in theme dev

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
@@ -21,13 +21,11 @@ module ShopifyCLI
 
           # Proxy the request, and replace the URLs in the response
           status, headers, body = @app.call(env)
-          # Use Rack::Response to get the content type header regardless of case
-          response = Rack::Response.new(nil, status, headers)
-          content_type = response.get_header("Content-Type")
+          content_type = headers["Content-Type"] || headers["content-type"]
           if content_type.nil? || content_type == "" || content_type&.start_with?("text/")
-            Rack::Response.new(replace_font_urls(body), status, headers).finish
+            [status, headers, replace_font_urls(body)]
           else
-            Rack::Response.new(body, status, headers).finish
+            [status, headers, body]
           end
         end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1893

<!--
  Context about the problem that’s being addressed.
-->

Theme development is currently dead in the water, due to introducing a constant reference we don't actually have access to during `theme dev`.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Removes the references to `Rack`, using the standard Rack `[status, headers, body]` interface instead.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`theme dev` should work now

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
