### PR TITLE
[Temp Fix] Use `handle` as context if available on extension deployConfig

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -270,7 +270,14 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   async bundleConfig({identifiers, token, apiKey, unifiedDeployment}: ExtensionBundleConfigOptions) {
     const configValue = await this.deployConfig({apiKey, token, unifiedDeployment})
     if (!configValue) return undefined
-    return {uuid: identifiers.extensions[this.localIdentifier]!, config: JSON.stringify(configValue), context: ''}
+
+    const contextValue = (configValue.handle as string) || ''
+
+    return {
+      uuid: identifiers.extensions[this.localIdentifier]!,
+      config: JSON.stringify(configValue),
+      context: contextValue,
+    }
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/flow/issues/19493
- Flow needs to use `handle` to simplify the trigger method for Flow triggers.
- This change is temporary until the `handle` config spec is fully developed.


### WHAT is this pull request doing?

- Temporarily pass `handle` from `deployConfig` to `context`.

### How to test your changes?

- Generate a Flow Action/Trigger extension and use `handle` in the config TOML.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
