### PR TITLE
Prevent CLI crashing when no specifications are passed in

### DIFF
--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -103,7 +103,7 @@ export async function findSpecificationForConfig(
   const {type} = TypeSchema.parse(obj)
   const specification = findSpecificationForType(specifications, type)
 
-  if (!specification) {
+  if (specifications.length > 0 && !specification) {
     const isShopifolk = await isShopify()
     const shopifolkMessage = '\nYou might need to enable some beta flags on your Organization or App'
     abortOrReport(


### PR DESCRIPTION
### WHY are these changes introduced?

We recently try to load the app without passing extension specifications. This is because:
- we really just need to parse the app configuration to grab the client ID
- in order to grab the extension specifications we need that client ID
- so we can't pass the correct specifications to the loader

The problem is that if the app contains some extensions, the loader will fail because it bumps into extensions that it doesn't recognize.

### WHAT is this pull request doing?

Put a temporary patch over the problem.

The correct solution is to stop relying on the app loader mechanism to parse the app configuration.

### How to test your changes?

- create an app 
- generate an extension
- run `app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
