### PR TITLE
Add warning message to deploy

### DIFF
--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -15,7 +15,7 @@ import {Extension, FunctionExtension} from '../models/app/extensions.js'
 import {OrganizationApp} from '../models/organization.js'
 import {validateExtensions} from '../validators/extensions.js'
 import {AllAppExtensionRegistrationsQuerySchema} from '../api/graphql/all_app_extension_registrations.js'
-import {renderInfo, renderSuccess, renderTasks} from '@shopify/cli-kit/node/ui'
+import {renderInfo, renderSuccess, renderTasks, renderWarning} from '@shopify/cli-kit/node/ui'
 import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
 import {outputNewline, outputInfo} from '@shopify/cli-kit/node/output'
@@ -43,6 +43,12 @@ interface TasksContext {
 }
 
 export async function deploy(options: DeployOptions) {
+  renderWarning({
+    headline: ['Stay tuned for changes to', {command: 'deploy'}, {char: '.'}],
+    body: "With the next CLI release, you'll have a cleaner way of releasing your extensions.\n\nYou'll be able to release all your extensions straight from the CLI. And you'll be able to track changes with app versions",
+    reference: [{link: {url: '', label: 'Introducing Deployments 2.0'}}],
+  })
+
   // eslint-disable-next-line prefer-const
   let {app, identifiers, partnersApp, token} = await ensureDeployContext(options)
   const apiKey = identifiers.app

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -15,7 +15,7 @@ import {Extension, FunctionExtension} from '../models/app/extensions.js'
 import {OrganizationApp} from '../models/organization.js'
 import {validateExtensions} from '../validators/extensions.js'
 import {AllAppExtensionRegistrationsQuerySchema} from '../api/graphql/all_app_extension_registrations.js'
-import {renderInfo, renderSuccess, renderTasks, renderWarning} from '@shopify/cli-kit/node/ui'
+import {renderInfo, renderSuccess, renderTasks} from '@shopify/cli-kit/node/ui'
 import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
 import {outputNewline, outputInfo} from '@shopify/cli-kit/node/output'
@@ -43,10 +43,12 @@ interface TasksContext {
 }
 
 export async function deploy(options: DeployOptions) {
-  renderWarning({
+  renderInfo({
     headline: ['Stay tuned for changes to', {command: 'deploy'}, {char: '.'}],
-    body: "With the next CLI release, you'll have a cleaner way of releasing your extensions.\n\nYou'll be able to release all your extensions straight from the CLI. And you'll be able to track changes with app versions",
-    reference: [{link: {url: '', label: 'Introducing Deployments 2.0'}}],
+    body: "When you upgrade to the late July CLI version, you'll be able to release all your extensions straight from the CLI. To track changes, you'll have a record of each app version you deploy.",
+    reference: [
+      {link: {url: 'https://shopify.dev/docs/apps/deployment/deployments-2.0', label: 'Introducing Deployments 2.0'}},
+    ],
   })
 
   // eslint-disable-next-line prefer-const


### PR DESCRIPTION
Fixes https://github.com/Shopify/app-deploys/issues/514

We want to notify users that changes are coming to deployments. This banner still lacks the URL so either way for it if it's going to come soon or ship it without the `Reference` section for now.

<img width="942" alt="Screenshot 2023-06-05 at 11 22 45" src="https://github.com/Shopify/cli/assets/151725/75129f5d-acd5-47fe-bfc2-d904dc792139">