### PR TITLE
Fix app loader error message when not specification found

### DIFF
--- a/.changeset/small-fishes-sleep.md
+++ b/.changeset/small-fishes-sleep.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix app loader error message when not specification is found

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -293,7 +293,11 @@ class AppLoader {
 
     const extensions = configPaths.map(async (configurationPath) => {
       const directory = dirname(configurationPath)
-      const specification = await findSpecificationForConfig(this.specifications, configurationPath, this.abortOrReport)
+      const specification = await findSpecificationForConfig(
+        this.specifications,
+        configurationPath,
+        this.abortOrReport.bind(this),
+      )
 
       if (!specification) return
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When you run any command for an app that includes an extension and the specification for the type inside the `shopify.ui.extension.toml` is not found, an error like this should be shown:

```sh
╭─ error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                              │
│  Unknown extension type web_pixel_extension2 in                                                                              │
│  /Users/alvarogutierrez/cli-apps/0531-webpixel/extensions/web-pixel/shopify.ui.extension.toml.                               │
│  You might need to enable some beta flags on your Organization or App                                                        │
│                                                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

However right now an error with stack trace information is displayed:

```sh
╭─ error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                              │
│  Cannot read properties of undefined (reading 'mode')                                                                        │
│                                                                                                                              │
│  To investigate the issue, examine this stack trace:                                                                         │
│    at abortOrReport (app/src/cli/models/app/loader.ts:426)                                                                   │
│      if (this.mode === 'strict') {                                                                                           │
│    at findSpecificationForConfig (app/src/cli/models/app/loader.ts:112)                                                      │
│      abortOrReport(                                                                                                          │
│    at (app/dist/cli/models/app/loader.js:197)                                                                                │
│    at all                                                                                                                    │
│    at loadUIExtensions (app/src/cli/models/app/loader.ts:354)                                                                │
│      const uiExtensions = getArrayRejectingUndefined(await Promise.all(extensions))                                          │
│    at loaded (app/src/cli/models/app/loader.ts:197)                                                                          │
│      const {uiExtensions, usedCustomLayout: usedCustomLayoutForUIExtensions} = await this.loadUIExtensions(                  │
│    at run (app/src/cli/commands/app/build.ts:38)                                                                             │
│      const app: AppInterface = await loadApp({specifications, directory: flags.path})                                        │
│                                                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Fix the way the way the method `abortOrReport` is passed as parameter

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Use an app with an extension and modify the `type` inside the `shopify.ui.extension.toml`  file to a non existing value
- Run `npm run shopify app build` and the proper erro should be shown

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
