### PR TITLE
Do not cut the autcomplete items list to 25

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -408,6 +408,7 @@ describe('AutocompletePrompt', async () => {
          twenty-fifth
 
          [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2m50 options available, 25 visible.[22m
       "
     `)
 
@@ -444,6 +445,7 @@ describe('AutocompletePrompt', async () => {
          th[1mi[22mrty-sixth
 
          [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2m36 options available, 25 visible.[22m
       "
     `)
 
@@ -479,6 +481,7 @@ describe('AutocompletePrompt', async () => {
          twenty-fifth
 
          [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2m50 options available, 25 visible.[22m
       "
     `)
 
@@ -516,6 +519,7 @@ describe('AutocompletePrompt', async () => {
          th[1mi[22mrty-sixth
 
          [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2m36 options available, 25 visible.[22m
       "
     `)
 
@@ -669,6 +673,7 @@ describe('AutocompletePrompt', async () => {
          th[1mi[22mrty-sixth
 
          [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2m36 options available, 25 visible.[22m
       "
     `)
 
@@ -704,6 +709,7 @@ describe('AutocompletePrompt', async () => {
          twenty-fifth
 
          [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2m50 options available, 25 visible.[22m
       "
     `)
   })
@@ -756,7 +762,8 @@ describe('AutocompletePrompt', async () => {
          twenty-fifth
 
          [2mPress ↑↓ arrows to select, enter to confirm.[22m
-         [1m1-25 of many[22m  Find what you're looking for by typing its name.
+         [1m1-50 of many[22m  Find what you're looking for by typing its name.
+         [2m50 options available, 25 visible.[22m
       "
     `)
   })

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -37,13 +37,12 @@ enum PromptState {
   Error = 'error',
 }
 
-const PAGE_SIZE = 25
 const MIN_NUMBER_OF_ITEMS_FOR_SEARCH = 5
 
 // eslint-disable-next-line react/function-component-definition
 function AutocompletePrompt<T>({
   message,
-  choices: initialChoices,
+  choices,
   infoTable,
   onSubmit,
   search,
@@ -51,14 +50,13 @@ function AutocompletePrompt<T>({
   abortSignal,
   infoMessage,
 }: React.PropsWithChildren<AutocompletePromptProps<T>>): ReactElement | null {
-  const paginatedInitialChoices = initialChoices.slice(0, PAGE_SIZE)
-  const [answer, setAnswer] = useState<SelectItem<T> | undefined>(paginatedInitialChoices[0])
+  const [answer, setAnswer] = useState<SelectItem<T> | undefined>(choices[0])
   const {exit: unmountInk} = useApp()
   const [promptState, setPromptState] = useState<PromptState>(PromptState.Idle)
   const [searchTerm, setSearchTerm] = useState('')
-  const [searchResults, setSearchResults] = useState<SelectItem<T>[]>(paginatedInitialChoices.slice(0, PAGE_SIZE))
+  const [searchResults, setSearchResults] = useState<SelectItem<T>[]>(choices)
   const {stdout} = useStdout()
-  const canSearch = initialChoices.length > MIN_NUMBER_OF_ITEMS_FOR_SEARCH
+  const canSearch = choices.length > MIN_NUMBER_OF_ITEMS_FOR_SEARCH
   const [hasMorePages, setHasMorePages] = useState(initialHasMorePages)
   const [wrapperHeight, setWrapperHeight] = useState(0)
   const [promptAreaHeight, setPromptAreaHeight] = useState(0)
@@ -68,7 +66,6 @@ function AutocompletePrompt<T>({
   const paginatedSearch = useCallback(
     async (term: string) => {
       const results = await search(term)
-      results.data = results.data.slice(0, PAGE_SIZE)
       return results
     },
     [search],
@@ -148,7 +145,7 @@ function AutocompletePrompt<T>({
           // has emptied the search term, so we want to show the default
           // choices instead
           if (searchTermRef.current.length === 0) {
-            setSearchResults(paginatedInitialChoices)
+            setSearchResults(choices)
             setHasMorePages(initialHasMorePages)
           } else {
             setSearchResults(result.data)
@@ -164,7 +161,7 @@ function AutocompletePrompt<T>({
           clearTimeout(setLoadingWhenSlow.current)
         })
     }, 300),
-    [initialHasMorePages, paginatedInitialChoices, paginatedSearch, searchResults],
+    [initialHasMorePages, choices, paginatedSearch, searchResults],
   )
 
   return isAborted ? null : (
@@ -186,7 +183,7 @@ function AutocompletePrompt<T>({
                 } else {
                   debounceSearch.cancel()
                   setPromptState(PromptState.Idle)
-                  setSearchResults(paginatedInitialChoices)
+                  setSearchResults(choices)
                 }
               }}
               placeholder="Type to search..."
@@ -221,7 +218,7 @@ function AutocompletePrompt<T>({
         <Box marginTop={1}>
           <SelectInput
             items={searchResults}
-            initialItems={paginatedInitialChoices}
+            initialItems={choices}
             enableShortcuts={false}
             emptyMessage="No results found."
             highlightedTerm={searchTerm}

--- a/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
@@ -134,7 +134,7 @@ function SelectInputInner<T>(
     hasMorePages = false,
     morePagesMessage,
     infoMessage,
-    availableLines = MAX_AVAILABLE_LINES,
+    availableLines,
     submitWithShortcuts = false,
     onSubmit,
   }: SelectInputProps<T>,
@@ -156,17 +156,19 @@ function SelectInputInner<T>(
     key: item.key ?? (index + 1).toString(),
   })) as ItemWithKey<T>[]
 
+  const availableLinesToUse = Math.min(availableLines ?? 0, MAX_AVAILABLE_LINES)
+
   function maximumLinesLostToGroups(items: Item<T>[]): number {
     // Calculate a safe estimate of the limit needed based on the space available
     const numberOfGroups = new Set(items.map((item) => item.group).filter((group) => group)).size
     // Add 1 to numberOfGroups because we also have a default Other group
-    const maxVisibleGroups = Math.ceil(Math.min((availableLines + 1) / 3, numberOfGroups + 1))
+    const maxVisibleGroups = Math.ceil(Math.min((availableLinesToUse + 1) / 3, numberOfGroups + 1))
     // If we have x visible groups, we lose 1 line to the first group + 2 lines to the rest
     return numberOfGroups > 0 ? (maxVisibleGroups - 1) * 2 + 1 : 0
   }
 
   const maxLinesLostToGroups = maximumLinesLostToGroups(items)
-  const limit = Math.max(2, availableLines - maxLinesLostToGroups)
+  const limit = Math.max(2, availableLinesToUse - maxLinesLostToGroups)
   const hasLimit = items.length > limit
 
   const inputStack = useRef<string | null>(null)
@@ -269,7 +271,7 @@ function SelectInputInner<T>(
       <Box flexDirection="column" ref={ref}>
         <Box
           flexDirection="column"
-          height={Math.max(minHeight, Math.min(availableLines, optionsHeight))}
+          height={Math.max(minHeight, Math.min(availableLinesToUse, optionsHeight))}
           overflowY="hidden"
         >
           {state.visibleOptions.map((item: ItemWithKey<T>, index: number) => (


### PR DESCRIPTION
We were artificially cutting the number of items in memory to 25. This doesn't make much sense since we're already limiting the height of the select prompt to 25. If there are more items returned by the server then they will be places outside the viewport and will be reachable through scrolling or filtering.