### PR TITLE
Ensure `link` generates correct TOML values for various repositories

### DIFF
--- a/packages/app/src/cli/api/graphql/create_app.ts
+++ b/packages/app/src/cli/api/graphql/create_app.ts
@@ -38,6 +38,7 @@ export interface CreateAppQueryVariables {
   appUrl: string
   redir: string[]
   type: string
+  requestedAccessScopes: string[]
 }
 
 export interface CreateAppQuerySchema {

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -26,6 +26,7 @@ export type OrganizationApp = MinimalOrganizationApp & {
   }
   applicationUrl: string
   redirectUrlWhitelist: string[]
+  requestedAccessScopes?: string[]
 }
 
 export interface OrganizationStore {

--- a/packages/app/src/cli/services/dev/TODOs
+++ b/packages/app/src/cli/services/dev/TODOs
@@ -1,0 +1,6 @@
+- refactor and lift load legacy TOML w/ error validation? and import into commands
+- redirectURL can't be blank..
+- DD on making scopes optional
+- tophat all use cases again based on https://docs.google.com/document/d/1KbPk09bnlR6RPeUMG0aQESeaWJ2xlF0mQr7C6kqLMGM/edit#bookmark=id.4dedr24b74z2
+- test coverage for create
+- refactor merge to call methods for each type of merge

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -71,7 +71,7 @@ describe('createApp', () => {
     }
 
     // When
-    const got = await createApp(ORG2, LOCAL_APP.name, 'token')
+    const got = await createApp(ORG2, LOCAL_APP, 'token')
 
     // Then
     expect(got).toEqual(APP1)
@@ -86,7 +86,7 @@ describe('createApp', () => {
     })
 
     // When
-    const got = createApp(ORG2, LOCAL_APP.name, 'token')
+    const got = createApp(ORG2, LOCAL_APP, 'token')
 
     // Then
     await expect(got).rejects.toThrow(`some-error`)
@@ -101,7 +101,7 @@ describe('selectOrCreateApp', () => {
     vi.mocked(partnersRequest).mockResolvedValueOnce({app: APP1})
 
     // When
-    const got = await selectOrCreateApp(LOCAL_APP.name, APP_LIST, ORG1, 'token')
+    const got = await selectOrCreateApp(LOCAL_APP, APP_LIST, ORG1, 'token')
 
     // Then
     expect(got).toEqual(APP1)
@@ -122,7 +122,7 @@ describe('selectOrCreateApp', () => {
     }
 
     // When
-    const got = await selectOrCreateApp(LOCAL_APP.name, APP_LIST, ORG1, 'token')
+    const got = await selectOrCreateApp(LOCAL_APP, APP_LIST, ORG1, 'token')
 
     // Then
     expect(got).toEqual(APP1)

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -1,10 +1,22 @@
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {Organization, OrganizationApp} from '../../models/organization.js'
 import {fetchAppFromApiKey, OrganizationAppsResponse} from '../dev/fetch.js'
-import {CreateAppQuery, CreateAppQuerySchema, CreateAppQueryVariables} from '../../api/graphql/create_app.js'
+import {CreateAppQuery, CreateAppQuerySchema} from '../../api/graphql/create_app.js'
+import {AppInterface, Web, WebType} from '../../models/app/app.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputInfo} from '@shopify/cli-kit/node/output'
+
+const MAGIC_URL = 'https://shopify.dev/magic-url'
+const MAGIC_REDIRECT_URL = `${MAGIC_URL}/api/auth`
+interface AppVars {
+  org: number
+  title: string
+  type: string
+  appUrl: string
+  redir?: string[]
+  requestedAccessScopes?: string[]
+}
 
 /**
  * Select an app from env, list or create a new one:
@@ -16,7 +28,7 @@ import {outputInfo} from '@shopify/cli-kit/node/output'
  * @returns The selected (or created) app
  */
 export async function selectOrCreateApp(
-  localAppName: string,
+  localApp: AppInterface,
   apps: OrganizationAppsResponse,
   org: Organization,
   token: string,
@@ -27,7 +39,7 @@ export async function selectOrCreateApp(
     createNewApp = await createAsNewAppPrompt()
   }
   if (createNewApp) {
-    return createApp(org, localAppName, token)
+    return createApp(org, localApp, token)
   } else {
     const selectedAppApiKey = await selectAppPrompt(apps, org.id, token)
     const fullSelectedApp = await fetchAppFromApiKey(selectedAppApiKey, token)
@@ -35,16 +47,35 @@ export async function selectOrCreateApp(
   }
 }
 
-export async function createApp(org: Organization, appName: string, token: string): Promise<OrganizationApp> {
-  const name = await appNamePrompt(appName)
+const getAppVars = async (localApp: AppInterface, org: Organization) => {
+  const name = await appNamePrompt(localApp.name)
+  const frontendConfig = localApp.webs.find((web) => isWebType(web, WebType.Frontend))
+  const backendConfig = localApp.webs.find((web) => isWebType(web, WebType.Backend))
 
-  const variables: CreateAppQueryVariables = {
+  const variables: AppVars = {
     org: parseInt(org.id, 10),
     title: `${name}`,
-    appUrl: 'https://example.com',
-    redir: ['https://example.com/api/auth'],
     type: 'undecided',
+    appUrl: '',
   }
+
+  if (frontendConfig || backendConfig) {
+    variables.appUrl = 'https://example.com'
+    variables.redir = ['https://example.com/api/auth']
+    if (localApp.configuration.scopes && localApp.configuration.scopes.length > 0) {
+      variables.requestedAccessScopes = [localApp.configuration.scopes]
+    }
+  } else {
+    variables.appUrl = MAGIC_URL
+    variables.redir = [MAGIC_REDIRECT_URL]
+    variables.requestedAccessScopes = []
+  }
+
+  return variables
+}
+
+export async function createApp(org: Organization, localApp: AppInterface, token: string): Promise<OrganizationApp> {
+  const variables = await getAppVars(localApp, org)
 
   const query = CreateAppQuery
   const result: CreateAppQuerySchema = await partnersRequest(query, token, variables)
@@ -57,4 +88,8 @@ export async function createApp(org: Organization, appName: string, token: strin
   createdApp.organizationId = org.id
   createdApp.newApp = true
   return createdApp
+}
+
+function isWebType(web: Web, type: WebType): boolean {
+  return web.configuration.roles.includes(type)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/internal-cli-foundations/issues/665

### WHAT is this pull request doing?
Implements recommended [option](https://docs.google.com/document/d/1KbPk09bnlR6RPeUMG0aQESeaWJ2xlF0mQr7C6kqLMGM/edit#bookmark=id.v5gw2un923ev)

- Add support for various scenarios described in this [doc](https://docs.google.com/document/d/1KbPk09bnlR6RPeUMG0aQESeaWJ2xlF0mQr7C6kqLMGM/edit#bookmark=id.4dedr24b74z2).
    * use appropriate default values when creating a new app
    * implement merge logic for special handling of `application_url` and `requested_access_scopes`

- Making scopes optional in the generated TOML is tracked via a separate [issue]()

### How to test your changes?

- `pnpm run shopify app config link  --path=`
- Same for all the modified commands

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
