### PR TITLE
Add none template

### DIFF
--- a/.changeset/many-chefs-invent.md
+++ b/.changeset/many-chefs-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': minor
+---
+
+Add none template option

--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -43,7 +43,7 @@
         "template": {
           "name": "template",
           "type": "option",
-          "description": "The app template. Accepts one of the following:\n       - <node|php|ruby>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
+          "description": "The app template. Accepts one of the following:\n       - <node|php|ruby|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
           "multiple": false
         },
         "package-manager": {

--- a/packages/create-app/src/prompts/init.test.ts
+++ b/packages/create-app/src/prompts/init.test.ts
@@ -1,6 +1,6 @@
 import init from './init.js'
 import {describe, expect, vi, test} from 'vitest'
-import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
+import {renderSelectPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 vi.mock('@shopify/cli-kit/node/ui')
 
@@ -38,5 +38,33 @@ describe('init', () => {
     // Then
     expect(renderTextPrompt).not.toHaveBeenCalled()
     expect(got).toEqual({...options, ...answers, templateType: 'custom'})
+  })
+
+  test('it renders the label for the template options', async () => {
+    const answers = {
+      name: 'app',
+      template: 'https://github.com/Shopify/shopify-app-template-none',
+    }
+    const options = {directory: '/'}
+
+    // Given
+    vi.mocked(renderTextPrompt).mockResolvedValueOnce(answers.name)
+    vi.mocked(renderSelectPrompt).mockResolvedValueOnce('none')
+
+    // When
+    const got = await init(options)
+
+    // Then
+    expect(renderSelectPrompt).toHaveBeenCalledWith({
+      choices: [
+        {label: 'node', value: 'node'},
+        {label: 'php', value: 'php'},
+        {label: 'ruby', value: 'ruby'},
+        {label: 'none (build an app with extensions only)', value: 'none'},
+      ],
+      message: 'Which template would you like to use?',
+      defaultValue: 'node',
+    })
+    expect(got).toEqual({...options, ...answers, templateType: 'none'})
   })
 })

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -20,7 +20,12 @@ export const templateURLMap = {
   node: 'https://github.com/Shopify/shopify-app-template-node',
   php: 'https://github.com/Shopify/shopify-app-template-php',
   ruby: 'https://github.com/Shopify/shopify-app-template-ruby',
+  none: 'https://github.com/Shopify/shopify-app-template-none',
 } as const
+
+const templateLabels: {[key: string]: string} = {
+  none: 'none (build an app with extensions only)',
+}
 
 const init = async (options: InitOptions): Promise<InitOutput> => {
   let name = options.name
@@ -55,13 +60,13 @@ const init = async (options: InitOptions): Promise<InitOutput> => {
     template = await renderSelectPrompt({
       choices: Object.keys(templateURLMap).map((key) => {
         return {
-          label: key,
+          label: templateLabels[key] || key,
           value: key,
         }
       }),
       message: 'Which template would you like to use?',
       defaultValue: Object.keys(templateURLMap).find(
-        (key) => templateURLMap[key as 'node' | 'php' | 'ruby'] === defaults.template,
+        (key) => templateURLMap[key as keyof typeof templateURLMap] === defaults.template,
       ),
     })
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Allows developer to select the "none" template on app creation (see: https://github.com/Shopify/internal-cli-foundations/issues/666)

### WHAT is this pull request doing?

Adds "none" template option with custom label

### How to test your changes?

1. `pnpm create-app`
2. Select "none" option
3. Validate that the "none" template was used.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

I'm assuming we have existing analytics as all I'm doing is adding a new option to an existing list.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes (documented in the new template repo)
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
