### PR TITLE
Hide `shopify theme update init` and `shopify theme update check` commands

### DIFF
--- a/.changeset/slimy-icons-flash.md
+++ b/.changeset/slimy-icons-flash.md
@@ -1,6 +1,0 @@
----
-'@shopify/theme': patch
-'@shopify/cli': patch
----
-
-Hide `shopify theme update init` and `shopify theme update check` commands

--- a/.changeset/slimy-icons-flash.md
+++ b/.changeset/slimy-icons-flash.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme': patch
+'@shopify/cli': patch
+---
+
+Hide `shopify theme update init` and `shopify theme update check` commands

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -142,7 +142,8 @@
         "description": "Build Liquid themes."
       },
       "theme:update": {
-        "description": "Manage 'update_extension.json' scripts."
+        "description": "Manage 'update_extension.json' scripts.",
+        "hidden": true
       },
       "app": {
         "description": "Build Shopify apps."

--- a/packages/features/snapshots/commands.txt
+++ b/packages/features/snapshots/commands.txt
@@ -41,8 +41,6 @@
  theme pull                @shopify/theme               
  theme push                @shopify/theme               
  theme share               @shopify/theme               
- theme update check        @shopify/theme               
- theme update init         @shopify/theme               
  upgrade                   @shopify/cli                 
  version                   @shopify/cli                 
  webhook trigger           @shopify/app                 

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -1269,6 +1269,7 @@
       "pluginName": "@shopify/theme",
       "pluginAlias": "@shopify/theme",
       "pluginType": "core",
+      "hidden": true,
       "aliases": [],
       "flags": {
         "no-color": {
@@ -1302,6 +1303,7 @@
       "pluginName": "@shopify/theme",
       "pluginAlias": "@shopify/theme",
       "pluginType": "core",
+      "hidden": true,
       "aliases": [],
       "flags": {
         "no-color": {

--- a/packages/theme/src/cli/commands/theme/update/check.ts
+++ b/packages/theme/src/cli/commands/theme/update/check.ts
@@ -5,6 +5,7 @@ import {Flags} from '@oclif/core'
 
 export default class UpdateCheck extends ThemeCommand {
   static description = `Validate an 'update_extension.json' script.`
+  static hidden = true
 
   static flags = {
     ...globalFlags,

--- a/packages/theme/src/cli/commands/theme/update/init.ts
+++ b/packages/theme/src/cli/commands/theme/update/init.ts
@@ -5,6 +5,7 @@ import {globalFlags} from '@shopify/cli-kit/node/cli'
 
 export default class UpdateInit extends ThemeCommand {
   static description = `Initialize an 'update_extension.json' script.`
+  static hidden = true
 
   static flags = {
     ...globalFlags,


### PR DESCRIPTION
Related to https://github.com/Shopify/cli/pull/1909

### How to test your changes?
- Checkout the feature branch
- Run `pnpm shopify:run theme` 
- Confirm no update commands are present

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
