### PR TITLE
Fix an issue in `shopify theme dev` and `shopify app dev` that was affecting image loading on local servers

### DIFF
--- a/.changeset/blue-carpets-sin.md
+++ b/.changeset/blue-carpets-sin.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+Fix an issue in `shopify theme dev` and `shopify app dev` that was affecting image loading on local servers

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/local_assets.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/local_assets.rb
@@ -4,8 +4,9 @@ module ShopifyCLI
   module Theme
     class DevServer
       class LocalAssets
-        THEME_REGEX = %r{//cdn\.shopify\.com/s/.+?/(assets/.+?\.(?:css|js))}
-        VANITY_THEME_REGEX = %r{/cdn/shop/.+?/(assets/.+?\.(?:css|js))}
+        SUPPORTED_EXTENSIONS = %i(jpg jpeg js css png svg).join('|')
+        THEME_REGEX = %r{//cdn\.shopify\.com/s/.+?/(assets/.+?\.(?:#{SUPPORTED_EXTENSIONS}))}
+        VANITY_THEME_REGEX = %r{/cdn/shop/.+?/(assets/.+?\.(?:#{SUPPORTED_EXTENSIONS}))}
 
         class FileBody
           def initialize(path)

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/extension/dev_server/local_assets.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/extension/dev_server/local_assets.rb
@@ -7,7 +7,8 @@ module ShopifyCLI
     module Extension
       class DevServer < ShopifyCLI::Theme::DevServer
         class LocalAssets < ShopifyCLI::Theme::DevServer::LocalAssets
-          TAE_ASSET_REGEX = %r{(http:|https:)?//cdn\.shopify\.com/extensions/.+?/(assets/.+?\.(?:css|js))}
+          SUPPORTED_EXTENSIONS = %i(jpg jpeg js css png svg).join('|')
+          TAE_ASSET_REGEX = %r{(http:|https:)?//cdn\.shopify\.com/extensions/.+?/(assets/.+?\.(?:#{SUPPORTED_EXTENSIONS}))}
 
           private
 

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/local_assets_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/local_assets_test.rb
@@ -109,15 +109,55 @@ module ShopifyCLI
           assert_equal("Not found", response.body)
         end
 
+        def test_replace_local_images_in_reponse_body
+          theme = stub("Theme", static_asset_paths: [
+            'assets/test-image.png',
+            'assets/test-image.png',
+            'assets/test-image.jpeg',
+            'assets/test-image.jpg',
+            'assets/test-vector.svg',
+            'assets/folha_de_estilo.css',
+            'assets/script.js',
+            'assets/static_object.json',
+          ])
+
+          original_html = <<~HTML
+            <html>
+              <body>
+                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/test-image.png?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/test-image.jpeg?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/test-image.jpg?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/test-vector.svg?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/folha_de_estilo.css?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/script.js?v=111111111111"></div>
+              </body>
+            </html>
+          HTML
+          expected_html = <<~HTML
+            <html>
+              <body>
+                <div data-src="/assets/test-image.png?v=111111111111"></div>
+                <div data-src="/assets/test-image.jpeg?v=111111111111"></div>
+                <div data-src="/assets/test-image.jpg?v=111111111111"></div>
+                <div data-src="/assets/test-vector.svg?v=111111111111"></div>
+                <div data-src="/assets/folha_de_estilo.css?v=111111111111"></div>
+                <div data-src="/assets/script.js?v=111111111111"></div>
+              </body>
+            </html>
+          HTML
+
+          assert_equal(expected_html, serve(original_html, theme_mock: theme).body)
+        end
+
         private
 
-        def serve(response_body, path: "/")
+        def serve(response_body, path: "/", theme_mock: nil)
           app = lambda do |_env|
             [200, {}, [response_body]]
           end
           root = ShopifyCLI::ROOT + "/test/fixtures/theme"
           ctx = TestHelpers::FakeContext.new(root: root)
-          theme = Theme.new(ctx, root: root)
+          theme = theme_mock || Theme.new(ctx, root: root)
           stack = LocalAssets.new(ctx, app, theme)
           request = Rack::MockRequest.new(stack)
           request.get(path)

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server/local_assets_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server/local_assets_test.rb
@@ -109,15 +109,56 @@ module ShopifyCLI
             assert_equal("Not found", response.body)
           end
 
+
+        def test_replace_local_images_in_reponse_body
+          extension = stub("Extension", static_asset_paths: [
+            'assets/test-image.png',
+            'assets/test-image.png',
+            'assets/test-image.jpeg',
+            'assets/test-image.jpg',
+            'assets/test-vector.svg',
+            'assets/folha_de_estilo.css',
+            'assets/script.js',
+            'assets/static_object.json',
+          ])
+
+          original_html = <<~HTML
+            <html>
+              <body>
+                <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/test-image.png?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/test-image.jpeg?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/test-image.jpg?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/test-vector.svg?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/folha_de_estilo.css?v=111111111111"></div>
+                <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/script.js?v=111111111111"></div>
+              </body>
+            </html>
+          HTML
+          expected_html = <<~HTML
+            <html>
+              <body>
+                <div data-src="/assets/test-image.png?v=111111111111"></div>
+                <div data-src="/assets/test-image.jpeg?v=111111111111"></div>
+                <div data-src="/assets/test-image.jpg?v=111111111111"></div>
+                <div data-src="/assets/test-vector.svg?v=111111111111"></div>
+                <div data-src="/assets/folha_de_estilo.css?v=111111111111"></div>
+                <div data-src="/assets/script.js?v=111111111111"></div>
+              </body>
+            </html>
+          HTML
+
+          assert_equal(expected_html, serve(original_html, extension_mock: extension).body)
+        end
+
           private
 
-          def serve(response_body, path: "/")
+          def serve(response_body, path: "/", extension_mock: nil)
             app = lambda do |_env|
               [200, {}, [response_body]]
             end
             root = ShopifyCLI::ROOT + "/test/fixtures/extension"
             ctx = TestHelpers::FakeContext.new(root: root)
-            extension = AppExtension.new(ctx, root: root)
+            extension = extension_mock || AppExtension.new(ctx, root: root)
             stack = LocalAssets.new(ctx, app, extension)
             request = Rack::MockRequest.new(stack)
             request.get(path)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2094

### WHAT is this pull request doing?

This PR modifies the regex for the assets middleware in both `shopify theme dev` and `shopify app dev`. This change allows images to load directly from the disk when users access the local server (`http://127.0.0.1:9292`), rather than pointing to the CDN URLs.

### How to test your changes?

- Run `shopify theme dev`
- Add an image called `test-image-1.jpg` in the `/assets` directory
- Add an snippet like `<img src="{{ 'test-image-1.jpg' | asset_url }}">` in the `sections/announcement-bar.liquid` file
- Open `http://127.0.0.1:9292`
- Notice that images load from the local server now

**Before**
<img src="https://github.com/Shopify/cli/assets/1079279/db6f5b37-480f-43cc-bb0c-a95451efe725" width="60%" />

**After**
<img src="https://github.com/Shopify/cli/assets/1079279/0c65c5b7-05d6-487f-a63f-1692268547b9" width="60%" />


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
