### PR TITLE
[Feature] Add Flow Extensions to the CLI

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_action.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_action.ts
@@ -1,0 +1,52 @@
+import {BaseSchema} from '../schemas.js'
+import {createExtensionSpecification} from '../specification.js'
+
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const FlowActionExtensionSchema = BaseSchema.extend({
+  name: zod.string(),
+  type: zod.literal('flow_action'),
+  task: zod.object({
+    title: zod.string(),
+    description: zod.string(),
+    url: zod.string(),
+    validationUrl: zod.string().optional(),
+    customConfigurationPageUrl: zod.string().optional(),
+    customConfigurationPagePreviewUrl: zod.string().optional(),
+    fields: zod
+      .array(
+        zod.object({
+          id: zod.string(),
+          name: zod.string(),
+          label: zod.string(),
+          description: zod.string().optional(),
+          required: zod.boolean(),
+          uiType: zod.string(),
+        }),
+      )
+      .optional(),
+  }),
+})
+
+/**
+ * Extension specification with all properties and methods needed to load a Flow Action.
+ */
+const flowActionSpecification = createExtensionSpecification({
+  identifier: 'flow_action',
+  schema: FlowActionExtensionSchema,
+  singleEntryPath: false,
+  appModuleFeatures: (_) => [],
+  deployConfig: async (config, _) => {
+    return {
+      title: config.task.title,
+      description: config.task.description,
+      url: config.task.url,
+      fields: config.task.fields,
+      validation_url: config.task.validationUrl,
+      custom_configuration_page_url: config.task.customConfigurationPageUrl,
+      custom_configuration_page_preview_url: config.task.customConfigurationPagePreviewUrl,
+    }
+  },
+})
+
+export default flowActionSpecification

--- a/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
@@ -1,0 +1,42 @@
+import {BaseSchema} from '../schemas.js'
+
+import {createExtensionSpecification} from '../specification.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const FlowTriggerExtensionSchema = BaseSchema.extend({
+  name: zod.string(),
+  type: zod.literal('flow_trigger'),
+  task: zod.object({
+    title: zod.string(),
+    description: zod.string(),
+    fields: zod
+      .array(
+        zod.object({
+          name: zod.string(),
+          description: zod.string().optional(),
+          id: zod.string(),
+          uiType: zod.string(),
+        }),
+      )
+      .min(1),
+  }),
+})
+
+/**
+ * Extension specification with all properties and methods needed to load a Flow Trigger.
+ */
+const flowTriggerSpecification = createExtensionSpecification({
+  identifier: 'flow_trigger',
+  schema: FlowTriggerExtensionSchema,
+  singleEntryPath: false,
+  appModuleFeatures: (_) => [],
+  deployConfig: async (config, _) => {
+    return {
+      title: config.task.title,
+      description: config.task.description,
+      fields: config.task.fields,
+    }
+  },
+})
+
+export default flowTriggerSpecification

--- a/packages/app/src/cli/models/templates/flow_action.ts
+++ b/packages/app/src/cli/models/templates/flow_action.ts
@@ -1,0 +1,27 @@
+import {ExtensionTemplate} from '../app/template.js'
+
+/**
+ * Flow Action extension template specification.
+ */
+const flowActionExtension: ExtensionTemplate = {
+  identifier: 'flow_action',
+  name: 'Flow Action',
+  group: 'Flow',
+  supportLinks: [],
+  types: [
+    {
+      url: 'https://github.com/Shopify/cli',
+      type: 'flow_action',
+      extensionPoints: [],
+      supportedFlavors: [
+        {
+          name: 'Config only',
+          value: 'config-only',
+          path: 'templates/extensions/projects/flow_action',
+        },
+      ],
+    },
+  ],
+}
+
+export default flowActionExtension

