### PR TITLE
Updated TOML file format + validation for Flow extensions

### DIFF
--- a/packages/app/src/cli/services/flow/constants.ts
+++ b/packages/app/src/cli/services/flow/constants.ts
@@ -1,0 +1,22 @@
+// Metafield-like types for commerce objects
+export const SUPPORTED_COMMERCE_OBJECTS = {
+  customer_reference: 'customer_reference',
+  order_reference: 'order_reference',
+  product_reference: 'product_reference',
+  marketing_activity_reference: 'marketing_activity_reference',
+  abandonment_reference: 'abandonment_reference',
+}
+
+export const TRIGGER_SUPPORTED_COMMERCE_OBJECTS = [
+  SUPPORTED_COMMERCE_OBJECTS.customer_reference,
+  SUPPORTED_COMMERCE_OBJECTS.order_reference,
+  SUPPORTED_COMMERCE_OBJECTS.product_reference,
+]
+
+export const ACTION_SUPPORTED_COMMERCE_OBJECTS = [
+  SUPPORTED_COMMERCE_OBJECTS.customer_reference,
+  SUPPORTED_COMMERCE_OBJECTS.order_reference,
+  SUPPORTED_COMMERCE_OBJECTS.product_reference,
+  SUPPORTED_COMMERCE_OBJECTS.marketing_activity_reference,
+  SUPPORTED_COMMERCE_OBJECTS.abandonment_reference,
+]

--- a/packages/app/src/cli/services/flow/serializeFields.ts
+++ b/packages/app/src/cli/services/flow/serializeFields.ts
@@ -1,0 +1,82 @@
+import {ConfigField, SerializedField, FlowExtensionTypes} from './types.js'
+import {
+  SUPPORTED_COMMERCE_OBJECTS,
+  ACTION_SUPPORTED_COMMERCE_OBJECTS,
+  TRIGGER_SUPPORTED_COMMERCE_OBJECTS,
+} from './constants.js'
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+// Mapping of metafield types to Flow's Partner's Dashboard UI types
+// Only the `email` type was added since it doesn't exist as a metafield type
+// https://shopify.dev/docs/apps/custom-data/metafields/types
+const uiTypesMap = new Map<string, string>([
+  ['boolean', 'checkbox'],
+  ['email', 'email'],
+  ['multi_line_text_field', 'text-multi-lines'],
+  ['number_integer', 'number'],
+  ['single_line_text_field', 'text-single-line'],
+  ['url', 'url'],
+])
+
+export const serializeConfigField = (field: ConfigField, type: FlowExtensionTypes) => {
+  const uiType = uiTypesMap.get(field.type)
+
+  if (typeof field.key !== 'string') {
+    throw new AbortError(`key property must be specified for non-commerce object fields in ${JSON.stringify(field)}`)
+  }
+
+  if (!uiType) {
+    throw new AbortError(`Field type ${field.type} is not supported`)
+  }
+
+  const serializedField: SerializedField = {
+    name: field.key,
+    description: field.description,
+    uiType,
+  }
+
+  if (type === 'flow_action') {
+    serializedField.label = field.name
+    serializedField.required = Boolean(field.required)
+  }
+
+  return serializedField
+}
+
+export const serializeCommerceObjectField = (field: ConfigField, type: FlowExtensionTypes) => {
+  if (type === 'flow_trigger' && !TRIGGER_SUPPORTED_COMMERCE_OBJECTS.includes(field.type)) {
+    throw new AbortError(`Commerce object ${field.type} is not supported for Flow Triggers`)
+  }
+
+  if (type === 'flow_action' && !ACTION_SUPPORTED_COMMERCE_OBJECTS.includes(field.type)) {
+    throw new AbortError(`Commerce object ${field.type} is not supported for Flow Actions`)
+  }
+
+  const commerceObject = field.type.replace('_reference', '')
+
+  const serializedField: SerializedField = {
+    name: `${commerceObject}_id`,
+    uiType: type === 'flow_action' ? 'commerce-object-id' : commerceObject,
+  }
+
+  if (type === 'flow_action') {
+    serializedField.label = `${commerceObject.charAt(0).toUpperCase() + commerceObject.slice(1)} ID`
+    serializedField.required = Boolean(field.required)
+  }
+
+  return serializedField
+}
+
+export const serializeFields = (type: FlowExtensionTypes, fields?: ConfigField[]) => {
+  if (!fields) return []
+
+  const serializedFields = fields.map((field) => {
+    if (Object.keys(SUPPORTED_COMMERCE_OBJECTS).includes(field.type)) {
+      return serializeCommerceObjectField(field, type)
+    }
+
+    return serializeConfigField(field, type)
+  })
+
+  return serializedFields
+}

