### PR TITLE
Dev-server-kit: enable adding a handler for when the websocket opens and closes

### DIFF
--- a/.changeset/new-masks-divide.md
+++ b/.changeset/new-masks-divide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-server-kit': minor
+---
+
+@shopify/ui-extensions-server-kit enable subscribing to connection open/close events

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
@@ -670,4 +670,81 @@ describe('ExtensionServerClient', () => {
       updatedSocket.close()
     })
   })
+
+  describe('onConnection()', () => {
+    test('enables listening to connection open events', async () => {
+      const {socket, client} = setup({
+        connection: {automaticConnect: false, url: 'ws://example-host.com:8000/extensions/'},
+      })
+      const openListener = vi.fn()
+      client.onConnection('open', openListener)
+      const disconnect = client.connect()
+
+      // Unfortunately I couldn't find a way to assert after the open event was dispatch
+      // without using a setTimeout
+      setTimeout(() => {
+        expect(openListener).toHaveBeenCalledTimes(1)
+        expect(openListener).toHaveBeenCalledWith(expect.objectContaining({type: 'open'}))
+
+        disconnect()
+        socket.close()
+      }, 100)
+    })
+
+    test('unsubscribes from connection open events', async () => {
+      const {socket, client} = setup({
+        connection: {automaticConnect: false, url: 'ws://example-host.com:8000/extensions/'},
+      })
+      const openListener = vi.fn()
+      const unsubscribe = client.onConnection('open', openListener)
+
+      unsubscribe()
+
+      const disconnect = client.connect()
+
+      // Unfortunately I couldn't find a way to assert after the open event was dispatch
+      // without using a setTimeout
+      setTimeout(() => {
+        expect(openListener).toHaveBeenCalledTimes(0)
+        disconnect()
+        socket.close()
+      }, 100)
+    })
+
+    test('enables listening to connection close events', async () => {
+      const {socket, client} = setup()
+      const closeListener = vi.fn()
+      client.onConnection('close', closeListener)
+      const disconnect = client.connect()
+
+      disconnect()
+
+      // Unfortunately I couldn't find a way to assert after the open event was dispatch
+      // without using a setTimeout
+      setTimeout(() => {
+        expect(closeListener).toHaveBeenCalledTimes(1)
+        expect(closeListener).toHaveBeenCalledWith(expect.objectContaining({type: 'close'}))
+        socket.close()
+      }, 100)
+    })
+
+    test('unsubscribes from connection close events', async () => {
+      const {socket, client} = setup()
+      const closeListener = vi.fn()
+      const unsubscribe = client.onConnection('close', closeListener)
+
+      unsubscribe()
+
+      const disconnect = client.connect()
+
+      disconnect()
+
+      // Unfortunately I couldn't find a way to assert after the open event was dispatch
+      // without using a setTimeout
+      setTimeout(() => {
+        expect(closeListener).toHaveBeenCalledTimes(0)
+        socket.close()
+      }, 100)
+    })
+  })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Enables users of `@shopify/ui-extensions-server-kit` to subscribe to open/close web socket events

### WHAT is this pull request doing?

Add a new `onConnection` method on the client

### How to test your changes?

The unit tests should suffices. The full flow will be tested in subsequent PRs.

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [X] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
