### PR TITLE
Skip scanning node modules

### DIFF
--- a/.changeset/tall-tables-hug.md
+++ b/.changeset/tall-tables-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Skip node_modules when scanning for webs and extensions

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -4,7 +4,13 @@ import metadata from '../../metadata.js'
 import {loadLocalExtensionsSpecifications} from '../extensions/load-specifications.js'
 import {ExtensionSpecification} from '../extensions/specification.js'
 import {describe, expect, beforeEach, afterEach, beforeAll, test} from 'vitest'
-import {yarnLockfile, pnpmLockfile, PackageJson, pnpmWorkspaceFile} from '@shopify/cli-kit/node/node-package-manager'
+import {
+  installNodeModules,
+  yarnLockfile,
+  pnpmLockfile,
+  PackageJson,
+  pnpmWorkspaceFile,
+} from '@shopify/cli-kit/node/node-package-manager'
 import {inTemporaryDirectory, moveFile, mkdir, mkTmpDir, rmdir, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname, cwd} from '@shopify/cli-kit/node/path'
 
@@ -202,6 +208,34 @@ scopes = "read_products"
     // Then
     expect(app.usesWorkspaces).toBe(true)
   })
+
+  test('does not double-count webs defined in workspaces', async () => {
+    // Given
+    await writeConfig(appConfiguration, {
+      workspaces: ['web'],
+      name: 'my_app',
+      dependencies: {'empty-npm-package': '1.0.0'},
+      devDependencies: {},
+    })
+
+    // When
+    let app = await load({directory: tmpDir, specifications})
+    const web = app.webs[0]
+    // Force npm to symlink the workspace directory
+    await writeFile(
+      joinPath(web.directory, 'package.json'),
+      JSON.stringify({name: 'web', dependencies: {'empty-npm-package': '1.0.0'}, devDependencies: {}}),
+    )
+    await installNodeModules({
+      directory: app.directory,
+      packageManager: 'npm',
+    })
+    app = await load({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.usesWorkspaces).toBe(true)
+    expect(app.webs.length).toBe(1)
+  }, 30000)
 
   test("throws an error if the extension configuration file doesn't exist", async () => {
     // Given

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -223,7 +223,7 @@ scopes = "read_products"
     const web = app.webs[0]
     // Force npm to symlink the workspace directory
     await writeFile(
-      joinPath(web.directory, 'package.json'),
+      joinPath(web!.directory, 'package.json'),
       JSON.stringify({name: 'web', dependencies: {'empty-npm-package': '1.0.0'}, devDependencies: {}}),
     )
     await installNodeModules({

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -266,7 +266,7 @@ class AppLoader {
     const webConfigGlobs = [...(webDirectories ?? [defaultWebDirectory])].map((webGlob) => {
       return joinPath(this.appDirectory, webGlob, configurationFileNames.web)
     })
-    webConfigGlobs.push('!' + joinPath(this.appDirectory, '**/node_modules/**'))
+    webConfigGlobs.push(`!${joinPath(this.appDirectory, '**/node_modules/**')}`)
     const webTomlPaths = await glob(webConfigGlobs)
 
     const webs = await Promise.all(webTomlPaths.map((path) => this.loadWeb(path)))
@@ -291,7 +291,7 @@ class AppLoader {
     const extensionConfigPaths = [...(extensionDirectories ?? [defaultExtensionDirectory])].map((extensionPath) => {
       return joinPath(this.appDirectory, extensionPath, '*.extension.toml')
     })
-    extensionConfigPaths.push('!' + joinPath(this.appDirectory, '**/node_modules/**'))
+    extensionConfigPaths.push(`!${joinPath(this.appDirectory, '**/node_modules/**')}`)
     const configPaths = await glob(extensionConfigPaths)
 
     const extensions = configPaths.map(async (configurationPath) => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -266,6 +266,7 @@ class AppLoader {
     const webConfigGlobs = [...(webDirectories ?? [defaultWebDirectory])].map((webGlob) => {
       return joinPath(this.appDirectory, webGlob, configurationFileNames.web)
     })
+    webConfigGlobs.push('!' + joinPath(this.appDirectory, '**/node_modules/**'))
     const webTomlPaths = await glob(webConfigGlobs)
 
     const webs = await Promise.all(webTomlPaths.map((path) => this.loadWeb(path)))

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -291,6 +291,7 @@ class AppLoader {
     const extensionConfigPaths = [...(extensionDirectories ?? [defaultExtensionDirectory])].map((extensionPath) => {
       return joinPath(this.appDirectory, extensionPath, '*.extension.toml')
     })
+    extensionConfigPaths.push('!' + joinPath(this.appDirectory, '**/node_modules/**'))
     const configPaths = await glob(extensionConfigPaths)
 
     const extensions = configPaths.map(async (configurationPath) => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

1. We were double-counting webs in workspaces of npm-managed projects, as npm uses symlinks to manage workspaces.
2. We were wasting time scanning `node_modules` for webs, to the tune of 500ms per command run on my machine. Also extensions if they have node_modules (though I'm guessing in most cases they don't, but maybe in the future with workspaces they might?)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Excludes `**/node_modules/**` from the scan for `shopify.(web|.*\.extension).toml` files.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Everything should work as before.
`shopify app info` is your friend.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
