### PR TITLE
Fix `app dev` hot reload for theme app extensions when blocks are rendered on section groups

### DIFF
--- a/.changeset/sharp-wasps-attend.md
+++ b/.changeset/sharp-wasps-attend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix a hot-reload for theme app extensions when blocks are rendered on section groups (in the `app dev` command)

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/hot_reload/resources/theme_extension.js
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/hot_reload/resources/theme_extension.js
@@ -8,7 +8,7 @@
       document.querySelectorAll(`[data-block-handle$='${handle}']`)
     );
     if (blocks.length) {
-      const queryString = "shopify-section-template";
+      const queryString = "shopify-section-";
       const is_section = blocks[0].closest(`[id^=${queryString}]`) !== null;
       if (is_section)
         return [


### PR DESCRIPTION
### WHY are these changes introduced?

The hot-reload mechanism for themes and theme app extensions rely on a injected script to change DOM elements when a change happens on developers machine.

In the context of theme app extensions, the mechanism was being too strict and it was not handling the following scenario:

<img src="https://github.com/Shopify/cli/assets/1079279/1a64df26-3503-4b30-b104-425455e2c64c" width="60%">
<img src="https://github.com/Shopify/cli/assets/1079279/eec9a1fa-411c-4b04-9808-d5ad7153bef6" width="60%">

### WHAT is this pull request doing?

This PR changes the logic the prefix that identifies sections from `shopify-section-template` to `shopify-section-`.

### How to test your changes?

- Run `yarn create @shopify/app`
- Run `yarn shopify app generate extension  -t theme_app_extension`
- Run `yarn dev`
- Install the app
- Enable extension
- Add a section in the editor
- Modify something in blocks/star_rating.liquid

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
