### PR TITLE
Add support for requestedAccessScopes to push command

### DIFF
--- a/packages/app/src/cli/api/graphql/push_config.ts
+++ b/packages/app/src/cli/api/graphql/push_config.ts
@@ -1,8 +1,20 @@
 import {gql} from 'graphql-request'
 
 export const PushConfig = gql`
-  mutation appUpdate($apiKey: String!, $applicationUrl: Url, $redirectUrlAllowlist: [Url]) {
-    appUpdate(input: {apiKey: $apiKey, applicationUrl: $applicationUrl, redirectUrlWhitelist: $redirectUrlAllowlist}) {
+  mutation appUpdate(
+    $apiKey: String!
+    $applicationUrl: Url
+    $redirectUrlAllowlist: [Url]
+    $requestedAccessScopes: [String!]
+  ) {
+    appUpdate(
+      input: {
+        apiKey: $apiKey
+        applicationUrl: $applicationUrl
+        redirectUrlWhitelist: $redirectUrlAllowlist
+        requestedAccessScopes: $requestedAccessScopes
+      }
+    ) {
       userErrors {
         message
         field
@@ -15,6 +27,7 @@ export interface PushConfigVariables {
   apiKey: string
   applicationUrl: string
   redirectUrlAllowlist: string[]
+  requestedAccessScopes: string[]
 }
 
 export interface PushConfigSchema {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -14,6 +14,7 @@ export const AppConfigurationSchema = zod.object({
   scopes: zod.string().default(''),
   application_url: zod.string().optional(),
   redirect_url_allowlist: zod.array(zod.string()).optional(),
+  requested_access_scopes: zod.array(zod.string()).optional(),
 })
 
 export enum WebType {

--- a/packages/app/src/cli/services/app/config/push.test.ts
+++ b/packages/app/src/cli/services/app/config/push.test.ts
@@ -19,6 +19,7 @@ describe('pushConfig', () => {
           scopes: 'read_products',
           application_url: 'https://my-apps-url.com',
           redirect_url_allowlist: ['https://my-apps-url.com/auth/shopify', 'https://my-apps-url.com/auth/callback'],
+          requested_access_scopes: [],
         },
       }),
     }
@@ -36,6 +37,7 @@ describe('pushConfig', () => {
       title: 'my-app',
       applicationUrl: 'https://my-apps-url.com',
       redirectUrlAllowlist: ['https://my-apps-url.com/auth/shopify', 'https://my-apps-url.com/auth/callback'],
+      requestedAccessScopes: [],
     })
 
     expect(renderSuccess).toHaveBeenCalledWith({

--- a/packages/app/src/cli/services/app/config/push.ts
+++ b/packages/app/src/cli/services/app/config/push.ts
@@ -21,12 +21,16 @@ export async function pushConfig(options: Options) {
   if (!configuration.client_id) {
     abort(`${configFileName} does not contain a client_id.`)
   }
-  const variables = {
+  const initialVariables = {
     apiKey: configuration.client_id,
     title: configuration.name,
     applicationUrl: configuration.application_url,
     redirectUrlAllowlist: configuration.redirect_url_allowlist,
+    requestedAccessScopes: configuration.requested_access_scopes,
   }
+
+  const variables = removeFalsyEntries(initialVariables)
+
   const result: PushConfigSchema = await partnersRequest(mutation, token, variables)
 
   if (result.appUpdate.userErrors.length > 0) {
@@ -42,4 +46,14 @@ export async function pushConfig(options: Options) {
 
 export const abort = (errorMessage: OutputMessage) => {
   throw new AbortError(errorMessage)
+}
+
+// this is placeholder for a more robust validation/clearing layer
+export const removeFalsyEntries = (obj: {[key: string]: string | string[] | undefined}) => {
+  return Object.keys(obj).reduce((acc: {[key: string]: string | string[] | undefined}, key) => {
+    if (obj[key]) {
+      acc[key] = obj[key]
+    }
+    return acc
+  }, {})
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves: https://github.com/Shopify/internal-cli-foundations/issues/667

### WHAT is this pull request doing?

Adds support for setting `requestedAccessScopes` via the `push`.
Omission / null field behaviour will be handled separately as part of this [issue](https://github.com/Shopify/partners/issues/48089).

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
