### PR TITLE
Add support for configuring a sidekick HMR server

### DIFF
--- a/.changeset/warm-ears-laugh.md
+++ b/.changeset/warm-ears-laugh.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Added support for configuring a sidekick HMR server in web frontend app TOML files

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -118,11 +118,7 @@ const baseWebConfigurationSchema = zod.object({
     dev: zod.string(),
   }),
   name: zod.string().optional(),
-  hmr_server: zod
-    .object({
-      http_paths: zod.string().array(),
-    })
-    .optional(),
+  hmr_server: zod.object({http_paths: zod.string().array()}).optional(),
 })
 const webTypes = zod.enum([WebType.Frontend, WebType.Backend, WebType.Background]).default(WebType.Frontend)
 export const WebConfigurationSchema = zod.union([

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -118,6 +118,11 @@ const baseWebConfigurationSchema = zod.object({
     dev: zod.string(),
   }),
   name: zod.string().optional(),
+  hmr_server: zod
+    .object({
+      http_paths: zod.string().array(),
+    })
+    .optional(),
 })
 const webTypes = zod.enum([WebType.Frontend, WebType.Backend, WebType.Background]).default(WebType.Frontend)
 export const WebConfigurationSchema = zod.union([

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -384,10 +384,11 @@ async function devProxyTarget(options: DevWebOptions): Promise<ReverseHTTPProxyT
     REMIX_DEV_ORIGIN: options.hostname,
   }
 
-  const hmrServerOptions = options.hmrServerPort && {
-    port: options.hmrServerPort,
-    httpPaths: options.web.configuration.hmr_server!.http_paths,
-  }
+  const hmrServerOptions = options.hmrServerPort &&
+    options.web.configuration.roles.includes(WebType.Frontend) && {
+      port: options.hmrServerPort,
+      httpPaths: options.web.configuration.hmr_server!.http_paths,
+    }
 
   return {
     logPrefix: options.web.configuration.name ?? ['web', ...options.web.configuration.roles].join('-'),

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -135,6 +135,7 @@ async function dev(options: DevOptions) {
   const proxyTargets: ReverseHTTPProxyTarget[] = []
   const proxyPort = usingLocalhost ? await getAvailableTCPPort() : frontendPort
   const proxyUrl = usingLocalhost ? `${frontendUrl}:${proxyPort}` : frontendUrl
+  const hmrServerPort = frontendConfig?.configuration.hmr_server ? await getAvailableTCPPort() : undefined
 
   let previewUrl
   let shouldUpdateURLs = false
@@ -174,6 +175,7 @@ async function dev(options: DevOptions) {
     apiSecret,
     backendPort,
     frontendServerPort,
+    hmrServerPort,
   }
 
   await Promise.all(
@@ -315,6 +317,7 @@ interface DevWebOptions {
   web: Web
   backendPort: number
   frontendServerPort: number
+  hmrServerPort?: number
   apiKey: string
   apiSecret?: string
   hostname?: string
@@ -372,13 +375,24 @@ async function devProxyTarget(options: DevWebOptions): Promise<ReverseHTTPProxyT
     }),
     BACKEND_PORT: `${options.backendPort}`,
     FRONTEND_PORT: `${options.frontendServerPort}`,
+    ...(options.hmrServerPort && {
+      HMR_SERVER_PORT: `${options.hmrServerPort}`,
+    }),
     APP_URL: options.hostname,
     APP_ENV: 'development',
+    // Note: These are Remix-specific variables
+    REMIX_DEV_ORIGIN: options.hostname,
+  }
+
+  const hmrServerOptions = options.hmrServerPort && {
+    port: options.hmrServerPort,
+    httpPaths: options.web.configuration.hmr_server!.http_paths,
   }
 
   return {
     logPrefix: options.web.configuration.name ?? ['web', ...options.web.configuration.roles].join('-'),
     customPort: port,
+    ...(hmrServerOptions && {hmrServer: hmrServerOptions}),
     action: async (stdout: Writable, stderr: Writable, signal: AbortSignal, port: number) => {
       await exec(cmd!, args, {
         cwd: options.web.directory,


### PR DESCRIPTION
### WHY are these changes introduced?

Some frameworks might use a separate server to handle HMR requests, which would typically require:
- a separate TCP port
- the ability to handle _some_ HTTP requests in the sidekick server

### WHAT is this pull request doing?

Adding a new `[hmr_server]` config option to the web TOML file, which must contain an `http_paths` array. If that is present, we'll spin up another port and redirect websocket (and HTTP within `http_paths`) traffic to that port.

### How to test your changes?

A framework that does this is Remix, but it's not very simple to set up for testing. Ping me if you want to actually run this. But essentially, if you add the config, you should see a new env var called `HMR_SERVER_PORT`.

### Post-release steps

We'll need to document the new fields in https://shopify.dev/docs/apps/tools/cli/structure#shopify-web-toml.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] ~Existing analytics will cater for this addition~
- [ ] ~PR includes analytics changes to measure impact~

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] ~I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).~
