### PR TITLE
Install exact versions with NPM by default

### DIFF
--- a/.changeset/big-goats-share.md
+++ b/.changeset/big-goats-share.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Install pos_ui_extension node dependencies as exact versions

--- a/.changeset/sixty-gifts-tan.md
+++ b/.changeset/sixty-gifts-tan.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+
+Install exact versions with NPM by default

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -121,9 +121,6 @@ async function uiExtensionInit({
           packageManager: app.packageManager,
           type: 'prod',
           directory: app.directory,
-          // This is a temporary workaround for POS extensions. By deafult all dependencies have the `^` prefix.
-          // We need an exact dependency version for the 1.0.1 release.
-          exact: specification.identifier === 'pos_ui_extension',
         })
       },
     },

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -790,11 +790,11 @@ describe('getPackageManager', () => {
 })
 
 describe('addNPMDependencies', () => {
-  test('when using npm with multiple dependencies they should be installed one by one', async () => {
+  test('when using npm with multiple dependencies they should be installed one by one, adding --save-exact if needed', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const dependencies: DependencyVersion[] = [
-        {name: 'first', version: '0.0.1'},
+        {name: 'first', version: '^0.0.1'},
         {name: 'second', version: '0.0.2'},
       ]
 
@@ -806,10 +806,10 @@ describe('addNPMDependencies', () => {
       })
 
       // Then
-      expect(mockedExec).toHaveBeenCalledWith('npm', ['install', 'first@0.0.1', '--save-prod'], {
+      expect(mockedExec).toHaveBeenNthCalledWith(1, 'npm', ['install', 'first@^0.0.1', '--save-prod'], {
         cwd: tmpDir,
       })
-      expect(mockedExec).toHaveBeenCalledWith('npm', ['install', 'second@0.0.2', '--save-prod'], {
+      expect(mockedExec).toHaveBeenNthCalledWith(2, 'npm', ['install', 'second@0.0.2', '--save-prod', '--save-exact'], {
         cwd: tmpDir,
       })
     })

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -380,30 +380,6 @@ describe('addNPMDependenciesIfNeeded', () => {
     })
   })
 
-  test("runs the right command when it's npm and exact versions", async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const packageJsonPath = joinPath(tmpDir, 'package.json')
-      const packageJson = {
-        dependencies: {existing: '1.2.3'},
-      }
-      await writeFile(packageJsonPath, JSON.stringify(packageJson))
-
-      // When
-      await addNPMDependenciesIfNeeded([{name: 'new', version: 'version'}], {
-        type: 'prod',
-        packageManager: 'npm',
-        directory: tmpDir,
-        exact: true,
-      })
-
-      // Then
-      expect(mockedExec).toHaveBeenCalledWith('npm', ['install', 'new@version', '--save-prod', '--save-exact'], {
-        cwd: tmpDir,
-      })
-    })
-  })
-
   test("runs the right command when it's yarn and dev dependencies", async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
@@ -473,30 +449,6 @@ describe('addNPMDependenciesIfNeeded', () => {
     })
   })
 
-  test("runs the right command when it's yarn and exact versions", async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const packageJsonPath = joinPath(tmpDir, 'package.json')
-      const packageJson = {
-        dependencies: {existing: '1.2.3'},
-      }
-      await writeFile(packageJsonPath, JSON.stringify(packageJson))
-
-      // When
-      await addNPMDependenciesIfNeeded([{name: 'new', version: 'version'}], {
-        type: 'prod',
-        packageManager: 'yarn',
-        directory: tmpDir,
-        exact: true,
-      })
-
-      // Then
-      expect(mockedExec).toHaveBeenCalledWith('yarn', ['add', 'new@version', '--prod', '--exact'], {
-        cwd: tmpDir,
-      })
-    })
-  })
-
   test("runs the right command when it's pnpm and dev dependencies", async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
@@ -561,30 +513,6 @@ describe('addNPMDependenciesIfNeeded', () => {
 
       // Then
       expect(mockedExec).toHaveBeenCalledWith('pnpm', ['add', 'new@version', '--save-peer'], {
-        cwd: tmpDir,
-      })
-    })
-  })
-
-  test("runs the right command when it's pnpm and exact versions", async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const packageJsonPath = joinPath(tmpDir, 'package.json')
-      const packageJson = {
-        dependencies: {existing: '1.2.3'},
-      }
-      await writeFile(packageJsonPath, JSON.stringify(packageJson))
-
-      // When
-      await addNPMDependenciesIfNeeded([{name: 'new', version: 'version'}], {
-        type: 'prod',
-        packageManager: 'pnpm',
-        directory: tmpDir,
-        exact: true,
-      })
-
-      // Then
-      expect(mockedExec).toHaveBeenCalledWith('pnpm', ['add', 'new@version', '--save-prod', '--save-exact'], {
         cwd: tmpDir,
       })
     })

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -405,7 +405,7 @@ export async function addNPMDependencies(
       // makes the task easier and npm can then proceed.
       for (const dep of dependenciesWithVersion) {
         // eslint-disable-next-line no-await-in-loop
-        await installDependencies(options, argumentsToAddDependenciesWithNPM([dep], options.type))
+        await installDependencies(options, argumentsToAddDependenciesWithNPM(dep, options.type))
       }
       break
     case 'yarn':
@@ -444,9 +444,9 @@ export async function addNPMDependenciesWithoutVersionIfNeeded(
  * @param type - The dependency type.
  * @returns An array with the arguments.
  */
-function argumentsToAddDependenciesWithNPM(dependencies: string[], type: DependencyType): string[] {
+function argumentsToAddDependenciesWithNPM(dependency: string, type: DependencyType): string[] {
   let command = ['install']
-  command = command.concat(dependencies)
+  command = command.concat(dependency)
   switch (type) {
     case 'dev':
       command.push('--save-dev')
@@ -457,6 +457,10 @@ function argumentsToAddDependenciesWithNPM(dependencies: string[], type: Depende
     case 'prod':
       command.push('--save-prod')
       break
+  }
+  // NPM adds ^ to the installed version by default. We want to install exact versions unless specified otherwise.
+  if (dependency.match(/@\d/g)) {
+    command.push('--save-exact')
   }
   return command
 }

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -327,9 +327,6 @@ interface AddNPMDependenciesIfNeededOptions {
 
   /** Abort signal to stop the process */
   signal?: AbortSignal
-
-  /** Whether or not to install exact versions of the dependencies */
-  exact?: boolean
 }
 
 /**
@@ -408,20 +405,14 @@ export async function addNPMDependencies(
       // makes the task easier and npm can then proceed.
       for (const dep of dependenciesWithVersion) {
         // eslint-disable-next-line no-await-in-loop
-        await installDependencies(options, argumentsToAddDependenciesWithNPM([dep], options.type, options.exact))
+        await installDependencies(options, argumentsToAddDependenciesWithNPM([dep], options.type))
       }
       break
     case 'yarn':
-      await installDependencies(
-        options,
-        argumentsToAddDependenciesWithYarn(dependenciesWithVersion, options.type, options.exact),
-      )
+      await installDependencies(options, argumentsToAddDependenciesWithYarn(dependenciesWithVersion, options.type))
       break
     case 'pnpm':
-      await installDependencies(
-        options,
-        argumentsToAddDependenciesWithPNPM(dependenciesWithVersion, options.type, options.exact),
-      )
+      await installDependencies(options, argumentsToAddDependenciesWithPNPM(dependenciesWithVersion, options.type))
       break
   }
 }
@@ -453,7 +444,7 @@ export async function addNPMDependenciesWithoutVersionIfNeeded(
  * @param type - The dependency type.
  * @returns An array with the arguments.
  */
-function argumentsToAddDependenciesWithNPM(dependencies: string[], type: DependencyType, exact = false): string[] {
+function argumentsToAddDependenciesWithNPM(dependencies: string[], type: DependencyType): string[] {
   let command = ['install']
   command = command.concat(dependencies)
   switch (type) {
@@ -467,7 +458,6 @@ function argumentsToAddDependenciesWithNPM(dependencies: string[], type: Depende
       command.push('--save-prod')
       break
   }
-  if (exact) command.push('--save-exact')
   return command
 }
 
@@ -477,7 +467,7 @@ function argumentsToAddDependenciesWithNPM(dependencies: string[], type: Depende
  * @param type - The dependency type.
  * @returns An array with the arguments.
  */
-function argumentsToAddDependenciesWithYarn(dependencies: string[], type: DependencyType, exact = false): string[] {
+function argumentsToAddDependenciesWithYarn(dependencies: string[], type: DependencyType): string[] {
   let command = ['add']
   command = command.concat(dependencies)
   switch (type) {
@@ -491,7 +481,6 @@ function argumentsToAddDependenciesWithYarn(dependencies: string[], type: Depend
       command.push('--prod')
       break
   }
-  if (exact) command.push('--exact')
   return command
 }
 
@@ -501,7 +490,7 @@ function argumentsToAddDependenciesWithYarn(dependencies: string[], type: Depend
  * @param type - The dependency type.
  * @returns An array with the arguments.
  */
-function argumentsToAddDependenciesWithPNPM(dependencies: string[], type: DependencyType, exact = false): string[] {
+function argumentsToAddDependenciesWithPNPM(dependencies: string[], type: DependencyType): string[] {
   let command = ['add']
   command = command.concat(dependencies)
   switch (type) {
@@ -515,7 +504,6 @@ function argumentsToAddDependenciesWithPNPM(dependencies: string[], type: Depend
       command.push('--save-prod')
       break
   }
-  if (exact) command.push('--save-exact')
   return command
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/1913, we added a fix to avoid NPM not installing the exact version of a dependency for a specific extension, but we have realized that the different package managers are not consistent when adding dependencies with exact versions:
- When you run `npm install whatever@1.2.3`, it adds `whatever: ^1.2.3` to the package.json.
- But if you run `yarn/pnpm add whatever@1.2.3`, they add `whatever: 1.2.3`

### WHAT is this pull request doing?

- Reverts Shopify/cli#1913
- Adds `--save-exact` only to NPM install commands when the provided version is exact (same behavior as Yarn/PNPM)

### How to test your changes?

- `p create-app --name test-npm  --path ~ --package-manager npm --template node`
- `p shopify app generate extension --path ~/test-npm`
- `cat ~/test-npm/package.json` should contain `"@shopify/retail-ui-extensions-react": "1.0.1",`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
