### PR TITLE
bumped checkout-ui-extensions version to 0.27.0

### DIFF
--- a/packages/app/templates/ui-extensions/projects/checkout_ui_extension/package.json.liquid
+++ b/packages/app/templates/ui-extensions/projects/checkout_ui_extension/package.json.liquid
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/checkout-ui-extensions-react": "^0.26.0"
+    "@shopify/checkout-ui-extensions-react": "^0.27.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -19,7 +19,7 @@
   "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/checkout-ui-extensions": "^0.26.0"
+    "@shopify/checkout-ui-extensions": "^0.27.0"
   }
 }
 {%- endif -%}

--- a/packages/app/templates/ui-extensions/projects/ui_extension/package.json.liquid
+++ b/packages/app/templates/ui-extensions/projects/ui_extension/package.json.liquid
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/checkout-ui-extensions-react": "^0.26.0"
+    "@shopify/checkout-ui-extensions-react": "^0.27.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -19,7 +19,7 @@
   "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/checkout-ui-extensions": "^0.26.0"
+    "@shopify/checkout-ui-extensions": "^0.27.0"
   }
 }
 {%- endif -%}


### PR DESCRIPTION
### WHY are these changes introduced?
A new version `0.27.0` of `@shopify/checkout-ui-extensions` was just published. We'd like to update the CLI template so newly scaffolded extensions are on the latest version by default.

### WHAT is this pull request doing?
Changes the version number used in a scaffolded checkout ui extension.

### How to test your changes?
Scaffold a new extension and expect to see version `0.27.0`.

### Post-release steps
N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
