### PR TITLE
Fix JS function generation

### DIFF
--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -128,7 +128,7 @@ async function functionExtensionInit({directory, url, app, name, extensionFlavor
     task: async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const templateDirectory = await downloadOrFindTemplateDirectory(url, extensionFlavor, tmpDir)
-        await recursiveLiquidTemplateCopy(templateDirectory, directory, {name})
+        await recursiveLiquidTemplateCopy(templateDirectory, directory, {name, flavor: extensionFlavor?.value})
       })
 
       if (templateLanguage === 'javascript') {


### PR DESCRIPTION
### WHY are these changes introduced?

Since https://github.com/Shopify/cli/pull/1941, the generation of Javascript/Typescript functions is broken. It's generating an empty index.js/index.ts.

### WHAT is this pull request doing?

Add missing liquid variable to generate JS functions

### How to test your changes?

- `p shopify app generate extension --type=product_discounts --name=prod-discount --template=typescript --path ~`
- Check that the generated src/index.ts contains the corresponding code from [this template](https://github.com/Shopify/function-examples/blob/main/discounts/javascript/product-discounts/default/src/index.liquid)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
