### PR TITLE
Validate specification access for remote templates

### DIFF
--- a/packages/app/src/cli/services/generate/fetch-template-specifications.test.ts
+++ b/packages/app/src/cli/services/generate/fetch-template-specifications.test.ts
@@ -10,10 +10,10 @@ describe('fetchTemplateSpecifications', () => {
   test('returns the remote and local specs', async () => {
     // Given
     vi.mocked(partnersRequest).mockResolvedValue({templateSpecifications: testRemoteExtensionTemplates})
-    const enabledLocalTemplates = ['checkout_ui_extension', 'theme']
+    const enabledSpecifications = ['checkout_ui_extension', 'theme', 'function']
 
     // When
-    const got: ExtensionTemplate[] = await fetchExtensionTemplates('token', 'apiKey', enabledLocalTemplates)
+    const got: ExtensionTemplate[] = await fetchExtensionTemplates('token', 'apiKey', enabledSpecifications)
 
     // Then
     expect(got.length).toEqual(6)
@@ -24,5 +24,8 @@ describe('fetchTemplateSpecifications', () => {
     expect(identifiers).toContain('order_discounts')
     expect(identifiers).toContain('theme_app_extension')
     expect(identifiers).toContain('checkout_ui')
+
+    // Since the ui_extension specification is not enabled, this template should not be included.
+    expect(identifiers).not.toContain('ui_extension')
   })
 })

--- a/packages/app/src/cli/services/generate/fetch-template-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-template-specifications.ts
@@ -24,12 +24,16 @@ export async function fetchExtensionTemplates(
     token,
     {apiKey},
   )
-  const localTemplates = localExtensionTemplates(availableSpecifications)
-  return remoteTemplates.templateSpecifications.concat(localTemplates)
+  const allTemplates = remoteTemplates.templateSpecifications.concat(localExtensionTemplates())
+  return allTemplates.filter(
+    (template) =>
+      availableSpecifications.includes(template.identifier) ||
+      availableSpecifications.includes(template.types[0]!.type),
+  )
 }
 
-export function localExtensionTemplates(availableSpecifications: string[]): ExtensionTemplate[] {
-  const allLocalTemplates = [
+export function localExtensionTemplates(): ExtensionTemplate[] {
+  return [
     themeExtension,
     checkoutPostPurchaseExtension,
     checkoutUIExtension,
@@ -40,9 +44,4 @@ export function localExtensionTemplates(availableSpecifications: string[]): Exte
     UIExtension,
     webPixelUIExtension,
   ]
-  return allLocalTemplates.filter(
-    (template) =>
-      availableSpecifications.includes(template.identifier) ||
-      availableSpecifications.includes(template.types[0]!.type),
-  )
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We were only checking specification access for local templates, but we need to verify remote ones too.
Only show a template if you have access to the app module specification that it uses.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Check that remote templates are accessible for the current user depending on the app module specifications.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
