### PR TITLE
Make the generic ui extensions previewable

### DIFF
--- a/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/ui-specifications/ui_extension.ts
@@ -27,6 +27,7 @@ const spec = createUIExtensionSpecification({
   partnersWebIdentifier: 'ui_extension',
   singleEntryPath: false,
   schema: UIExtensionSchema,
+  isPreviewable: true,
   validate: async (config, directory) => {
     return validateUIExtensionPointConfig(directory, config.extensionPoints)
   },


### PR DESCRIPTION
Generic UI Extension needs to be previewable so that we don't upload the draft while running dev.