### PR TITLE
Adds `bundling` feature to flow extensions to update extension config on deploy

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_action.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_action.ts
@@ -81,7 +81,11 @@ const flowActionSpecification = createExtensionSpecification({
   identifier: 'flow_action',
   schema: FlowActionExtensionSchema,
   singleEntryPath: false,
-  appModuleFeatures: (_) => [],
+  // Flow doesn't have anything to bundle but we need to set this to true to
+  // ensure that the extension configuration is uploaded after registration in
+  // https://github.com/Shopify/cli/blob/73ac91c0f40be0a57d1b18cb34254b12d3a071af/packages/app/src/cli/services/deploy.ts#L107
+  // Should be removed after unified deployment is 100% rolled out
+  appModuleFeatures: (_) => ['bundling'],
   deployConfig: async (config, extensionPath) => {
     const {extensions} = config
     const extension = extensions[0]!

--- a/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
@@ -41,7 +41,11 @@ const flowTriggerSpecification = createExtensionSpecification({
   identifier: 'flow_trigger',
   schema: FlowTriggerExtensionSchema,
   singleEntryPath: false,
-  appModuleFeatures: (_) => [],
+  // Flow doesn't have anything to bundle but we need to set this to true to
+  // ensure that the extension configuration is uploaded after registration in
+  // https://github.com/Shopify/cli/blob/73ac91c0f40be0a57d1b18cb34254b12d3a071af/packages/app/src/cli/services/deploy.ts#L107
+  // Should be removed after unified deployment is 100% rolled out
+  appModuleFeatures: (_) => ['bundling'],
   deployConfig: async (config) => {
     const {extensions} = config
     const extension = extensions[0]!


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/flow/issues/19464

Adds `bundling` feature to flow extensions to update extension config on deploy. We need to use the bunlding feature to update the extension's config since the initial registration call sends in a empty config object

- Config is hardcoded to empty [here](https://github.com/Shopify/cli/blob/3f7fbad7db0c6e28c10a70a550d5a859cd5eddc7/packages/app/src/cli/services/dev/create-extension.ts#L36)
	- Code path deploy.ts -> [`ensureDeployContext`](https://github.com/Shopify/cli/blob/cedea083cccbd10f0cf0ca4d09a7a8e7dfb2c34b/packages/app/src/cli/services/context.ts#L291) ->[`ensureDeploymentIsPresence`](https://github.com/Shopify/cli/blob/3f7fbad7db0c6e28c10a70a550d5a859cd5eddc7/packages/app/src/cli/services/context/identifiers.ts#L38) -> [`ensureExtensionsIds`](https://github.com/Shopify/cli/blob/647bdcfd9f0f8355f01fbb1aaac044fbbc4ca905/packages/app/src/cli/services/context/identifiers-extensions.ts#L17) -> [`createExtensions`](https://github.com/Shopify/cli/blob/647bdcfd9f0f8355f01fbb1aaac044fbbc4ca905/packages/app/src/cli/services/context/identifiers-extensions.ts#L85) which creates the extension without the configurations.
- In this [deploy task](https://github.com/Shopify/cli/blob/d925436d2c0698334c6d7fedd0bb361cc7f5291a/packages/app/src/cli/services/deploy.ts#L82-L83), we gather all the [extension configurations](https://github.com/Shopify/cli/blob/d925436d2c0698334c6d7fedd0bb361cc7f5291a/packages/app/src/cli/services/deploy.ts#L84-L88). However, without being a bundle, theme, or functions, the deploy process doesn't do anything with the config data.

Flow doesn't have anything to "bundle" and upload, this is a workaround until unified_app_deployment is rolled out 100%. We'll remove the `bundling` flag at that time.

### WHAT is this pull request doing?

- Force `bundling` feature on Flow extension types.

### How to test your changes?

- Create a Flow extension.
- Update the TOML configuration of the new extension
- Runs `shopify app deploy`.
- Checks in the partners dashboard that the new extension allows you to create a new version like this video https://videobin.shopify.io/v/6g9LMM

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
