### PR TITLE
Fix login on theme dev

### DIFF
--- a/.changeset/silly-shoes-visit.md
+++ b/.changeset/silly-shoes-visit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix clean login on theme dev

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -1,11 +1,10 @@
 import {themeFlags} from '../../flags.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
 import ThemeCommand from '../../utilities/theme-command.js'
-import {dev, showDeprecationWarnings} from '../../services/dev.js'
+import {dev, refreshTokens, showDeprecationWarnings} from '../../services/dev.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 
 export default class Dev extends ThemeCommand {
   static description =
@@ -103,8 +102,7 @@ export default class Dev extends ThemeCommand {
     let {flags} = await this.parse(Dev)
     const store = ensureThemeStore(flags)
 
-    const adminSession = await ensureAuthenticatedThemes(store, flags.password, [], true)
-    const storefrontToken = await ensureAuthenticatedStorefront([], flags.password)
+    const {adminSession, storefrontToken} = await refreshTokens(store, flags.password)
 
     if (!flags.theme) {
       const theme = await new DevelopmentThemeManager(adminSession).findOrCreate()
@@ -121,7 +119,7 @@ export default class Dev extends ThemeCommand {
       adminSession,
       storefrontToken,
       directory: flags.path,
-      store: ensureThemeStore(flags),
+      store,
       password: flags.password,
       theme: flags.theme!,
       host: flags.host,

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -114,6 +114,17 @@ describe('showDeprecationWarnings', () => {
 })
 
 describe('refreshTokens', () => {
+  test('returns the admin session and storefront token', async () => {
+    // When
+    const result = await refreshTokens('my-store', 'my-password')
+
+    // Then
+    expect(result).toEqual({
+      adminSession: {storeFqdn: 'my-store.myshopify.com', token: 'my-password'},
+      storefrontToken: 'my-password',
+    })
+  })
+
   test('refreshes CLI2 cache with theme token command', async () => {
     // When
     await refreshTokens('my-store', 'my-password')

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -134,5 +134,8 @@ export function showDeprecationWarnings(args: string[]) {
 export async function refreshTokens(store: string, password: string | undefined) {
   const adminSession = await ensureAuthenticatedThemes(store, password, [], true)
   const storefrontToken = await ensureAuthenticatedStorefront([], password)
-  await execCLI2(['theme', 'token', '--admin', adminSession.token, '--sfr', storefrontToken])
+  if (useEmbeddedThemeCLI()) {
+    await execCLI2(['theme', 'token', '--admin', adminSession.token, '--sfr', storefrontToken])
+  }
+  return {adminSession, storefrontToken}
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1843
Fixes https://github.com/Shopify/cli/issues/1554

In https://github.com/Shopify/cli/pull/2137 I made a small refactor that broke a fresh login from `theme dev` when no password is provided.

### WHAT is this pull request doing?

Ensures the auth tokens are stored in CLI2's cache after a new login, and not only when they are refreshed.

### How to test your changes?

- `p shopify auth logout`
- `p shopify theme dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
