### PR TITLE
Show confirmation prompt with the extensions as part of the app relea…

### DIFF
--- a/.changeset/tame-hotels-confess.md
+++ b/.changeset/tame-hotels-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Show confirmation prompt with the extensions as part of the app release command

--- a/packages/app/src/cli/api/graphql/app_version_by_tag.ts
+++ b/packages/app/src/cli/api/graphql/app_version_by_tag.ts
@@ -1,0 +1,32 @@
+import {gql} from 'graphql-request'
+
+export const AppVersionByTagQuery = gql`
+  query AppVersionByTag($apiKey: String!, $versionTag: String!) {
+    app(apiKey: $apiKey) {
+      deployment(versionTag: $versionTag) {
+        id
+        uuid
+        versionTag
+        location
+        message
+      }
+    }
+  }
+`
+
+interface ErrorDetail {
+  extension_id: number
+  extension_title: string
+}
+
+export interface AppVersionByTagSchema {
+  app: {
+    deployment: {
+      id: number
+      uuid: string
+      versionTag: string
+      location: string
+      message: string
+    }
+  }
+}

--- a/packages/app/src/cli/prompts/release.test.ts
+++ b/packages/app/src/cli/prompts/release.test.ts
@@ -6,12 +6,57 @@ import {AbortSilentError} from '@shopify/cli-kit/node/error'
 vi.mock('@shopify/cli-kit/node/ui')
 
 describe('confirmReleasePrompt', () => {
-  test('returns without error in case the user confirm the release prompt', async () => {
+  test('shows extensions in the infoTable if the diff contains added or update extensions', async () => {
     // Given
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
-    // When/ Then
-    await expect(confirmReleasePrompt('test app')).resolves
+    // When / Then
+    await expect(
+      confirmReleasePrompt('test app', {
+        added: [{uuid: '2be20cc3-c102-4192-bd5c-e0aaccd25ede', registrationTitle: 'theme-app-ext'}],
+        updated: [{uuid: 'abc8049d-af76-4430-84df-a6c2d8ed88aa', registrationTitle: 'sub-ui-ext'}],
+        removed: [],
+      }),
+    ).resolves
+    expect(renderConfirmationPrompt).toHaveBeenCalledWith({
+      message: 'Release this version of test app?',
+      infoTable: [
+        {
+          header: 'Extensions',
+          items: ['theme-app-ext', 'sub-ui-ext'],
+        },
+      ],
+      confirmationMessage: 'Yes, release this version',
+      cancellationMessage: 'No, cancel',
+    })
+  })
+
+  test('shows removed extensions in the infoTable if the diff contains removed extensions', async () => {
+    // Given
+    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+
+    // When / Then
+    await expect(
+      confirmReleasePrompt('test app', {
+        added: [],
+        updated: [],
+        removed: [{uuid: 'abc8049d-af76-4430-84df-a6c2d8ed88aa', registrationTitle: 'sub-ui-ext'}],
+      }),
+    ).resolves
+
+    expect(renderConfirmationPrompt).toHaveBeenCalledWith({
+      message: 'Release this version of test app?',
+      infoTable: [
+        {
+          header: 'Removed',
+          color: 'red',
+          helperText: 'Will be removed for users when this version is released.',
+          items: ['sub-ui-ext'],
+        },
+      ],
+      confirmationMessage: 'Yes, release this version',
+      cancellationMessage: 'No, cancel',
+    })
   })
 
   test('throws a silent exception in case the user rejects the release prompt', async () => {
@@ -19,6 +64,12 @@ describe('confirmReleasePrompt', () => {
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
 
     // When/ Then
-    await expect(confirmReleasePrompt('test app')).rejects.toThrow(AbortSilentError)
+    await expect(
+      confirmReleasePrompt('test app', {
+        added: [],
+        updated: [],
+        removed: [],
+      }),
+    ).rejects.toThrow(AbortSilentError)
   })
 })

--- a/packages/app/src/cli/prompts/release.ts
+++ b/packages/app/src/cli/prompts/release.ts
@@ -1,9 +1,32 @@
+import {AppVersionsDiffSchema} from '../api/graphql/app_versions_diff.js'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
 import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
 
-export async function confirmReleasePrompt(appName: string) {
+export async function confirmReleasePrompt(
+  appName: string,
+  versionsDiff: AppVersionsDiffSchema['app']['versionsDiff'],
+) {
+  const infoTable = []
+  const extensions = [...versionsDiff.added, ...versionsDiff.updated]
+
+  if (extensions.length > 0) {
+    infoTable.push({
+      header: 'Extensions',
+      items: extensions.map((extension) => extension.registrationTitle),
+    })
+  }
+
+  if (versionsDiff.removed.length > 0) {
+    infoTable.push({
+      header: 'Removed',
+      color: 'red',
+      helperText: 'Will be removed for users when this version is released.',
+      items: versionsDiff.removed.map((extension) => extension.registrationTitle),
+    })
+  }
   const confirm = await renderConfirmationPrompt({
     message: `Release this version of ${appName}?`,
+    infoTable,
     confirmationMessage: 'Yes, release this version',
     cancellationMessage: 'No, cancel',
   })

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -1,7 +1,7 @@
 import {ensureReleaseContext} from './context.js'
 import {release} from './release.js'
+import {versionDiffByVersion} from './release/version-diff.js'
 import {testApp} from '../models/app/app.test-data.js'
-import {updateAppIdentifiers} from '../models/app/identifiers.js'
 import {AppInterface} from '../models/app/app.js'
 import {OrganizationApp} from '../models/organization.js'
 import {confirmReleasePrompt} from '../prompts/release.js'
@@ -16,6 +16,8 @@ vi.mock('../models/app/identifiers.js')
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('../prompts/release.js')
 vi.mock('@shopify/cli-kit/node/api/partners')
+vi.mock('../api/graphql/app_release.js')
+vi.mock('./release/version-diff.js')
 
 beforeEach(() => {
   // this is needed because using importActual to mock the ui module
@@ -54,11 +56,6 @@ describe('release', () => {
       return {
         appRelease: {
           appRelease: {
-            deployment: {
-              location: 'https://example.com',
-              versionTag: '1.0.0',
-              message: 'message',
-            },
             userErrors: [],
           },
         },
@@ -96,7 +93,7 @@ describe('release', () => {
     })
   })
 
-  test('shows a custom error message without link and message if no deployment is returned', async () => {
+  test('shows a custom error message with link and message if errors are returned', async () => {
     // Given
     const app = testApp()
     vi.mocked(confirmReleasePrompt).mockResolvedValue()
@@ -127,44 +124,6 @@ describe('release', () => {
 
     // Then
     expect(renderError).toHaveBeenCalledWith({
-      body: ['some kind of error 1, some kind of error 2'],
-      headline: "Version couldn't be released",
-    })
-  })
-
-  test('shows a custom error message with link and message if a deployment is returned', async () => {
-    // given
-    const app = testApp()
-    vi.mocked(confirmReleasePrompt).mockResolvedValue()
-    vi.mocked(renderTasks).mockImplementation(async (tasks: Task[]) => {
-      for (const task of tasks) {
-        // eslint-disable-next-line no-await-in-loop
-        await task.task({}, task)
-      }
-
-      return {
-        appRelease: {
-          appRelease: {
-            deployment: {
-              location: 'https://example.com',
-              versionTag: '1.0.0',
-              message: 'message',
-            },
-            userErrors: [
-              {
-                message: 'needs to be submitted for review and approved by Shopify before it can be released',
-              },
-            ],
-          },
-        },
-      }
-    })
-
-    // When
-    await testRelease(app, 'app-version')
-
-    // Then
-    expect(renderError).toHaveBeenCalledWith({
       body: [
         {
           link: {
@@ -173,7 +132,7 @@ describe('release', () => {
           },
         },
         '\nmessage',
-        '\n\nneeds to be submitted for review and approved by Shopify before it can be released',
+        '\n\nsome kind of error 1, some kind of error 2',
       ],
       headline: "Version couldn't be released",
     })
@@ -194,7 +153,11 @@ async function testRelease(
     token: 'api-token',
     apiKey: partnersApp?.id ?? 'app-id',
   })
-  vi.mocked(updateAppIdentifiers).mockResolvedValue(app)
+
+  vi.mocked(versionDiffByVersion).mockResolvedValue({
+    versionsDiff: {added: [], removed: [], updated: []},
+    versionDetails: {id: 1, uuid: 'uuid', location: 'https://example.com', versionTag: '1.0.0', message: 'message'},
+  })
 
   await release({
     app,

--- a/packages/app/src/cli/services/release/version-diff.test.ts
+++ b/packages/app/src/cli/services/release/version-diff.test.ts
@@ -1,0 +1,46 @@
+import {versionDiffByVersion} from './version-diff.js'
+import {describe, expect, vi, test} from 'vitest'
+import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+
+vi.mock('@shopify/cli-kit/node/api/partners')
+
+describe('versionDiffByVersion', () => {
+  test('throws an abort silent error and display an error message when the version is not found', async () => {
+    // Given
+    vi.mocked(partnersRequest).mockRejectedValue(new AbortError('Not found'))
+    const outputMock = mockAndCaptureOutput()
+
+    // When/Then
+    await expect(versionDiffByVersion('apiKey', 'version', 'token')).rejects.toThrow(AbortSilentError)
+    expect(outputMock.error()).toMatchInlineSnapshot(`
+      "╭─ error ──────────────────────────────────────────────────────────────────────╮
+      │                                                                              │
+      │  Version couldn't be released                                                │
+      │                                                                              │
+      │  Version version could not be found.                                         │
+      │                                                                              │
+      ╰──────────────────────────────────────────────────────────────────────────────╯
+      "
+    `)
+  })
+
+  test('returns versionDiff and versionDetails when the version is found', async () => {
+    // Given
+    const versionDetails = {id: 'id', uuid: 'uuid', versionTag: 'versionTag', location: 'location', message: 'message'}
+    const versionsDiff = {
+      added: [{registrationTitle: 'Extension 1', uuid: 'uuid1'}],
+      updated: [{registrationTitle: 'Extension 2', uuid: 'uuid2'}],
+      removed: [{registrationTitle: 'Extension 3', uuid: 'uuid3'}],
+    }
+    vi.mocked(partnersRequest).mockResolvedValueOnce({app: {deployment: versionDetails}})
+    vi.mocked(partnersRequest).mockResolvedValueOnce({app: {versionsDiff}})
+
+    // When
+    const result = await versionDiffByVersion('apiKey', 'version', 'token')
+
+    // Then
+    expect(result).toEqual({versionsDiff, versionDetails})
+  })
+})

--- a/packages/app/src/cli/services/release/version-diff.ts
+++ b/packages/app/src/cli/services/release/version-diff.ts
@@ -1,0 +1,42 @@
+import {AppVersionsDiffQuery, AppVersionsDiffSchema} from '../../api/graphql/app_versions_diff.js'
+import {AppVersionByTagQuery, AppVersionByTagSchema} from '../../api/graphql/app_version_by_tag.js'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {renderError} from '@shopify/cli-kit/node/ui'
+import {AbortSilentError} from '@shopify/cli-kit/node/error'
+
+export async function versionDiffByVersion(
+  apiKey: string,
+  version: string,
+  token: string,
+): Promise<{
+  versionsDiff: AppVersionsDiffSchema['app']['versionsDiff']
+  versionDetails: AppVersionByTagSchema['app']['deployment']
+}> {
+  const versionDetails = await versionDetailsByVersion(apiKey, version, token)
+  const {
+    app: {versionsDiff},
+  }: AppVersionsDiffSchema = await partnersRequest(AppVersionsDiffQuery, token, {
+    apiKey,
+    versionId: versionDetails.id,
+  })
+
+  return {versionsDiff, versionDetails}
+}
+
+async function versionDetailsByVersion(apiKey: string, version: string, token: string) {
+  try {
+    const {
+      app: {deployment},
+    }: AppVersionByTagSchema = await partnersRequest(AppVersionByTagQuery, token, {
+      apiKey,
+      versionTag: version,
+    })
+    return deployment
+  } catch (err) {
+    renderError({
+      headline: "Version couldn't be released",
+      body: `Version ${version} could not be found.`,
+    })
+    throw new AbortSilentError()
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/552

IMPORTANT: Should we wait until this [PR](https://github.com/Shopify/shopify/pull/432410) is merged or should we create another issue to handle the version not found error properly?

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Integrate the API operation to get version detail from the version tag
- Show a fixed `not found` error message when fetching the version details return an error
- Integrate the API operation to get diffs between a versionId and the current active version
- Add diff information to the confirmation prompt
- Use version details in the banner shown when the release mutation fails

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

#### Happy path
- Run deploy no release `pnpm shopify app deploy --path  <YOUR_APP_PATH> --reset --no-release`
- Run release with the version generated `pnpm shopify app release --path  <YOUR_APP_PATH> --version=last_v3-1`
- You should see the diffs in the confirmation prompt
<img src="https://github.com/Shopify/cli/assets/105213827/24b89ae1-6a5e-4a83-a06a-dff9592dd15d" width="400"/>

#### Version not found
- Run release with a non existing `pnpm shopify app release --path <YOUR_APP_PATH> --version=last_v3-1-non-existing`
- You should see the not found error
<img src="https://github.com/Shopify/cli/assets/105213827/00cef193-b99c-43af-b77d-c01f963b481c" width="400"/>

#### Version not approved
-  [Add Payments App membership to your org](https://payments-platform.docs.shopify.io/payments_partners/how_to/shopifolks/grant_payments_apps).
- Create a payment extension from the Partner Dashboard in your remote app
- Run deploy no release `pnpm shopify app deploy --path  <YOUR_APP_PATH> --reset --no-release`
- Run release with the version generated `pnpm shopify app release --path  <YOUR_APP_PATH> --version=last_v3-1`
- You should see the server side error
<img src="https://github.com/Shopify/cli/assets/105213827/caee9121-186c-4624-bd57-9d126e4d5673" width="400"/>


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
