### PR TITLE
Create extensions when match is cancelled

### DIFF
--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -366,7 +366,7 @@ describe('ensureExtensionsIds: matchmaking returns ok with some pending confirma
 })
 
 describe('ensureExtensionsIds: matchmaking returns ok with some pending confirmation', () => {
-  test('do not confirms the pending ones and fails', async () => {
+  test('does not confirm the pending ones and creates them as new extensions', async () => {
     // Given
     vi.mocked(matchConfirmationPrompt).mockResolvedValueOnce(false)
     vi.mocked(automaticMatchmaking).mockResolvedValueOnce({
@@ -379,6 +379,7 @@ describe('ensureExtensionsIds: matchmaking returns ok with some pending confirma
       },
     })
     vi.mocked(deployConfirmationPrompt).mockResolvedValueOnce(true)
+    vi.mocked(createExtension).mockResolvedValueOnce(REGISTRATION_B)
 
     // When
     const got = await ensureExtensionsIds(options([EXTENSION_B]), {
@@ -387,7 +388,13 @@ describe('ensureExtensionsIds: matchmaking returns ok with some pending confirma
     })
 
     // Then
-    expect(got).toEqual(err('user-cancelled'))
+    expect(createExtension).toBeCalledTimes(1)
+    expect(got).toEqual(
+      ok({
+        extensions: {EXTENSION_B: 'UUID_B'},
+        extensionIds: {EXTENSION_B: 'B'},
+      }),
+    )
   })
 })
 
@@ -587,13 +594,14 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
         remote: [],
       },
     })
+    vi.mocked(createExtension).mockResolvedValueOnce(REGISTRATION_B)
 
-    const opts = options([EXTENSION_A, EXTENSION_A_2])
+    const opts = options([EXTENSION_A, EXTENSION_A_2, EXTENSION_B])
     opts.force = true
 
     // When
     await ensureExtensionsIds(opts, {
-      extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2],
+      extensionRegistrations: [REGISTRATION_A, REGISTRATION_A_2, REGISTRATION_B],
       dashboardManagedExtensionRegistrations: [],
     })
 

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -47,14 +47,18 @@ export async function ensureExtensionsIds(
   let validMatches = matchExtensions.identifiers
   const validMatchesById: {[key: string]: string} = {}
 
+  const extensionsToCreate = matchExtensions.toCreate ?? []
+
   for (const pending of matchExtensions.toConfirm) {
     // eslint-disable-next-line no-await-in-loop
     const confirmed = await matchConfirmationPrompt(pending.local, pending.remote)
-    if (!confirmed) return err('user-cancelled')
-    validMatches[pending.local.localIdentifier] = pending.remote.uuid
+    if (confirmed) {
+      validMatches[pending.local.localIdentifier] = pending.remote.uuid
+    } else {
+      extensionsToCreate.push(pending.local)
+    }
   }
 
-  const extensionsToCreate = matchExtensions.toCreate ?? []
   let onlyRemoteExtensions = matchExtensions.toManualMatch.remote ?? []
 
   if (matchExtensions.toManualMatch.local.length > 0) {

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -14,7 +14,7 @@ export async function matchConfirmationPrompt(local: LocalSource, remote: Remote
   return renderConfirmationPrompt({
     message: `Match ${local.configuration.name} (local name) with ${remote.title} (name on Shopify Partners, ID: ${remote.id})?`,
     confirmationMessage: `Yes, that's right`,
-    cancellationMessage: `No, cancel`,
+    cancellationMessage: `No, create as a new extension`,
   })
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/internal-cli-foundations/issues/681

If someone deployed an extension, deleted it, created a new one of the same type and then run `dev` or `deploy`, they would see the matching prompt but they wouldn't be allowed to continue and create the newly added extension.

### WHAT is this pull request doing?

Instead of cancelling, the second option of the matching prompt allows to continue and creates a new extension.

### How to test your changes?

With unified deployments

- Add a function/extension with `extension generate`
- Deploy
- Remove the extension
- Dev

You should be allowed to continue without matching.