### PR TITLE
134 add localizable label dev server kit

### DIFF
--- a/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.test.ts
@@ -10,7 +10,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 describe('ui_extension', async () => {
   interface GetUIExtensionProps {
     directory: string
-    extensionPoints?: {target: string; module: string}[]
+    extensionPoints?: {target: string; module: string; label?: string}[]
   }
 
   async function getTestUIExtension({directory, extensionPoints}: GetUIExtensionProps) {

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
@@ -177,9 +177,14 @@ describe('ExtensionServerClient', () => {
             uuid: '123',
             type: 'ui_extension',
             localization,
-            extensionPoints: [{localization}],
+            extensionPoints: [{localization, label: 't:welcome'}],
           },
-          {uuid: '456', type: 'ui_extension', localization: null, extensionPoints: [{localization: null}]},
+          {
+            uuid: '456',
+            type: 'ui_extension',
+            localization: null,
+            extensionPoints: [{localization: null, label: 'Fixed label'}],
+          },
           {uuid: '789', type: 'product_subscription'},
         ],
       }
@@ -195,13 +200,18 @@ describe('ExtensionServerClient', () => {
               uuid: '123',
               type: 'ui_extension',
               localization: translatedLocalization,
-              extensionPoints: [{localization: translatedLocalization}],
+              extensionPoints: [
+                {
+                  localization: translatedLocalization,
+                  label: 'いらっしゃいませ!',
+                },
+              ],
             },
             {
               uuid: '456',
               type: 'ui_extension',
               localization: null,
-              extensionPoints: [{localization: null}],
+              extensionPoints: [{localization: null, label: 'Fixed label'}],
             },
             {uuid: '789', type: 'product_subscription'},
           ],
@@ -289,9 +299,14 @@ describe('ExtensionServerClient', () => {
             uuid: '123',
             type: 'ui_extension',
             localization,
-            extensionPoints: [{localization}],
+            extensionPoints: [{localization, label: 't:welcome'}],
           },
-          {uuid: '456', type: 'ui_extension', localization: null, extensionPoints: [{localization: null}]},
+          {
+            uuid: '456',
+            type: 'ui_extension',
+            localization: null,
+            extensionPoints: [{localization: null, label: 'Fixed label'}],
+          },
           {uuid: '789', type: 'product_subscription'},
         ],
       }
@@ -341,7 +356,7 @@ describe('ExtensionServerClient', () => {
             uuid: '123',
             type: 'ui_extension',
             localization,
-            extensionPoints: [{localization}],
+            extensionPoints: [{localization, label: 't:welcome'}],
           },
           {uuid: '456', type: 'ui_extension', localization: null, extensionPoints: [{localization: null}]},
           {uuid: '789', type: 'product_subscription'},
@@ -359,7 +374,7 @@ describe('ExtensionServerClient', () => {
               uuid: '123',
               type: 'ui_extension',
               localization: translatedLocalization,
-              extensionPoints: [{localization: translatedLocalization}],
+              extensionPoints: [{localization: translatedLocalization, label: 'いらっしゃいませ!'}],
             },
             {
               uuid: '456',
@@ -482,7 +497,14 @@ describe('ExtensionServerClient', () => {
       }
 
       client.persist('update', {
-        extensions: [{uuid: '123', type: 'ui_extension', localization: {}, extensionPoints: [{localization: {}}]}],
+        extensions: [
+          {
+            uuid: '123',
+            type: 'ui_extension',
+            localization: {},
+            extensionPoints: [{localization: {}, label: 'いらっしゃいませ!'}],
+          },
+        ],
       })
 
       await expect(socket).toReceiveMessage(data)

--- a/packages/ui-extensions-server-kit/src/i18n.ts
+++ b/packages/ui-extensions-server-kit/src/i18n.ts
@@ -67,7 +67,7 @@ export interface ExtensionTranslationMap {
   [key: string]: string
 }
 
-export const TRANSLATED_KEYS = ['localization']
+export const TRANSLATED_KEYS = ['localization', 'label']
 /**
  * From a nested dictionary like the following :
  *


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [#134](https://github.com/Shopify/app-ui/issues/134)

Add localizable label on dev server kit, enabling this feature when running `dev.

### WHAT is this pull request doing?
- Added `label` and `original_label` to `ExtensionPoint type`.
- Translate base in the user locale the label and keep original label to recover the value.
- Remove the translated value and rollback to original value when persisting.

### How to test your changes?

It isn't possible to do an end-to-end test at this stage (follow up PRs in Web will be tested end-to-end). The unit tests should be sufficient.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
