### PR TITLE
Show deploy confirmation prompt when deployments is enabled and no local extensions

### DIFF
--- a/.changeset/eighty-waves-brake.md
+++ b/.changeset/eighty-waves-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Show deploy confirmation prompt when deploying with no local extensions

--- a/packages/app/src/cli/services/context/identifiers.test.ts
+++ b/packages/app/src/cli/services/context/identifiers.test.ts
@@ -263,3 +263,46 @@ describe('ensureDeploymentIdsPresence: matchmaking is valid', () => {
     })
   })
 })
+
+describe('app has no local extensions', () => {
+  test('ensureDeploymentIdsPresence() returns early when deploymentMode is legacy', async () => {
+    // When
+    const got = await ensureDeploymentIdsPresence(options([], []))
+
+    // Then
+    expect(fetchAppExtensionRegistrations).not.toHaveBeenCalled()
+    expect(ensureFunctionsIds).not.toHaveBeenCalled()
+    expect(ensureExtensionsIds).not.toHaveBeenCalled()
+    expect(got).toEqual({app: 'appId', extensions: {}, extensionIds: {}})
+  })
+
+  test('ensureDeploymentIdsPresence() fully executes when deploymentMode is unified', async () => {
+    // Given
+    vi.mocked(ensureExtensionsIds).mockResolvedValue(ok({extensions: {}, extensionIds: {}}))
+
+    // When
+    const got = await ensureDeploymentIdsPresence(
+      options([], [], {}, PARTNERS_APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA, 'unified'),
+    )
+
+    // Then
+    expect(fetchAppExtensionRegistrations).toHaveBeenCalledOnce()
+    expect(ensureExtensionsIds).toHaveBeenCalledOnce()
+    expect(got).toEqual({app: 'appId', extensions: {}, extensionIds: {}})
+  })
+
+  test('ensureDeploymentIdsPresence() fully executes when deploymentMode is unified-skip-release', async () => {
+    // Given
+    vi.mocked(ensureExtensionsIds).mockResolvedValue(ok({extensions: {}, extensionIds: {}}))
+
+    // When
+    const got = await ensureDeploymentIdsPresence(
+      options([], [], {}, PARTNERS_APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA, 'unified-skip-release'),
+    )
+
+    // Then
+    expect(fetchAppExtensionRegistrations).toHaveBeenCalledOnce()
+    expect(ensureExtensionsIds).toHaveBeenCalledOnce()
+    expect(got).toEqual({app: 'appId', extensions: {}, extensionIds: {}})
+  })
+})

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -38,8 +38,9 @@ export interface LocalSource {
 export type MatchingError = 'pending-remote' | 'invalid-environment' | 'user-cancelled'
 
 export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPresenceOptions) {
-  // We need local extensions to deploy
-  if (!options.app.hasExtensions()) return {app: options.appId, extensions: {}, extensionIds: {}}
+  // We need local extensions to deploy when deploymentMode is 'legacy'
+  if (!options.app.hasExtensions() && options.deploymentMode === 'legacy')
+    return {app: options.appId, extensions: {}, extensionIds: {}}
 
   const remoteSpecifications = await fetchAppExtensionRegistrations({token: options.token, apiKey: options.appId})
 

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -81,10 +81,6 @@ export async function deployConfirmationPrompt(
     infoTable.push(missingLocallySection)
   }
 
-  if (Object.keys(infoTable).length === 0) {
-    return new Promise((resolve) => resolve(true))
-  }
-
   const confirmationMessage = (() => {
     switch (deploymentMode) {
       case 'legacy':


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-foundations/issues/282

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
When the deployments beta is enabled, the deploy confirmation prompt will be shown to users regardless of whether their local app has local extensions.

### How to test your changes?

1. Create an app with no extensions
2. Run `app deploy` and verify that the deploy confirmation prompt is not shown
3. Enable the deployments beta flag
4. Run `app deploy` and verify that the deploy confirmation prompt is shown

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
