### PR TITLE
Fix tax calculation deployment

### DIFF
--- a/.changeset/wet-mice-smell.md
+++ b/.changeset/wet-mice-smell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix deploy for tax calculation extensions

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -134,6 +134,30 @@ export async function testWebPixelExtension(): Promise<ExtensionInstance> {
   return extension
 }
 
+export async function testTaxCalculationExtension(directory = './my-extension'): Promise<ExtensionInstance> {
+  const configuration = {
+    name: 'tax',
+    type: 'tax_calculation' as const,
+    metafields: [],
+    runtime_context: 'strict',
+    settings: [],
+  }
+
+  const allSpecs = await loadLocalExtensionsSpecifications()
+  const specification = allSpecs.find((spec) => spec.identifier === 'tax_calculation')!
+
+  const extension = new ExtensionInstance({
+    configuration,
+    configurationPath: '',
+    directory,
+    specification,
+  })
+
+  extension.outputPath = directory
+
+  return extension
+}
+
 function defaultFunctionConfiguration(): FunctionConfigType {
   return {
     name: 'test function extension',

--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -1,5 +1,7 @@
 import {
+  testApp,
   testFunctionExtension,
+  testTaxCalculationExtension,
   testThemeExtensions,
   testUIExtension,
   testWebPixelExtension,
@@ -7,6 +9,8 @@ import {
 import {FunctionConfigType} from '../extensions/specifications/function.js'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {describe, expect, test} from 'vitest'
+import {inTemporaryDirectory, readFile} from '@shopify/cli-kit/node/fs'
+import {Writable} from 'stream'
 
 function functionConfiguration(): FunctionConfigType {
   return {
@@ -128,5 +132,27 @@ describe('isDraftable', () => {
     const got = extensionInstance.isDraftable(false)
 
     expect(got).toBe(true)
+  })
+})
+
+describe('build', async () => {
+  test('creates a valid JS file for tax calculation extensions', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionInstance = await testTaxCalculationExtension(tmpDir)
+      const options = {
+        stdout: new Writable(),
+        stderr: new Writable(),
+        app: testApp(),
+      }
+
+      // When
+      await extensionInstance.build(options)
+
+      // Then
+      const outputFilePath = joinPath(tmpDir, 'dist/main.js')
+      const outputFileContent = await readFile(outputFilePath)
+      expect(outputFileContent).toEqual('(()=>{})();')
+    })
   })
 })

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -246,8 +246,9 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
     // Workaround for tax_calculations because they remote spec NEEDS a valid js file to be included.
     if (this.type === 'tax_calculation') {
-      await touchFile(this.outputPath)
-      await writeFile(this.outputPath, '(()=>{})();')
+      const outputJsFilePath = joinPath(this.outputPath, 'dist/main.js')
+      await touchFile(outputJsFilePath)
+      await writeFile(outputJsFilePath, '(()=>{})();')
     }
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The deployment of tax calculation extensions is broken:

```
Deploying your work to Shopify Partners. It will be part of 2023-06-28

╭─ error ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                            │
│  EISDIR: illegal operation on a directory, open '/Users/gonzalo/tests/2023-06-28/extensions/tax'           │
│                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

### WHAT is this pull request doing?

Fixes the path where we need to write a valid JS file.

### How to test your changes?

- Enable Tax Calculation App Extension beta flag on the partner org
- `p shopify app generate extension -t tax_calculation --path ~/your-app`
- `p shopify app deploy --path ~/your-app`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
