### PR TITLE
Fix localhost as host to run the library get port please

### DIFF
--- a/.changeset/soft-oranges-greet.md
+++ b/.changeset/soft-oranges-greet.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix localhost as host to run the library get port please

--- a/packages/cli-kit/src/public/node/tcp.ts
+++ b/packages/cli-kit/src/public/node/tcp.ts
@@ -11,7 +11,7 @@ import * as port from 'get-port-please'
  */
 export async function getAvailableTCPPort(): Promise<number> {
   outputDebug(outputContent`Getting a random port...`)
-  const randomPort = await retryOnError(() => port.getRandomPort())
+  const randomPort = await retryOnError(() => port.getRandomPort('localhost'))
   outputDebug(outputContent`Random port obtained: ${outputToken.raw(`${randomPort}`)}`)
   return randomPort
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Some users are receiving this error when they try to run the `dev` command.

```sh
╭─ error ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                    │
│  Unable to obtain an available random port number!                                                                                                                 │
│                                                                                                                                                                    │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

We are using the library [get-port-please](https://github.com/unjs/get-port-please) to get free ports and assign them to the external services (backend, frontend, tunnelling). 
To get the port we call the method `getRandomPort`. That method relay on the env variable `HOST` to create a temporary server that checks if the port is available. The problem is that if that env variable is set in the system to a value that is not `listenable` then the method returns always `Unable to obtain an available random port number!  `

To check this scenario you can run the `dev` command like this:
```sh
HOST=invalid.host npm run shopify app dev
````
and you should see the error

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Force always using `localhost` when the cli calls the method `getRandomPort`
- Other alternative could be unset the `process.env.HOST` that only affects to the current cli running.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Run
```sh
HOST=invalid.host npm run shopify app dev
````
and no error should be displayed

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
