### PR TITLE
Map number_integer to number in Flow's uiTypesMap

### DIFF
--- a/packages/app/src/cli/services/flow/constants.ts
+++ b/packages/app/src/cli/services/flow/constants.ts
@@ -30,7 +30,7 @@ export const uiTypesMap: [string, string][] = [
   ['boolean', 'checkbox'],
   ['email', 'email'],
   ['multi_line_text_field', 'text-multi-lines'],
-  ['number_integer', 'int'],
+  ['number_integer', 'number'],
   ['single_line_text_field', 'text-single-line'],
   ['url', 'url'],
   ['number_decimal', 'number'],


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The mapping of the `number_integer` metafield type should be to `number` to match the existing Flow config field types.

### WHAT is this pull request doing?

Corrects the mapping of `number_integer` to `number`.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
