### PR TITLE
Add `debug command-flags` command

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -43,6 +43,25 @@
       "flags": {},
       "args": {}
     },
+    "debug:command-flags": {
+      "id": "debug:command-flags",
+      "description": "View all the available command flags",
+      "strict": true,
+      "pluginName": "@shopify/cli",
+      "pluginAlias": "@shopify/cli",
+      "pluginType": "core",
+      "hidden": true,
+      "aliases": [],
+      "flags": {
+        "csv": {
+          "name": "csv",
+          "type": "boolean",
+          "description": "Output as CSV",
+          "allowNo": false
+        }
+      },
+      "args": {}
+    },
     "kitchen-sink:async": {
       "id": "kitchen-sink:async",
       "description": "View the UI kit components that process async tasks",

--- a/packages/cli/src/cli/commands/debug/command-flags.ts
+++ b/packages/cli/src/cli/commands/debug/command-flags.ts
@@ -1,0 +1,81 @@
+import Command from '@shopify/cli-kit/node/base-command'
+import {renderTable, renderText} from '@shopify/cli-kit/node/ui'
+import {Flags} from '@oclif/core'
+
+export default class CommandFlags extends Command {
+  static description = 'View all the available command flags'
+  static hidden = true
+
+  static flags = {
+    // Similar options as the `commands` command from `plugin-commands`
+    csv: Flags.boolean({
+      description: 'Output as CSV',
+      env: 'SHOPIFY_FLAG_OUTPUT_CSV',
+      default: false,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(CommandFlags)
+
+    const data: {pluginName: string; command: string; flagName: string; flagChar: string; flagEnv?: string}[] = []
+    for (const plugin of this.config.plugins) {
+      for (const command of plugin.commands) {
+        // We have to load the command, otherwise OCLIF will just use the manifest, and we need the actual class
+        // eslint-disable-next-line no-await-in-loop
+        const loaded = await command.load()
+
+        let pluginName
+        if (plugin.name.startsWith('@shopify')) {
+          pluginName = plugin.name.substring('@shopify/'.length)
+        } else {
+          pluginName = plugin.name.startsWith('@oclif') ? plugin.name.substring('@oclif/'.length) : plugin.name
+        }
+
+        const flags = loaded.flags
+        if (flags) {
+          for (const [flagName, flagConfig] of Object.entries(flags)) {
+            data.push({
+              pluginName,
+              command: command.id,
+              flagName: `--${flagName}`,
+              flagChar: flagConfig.char ? `-${flagConfig.char}` : '',
+              flagEnv: flagConfig.env,
+            })
+          }
+        }
+      }
+    }
+
+    if (flags.csv) {
+      const columns = ['pluginName', 'command', 'flagName', 'flagChar', 'flagEnv'] as const
+      const header = `${columns.join(',')}\n`
+      const rows = data.map((obj) => columns.map((key) => obj[key]).join(',')).join('\n')
+      const csvString = header + rows
+      renderText({text: csvString})
+    } else {
+      renderTable({
+        rows: data,
+        columns: {
+          pluginName: {
+            header: 'plugin',
+            color: 'red',
+          },
+          command: {},
+          flagName: {
+            header: 'long flag',
+            color: 'green',
+          },
+          flagChar: {
+            header: 'short flag',
+            color: 'green',
+          },
+          flagEnv: {
+            header: 'env variable',
+            color: 'blueBright',
+          },
+        },
+      })
+    }
+  }
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Help us identify discrepancies in how flags and environment variables are used, by being able to export a list of them.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds ` shopify debug command-flags` -- similar to the `commands` command from `plugin-commands`. Outputs all the flags used by all the commands.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

<img width="944" alt="image" src="https://user-images.githubusercontent.com/234027/235964688-a23341ac-4a26-4ef6-92ae-bdecabc71930.png">

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Run `shopify debug command-flags`

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
