### PR TITLE
Updated the upgrade error message

### DIFF
--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -461,11 +461,9 @@ async function handlePartnersErrors<T>(request: () => Promise<T>): Promise<T> {
     if (error.errors?.[0]?.extensions?.type === 'unsupported_client_version') {
       const packageManager = await getPackageManager(cwd())
 
-      throw new AbortError(
-        {bold: '`deploy` is no longer supported in this CLI version.'},
-        ['Upgrade your CLI version to use the', {command: 'deploy'}, 'command.'],
-        [['Run', {command: formatPackageManagerCommand(packageManager, 'shopify upgrade')}]],
-      )
+      throw new AbortError(['Upgrade your CLI version to run the', {command: 'deploy'}, 'command.'], null, [
+        ['Run', {command: formatPackageManagerCommand(packageManager, 'shopify upgrade')}],
+      ])
     }
 
     throw error


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/592

### WHAT is this pull request doing?
It updates the error message we are going to show when we force users to upgrade their Shopify CLI version when everyone is opted into using deployments.

### How to test your changes?
- Set the CLI version to 3.46
- Make sure the `app_unified_deployment` beta flag is enabled
- Run `app deploy`

You should get the error in the screenshot below.


<img width="1270" alt="Screenshot 2023-06-23 at 10 31 45 AM" src="https://github.com/Shopify/cli/assets/99370588/99fdac54-084b-4970-9b6a-11b5662db039">

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
