### PR TITLE
Only load app configuration instead of loading the whole app

### DIFF
--- a/packages/app/src/cli/commands/app/build.ts
+++ b/packages/app/src/cli/commands/app/build.ts
@@ -3,7 +3,7 @@ import {AppInterface} from '../../models/app/app.js'
 import {load as loadApp} from '../../models/app/loader.js'
 import build from '../../services/build.js'
 import Command from '../../utilities/app-command.js'
-import {loadExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -42,7 +42,7 @@ export default class Build extends Command {
       cmd_app_dependency_installation_skipped: flags['skip-dependencies-installation'],
     }))
 
-    const specifications = await loadExtensionsSpecifications(this.config)
+    const specifications = await loadLocalExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path})
     await build({app, skipDependenciesInstallation: flags['skip-dependencies-installation'], apiKey})
   }

--- a/packages/app/src/cli/commands/app/config/push.ts
+++ b/packages/app/src/cli/commands/app/config/push.ts
@@ -1,6 +1,6 @@
 import {appFlags} from '../../../flags.js'
 import Command from '../../../utilities/app-command.js'
-import {load as loadApp} from '../../../models/app/loader.js'
+import {loadAppConfiguration} from '../../../models/app/loader.js'
 import {getAppInfo} from '../../../services/local-storage.js'
 import {pushConfig} from '../../../services/app/config/push.js'
 import {Flags} from '@oclif/core'
@@ -24,8 +24,8 @@ export default class ConfigPush extends Command {
   public async run(): Promise<void> {
     const {flags} = await this.parse(ConfigPush)
     const configName = flags.config || getAppInfo(flags.path)?.configFile
-    const app = await loadApp({specifications: [], configName, directory: flags.path, mode: 'report'})
+    const {configuration, configurationPath} = await loadAppConfiguration({configName, directory: flags.path})
 
-    await pushConfig({app})
+    await pushConfig({configuration, configurationPath})
   }
 }

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -4,7 +4,7 @@ import {AppInterface} from '../../models/app/app.js'
 import {load as loadApp} from '../../models/app/loader.js'
 import {validateVersion} from '../../validations/version-name.js'
 import Command from '../../utilities/app-command.js'
-import {loadExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {validateMessage} from '../../validations/message.js'
 import {Flags} from '@oclif/core'
@@ -77,7 +77,7 @@ export default class Deploy extends Command {
       cmd_app_reset_used: flags.reset,
     }))
 
-    const specifications = await loadExtensionsSpecifications(this.config)
+    const specifications = await loadLocalExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path})
     await deploy({
       app,

--- a/packages/app/src/cli/commands/app/env/pull.ts
+++ b/packages/app/src/cli/commands/app/env/pull.ts
@@ -3,7 +3,7 @@ import {AppInterface} from '../../../models/app/app.js'
 import {load as loadApp} from '../../../models/app/loader.js'
 import {pullEnv} from '../../../services/app/env/pull.js'
 import Command from '../../../utilities/app-command.js'
-import {loadExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
@@ -26,7 +26,7 @@ export default class EnvPull extends Command {
   public async run(): Promise<void> {
     const {flags} = await this.parse(EnvPull)
     const envFile = joinPath(flags.path, flags['env-file'])
-    const specifications = await loadExtensionsSpecifications(this.config)
+    const specifications = await loadLocalExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path, mode: 'report'})
     outputInfo(await pullEnv(app, {envFile}))
   }

--- a/packages/app/src/cli/commands/app/env/show.ts
+++ b/packages/app/src/cli/commands/app/env/show.ts
@@ -3,7 +3,7 @@ import {AppInterface} from '../../../models/app/app.js'
 import {load as loadApp} from '../../../models/app/loader.js'
 import {showEnv} from '../../../services/app/env/show.js'
 import Command from '../../../utilities/app-command.js'
-import {loadExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 
@@ -17,7 +17,7 @@ export default class EnvShow extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(EnvShow)
-    const specifications = await loadExtensionsSpecifications(this.config)
+    const specifications = await loadLocalExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path, mode: 'report'})
     outputInfo(await showEnv(app))
   }

--- a/packages/app/src/cli/commands/app/import-flow-legacy-extensions.ts
+++ b/packages/app/src/cli/commands/app/import-flow-legacy-extensions.ts
@@ -1,5 +1,5 @@
 import {appFlags} from '../../flags.js'
-import {loadExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {load as loadApp} from '../../models/app/loader.js'
 import {AppInterface} from '../../models/app/app.js'
 import {importFlowExtensions} from '../../services/import-flow-legacy-extensions.js'
@@ -23,7 +23,7 @@ export default class AppImportFlowExtension extends Command {
   async run(): Promise<void> {
     const {flags} = await this.parse(AppImportFlowExtension)
 
-    const specifications = await loadExtensionsSpecifications(this.config)
+    const specifications = await loadLocalExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path})
 
     await importFlowExtensions({app, config: this.config, apiKey: flags['client-id']})

--- a/packages/app/src/cli/commands/app/info.ts
+++ b/packages/app/src/cli/commands/app/info.ts
@@ -3,7 +3,7 @@ import {AppInterface} from '../../models/app/app.js'
 import {Format, info} from '../../services/info.js'
 import {load as loadApp} from '../../models/app/loader.js'
 import Command from '../../utilities/app-command.js'
-import {loadExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
@@ -29,7 +29,7 @@ export default class AppInfo extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(AppInfo)
-    const specifications = await loadExtensionsSpecifications(this.config)
+    const specifications = await loadLocalExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path, mode: 'report'})
     outputInfo(await info(app, {format: (flags.json ? 'json' : 'text') as Format, webEnv: flags['web-env']}))
     if (app.errors) process.exit(2)

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -2,7 +2,7 @@ import {appFlags} from '../../flags.js'
 import {AppInterface} from '../../models/app/app.js'
 import {load as loadApp} from '../../models/app/loader.js'
 import Command from '../../utilities/app-command.js'
-import {loadExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {release} from '../../services/release.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -41,7 +41,7 @@ export default class Release extends Command {
       cmd_app_reset_used: flags.reset,
     }))
 
