### PR TITLE
Also run webhook requests in frontend-only apps

### DIFF
--- a/.changeset/tall-cycles-think.md
+++ b/.changeset/tall-cycles-think.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix APP_UNINSTALLED webhook triggered on app reset so it also works for frontend-only apps

--- a/packages/app/src/cli/services/webhook/send-app-uninstalled-webhook.ts
+++ b/packages/app/src/cli/services/webhook/send-app-uninstalled-webhook.ts
@@ -31,6 +31,7 @@ export async function sendUninstallWebhookToAppServer(
 
   options.stdout.write('Sending APP_UNINSTALLED webhook to app server')
 
+  await sleep(3)
   const result = await triggerWebhook(options, sample)
 
   options.stdout.write(result ? 'APP_UNINSTALLED webhook delivered' : 'APP_UNINSTALLED webhook delivery failed')


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, we run the `APP_UNINSTALLED` webhook when the CLI switches apps, so that we can clean up the database and trigger a new install flow.

The issue here was that the CLI was assuming a `backend` config would always be present, which isn't necessarily true, since apps can sometimes use only `frontend` configs.

### WHAT is this pull request doing?

Ensuring that the webhook flow also works for frontend-only apps, preferring the backend config when present.

I've also added a 3s backoff period before firing the first attempt to give the app some time to spin up before we start trying, since it's almost guaranteed that the first try will fail if we fire it right away.

### How to test your changes?

Run `dev --reset` and ensure the webhook is fired and received.

### Post-release steps

None!

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
