### PR TITLE
Fix `shopify theme dev` command to show valid URLs when `--theme` flag is used with a theme name

### DIFF
--- a/.changeset/three-students-whisper.md
+++ b/.changeset/three-students-whisper.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Fix `shopify theme dev` command to show valid URLs when `--theme` flag is used with a theme name

--- a/packages/theme/src/cli/utilities/theme-selector.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.ts
@@ -19,7 +19,7 @@ import {capitalize} from '@shopify/cli-kit/common/string'
  */
 export async function findOrSelectTheme(
   session: AdminSession,
-  options: {header: string; filter: FilterProps; developmentTheme?: number},
+  options: {header?: string; filter: FilterProps; developmentTheme?: number},
 ) {
   const themes = await fetchStoreThemes(session)
   const filter = new Filter(options.filter)
@@ -30,7 +30,7 @@ export async function findOrSelectTheme(
   }
 
   return renderSelectPrompt({
-    message: options.header,
+    message: options.header ?? '',
     choices: themes.map((theme) => {
       const yoursLabel = theme.id.toString() === getDevelopmentTheme() ? ' [yours]' : ''
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2036

### WHAT is this pull request doing?

This PR changes the `packages/theme/src/cli/commands/theme/dev.ts` command to find the ID of the theme, before rendering theme links.

### How to test your changes?

- Run `shopify theme dev`

**Before**
<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/f124845d-7f10-494b-ab96-0064d5a4e648"/>

**After**
<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/4d5466ca-5a5d-484f-8d8d-43b4cfe63224"/>

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