-    const specifications = await loadExtensionsSpecifications(this.config)
+    const specifications = await loadLocalExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path})
     await release({
       app,

--- a/packages/app/src/cli/commands/app/versions/list.ts
+++ b/packages/app/src/cli/commands/app/versions/list.ts
@@ -1,7 +1,7 @@
 import {appFlags} from '../../../flags.js'
 import Command from '../../../utilities/app-command.js'
 import versionList from '../../../services/versions-list.js'
-import {loadExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {AppInterface} from '../../../models/app/app.js'
 import {load as loadApp} from '../../../models/app/loader.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -27,7 +27,7 @@ export default class VersionsList extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(VersionsList)
-    const specifications = await loadExtensionsSpecifications(this.config)
+    const specifications = await loadLocalExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path})
 
     await versionList({app, apiKey: flags['api-key']})

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -5,7 +5,7 @@ import themeExtension from '../templates/theme-specifications/theme.js'
 import checkoutPostPurchaseExtension from '../templates/ui-specifications/checkout_post_purchase.js'
 import checkoutUIExtension from '../templates/ui-specifications/checkout_ui_extension.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
-import {loadLocalExtensionsSpecifications} from '../extensions/load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../extensions/load-specifications.js'
 import {FunctionConfigType} from '../extensions/specifications/function.js'
 import UIExtensionTemplate from '../templates/ui-specifications/ui_extension.js'
 import {OrganizationApp} from '../organization.js'
@@ -73,7 +73,7 @@ export async function testUIExtension(uiExtension: Partial<ExtensionInstance> = 
   const configurationPath = uiExtension?.configurationPath ?? `${directory}/shopify.ui.extension.toml`
   const entryPath = uiExtension?.entrySourceFilePath ?? `${directory}/src/index.js`
 
-  const allSpecs = await loadLocalExtensionsSpecifications()
+  const allSpecs = await loadFSExtensionsSpecifications()
   const specification = allSpecs.find((spec) => spec.identifier === configuration.type)!
 
   const extension = new ExtensionInstance({
@@ -95,7 +95,7 @@ export async function testThemeExtensions(directory = './my-extension'): Promise
     metafields: [],
   }
 
-  const allSpecs = await loadLocalExtensionsSpecifications()
+  const allSpecs = await loadFSExtensionsSpecifications()
   const specification = allSpecs.find((spec) => spec.identifier === 'theme')!
 
   const extension = new ExtensionInstance({
@@ -117,7 +117,7 @@ export async function testWebPixelExtension(directory = './my-extension'): Promi
     settings: [],
   }
 
-  const allSpecs = await loadLocalExtensionsSpecifications()
+  const allSpecs = await loadFSExtensionsSpecifications()
   const specification = allSpecs.find((spec) => spec.identifier === 'web_pixel_extension')!
 
   const extension = new ExtensionInstance({
@@ -139,7 +139,7 @@ export async function testTaxCalculationExtension(directory = './my-extension'):
     settings: [],
   }
 
-  const allSpecs = await loadLocalExtensionsSpecifications()
+  const allSpecs = await loadFSExtensionsSpecifications()
   const specification = allSpecs.find((spec) => spec.identifier === 'tax_calculation')!
 
   const extension = new ExtensionInstance({
@@ -179,7 +179,7 @@ export async function testFunctionExtension(
   const directory = opts.dir ?? '/tmp/project/extensions/my-function'
   const configuration = opts.config ?? defaultFunctionConfiguration()
 
-  const allSpecs = await loadLocalExtensionsSpecifications()
+  const allSpecs = await loadFSExtensionsSpecifications()
   const specification = allSpecs.find((spec) => spec.identifier === 'function')!
 
   const extension = new ExtensionInstance({

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1,7 +1,7 @@
 import {getAppConfigurationFileName, load} from './loader.js'
 import {configurationFileNames, blocks} from '../../constants.js'
 import metadata from '../../metadata.js'
-import {loadLocalExtensionsSpecifications} from '../extensions/load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../extensions/load-specifications.js'
 import {ExtensionSpecification} from '../extensions/specification.js'
 import {describe, expect, beforeEach, afterEach, beforeAll, test} from 'vitest'
 import {
@@ -23,7 +23,7 @@ scopes = "read_products"
 `
 
   beforeAll(async () => {
-    specifications = await loadLocalExtensionsSpecifications()
+    specifications = await loadFSExtensionsSpecifications()
   })
 
   beforeEach(async () => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -112,7 +112,7 @@ export async function findSpecificationForConfig(
   const {type} = TypeSchema.parse(obj)
   const specification = findSpecificationForType(specifications, type)
 
-  if (specifications.length > 0 && !specification) {
+  if (!specification) {
     const isShopifolk = await isShopify()
     const shopifolkMessage = '\nYou might need to enable some beta flags on your Organization or App'
     abortOrReport(

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -412,7 +412,7 @@ class AppConfigurationLoader {
   async loaded() {
     const appDirectory = await this.getAppDirectory()
     const configurationPath = await this.getConfigurationPath()
-    const configuration = await this.parseConfigurationFile(AppConfigurationSchema, configurationPath)
+    const configuration = await parseConfigurationFile(AppConfigurationSchema, configurationPath, this.abort)
     return {appDirectory, configuration, configurationPath}
   }
 
@@ -421,15 +421,6 @@ class AppConfigurationLoader {
       throw new AbortError(outputContent`Couldn't find directory ${outputToken.path(this.directory)}`)
     }
     return dirname(await this.getConfigurationPath())
-  }
-
-  parseConfigurationFile<TSchema extends zod.ZodType>(
-    schema: TSchema,
-    filepath: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    decode: (input: any) => any = decodeToml,
-  ) {
-    return parseConfigurationFile(schema, filepath, this.abort, decode)
   }
 
   async getConfigurationPath() {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -385,9 +385,9 @@ export interface AppConfigurationInterface {
 
 /**
  * Parse the app configuration file from the given directory.
- * If the app configuration does not match known schemas, it will throw an error.
+ * If the app configuration does not match any known schemas, it will throw an error.
  */
-export async function loadConfiguration(
+export async function loadAppConfiguration(
   options: AppConfigurationLoaderConstructorArgs,
 ): Promise<AppConfigurationInterface> {
   const loader = new AppConfigurationLoader(options)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -1,4 +1,13 @@
-import {AppConfigurationSchema, Web, WebConfigurationSchema, App, AppInterface, WebType, getAppScopes} from './app.js'
+import {
+  AppConfigurationSchema,
+  Web,
+  WebConfigurationSchema,
+  App,
+  AppInterface,
+  WebType,
+  getAppScopes,
+  AppConfiguration,
+} from './app.js'
 import {configurationFileNames, dotEnvFileNames} from '../../constants.js'
 import metadata from '../../metadata.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
@@ -161,8 +170,6 @@ class AppLoader {
   private directory: string
   private mode: AppLoaderMode
   private configName?: string
-  private appDirectory = ''
-  private configurationPath = ''
   private errors: AppErrors = new AppErrors()
   private specifications: ExtensionSpecification[]
 
@@ -187,24 +194,32 @@ class AppLoader {
   }
 
   async loaded() {
-    this.appDirectory = await this.findAppDirectory()
-    const configurationPath = await this.getConfigurationPath()
-    const configuration = await this.parseConfigurationFile(AppConfigurationSchema, configurationPath)
-    const dotenv = await this.loadDotEnv()
+    const configurationLoader = new AppConfigurationLoader({
+      directory: this.directory,
+      configName: this.configName,
+    })
+    const {appDirectory, configurationPath, configuration} = await configurationLoader.loaded()
+    const dotenv = await this.loadDotEnv(appDirectory)
 
-    const {allExtensions, usedCustomLayout} = await this.loadExtensions(configuration.extension_directories)
+    const {allExtensions, usedCustomLayout} = await this.loadExtensions(
+      appDirectory,
+      configuration.extension_directories,
+    )
 
-    const packageJSONPath = joinPath(this.appDirectory, 'package.json')
-    const name = await loadAppName(this.appDirectory)
+    const packageJSONPath = joinPath(appDirectory, 'package.json')
+    const name = await loadAppName(appDirectory)
     const nodeDependencies = await getDependencies(packageJSONPath)
-    const packageManager = await getPackageManager(this.appDirectory)
-    const {webs, usedCustomLayout: usedCustomLayoutForWeb} = await this.loadWebs(configuration.web_directories)
-    const usesWorkspaces = await appUsesWorkspaces(this.appDirectory)
+    const packageManager = await getPackageManager(appDirectory)
+    const {webs, usedCustomLayout: usedCustomLayoutForWeb} = await this.loadWebs(
+      appDirectory,
+      configuration.web_directories,
+    )
+    const usesWorkspaces = await appUsesWorkspaces(appDirectory)
 
     const appClass = new App(
       name,
       'SHOPIFY_API_KEY',
-      this.appDirectory,
+      appDirectory,
       packageManager,
       configuration,
       configurationPath,
@@ -225,54 +240,27 @@ class AppLoader {
     return appClass
   }
 
-  async loadDotEnv(): Promise<DotEnvFile | undefined> {
+  async loadDotEnv(appDirectory: string): Promise<DotEnvFile | undefined> {
     let dotEnvFile: DotEnvFile | undefined
-    const dotEnvPath = joinPath(this.appDirectory, dotEnvFileNames.production)
+    const dotEnvPath = joinPath(appDirectory, dotEnvFileNames.production)
     if (await fileExists(dotEnvPath)) {
       dotEnvFile = await readAndParseDotEnv(dotEnvPath)
     }
     return dotEnvFile
   }
 
-  async findAppDirectory() {
-    if (!(await fileExists(this.directory))) {
-      throw new AbortError(outputContent`Couldn't find directory ${outputToken.path(this.directory)}`)
-    }
-    return dirname(await this.getConfigurationPath())
-  }
-
-  async getConfigurationPath() {
-    if (this.configurationPath) return this.configurationPath
-
-    const configurationFileName = getAppConfigurationFileName(this.configName)
-    const configurationPath = await findPathUp(configurationFileName, {
-      cwd: this.directory,
-      type: 'file',
-    })
-    if (!configurationPath) {
-      throw new AbortError(
-        outputContent`Couldn't find the configuration file for ${outputToken.path(
-          this.directory,
-        )}, are you in an app directory?`,
-      )
-    }
-
-    this.configurationPath = configurationPath
-    return configurationPath
-  }
-
-  async loadWebs(webDirectories?: string[]): Promise<{webs: Web[]; usedCustomLayout: boolean}> {
+  async loadWebs(appDirectory: string, webDirectories?: string[]): Promise<{webs: Web[]; usedCustomLayout: boolean}> {
     const defaultWebDirectory = '**'
     const webConfigGlobs = [...(webDirectories ?? [defaultWebDirectory])].map((webGlob) => {
-      return joinPath(this.appDirectory, webGlob, configurationFileNames.web)
+      return joinPath(appDirectory, webGlob, configurationFileNames.web)
     })
-    webConfigGlobs.push(`!${joinPath(this.appDirectory, '**/node_modules/**')}`)
+    webConfigGlobs.push(`!${joinPath(appDirectory, '**/node_modules/**')}`)
     const webTomlPaths = await glob(webConfigGlobs)
 
     const webs = await Promise.all(webTomlPaths.map((path) => this.loadWeb(path)))
     this.validateWebs(webs)
 
-    const webTomlsInStandardLocation = await glob(joinPath(this.appDirectory, `web/**/${configurationFileNames.web}`))
+    const webTomlsInStandardLocation = await glob(joinPath(appDirectory, `web/**/${configurationFileNames.web}`))
     const usedCustomLayout = webDirectories !== undefined || webTomlsInStandardLocation.length !== webTomlPaths.length
 
     return {webs, usedCustomLayout}
@@ -304,12 +292,13 @@ class AppLoader {
   }
 
   async loadExtensions(
+    appDirectory: string,
     extensionDirectories?: string[],
   ): Promise<{allExtensions: ExtensionInstance[]; usedCustomLayout: boolean}> {
     const extensionConfigPaths = [...(extensionDirectories ?? [defaultExtensionDirectory])].map((extensionPath) => {
-      return joinPath(this.appDirectory, extensionPath, '*.extension.toml')
+      return joinPath(appDirectory, extensionPath, '*.extension.toml')
     })
-    extensionConfigPaths.push(`!${joinPath(this.appDirectory, '**/node_modules/**')}`)
+    extensionConfigPaths.push(`!${joinPath(appDirectory, '**/node_modules/**')}`)
     const configPaths = await glob(extensionConfigPaths)
 
     const extensions = configPaths.map(async (configurationPath) => {
@@ -385,6 +374,86 @@ class AppLoader {
       this.errors.addError(configurationPath, errorMessage)
       return fallback
     }
+  }
+}
+
+export interface AppConfigurationInterface {
+  appDirectory: string
+  configuration: AppConfiguration
+  configurationPath: string
+}
+
+/**
+ * Parse the app configuration file from the given directory.
+ * If the app configuration does not match known schemas, it will throw an error.
+ */
+export async function loadConfiguration(
+  options: AppConfigurationLoaderConstructorArgs,
+): Promise<AppConfigurationInterface> {
+  const loader = new AppConfigurationLoader(options)
+  return loader.loaded()
+}
+
+interface AppConfigurationLoaderConstructorArgs {
+  directory: string
+  configName?: string
+}
+
+class AppConfigurationLoader {
+  private directory: string
+  private configName?: string
+  private configurationPath = ''
+
+  constructor({directory, configName}: AppConfigurationLoaderConstructorArgs) {
+    this.directory = directory
+    this.configName = configName
+  }
+
+  async loaded() {
+    const appDirectory = await this.getAppDirectory()
+    const configurationPath = await this.getConfigurationPath()
+    const configuration = await this.parseConfigurationFile(AppConfigurationSchema, configurationPath)
+    return {appDirectory, configuration, configurationPath}
+  }
+
+  async getAppDirectory() {
+    if (!(await fileExists(this.directory))) {
+      throw new AbortError(outputContent`Couldn't find directory ${outputToken.path(this.directory)}`)
+    }
+    return dirname(await this.getConfigurationPath())
+  }
+
+  parseConfigurationFile<TSchema extends zod.ZodType>(
+    schema: TSchema,
+    filepath: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    decode: (input: any) => any = decodeToml,
+  ) {
+    return parseConfigurationFile(schema, filepath, this.abort, decode)
+  }
+
+  async getConfigurationPath() {
+    if (this.configurationPath) return this.configurationPath
+
+    const configurationFileName = getAppConfigurationFileName(this.configName)
+    const configurationPath = await findPathUp(configurationFileName, {
+      cwd: this.directory,
+      type: 'file',
+    })
+    if (!configurationPath) {
+      throw new AbortError(
+        outputContent`Couldn't find the configuration file for ${outputToken.path(
+          this.directory,
+        )}, are you in an app directory?`,
+      )
+    }
+
+    this.configurationPath = configurationPath
+    return configurationPath
+  }
+
+  abort<T>(errorMessage: OutputMessage, fallback: T, configurationPath: string): T {
+    throw new AbortError(errorMessage)
   }
 }
 

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -11,7 +11,7 @@ import {fileURLToPath} from 'url'
  * Load all specifications from the local file system AND plugins
  */
 export async function loadExtensionsSpecifications(config: Config): Promise<ExtensionSpecification[]> {
-  const local = await loadLocalExtensionsSpecifications()
+  const local = await loadFSExtensionsSpecifications()
   const plugins = await loadUIExtensionSpecificationsFromPlugins(config)
   return [...local, ...plugins]
 }
@@ -19,7 +19,7 @@ export async function loadExtensionsSpecifications(config: Config): Promise<Exte
 /**
  * Load all specifications ONLY from the local file system
  */
-export async function loadLocalExtensionsSpecifications(): Promise<ExtensionSpecification[]> {
+export async function loadFSExtensionsSpecifications(): Promise<ExtensionSpecification[]> {
   return memoizedLoadSpecs('specifications')
 }
 

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -1,5 +1,5 @@
 import {ExtensionSpecification} from './specification.js'
-import {loadUIExtensionSpecificiationsFromPlugins} from '../../private/plugins/extension.js'
+import {loadUIExtensionSpecificationsFromPlugins} from '../../private/plugins/extension.js'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
 import {memoize} from '@shopify/cli-kit/common/function'
 import {Config} from '@oclif/core'
@@ -12,7 +12,7 @@ import {fileURLToPath} from 'url'
  */
 export async function loadExtensionsSpecifications(config: Config): Promise<ExtensionSpecification[]> {
   const local = await loadLocalExtensionsSpecifications()
-  const plugins = await loadUIExtensionSpecificiationsFromPlugins(config)
+  const plugins = await loadUIExtensionSpecificationsFromPlugins(config)
   return [...local, ...plugins]
 }
 

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -10,7 +10,7 @@ import {fileURLToPath} from 'url'
 /**
  * Load all specifications from the local file system AND plugins
  */
-export async function loadExtensionsSpecifications(config: Config): Promise<ExtensionSpecification[]> {
+export async function loadLocalExtensionsSpecifications(config: Config): Promise<ExtensionSpecification[]> {
   const local = await loadFSExtensionsSpecifications()
   const plugins = await loadUIExtensionSpecificationsFromPlugins(config)
   return [...local, ...plugins]

--- a/packages/app/src/cli/models/extensions/specification.integration.test.ts
+++ b/packages/app/src/cli/models/extensions/specification.integration.test.ts
@@ -1,11 +1,11 @@
-import {loadLocalExtensionsSpecifications} from './load-specifications.js'
+import {loadFSExtensionsSpecifications} from './load-specifications.js'
 import {testFunctionExtension} from '../app/app.test-data.js'
 import {describe, test, expect} from 'vitest'
 
 describe('allUISpecifications', () => {
   test('loads the specifications successfully', async () => {
     // When
-    const got = await loadLocalExtensionsSpecifications()
+    const got = await loadFSExtensionsSpecifications()
 
     // Then
     expect(got.length).not.toEqual(0)
@@ -15,7 +15,7 @@ describe('allUISpecifications', () => {
 describe('allLocalSpecs', () => {
   test('loads the specifications successfully', async () => {
     // When
-    const got = await loadLocalExtensionsSpecifications()
+    const got = await loadFSExtensionsSpecifications()
 
     // Then
     expect(got.length).not.toEqual(0)

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -1,7 +1,7 @@
 import {configurationFileNames} from '../../../constants.js'
 import * as loadLocales from '../../../utilities/extensions/locales-configuration.js'
 import {ExtensionInstance} from '../extension-instance.js'
-import {loadLocalExtensionsSpecifications} from '../load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../load-specifications.js'
 import {describe, expect, test, vi} from 'vitest'
 import {err, ok} from '@shopify/cli-kit/node/result'
 import {inTemporaryDirectory, mkdir, touchFile} from '@shopify/cli-kit/node/fs'
@@ -15,7 +15,7 @@ describe('ui_extension', async () => {
 
   async function getTestUIExtension({directory, extensionPoints}: GetUIExtensionProps) {
     const configurationPath = joinPath(directory, configurationFileNames.extension.ui)
-    const allSpecs = await loadLocalExtensionsSpecifications()
+    const allSpecs = await loadFSExtensionsSpecifications()
     const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
     const configuration = {
       extension_points: extensionPoints,

--- a/packages/app/src/cli/private/plugins/extension.ts
+++ b/packages/app/src/cli/private/plugins/extension.ts
@@ -4,7 +4,7 @@ import {Config} from '@oclif/core'
 import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
 import {fanoutHooks} from '@shopify/cli-kit/node/plugins'
 
-export async function loadUIExtensionSpecificiationsFromPlugins(config: Config): Promise<ExtensionSpecification[]> {
+export async function loadUIExtensionSpecificationsFromPlugins(config: Config): Promise<ExtensionSpecification[]> {
   const hooks = await fanoutHooks<HookReturnPerExtensionPlugin, 'extension_specs'>(config, 'extension_specs', {})
   const specs = getArrayRejectingUndefined(Object.values(hooks)).flat()
   return specs

--- a/packages/app/src/cli/public/plugins/extension.test.ts
+++ b/packages/app/src/cli/public/plugins/extension.test.ts
@@ -1,4 +1,4 @@
-import {loadUIExtensionSpecificiationsFromPlugins} from '../../private/plugins/extension.js'
+import {loadUIExtensionSpecificationsFromPlugins} from '../../private/plugins/extension.js'
 import {Config} from '@oclif/core'
 import {describe, test, vi, expect} from 'vitest'
 
@@ -9,7 +9,7 @@ describe('getListOfExtensionSpecs', () => {
     vi.spyOn(config, 'runHook').mockResolvedValue({successes: [], errors: []} as any)
 
     // When
-    const got = await loadUIExtensionSpecificiationsFromPlugins(config)
+    const got = await loadUIExtensionSpecificationsFromPlugins(config)
 
     // Then
     expect(got).toEqual([])
@@ -27,7 +27,7 @@ describe('getListOfExtensionSpecs', () => {
     } as any)
 
     // When
-    const got = await loadUIExtensionSpecificiationsFromPlugins(config)
+    const got = await loadUIExtensionSpecificationsFromPlugins(config)
 
     // Then
     expect(got).toEqual([{firstSpec: 1}, {secondSpec: 2}, {thirdSpec: 3}, {fourthSpec: 4}])

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -2,7 +2,7 @@ import {saveCurrentConfig} from './use.js'
 import {AppConfiguration, AppInterface, CurrentAppConfiguration} from '../../../models/app/app.js'
 import {OrganizationApp} from '../../../models/organization.js'
 import {selectConfigName} from '../../../prompts/config.js'
-import {loadExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {load} from '../../../models/app/loader.js'
 import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../context.js'
 import {fetchAppFromApiKey} from '../../dev/fetch.js'
@@ -46,7 +46,7 @@ export default async function link(options: LinkOptions): Promise<void> {
 
 async function loadAppConfigFromLegacyToml(options: LinkOptions): Promise<AppInterface> {
   try {
-    const specifications = await loadExtensionsSpecifications(options.commandConfig)
+    const specifications = await loadLocalExtensionsSpecifications(options.commandConfig)
     const app = await load({specifications, directory: options.directory, mode: 'report'})
     return app
     // eslint-disable-next-line no-catch-all/no-catch-all

--- a/packages/app/src/cli/services/app/config/push.test.ts
+++ b/packages/app/src/cli/services/app/config/push.test.ts
@@ -10,18 +10,20 @@ vi.mock('@shopify/cli-kit/node/session')
 
 describe('pushConfig', () => {
   test('successfully calls the update mutation when push is run and a file is present', async () => {
+    const app = testApp({
+      configurationPath: 'shopify.app.development.toml',
+      configuration: {
+        name: 'my app',
+        api_contact_email: 'ryan@app.com',
+        client_id: '12345',
+        scopes: 'write_products',
+        webhook_api_version: '04-2023',
+        application_url: 'https://myapp.com',
+      },
+    })
     const options: Options = {
-      app: testApp({
-        configurationPath: 'shopify.app.development.toml',
-        configuration: {
-          name: 'my app',
-          api_contact_email: 'ryan@app.com',
-          client_id: '12345',
-          scopes: 'write_products',
-          webhook_api_version: '04-2023',
-          application_url: 'https://myapp.com',
-        },
-      }),
+      configuration: app.configuration,
+      configurationPath: app.configurationPath,
     }
 
     vi.mocked(partnersRequest).mockResolvedValue({
@@ -46,18 +48,20 @@ describe('pushConfig', () => {
   })
 
   test('returns error when update mutation fails', async () => {
+    const app = testApp({
+      configurationPath: 'shopify.app.development.toml',
+      configuration: {
+        name: 'my app',
+        api_contact_email: 'ryan@app.com',
+        client_id: '12345',
+        scopes: 'write_products',
+        webhook_api_version: '04-2023',
+        application_url: 'https://myapp.com',
+      },
+    })
     const options: Options = {
-      app: testApp({
-        configurationPath: 'shopify.app.development.toml',
-        configuration: {
-          name: 'my app',
-          api_contact_email: 'ryan@app.com',
-          client_id: '12345',
-          scopes: 'write_products',
-          webhook_api_version: '04-2023',
-          application_url: 'https://myapp.com',
-        },
-      }),
+      configuration: app.configuration,
+      configurationPath: app.configurationPath,
     }
 
     vi.mocked(partnersRequest).mockResolvedValue({

--- a/packages/app/src/cli/services/app/config/push.ts
+++ b/packages/app/src/cli/services/app/config/push.ts
@@ -1,6 +1,6 @@
 import {PushConfig, PushConfigSchema} from '../../../api/graphql/push_config.js'
 import {App, GetConfig, GetConfigQuerySchema} from '../../../api/graphql/get_config.js'
-import {AppInterface, CurrentAppConfiguration, isCurrentAppSchema} from '../../../models/app/app.js'
+import {AppConfiguration, CurrentAppConfiguration, isCurrentAppSchema} from '../../../models/app/app.js'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -9,18 +9,17 @@ import {OutputMessage} from '@shopify/cli-kit/node/output'
 import {basename} from '@shopify/cli-kit/node/path'
 
 export interface Options {
-  app: AppInterface
+  configuration: AppConfiguration
+  configurationPath: string
 }
 
-export async function pushConfig(options: Options) {
-  const {configuration} = options.app
-
+export async function pushConfig({configuration, configurationPath}: Options) {
   if (isCurrentAppSchema(configuration)) {
     const token = await ensureAuthenticatedPartners()
     const mutation = PushConfig
     const query = GetConfig
 
-    const configFileName = basename(options.app.configurationPath)
+    const configFileName = basename(configurationPath)
 
     const queryVariables = {apiKey: configuration.client_id}
     const queryResult: GetConfigQuerySchema = await partnersRequest(query, token, queryVariables)

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -1,6 +1,6 @@
 import use, {UseOptions} from './use.js'
 import {testApp, testAppWithConfig} from '../../../models/app/app.test-data.js'
-import {getAppConfigurationFileName, load} from '../../../models/app/loader.js'
+import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
 import {clearCurrentConfigFile, setAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
 import {describe, expect, test, vi} from 'vitest'
@@ -32,7 +32,7 @@ describe('use', () => {
       // Then
       expect(clearCurrentConfigFile).toHaveBeenCalledWith(tmp)
       expect(setAppInfo).not.toHaveBeenCalled()
-      expect(load).not.toHaveBeenCalled()
+      expect(loadAppConfiguration).not.toHaveBeenCalled()
 
       expect(renderSuccess).toHaveBeenCalledWith({
         headline: 'Cleared current configuration.',
@@ -69,7 +69,11 @@ describe('use', () => {
       vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.no-id.toml')
 
       const appWithoutClientID = testApp()
-      vi.mocked(load).mockResolvedValue(appWithoutClientID)
+      vi.mocked(loadAppConfiguration).mockResolvedValue({
+        appDirectory: tmp,
+        configurationPath: appWithoutClientID.configurationPath,
+        configuration: appWithoutClientID.configuration,
+      })
 
       // When
       const result = use(options)
@@ -101,7 +105,7 @@ describe('use', () => {
     "message": "Expected array, received string"
   }
 ]'`)
-      vi.mocked(load).mockRejectedValue(error)
+      vi.mocked(loadAppConfiguration).mockRejectedValue(error)
 
       // When
       const result = use(options)
@@ -130,7 +134,11 @@ describe('use', () => {
           application_url: 'https://example.com',
         },
       })
-      vi.mocked(load).mockResolvedValue(app)
+      vi.mocked(loadAppConfiguration).mockResolvedValue({
+        appDirectory: tmp,
+        configurationPath: app.configurationPath,
+        configuration: app.configuration,
+      })
 
       // When
       await use(options)
@@ -164,7 +172,11 @@ describe('use', () => {
           application_url: 'https://example.com',
         },
       })
-      vi.mocked(load).mockResolvedValue(app)
+      vi.mocked(loadAppConfiguration).mockResolvedValue({
+        appDirectory: tmp,
+        configurationPath: app.configurationPath,
+        configuration: app.configuration,
+      })
 
       // When
       await use(options)

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -1,4 +1,4 @@
-import {getAppConfigurationFileName, load as loadApp} from '../../../models/app/loader.js'
+import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
 import {clearCurrentConfigFile, setAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
 import {isCurrentAppSchema} from '../../../models/app/app.js'
@@ -39,9 +39,9 @@ interface SaveCurrentConfigOptions {
 }
 
 export async function saveCurrentConfig({configFileName, directory}: SaveCurrentConfigOptions) {
-  const app = await loadApp({specifications: [], configName: configFileName, directory, mode: 'strict'})
+  const {configuration} = await loadAppConfiguration({configName: configFileName, directory})
 
-  if (isCurrentAppSchema(app.configuration) && app.configuration.client_id) {
+  if (isCurrentAppSchema(configuration) && configuration.client_id) {
     setAppInfo({
       directory,
       configFile: configFileName,

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -26,7 +26,7 @@ import {updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
 import {testApp, testOrganizationApp, testThemeExtensions} from '../models/app/app.test-data.js'
 import metadata from '../metadata.js'
-import {load, loadAppName} from '../models/app/loader.js'
+import {loadAppConfiguration, loadAppName} from '../models/app/loader.js'
 import {AppInterface} from '../models/app/app.js'
 import {DevelopmentStorePreviewUpdateQuery} from '../api/graphql/development_preview.js'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
@@ -226,32 +226,37 @@ describe('ensureGenerateContext', () => {
 
 describe('ensureDevContext', async () => {
   beforeEach(() => {
-    vi.mocked(load).mockResolvedValueOnce(testApp())
+    vi.mocked(loadAppConfiguration).mockResolvedValueOnce({
+      appDirectory: '/app',
+      configurationPath: '/app/shopify.app.toml',
+      configuration: {
+        scopes: 'read_products',
+      },
+    })
   })
 
   test('returns selected data using config file set in cache', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       vi.mocked(getAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
-      vi.mocked(load).mockReset()
-      vi.mocked(load).mockResolvedValue(
-        testApp({
-          configurationPath: joinPath(tmp, CACHED1_WITH_CONFIG.configFile!),
-          configuration: {
-            client_id: APP2.apiKey,
-            name: APP2.title,
-            scopes: 'read_products',
-            application_url: 'https://my-apps-url.com',
-            auth: {
-              redirect_urls: ['https://my-apps-url.com/auth/shopify'],
-            },
-            cli: {
-              automatically_update_urls_on_dev: true,
-              dev_store_url: STORE1.shopDomain,
-            },
+      vi.mocked(loadAppConfiguration).mockReset()
+      vi.mocked(loadAppConfiguration).mockResolvedValue({
+        appDirectory: tmp,
+        configurationPath: joinPath(tmp, CACHED1_WITH_CONFIG.configFile!),
+        configuration: {
+          client_id: APP2.apiKey,
+          name: APP2.title,
+          scopes: 'read_products',
+          application_url: 'https://my-apps-url.com',
+          auth: {
+            redirect_urls: ['https://my-apps-url.com/auth/shopify'],
           },
-        }),
-      )
+          cli: {
+            automatically_update_urls_on_dev: true,
+            dev_store_url: STORE1.shopDomain,
+          },
+        },
+      })
       vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
       vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
@@ -287,25 +292,24 @@ describe('ensureDevContext', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       vi.mocked(getAppInfo).mockReturnValue(undefined)
-      vi.mocked(load).mockReset()
-      vi.mocked(load).mockResolvedValue(
-        testApp({
-          configurationPath: joinPath(tmp, 'shopify.app.dev.toml'),
-          configuration: {
-            client_id: APP2.apiKey,
-            name: APP2.title,
-            scopes: 'read_products',
-            application_url: 'https://my-apps-url.com',
-            auth: {
-              redirect_urls: ['https://my-apps-url.com/auth/shopify'],
-            },
-            cli: {
-              automatically_update_urls_on_dev: true,
-              dev_store_url: STORE1.shopDomain,
-            },
+      vi.mocked(loadAppConfiguration).mockReset()
+      vi.mocked(loadAppConfiguration).mockResolvedValue({
+        appDirectory: tmp,
+        configurationPath: joinPath(tmp, 'shopify.app.dev.toml'),
+        configuration: {
+          client_id: APP2.apiKey,
+          name: APP2.title,
+          scopes: 'read_products',
+          application_url: 'https://my-apps-url.com',
+          auth: {
+            redirect_urls: ['https://my-apps-url.com/auth/shopify'],
           },
-        }),
-      )
+          cli: {
+            automatically_update_urls_on_dev: true,
+            dev_store_url: STORE1.shopDomain,
+          },
+        },
+      })
       vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
       vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
@@ -320,9 +324,8 @@ describe('ensureDevContext', async () => {
       )
 
       // Then
-      expect(load).toHaveBeenCalledWith({
+      expect(loadAppConfiguration).toHaveBeenCalledWith({
         directory: 'app_directory',
-        specifications: [],
         configName: 'dev',
       })
     })
@@ -333,24 +336,23 @@ describe('ensureDevContext', async () => {
       // Given
       const filePath = joinPath(tmp, 'shopify.app.dev.toml')
       writeFileSync(filePath, '')
-      vi.mocked(load).mockReset()
-      vi.mocked(load).mockResolvedValue(
-        testApp({
-          configurationPath: filePath,
-          configuration: {
-            client_id: APP2.apiKey,
-            name: APP2.title,
-            scopes: 'read_products',
-            application_url: 'https://my-apps-url.com',
-            auth: {
-              redirect_urls: ['https://my-apps-url.com/auth/shopify'],
-            },
-            cli: {
-              automatically_update_urls_on_dev: true,
-            },
+      vi.mocked(loadAppConfiguration).mockReset()
+      vi.mocked(loadAppConfiguration).mockResolvedValue({
+        appDirectory: tmp,
+        configurationPath: filePath,
+        configuration: {
+          client_id: APP2.apiKey,
+          name: APP2.title,
+          scopes: 'read_products',
+          application_url: 'https://my-apps-url.com',
+          auth: {
+            redirect_urls: ['https://my-apps-url.com/auth/shopify'],
           },
-        }),
-      )
+          cli: {
+            automatically_update_urls_on_dev: true,
+          },
+        },
+      })
       vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
 
       // When

--- a/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.test.ts
@@ -1,5 +1,5 @@
 import {themeExtensionConfig} from './theme-extension-config.js'
-import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
@@ -9,7 +9,7 @@ describe('themeExtensionConfig', () => {
   test('builds a base64 encoded payload containing all theme files', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
-      const allSpecs = await loadLocalExtensionsSpecifications()
+      const allSpecs = await loadFSExtensionsSpecifications()
       const specification = allSpecs.find((spec) => spec.identifier === 'theme')!
       const themeExtension = new ExtensionInstance({
         configuration: {
@@ -39,7 +39,7 @@ describe('themeExtensionConfig', () => {
   test('excludes system files', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
-      const allSpecs = await loadLocalExtensionsSpecifications()
+      const allSpecs = await loadFSExtensionsSpecifications()
       const specification = allSpecs.find((spec) => spec.identifier === 'theme')!
       const themeExtension = new ExtensionInstance({
         configuration: {

--- a/packages/app/src/cli/services/dev.test.ts
+++ b/packages/app/src/cli/services/dev.test.ts
@@ -3,7 +3,7 @@ import {setupConfigWatcher, setupDraftableExtensionBundler, setupFunctionWatcher
 import {buildFunctionExtension} from './build/extension.js'
 import {updateExtensionDraft} from './dev/update-extension.js'
 import {testApp, testUIExtension, testFunctionExtension} from '../models/app/app.test-data.js'
-import {loadLocalExtensionsSpecifications} from '../models/extensions/load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../models/extensions/load-specifications.js'
 import {describe, expect, test, vi} from 'vitest'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import {Writable} from 'node:stream'
@@ -32,7 +32,7 @@ describe('devDraftableExtensionTarget()', () => {
     const remoteExtensions = {} as any
     remoteExtensions[extension1.localIdentifier] = 'mock-registration-id-1'
     remoteExtensions[extension2.localIdentifier] = 'mock-registration-id-2'
-    const specifications = await loadLocalExtensionsSpecifications()
+    const specifications = await loadFSExtensionsSpecifications()
 
     const process = devDraftableExtensionTarget({
       extensions,
@@ -87,7 +87,7 @@ describe('devDraftableExtensionTarget()', () => {
     const remoteExtensions = {} as any
     remoteExtensions[function1.localIdentifier] = 'mock-registration-id-1'
     remoteExtensions[function2.localIdentifier] = 'mock-registration-id-2'
-    const specifications = await loadLocalExtensionsSpecifications()
+    const specifications = await loadFSExtensionsSpecifications()
 
     const process = devDraftableExtensionTarget({
       extensions,

--- a/packages/app/src/cli/services/dev/extension/bundler.test.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.test.ts
@@ -9,7 +9,7 @@ import {
 import * as bundle from '../../extensions/bundle.js'
 import {testUIExtension, testFunctionExtension, testApp} from '../../../models/app/app.test-data.js'
 import {updateExtensionConfig, updateExtensionDraft} from '../update-extension.js'
-import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {FunctionConfigType} from '../../../models/extensions/specifications/function.js'
 import * as extensionBuild from '../../../services/build/extension.js'
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
@@ -232,7 +232,7 @@ describe('setupConfigWatcher()', async () => {
   const registrationId = 'mock-registration-id'
   const stdout = new Writable()
   const stderr = new Writable()
-  const specifications = await loadLocalExtensionsSpecifications()
+  const specifications = await loadFSExtensionsSpecifications()
 
   test('starts watching the configuration file', async () => {
     const chokidarCloseSpy = vi.fn()

--- a/packages/app/src/cli/services/dev/update-extension.test.ts
+++ b/packages/app/src/cli/services/dev/update-extension.test.ts
@@ -2,7 +2,7 @@ import {updateExtensionConfig, updateExtensionDraft} from './update-extension.js
 import {ExtensionUpdateDraftMutation} from '../../api/graphql/update_draft.js'
 import {testUIExtension} from '../../models/app/app.test-data.js'
 import {findSpecificationForConfig, parseConfigurationFile} from '../../models/app/loader.js'
-import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {inTemporaryDirectory, mkdir, writeFile} from '@shopify/cli-kit/node/fs'
 import {outputInfo} from '@shopify/cli-kit/node/output'
@@ -152,7 +152,7 @@ describe('updateExtensionDraft()', () => {
 
 describe('updateExtensionConfig()', () => {
   test('updates draft with new config', async () => {
-    const specifications = await loadLocalExtensionsSpecifications()
+    const specifications = await loadFSExtensionsSpecifications()
 
     await inTemporaryDirectory(async (tmpDir) => {
       const configuration = {

--- a/packages/app/src/cli/services/extensions/bundle.test.ts
+++ b/packages/app/src/cli/services/extensions/bundle.test.ts
@@ -1,6 +1,6 @@
 import {bundleExtension, bundleThemeExtension} from './bundle.js'
 import {testApp, testUIExtension} from '../../models/app/app.test-data.js'
-import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {describe, expect, test, vi} from 'vitest'
 import {context as esContext} from 'esbuild'
@@ -262,7 +262,7 @@ describe('bundleExtension()', () => {
     test('should skip all ignored file patterns', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
-        const allSpecs = await loadLocalExtensionsSpecifications()
+        const allSpecs = await loadFSExtensionsSpecifications()
         const specification = allSpecs.find((spec) => spec.identifier === 'theme')!
         const themeExtension = new ExtensionInstance({
           configuration: {

--- a/packages/app/src/cli/services/function/common.ts
+++ b/packages/app/src/cli/services/function/common.ts
@@ -1,6 +1,6 @@
 import {App, AppInterface} from '../../models/app/app.js'
 import {load as loadApp} from '../../models/app/loader.js'
-import {loadExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
@@ -22,7 +22,7 @@ export async function inFunctionContext(
   path: string,
   callback: (app: App, ourFunction: ExtensionInstance<FunctionConfigType>) => Promise<void>,
 ) {
-  const specifications = await loadExtensionsSpecifications(config)
+  const specifications = await loadLocalExtensionsSpecifications(config)
   const app: AppInterface = await loadApp({specifications, directory: path})
 
   const allFunctions = app.allExtensions.filter((ext) => ext.isFunctionExtension)

--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -12,7 +12,7 @@ import {testRemoteExtensionTemplates} from '../../models/app/app.test-data.js'
 import checkoutPostPurchaseExtension from '../../models/templates/ui-specifications/checkout_post_purchase.js'
 import {ExtensionTemplate} from '../../models/app/template.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
-import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {describe, expect, vi, test} from 'vitest'
 import * as output from '@shopify/cli-kit/node/output'
 import {
@@ -39,7 +39,7 @@ vi.mock('@shopify/cli-kit/node/node-package-manager', async () => {
 describe('initialize a extension', async () => {
   const allUITemplates = [checkoutPostPurchaseExtension]
   const allFunctionTemplates = testRemoteExtensionTemplates
-  const specifications = await loadLocalExtensionsSpecifications()
+  const specifications = await loadFSExtensionsSpecifications()
 
   test('successfully generates the extension when no other extensions exist', async () => {
     await withTemporaryApp(async (tmpDir) => {

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -1,4 +1,4 @@
-import {loadExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {
   ExtensionSpecificationsQuery,
   ExtensionSpecificationsQuerySchema,
@@ -53,7 +53,7 @@ export async function fetchSpecifications({
       return newSpec
     })
 
-  const local = await loadExtensionsSpecifications(config)
+  const local = await loadLocalExtensionsSpecifications(config)
   const updatedSpecs = mergeLocalAndRemoteSpecs(local, extensionSpecifications)
   return [...updatedSpecs]
 }

--- a/packages/app/src/cli/utilities/extensions/theme.test.ts
+++ b/packages/app/src/cli/utilities/extensions/theme.test.ts
@@ -1,6 +1,6 @@
 import {themeExtensionFiles, parseIgnoreFile} from './theme.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
-import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {loadFSExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {describe, expect, test} from 'vitest'
@@ -9,7 +9,7 @@ describe('themeExtensionConfig', () => {
   test('excludes system files', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
-      const allSpecs = await loadLocalExtensionsSpecifications()
+      const allSpecs = await loadFSExtensionsSpecifications()
       const specification = allSpecs.find((spec) => spec.identifier === 'theme')!
       const themeExtension = new ExtensionInstance({
         configuration: {


### PR DESCRIPTION
### WHY are these changes introduced?

We used to use the loader `load` interface to load the whole app even when we only just needed to load the app configuration. This caused bugs when we skipped on passing specifications that required workarounds like [this](https://github.com/Shopify/cli/pull/2267).

### WHAT is this pull request doing?

- Extract the app configuration loading behaviour into a separate class
- Make it so the AppLoader uses the new AppConfigurationLoader
- Change all the callsites where we were calling `load` unnecessarily and use `loadAppConfiguration` instead.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
