### PR TITLE
Hide "Stay tuned" banner after opting in

### DIFF
--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -359,6 +359,26 @@ export async function ensureThemeExtensionDevContext(
 export async function ensureDeployContext(options: DeployContextOptions): Promise<DeployContextOutput> {
   const token = await ensureAuthenticatedPartners()
   const [partnersApp, envIdentifiers] = await fetchAppAndIdentifiers(options, token)
+
+  if (!partnersApp.betas?.unifiedAppDeployment) {
+    renderInfo({
+      headline: [
+        'Stay tuned for changes to',
+        {command: formatPackageManagerCommand(options.app.packageManager, 'deploy')},
+        {char: '.'},
+      ],
+      body: "Soon, you'll be able to release all your extensions at the same time, directly from Shopify CLI.",
+      reference: [
+        {
+          link: {
+            url: 'https://shopify.dev/docs/apps/deployment/simplified-deployment',
+            label: 'Simplified extension deployment',
+          },
+        },
+      ],
+    })
+  }
+
   const deploymentMode = await resolveDeploymentMode(partnersApp, options, token)
 
   if (deploymentMode === 'legacy' && options.commitReference) {

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -56,23 +56,6 @@ interface TasksContext {
 }
 
 export async function deploy(options: DeployOptions) {
-  renderInfo({
-    headline: [
-      'Stay tuned for changes to',
-      {command: formatPackageManagerCommand(options.app.packageManager, 'deploy')},
-      {char: '.'},
-    ],
-    body: "Soon, you'll be able to release all your extensions at the same time, directly from Shopify CLI.",
-    reference: [
-      {
-        link: {
-          url: 'https://shopify.dev/docs/apps/deployment/simplified-deployment',
-          label: 'Simplified extension deployment',
-        },
-      },
-    ],
-  })
-
   // eslint-disable-next-line prefer-const
   let {app, identifiers, partnersApp, token, deploymentMode} = await ensureDeployContext(options)
   const apiKey = identifiers.app


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/608

We were showing the "Stay tuned" banner even after opting in the unified deployments feature.

### WHAT is this pull request doing?

This PR makes sure we don't do that.

### How to test your changes?

Try running `deploy` and opting in, the "stay tuned" banner should not be shown the second time you deploy.