### PR TITLE
Use theme bundling by default

### DIFF
--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -23,7 +23,7 @@ export const environmentVariables = {
   themeToken: 'SHOPIFY_CLI_THEME_TOKEN',
   unitTest: 'SHOPIFY_UNIT_TEST',
   verbose: 'SHOPIFY_FLAG_VERBOSE',
-  themeBundling: 'SHOPIFY_CLI_THEME_BUNDLING',
+  noThemeBundling: 'SHOPIFY_CLI_NO_THEME_BUNDLING',
   // Variables to detect if the CLI is running in a cloud environment
   codespaceName: 'CODESPACE_NAME',
   codespaces: 'CODESPACES',

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -116,10 +116,10 @@ export function useDeviceAuth(env = process.env): boolean {
  * Returns true if the CLI should use theme bundling.
  *
  * @param env - The environment variables from the environment of the current process.
- * @returns True if SHOPIFY_NO_THEME_BUNDLING is truthy.
+ * @returns False if SHOPIFY_CLI_NO_THEME_BUNDLING is truthy.
  */
 export function useThemebundling(env = process.env): boolean {
-  return isTruthy(env[environmentVariables.themeBundling])
+  return !isTruthy(env[environmentVariables.noThemeBundling])
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/Shopify/app-deploys/issues/318

We want to make theme bundling opt-out instead of opt-in now that we're more confident in the feature.

## Testing

- Create a new app with `./bin/create-test-app.js -e theme`
- Try deploying, it should work
- Try introducing an error in the theme
- Try deploying, the error should be visible in the error messages banner