### PR TITLE
Fix paths for UI extension templates

### DIFF
--- a/packages/app/src/cli/models/templates/theme-specifications/theme.ts
+++ b/packages/app/src/cli/models/templates/theme-specifications/theme.ts
@@ -17,7 +17,7 @@ const themeExtension: ExtensionTemplate = {
         {
           name: 'Liquid',
           value: 'liquid',
-          path: 'packages/app/templates/theme-extension',
+          path: 'templates/theme-extension',
         },
       ],
     },

--- a/packages/app/src/cli/models/templates/ui-specifications/checkout_post_purchase.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/checkout_post_purchase.ts
@@ -14,7 +14,7 @@ const checkoutPostPurchaseExtension: ExtensionTemplate = {
       url: 'https://github.com/Shopify/cli',
       type: 'checkout_post_purchase',
       extensionPoints: [],
-      supportedFlavors: uiFlavors('packages/app/templates/ui-extensions/projects/checkout_post_purchase'),
+      supportedFlavors: uiFlavors('templates/ui-extensions/projects/checkout_post_purchase'),
     },
   ],
 }

--- a/packages/app/src/cli/models/templates/ui-specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/checkout_ui_extension.ts
@@ -14,7 +14,7 @@ const checkoutUIExtension: ExtensionTemplate = {
       url: 'https://github.com/Shopify/cli',
       type: 'checkout_ui_extension',
       extensionPoints: [],
-      supportedFlavors: uiFlavors('packages/app/templates/ui-extensions/projects/checkout_ui_extension'),
+      supportedFlavors: uiFlavors('templates/ui-extensions/projects/checkout_ui_extension'),
     },
   ],
 }

--- a/packages/app/src/cli/models/templates/ui-specifications/customer_accounts_ui_extension.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/customer_accounts_ui_extension.ts
@@ -14,7 +14,7 @@ const customerAccountsUIExtension: ExtensionTemplate = {
       url: 'https://github.com/Shopify/cli',
       type: 'customer_accounts_ui_extension',
       extensionPoints: [],
-      supportedFlavors: uiFlavors('packages/app/templates/ui-extensions/projects/customer_accounts_ui_extension'),
+      supportedFlavors: uiFlavors('templates/ui-extensions/projects/customer_accounts_ui_extension'),
     },
   ],
 }

--- a/packages/app/src/cli/models/templates/ui-specifications/pos_ui_extension.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/pos_ui_extension.ts
@@ -14,7 +14,7 @@ const posUIExtension: ExtensionTemplate = {
       url: 'https://github.com/Shopify/cli',
       type: 'pos_ui_extension',
       extensionPoints: [],
-      supportedFlavors: uiFlavors('packages/app/templates/ui-extensions/projects/pos_ui_extension'),
+      supportedFlavors: uiFlavors('templates/ui-extensions/projects/pos_ui_extension'),
     },
   ],
 }

--- a/packages/app/src/cli/models/templates/ui-specifications/product_subscription.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/product_subscription.ts
@@ -14,7 +14,7 @@ const productSubscriptionUIExtension: ExtensionTemplate = {
       url: 'https://github.com/Shopify/cli',
       type: 'product_subscription',
       extensionPoints: [],
-      supportedFlavors: uiFlavors('packages/app/templates/ui-extensions/projects/product_subscription'),
+      supportedFlavors: uiFlavors('templates/ui-extensions/projects/product_subscription'),
     },
   ],
 }

--- a/packages/app/src/cli/models/templates/ui-specifications/tax_calculation.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/tax_calculation.ts
@@ -17,7 +17,7 @@ const taxCalculationUIExtension: ExtensionTemplate = {
         {
           name: 'Config only',
           value: 'config-only',
-          path: 'packages/app/templates/ui-extensions/projects/tax_calculation',
+          path: 'templates/ui-extensions/projects/tax_calculation',
         },
       ],
     },

--- a/packages/app/src/cli/models/templates/ui-specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/ui_extension.ts
@@ -14,7 +14,7 @@ const UIExtension: ExtensionTemplate = {
       url: 'https://github.com/Shopify/cli',
       type: 'ui_extension',
       extensionPoints: [],
-      supportedFlavors: uiFlavors('packages/app/templates/ui-extensions/projects/ui_extension'),
+      supportedFlavors: uiFlavors('templates/ui-extensions/projects/ui_extension'),
     },
   ],
 }

--- a/packages/app/src/cli/models/templates/ui-specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/web_pixel_extension.ts
@@ -17,12 +17,12 @@ const webPixelUIExtension: ExtensionTemplate = {
         {
           name: 'TypeScript',
           value: 'typescript',
-          path: 'packages/app/templates/ui-extensions/projects/web_pixel_extension',
+          path: 'templates/ui-extensions/projects/web_pixel_extension',
         },
         {
           name: 'JavaScript',
           value: 'vanilla-js',
-          path: 'packages/app/templates/ui-extensions/projects/web_pixel_extension',
+          path: 'templates/ui-extensions/projects/web_pixel_extension',
         },
       ],
     },


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/pull/1941

The extension generation is broken for UI extensions from the nightly release because we are searching for paths starting with `packages/app`, which is present locally, but not in the bundled package.

### WHAT is this pull request doing?

Leave the part of the path that is present in the bundle. It will work anyway because we are looking for that path in the parent folders, it's not an absolute path.

### How to test your changes?

- `p shopify app generate extension --type=subscription_ui`
- Release the nightly and test with that version

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
