### PR TITLE
Use config to deploy, release or generate

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -50,6 +50,7 @@ program
   )
   .option("--cleanup", "delete temp app afterwards", false)
   .option("--deploy", "deploy the app to Shopify", false)
+  .option("--config-as-code", "enable config as code", false)
   .action(async (options) => {
     // helpers
     const log = (message) => {
@@ -222,6 +223,11 @@ program
     // on windows pnpm sets the wrong paths, rerunning install fixes it
     log("Making sure node is setup correctly...");
     await appExec(nodePackageManager, ["install"]);
+
+    if (options.configAsCode) {
+      log("Enabling config as code...");
+      await appNodeExec(["shopify", "app", "config", "link"], []);
+    }
 
     if (extensions.has("ui")) {
       log("Generating UI extension...");

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -83,7 +83,7 @@ export default class AppGenerateExtension extends Command {
       name: flags.name,
       cloneUrl: flags['clone-url'],
       template: flags.template,
-      config: this.config,
+      commandConfig: this.config,
     })
   }
 }

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -46,7 +46,7 @@ interface TestAppWithConfigOptions {
   app?: Partial<AppInterface>
   config: Partial<AppConfiguration>
 }
-export function testAppWithConfig({app = {}, config = {}}: TestAppWithConfigOptions): AppInterface {
+export function testAppWithLegacyConfig({app = {}, config = {}}: TestAppWithConfigOptions): AppInterface {
   const configuration = {
     scopes: '',
     extension_directories: [],
@@ -54,6 +54,22 @@ export function testAppWithConfig({app = {}, config = {}}: TestAppWithConfigOpti
   }
 
   return testApp({...app, configuration})
+}
+
+export function testAppWithConfig(options?: TestAppWithConfigOptions): AppInterface {
+  const app = options?.app || testApp()
+  app.configuration = {
+    client_id: 'config-api-key',
+    name: 'app1',
+    scopes: 'read_products',
+    application_url: 'https://my-apps-url.com',
+    auth: {
+      redirect_urls: ['https://my-apps-url.com/auth/shopify'],
+    },
+    ...options?.config,
+  }
+
+  return app as AppInterface
 }
 
 export function testOrganizationApp(app: Partial<OrganizationApp> = {}): OrganizationApp {

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -1,5 +1,5 @@
 import use, {UseOptions} from './use.js'
-import {testApp, testAppWithConfig} from '../../../models/app/app.test-data.js'
+import {testApp, testAppWithLegacyConfig} from '../../../models/app/app.test-data.js'
 import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
 import {clearCurrentConfigFile, setAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
@@ -125,7 +125,7 @@ describe('use', () => {
       }
       vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.staging.toml')
 
-      const app = testAppWithConfig({
+      const app = testAppWithLegacyConfig({
         config: {
           name: 'something',
           client_id: 'something',
@@ -163,7 +163,7 @@ describe('use', () => {
       }
       vi.mocked(selectConfigFile).mockResolvedValue(ok('shopify.app.local.toml'))
 
-      const app = testAppWithConfig({
+      const app = testAppWithLegacyConfig({
         config: {
           name: 'something',
           client_id: 'something',

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -214,7 +214,8 @@ describe('ensureGenerateContext', () => {
     // Given
     const input = {directory: '/app', reset: false, token: 'token'}
     vi.mocked(getAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
-    vi.mocked(loadAppConfiguration).mockResolvedValue({
+    vi.mocked(loadAppConfiguration).mockReset()
+    vi.mocked(loadAppConfiguration).mockResolvedValueOnce({
       appDirectory: '/app',
       configurationPath: CACHED1_WITH_CONFIG.configFile!,
       configuration: testAppWithConfig().configuration,

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -24,7 +24,7 @@ import {resolveDeploymentMode} from './deploy/mode.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
 import {updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
-import {testApp, testOrganizationApp, testThemeExtensions} from '../models/app/app.test-data.js'
+import {testApp, testAppWithConfig, testOrganizationApp, testThemeExtensions} from '../models/app/app.test-data.js'
 import metadata from '../metadata.js'
 import {getAppConfigurationFileName, isWebType, loadAppConfiguration, loadAppName} from '../models/app/loader.js'
 import {AppInterface} from '../models/app/app.js'
@@ -175,6 +175,16 @@ beforeEach(async () => {
 })
 
 describe('ensureGenerateContext', () => {
+  beforeEach(() => {
+    vi.mocked(loadAppConfiguration).mockResolvedValueOnce({
+      appDirectory: '/app',
+      configurationPath: '/app/shopify.app.toml',
+      configuration: {
+        scopes: 'read_products',
+      },
+    })
+  })
+
   test('returns the provided app apiKey if valid, without cached state', async () => {
     // Given
     const input = {apiKey: 'key2', directory: '/app', reset: false, token: 'token'}
@@ -186,6 +196,7 @@ describe('ensureGenerateContext', () => {
     // Then
     expect(got).toEqual(APP2.apiKey)
   })
+
   test('returns the cached api key', async () => {
     // Given
     const input = {directory: '/app', reset: false, token: 'token'}
@@ -198,6 +209,26 @@ describe('ensureGenerateContext', () => {
     // Then
     expect(got).toEqual(APP2.apiKey)
   })
+
+  test('returns the api key from the current config', async () => {
+    // Given
+    const input = {directory: '/app', reset: false, token: 'token'}
+    vi.mocked(getAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
+    vi.mocked(loadAppConfiguration).mockResolvedValue({
+      appDirectory: '/app',
+      configurationPath: CACHED1_WITH_CONFIG.configFile!,
+      configuration: testAppWithConfig().configuration,
+    })
+    vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP2)
+
+    // When
+    const got = await ensureGenerateContext(input)
+
+    // Then
+    expect(fetchAppFromApiKey).toHaveBeenCalledWith('config-api-key', 'token')
+    expect(got).toEqual(APP2.apiKey)
+  })
+
   test('selects a new app and returns the api key', async () => {
     // Given
     const input = {directory: '/app', reset: true, token: 'token'}
@@ -698,6 +729,32 @@ describe('ensureDeployContext', () => {
     // Then
     expect(selectOrCreateApp).not.toHaveBeenCalled()
     expect(reuseDevConfigPrompt).toHaveBeenCalled()
+    expect(got.partnersApp.id).toEqual(APP2.id)
+    expect(got.partnersApp.title).toEqual(APP2.title)
+    expect(got.partnersApp.appType).toEqual(APP2.appType)
+    expect(got.identifiers).toEqual(identifiers)
+    expect(got.deploymentMode).toEqual('legacy')
+  })
+
+  test("fetches the app from the partners' API and returns it alongside the id when config as code is enabled", async () => {
+    // Given
+    const app = testAppWithConfig()
+    const identifiers = {
+      app: APP2.apiKey,
+      extensions: {},
+      extensionIds: {},
+    }
+    vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
+    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+
+    // When
+    const got = await ensureDeployContext(options(app))
+
+    // Then
+    expect(selectOrCreateApp).not.toHaveBeenCalled()
+    expect(reuseDevConfigPrompt).not.toHaveBeenCalled()
+    expect(fetchAppFromApiKey).toHaveBeenCalledWith('config-api-key', 'token')
     expect(got.partnersApp.id).toEqual(APP2.id)
     expect(got.partnersApp.title).toEqual(APP2.title)
     expect(got.partnersApp.appType).toEqual(APP2.appType)

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -88,6 +88,7 @@ export async function ensureGenerateContext(options: {
   directory: string
   reset: boolean
   token: string
+  config?: string
 }): Promise<string> {
   if (options.apiKey) {
     const app = await fetchAppFromApiKey(options.apiKey, options.token)

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -208,7 +208,7 @@ export async function ensureDevContext(options: DevContextOptions, token: string
     })
   }
 
-  await showCachedContextSummary({
+  await showDevReusedValues({
     directory: options.directory,
     selectedApp,
     selectedStore,
@@ -609,7 +609,7 @@ interface ReusedValuesOptions {
 /**
  * Message shown to the user in case we are reusing a previous configuration
  */
-async function showCachedContextSummary({
+async function showDevReusedValues({
   directory,
   organization,
   selectedApp,
@@ -637,11 +637,8 @@ async function showCachedContextSummary({
   }
 
   const packageManager = await getPackageManager(directory)
-  const headline = cachedInfo.configFile
-    ? `Using ${getAppConfigurationFileName(cachedInfo.configFile)}:`
-    : 'Using these settings:'
   renderInfo({
-    headline,
+    headline: reusedValuesTableTitle(cachedInfo),
     body: [
       {
         list: {
@@ -656,7 +653,7 @@ async function showCachedContextSummary({
 
 function showGenerateReusedValues(org: string, cachedAppInfo: CachedAppInfo, packageManager: PackageManager) {
   renderInfo({
-    headline: 'Using these settings:',
+    headline: reusedValuesTableTitle(cachedAppInfo),
     body: [
       {
         list: {
@@ -667,6 +664,12 @@ function showGenerateReusedValues(org: string, cachedAppInfo: CachedAppInfo, pac
       {command: formatPackageManagerCommand(packageManager, 'dev', '--reset')},
     ],
   })
+}
+
+function reusedValuesTableTitle(cachedInfo: CachedAppInfo) {
+  return cachedInfo.configFile
+    ? `Using ${getAppConfigurationFileName(cachedInfo.configFile)}:`
+    : 'Using these settings:'
 }
 
 /**

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -105,8 +105,9 @@ export async function ensureGenerateContext(options: {
     configName: cachedInfo?.configFile,
   })
 
+  let remoteApp
   if (isCurrentAppSchema(localAppConfiguration)) {
-    const remoteApp = (await appFromId(localAppConfiguration.client_id, options.token))!
+    remoteApp = (await appFromId(localAppConfiguration.client_id, options.token))!
     cachedInfo = {
       ...cachedInfo,
       directory: options.directory,
@@ -128,7 +129,7 @@ export async function ensureGenerateContext(options: {
 
   if (cachedInfo?.appId && cachedInfo?.orgId) {
     const org = await fetchOrgFromId(cachedInfo.orgId, options.token)
-    const app = await fetchAppFromApiKey(cachedInfo.appId, options.token)
+    const app = remoteApp || (await fetchAppFromApiKey(cachedInfo.appId, options.token))
     if (!app || !org) {
       const errorMessage = InvalidApiKeyErrorMessage(cachedInfo.appId)
       throw new AbortError(errorMessage.message, errorMessage.tryMessage)

--- a/packages/app/src/cli/services/generate.test.ts
+++ b/packages/app/src/cli/services/generate.test.ts
@@ -54,7 +54,7 @@ describe('generate', () => {
     const outputInfo = await mockSuccessfulCommandExecution('checkout_ui')
 
     // When
-    await generate({directory: '/', reset: false, config: mockConfig})
+    await generate({directory: '/', reset: false, commandConfig: mockConfig})
 
     // Then
     expect(outputInfo.info()).toMatchInlineSnapshot(`
@@ -76,7 +76,7 @@ describe('generate', () => {
     const outputInfo = await mockSuccessfulCommandExecution('theme_app_extension')
 
     // When
-    await generate({directory: '/', reset: false, config: mockConfig})
+    await generate({directory: '/', reset: false, commandConfig: mockConfig})
 
     // Then
     expect(outputInfo.info()).toMatchInlineSnapshot(`
@@ -98,7 +98,7 @@ describe('generate', () => {
     const outputInfo = await mockSuccessfulCommandExecution('product_discounts')
 
     // When
-    await generate({directory: '/', reset: false, config: mockConfig})
+    await generate({directory: '/', reset: false, commandConfig: mockConfig})
 
     // Then
     expect(outputInfo.info()).toMatchInlineSnapshot(`
@@ -120,7 +120,7 @@ describe('generate', () => {
     await mockSuccessfulCommandExecution('unknown_type')
 
     // When
-    const got = generate({directory: '/', reset: false, config: mockConfig, type: 'unknown_type'})
+    const got = generate({directory: '/', reset: false, commandConfig: mockConfig, type: 'unknown_type'})
 
     // Then
     await expect(got).rejects.toThrow(/Unknown extension type: unknown_type/)
@@ -132,7 +132,7 @@ describe('generate', () => {
     await mockSuccessfulCommandExecution('theme_app_extension', [themeExtension])
 
     // When
-    const got = generate({directory: '/', reset: false, config: mockConfig, type: 'theme_app_extension'})
+    const got = generate({directory: '/', reset: false, commandConfig: mockConfig, type: 'theme_app_extension'})
 
     // Then
     await expect(got).rejects.toThrow(/Invalid extension type/)
@@ -144,7 +144,7 @@ describe('generate', () => {
     await mockSuccessfulCommandExecution('product_discounts', [discountsFunction])
 
     // When
-    const got = generate({directory: '/', reset: false, config: mockConfig, type: 'product_discounts'})
+    const got = generate({directory: '/', reset: false, commandConfig: mockConfig, type: 'product_discounts'})
 
     // Then
     await expect(got).rejects.toThrow(/Invalid extension type/)
@@ -158,7 +158,7 @@ describe('generate', () => {
     const got = generate({
       directory: '/',
       reset: false,
-      config: mockConfig,
+      commandConfig: mockConfig,
       type: 'checkout_ui',
       template: 'unknown',
     })

--- a/packages/app/src/cli/services/generate.ts
+++ b/packages/app/src/cli/services/generate.ts
@@ -29,18 +29,19 @@ import {groupBy} from '@shopify/cli-kit/common/collection'
 export interface GenerateOptions {
   directory: string
   reset: boolean
-  config: Config
+  commandConfig: Config
   apiKey?: string
   type?: string
   template?: string
   name?: string
   cloneUrl?: string
+  config?: string
 }
 
 async function generate(options: GenerateOptions) {
   const token = await ensureAuthenticatedPartners()
   const apiKey = await ensureGenerateContext({...options, token})
-  const specifications = await fetchSpecifications({token, apiKey, config: options.config})
+  const specifications = await fetchSpecifications({token, apiKey, config: options.commandConfig})
   const app: AppInterface = await loadApp({directory: options.directory, specifications})
   const availableSpecifications = specifications.map((spec) => spec.identifier)
   const extensionTemplates = await fetchExtensionTemplates(token, apiKey, availableSpecifications)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/internal-cli-foundations/issues/682
Fixes https://github.com/Shopify/internal-cli-foundations/issues/688

### WHAT is this pull request doing?

Make it so that `ensureDevContext`, `ensureGenerateContext`, and `ensureDeployContext` use the config-as-code information instead of prompting the user.

### How to test your changes?

`bin/create-test-app.js -i local -e ui --config-as-code --deploy`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
