### PR TITLE
Show intro line on first used prompt during app create

### DIFF
--- a/packages/create-app/src/prompts/init.test.ts
+++ b/packages/create-app/src/prompts/init.test.ts
@@ -1,6 +1,6 @@
 import init from './init.js'
 import {describe, expect, vi, test} from 'vitest'
-import {renderSelectPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
+import {renderSelectPrompt, renderText, renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 vi.mock('@shopify/cli-kit/node/ui')
 
@@ -18,6 +18,9 @@ describe('init', () => {
     const got = await init(options)
 
     // Then
+    expect(renderText).toHaveBeenCalledWith({
+      text: '\nWelcome. Let’s get started by naming your app project. You can change it later.',
+    })
     expect(renderTextPrompt).toHaveBeenCalledWith({
       message: 'Your app project name?',
       defaultValue: expect.stringMatching(/^\w+-\w+-app$/),
@@ -36,6 +39,9 @@ describe('init', () => {
     const got = await init(options)
 
     // Then
+    expect(renderText).toHaveBeenCalledWith({
+      text: '\nWelcome. Let’s get started by choosing a template for your app project.',
+    })
     expect(renderTextPrompt).not.toHaveBeenCalled()
     expect(got).toEqual({...options, ...answers, templateType: 'custom'})
   })

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -36,9 +36,11 @@ const init = async (options: InitOptions): Promise<InitOutput> => {
     template: templateURLMap.node,
   } as const
 
-  renderText({text: '\nWelcome. Let’s get started by naming your app project. You can change it later.'})
+  let welcomed = false
 
   if (!name) {
+    renderText({text: '\nWelcome. Let’s get started by naming your app project. You can change it later.'})
+    welcomed = true
     name = await renderTextPrompt({
       message: 'Your app project name?',
       defaultValue: defaults.name,
@@ -57,6 +59,10 @@ const init = async (options: InitOptions): Promise<InitOutput> => {
   }
 
   if (!template) {
+    if (!welcomed) {
+      renderText({text: '\nWelcome. Let’s get started by choosing a template for your app project.'})
+      welcomed = true
+    }
     template = await renderSelectPrompt({
       choices: Object.keys(templateURLMap).map((key) => {
         return {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We shouldn't show `Let’s get started by naming your app project.` if we're not going to prompt them for a name.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Before:

```
$ npm init @shopify/app --name somename

Welcome. Let’s get started by naming your app project. You can change it later.

?  Which template would you like to use?

>  (1) node
   (2) php
   (3) ruby
   (4) none (build an app with extensions only)

   Press ↑↓ arrows to select, enter to confirm.
```

After:

```
$ npm init @shopify/app --name somename

Welcome. Let’s get started by choosing a template for your app project.

?  Which template would you like to use?

>  (1) node
   (2) php
   (3) ruby
   (4) none (build an app with extensions only)

   Press ↑↓ arrows to select, enter to confirm.
```

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`dev create-app` with and without `--name`

You can also run `bin/ create-test-app.js` for another example of why this is irritating.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
