### PR TITLE
Use config name in flow migrate command

### DIFF
--- a/packages/app/src/cli/services/flow/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/flow/extension-to-toml.test.ts
@@ -26,7 +26,7 @@ describe('extension-to-toml', () => {
     const decodedToml = decodeToml(got)
     const parsed = FlowActionExtensionSchema.parse(decodedToml)
     expect(parsed.type).toEqual('flow_action')
-    expect(got).toEqual(`name = "flow action @ Char!"
+    expect(got).toEqual(`name = "action title"
 type = "flow_action"
 description = "action description"
 
@@ -92,7 +92,7 @@ required = true
     const decodedToml = decodeToml(got)
     const parsed = FlowTriggerExtensionSchema.parse(decodedToml)
     expect(parsed.type).toEqual('flow_trigger')
-    expect(got).toEqual(`name = 'trigger ext!"*^ÑÇ¨:"!'
+    expect(got).toEqual(`name = "trigger title"
 type = "flow_trigger"
 description = "trigger description"
 

--- a/packages/app/src/cli/services/flow/extension-to-toml.ts
+++ b/packages/app/src/cli/services/flow/extension-to-toml.ts
@@ -32,7 +32,7 @@ export function buildTomlObject(extension: ExtensionRegistration) {
   const fields = configFromSerializedFields(extension.type as FlowPartnersExtensionTypes, config.fields ?? [])
 
   const localExtensionRepresentation = {
-    name: extension.title,
+    name: config.title,
     type: extension.type.replace('_definition', ''),
     description: config.description,
     extensions: [


### PR DESCRIPTION
### WHY are these changes introduced?

It is important to maintain the same name when importing existing Partners Dashboard managed Flow extensions as that name is what appears in the Flow app.

### WHAT is this pull request doing?

Changes the `import-flow-legacy-extensions` command to use the name from the Flow action or trigger's configuration instead of the extension's name.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
