### PR TITLE
Improve error message on login from non-tty

### DIFF
--- a/.changeset/nine-elephants-applaud.md
+++ b/.changeset/nine-elephants-applaud.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Improve error message on non-tty when prompting for a key press

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -553,6 +553,8 @@ export function renderText({text, logLevel = 'info', logger = consoleLog}: Rende
 
 /** Waits for any key to be pressed except Ctrl+C which will terminate the process. */
 export const keypress = async () => {
+  throwInNonTTY({message: 'Press any key'})
+
   // eslint-disable-next-line max-params
   return new Promise((resolve, reject) => {
     const handler = (buffer: Buffer) => {
@@ -579,8 +581,8 @@ interface ThrowInNonTTYOptions {
   stdin?: NodeJS.ReadStream
 }
 
-function throwInNonTTY({message, stdin}: ThrowInNonTTYOptions) {
-  if (stdin || terminalSupportsRawMode()) return
+function throwInNonTTY({message}: ThrowInNonTTYOptions) {
+  if (terminalSupportsRawMode()) return
 
   const promptText = tokenItemToString(message)
   const errorMessage = `Failed to prompt:

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -581,8 +581,8 @@ interface ThrowInNonTTYOptions {
   stdin?: NodeJS.ReadStream
 }
 
-function throwInNonTTY({message}: ThrowInNonTTYOptions) {
-  if (terminalSupportsRawMode()) return
+function throwInNonTTY({message, stdin = undefined}: ThrowInNonTTYOptions) {
+  if (stdin || terminalSupportsRawMode()) return
 
   const promptText = tokenItemToString(message)
   const errorMessage = `Failed to prompt:


### PR DESCRIPTION
### WHY are these changes introduced?

The [most common error in Bugsnag](https://app.bugsnag.com/shopify/cli/errors/63e122a25a1dd100099b390c) is `Error process.stdin.setRawMode is not a function`, which is shown when the CLI tries to authenticate in a non-tty terminal.

### WHAT is this pull request doing?

Check if the terminal is compatible before prompting for a key press and show a proper error otherwise, as we do for other prompts, and avoid reporting it to Bugsnag.

**Before**:
<img width="893" alt="before" src="https://github.com/Shopify/cli/assets/14979109/51986698-ccae-416e-99cf-59cdec38c262">

**After**:
<img width="891" alt="after" src="https://github.com/Shopify/cli/assets/14979109/95480f5c-b5f2-4d13-ae3b-8fc6742c70a3">

### How to test your changes?

`true | p shopify app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