--- a/packages/app/src/cli/services/flow/tests/serializeFields.test.ts
+++ b/packages/app/src/cli/services/flow/tests/serializeFields.test.ts
@@ -1,0 +1,160 @@
+import {ConfigField} from '../types.js'
+import {serializeConfigField, serializeCommerceObjectField} from '../serializeFields.js'
+import {describe, expect, test} from 'vitest'
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+describe('serializeConfigField', () => {
+  test('should serialize a field for a flow action', () => {
+    // given
+    const field: ConfigField = {
+      type: 'single_line_text_field',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // when
+    const serializedField = serializeConfigField(field, 'flow_action')
+
+    // then
+    expect(serializedField).toEqual({
+      name: 'my-field',
+      description: 'This is my field',
+      uiType: 'text-single-line',
+      label: 'My Field',
+      required: true,
+    })
+  })
+
+  test('should serialize a field for a flow trigger', () => {
+    // given
+    const field: ConfigField = {
+      type: 'single_line_text_field',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // when
+    const serializedField = serializeConfigField(field, 'flow_trigger')
+
+    // then
+    expect(serializedField).toEqual({
+      name: 'my-field',
+      description: 'This is my field',
+      uiType: 'text-single-line',
+    })
+  })
+
+  test('should throw an error if key is not a string', () => {
+    // given
+    const invalidField: ConfigField = {
+      type: 'string',
+      key: undefined,
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // then
+    expect(() => serializeConfigField(invalidField, 'flow_action')).toThrowError(
+      new AbortError(
+        'key property must be specified for non-commerce object fields in {"type":"string","name":"My Field","description":"This is my field","required":true}',
+      ),
+    )
+  })
+
+  test('should throw an error if field type is not supported', () => {
+    // given
+    const invalidField: ConfigField = {
+      type: 'invalid-type',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // then
+    expect(() => serializeConfigField(invalidField, 'flow_action')).toThrowError(
+      new AbortError('Field type invalid-type is not supported'),
+    )
+  })
+})
+
+describe('serializeCommerceObjectField', () => {
+  test('should serialize a commerce object field for a flow action', () => {
+    // given
+    const commerceObjectField: ConfigField = {
+      type: 'product_reference',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // when
+    const serializedField = serializeCommerceObjectField(commerceObjectField, 'flow_action')
+
+    // then
+    expect(serializedField).toEqual({
+      name: 'product_id',
+      uiType: 'commerce-object-id',
+      label: 'Product ID',
+      required: true,
+    })
+  })
+
+  test('should serialize a commerce object field for a flow trigger', () => {
+    // given
+    const commerceObjectField: ConfigField = {
+      type: 'product_reference',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // when
+    const serializedField = serializeCommerceObjectField(commerceObjectField, 'flow_trigger')
+
+    // then
+    expect(serializedField).toEqual({
+      name: 'product_id',
+      uiType: 'product',
+    })
+  })
+
+  test('should throw an error if commerce object is not supported for flow trigger', () => {
+    // given
+    const invalidField: ConfigField = {
+      type: 'invalid_reference',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // then
+    expect(() => serializeCommerceObjectField(invalidField, 'flow_trigger')).toThrowError(
+      new AbortError('Commerce object invalid_reference is not supported for Flow Triggers'),
+    )
+  })
+
+  test('should throw an error if commerce object is not supported for flow action', () => {
+    // given
+    const invalidField: ConfigField = {
+      type: 'invalid_reference',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // then
+    expect(() => serializeCommerceObjectField(invalidField, 'flow_action')).toThrowError(
+      new AbortError('Commerce object invalid_reference is not supported for Flow Actions'),
+    )
+  })
+})

--- a/packages/app/src/cli/services/flow/tests/validation.test.ts
+++ b/packages/app/src/cli/services/flow/tests/validation.test.ts
@@ -1,0 +1,167 @@
+import {ConfigField} from '../types.js'
+import {validateNonCommerceObjectShape, validateCustomConfigurationPageConfig} from '../validation.js'
+import {describe, expect, test} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+describe('validateNonCommerceObjectShape', () => {
+  test('should return true when non-commerce object field has valid shape', () => {
+    // given
+    const nonCommerceObjectField: ConfigField = {
+      type: 'multi_line_text_field',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // when
+    const result = validateNonCommerceObjectShape(nonCommerceObjectField, 'flow_action')
+
+    // then
+    expect(result).toBe(true)
+  })
+
+  test('should return true when field is a commerce object', () => {
+    // given
+    const commerceObjectField: ConfigField = {
+      type: 'product_reference',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // when
+    const result = validateNonCommerceObjectShape(commerceObjectField, 'flow_action')
+
+    // then
+    expect(result).toBe(true)
+  })
+
+  test('should throw an error if key is not specified for non-commerce object field', () => {
+    // given
+    const invalidField: ConfigField = {
+      type: 'string',
+      key: undefined,
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // then
+    expect(() => validateNonCommerceObjectShape(invalidField, 'flow_action')).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['settings.fields.key'],
+          message: 'Key must be specified for non-commerce object fields',
+        },
+      ]),
+    )
+  })
+
+  test('should throw an error if name is not specified for non-commerce object field in flow action', () => {
+    // given
+    const invalidField: ConfigField = {
+      type: 'string',
+      key: 'my-field',
+      name: undefined,
+      description: 'This is my field',
+      required: true,
+    }
+
+    // then
+    expect(() => validateNonCommerceObjectShape(invalidField, 'flow_action')).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['settings.fields.name'],
+          message: 'Name must be specified for non-commerce object fields',
+        },
+      ]),
+    )
+  })
+})
+
+describe('validateCustomConfigurationPageConfig', () => {
+  test('should return true if no custom configuration page properties are specified', () => {
+    // when
+    const result = validateCustomConfigurationPageConfig()
+
+    // then
+    expect(result).toBe(true)
+  })
+
+  test('should throw an error if config page URL is missing but a preview url is provided', () => {
+    // given
+    const configPageUrl = undefined
+    const configPagePreviewUrl = 'preview-url'
+    const validationUrl = 'validation-url'
+
+    // then
+    expect(() =>
+      validateCustomConfigurationPageConfig(configPageUrl, configPagePreviewUrl, validationUrl),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['extensions[0].config_page_url'],
+          message: 'To set a custom configuration page a `config_page_url` must be specified.',
+        },
+      ]),
+    )
+  })
+
+  test('should throw an error if config page preview URL is missing but a config page url is provided', () => {
+    // given
+    const configPageUrl = 'config-url'
+    const configPagePreviewUrl = undefined
+    const validationUrl = 'validation-url'
+
+    // then
+    expect(() =>
+      validateCustomConfigurationPageConfig(configPageUrl, configPagePreviewUrl, validationUrl),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['extensions[0].config_page_preview_url'],
+          message: 'To set a custom configuration page a `config_page_preview_url` must be specified.',
+        },
+      ]),
+    )
+  })
+
+  test('should throw an error if validation URL is missing when both a config page and preview urls are provided', () => {
+    // given
+    const configPageUrl = 'config-url'
+    const configPagePreviewUrl = 'preview-url'
+    const validationUrl = undefined
+
+    // then
+    expect(() =>
+      validateCustomConfigurationPageConfig(configPageUrl, configPagePreviewUrl, validationUrl),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['extensions[0].validation_url'],
+          message: 'To set a custom configuration page a `validation_url` must be specified.',
+        },
+      ]),
+    )
+  })
+
+  test('should return true if all custom configuration page URLs are specified', () => {
+    // given
+    const configPageUrl = 'config-url'
+    const configPagePreviewUrl = 'preview-url'
+    const validationUrl = 'validation-url'
+
+    // when
+    const result = validateCustomConfigurationPageConfig(configPageUrl, configPagePreviewUrl, validationUrl)
+
+    // then
+    expect(result).toBe(true)
+  })
+})

