### PR TITLE
Fix tax calculation deployment (on stable/3.47)

### DIFF
--- a/.changeset/wet-mice-smell.md
+++ b/.changeset/wet-mice-smell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix deploy for tax calculation extensions

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -88,7 +88,7 @@ export async function testUIExtension(uiExtension: Partial<ExtensionInstance> = 
   return extension
 }
 
-export async function testThemeExtensions(): Promise<ExtensionInstance> {
+export async function testThemeExtensions(directory = './my-extension'): Promise<ExtensionInstance> {
   const configuration = {
     name: 'theme extension name',
     type: 'theme' as const,
@@ -101,16 +101,14 @@ export async function testThemeExtensions(): Promise<ExtensionInstance> {
   const extension = new ExtensionInstance({
     configuration,
     configurationPath: '',
-    directory: './my-extension',
+    directory,
     specification,
   })
-
-  extension.outputPath = './my-extension'
 
   return extension
 }
 
-export async function testWebPixelExtension(): Promise<ExtensionInstance> {
+export async function testWebPixelExtension(directory = './my-extension'): Promise<ExtensionInstance> {
   const configuration = {
     name: 'web pixel name',
     type: 'web_pixel' as const,
@@ -125,11 +123,9 @@ export async function testWebPixelExtension(): Promise<ExtensionInstance> {
   const extension = new ExtensionInstance({
     configuration,
     configurationPath: '',
-    directory: './my-extension',
+    directory,
     specification,
   })
-
-  extension.outputPath = './my-extension'
 
   return extension
 }
@@ -152,8 +148,6 @@ export async function testTaxCalculationExtension(directory = './my-extension'):
     directory,
     specification,
   })
-
-  extension.outputPath = directory
 
   return extension
 }

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -134,6 +134,30 @@ export async function testWebPixelExtension(): Promise<ExtensionInstance> {
   return extension
 }
 
+export async function testTaxCalculationExtension(directory = './my-extension'): Promise<ExtensionInstance> {
+  const configuration = {
+    name: 'tax',
+    type: 'tax_calculation' as const,
+    metafields: [],
+    runtime_context: 'strict',
+    settings: [],
+  }
+
+  const allSpecs = await loadLocalExtensionsSpecifications()
+  const specification = allSpecs.find((spec) => spec.identifier === 'tax_calculation')!
+
+  const extension = new ExtensionInstance({
+    configuration,
+    configurationPath: '',
+    directory,
+    specification,
+  })
+
+  extension.outputPath = directory
+
+  return extension
+}
+
 function defaultFunctionConfiguration(): FunctionConfigType {
   return {
     name: 'test function extension',

--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -1,5 +1,7 @@
 import {
+  testApp,
   testFunctionExtension,
+  testTaxCalculationExtension,
   testThemeExtensions,
   testUIExtension,
   testWebPixelExtension,
@@ -7,6 +9,8 @@ import {
 import {FunctionConfigType} from '../extensions/specifications/function.js'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {describe, expect, test} from 'vitest'
+import {inTemporaryDirectory, readFile} from '@shopify/cli-kit/node/fs'
+import {Writable} from 'stream'
 
 function functionConfiguration(): FunctionConfigType {
   return {
@@ -128,5 +132,27 @@ describe('isDraftable', () => {
     const got = extensionInstance.isDraftable(false)
 
     expect(got).toBe(true)
+  })
+})
+
+describe('build', async () => {
+  test('creates a valid JS file for tax calculation extensions', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionInstance = await testTaxCalculationExtension(tmpDir)
+      const options = {
+        stdout: new Writable(),
+        stderr: new Writable(),
+        app: testApp(),
+      }
+
+      // When
+      await extensionInstance.build(options)
+
+      // Then
+      const outputFilePath = joinPath(tmpDir, 'dist/main.js')
+      const outputFileContent = await readFile(outputFilePath)
+      expect(outputFileContent).toEqual('(()=>{})();')
+    })
   })
 })

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -246,8 +246,9 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
     // Workaround for tax_calculations because they remote spec NEEDS a valid js file to be included.
     if (this.type === 'tax_calculation') {
-      await touchFile(this.outputPath)
-      await writeFile(this.outputPath, '(()=>{})();')
+      const outputJsFilePath = joinPath(this.outputPath, 'dist/main.js')
+      await touchFile(outputJsFilePath)
+      await writeFile(outputJsFilePath, '(()=>{})();')
     }
   }
 


### PR DESCRIPTION
Cherrypicking commits from https://github.com/Shopify/cli/pull/2259 to create a patch release on 3.47 branch.