### PR TITLE
Make it so the app loader can load the preferred config used by an app

### DIFF
--- a/packages/app/src/cli/commands/app/config/push.ts
+++ b/packages/app/src/cli/commands/app/config/push.ts
@@ -1,7 +1,6 @@
 import {appFlags} from '../../../flags.js'
 import Command from '../../../utilities/app-command.js'
 import {loadAppConfiguration} from '../../../models/app/loader.js'
-import {getAppInfo} from '../../../services/local-storage.js'
 import {pushConfig} from '../../../services/app/config/push.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -23,8 +22,10 @@ export default class ConfigPush extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(ConfigPush)
-    const configName = flags.config || getAppInfo(flags.path)?.configFile
-    const {configuration, configurationPath} = await loadAppConfiguration({configName, directory: flags.path})
+    const {configuration, configurationPath} = await loadAppConfiguration({
+      configName: flags.config,
+      directory: flags.path,
+    })
 
     await pushConfig({configuration, configurationPath})
   }


### PR DESCRIPTION
### WHY are these changes introduced?

I'd prefer for the app loader to be aware of the preferred config, so that we don't have to load it everywhere.

### WHAT is this pull request doing?

Do the above, you can look at an example of the `config push` command to see how it simplifies things.

### How to test your changes?

- `pnpm create-app --local --template=node --path ~/Desktop`
- `pnpm shopify app config link --path ~/Desktop/your-app`
- `pnpm shopify app dev --path ~/Desktop/your-app`
- `pnpm shopify app config push --path ~/Desktop/your-app`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