--- a/packages/app/src/cli/models/templates/flow_trigger.ts
+++ b/packages/app/src/cli/models/templates/flow_trigger.ts
@@ -1,0 +1,27 @@
+import {ExtensionTemplate} from '../app/template.js'
+
+/**
+ * Flow Trigger extension template specification.
+ */
+const flowTriggerExtension: ExtensionTemplate = {
+  identifier: 'flow_trigger',
+  name: 'Flow Trigger',
+  group: 'Flow',
+  supportLinks: [],
+  types: [
+    {
+      url: 'https://github.com/Shopify/cli',
+      type: 'flow_trigger',
+      extensionPoints: [],
+      supportedFlavors: [
+        {
+          name: 'Config only',
+          value: 'config-only',
+          path: 'templates/extensions/projects/flow_trigger',
+        },
+      ],
+    },
+  ],
+}
+
+export default flowTriggerExtension

--- a/packages/app/src/cli/services/generate/fetch-template-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-template-specifications.ts
@@ -7,6 +7,8 @@ import themeExtension from '../../models/templates/theme-specifications/theme.js
 import checkoutPostPurchaseExtension from '../../models/templates/ui-specifications/checkout_post_purchase.js'
 import checkoutUIExtension from '../../models/templates/ui-specifications/checkout_ui_extension.js'
 import customerAccountsUIExtension from '../../models/templates/ui-specifications/customer_accounts_ui_extension.js'
+import flowActionExtension from '../../models/templates/flow_action.js'
+import flowTriggerExtension from '../../models/templates/flow_trigger.js'
 import posUIExtension from '../../models/templates/ui-specifications/pos_ui_extension.js'
 import productSubscriptionUIExtension from '../../models/templates/ui-specifications/product_subscription.js'
 import taxCalculationUIExtension from '../../models/templates/ui-specifications/tax_calculation.js'
@@ -39,6 +41,8 @@ export function localExtensionTemplates(availableSpecifications: string[]): Exte
     taxCalculationUIExtension,
     UIExtension,
     webPixelUIExtension,
+    flowTriggerExtension,
+    flowActionExtension,
   ]
   return allLocalTemplates.filter(
     (template) =>

--- a/packages/app/templates/extensions/projects/flow_action/shopify.extension.toml.liquid
+++ b/packages/app/templates/extensions/projects/flow_action/shopify.extension.toml.liquid
@@ -1,0 +1,26 @@
+name = "{{name}}"
+type = "flow_action"
+
+[task]
+title = "extension-title"
+description = "extension-description"
+url = "https://runtime-endpoint.com"
+validation_url = "https://validation-url"
+custom_configuration_page_url = "https://custom-configuration-page-url"
+custom_configuration_page_preview_url = "https://custom-configuration-page-preview-url"
+
+[[task.fields]]
+name = "customer_id"
+label = "Customer ID"
+description = ""
+required = true
+id = "a-unique-uuid"
+uiType = "commerce-object-id"
+
+[[task.fields]]
+name = "your-field-name"
+label = "your-field-label"
+description = ""
+required = true
+id = "a-unique-uuid"
+uiType = "text-single-line"

--- a/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
+++ b/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
@@ -1,0 +1,18 @@
+name = "{{name}}"
+type = "flow_trigger"
+
+[task]
+title = "custom-title"
+description = "custom-description"
+
+[[task.fields]]
+name = "customer_id"
+description = ""
+id = "a-unique-uuid"
+uiType = "customer"
+
+[[task.fields]]
+name = "test"
+description = "test property"
+id = "a-unique-uuid"
+uiType = "text-single-line"


### PR DESCRIPTION
### WHY are these changes introduced?

We're moving the Flow extension generation process from the Partner's Dashboard to the CLI. This is the first step towards that.

### WHAT is this pull request doing?

We're adding the capacity to generate both Flow actions and triggers from the CLI. This feature will be gated by a [beta flag in Partners](https://github.com/Shopify/partners/pull/48052).

### How to test your changes?

You can use my [spin instance](https://generic-extensions-1.maxime-leduc.us.spin.dev/) to test this out or create your own with these PRs from [Core](https://github.com/Shopify/shopify/pull/430734) and [Partners](https://github.com/Shopify/partners/pull/48052).
