### PR TITLE
Upload extension points for POS UI extensions

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
@@ -19,6 +19,7 @@ const spec = createExtensionSpecification({
       name: config.name,
       description: config.description,
       renderer_version: result?.version,
+      extension_points: config.extensionPoints,
     }
   },
   previewMessage: () => undefined,


### PR DESCRIPTION
### WHY are these changes introduced?

Partly fixes https://github.com/Shopify/pos-next-react-native/issues/25175

### WHAT is this pull request doing?

Including the POS extension points as part of the payload for the `deploymentCreate` mutation.

### How to test your changes?


#### Generate a new extension

```bash
$ pnpm run generate extension

> my-app-1@1.0.0 generate /Users/me/my-app-1
> shopify app generate "extension"
...
   Point-of-Sale
>  (14) POS UI
```

#### Edit extensions/my-extension/shopify.ui.extension.toml

```toml
type = "pos_ui_extension"
name = "my-extension"

extension_points = [
  'Retail::SmartGrid::Tile',
  'Retail::SmartGrid::Modal'
]
```

#### Deploy

````bash
$ pnpm run deploy
````

#### [Verify database contains the new data](https://app.shopify.com/services/internal/queries/new?q=SELECT%20*%20FROM%20app_static_extension_configs%20C%0AINNER%20JOIN%20app_extension_registrations%20R%20ON%20R.id%20%3D%20C.registration_id%0AWHERE%20R.id%20%3D%2020348207105%3B&shard_by=master) in config

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [X] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