--- a/packages/app/src/cli/services/flow/types.ts
+++ b/packages/app/src/cli/services/flow/types.ts
@@ -1,0 +1,17 @@
+export interface ConfigField {
+  type: string
+  required?: boolean
+  key?: string
+  name?: string
+  description?: string
+}
+
+export interface SerializedField {
+  name: string
+  label?: string
+  description?: string
+  required?: boolean
+  uiType: string
+}
+
+export type FlowExtensionTypes = 'flow_action' | 'flow_trigger'

--- a/packages/app/src/cli/services/flow/validation.ts
+++ b/packages/app/src/cli/services/flow/validation.ts
@@ -1,0 +1,71 @@
+import {ConfigField, FlowExtensionTypes} from './types.js'
+import {SUPPORTED_COMMERCE_OBJECTS} from './constants.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+export const validateNonCommerceObjectShape = (configField: ConfigField, type: FlowExtensionTypes) => {
+  if (!Object.keys(SUPPORTED_COMMERCE_OBJECTS).includes(configField.type)) {
+    if (!configField.key) {
+      throw new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['settings.fields.key'],
+          message: 'Key must be specified for non-commerce object fields',
+        },
+      ])
+    }
+
+    if (!configField.name && type === 'flow_action') {
+      throw new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['settings.fields.name'],
+          message: 'Name must be specified for non-commerce object fields',
+        },
+      ])
+    }
+  }
+
+  return true
+}
+
+export const startsWithHttps = (url: string) => url.startsWith('https://')
+
+export const validateCustomConfigurationPageConfig = (
+  configPageUrl?: string,
+  configPagePreviewUrl?: string,
+  validationUrl?: string,
+) => {
+  if (configPageUrl || configPagePreviewUrl) {
+    if (!configPageUrl) {
+      throw new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['extensions[0].config_page_url'],
+          message: 'To set a custom configuration page a `config_page_url` must be specified.',
+        },
+      ])
+    }
+
+    if (!configPagePreviewUrl) {
+      throw new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['extensions[0].config_page_preview_url'],
+          message: 'To set a custom configuration page a `config_page_preview_url` must be specified.',
+        },
+      ])
+    }
+
+    if (!validationUrl) {
+      throw new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          path: ['extensions[0].validation_url'],
+          message: 'To set a custom configuration page a `validation_url` must be specified.',
+        },
+      ])
+    }
+  }
+
+  return true
+}

