### PR TITLE
Introduce `.jpeg` support in theme app extensions

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -57,6 +57,7 @@ export async function fileServerMiddleware(
     '.css': 'text/css',
     '.png': 'image/png',
     '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
     '.wav': 'audio/wav',
     '.mp3': 'audio/mpeg',
     '.svg': 'image/svg+xml',

--- a/packages/app/src/cli/validators/extensions/theme.ts
+++ b/packages/app/src/cli/validators/extensions/theme.ts
@@ -18,7 +18,7 @@ const BUNDLE_SIZE_LIMIT = BUNDLE_SIZE_LIMIT_MB * megabytes
 const LIQUID_SIZE_LIMIT_KB = 100
 const LIQUID_SIZE_LIMIT = LIQUID_SIZE_LIMIT_KB * kilobytes
 
-const SUPPORTED_ASSET_EXTS = ['.jpg', '.js', '.css', '.png', '.svg']
+const SUPPORTED_ASSET_EXTS = ['.jpg', '.jpeg', '.js', '.css', '.png', '.svg']
 const SUPPORTED_LOCALE_EXTS = ['.json']
 const SUPPORTED_EXTS: {[dirname: string]: FilenameValidation} = {
   assets: {

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -10,7 +10,7 @@ module Extension
         SUPPORTED_BUCKETS = %w(assets blocks snippets locales)
         BUNDLE_SIZE_LIMIT = 10 * 1024 * 1024 # 10MB
         LIQUID_SIZE_LIMIT = 100 * 1024 # 100kb
-        SUPPORTED_ASSET_EXTS = %w(.jpg .js .css .png .svg)
+        SUPPORTED_ASSET_EXTS = %w(.jpg .jpeg .js .css .png .svg)
         SUPPORTED_LOCALE_EXTS = %w(.json)
 
         def create(directory_name, context, getting_started: false)


### PR DESCRIPTION
⚠️ Please, do not merge until [#424761](https://github.com/Shopify/shopify/pull/424761) doesn't get merged.

### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1844

### WHAT is this pull request doing?

This PR introduces support to `.jpeg` files.

### How to test your changes?

- Create a new app with a theme app extension
- Add a `.jpeg` file in the assets folder
- Run the `app dev` command
- Notice the theme app extension is pushed as expected


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
