### PR TITLE
Add app_release mutation

### DIFF
--- a/docs/cli-kit/ui-kit/readme.md
+++ b/docs/cli-kit/ui-kit/readme.md
@@ -4,7 +4,7 @@
 - [Principles](#principles)
 - [API](#api)
   - [Static output](#static-output)
-    - [`renderInfo` / `renderWarning` / `renderSuccess`](#renderinfo--renderwarning--rendersuccess)
+    - [`renderInfo` / `renderWarning` / `renderSuccess` / `renderError`](#renderinfo--renderwarning--rendersuccess--rendererror)
     - [Errors](#errors)
     - [`renderText`](#rendertext)
   - [Prompts](#prompts)
@@ -54,7 +54,7 @@ Prompts and async tasks, on the other hand, return promises that must be awaited
 
 Static output is usually displayed in the form of banners with appropriate titles and border colors.
 
-#### `renderInfo` / `renderWarning` / `renderSuccess`
+#### `renderInfo` / `renderWarning` / `renderSuccess` / `renderError`
 
 All these functions take the same params. What changes are the color and the title of the box in the output. None of the params is required so you can choose to compose your banners however you prefer. Most banners will need a `headline`, which will be highlighted in **bold**, and a body containing some details. Check out the `simple` and `complete` examples above those functions to see how they can be used.
 

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -402,19 +402,10 @@
           "type": "option",
           "description": "Version tag of the version you want to release.",
           "hidden": false,
+          "required": true,
           "multiple": false,
           "exclusive": [
             "app-version-id"
-          ]
-        },
-        "app-version-id": {
-          "name": "app-version-id",
-          "type": "option",
-          "description": "Version identifier of the version you want to release.",
-          "hidden": false,
-          "multiple": false,
-          "exclusive": [
-            "version"
           ]
         }
       },

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -400,7 +400,7 @@
         "version": {
           "name": "version",
           "type": "option",
-          "description": "Version tag of the version you want to release.",
+          "description": "The name of the app version to release.",
           "hidden": false,
           "required": true,
           "multiple": false,

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -345,6 +345,68 @@
       },
       "args": {}
     },
+    "app:release": {
+      "id": "app:release",
+      "description": "Release an app version.",
+      "strict": true,
+      "pluginName": "@shopify/app",
+      "pluginAlias": "@shopify/app",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your app directory.",
+          "multiple": false,
+          "default": "."
+        },
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "hidden": true,
+          "multiple": false
+        },
+        "api-key": {
+          "name": "api-key",
+          "type": "option",
+          "description": "The API key of your app.",
+          "hidden": false,
+          "multiple": false
+        },
+        "reset": {
+          "name": "reset",
+          "type": "boolean",
+          "description": "Reset all your settings.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "version": {
+          "name": "version",
+          "type": "option",
+          "description": "Version tag of the version you want to release.",
+          "hidden": false,
+          "multiple": false
+        }
+      },
+      "args": {}
+    },
     "app:update-url": {
       "id": "app:update-url",
       "description": "Update your app and redirect URLs in the Partners Dashboard.",

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -402,7 +402,20 @@
           "type": "option",
           "description": "Version tag of the version you want to release.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "app-version-id"
+          ]
+        },
+        "app-version-id": {
+          "name": "app-version-id",
+          "type": "option",
+          "description": "Version identifier of the version you want to release.",
+          "hidden": false,
+          "multiple": false,
+          "exclusive": [
+            "version"
+          ]
         }
       },
       "args": {}

--- a/packages/app/src/cli/api/graphql/app_release.ts
+++ b/packages/app/src/cli/api/graphql/app_release.ts
@@ -23,6 +23,11 @@ interface ErrorDetail {
   extension_title: string
 }
 
