### PR TITLE
Show a warning when using NPM without the -- separator

### DIFF
--- a/.changeset/shy-students-admire.md
+++ b/.changeset/shy-students-admire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Show a warning when passing a flag witn npm without the -- separator


### PR DESCRIPTION
### WHY are these changes introduced?

There have been tons of questions/issues because of people running NPM scripts without using the `--` separator. Like running `npm run dev --reset` instead of `npm run dev -- --reset`.

### WHAT is this pull request doing?

Shows a warning when passing a CLI flag with NPM without the separator:

<img width="808" alt="05-48-6f9i6-fxmmo" src="https://github.com/Shopify/cli/assets/14979109/81a9af97-2bbc-41fa-b120-e00c25c5c194">

Idea by @shauns

### How to test your changes?

- `npm run shopify app dev --reset`
- `npm run shopify app dev -- --reset`
- `npm run shopify app dev --not-existing`
- `npm run shopify app info --path=whatever`
- `pnpm run shopify app dev --reset`
- `yarn run shopify app dev --reset`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
