### PR TITLE
Watch all non-hidden GrahpQL files in functions

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -36,7 +36,7 @@ describe('watchPaths', async () => {
 
     const got = extensionInstance.watchPaths
 
-    expect(got).toEqual([joinPath('foo', 'src', 'single-path.foo'), joinPath('foo', '**', 'input*.graphql')])
+    expect(got).toEqual([joinPath('foo', 'src', 'single-path.foo'), joinPath('foo', '**', '!(.)*.graphql')])
   })
 
   test('returns default paths for javascript', async () => {
@@ -53,7 +53,7 @@ describe('watchPaths', async () => {
     expect(got).toEqual([
       joinPath('foo', 'src', '**', '*.js'),
       joinPath('foo', 'src', '**', '*.ts'),
-      joinPath('foo', '**', 'input*.graphql'),
+      joinPath('foo', '**', '!(.)*.graphql'),
     ])
   })
 
@@ -72,7 +72,7 @@ describe('watchPaths', async () => {
     expect(got).toEqual([
       joinPath('foo', 'src/**/*.rs'),
       joinPath('foo', 'src/**/*.foo'),
-      joinPath('foo', '**', 'input*.graphql'),
+      joinPath('foo', '**', '!(.)*.graphql'),
     ])
   })
 

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -222,7 +222,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
       watchPaths.push(joinPath('src', '**', '*.js'))
       watchPaths.push(joinPath('src', '**', '*.ts'))
     }
-    watchPaths.push(joinPath('**', 'input*.graphql'))
+    watchPaths.push(joinPath('**', '!(.)*.graphql'))
 
     return watchPaths.map((path) => joinPath(this.directory, path))
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, functions dev mode only watches for GraphQL files starting with `input.*`. Because we don't know how people will name their GraphQL files, it's best not to force a `input.*` prefix. The main reason for this prefix is because our current Rust crate touches a hidden GraphQL file which sends the CLI in a build loop (rebuild triggers a file change, which triggers a rebuild, rinse & repeat).

### WHAT is this pull request doing?

Instead of using a prefix, this commit fixes that by globbing on all non-hidden graphql file.

### How to test your changes?

Run `shopify app dev` with a function:
- change any graphql file, notice the CLI updates the draft
- change a rust file (which will touch a hidden file) and notice the CLI does not fall in loop.
