### PR TITLE
remove the update action from theme update_extension schema

### DIFF
--- a/packages/theme/src/cli/services/update/check.test.ts
+++ b/packages/theme/src/cli/services/update/check.test.ts
@@ -133,7 +133,7 @@ describe('check', () => {
   })
 
   test(`when an operation doesn't have the id property`, async () => {
-    const actions = ['add', 'delete', 'copy', 'move', 'update']
+    const actions = ['add', 'delete', 'copy', 'move']
 
     for (const action of actions) {
       // Given
@@ -165,7 +165,7 @@ describe('check', () => {
   })
 
   test(`when an operation doesn't have the action property`, async () => {
-    const actions = ['add', 'delete', 'copy', 'move', 'update']
+    const actions = ['add', 'delete', 'copy', 'move']
 
     for (const action of actions) {
       // Given
@@ -193,7 +193,7 @@ describe('check', () => {
   })
 
   test(`when operations contain a step with an invalid file property`, async () => {
-    const actions = ['add', 'delete', 'copy', 'move', 'update']
+    const actions = ['add', 'delete', 'copy', 'move']
 
     for (const action of actions) {
       // Given
@@ -227,7 +227,7 @@ describe('check', () => {
   })
 
   test(`when operations contain a step with an invalid key property`, async () => {
-    const actions = ['add', 'delete', 'update']
+    const actions = ['add', 'delete']
 
     for (const action of actions) {
       // Given
@@ -295,7 +295,7 @@ describe('check', () => {
   })
 
   test(`when operations contain a step with an invalid action property`, async () => {
-    const actions = ['add', 'delete', 'copy', 'move', 'update']
+    const actions = ['add', 'delete', 'copy', 'move']
 
     for (const action of actions) {
       // Given
@@ -329,7 +329,7 @@ describe('check', () => {
   })
 
   test(`when operations contain a step with an invalid action property`, async () => {
-    const actions = ['add', 'delete', 'copy', 'move', 'update']
+    const actions = ['add', 'delete', 'copy', 'move']
 
     for (const action of actions) {
       // Given
@@ -364,7 +364,7 @@ describe('check', () => {
   })
 
   test(`when operations contain a step missing required properties`, async () => {
-    const actions = ['add', 'delete', 'copy', 'move', 'update']
+    const actions = ['add', 'delete', 'copy', 'move']
 
     for (const action of actions) {
       // Given
@@ -418,7 +418,7 @@ describe('check', () => {
   })
 
   test(`when a step has additional properties`, async () => {
-    const actions = ['add', 'delete', 'copy', 'move', 'update']
+    const actions = ['add', 'delete', 'copy', 'move']
 
     for (const action of actions) {
       // Given
@@ -478,13 +478,6 @@ function data() {
             from_key: 'key1',
             to_key: 'key2',
           },
-          {
-            action: 'update',
-            file: 'file.json',
-            key: 'key1',
-            old_value: 'key1',
-            new_value: 'key2',
-          },
         ],
       },
       {
@@ -514,13 +507,6 @@ function operation(action: string) {
       file: 'file.json',
       key: 'key1',
       value: ['key1'],
-    },
-    update: {
-      action: 'update',
-      file: 'file.json',
-      key: 'key1',
-      old_value: 'key1',
-      new_value: 'key2',
     },
     move: {
       action: 'move',

--- a/packages/theme/src/cli/services/update/schemas/update_extension_schema_v1.ts
+++ b/packages/theme/src/cli/services/update/schemas/update_extension_schema_v1.ts
@@ -18,9 +18,9 @@ export const schemaUrlV1 =
 
 export const schemaV1 = z
   .object({
-    $schema: z.string(),
-    theme_name: z.string(),
-    theme_version: z.string(),
+    $schema: z.string().describe('The URL for the JSON schema version used for validation and execution.'),
+    theme_name: z.string().describe('The name of the theme to which the update extension script applies.'),
+    theme_version: z.string().describe('The version of the theme to which the update extension script applies.'),
     operations: z
       .array(
         z
@@ -31,88 +31,114 @@ export const schemaV1 = z
                 z.union([
                   z
                     .object({
-                      action: z.literal('move'),
-                      file: z.any().superRefine((x, ctx) => {
-                        const schemas = [z.string(), z.object({source: z.string(), target: z.string()})]
-                        const errors = schemas.reduce(
-                          (errors: z.ZodError[], schema) =>
-                            ((result) => ('error' in result ? [...errors, result.error] : errors))(schema.safeParse(x)),
-                          [],
-                        )
-                        if (schemas.length - errors.length !== 1) {
-                          ctx.addIssue({
-                            path: ctx.path,
-                            code: 'invalid_union',
-                            unionErrors: errors,
-                            message: 'Invalid input: Should pass single schema',
-                          })
-                        }
-                      }),
-                      from_key: z.string(),
-                      to_key: z.string(),
+                      action: z.literal('move').describe('The action type.'),
+                      file: z
+                        .any()
+                        .superRefine((x, ctx) => {
+                          const schemas = [
+                            z
+                              .string()
+                              .describe(
+                                'The relative path of the file, within the theme folder, to move the key-value pair.',
+                              ),
+                            z.object({
+                              source: z.string().describe('The relative path of source file.'),
+                              target: z.string().describe('The relative path of target file.'),
+                            }),
+                          ]
+                          const errors = schemas.reduce(
+                            (errors: z.ZodError[], schema) =>
+                              ((result) => ('error' in result ? [...errors, result.error] : errors))(
+                                schema.safeParse(x),
+                              ),
+                            [],
+                          )
+                          if (schemas.length - errors.length !== 1) {
+                            ctx.addIssue({
+                              path: ctx.path,
+                              code: 'invalid_union',
+                              unionErrors: errors,
+                              message: 'Invalid input: Should pass single schema',
+                            })
+                          }
+                        })
+                        .describe(
+                          "The file referenced in this step can be either a string, if the source and target are the same, or an object with 'source' and 'target' properties.",
+                        ),
+                      from_key: z.string().describe('The key to move from.'),
+                      to_key: z.string().describe('The key to move to.'),
                     })
                     .strict(),
                   z
                     .object({
-                      action: z.literal('copy'),
-                      file: z.any().superRefine((x, ctx) => {
-                        const schemas = [z.string(), z.object({source: z.string(), target: z.string()})]
-                        const errors = schemas.reduce(
-                          (errors: z.ZodError[], schema) =>
-                            ((result) => ('error' in result ? [...errors, result.error] : errors))(schema.safeParse(x)),
-                          [],
-                        )
-                        if (schemas.length - errors.length !== 1) {
-                          ctx.addIssue({
-                            path: ctx.path,
-                            code: 'invalid_union',
-                            unionErrors: errors,
-                            message: 'Invalid input: Should pass single schema',
-                          })
-                        }
-                      }),
-                      from_key: z.string(),
-                      to_key: z.string(),
+                      action: z.literal('copy').describe('The action type.'),
+                      file: z
+                        .any()
+                        .superRefine((x, ctx) => {
+                          const schemas = [
+                            z.string().describe('The relative path of the file to copy the key-value pair.'),
+                            z.object({
+                              source: z.string().describe('The relative path of source file.'),
+                              target: z.string().describe('The relative path of target file.'),
+                            }),
+                          ]
+                          const errors = schemas.reduce(
+                            (errors: z.ZodError[], schema) =>
+                              ((result) => ('error' in result ? [...errors, result.error] : errors))(
+                                schema.safeParse(x),
+                              ),
+                            [],
+                          )
+                          if (schemas.length - errors.length !== 1) {
+                            ctx.addIssue({
+                              path: ctx.path,
+                              code: 'invalid_union',
+                              unionErrors: errors,
+                              message: 'Invalid input: Should pass single schema',
+                            })
+                          }
+                        })
+                        .describe(
+                          "The file referenced in this step can be either a string, if the source and target are the same, or an object with 'source' and 'target' properties.",
+                        ),
+                      from_key: z.string().describe('The key to copy from.'),
+                      to_key: z.string().describe('The key to copy to.'),
                     })
                     .strict(),
                   z
                     .object({
-                      action: z.literal('add'),
-                      file: z.string(),
-                      key: z.string(),
-                      value: z.any().superRefine((x, ctx) => {
-                        const schemas = [z.record(z.any()), z.array(z.any())]
-                        const errors = schemas.reduce(
-                          (errors: z.ZodError[], schema) =>
-                            ((result) => ('error' in result ? [...errors, result.error] : errors))(schema.safeParse(x)),
-                          [],
-                        )
-                        if (schemas.length - errors.length !== 1) {
-                          ctx.addIssue({
-                            path: ctx.path,
-                            code: 'invalid_union',
-                            unionErrors: errors,
-                            message: 'Invalid input: Should pass single schema',
-                          })
-                        }
-                      }),
+                      action: z.literal('add').describe('The action type.'),
+                      file: z.string().describe('The relative path of the file to add the key-value pair to.'),
+                      key: z.string().describe('The existing key to add the value to.'),
+                      value: z
+                        .any()
+                        .superRefine((x, ctx) => {
+                          const schemas = [z.record(z.any()), z.array(z.any())]
+                          const errors = schemas.reduce(
+                            (errors: z.ZodError[], schema) =>
+                              ((result) => ('error' in result ? [...errors, result.error] : errors))(
+                                schema.safeParse(x),
+                              ),
+                            [],
+                          )
+                          if (schemas.length - errors.length !== 1) {
+                            ctx.addIssue({
+                              path: ctx.path,
+                              code: 'invalid_union',
+                              unionErrors: errors,
+                              message: 'Invalid input: Should pass single schema',
+                            })
+                          }
+                        })
+                        .describe('The value to add, either as an object or an array.'),
                     })
                     .strict(),
                   z
                     .object({
-                      action: z.literal('update'),
-                      file: z.string(),
-                      key: z.string(),
-                      old_value: z.string(),
-                      new_value: z.string(),
-                    })
-                    .strict(),
-                  z
-                    .object({
-                      action: z.literal('delete'),
-                      file: z.string(),
-                      key: z.string(),
-                      value: z.string().optional(),
+                      action: z.literal('delete').describe('The action type.'),
+                      file: z.string().describe('The relative path of the file to delete the key-value pair from.'),
+                      key: z.string().describe('The key to delete.'),
+                      value: z.string().describe('The optional value to delete in the key.').optional(),
                     })
                     .strict(),
                 ]),
@@ -121,6 +147,7 @@ export const schemaV1 = z
           })
           .strict(),
       )
-      .min(1),
+      .min(1)
+      .describe('An array of operations to be performed on the theme during an update.'),
   })
   .strict()


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify/issues/437598
tl;dr: Update action is descoped from the project. Further context can be found [here](https://docs.google.com/document/d/1kfeB1SFg9oygW_0mEHON51eB4du_2QNq5US46mEJd_A/edit#heading=h.243m6mt93xx0)  


### WHAT is this pull request doing?

Removing the Update action from the update_extension schema. The zod schema should be consistent with core and [theme-liquid-docs](https://github.com/Shopify/theme-liquid-docs). Given I've already updated the schema in our liquid-docs ([PR](https://github.com/Shopify/theme-liquid-docs/pull/228)), I regenerated the schema here by running `pnpm run schema:generate` which in turn generates the schema based on the [theme-liquid-docs](https://github.com/Shopify/theme-liquid-docs). 

### How to test your changes?
Updated and ran the related test suite, which is `packages/theme/src/cli/services/update/check.test.ts` 

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
