### PR TITLE
[3.46] Remove images from the local assets middleware

### DIFF
--- a/.changeset/giant-emus-lie.md
+++ b/.changeset/giant-emus-lie.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+Remove image proxying through local server to enable proper functioning of Liquid filters

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/local_assets.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/local_assets.rb
@@ -4,7 +4,7 @@ module ShopifyCLI
   module Theme
     class DevServer
       class LocalAssets
-        SUPPORTED_EXTENSIONS = [:jpg, :jpeg, :js, :css, :png, :svg].join("|")
+        SUPPORTED_EXTENSIONS = [:js, :css].join("|")
         CDN_REGEX = %r{(//cdn)\.shopify\.com/s/.+?/(assets/.+?\.(?:#{SUPPORTED_EXTENSIONS}))}
         VANITY_CDN_REGEX = %r{(/cdn)/shop/.+?/(assets/.+?\.(?:#{SUPPORTED_EXTENSIONS}))}
 

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/extension/dev_server/local_assets.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/extension/dev_server/local_assets.rb
@@ -7,7 +7,7 @@ module ShopifyCLI
     module Extension
       class DevServer < ShopifyCLI::Theme::DevServer
         class LocalAssets < ShopifyCLI::Theme::DevServer::LocalAssets
-          SUPPORTED_EXTENSIONS = [:jpg, :jpeg, :js, :css, :png, :svg].join("|")
+          SUPPORTED_EXTENSIONS = [:js, :css].join("|")
           TAE_ASSET_REGEX = %r{(http:|https:)?//cdn\.shopify\.com/extensions/.+?/(assets/.+?\.(?:#{SUPPORTED_EXTENSIONS}))}
 
           private

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/local_assets_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/local_assets_test.rb
@@ -114,46 +114,6 @@ module ShopifyCLI
           assert_equal("Not found", response.body)
         end
 
-        def test_replace_local_images_in_reponse_body
-          theme = stub("Theme", static_asset_paths: [
-            "assets/test-image.png",
-            "assets/test-image.png",
-            "assets/test-image.jpeg",
-            "assets/test-image.jpg",
-            "assets/test-vector.svg",
-            "assets/folha_de_estilo.css",
-            "assets/script.js",
-            "assets/static_object.json",
-          ])
-
-          original_html = <<~HTML
-            <html>
-              <body>
-                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/test-image.png?v=111111111111"></div>
-                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/test-image.jpeg?v=111111111111"></div>
-                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/test-image.jpg?v=111111111111"></div>
-                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/test-vector.svg?v=111111111111"></div>
-                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/folha_de_estilo.css?v=111111111111"></div>
-                <div data-src="//cdn.shopify.com/s/files/1/0000/1111/2222/t/333/assets/script.js?v=111111111111"></div>
-              </body>
-            </html>
-          HTML
-          expected_html = <<~HTML
-            <html>
-              <body>
-                <div data-src="/assets/test-image.png?v=111111111111"></div>
-                <div data-src="/assets/test-image.jpeg?v=111111111111"></div>
-                <div data-src="/assets/test-image.jpg?v=111111111111"></div>
-                <div data-src="/assets/test-vector.svg?v=111111111111"></div>
-                <div data-src="/assets/folha_de_estilo.css?v=111111111111"></div>
-                <div data-src="/assets/script.js?v=111111111111"></div>
-              </body>
-            </html>
-          HTML
-
-          assert_equal(expected_html, serve(original_html, theme_mock: theme).body)
-        end
-
         def test_replace_shop_assets_urls_in_reponse_body
           theme = stub("Theme", static_asset_paths: [
             "assets/component-list-menu.css",

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server/local_assets_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server/local_assets_test.rb
@@ -110,46 +110,6 @@ module ShopifyCLI
             assert_equal("Not found", response.body)
           end
 
-          def test_replace_local_images_in_reponse_body
-            extension = stub("Extension", static_asset_paths: [
-              "assets/test-image.png",
-              "assets/test-image.png",
-              "assets/test-image.jpeg",
-              "assets/test-image.jpg",
-              "assets/test-vector.svg",
-              "assets/folha_de_estilo.css",
-              "assets/script.js",
-              "assets/static_object.json",
-            ])
-
-            original_html = <<~HTML
-              <html>
-                <body>
-                  <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/test-image.png?v=111111111111"></div>
-                  <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/test-image.jpeg?v=111111111111"></div>
-                  <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/test-image.jpg?v=111111111111"></div>
-                  <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/test-vector.svg?v=111111111111"></div>
-                  <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/folha_de_estilo.css?v=111111111111"></div>
-                  <div data-src="//cdn.shopify.com/extensions/s/files/1/0000/1111/2222/t/333/assets/script.js?v=111111111111"></div>
-                </body>
-              </html>
-            HTML
-            expected_html = <<~HTML
-              <html>
-                <body>
-                  <div data-src="/assets/test-image.png?v=111111111111"></div>
-                  <div data-src="/assets/test-image.jpeg?v=111111111111"></div>
-                  <div data-src="/assets/test-image.jpg?v=111111111111"></div>
-                  <div data-src="/assets/test-vector.svg?v=111111111111"></div>
-                  <div data-src="/assets/folha_de_estilo.css?v=111111111111"></div>
-                  <div data-src="/assets/script.js?v=111111111111"></div>
-                </body>
-              </html>
-            HTML
-
-            assert_equal(expected_html, serve(original_html, extension_mock: extension).body)
-          end
-
           private
 
           def serve(response_body, path: "/", extension_mock: nil)


### PR DESCRIPTION
Backport https://github.com/Shopify/cli/pull/2138

---

### WHY are these changes introduced?

I previously assumed that the `LocalAssets` middleware was required to serve images locally in order to avoid 404 errors, as mentioned in https://github.com/Shopify/cli/pull/2105. However, the root cause was actually addressed by https://github.com/Shopify/cli/pull/2110.

While serving images locally does offer faster performance and can prevent some 404 errors, even when images haven't been fully updated in the theme library, the `LocalAssets` middleware is unable to handle the URL modifications made by Liquid filters.

Thus, this PR reverts that performance enhancement for now, since the true solution is provided by https://github.com/Shopify/cli/pull/2110.

### WHAT is this pull request doing?

This PR reverts https://github.com/Shopify/cli/pull/2105.

### How to test your changes?

- Run `shopify theme dev`
- Add an image called `test-image-1.jpg` in the `/assets` directory
- Add an snippet like `<img src="{{ 'test-image-1.jpg' | asset_img_url: 'master' }}">` in the `sections/announcement-bar.liquid` file
- Open `http://127.0.0.1:9292`
- Notice that images load from CDN successfully
- Activate the `storefront_vanity_assets_url` flag
- Reload `http://127.0.0.1:9292`
- Notice that images load from CDN successfully
- Notice that fonts load from the local server

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
