### PR TITLE
Add scopes during app creation for non-launchable apps

### DIFF
--- a/packages/app/src/cli/api/graphql/create_app.ts
+++ b/packages/app/src/cli/api/graphql/create_app.ts
@@ -1,7 +1,14 @@
 import {gql} from 'graphql-request'
 
 export const CreateAppQuery = gql`
-  mutation AppCreate($org: Int!, $title: String!, $appUrl: Url!, $redir: [Url]!, $type: AppType) {
+  mutation AppCreate(
+    $org: Int!
+    $title: String!
+    $appUrl: Url!
+    $redir: [Url]!
+    $type: AppType
+    $requestedAccessScopes: [String!]
+  ) {
     appCreate(
       input: {
         organizationID: $org
@@ -9,6 +16,7 @@ export const CreateAppQuery = gql`
         applicationUrl: $appUrl
         redirectUrlWhitelist: $redir
         appType: $type
+        requestedAccessScopes: $requestedAccessScopes
       }
     ) {
       app {
@@ -18,6 +26,7 @@ export const CreateAppQuery = gql`
         appType
         applicationUrl
         redirectUrlWhitelist
+        requestedAccessScopes
         apiSecretKeys {
           secret
         }
@@ -55,6 +64,7 @@ export interface CreateAppQuerySchema {
       }[]
       appType: string
       grantedScopes: string[]
+      requestedAccessScopes: string[]
     }
     userErrors: {
       field: string[]


### PR DESCRIPTION
Resolves: Part 3 of https://github.com/Shopify/partners/issues/48560

### WHY are these changes introduced?
We need to set scopes to the empty Scope Set for non-launchable apps.

### WHAT is this pull request doing?
It is adding requestedAccessScopes to the Partners CLI AppCreate mutation.

### How to test your changes?
bin/spin pnpm shopify app config link --path={PATH_TO_REPO}

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
