### PR TITLE
Use dynamic install URL

### DIFF
--- a/.changeset/loud-hairs-sell.md
+++ b/.changeset/loud-hairs-sell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Use platform-hosted endpoint for web app URL

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -140,7 +140,7 @@ async function dev(options: DevOptions) {
 
   let previewUrl
   if (frontendConfig || backendConfig) {
-    previewUrl = buildAppURLForWeb(storeFqdn, exposedUrl)
+    previewUrl = buildAppURLForWeb(storeFqdn, apiKey)
     if (options.update) {
       const newURLs = generatePartnersURLs(
         exposedUrl,

--- a/packages/app/src/cli/services/dev/extension/payload/store.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.test.ts
@@ -36,7 +36,7 @@ describe('getExtensionsPayloadStoreRawPayload()', () => {
       app: {
         title: 'mock-app-name',
         apiKey: 'mock-api-key',
-        url: 'https://mock-url.com?shop=mock-store-fqdn.shopify.com&host=bW9jay1zdG9yZS1mcWRuLnNob3BpZnkuY29tL2FkbWlu',
+        url: 'https://mock-store-fqdn.shopify.com/admin/oauth/redirect_from_cli?client_id=mock-api-key',
         mobileUrl:
           'https://mock-store-fqdn.shopify.com/admin/apps/mock-api-key?shop=mock-store-fqdn.shopify.com&host=bW9jay1zdG9yZS1mcWRuLnNob3BpZnkuY29tL2FkbWluL2FwcHMvbW9jay1hcGkta2V5',
       },

--- a/packages/app/src/cli/services/dev/extension/payload/store.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.ts
@@ -22,7 +22,7 @@ export async function getExtensionsPayloadStoreRawPayload(
     app: {
       title: options.app.name,
       apiKey: options.apiKey,
-      url: buildAppURLForWeb(options.storeFqdn, options.url),
+      url: buildAppURLForWeb(options.storeFqdn, options.apiKey),
       mobileUrl: buildAppURLForMobile(options.storeFqdn, options.apiKey),
     },
     appId: options.id,

--- a/packages/app/src/cli/utilities/app/app-url.ts
+++ b/packages/app/src/cli/utilities/app/app-url.ts
@@ -1,7 +1,5 @@
-export function buildAppURLForWeb(storeFqdn: string, publicURL: string) {
-  const hostUrl = `${storeFqdn}/admin`
-  const hostParam = Buffer.from(hostUrl).toString('base64').replace(/[=]/g, '')
-  return `${publicURL}?shop=${storeFqdn}&host=${hostParam}`
+export function buildAppURLForWeb(storeFqdn: string, apiKey: string) {
+  return `https://${storeFqdn}/admin/oauth/redirect_from_cli?client_id=${apiKey}`
 }
 
 export function buildAppURLForMobile(storeFqdn: string, apiKey: string) {


### PR DESCRIPTION
### WHY are these changes introduced?

We'd like the flexibility to modify the install process in the future, so move install URL generation to the platform.

### WHAT is this pull request doing?

Sends the developer through `redirect_from_cli` instead of the app home.

### How to test your changes?

1. Run `app dev`
2. Verify that the preview URL correctly installs the app.
3. Run `app dev` again.
4. Verify that the preview URL correctly loads the app.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
