### PR TITLE
Use `stdout: inherit` when running javy

### DIFF
--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -145,8 +145,8 @@ describe('runJavy', () => {
       ],
       {
         cwd: ourFunction.directory,
-        stderr,
-        stdout,
+        stderr: 'inherit',
+        stdout: 'inherit',
         signal,
       },
     )

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -109,8 +109,8 @@ function getESBuildOptions(directory: string, entryPoint: string, userFunction: 
 export async function runJavy(fun: FunctionExtension, options: JSFunctionBuildOptions) {
   return exec('npm', ['exec', '--', 'javy', 'compile', '-d', '-o', fun.buildWasmPath, 'dist/function.js'], {
     cwd: fun.directory,
-    stdout: options.stdout,
-    stderr: options.stderr,
+    stdout: 'inherit',
+    stderr: 'inherit',
     signal: options.signal,
   })
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Apparently, the cli crashes running deploy using the javascript debug terminal when there is a JS function. This is because of the `stdout` config used when running `javy`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Force `javy` to run using `inherit` 
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create an app with a JS function
- run deploy inside vscode's javascript debug terminal
- Also test running function build and function run

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
