### PR TITLE
Introduce support for update extension files

### DIFF
--- a/.changeset/little-eels-study.md
+++ b/.changeset/little-eels-study.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Introduce support for update extension files

--- a/packages/theme/src/cli/services/package.test.ts
+++ b/packages/theme/src/cli/services/package.test.ts
@@ -19,6 +19,7 @@ describe('packageTheme', () => {
         'layout/theme.liquid',
         'config/settings_schema.json',
         'release-notes.md',
+        'update_extension.json',
       ]
       await createFiles(themeRelativePaths, inputDirectory)
       await createSettingsSchema(
@@ -92,6 +93,7 @@ describe('packageTheme', () => {
         'layout/theme.liquid',
         'config/settings_schema.json',
         'release-notes.md',
+        'update_extension.json',
       ]
       await createFiles(themeRelativePaths, inputDirectory)
       await createSettingsSchema('[{"name": "theme_info", "theme_name": "Dawn"}]', inputDirectory)

--- a/packages/theme/src/cli/services/package.ts
+++ b/packages/theme/src/cli/services/package.ts
@@ -4,24 +4,25 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {resolvePath, relativizePath} from '@shopify/cli-kit/node/path'
 
-const themeDirectoriesPattern = [
-  'assets',
-  'config',
-  'layout',
-  'locales',
-  'sections',
-  'snippets',
-  'templates',
-  'templates/customers',
+const themeFilesPattern = [
+  'assets/**',
+  'config/**',
+  'layout/**',
+  'locales/**',
+  'sections/**',
+  'snippets/**',
+  'templates/**',
+  'templates/customers/**',
   'release-notes.md',
-].join('/**|')
+  'update_extension.json',
+].join('|')
 
 // package is a reserved word so the function needs to be named packageTheme
 export async function packageTheme(inputDirectory: string) {
   const packageName = await getThemePackageName(inputDirectory)
 
   const outputZipPath = `${inputDirectory}/${packageName}`
-  const matchFilePattern = `${inputDirectory}/(${themeDirectoriesPattern})`
+  const matchFilePattern = `${inputDirectory}/(${themeFilesPattern})`
 
   await zip({
     inputDirectory,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#420493](https://github.com/Shopify/shopify/issues/420493)

### WHAT is this pull request doing?

Introduces support to `update_extension.json` files.

### How to test your changes?

- Run `shopify theme init my_theme`
- Run `cd my_theme`
- Run `touch update_extension.json`
- Run `shopify theme package`
- Unzip the generated zip file
- Notice the `update_extension.json` was included in the zip

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
