### PR TITLE
add app key to function extension config

### DIFF
--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -112,7 +112,7 @@ export async function deploy(options: DeployOptions) {
                   const {moduleId} = await uploadWasmBlob(extension, identifiers.app, token)
                   return {
                     uuid: identifiers.extensions[extension.localIdentifier]!,
-                    config: JSON.stringify(await functionConfiguration(extension, moduleId)),
+                    config: JSON.stringify(await functionConfiguration(extension, moduleId, apiKey)),
                     context: '',
                   }
                 }),

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -1110,17 +1110,19 @@ describe('functionConfiguration', () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const moduleId = 'module_id'
+      const appKey = 'app-key'
       const inputQuery = 'inputQuery'
       extension.inputQueryPath = joinPath(tmpDir, extension.inputQueryPath)
       await writeFile(extension.inputQueryPath, inputQuery)
 
       // When
-      const got = await functionConfiguration(extension, moduleId)
+      const got = await functionConfiguration(extension, moduleId, appKey)
 
       // Then
       expect(got).toEqual({
         title: extension.configuration.name,
         description: extension.configuration.description,
+        app_key: appKey,
         api_type: 'order_discounts',
         api_version: extension.configuration.apiVersion,
         ui: {
@@ -1146,16 +1148,18 @@ describe('functionConfiguration', () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const moduleId = 'module_id'
+      const appKey = 'app-key'
       extension.configuration.input = undefined
       extension.configuration.ui = undefined
 
       // When
-      const got = await functionConfiguration(extension, moduleId)
+      const got = await functionConfiguration(extension, moduleId, appKey)
 
       // Then
       expect(got).toEqual({
         title: extension.configuration.name,
         description: extension.configuration.description,
+        app_key: appKey,
         api_type: 'order_discounts',
         api_version: extension.configuration.apiVersion,
         module_id: moduleId,

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -447,7 +447,11 @@ async function getFunctionExtensionUploadURL(
   return res.data.uploadUrlGenerate
 }
 
-export async function functionConfiguration(extension: FunctionExtension, moduleId: string): Promise<object> {
+export async function functionConfiguration(
+  extension: FunctionExtension,
+  moduleId: string,
+  appKey: string,
+): Promise<object> {
   let inputQuery: string | undefined
   if (await fileExists(extension.inputQueryPath)) {
     inputQuery = await readFile(extension.inputQueryPath)
@@ -457,6 +461,7 @@ export async function functionConfiguration(extension: FunctionExtension, module
     title: extension.configuration.name,
     module_id: moduleId,
     description: extension.configuration.description,
+    app_key: appKey,
     api_type: extension.configuration.type,
     api_version: extension.configuration.apiVersion,
     input_query: inputQuery,


### PR DESCRIPTION
### WHY are these changes introduced?
#gsd:30370

We added a new `appKey` field to the function extension config.

### WHAT is this pull request doing?

Include the `appKey` field in the function configuration payload.

### How to test your changes?

Deploy a function with the unified app deployments beta set and make sure it works

<img width="737" alt="image" src="https://github.com/Shopify/cli/assets/28009669/84a8e461-81b3-47ab-8c4d-0c6f317b6108">

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] ~~I've considered possible cross-platform impacts (Mac, Linux, Windows)~~
- [X] ~~I've considered possible [documentation](https://shopify.dev) changes~~
- [X] ~~I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).~~
