### PR TITLE
Set current CLI3 version as the version used by the cli-ruby API requests

### DIFF
--- a/.changeset/funny-snails-give.md
+++ b/.changeset/funny-snails-give.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Set current CLI3 version as the version used by the cli-ruby API requests

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/version.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = ENV.fetch("SHOPIFY_CLI_VERSION")
+  VERSION = ENV.fetch("SHOPIFY_CLI_VERSION", "2.34.0")
 end

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/version.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = ENV.fetch("SHOPIFY_CLI_VERSION", "2.34.0")
+  VERSION = ENV.fetch("SHOPIFY_CLI_VERSION")
 end

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/version.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.34.0"
+  VERSION = ENV.fetch("SHOPIFY_CLI_VERSION", "2.34.0")
 end

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/version.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = ENV.fetch("SHOPIFY_CLI_VERSION", "2.34.0")
+  VERSION = ENV.fetch("SHOPIFY_CLI_VERSION", "3.46.0")
 end

--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -12,6 +12,7 @@ import {AdminSession} from '../../public/node/session.js'
 import {outputContent, outputToken} from '../../public/node/output.js'
 import {isTruthy} from '../../private/node/context/utilities.js'
 import {coerceSemverVersion} from '../../private/node/semver.js'
+import {CLI_KIT_VERSION} from '../common/version.js'
 import envPaths from 'env-paths'
 import {Writable} from 'stream'
 import {fileURLToPath} from 'url'
@@ -66,6 +67,7 @@ export async function execCLI2(args: string[], options: ExecCLI2Options = {}): P
     BUNDLE_GEMFILE: joinPath(await shopifyCLIDirectory(embedded), 'Gemfile'),
     ...(await getSpinEnvironmentVariables()),
     SHOPIFY_CLI_1P_DEV: firstPartyDev() ? '1' : '0',
+    SHOPIFY_CLI_VERSION: CLI_KIT_VERSION,
   }
 
   try {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes partially https://github.com/Shopify/internal-cli-foundations/issues/633
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Set a new env variable `SHOPIFY_CLI_VERSION` when a cli-ruby command is executed
- cli-ruby api requests use the SHOPIFY_CLI_VERSION version to set the proper cli version header when it makes API request
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new partners instance from this branch `spin up partners -c partners.branch=filter-request-from-old-cli-version`
- Using an app with a TAE, run the CLI3  `dev` command against spin `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name) yarn shopify app dev` and it should work as usual
- Using an app with a TAE, run the CLI3  `dev` command against production services `yarn shopify app dev` and  it should work as usual
- Run any `theme` command against production services and it should work as usual

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
