### PR TITLE
Add missing apiVersion type in ui-extension-server-kit

### DIFF
--- a/.changeset/tender-dogs-train.md
+++ b/.changeset/tender-dogs-train.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-server-kit': patch
+---
+
+Add missing apiVersion prop to the UIExtension interface

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -61,6 +61,7 @@ declare global {
 
     interface UIExtension extends ExtensionPayload {
       extensionPoints: ExtensionPoint[]
+      apiVersion: string
     }
   }
 }


### PR DESCRIPTION
Related to https://github.com/Shopify/app-ui/issues/154

### WHY are these changes introduced?

The CLI was passing through the `apiVersion` but the Dev Server Kit was missing this in the UIExtension interface

### WHAT is this pull request doing?

Add the missing `apiVersion` prop

### How to test your changes?

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [X] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
