### PR TITLE
Disable dev preview when dev command finished

### DIFF
--- a/.changeset/sweet-avocados-look.md
+++ b/.changeset/sweet-avocados-look.md
@@ -1,0 +1,10 @@
+---
+'@shopify/eslint-plugin-cli': patch
+'@shopify/features': patch
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+'@shopify/app': patch
+'@shopify/cli': patch
+---
+
+Disable dev preview when dev command finished

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -43,7 +43,6 @@ import {
   OutputMessage,
   Logger,
   outputDebug,
-  outputWarn,
 } from '@shopify/cli-kit/node/output'
 import {getOrganization} from '@shopify/cli-kit/node/environment'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -114,7 +114,7 @@ ${outputToken.json(JSON.stringify(rules))}
 
   const renderConcurrentOptions: RenderConcurrentOptions = {
     processes: [...processes, ...additionalProcesses],
-    abortSignal: abortController.signal,
+    abortController,
   }
 
   await Promise.all([renderDev(renderConcurrentOptions, previewUrl), server.listen(portNumber)])

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -35,6 +35,7 @@ interface Options {
   portNumber: number
   proxyTargets: ReverseHTTPProxyTarget[]
   additionalProcesses: OutputProcess[]
+  abortController?: AbortController
 }
 
 /**
@@ -51,6 +52,7 @@ export async function runConcurrentHTTPProcessesAndPathForwardTraffic({
   portNumber,
   proxyTargets,
   additionalProcesses,
+  abortController,
 }: Options): Promise<void> {
   // Lazy-importing it because it's CJS and we don't want it
   // to block the loading of the ESM module graph.
@@ -107,14 +109,16 @@ ${outputToken.json(JSON.stringify(rules))}
     socket.destroy()
   })
 
-  const abortController = new AbortController()
-  abortController.signal.addEventListener('abort', () => {
+  const controller = abortController ?? new AbortController()
+
+  controller.signal.addEventListener('abort', () => {
+    outputDebug('Closing reverse HTTP proxy')
     server.close()
   })
 
   const renderConcurrentOptions: RenderConcurrentOptions = {
     processes: [...processes, ...additionalProcesses],
-    abortController,
+    abortController: controller,
   }
 
   await Promise.all([renderDev(renderConcurrentOptions, previewUrl), server.listen(portNumber)])

--- a/packages/cli-kit/src/private/node/ui.tsx
+++ b/packages/cli-kit/src/private/node/ui.tsx
@@ -1,4 +1,3 @@
-import {treeKill} from './tree-kill.js'
 import {collectLog, consoleLog, Logger, LogLevel, outputWhereAppropriate} from '../../public/node/output.js'
 import {isUnitTest} from '../../public/node/context/local.js'
 import {ReactElement} from 'react'
@@ -77,9 +76,9 @@ const renderString = (element: ReactElement, renderOptions?: RenderOptions): Ins
   }
 }
 
-export function handleCtrlC(input: string, key: Key) {
+export function handleCtrlC(input: string, key: Key, exit?: () => void) {
   if (input === 'c' && key.ctrl) {
     // Exceptions thrown in hooks aren't caught by our errorHandler.
-    treeKill('SIGINT')
+    if (exit) exit()
   }
 }

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
@@ -51,7 +51,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess, frontendProcess]}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
         footer={{
           shortcuts: [
             {
@@ -131,7 +131,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess, frontendProcess]}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
         footer={{
           shortcuts: [
             {
@@ -181,7 +181,7 @@ describe('ConcurrentOutput', () => {
       <ConcurrentOutput
         processes={[neverEndingProcess]}
         onInput={(input, key) => onInput(input, key)}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
       />,
     )
 
@@ -214,7 +214,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortSignal={abortController.signal}
+        abortController={abortController}
         footer={{
           shortcuts: [
             {
@@ -239,8 +239,6 @@ describe('ConcurrentOutput', () => {
       "0000-00-00 00:00:00 │ backend │ first backend message
       0000-00-00 00:00:00 │ backend │ second backend message
       0000-00-00 00:00:00 │ backend │ third backend message
-
-      Preview URL: https://shopify.com
       "
     `)
 
@@ -265,7 +263,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
         footer={{
           shortcuts: [
             {
@@ -310,7 +308,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
         footer={{
           shortcuts: [
             {

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
@@ -393,12 +393,11 @@ describe('Tasks', () => {
     }
 
     // When
-    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} initialContext={{foo: 'initial'}}/>)
+    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} initialContext={{foo: 'initial'}} />)
 
     // Then
     await expect(renderInstance.waitUntilExit()).rejects.toThrow('initial context set')
   })
-
 
   test('has an onComplete function that is called with the context', async () => {
     // Given

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
@@ -381,6 +381,25 @@ describe('Tasks', () => {
     await expect(renderInstance.waitUntilExit()).rejects.toThrow('context is shared')
   })
 
+  test('has an initial context', async () => {
+    // Given
+    const firstTask: Task<{foo: string}> = {
+      title: 'task 1',
+      task: async (ctx) => {
+        if (ctx.foo === 'initial') {
+          throw new Error('initial context set')
+        }
+      },
+    }
+
+    // When
+    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} initialContext={{foo: 'initial'}}/>)
+
+    // Then
+    await expect(renderInstance.waitUntilExit()).rejects.toThrow('initial context set')
+  })
+
+
   test('has an onComplete function that is called with the context', async () => {
     // Given
     const taskFunction = vi.fn(async (ctx) => {

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
@@ -24,6 +24,7 @@ export interface TasksProps<TContext> {
   silent?: boolean
   onComplete?: (ctx: TContext) => void
   abortSignal?: AbortSignal
+  initialContext?: TContext
 }
 
 enum TasksState {
@@ -64,12 +65,13 @@ function Tasks<TContext>({
   silent = isUnitTest(),
   onComplete = noop,
   abortSignal,
+  initialContext = {} as TContext,
 }: React.PropsWithChildren<TasksProps<TContext>>) {
   const {twoThirds} = useLayout()
   const loadingBar = new Array(twoThirds).fill(loadingBarChar).join('')
   const [currentTask, setCurrentTask] = useState<Task<TContext>>(tasks[0]!)
   const [state, setState] = useState<TasksState>(TasksState.Loading)
-  const ctx = useRef<TContext>({} as TContext)
+  const ctx = useRef<TContext>(initialContext)
   const {isRawModeSupported} = useStdin()
 
   const runTasks = async () => {

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -62,6 +62,7 @@ export async function exec(command: string, args: string[], options?: ExecOption
   options?.signal?.addEventListener('abort', () => {
     const pid = commandProcess.pid
     if (pid) {
+      outputDebug(`Killing process ${options.cwd} ${command} ${args.join(' ')} ${pid}...`)
       aborted = true
       treeKill(pid, (err) => {
         if (err) throw new AbortError(`Failed to kill process ${pid}: ${err}`)

--- a/packages/cli-kit/src/public/node/tree-kill.ts
+++ b/packages/cli-kit/src/public/node/tree-kill.ts
@@ -1,0 +1,3 @@
+import {treeKill} from '../../private/node/tree-kill.js'
+
+export {treeKill as default}

--- a/packages/cli-kit/src/public/node/ui.test.ts
+++ b/packages/cli-kit/src/public/node/ui.test.ts
@@ -1,4 +1,4 @@
-import {renderConcurrent, renderFatalError, renderInfo, renderSuccess, renderTasks, renderWarning} from './ui.js'
+import {Task, renderConcurrent, renderFatalError, renderInfo, renderSuccess, renderTasks, renderWarning} from './ui.js'
 import {AbortSignal} from './abort.js'
 import {BugError, FatalError, AbortError} from './error.js'
 import {mockAndCaptureOutput} from './testing/output.js'
@@ -354,6 +354,38 @@ describe('renderTasks', async () => {
       "╭─ warning ────────────────────────────────────────────────────────────────────╮
       │                                                                              │
       │  example error                                                               │
+      │                                                                              │
+      ╰──────────────────────────────────────────────────────────────────────────────╯
+      "
+    `)
+  })
+
+  test('renders a initial message correctly when the task throws an error ', async () => {
+    // Given
+    const mockOutput = mockAndCaptureOutput()
+
+    // When
+    const throwingTask: Task<{initial: string}> = {
+      title: 'throwing task',
+      task: async (ctx) => {
+        throw new Error(ctx.initial)
+      },
+    }
+
+    try {
+      await renderTasks([throwingTask], {}, {initial: 'initial error message'})
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error: any) {
+      renderWarning({
+        headline: error.message,
+      })
+    }
+
+    // Then
+    expect(mockOutput.warn()).toMatchInlineSnapshot(`
+      "╭─ warning ────────────────────────────────────────────────────────────────────╮
+      │                                                                              │
+      │  initial error message                                                       │
       │                                                                              │
       ╰──────────────────────────────────────────────────────────────────────────────╯
       "

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -39,7 +39,7 @@ import {Key as InkKey, RenderOptions} from 'ink'
 
 type PartialBy<T, TKey extends keyof T> = Omit<T, TKey> & Partial<Pick<T, TKey>>
 
-export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps, 'abortSignal'> {
+export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps, 'abortController'> {
   renderOptions?: RenderOptions
 }
 
@@ -60,17 +60,17 @@ export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps
  *
  */
 export async function renderConcurrent({renderOptions, ...props}: RenderConcurrentOptions) {
-  const abortSignal = props.abortSignal ?? new AbortController().signal
+  const abortController = props.abortController ?? new AbortController()
 
   if (terminalSupportsRawMode(renderOptions?.stdin)) {
-    return render(<ConcurrentOutput {...props} abortSignal={abortSignal} />, {
+    return render(<ConcurrentOutput {...props} abortController={abortController} />, {
       ...renderOptions,
       exitOnCtrlC: typeof props.onInput === 'undefined',
     })
   } else {
     return Promise.all(
       props.processes.map(async (concurrentProcess) => {
-        await concurrentProcess.action(process.stdout, process.stderr, abortSignal)
+        await concurrentProcess.action(process.stdout, process.stderr, abortController.signal)
       }),
     )
   }
@@ -480,7 +480,8 @@ export async function renderTasks<TContext>(
   tasks: Task<TContext>[],
   {renderOptions}: RenderTasksOptions = {},
   initialContext: TContext = {} as TContext,
-) {  recordUIEvent({
+) {
+  recordUIEvent({
     type: 'taskbar',
     properties: {
       // Rather than timing exactly, pretend each step takes 2 seconds. This
@@ -493,7 +494,7 @@ export async function renderTasks<TContext>(
 
   // eslint-disable-next-line max-params
   return new Promise<TContext>((resolve, reject) => {
-    render(<Tasks tasks={tasks} onComplete={resolve} initialContext={initialContext}/>, {
+    render(<Tasks tasks={tasks} onComplete={resolve} initialContext={initialContext} />, {
       ...renderOptions,
       exitOnCtrlC: false,
     })

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -476,8 +476,11 @@ interface RenderTasksOptions {
  * Installing dependencies ...
  */
 // eslint-disable-next-line max-params
-export async function renderTasks<TContext>(tasks: Task<TContext>[], {renderOptions}: RenderTasksOptions = {}) {
-  recordUIEvent({
+export async function renderTasks<TContext>(
+  tasks: Task<TContext>[],
+  {renderOptions}: RenderTasksOptions = {},
+  initialContext: TContext = {} as TContext,
+) {  recordUIEvent({
     type: 'taskbar',
     properties: {
       // Rather than timing exactly, pretend each step takes 2 seconds. This
@@ -490,7 +493,7 @@ export async function renderTasks<TContext>(tasks: Task<TContext>[], {renderOpti
 
   // eslint-disable-next-line max-params
   return new Promise<TContext>((resolve, reject) => {
-    render(<Tasks tasks={tasks} onComplete={resolve} />, {
+    render(<Tasks tasks={tasks} onComplete={resolve} initialContext={initialContext}/>, {
       ...renderOptions,
       exitOnCtrlC: false,
     })


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?


Extracted disable dev preview when dev command finishes

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Disable developer preview when `dev` commands finishes
-  Modify `ConcurrentOutput` component to finish the command (press `q` or `ctrl + c` using the `AbortController` instead of `treeKill`
- `dev` add a graceful finishing process to close every open external process. 
  - Include a timeout to force the finishing of the command
  - dev analytics is sent when the command is finished
- Add support to pass an `initialContext` to UI Task component. That way we can dynamically attach a method to the task implementation and pass the input arguments in the  `renderTasks` method
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
