### PR TITLE
Show custom error message when version already taken

### DIFF
--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -1236,4 +1236,39 @@ describe('deploymentErrorsToCustomSections', () => {
       },
     ])
   })
+
+  test('returns a specific error message when the error is about the version being already taken', () => {
+    // Given
+    const errors = [
+      {
+        field: ['version_tag'],
+        message: 'has already been taken',
+        category: '',
+        details: [],
+      },
+    ]
+
+    // When
+    const customSections = deploymentErrorsToCustomSections(
+      errors,
+      {
+        'amortizable-marketplace-ext': '123',
+        'amortizable-marketplace-ext-2': '456',
+      },
+      {
+        version: 'already-taken-version',
+      },
+    )
+
+    // Then
+    expect(customSections).toEqual([
+      {
+        body: [
+          'An app version with the name',
+          {userInput: 'already-taken-version'},
+          'already exists. Deploy again with a different version name.',
+        ],
+      },
+    ])
+  })
 })

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -173,6 +173,9 @@ export async function uploadExtensionsBundle(
     const customSections: AlertCustomSection[] = deploymentErrorsToCustomSections(
       result.appDeploy.userErrors,
       options.extensionIds,
+      {
+        version: options.version,
+      },
     )
 
     if (result.appDeploy.deployment) {
@@ -203,6 +206,9 @@ const GENERIC_ERRORS_TITLE = '\n'
 export function deploymentErrorsToCustomSections(
   errors: AppDeploySchema['appDeploy']['userErrors'],
   extensionIds: IdentifiersExtensions,
+  flags: {
+    version?: string
+  } = {},
 ): ErrorCustomSection[] {
   const isExtensionError = (error: (typeof errors)[0]) => {
     return error.details?.some((detail) => detail.extension_id) ?? false
@@ -220,15 +226,30 @@ export function deploymentErrorsToCustomSections(
   const [cliErrors, partnersErrors] = partition(extensionErrors, (error) => isCliError(error, extensionIds))
 
   const customSections = [
-    ...generalErrorsSection(nonExtensionErrors),
+    ...generalErrorsSection(nonExtensionErrors, {version: flags.version}),
     ...cliErrorsSections(cliErrors),
     ...partnersErrorsSections(partnersErrors),
   ]
   return customSections
 }
 
-function generalErrorsSection(errors: AppDeploySchema['appDeploy']['userErrors']) {
+function generalErrorsSection(errors: AppDeploySchema['appDeploy']['userErrors'], flags: {version?: string} = {}) {
   if (errors.length > 0) {
+    if (
+      errors.filter((error) => error.field.includes('version_tag') && error.message === 'has already been taken')
+        .length > 0 &&
+      flags.version
+    ) {
+      return [
+        {
+          body: [
+            'An app version with the name',
+            {userInput: flags.version},
+            'already exists. Deploy again with a different version name.',
+          ],
+        },
+      ]
+    }
     const errorsBody =
       errors.length === 1
         ? errors[0]?.message


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/587

We want to show a custom error message when the version is already taken.

### WHAT is this pull request doing?

Add that error message.

<img width="932" alt="Screenshot 2023-07-05 at 14 32 33" src="https://github.com/Shopify/cli/assets/151725/0c34d511-4853-45f8-9685-779c75dc7b0b">

### How to test your changes?

- Deploy with `--version=something`
- Deploy again with the same version
- You should see the error message above