--- a/packages/app/templates/extensions/projects/flow_action/shopify.extension.toml.liquid
+++ b/packages/app/templates/extensions/projects/flow_action/shopify.extension.toml.liquid
@@ -1,28 +1,20 @@
-name = "{{name}}"
+name = "{{ name }}"
+description = "Your description"
 type = "flow_action"
 
-[task]
-title = "extension-title"
-description = "extension-description"
-url = "https://runtime-endpoint.com"
-validation_url = "https://validation-url"
-custom_configuration_page_url = "https://custom-configuration-page-url"
-custom_configuration_page_preview_url = "https://custom-configuration-page-preview-url"
-return_type_ref = "SomeTypeFromSchema"
-schema = "./schema.graphql"
+[[extensions]]
+type = "flow_action"
+runtime_url = "https://url.com/api/execute"
 
-[[task.fields]]
-name = "customer_id"
-label = "Customer ID"
-description = ""
-required = true
-id = "a-unique-uuid"
-ui_type = "commerce-object-id"
+[settings]
 
-[[task.fields]]
-name = "your-field-name"
-label = "your-field-label"
-description = ""
-required = true
-id = "a-unique-uuid"
-ui_type = "text-single-line"
+  [[settings.fields]]
+  type = "customer_reference"
+  required = true
+
+  [[settings.fields]]
+  type = "single_line_text_field"
+  key = "your-field-key"
+  name = "Display name"
+  description = "A description of my field"
+  required = true

