### PR TITLE
Show new error if rosetta 2 is not installed

### DIFF
--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -103,7 +103,7 @@ async function pollTunnelURL(tunnelClient: TunnelClient): Promise<string> {
     const pollTunnelStatus = async () => {
       const result = tunnelClient.getTunnelStatus()
       outputDebug(`Polling tunnel status for ${tunnelClient.provider} (attempt ${retries}): ${result.status}`)
-      if (result.status === 'error') return reject(new BugError(result.message))
+      if (result.status === 'error') return reject(new BugError(result.message, result.tryMessage))
       if (result.status === 'connected') {
         resolve(result.url)
       } else {

--- a/packages/cli-kit/src/public/node/plugins/tunnel.ts
+++ b/packages/cli-kit/src/public/node/plugins/tunnel.ts
@@ -13,7 +13,7 @@ export type TunnelStatusType =
   | {status: 'not-started'}
   | {status: 'starting'}
   | {status: 'connected'; url: string}
-  | {status: 'error'; message: string}
+  | {status: 'error'; message: string; tryMessage?: string}
 
 export class TunnelError extends ExtendableError {
   type: TunnelErrorType

--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -109,7 +109,17 @@ class TunnelClientInstance implements TunnelClient {
       stdout: customStdout,
       stderr: customStdout,
       signal: this.abortController.signal,
-      externalErrorHandler: async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      externalErrorHandler: async (error: any) => {
+        if (error.message.includes('Unknown system error -86')) {
+          // Cloudflare crashed because Rosetta 2 is not installed
+          this.currentStatus = {
+            status: 'error',
+            message: `Error starting cloudflared tunnel. Missing Rosetta 2.`,
+            tryMessage: "Install it by running 'softwareupdate --install-rosetta' and try again",
+          }
+          return
+        }
         // If already resolved, means that the CLI already received the tunnel URL.
         // Can't retry because the CLI is running with an invalid URL
         if (resolved) throw processCrashed()


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- The `cloudflared` binary needs rosetta tu run (is an intel app still...)
- MacOS automatically installs rosetta for apps that need it, but not for binaries run from the terminal.
- If Rosetta2 is not installed we'll prompt a specific error with instructions on how to install it.

Fixes https://github.com/Shopify/cli/issues/2170

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Show an error if cloudflare crashes because Rosetta is not installed.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a Mac virtual machine with parallels
- Make sure to no install anything that could trigger rosetta, just install node
- `npm init @shopify/app@latest`
- `npm run dev`
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
