### PR TITLE
Add dashboard-managed extensions to infoTable

### DIFF
--- a/packages/app/src/cli/api/graphql/all_app_extension_registrations.ts
+++ b/packages/app/src/cli/api/graphql/all_app_extension_registrations.ts
@@ -9,6 +9,12 @@ export const AllAppExtensionRegistrationsQuery = gql`
         title
         type
       }
+      dashboardManagedExtensionRegistrations {
+        id
+        uuid
+        title
+        type
+      }
       functions {
         id
         uuid
@@ -23,19 +29,17 @@ export interface AllAppExtensionRegistrationsQueryVariables {
   apiKey: string
 }
 
+interface ExtensionRegistration {
+  id: string
+  uuid: string
+  title: string
+  type: string
+}
+
 export interface AllAppExtensionRegistrationsQuerySchema {
   app: {
-    extensionRegistrations: {
-      id: string
-      uuid: string
-      title: string
-      type: string
-    }[]
-    functions: {
-      id: string
-      uuid: string
-      title: string
-      type: string
-    }[]
+    extensionRegistrations: ExtensionRegistration[]
+    dashboardManagedExtensionRegistrations: ExtensionRegistration[]
+    functions: ExtensionRegistration[]
   }
 }

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -488,6 +488,7 @@ describe('ensureThemeExtensionDevContext', () => {
             type: 'THEME_APP_EXTENSION',
           },
         ],
+        dashboardManagedExtensionRegistrations: [],
         functions: [],
       },
     })
@@ -509,7 +510,7 @@ describe('ensureThemeExtensionDevContext', () => {
     const extension = await testThemeExtensions()
 
     vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({
-      app: {extensionRegistrations: [], functions: []},
+      app: {extensionRegistrations: [], dashboardManagedExtensionRegistrations: [], functions: []},
     })
     vi.mocked(createExtension).mockResolvedValue({
       id: 'new ID',

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -595,6 +595,44 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
     )
   })
 
+  test('does not include dashboard managed extensions in confirmation prompt if the beta flag is off', async () => {
+    // Given
+    vi.mocked(automaticMatchmaking).mockResolvedValueOnce({
+      identifiers: {EXTENSION_A: 'UUID_A', EXTENSION_A_2: 'UUID_A_2'},
+      toCreate: [],
+      toConfirm: [],
+      toManualMatch: {
+        local: [],
+        remote: [],
+      },
+    })
+    vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
+
+    // When
+    await ensureExtensionsIds(
+      options([EXTENSION_A, EXTENSION_A_2], [], {}, PARTNERS_APP_WITHOUT_UNIFIED_APP_DEPLOYMENTS_BETA),
+      {
+        extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
+        dashboardManagedExtensionRegistrations: [DASHBOARD_REGISTRATION_A],
+      },
+    )
+
+    // Then
+    expect(deployConfirmationPrompt).toBeCalledWith(
+      {
+        question: 'Make the following changes to your extensions in Shopify Partners?',
+        identifiers: {
+          EXTENSION_A: 'UUID_A',
+          EXTENSION_A_2: 'UUID_A_2',
+        },
+        onlyRemote: [],
+        dashboardOnly: [],
+        toCreate: [],
+      },
+      PARTNERS_APP_WITHOUT_UNIFIED_APP_DEPLOYMENTS_BETA,
+    )
+  })
+
   test('skips confirmation prompt if --force is passed', async () => {
     // Given
     vi.mocked(automaticMatchmaking).mockResolvedValueOnce({

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -41,6 +41,13 @@ const REGISTRATION_B = {
   type: 'SUBSCRIPTION_MANAGEMENT',
 }
 
+const DASHBOARD_REGISTRATION_A = {
+  uuid: 'UUID_DASHBOARD_A',
+  id: 'DASHBOARD_A',
+  title: 'DASHBOARD_A',
+  type: 'APP_LINK',
+}
+
 const FUNCTION_REGISTRATION_A = {
   uuid: 'FUNCTION_A_UUID',
   id: 'FUNCTION_A',
@@ -74,7 +81,7 @@ const EXTENSION_A: UIExtension = {
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
   shouldFetchCartUrl: () => true,
-  hasExtensionPointTarget: (target: string) => true,
+  hasExtensionPointTarget: (_target: string) => true,
   isPreviewable: true,
 }
 
@@ -104,7 +111,7 @@ const EXTENSION_A_2: UIExtension = {
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
   shouldFetchCartUrl: () => true,
-  hasExtensionPointTarget: (target: string) => true,
+  hasExtensionPointTarget: (_target: string) => true,
   isPreviewable: true,
 }
 
@@ -134,7 +141,7 @@ const EXTENSION_B: UIExtension = {
   validate: () => Promise.resolve(ok({})),
   getBundleExtensionStdinContent: () => '',
   shouldFetchCartUrl: () => true,
-  hasExtensionPointTarget: (target: string) => true,
+  hasExtensionPointTarget: (_target: string) => true,
   isPreviewable: true,
 }
 
@@ -569,7 +576,7 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
     // When
     await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), {
       extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
-      dashboardManagedExtensionRegistrations: [],
+      dashboardManagedExtensionRegistrations: [DASHBOARD_REGISTRATION_A],
     })
 
     // Then
@@ -581,7 +588,7 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
           EXTENSION_A_2: 'UUID_A_2',
         },
         onlyRemote: [],
-        dashboardOnly: [],
+        dashboardOnly: [DASHBOARD_REGISTRATION_A],
         toCreate: [],
       },
       PARTNERS_APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA,

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -491,7 +491,10 @@ describe('ensureExtensionsIds: excludes functions when unifiedAppDeployment beta
     // When
     const got = await ensureExtensionsIds(
       options([EXTENSION_A], [FUNCTION_A], {}, PARTNERS_APP_WITHOUT_UNIFIED_APP_DEPLOYMENTS_BETA),
-      [REGISTRATION_A, FUNCTION_REGISTRATION_A],
+      {
+        extensionRegistrations: [REGISTRATION_A, FUNCTION_REGISTRATION_A],
+        dashboardManagedExtensionRegistrations: [],
+      },
     )
 
     // Then
@@ -527,7 +530,10 @@ describe('ensureExtensionsIds: includes functions when unifiedAppDeployment beta
     // When
     const got = await ensureExtensionsIds(
       options([EXTENSION_A], [FUNCTION_A], {}, PARTNERS_APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA),
-      [REGISTRATION_A, FUNCTION_REGISTRATION_A],
+      {
+        extensionRegistrations: [REGISTRATION_A, FUNCTION_REGISTRATION_A],
+        dashboardManagedExtensionRegistrations: [],
+      },
     )
 
     // Then

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -247,7 +247,10 @@ describe('ensureExtensionsIds: matchmaking returns more remote sources than loca
     vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await ensureExtensionsIds(options([EXTENSION_A]), [REGISTRATION_A, REGISTRATION_B])
+    const got = await ensureExtensionsIds(options([EXTENSION_A]), {
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_B],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(got).toEqual(
@@ -283,7 +286,10 @@ describe('ensureExtensionsIds: matchmaking returns ok with pending manual matche
     vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), [REGISTRATION_A, REGISTRATION_A_2])
+    const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), {
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(manualMatchIds).toHaveBeenCalledWith(
@@ -325,7 +331,10 @@ describe('ensureExtensionsIds: matchmaking returns ok with pending manual matche
     vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), [REGISTRATION_A, REGISTRATION_A_2])
+    const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), {
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(got).toEqual(
@@ -361,7 +370,10 @@ describe('ensureExtensionsIds: matchmaking returns ok with pending some pending 
     vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), [REGISTRATION_A, REGISTRATION_A_2])
+    const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), {
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(createExtension).toBeCalledTimes(2)
@@ -390,7 +402,10 @@ describe('ensureExtensionsIds: matchmaking returns ok with some pending confirma
     vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await ensureExtensionsIds(options([EXTENSION_B]), [REGISTRATION_B])
+    const got = await ensureExtensionsIds(options([EXTENSION_B]), {
+      extensionRegistrations: [REGISTRATION_B],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(createExtension).not.toBeCalled()
@@ -419,7 +434,10 @@ describe('ensureExtensionsIds: matchmaking returns ok with some pending confirma
     vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await ensureExtensionsIds(options([EXTENSION_B]), [REGISTRATION_B])
+    const got = await ensureExtensionsIds(options([EXTENSION_B]), {
+      extensionRegistrations: [REGISTRATION_B],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(got).toEqual(err('user-cancelled'))
@@ -441,7 +459,10 @@ describe('ensureExtensionsIds: matchmaking returns ok with nothing pending', () 
     vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), [REGISTRATION_A, REGISTRATION_A_2])
+    const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), {
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(got).toEqual(
@@ -540,7 +561,10 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
     vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), [REGISTRATION_A, REGISTRATION_A_2])
+    await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), {
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(deployConfirmationPrompt).toBeCalledWith(
@@ -551,6 +575,7 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
           EXTENSION_A_2: 'UUID_A_2',
         },
         onlyRemote: [],
+        dashboardOnly: [],
         toCreate: [],
       },
       PARTNERS_APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA,
@@ -573,7 +598,10 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
     opts.force = true
 
     // When
-    await ensureExtensionsIds(opts, [REGISTRATION_A, REGISTRATION_A_2])
+    await ensureExtensionsIds(opts, {
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(deployConfirmationPrompt).not.toBeCalled()
@@ -600,7 +628,10 @@ describe('ensureExtensionsIds: Migrates extension', () => {
     vi.mocked(getExtensionsToMigrate).mockReturnValueOnce(extensionsToMigrate)
 
     // When
-    await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), [REGISTRATION_A, REGISTRATION_A_2])
+    await ensureExtensionsIds(options([EXTENSION_A, EXTENSION_A_2]), {
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(extensionMigrationPrompt).toBeCalledWith(extensionsToMigrate)
@@ -627,7 +658,10 @@ describe('ensureExtensionsIds: Migrates extension', () => {
     const remoteExtensions = [REGISTRATION_A, REGISTRATION_A_2]
 
     // When
-    await ensureExtensionsIds(opts, remoteExtensions)
+    await ensureExtensionsIds(opts, {
+      extensionRegistrations: remoteExtensions,
+      dashboardManagedExtensionRegistrations: [],
+    })
 
     // Then
     expect(migrateExtensionsToUIExtension).toBeCalledWith(extensionsToMigrate, opts.appId, remoteExtensions)

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -10,9 +10,17 @@ import {err, ok, Result} from '@shopify/cli-kit/node/result'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {outputCompleted} from '@shopify/cli-kit/node/output'
 
+interface AppWithExtensions {
+  extensionRegistrations: RemoteSource[]
+  dashboardManagedExtensionRegistrations: RemoteSource[]
+}
+
 export async function ensureExtensionsIds(
   options: EnsureDeploymentIdsPresenceOptions,
-  initialRemoteExtensions: RemoteSource[],
+  {
+    extensionRegistrations: initialRemoteExtensions,
+    dashboardManagedExtensionRegistrations: dashboardOnlyExtensions,
+  }: AppWithExtensions,
 ): Promise<Result<{extensions: IdentifiersExtensions; extensionIds: IdentifiersExtensions}, MatchingError>> {
   let remoteExtensions = initialRemoteExtensions
   const validIdentifiers = options.envIdentifiers.extensions ?? {}
@@ -66,6 +74,7 @@ export async function ensureExtensionsIds(
         identifiers: validMatches,
         toCreate: extensionsToCreate,
         onlyRemote: onlyRemoteExtensions,
+        dashboardOnly: dashboardOnlyExtensions,
       },
       options.partnersApp,
     )

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -74,7 +74,7 @@ export async function ensureExtensionsIds(
         identifiers: validMatches,
         toCreate: extensionsToCreate,
         onlyRemote: onlyRemoteExtensions,
-        dashboardOnly: dashboardOnlyExtensions,
+        dashboardOnly: options.partnersApp?.betas?.unifiedAppDeployment ? dashboardOnlyExtensions : [],
       },
       options.partnersApp,
     )

--- a/packages/app/src/cli/services/context/identifiers-functions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-functions.test.ts
@@ -343,6 +343,7 @@ describe('ensureFunctionsIds: asks user to confirm deploy', () => {
       },
       onlyRemote: [],
       toCreate: [],
+      dashboardOnly: [],
     })
   })
 

--- a/packages/app/src/cli/services/context/identifiers-functions.ts
+++ b/packages/app/src/cli/services/context/identifiers-functions.ts
@@ -38,6 +38,7 @@ export async function ensureFunctionsIds(
       identifiers: validMatches,
       toCreate: functionsToCreate,
       onlyRemote: onlyRemoteFunctions,
+      dashboardOnly: [],
     })
     if (!confirmed) return err('user-cancelled')
   }

--- a/packages/app/src/cli/services/context/identifiers.test.ts
+++ b/packages/app/src/cli/services/context/identifiers.test.ts
@@ -163,7 +163,11 @@ vi.mock('./identifiers-functions')
 beforeEach(() => {
   vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
   vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({
-    app: {extensionRegistrations: [REGISTRATION_A, REGISTRATION_B], functions: [REGISTRATION_C]},
+    app: {
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_B],
+      dashboardManagedExtensionRegistrations: [],
+      functions: [REGISTRATION_C],
+    },
   })
 })
 

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -48,7 +48,7 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     functions = result.value
   }
 
-  const extensions = await ensureExtensionsIds(options, remoteSpecifications.app.extensionRegistrations)
+  const extensions = await ensureExtensionsIds(options, remoteSpecifications.app)
   if (extensions.isErr()) throw handleIdsError(extensions.error, options.appName, options.app.packageManager)
 
   return {

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -59,7 +59,7 @@ export async function deployConfirmationPrompt(
   }
 
   if (dashboardOnly.length > 0) {
-    infoTable.push({header: 'Included from Partner dashboard', items: dashboardOnly.map((source) => source.title)})
+    infoTable.push({header: 'Included from\nPartner dashboard', items: dashboardOnly.map((source) => source.title)})
   }
 
   if (onlyRemote.length > 0) {

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -39,28 +39,33 @@ interface SourceSummary {
   identifiers: IdentifiersExtensions
   toCreate: LocalSource[]
   onlyRemote: RemoteSource[]
+  dashboardOnly?: RemoteSource[]
 }
 
 export async function deployConfirmationPrompt(
-  summary: SourceSummary,
+  {question, identifiers, toCreate, onlyRemote, dashboardOnly}: SourceSummary,
   partnersApp?: OrganizationApp,
 ): Promise<boolean> {
   const infoTable: InfoTableSection[] = []
 
-  if (summary.toCreate.length > 0) {
-    infoTable.push({header: 'Add', items: summary.toCreate.map((source) => source.localIdentifier)})
+  if (toCreate.length > 0) {
+    infoTable.push({header: 'Add', items: toCreate.map((source) => source.localIdentifier)})
   }
 
-  const toUpdate = Object.keys(summary.identifiers)
+  const toUpdate = Object.keys(identifiers)
 
   if (toUpdate.length > 0) {
     infoTable.push({header: 'Update', items: toUpdate})
   }
 
-  if (summary.onlyRemote.length > 0) {
+  if (dashboardOnly?.length && dashboardOnly.length > 0) {
+    infoTable.push({header: 'Included from Partner dashboard', items: dashboardOnly.map((source) => source.title)})
+  }
+
+  if (onlyRemote.length > 0) {
     let missingLocallySection: InfoTableSection = {
       header: 'Missing locally',
-      items: summary.onlyRemote.map((source) => source.title),
+      items: onlyRemote.map((source) => source.title),
     }
 
     if (partnersApp?.betas?.unifiedAppDeployment) {
@@ -79,7 +84,7 @@ export async function deployConfirmationPrompt(
   }
 
   return renderConfirmationPrompt({
-    message: summary.question,
+    message: question,
     infoTable,
     confirmationMessage: 'Yes, deploy to push changes',
     cancellationMessage: 'No, cancel',

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -39,7 +39,7 @@ interface SourceSummary {
   identifiers: IdentifiersExtensions
   toCreate: LocalSource[]
   onlyRemote: RemoteSource[]
-  dashboardOnly?: RemoteSource[]
+  dashboardOnly: RemoteSource[]
 }
 
 export async function deployConfirmationPrompt(
@@ -58,7 +58,7 @@ export async function deployConfirmationPrompt(
     infoTable.push({header: 'Update', items: toUpdate})
   }
 
-  if (dashboardOnly?.length && dashboardOnly.length > 0) {
+  if (dashboardOnly.length > 0) {
     infoTable.push({header: 'Included from Partner dashboard', items: dashboardOnly.map((source) => source.title)})
   }
 

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -331,7 +331,9 @@ async function testDeployBundle(
   vi.mocked(uploadFunctionExtensions).mockResolvedValue(identifiers)
   vi.mocked(uploadExtensionsBundle).mockResolvedValue({validationErrors: [], deploymentId: 2})
   vi.mocked(updateAppIdentifiers).mockResolvedValue(app)
-  vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({app: {extensionRegistrations: [], functions: []}})
+  vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({
+    app: {extensionRegistrations: [], dashboardManagedExtensionRegistrations: [], functions: []},
+  })
 
   await deploy({
     app,

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.test.tsx
@@ -10,16 +10,17 @@ describe('InfoTable', async () => {
       <InfoTable
         table={{
           'header 1': ['some', 'items'],
-          'header 2': [['one item', {link: {label: 'Shopify', url: 'https://shopify.com'}}]],
+          'header 2\nlonger text here': [['one item', {link: {label: 'Shopify', url: 'https://shopify.com'}}]],
         }}
       />,
     )
 
     expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
-      "Header 1:  • some
-                 • items
+      "Header 1:          • some
+                         • items
 
-      Header 2:  • one item Shopify ( https://shopify.com )"
+      Header 2           • one item Shopify ( https://shopify.com )
+      longer text here:"
     `)
   })
 

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
@@ -25,7 +25,12 @@ const InfoTable: FunctionComponent<InfoTableProps> = ({table}) => {
   const sections = Array.isArray(table)
     ? table
     : Object.keys(table).map((header) => ({header, items: table[header]!, color: undefined, helperText: undefined}))
-  const headerColumnWidth = Math.min(Math.max(...sections.map((section) => section.header.length)), 20)
+
+  const headerColumnWidth = Math.max(...sections.map((section) => {
+    return Math.max(...section.header.split('\n').map(line => {
+      return line.length
+    }))
+  }))
 
   return (
     <Box flexDirection="column">

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
@@ -25,7 +25,7 @@ const InfoTable: FunctionComponent<InfoTableProps> = ({table}) => {
   const sections = Array.isArray(table)
     ? table
     : Object.keys(table).map((header) => ({header, items: table[header]!, color: undefined, helperText: undefined}))
-  const headerColumnWidth = Math.max(...sections.map((section) => section.header.length))
+  const headerColumnWidth = Math.min(Math.max(...sections.map((section) => section.header.length)), 20)
 
   return (
     <Box flexDirection="column">

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoTable.tsx
@@ -26,11 +26,15 @@ const InfoTable: FunctionComponent<InfoTableProps> = ({table}) => {
     ? table
     : Object.keys(table).map((header) => ({header, items: table[header]!, color: undefined, helperText: undefined}))
 
-  const headerColumnWidth = Math.max(...sections.map((section) => {
-    return Math.max(...section.header.split('\n').map(line => {
-      return line.length
-    }))
-  }))
+  const headerColumnWidth = Math.max(
+    ...sections.map((section) => {
+      return Math.max(
+        ...section.header.split('\n').map((line) => {
+          return line.length
+        }),
+      )
+    }),
+  )
 
   return (
     <Box flexDirection="column">


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This is a companion PR to https://github.com/Shopify/partners/pull/47589 and should only be merged afterwards.

Fixes https://github.com/Shopify/app-deploys/issues/372

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Add the `Included from Partners dashboard` section:

<img width="1158" alt="Screenshot 2023-05-11 at 20 55 22" src="https://github.com/Shopify/cli/assets/6288426/e9eba119-2837-41cf-962e-b2cd4d7228b1">

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Create a spin instance with partners on the `expose-dashboard-managed-extensions` branch
2. Create an app with some extensions
3. Deploy
4. In the partners admin, add dashboard-managed extensions (e.g. admin links)
5. Deploy and see the `Included from Partner dashboard` is included

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