--- a/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
+++ b/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
@@ -1,18 +1,15 @@
-name = "{{name}}"
+name = "{{ name }}"
+description = "Your description"
 type = "flow_trigger"
 
-[task]
-title = "custom-title"
-description = "custom-description"
+[[extensions]]
+type = "flow_trigger"
 
-[[task.fields]]
-name = "customer_id"
-description = ""
-id = "a-unique-uuid"
-uiType = "customer"
+[settings]
 
-[[task.fields]]
-name = "test"
-description = "test property"
-id = "a-unique-uuid"
-ui_type = "text-single-line"
+  [[settings.fields]]
+  type = "customer_reference"
+
+  [[settings.fields]]
+  type = "single_line_text_field"
+  key = "your-field-key"


### PR DESCRIPTION
### WHY are these changes introduced?

- We're aligning with the TOML config file standards as discussed on the `#unified-extension-config` channel and in our proposal [PR](https://github.com/Shopify/core-build-north-star-app/pull/9).
- We're also introducing more comprehensive validation to match the current Partner's Dashboard validation.

#### Example Flow Action Config File Content

```
name = "Send Email"
description = "An action that sends and email."
type = "flow_action"

[[extensions]]
runtime_url = "https://url.com/api/execute"

[settings]

  [[settings.fields]]
  type = "customer_reference"
  required = true

  [[settings.fields]]
  type = "single_line_text_field"
  key = "email-subject-line"
  name = "Email Subject Line"
  description = "The subject line to your email."
  required = true
```

#### Example Flow Trigger Config File Content

```
name = "Bid Placed"
description = "A trigger for when bids are placed on your products."
type = "flow_trigger"

[settings]

  [[settings.fields]]
  type = "customer_reference"

  [[settings.fields]]
  type = "product_reference"

  [[settings.fields]]
  type = "single_line_text_field"
  key = "bid-type"
```

### WHAT is this pull request doing?

#### TOML config file
- The `task` object has been updated to an `extensions` array.
- The `task.fields` object is now located in `settings.fields`.
- The `custom_configuration_page_url` property has been shorten to `config_page_url`.
- The `custom_configuration_page_preview_url` property has been shorten to `config_page_preview_url`.
- The `url` property has been renamed to `runtime_url`.
- Dropped the `id` field property since it is not actually required for Flow extensions.
- Changed the `name` field property to `key`.
- Changed the `label` field property to `name`.
- Changed the `uiType` field property to `type`.

#### Validation for actions
- Urls are now validated as such.
- The CCP fields now have inter-fields validation (if CCP or CCP preview then both of those properties and the validation url are required).
- For commerce objects the only required property is `type`.
- For non commerce objects the required properties are `key` and `name`.

#### Validation for triggers
- For commerce objects the only required property is `type`.
- For non commerce objects the only required property is `key`.

### How to test your changes?

Pull this PR in a `flow:with-partners-and-extensions` constellation instance and generate/deploy triggers and actions.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
