### PR TITLE
Introduce the `--open` flag to open a browser window only when users specifically request it

### DIFF
--- a/.changeset/hip-brooms-mate.md
+++ b/.changeset/hip-brooms-mate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Introduce the `--open` flag to open a browser window only when users specifically request it

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/serve.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/serve.rb
@@ -36,6 +36,7 @@ module Theme
         end
         parser.on("-f", "--force") { flags[:force] = true }
         parser.on("--overwrite-json") { flags[:overwrite_json] = true }
+        parser.on("--open") { flags[:open_browser] = true }
         parser.on("-n", "--notify=PATH") { |path| flags[:notify] = path }
       end
 

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server.rb
@@ -43,6 +43,7 @@ module ShopifyCLI
           poll: false,
           editor_sync: false,
           overwrite_json: false,
+          open_browser: false,
           stable: false,
           mode: ReloadMode.default,
           includes: nil,
@@ -59,6 +60,7 @@ module ShopifyCLI
             poll,
             editor_sync,
             overwrite_json,
+            open_browser,
             stable,
             mode,
             includes,
@@ -84,6 +86,7 @@ module ShopifyCLI
         poll,
         editor_sync,
         overwrite_json,
+        open_browser,
         stable,
         mode,
         includes,
@@ -99,6 +102,7 @@ module ShopifyCLI
         @poll = poll
         @editor_sync = editor_sync
         @overwrite_json = overwrite_json
+        @open_browser = open_browser
         @stable = stable
         @mode = mode
         @includes = includes
@@ -184,7 +188,7 @@ module ShopifyCLI
           syncer.upload_theme!(delay_low_priority_files: true)
         end
 
-        ctx.open_browser_url!(address)
+        ctx.open_browser_url!(address) if @open_browser
       end
 
       def theme

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server_test.rb
@@ -118,10 +118,10 @@ module ShopifyCLI
       private
 
       def dev_server(identifier: nil, ignores: nil, includes: nil)
-        host, port, poll, editor_sync, overwrite_json, stable, mode, notify = nil
+        host, port, poll, editor_sync, overwrite_json, open_browser, stable, mode, notify = nil
         server = DevServer.instance
-        server.setup(ctx, root, host, identifier, port, poll, editor_sync, overwrite_json, stable, mode, includes,
-          ignores, notify)
+        server.setup(ctx, root, host, identifier, port, poll, editor_sync, overwrite_json, open_browser,
+          stable, mode, includes, ignores, notify)
         server
       end
 

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server_test.rb
@@ -147,10 +147,10 @@ module ShopifyCLI
         private
 
         def dev_server(identifier: nil)
-          host, port, poll, editor_sync, overwrite_json, stable, mode, ignores, includes, notify = nil
+          host, port, poll, editor_sync, overwrite_json, open_browser, stable, mode, ignores, includes, notify = nil
           server = Extension::DevServer.instance
-          server.setup(ctx, root, host, identifier, port, poll, editor_sync, overwrite_json, stable, mode, ignores,
-            includes, notify)
+          server.setup(ctx, root, host, identifier, port, poll, editor_sync, overwrite_json, open_browser,
+            stable, mode, ignores, includes, notify)
           server.project = project
           server.specification_handler = specification_handler
           server

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -395,6 +395,12 @@
           "type": "option",
           "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
           "multiple": false
+        },
+        "open": {
+          "name": "open",
+          "type": "boolean",
+          "description": "Automatically launch the theme preview in your default web browser.",
+          "allowNo": false
         }
       },
       "args": {},
@@ -1182,6 +1188,12 @@
           "type": "option",
           "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
           "multiple": false
+        },
+        "open": {
+          "name": "open",
+          "type": "boolean",
+          "description": "Automatically launch the theme preview in your default web browser.",
+          "allowNo": false
         }
       },
       "args": {}

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -76,6 +76,11 @@ export default class Dev extends ThemeCommand {
         'The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.',
       env: 'SHOPIFY_FLAG_NOTIFY',
     }),
