### PR TITLE
Fetch templates with api key

### DIFF
--- a/.changeset/kind-melons-swim.md
+++ b/.changeset/kind-melons-swim.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Add api key to template specifications query

--- a/packages/app/src/cli/api/graphql/template_specifications.ts
+++ b/packages/app/src/cli/api/graphql/template_specifications.ts
@@ -2,8 +2,8 @@ import {ExtensionTemplate} from '../../models/app/template.js'
 import {gql} from 'graphql-request'
 
 export const RemoteTemplateSpecificationsQuery = gql`
-  query RemoteTemplateSpecifications($version: String) {
-    templateSpecifications(version: $version) {
+  query RemoteTemplateSpecifications($version: String, $apiKey: String) {
+    templateSpecifications(version: $version, apiKey: $apiKey) {
       identifier
       name
       group

--- a/packages/app/src/cli/services/generate.ts
+++ b/packages/app/src/cli/services/generate.ts
@@ -44,7 +44,7 @@ async function generate(options: GenerateOptions) {
   const specifications = await fetchSpecifications({token, apiKey, config: options.config})
   const app: AppInterface = await loadApp({directory: options.directory, specifications})
   const availableSpecifications = specifications.map((spec) => spec.identifier)
-  const extensionTemplates = await fetchExtensionTemplates(token, availableSpecifications)
+  const extensionTemplates = await fetchExtensionTemplates(token, apiKey, availableSpecifications)
 
   const promptOptions = await buildPromptOptions(extensionTemplates, specifications, app, options)
   const promptAnswers = await generateExtensionPrompts(promptOptions)

--- a/packages/app/src/cli/services/generate/fetch-template-specifications.test.ts
+++ b/packages/app/src/cli/services/generate/fetch-template-specifications.test.ts
@@ -13,7 +13,7 @@ describe('fetchTemplateSpecifications', () => {
     const enabledLocalTemplates = ['checkout_ui_extension', 'theme']
 
     // When
-    const got: ExtensionTemplate[] = await fetchExtensionTemplates('token', enabledLocalTemplates)
+    const got: ExtensionTemplate[] = await fetchExtensionTemplates('token', 'apiKey', enabledLocalTemplates)
 
     // Then
     expect(got.length).toEqual(6)

--- a/packages/app/src/cli/services/generate/fetch-template-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-template-specifications.ts
@@ -16,11 +16,13 @@ import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 
 export async function fetchExtensionTemplates(
   token: string,
+  apiKey: string,
   availableSpecifications: string[],
 ): Promise<ExtensionTemplate[]> {
   const remoteTemplates: RemoteTemplateSpecificationsQuerySchema = await partnersRequest(
     RemoteTemplateSpecificationsQuery,
     token,
+    {apiKey},
   )
   const localTemplates = localExtensionTemplates(availableSpecifications)
   return remoteTemplates.templateSpecifications.concat(localTemplates)


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/internal-cli-foundations/issues/635

### WHAT is this pull request doing?

Adds the api key to the template specifications query, so that the server can filter out templates under a beta flag.

### How to test your changes?

- `p shopify app generate extension --path ~/your-app`

To test with a beta flag:
- `spin up partners`
- `spin code --latest partners`
- Edit `app/operations/apps/templates/specifications/base.rb` and add `organization_beta_flags: ['tax_calculation']` to any template specification
- `SHOPIFY_SERVICE_ENV=spin p shopify app generate extension --path ~/your-app` with/without the `Tax Calculation App Extension` beta flag enabled for your org (it should show/hide the template)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