+export interface AppReleaseVariables {
+  apiKey: string
+  versionTag: string
+}
+
 export interface AppReleaseSchema {
   appRelease: {
     deployment: {

--- a/packages/app/src/cli/api/graphql/app_release.ts
+++ b/packages/app/src/cli/api/graphql/app_release.ts
@@ -1,0 +1,40 @@
+import {gql} from 'graphql-request'
+
+export const AppRelease = gql`
+  mutation AppRelease($apiKey: String!, $appVersionId: ID) {
+    appRelease(input: {apiKey: $apiKey, appVersionId: $appVersionId}) {
+      deployment {
+        versionTag
+        message
+        location
+      }
+      userErrors {
+        message
+        field
+        category
+        details
+      }
+    }
+  }
+`
+
+interface ErrorDetail {
+  extension_id: number
+  extension_title: string
+}
+
+export interface AppReleaseSchema {
+  appRelease: {
+    deployment: {
+      versionTag: string
+      message: string
+      location: string
+    }
+    userErrors: {
+      field: string[]
+      message: string
+      category: string
+      details: ErrorDetail[]
+    }[]
+  }
+}

--- a/packages/app/src/cli/api/graphql/app_release.ts
+++ b/packages/app/src/cli/api/graphql/app_release.ts
@@ -1,8 +1,8 @@
 import {gql} from 'graphql-request'
 
 export const AppRelease = gql`
-  mutation AppRelease($apiKey: String!, $appVersionId: ID) {
-    appRelease(input: {apiKey: $apiKey, appVersionId: $appVersionId}) {
+  mutation AppRelease($apiKey: String!, $deploymentId: ID, $versionTag: String) {
+    appRelease(input: {apiKey: $apiKey, deploymentId: $deploymentId, versionTag: $versionTag}) {
       deployment {
         versionTag
         message

--- a/packages/app/src/cli/api/graphql/app_versions_diff.ts
+++ b/packages/app/src/cli/api/graphql/app_versions_diff.ts
@@ -1,0 +1,41 @@
+import {gql} from 'graphql-request'
+
+export const AppVersionsDiffQuery = gql`
+  query AppVersionsDiff($apiKey: String!, $versionId: ID!) {
+    app(apiKey: $apiKey) {
+      versionsDiff(deploymentId: $versionId) {
+        added {
+          uuid
+          registrationTitle
+        }
+        updated {
+          uuid
+          registrationTitle
+        }
+        removed {
+          uuid
+          registrationTitle
+        }
+      }
+    }
+  }
+`
+
+export interface AppVersionsDiffSchema {
+  app: {
+    versionsDiff: {
+      added: {
+        uuid: string
+        registrationTitle: string
+      }[]
+      updated: {
+        uuid: string
+        registrationTitle: string
+      }[]
+      removed: {
+        uuid: string
+        registrationTitle: string
+      }[]
+    }
+  }
+}

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -27,7 +27,7 @@ export default class Release extends Command {
     }),
     version: Flags.string({
       hidden: false,
-      description: 'Version tag of the version you want to release.',
+      description: 'The name of the app version to release.',
       env: 'SHOPIFY_FLAG_VERSION',
       exclusive: ['app-version-id'],
       required: true,

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -30,12 +30,7 @@ export default class Release extends Command {
       description: 'Version tag of the version you want to release.',
       env: 'SHOPIFY_FLAG_VERSION',
       exclusive: ['app-version-id'],
-    }),
-    'app-version-id': Flags.string({
-      hidden: false,
-      description: 'Version identifier of the version you want to release.',
-      env: 'SHOPIFY_FLAG_VERSION_ID',
-      exclusive: ['version'],
+      required: true,
     }),
   }
 
@@ -54,7 +49,6 @@ export default class Release extends Command {
       reset: flags.reset,
       force: flags.force,
       version: flags.version,
-      versionId: flags['app-version-id'],
     })
   }
 }

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -29,6 +29,13 @@ export default class Release extends Command {
       hidden: false,
       description: 'Version tag of the version you want to release.',
       env: 'SHOPIFY_FLAG_VERSION',
+      exclusive: ['app-version-id'],
+    }),
+    'app-version-id': Flags.string({
+      hidden: false,
+      description: 'Version identifier of the version you want to release.',
+      env: 'SHOPIFY_FLAG_VERSION_ID',
+      exclusive: ['version'],
     }),
   }
 
@@ -47,6 +54,7 @@ export default class Release extends Command {
       reset: flags.reset,
       force: flags.force,
       version: flags.version,
+      versionId: flags['app-version-id'],
     })
   }
 }

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -1,0 +1,52 @@
+import {appFlags} from '../../flags.js'
+import {AppInterface} from '../../models/app/app.js'
+import {load as loadApp} from '../../models/app/loader.js'
+import Command from '../../utilities/app-command.js'
+import {loadExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {release} from '../../services/release.js'
+import {Flags} from '@oclif/core'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
+
+export default class Release extends Command {
+  static description = 'Release an app version.'
+
+  static flags = {
+    ...globalFlags,
+    ...appFlags,
+    'api-key': Flags.string({
+      hidden: false,
+      description: 'The API key of your app.',
+      env: 'SHOPIFY_FLAG_APP_API_KEY',
+    }),
+    reset: Flags.boolean({
+      hidden: false,
+      description: 'Reset all your settings.',
+      env: 'SHOPIFY_FLAG_RESET',
+      default: false,
+    }),
+    version: Flags.string({
+      hidden: false,
+      description: 'Version tag of the version you want to release.',
+      env: 'SHOPIFY_FLAG_VERSION',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(Release)
+
+    await addPublicMetadata(() => ({
+      cmd_app_reset_used: flags.reset,
+    }))
+
+    const specifications = await loadExtensionsSpecifications(this.config)
+    const app: AppInterface = await loadApp({specifications, directory: flags.path})
+    await release({
+      app,
+      apiKey: flags['api-key'],
+      reset: flags.reset,
+      force: flags.force,
+      version: flags.version,
+    })
+  }
+}

--- a/packages/app/src/cli/models/app/identifiers.ts
+++ b/packages/app/src/cli/models/app/identifiers.ts
@@ -25,7 +25,7 @@ export interface Identifiers {
 }
 
 export type UuidOnlyIdentifiers = Omit<Identifiers, 'extensionIds'>
-type UpdateAppIdentifiersCommand = 'dev' | 'deploy'
+type UpdateAppIdentifiersCommand = 'dev' | 'deploy' | 'release'
 interface UpdateAppIdentifiersOptions {
   app: AppInterface
   identifiers: UuidOnlyIdentifiers
@@ -59,7 +59,9 @@ export async function updateAppIdentifiers(
     }
   })
 
-  const write = JSON.stringify(dotenvFile.variables) !== JSON.stringify(updatedVariables) && command === 'deploy'
+  const write =
+    JSON.stringify(dotenvFile.variables) !== JSON.stringify(updatedVariables) &&
+    (command === 'deploy' || command === 'release')
   dotenvFile.variables = updatedVariables
   if (write) {
     await writeDotEnv(dotenvFile)

--- a/packages/app/src/cli/prompts/release.test.ts
+++ b/packages/app/src/cli/prompts/release.test.ts
@@ -1,53 +1,24 @@
 import {confirmReleasePrompt} from './release.js'
 import {describe, expect, vi, test} from 'vitest'
 import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
+import {AbortSilentError} from '@shopify/cli-kit/node/error'
 
 vi.mock('@shopify/cli-kit/node/ui')
 
 describe('confirmReleasePrompt', () => {
-  test('shows extensions in the infoTable if the diff contains added or update extensions', async () => {
-    // When
-    await confirmReleasePrompt('test app', {
-      added: [{uuid: '2be20cc3-c102-4192-bd5c-e0aaccd25ede', registrationTitle: 'theme-app-ext'}],
-      updated: [{uuid: 'abc8049d-af76-4430-84df-a6c2d8ed88aa', registrationTitle: 'sub-ui-ext'}],
-      removed: [],
-    })
+  test('returns without error in case the user confirm the release prompt', async () => {
+    // Given
+    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
-    // Then
-    expect(renderConfirmationPrompt).toHaveBeenCalledWith({
-      message: 'Release this version of test app?',
-      infoTable: [
-        {
-          header: 'Extensions',
-          items: ['theme-app-ext', 'sub-ui-ext'],
-        },
-      ],
-      confirmationMessage: 'Yes, release this version',
-      cancellationMessage: 'No, cancel',
-    })
+    // When/ Then
+    await expect(confirmReleasePrompt('test app')).resolves
   })
 
-  test('shows removed extensions in the infoTable if the diff contains removed extensions', async () => {
-    // When
-    await confirmReleasePrompt('test app', {
-      added: [],
-      updated: [],
-      removed: [{uuid: 'abc8049d-af76-4430-84df-a6c2d8ed88aa', registrationTitle: 'sub-ui-ext'}],
-    })
+  test('throws a silent exception in case the user rejects the release prompt', async () => {
+    // Given
+    vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
 
-    // Then
-    expect(renderConfirmationPrompt).toHaveBeenCalledWith({
-      message: 'Release this version of test app?',
-      infoTable: [
-        {
-          header: 'Removed',
-          color: 'red',
-          helperText: 'Will be removed for users when this version is released.',
-          items: ['sub-ui-ext'],
-        },
-      ],
-      confirmationMessage: 'Yes, release this version',
-      cancellationMessage: 'No, cancel',
-    })
+    // When/ Then
+    await expect(confirmReleasePrompt('test app')).rejects.toThrow(AbortSilentError)
   })
 })

--- a/packages/app/src/cli/prompts/release.test.ts
+++ b/packages/app/src/cli/prompts/release.test.ts
@@ -1,0 +1,53 @@
+import {confirmReleasePrompt} from './release.js'
+import {describe, expect, vi, test} from 'vitest'
+import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
+
+vi.mock('@shopify/cli-kit/node/ui')
+
+describe('confirmReleasePrompt', () => {
+  test('shows extensions in the infoTable if the diff contains added or update extensions', async () => {
+    // When
+    await confirmReleasePrompt('test app', {
+      added: [{uuid: '2be20cc3-c102-4192-bd5c-e0aaccd25ede', registrationTitle: 'theme-app-ext'}],
+      updated: [{uuid: 'abc8049d-af76-4430-84df-a6c2d8ed88aa', registrationTitle: 'sub-ui-ext'}],
+      removed: [],
+    })
+
+    // Then
+    expect(renderConfirmationPrompt).toHaveBeenCalledWith({
+      message: 'Release this version of test app?',
+      infoTable: [
+        {
+          header: 'Extensions',
+          items: ['theme-app-ext', 'sub-ui-ext'],
+        },
+      ],
+      confirmationMessage: 'Yes, release this version',
+      cancellationMessage: 'No, cancel',
+    })
+  })
+
+  test('shows removed extensions in the infoTable if the diff contains removed extensions', async () => {
+    // When
+    await confirmReleasePrompt('test app', {
+      added: [],
+      updated: [],
+      removed: [{uuid: 'abc8049d-af76-4430-84df-a6c2d8ed88aa', registrationTitle: 'sub-ui-ext'}],
+    })
+
+    // Then
+    expect(renderConfirmationPrompt).toHaveBeenCalledWith({
+      message: 'Release this version of test app?',
+      infoTable: [
+        {
+          header: 'Removed',
+          color: 'red',
+          helperText: 'Will be removed for users when this version is released.',
+          items: ['sub-ui-ext'],
+        },
+      ],
+      confirmationMessage: 'Yes, release this version',
+      cancellationMessage: 'No, cancel',
+    })
+  })
+})

--- a/packages/app/src/cli/prompts/release.ts
+++ b/packages/app/src/cli/prompts/release.ts
@@ -1,0 +1,33 @@
+import {AppVersionsDiffSchema} from '../api/graphql/app_versions_diff.js'
+import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
+
+export async function confirmReleasePrompt(
+  appName: string,
+  versionsDiff: AppVersionsDiffSchema['app']['versionsDiff'],
+) {
+  const infoTable = []
+  const extensions = [...versionsDiff.added, ...versionsDiff.updated]
+
+  if (extensions.length > 0) {
+    infoTable.push({
+      header: 'Extensions',
+      items: extensions.map((extension) => extension.registrationTitle),
+    })
+  }
+
+  if (versionsDiff.removed.length > 0) {
+    infoTable.push({
+      header: 'Removed',
+      color: 'red',
+      helperText: 'Will be removed for users when this version is released.',
+      items: versionsDiff.removed.map((extension) => extension.registrationTitle),
+    })
+  }
+
+  return renderConfirmationPrompt({
+    message: `Release this version of ${appName}?`,
+    infoTable,
+    confirmationMessage: 'Yes, release this version',
+    cancellationMessage: 'No, cancel',
+  })
+}

--- a/packages/app/src/cli/prompts/release.ts
+++ b/packages/app/src/cli/prompts/release.ts
@@ -1,33 +1,14 @@
-import {AppVersionsDiffSchema} from '../api/graphql/app_versions_diff.js'
+import {AbortSilentError} from '@shopify/cli-kit/node/error'
 import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
 
-export async function confirmReleasePrompt(
-  appName: string,
-  versionsDiff: AppVersionsDiffSchema['app']['versionsDiff'],
-) {
-  const infoTable = []
-  const extensions = [...versionsDiff.added, ...versionsDiff.updated]
-
-  if (extensions.length > 0) {
-    infoTable.push({
-      header: 'Extensions',
-      items: extensions.map((extension) => extension.registrationTitle),
-    })
-  }
-
-  if (versionsDiff.removed.length > 0) {
-    infoTable.push({
-      header: 'Removed',
-      color: 'red',
-      helperText: 'Will be removed for users when this version is released.',
-      items: versionsDiff.removed.map((extension) => extension.registrationTitle),
-    })
-  }
-
-  return renderConfirmationPrompt({
+export async function confirmReleasePrompt(appName: string) {
+  const confirm = await renderConfirmationPrompt({
     message: `Release this version of ${appName}?`,
-    infoTable,
     confirmationMessage: 'Yes, release this version',
     cancellationMessage: 'No, cancel',
   })
+
+  if (!confirm) {
+    throw new AbortSilentError()
+  }
 }

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -538,7 +538,7 @@ describe('ensureReleaseContext', () => {
     const app = testApp()
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA.apiKey})
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
-    vi.mocked(updateAppIdentifiers).mockResolvedValue(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
+    vi.mocked(updateAppIdentifiers).mockResolvedValue(app)
 
     // When
     const got = await ensureReleaseContext({
@@ -556,7 +556,7 @@ describe('ensureReleaseContext', () => {
       },
       command: 'release',
     })
-    expect(got.app).toEqual(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
+    expect(got.app).toEqual(app)
     expect(got.apiKey).toEqual(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA.apiKey)
     expect(got.token).toEqual('token')
   })

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -346,12 +346,18 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
 
 export async function ensureReleaseContext(options: ReleaseContextOptions): Promise<ReleaseContextOutput> {
   const token = await ensureAuthenticatedPartners()
-  const [partnersApp] = await fetchAppAndIdentifiers(options, token)
+  const [partnersApp, envIdentifiers] = await fetchAppAndIdentifiers(options, token)
+  const identifiers: Identifiers = envIdentifiers as Identifiers
 
   if (!partnersApp.betas?.unifiedAppDeployment) {
     throw new AbortSilentError()
   }
 
+  // eslint-disable-next-line no-param-reassign
+  options = {
+    ...options,
+    app: await updateAppIdentifiers({app: options.app, identifiers, command: 'release'}),
+  }
   const result = {
     app: options.app,
     apiKey: partnersApp.apiKey,

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -349,7 +349,8 @@ export async function ensureReleaseContext(options: ReleaseContextOptions): Prom
   const [partnersApp, envIdentifiers] = await fetchAppAndIdentifiers(options, token)
   const identifiers: Identifiers = envIdentifiers as Identifiers
 
-  if (!partnersApp.betas?.unifiedAppDeployment) {
+  const deploymentMode: DeploymentMode = partnersApp.betas?.unifiedAppDeployment ? 'unified' : 'legacy'
+  if (deploymentMode === 'legacy') {
     throw new AbortSilentError()
   }
 

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -364,7 +364,7 @@ describe('deploy', () => {
       bundlePath: expect.stringMatching(/bundle.zip$/),
       appModules: [
         {uuid: uiExtension.localIdentifier, config: '{}', context: ''},
-        {uuid: themeExtension.localIdentifier, config: '{"theme_extension":{"files":{}}}', context: ''},
+        {uuid: themeExtension.localIdentifier, config: '{"theme_extension": {"files": {}}}', context: ''},
       ],
       token: 'api-token',
       extensionIds: {},

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -83,7 +83,7 @@ describe('release', () => {
         },
         '\nmessage',
       ],
-      headline: 'Version released to users.',
+      headline: 'Version released to users',
       nextSteps: [
         [
           'Run',
@@ -96,7 +96,7 @@ describe('release', () => {
     })
   })
 
-  test('shows errors if there are any', async () => {
+  test('shows a custom error message without link and message if no deployment is returned', async () => {
     // Given
     const app = testApp()
     vi.mocked(confirmReleasePrompt).mockResolvedValue()
@@ -122,25 +122,17 @@ describe('release', () => {
       }
     })
 
-    vi.mocked(ensureReleaseContext).mockResolvedValue({
-      app,
-      token: 'api-token',
-      apiKey: 'app-id',
-    })
-    vi.mocked(updateAppIdentifiers).mockResolvedValue(app)
+    // When
+    await testRelease(app, 'app-version')
 
     // Then
-    await expect(() =>
-      release({
-        app,
-        reset: false,
-        force: false,
-        version: 'app-version',
-      }),
-    ).rejects.toThrowError('some kind of error 1, some kind of error 2')
+    expect(renderError).toHaveBeenCalledWith({
+      body: ['some kind of error 1, some kind of error 2'],
+      headline: "Version couldn't be released",
+    })
   })
 
-  test('shows a custom error message when the version needs to be approved', async () => {
+  test('shows a custom error message with link and message if a deployment is returned', async () => {
     // given
     const app = testApp()
     vi.mocked(confirmReleasePrompt).mockResolvedValue()
@@ -183,7 +175,7 @@ describe('release', () => {
         '\nmessage',
         '\n\nneeds to be submitted for review and approved by Shopify before it can be released',
       ],
-      headline: "Version couldn't be released.",
+      headline: "Version couldn't be released",
     })
   })
 })

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -1,0 +1,293 @@
+import {ensureReleaseContext} from './context.js'
+import {release} from './release.js'
+import {testApp} from '../models/app/app.test-data.js'
+import {updateAppIdentifiers} from '../models/app/identifiers.js'
+import {AppInterface} from '../models/app/app.js'
+import {OrganizationApp} from '../models/organization.js'
+import {confirmReleasePrompt} from '../prompts/release.js'
+import {AppRelease} from '../api/graphql/app_release.js'
+import {beforeEach, describe, expect, vi, test} from 'vitest'
+import {renderError, renderSuccess, renderTasks, Task} from '@shopify/cli-kit/node/ui'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+
+vi.mock('./context.js')
+vi.mock('../models/app/identifiers.js')
+vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('../prompts/release.js')
+vi.mock('@shopify/cli-kit/node/api/partners')
+
+beforeEach(() => {
+  // this is needed because using importActual to mock the ui module
+  // creates a circular dependency between ui and context/local
+  // so we need to mock the whole module and just replace the functions we use
+  vi.mocked(renderTasks).mockImplementation(async (tasks: Task[]) => {
+    for (const task of tasks) {
+      // eslint-disable-next-line no-await-in-loop
+      await task.task({}, task)
+    }
+
+    return {}
+  })
+})
+
+describe('release', () => {
+  test('throws an error if versionDiff is empty', async () => {
+    // Given
+    const app = testApp()
+    vi.mocked(partnersRequest).mockResolvedValueOnce({app: {versionsDiff: {}}})
+
+    // When
+    vi.mocked(ensureReleaseContext).mockResolvedValue({
+      app,
+      token: 'api-token',
+      apiKey: 'app-id',
+    })
+    vi.mocked(updateAppIdentifiers).mockResolvedValue(app)
+
+    await expect(() =>
+      release({
+        app,
+        reset: false,
+        force: false,
+        version: 'app-version',
+      }),
+    ).rejects.toThrow('Version not found')
+
+    // Then
+    expect(confirmReleasePrompt).not.toHaveBeenCalled()
+    expect(partnersRequest).not.toHaveBeenCalledWith(AppRelease, 'api-token', {
+      apiKey: 'app-id',
+      appVersionId: 'app-version',
+    })
+  })
+
+  test("doesn't trigger mutations if the user doesn't confirm", async () => {
+    // Given
+    const app = testApp()
+    vi.mocked(partnersRequest).mockResolvedValueOnce({
+      app: {
+        versionsDiff: {
+          added: [],
+          updated: [{registrationTitle: 'extension-title', uuid: 'extension-uuid'}],
+          removed: [],
+        },
+      },
+    })
+
+    vi.mocked(confirmReleasePrompt).mockResolvedValue(false)
+
+    // When
+    await testRelease(app, 'app-version')
+
+    // Then
+    expect(partnersRequest).not.toHaveBeenCalledWith(AppRelease, 'api-token', {
+      apiKey: 'app-id',
+      appVersionId: 'app-version',
+    })
+  })
+
+  test('triggers mutations if the user confirms', async () => {
+    // Given
+    const app = testApp()
+    vi.mocked(partnersRequest).mockResolvedValueOnce({
+      app: {
+        versionsDiff: {
+          added: [],
+          updated: [{registrationTitle: 'extension-title', uuid: 'extension-uuid'}],
+          removed: [],
+        },
+      },
+    })
+
+    vi.mocked(confirmReleasePrompt).mockResolvedValue(true)
+    vi.mocked(renderTasks).mockImplementation(async (tasks: Task[]) => {
+      for (const task of tasks) {
+        // eslint-disable-next-line no-await-in-loop
+        await task.task({}, task)
+      }
+
+      return {
+        appRelease: {
+          appRelease: {
+            deployment: {
+              location: 'https://example.com',
+              versionTag: '1.0.0',
+              message: 'message',
+            },
+            userErrors: [],
+          },
+        },
+      }
+    })
+
+    // When
+    await testRelease(app, 'app-version')
+
+    // Then
+    expect(partnersRequest).toHaveBeenCalledWith(AppRelease, 'api-token', {
+      apiKey: 'app-id',
+      appVersionId: 'app-version',
+    })
+    expect(renderSuccess).toHaveBeenCalledWith({
+      body: [
+        {
+          link: {
+            label: '1.0.0',
+            url: 'https://example.com',
+          },
+        },
+        '\nmessage',
+      ],
+      headline: 'Version released to users.',
+      nextSteps: [
+        [
+          'Run',
+          {
+            command: 'yarn shopify app versions list',
+          },
+          'to see rollout progress.',
+        ],
+      ],
+    })
+  })
+
+  test('shows errors if there are any', async () => {
+    // Given
+    const app = testApp()
+    vi.mocked(partnersRequest).mockResolvedValueOnce({
+      app: {
+        versionsDiff: {
+          added: [],
+          updated: [{registrationTitle: 'extension-title', uuid: 'extension-uuid'}],
+          removed: [],
+        },
+      },
+    })
+
+    vi.mocked(confirmReleasePrompt).mockResolvedValue(true)
+    vi.mocked(renderTasks).mockImplementation(async (tasks: Task[]) => {
+      for (const task of tasks) {
+        // eslint-disable-next-line no-await-in-loop
+        await task.task({}, task)
+      }
+
+      return {
+        appRelease: {
+          appRelease: {
+            deployment: {
+              location: 'https://example.com',
+              versionTag: '1.0.0',
+              message: 'message',
+            },
+            userErrors: [
+              {
+                message: 'some kind of error 1',
+              },
+              {
+                message: 'some kind of error 2',
+              },
+            ],
+          },
+        },
+      }
+    })
+
+    vi.mocked(ensureReleaseContext).mockResolvedValue({
+      app,
+      token: 'api-token',
+      apiKey: 'app-id',
+    })
+    vi.mocked(updateAppIdentifiers).mockResolvedValue(app)
+
+    // Then
+    await expect(() =>
+      release({
+        app,
+        reset: false,
+        force: false,
+        version: 'app-version',
+      }),
+    ).rejects.toThrowError('some kind of error 1, some kind of error 2')
+  })
+
+  test('shows a custom error message when the version needs to be approved', async () => {
+    // given
+    const app = testApp()
+    vi.mocked(partnersRequest).mockResolvedValueOnce({
+      app: {
+        versionsDiff: {
+          added: [],
+          updated: [{registrationTitle: 'extension-title', uuid: 'extension-uuid'}],
+          removed: [],
+        },
+      },
+    })
+
+    vi.mocked(confirmReleasePrompt).mockResolvedValue(true)
+    vi.mocked(renderTasks).mockImplementation(async (tasks: Task[]) => {
+      for (const task of tasks) {
+        // eslint-disable-next-line no-await-in-loop
+        await task.task({}, task)
+      }
+
+      return {
+        appRelease: {
+          appRelease: {
+            deployment: {
+              location: 'https://example.com',
+              versionTag: '1.0.0',
+              message: 'message',
+            },
+            userErrors: [
+              {
+                message: 'needs to be submitted for review and approved by Shopify before it can be released',
+              },
+            ],
+          },
+        },
+      }
+    })
+
+    // When
+    await testRelease(app, 'app-version')
+
+    // Then
+    expect(renderError).toHaveBeenCalledWith({
+      body: [
+        {
+          link: {
+            label: '1.0.0',
+            url: 'https://example.com',
+          },
+        },
+        '\nmessage',
+        '\n\nThis version needs to be submitted for review and approved by Shopify before it can be released.',
+      ],
+      headline: "Version couldn't be released.",
+    })
+  })
+})
+
+async function testRelease(
+  app: AppInterface,
+  version: string,
+  partnersApp?: Omit<OrganizationApp, 'apiSecretKeys' | 'apiKey'>,
+  options?: {
+    force?: boolean
+  },
+) {
+  // Given
+  vi.mocked(ensureReleaseContext).mockResolvedValue({
+    app,
+    token: 'api-token',
+    apiKey: partnersApp?.id ?? 'app-id',
+  })
+  vi.mocked(updateAppIdentifiers).mockResolvedValue(app)
+
+  await release({
+    app,
+    reset: false,
+    force: Boolean(options?.force),
+    version,
+  })
+}

--- a/packages/app/src/cli/services/release.ts
+++ b/packages/app/src/cli/services/release.ts
@@ -1,12 +1,11 @@
 import {ensureReleaseContext} from './context.js'
 import {AppInterface} from '../models/app/app.js'
-import {AppVersionsDiffQuery, AppVersionsDiffSchema} from '../api/graphql/app_versions_diff.js'
 import {AppRelease, AppReleaseSchema} from '../api/graphql/app_release.js'
 import {confirmReleasePrompt} from '../prompts/release.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
-import {AbortError} from '@shopify/cli-kit/node/error'
 import {renderError, renderSuccess, renderTasks} from '@shopify/cli-kit/node/ui'
 import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 interface ReleaseOptions {
   /** The app to be built and uploaded */
@@ -21,80 +20,62 @@ interface ReleaseOptions {
   /** If true, proceed with deploy without asking for confirmation */
   force: boolean
 
-  /** App version identifier */
+  /** App version tag */
   version?: string
+
+  /** App version identifier */
+  versionId?: string
 }
 
 export async function release(options: ReleaseOptions) {
   const {token, apiKey, app} = await ensureReleaseContext(options)
 
-  const {
-    app: {versionsDiff},
-  }: AppVersionsDiffSchema = await partnersRequest(AppVersionsDiffQuery, token, {
-    apiKey,
-    versionId: options.version,
-  })
-
-  if (Object.keys(versionsDiff).length === 0) {
-    throw new AbortError('Version not found')
-  }
-
-  const confirmRelease = await confirmReleasePrompt(app.name, versionsDiff)
-
+  await confirmReleasePrompt(app.name)
   interface Context {
     appRelease: AppReleaseSchema
   }
 
-  if (confirmRelease) {
-    const tasks = [
-      {
-        title: 'Releasing version',
-        task: async (context: Context) => {
-          context.appRelease = await partnersRequest(AppRelease, token, {
-            apiKey,
-            appVersionId: options.version,
-          })
-        },
-      },
-    ]
-
-    const {
-      appRelease: {appRelease: release},
-    } = await renderTasks<Context>(tasks)
-
-    const deployment = release.deployment
-
-    if (release.userErrors?.length > 0) {
-      if (
-        // need to check that this is true
-        release.userErrors[0]!.message.includes(
-          'needs to be submitted for review and approved by Shopify before it can be released',
-        )
-      ) {
-        renderError({
-          headline: "Version couldn't be released.",
-          body: [
-            {link: {url: deployment.location, label: deployment.versionTag}},
-            `\n${deployment.message}`,
-            '\n\nThis version needs to be submitted for review and approved by Shopify before it can be released.',
-          ],
+  const tasks = [
+    {
+      title: 'Releasing version',
+      task: async (context: Context) => {
+        context.appRelease = await partnersRequest(AppRelease, token, {
+          apiKey,
+          deploymentId: options.versionId,
+          versionTag: options.version,
         })
-      } else {
-        const errors = release.userErrors.map((error) => error.message).join(', ')
-        throw new AbortError(errors)
-      }
-    } else {
-      renderSuccess({
-        headline: 'Version released to users.',
-        body: [{link: {url: deployment.location, label: deployment.versionTag}}, `\n${deployment.message}`],
-        nextSteps: [
-          [
-            'Run',
-            {command: formatPackageManagerCommand(app.packageManager, 'shopify app versions list')},
-            'to see rollout progress.',
-          ],
+      },
+    },
+  ]
+
+  const {
+    appRelease: {appRelease: release},
+  } = await renderTasks<Context>(tasks)
+
+  const deployment = release.deployment
+
+  if (release.userErrors?.length > 0) {
+    const errorsMessage = release.userErrors.map((error) => error.message).join(', ')
+    if (!deployment) throw new AbortError(errorsMessage)
+    renderError({
+      headline: "Version couldn't be released.",
+      body: [
+        {link: {url: deployment.location, label: deployment.versionTag}},
+        `\n${deployment.message}`,
+        `\n\n${errorsMessage}`,
+      ],
+    })
+  } else {
+    renderSuccess({
+      headline: 'Version released to users.',
+      body: [{link: {url: deployment.location, label: deployment.versionTag}}, `\n${deployment.message}`],
+      nextSteps: [
+        [
+          'Run',
+          {command: formatPackageManagerCommand(app.packageManager, 'shopify app versions list')},
+          'to see rollout progress.',
         ],
-      })
-    }
+      ],
+    })
   }
 }

--- a/packages/app/src/cli/services/release.ts
+++ b/packages/app/src/cli/services/release.ts
@@ -1,0 +1,111 @@
+import {ensureReleaseContext} from './context.js'
+import {AppInterface} from '../models/app/app.js'
+import {AppVersionsDiffQuery, AppVersionsDiffSchema} from '../api/graphql/app_versions_diff.js'
+import {AppRelease, AppReleaseSchema} from '../api/graphql/app_release.js'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {renderConfirmationPrompt, renderError, renderSuccess} from '@shopify/cli-kit/node/ui'
+import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+
+interface ReleaseOptions {
+  /** The app to be built and uploaded */
+  app: AppInterface
+
+  /** API key of the app in Partners admin */
+  apiKey?: string
+
+  /** If true, ignore any cached appId or extensionId */
+  reset: boolean
+
+  /** If true, proceed with deploy without asking for confirmation */
+  force: boolean
+
+  /** App version identifier */
+  version?: string
+}
+
+export async function release(options: ReleaseOptions) {
+  // eslint-disable-next-line prefer-const
+  let {token, apiKey, app} = await ensureReleaseContext(options)
+
+  const {
+    app: {versionsDiff},
+  }: AppVersionsDiffSchema = await partnersRequest(AppVersionsDiffQuery, token, {
+    apiKey,
+    versionId: options.version,
+  })
+
+  if (Object.keys(versionsDiff).length === 0) {
+    throw new AbortError('Version not found')
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(versionsDiff))
+
+  const infoTable = []
+  const extensions = [...versionsDiff.added, ...versionsDiff.updated]
+
+  if (extensions.length > 0) {
+    infoTable.push({
+      header: 'Extensions',
+      items: extensions.map((extension) => extension.registrationTitle),
+    })
+  }
+
+  if (versionsDiff.removed.length > 0) {
+    infoTable.push({
+      header: 'Removed',
+      color: 'red',
+      helperText: 'Will be removed for users when this version is released.',
+      items: versionsDiff.removed.map((extension) => extension.registrationTitle),
+    })
+  }
+
+  const confirmRelease = await renderConfirmationPrompt({
+    message: `Release this version of ${app.name}?`,
+    infoTable,
+    confirmationMessage: 'Yes, release this version',
+    cancellationMessage: 'No, cancel',
+  })
+
+  if (confirmRelease) {
+    const appRelease: AppReleaseSchema = await partnersRequest(AppRelease, token, {
+      apiKey,
+      appVersionId: options.version,
+    })
+    const release = appRelease.appRelease
+    const deployment = release.deployment
+
+    if (release.userErrors.length > 0) {
+      if (
+        release.userErrors[0]!.message.includes(
+          'needs to be submitted for review and approved by Shopify before it can be released',
+        )
+      ) {
+        renderError({
+          headline: "Version couldn't be released.",
+          body: [
+            {link: {url: deployment.location, label: deployment.versionTag}},
+            `\n${deployment.message}`,
+            '\n\nThis version needs to be submitted for review and approved by Shopify before it can be released.',
+          ],
+        })
+      } else {
+        const errors = release.userErrors.map((error) => error.message).join(', ')
+        throw new AbortError(errors)
+      }
+    } else {
+      renderSuccess({
+        headline: 'Version released to users.',
+        body: [{link: {url: deployment.location, label: deployment.versionTag}}, `\n${deployment.message}`],
+        nextSteps: [
+          [
+            'Run',
+            {command: formatPackageManagerCommand(app.packageManager, 'shopify app versions list')},
+            'to see rollout progress.',
+          ],
+        ],
+      })
+    }
+  }
+}

--- a/packages/cli-kit/bin/documentation/examples.ts
+++ b/packages/cli-kit/bin/documentation/examples.ts
@@ -4,6 +4,7 @@ import {
   renderAutocompletePrompt,
   renderConcurrent,
   renderConfirmationPrompt,
+  renderError,
   renderFatalError,
   renderInfo,
   renderSelectPrompt,
@@ -216,6 +217,20 @@ export const examples: {[key in string]: Example} = {
             },
           },
         ],
+        renderOptions: {
+          stdout: stdout as any,
+        },
+      })!
+    },
+  },
+  renderError: {
+    type: 'static',
+    basic: async () => {
+      const stdout = new Stdout({columns: TERMINAL_WIDTH})
+
+      return renderError({
+        headline: "Version couldn't be released.",
+        body: 'This version needs to be submitted for review and approved by Shopify before it can be released.',
         renderOptions: {
           stdout: stdout as any,
         },

--- a/packages/cli-kit/src/private/node/ui/alert.tsx
+++ b/packages/cli-kit/src/private/node/ui/alert.tsx
@@ -1,6 +1,6 @@
 import {Alert, AlertProps} from './components/Alert.js'
 import {renderOnce} from '../ui.js'
-import {consoleLog, consoleWarn, Logger, LogLevel} from '../../../public/node/output.js'
+import {consoleError, consoleLog, consoleWarn, Logger, LogLevel} from '../../../public/node/output.js'
 import {recordUIEvent} from '../demo-recorder.js'
 import React from 'react'
 import {RenderOptions} from 'ink'
@@ -9,12 +9,14 @@ const typeToLogLevel: {[key in AlertProps['type']]: LogLevel} = {
   info: 'info',
   warning: 'warn',
   success: 'info',
+  error: 'error',
 }
 
 const typeToLogger: {[key in AlertProps['type']]: Logger} = {
   info: consoleLog,
   warning: consoleWarn,
   success: consoleLog,
+  error: consoleError,
 }
 
 export interface AlertOptions extends AlertProps {

--- a/packages/cli-kit/src/private/node/ui/components/Alert.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Alert.tsx
@@ -11,7 +11,7 @@ export interface CustomSection {
 }
 
 export interface AlertProps {
-  type: Exclude<BannerType, 'error' | 'external_error'>
+  type: Exclude<BannerType, 'external_error'>
   headline?: TokenItem<Exclude<InlineToken, LinkToken | BoldToken>>
   body?: TokenItem
   nextSteps?: TokenItem<InlineToken>[]

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -185,6 +185,23 @@ export function renderWarning(options: RenderAlertOptions) {
   return alert({...options, type: 'warning'})
 }
 
+/**
+ * Renders an error banner to the console.
+ * @example
+ * ╭─ error ──────────────────────────────────────────────────╮
+ * │                                                          │
+ * │  Version couldn't be released.                           │
+ * │                                                          │
+ * │  This version needs to be submitted for review and       │
+ * │  approved by Shopify before it can be released.          │
+ * │                                                          │
+ * ╰──────────────────────────────────────────────────────────╯
+ *
+ */
+export function renderError(options: RenderAlertOptions) {
+  return alert({...options, type: 'error'})
+}
+
 interface RenderFatalErrorOptions {
   renderOptions?: RenderOptions
 }

--- a/packages/cli/src/cli/services/kitchen-sink/static.ts
+++ b/packages/cli/src/cli/services/kitchen-sink/static.ts
@@ -1,5 +1,12 @@
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
-import {renderFatalError, renderInfo, renderSuccess, renderTable, renderWarning} from '@shopify/cli-kit/node/ui'
+import {
+  renderError,
+  renderFatalError,
+  renderInfo,
+  renderSuccess,
+  renderTable,
+  renderWarning,
+} from '@shopify/cli-kit/node/ui'
 
 export async function staticService() {
   // Banners
@@ -156,6 +163,11 @@ export async function staticService() {
   ]
 
   renderFatalError(new AbortError('No Organization found', undefined, nextSteps))
+
+  renderError({
+    headline: "Version couldn't be released.",
+    body: 'This version needs to be submitted for review and approved by Shopify before it can be released.',
+  })
 
   renderTable({
     rows: [

--- a/packages/eslint-plugin-cli/rules/banner-headline-format.js
+++ b/packages/eslint-plugin-cli/rules/banner-headline-format.js
@@ -48,7 +48,12 @@ module.exports = {
         const callee = node.callee
         const functionName = callee.name
 
-        if (functionName === 'renderSuccess' || functionName === 'renderInfo' || functionName === 'renderWarning') {
+        if (
+          functionName === 'renderSuccess' ||
+          functionName === 'renderInfo' ||
+          functionName === 'renderWarning' ||
+          functionName === 'renderError'
+        ) {
           const firstArgument = node.arguments[0]
 
           if (firstArgument.type === 'ObjectExpression') {

--- a/packages/features/snapshots/commands.txt
+++ b/packages/features/snapshots/commands.txt
@@ -10,6 +10,7 @@
  app generate extension    @shopify/app                 
  app generate schema       @shopify/app                 
  app info                  @shopify/app                 
+ app release               @shopify/app                 
  app update-url            @shopify/app                 
  auth logout               @shopify/cli                 
  commands                  @oclif/plugin-commands       


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/474

We want to add a `release` command to make a specific `version` active.

### WHAT is this pull request doing?

We've added a `app release --version=1` command to make the specified version active. If the version doesn't exist we throw an error. The user is then prompted with a diff of all the extensions from the last released version to the one specified. If the user confirms we then call the `appRelease` mutation. Releases might have to be reviewed so we handle that scenario.

It seems like the `versionsDiff` not returning what we expect for now.

### How to test your changes?

- Run `shopify app deploy --no-release`
- Copy the version number
- Run `shopify app release --version={versionNumber}`

### Post-release steps

We need to add this command to the docs.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