+    open: Flags.boolean({
+      description: 'Automatically launch the theme preview in your default web browser.',
+      env: 'SHOPIFY_FLAG_OPEN',
+      default: false,
+    }),
   }
 
   static cli2Flags = [
@@ -129,6 +134,7 @@ export default class Dev extends ThemeCommand {
       host: flags.host,
       port: flags.port,
       force: flags.force,
+      open: flags.open,
       flagsToPass,
     })
   }

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -8,19 +8,25 @@ import {execCLI2} from '@shopify/cli-kit/node/ruby'
 vi.mock('@shopify/cli-kit/node/ruby')
 
 describe('dev', () => {
+  const adminSession = {storeFqdn: 'my-store.myshopify.com', token: 'my-token'}
+  const options = {
+    adminSession,
+    storefrontToken: 'my-storefront-token',
+    directory: 'my-directory',
+    store: 'my-store',
+    theme: '123',
+    force: false,
+    open: false,
+    flagsToPass: [],
+    password: 'my-token',
+  }
+
   test('runs theme serve on CLI2 without passing a token when no password is used', async () => {
+    // Given
+    const devOptions = {...options, password: undefined}
+
     // When
-    const adminSession = {storeFqdn: 'my-store.myshopify.com', token: 'my-token'}
-    const options = {
-      adminSession,
-      storefrontToken: 'my-storefront-token',
-      directory: 'my-directory',
-      store: 'my-store',
-      theme: '123',
-      force: false,
-      flagsToPass: [],
-    }
-    await dev(options)
+    await dev(devOptions)
 
     // Then
     const expectedParams = ['theme', 'serve', 'my-directory']
@@ -32,19 +38,43 @@ describe('dev', () => {
   })
 
   test('runs theme serve on CLI2 passing a token when a password is used', async () => {
+    // Given
+    const devOptions = {...options, password: 'my-token'}
+
     // When
-    const adminSession = {storeFqdn: 'my-store.myshopify.com', token: 'my-token'}
-    const options = {
-      adminSession,
-      storefrontToken: 'my-storefront-token',
-      directory: 'my-directory',
+    await dev(devOptions)
+
+    // Then
+    const expectedParams = ['theme', 'serve', 'my-directory']
+    expect(execCLI2).toHaveBeenCalledWith(expectedParams, {
       store: 'my-store',
-      theme: '123',
-      force: false,
-      flagsToPass: [],
-      password: 'my-token',
-    }
-    await dev(options)
+      adminToken: 'my-token',
+      storefrontToken: 'my-storefront-token',
+    })
+  })
+
+  test("runs theme serve on CLI2 passing '--open' flag when it's true", async () => {
+    // Given
+    const devOptions = {...options, open: true}
+
+    // When
+    await dev(devOptions)
+
+    // Then
+    const expectedParams = ['theme', 'serve', 'my-directory', '--open']
+    expect(execCLI2).toHaveBeenCalledWith(expectedParams, {
+      store: 'my-store',
+      adminToken: 'my-token',
+      storefrontToken: 'my-storefront-token',
+    })
+  })
+
+  test("runs theme serve on CLI2 passing '--open' flag when it's false", async () => {
+    // Given
+    const devOptions = {...options, open: false}
+
+    // When
+    await dev(devOptions)
 
     // Then
     const expectedParams = ['theme', 'serve', 'my-directory']

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -18,6 +18,7 @@ export interface DevOptions {
   directory: string
   store: string
   password?: string
+  open: boolean
   theme: string
   host?: string
   port?: string
@@ -36,6 +37,10 @@ export async function dev(options: DevOptions) {
 
   let adminToken: string | undefined = options.adminSession.token
   let storefrontToken: string | undefined = options.storefrontToken
+
+  if (options.open && useEmbeddedThemeCLI()) {
+    command.push('--open')
+  }
 
   if (!options.password && useEmbeddedThemeCLI()) {
     adminToken = undefined


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1777

During the modifications in the theme development server to ensure better integration with the UI kit, we introduced a change to auto-open the browser. However, this change led to more difficulties than support for theme developers.

As a result, this PR rolls back that change, and now, if developers want to open the browser, they need to specifically request it with the `--open` flag.

### WHAT is this pull request doing?

This PR introduces the `--open` flag, which defaults to `false`.

### How to test your changes?

- Run `shopify theme dev`
- Notice the development server no longer auto opens the browser
- Run `shopify theme dev --open`
- Notice the development server no longer auto opens the browser

**Before**

<img src="https://github.com/Shopify/cli/assets/1079279/5b10f73c-0ece-4356-8245-3fca6d9001ca" width="60%">


**After**

<img src="https://github.com/Shopify/cli/assets/1079279/c1b76ed7-57a3-48f9-9847-917a75255ab3" width="60%">



### Post-release steps

Introduce documentation at [shopify.dev](https://shopify.dev/docs/themes/tools/cli/commands#dev).

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).

