### PR TITLE
Link an unlinked shopify.app.toml by default

### DIFF
--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -574,10 +574,14 @@ async function logMetadataForLoadedApp(
   })
 }
 
+export function isValidAppConfigurationFile(config: string) {
+  const validFileRegex = /^shopify\.app(\.[-\w]+)?\.toml$/g
+  return validFileRegex.test(config)
+}
+
 export function getAppConfigurationFileName(config?: string) {
   if (config) {
-    const validFileRegex = /^shopify\.app(\.[-\w]+)?\.toml$/g
-    if (validFileRegex.test(config)) {
+    if (isValidAppConfigurationFile(config)) {
       return config
     }
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -1,11 +1,13 @@
 import {saveCurrentConfig} from './use.js'
-import {AppConfiguration, AppInterface} from '../../../models/app/app.js'
+import {AppConfiguration, AppInterface, isLegacyAppSchema} from '../../../models/app/app.js'
 import {OrganizationApp} from '../../../models/organization.js'
 import {selectConfigName} from '../../../prompts/config.js'
-import {load} from '../../../models/app/loader.js'
+import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
+import {isValidAppConfigurationFile, load} from '../../../models/app/loader.js'
 import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../context.js'
 import {fetchAppFromApiKey} from '../../dev/fetch.js'
-import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
+import {configurationFileNames} from '../../../constants.js'
+import {Config} from '@oclif/core'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {fileExists, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -13,7 +15,6 @@ import {encodeToml} from '@shopify/cli-kit/node/toml'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {slugify} from '@shopify/cli-kit/common/string'
-import {Config} from '@oclif/core'
 
 export interface LinkOptions {
   commandConfig: Config
@@ -23,11 +24,9 @@ export interface LinkOptions {
 }
 
 export default async function link(options: LinkOptions): Promise<void> {
-  const localApp = await loadAppConfigFromLegacyToml(options)
+  const localApp = await loadAppConfigFromDefaultToml(options)
   const remoteApp = await loadRemoteApp(localApp, options.apiKey)
-  const configName =
-    (options.configName && slugify(options.configName)) || (await selectConfigName(options.directory, remoteApp.title))
-  const configFileName = `shopify.app.${configName}.toml`
+  const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
   const configFilePath = joinPath(options.directory, configFileName)
   const fileAlreadyExists = await fileExists(configFilePath)
 
@@ -44,10 +43,15 @@ export default async function link(options: LinkOptions): Promise<void> {
   })
 }
 
-async function loadAppConfigFromLegacyToml(options: LinkOptions): Promise<AppInterface> {
+async function loadAppConfigFromDefaultToml(options: LinkOptions): Promise<AppInterface> {
   try {
     const specifications = await loadLocalExtensionsSpecifications(options.commandConfig)
-    const app = await load({specifications, directory: options.directory, mode: 'report'})
+    const app = await load({
+      specifications,
+      directory: options.directory,
+      mode: 'report',
+      configName: configurationFileNames.app,
+    })
     return app
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
@@ -66,6 +70,25 @@ async function loadRemoteApp(localApp: AppInterface, apiKey: string | undefined)
     throw new AbortError(errorMessage.message, errorMessage.tryMessage)
   }
   return app
+}
+
+async function loadConfigurationFileName(
+  remoteApp: OrganizationApp,
+  options: LinkOptions,
+  localApp?: AppInterface,
+): Promise<string> {
+  if (options.configName) {
+    return isValidAppConfigurationFile(options.configName)
+      ? options.configName
+      : `shopify.app.${slugify(options.configName)}.toml`
+  }
+
+  if (!localApp?.configuration || (localApp && isLegacyAppSchema(localApp.configuration))) {
+    return configurationFileNames.app
+  }
+
+  const configName = await selectConfigName(options.directory, remoteApp.title)
+  return `shopify.app.${configName}.toml`
 }
 
 function mergeAppConfiguration(localApp: AppInterface, remoteApp: OrganizationApp): AppConfiguration {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes: https://github.com/Shopify/internal-cli-foundations/issues/755

This PR adds support for linking `shopify.app.toml` by default if it is unlinked or does not exist.

### WHAT is this pull request doing?

It tries to load the `shopify.app.toml` on `link` and will use that as the file to be linked to if it isn't already linked or doesn't exist.

### How to test your changes?

- `pnpm create-app --local --template=node --path ~/Desktop`
- `pnpm shopify app config link --path ~/Desktop/your-app` -> should see a linked `shopify.app.toml`
- `pnpm shopify app config link --path ~/Desktop/your-app` -> should prompt to select a file name

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
