### PR TITLE
Bump the version and add the caret to version

### DIFF
--- a/packages/app/templates/ui-extensions/projects/pos_ui_extension/package.json.liquid
+++ b/packages/app/templates/ui-extensions/projects/pos_ui_extension/package.json.liquid
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/retail-ui-extensions-react": "1.0.1"
+    "@shopify/retail-ui-extensions-react": "^1.1.2"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -19,7 +19,7 @@
   "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/retail-ui-extensions": "1.0.1"
+    "@shopify/retail-ui-extensions": "^1.1.2"
   }
 }
 {%- endif -%}


### PR DESCRIPTION
### WHY are these changes introduced?

- Now that https://github.com/Shopify/pos-next-react-native/issues/20483 is merged, the caret can be added back.
- Used latest version. 

### How to test your changes?

Scaffold a POS UI Extension. 

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
