### PR TITLE
Keep track previously used app id

### DIFF
--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -1,7 +1,7 @@
 import use, {UseOptions} from './use.js'
-import {testApp, testAppWithLegacyConfig} from '../../../models/app/app.test-data.js'
+import {testApp, testAppWithConfig, testAppWithLegacyConfig} from '../../../models/app/app.test-data.js'
 import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
-import {clearCurrentConfigFile, setAppInfo} from '../../local-storage.js'
+import {clearCurrentConfigFile, getAppInfo, setAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
 import {describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
@@ -147,6 +147,171 @@ describe('use', () => {
       expect(setAppInfo).toHaveBeenCalledWith({
         directory: tmp,
         configFile: 'shopify.app.staging.toml',
+        previousAppId: undefined,
+      })
+      expect(renderSuccess).toHaveBeenCalledWith({
+        headline: 'Using configuration file shopify.app.staging.toml',
+      })
+    })
+  })
+
+  test('saves previousAppId when user switches to different config', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      createConfigFile(tmp, 'shopify.app.dev.toml')
+      createConfigFile(tmp, 'shopify.app.staging.toml')
+
+      const options: UseOptions = {
+        directory: tmp,
+        config: 'staging',
+      }
+
+      vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.staging.toml')
+
+      const previousApp = testAppWithConfig({
+        config: {
+          name: 'something old',
+          client_id: 'previous-app',
+          api_contact_email: 'bob@bob.com',
+          webhook_api_version: '2023-04',
+          application_url: 'https://example.com',
+        },
+      })
+      const app = testAppWithConfig({
+        config: {
+          name: 'something new',
+          client_id: 'new-app',
+          api_contact_email: 'bob@bob.com',
+          webhook_api_version: '2023-04',
+          application_url: 'https://example.com',
+        },
+      })
+
+      vi.mocked(getAppInfo).mockReturnValue({directory: tmp, configFile: 'shopify.app.dev.toml'})
+
+      vi.mocked(loadAppConfiguration)
+        .mockResolvedValueOnce({
+          appDirectory: tmp,
+          configurationPath: `${tmp}/shopify.app.staging.toml`,
+          configuration: app.configuration,
+        })
+        .mockResolvedValueOnce({
+          appDirectory: tmp,
+          configurationPath: `${tmp}/shopify.app.dev.toml`,
+          configuration: previousApp.configuration,
+        })
+
+      // When
+      await use(options)
+
+      // Then
+      expect(setAppInfo).toHaveBeenCalledWith({
+        directory: tmp,
+        configFile: 'shopify.app.staging.toml',
+        previousAppId: 'previous-app',
+      })
+      expect(renderSuccess).toHaveBeenCalledWith({
+        headline: 'Using configuration file shopify.app.staging.toml',
+      })
+    })
+  })
+
+  test('sets previousAppId to undefined when previous config file does not exist', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      createConfigFile(tmp, 'shopify.app.staging.toml')
+
+      const options: UseOptions = {
+        directory: tmp,
+        config: 'staging',
+      }
+
+      vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.staging.toml')
+
+      const app = testAppWithConfig({
+        config: {
+          name: 'something new',
+          client_id: 'new-app',
+          api_contact_email: 'bob@bob.com',
+          webhook_api_version: '2023-04',
+          application_url: 'https://example.com',
+        },
+      })
+
+      vi.mocked(getAppInfo).mockReturnValue({directory: tmp, configFile: 'shopify.app.dev.toml'})
+
+      vi.mocked(loadAppConfiguration).mockResolvedValue({
+        appDirectory: tmp,
+        configurationPath: `${tmp}/shopify.app.staging.toml`,
+        configuration: app.configuration,
+      })
+
+      // When
+      await use(options)
+
+      // Then
+      expect(setAppInfo).toHaveBeenCalledWith({
+        directory: tmp,
+        configFile: 'shopify.app.staging.toml',
+        previousAppId: undefined,
+      })
+      expect(renderSuccess).toHaveBeenCalledWith({
+        headline: 'Using configuration file shopify.app.staging.toml',
+      })
+    })
+  })
+
+  test('sets previousAppId to undefined when previous config file is legacy schema', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      createConfigFile(tmp, 'shopify.app.dev.toml')
+      createConfigFile(tmp, 'shopify.app.staging.toml')
+
+      const options: UseOptions = {
+        directory: tmp,
+        config: 'staging',
+      }
+
+      vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.staging.toml')
+
+      const previousApp = testAppWithLegacyConfig({
+        config: {
+          name: 'something old',
+          scopes: 'read_products',
+        },
+      })
+      const app = testAppWithConfig({
+        config: {
+          name: 'something new',
+          client_id: 'new-app',
+          api_contact_email: 'bob@bob.com',
+          webhook_api_version: '2023-04',
+          application_url: 'https://example.com',
+        },
+      })
+
+      vi.mocked(getAppInfo).mockReturnValue({directory: tmp, configFile: 'shopify.app.dev.toml'})
+
+      vi.mocked(loadAppConfiguration)
+        .mockResolvedValueOnce({
+          appDirectory: tmp,
+          configurationPath: `${tmp}/shopify.app.staging.toml`,
+          configuration: app.configuration,
+        })
+        .mockResolvedValueOnce({
+          appDirectory: tmp,
+          configurationPath: `${tmp}/shopify.app.dev.toml`,
+          configuration: previousApp.configuration,
+        })
+
+      // When
+      await use(options)
+
+      // Then
+      expect(setAppInfo).toHaveBeenCalledWith({
+        directory: tmp,
+        configFile: 'shopify.app.staging.toml',
+        previousAppId: undefined,
       })
       expect(renderSuccess).toHaveBeenCalledWith({
         headline: 'Using configuration file shopify.app.staging.toml',

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -1,5 +1,5 @@
 import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
-import {clearCurrentConfigFile, setAppInfo} from '../../local-storage.js'
+import {clearCurrentConfigFile, getAppInfo, setAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
 import {isCurrentAppSchema} from '../../../models/app/app.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -42,9 +42,21 @@ export async function saveCurrentConfig({configFileName, directory}: SaveCurrent
   const {configuration} = await loadAppConfiguration({configName: configFileName, directory})
 
   if (isCurrentAppSchema(configuration) && configuration.client_id) {
+    const previousConfigFile = getAppInfo(directory)?.configFile
+    let previousAppId
+    if (previousConfigFile) {
+      const {configuration: previousConfiguration} = await loadAppConfiguration({
+        configName: previousConfigFile,
+        directory,
+      })
+
+      if (isCurrentAppSchema(previousConfiguration)) previousAppId = previousConfiguration.client_id
+    }
+
     setAppInfo({
       directory,
       configFile: configFileName,
+      previousAppId,
     })
   } else {
     throw new AbortError(`Configuration file ${configFileName} needs a client_id.`)

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -3,7 +3,7 @@ import {clearCurrentConfigFile, getAppInfo, setAppInfo} from '../../local-storag
 import {selectConfigFile} from '../../../prompts/config.js'
 import {isCurrentAppSchema} from '../../../models/app/app.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {fileExists} from '@shopify/cli-kit/node/fs'
+import {fileExists, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {Result, err, ok} from '@shopify/cli-kit/node/result'
@@ -44,7 +44,7 @@ export async function saveCurrentConfig({configFileName, directory}: SaveCurrent
   if (isCurrentAppSchema(configuration) && configuration.client_id) {
     const previousConfigFile = getAppInfo(directory)?.configFile
     let previousAppId
-    if (previousConfigFile) {
+    if (previousConfigFile && fileExistsSync(joinPath(directory, previousConfigFile))) {
       const {configuration: previousConfiguration} = await loadAppConfiguration({
         configName: previousConfigFile,
         directory,

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -306,7 +306,7 @@ describe('ensureDevContext', async () => {
       expect(got).toEqual({
         remoteApp: {...APP2, apiSecret: 'secret2'},
         storeFqdn: STORE1.shopDomain,
-        remoteAppUpdated: false,
+        remoteAppUpdated: true,
         useCloudflareTunnels: true,
         updateURLs: true,
         config: CACHED1_WITH_CONFIG.configFile,
@@ -503,6 +503,28 @@ dev_store_url = "domain1"
     })
   })
 
+  test('returns remoteAppUpdated true when previous app id is different', async () => {
+    // Given
+    vi.mocked(getAppInfo).mockReturnValue({...CACHED1_WITH_CONFIG, previousAppId: APP2.apiKey})
+    // vi.mocked(fetchOrgFromId).mockResolvedValueOnce(ORG2)
+    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1)
+    vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
+
+    // When
+    const got = await ensureDevContext(INPUT, 'token')
+
+    // Then
+    expect(got).toEqual({
+      remoteApp: {...APP1, apiSecret: 'secret1'},
+      storeFqdn: STORE1.shopDomain,
+      remoteAppUpdated: true,
+      useCloudflareTunnels: true,
+      updateURLs: undefined,
+      deploymentMode: 'legacy',
+      config: CACHED1_WITH_CONFIG.configFile,
+    })
+  })
+
   test('returns useCloudflareTunnels false if the beta is enabled in partners', async () => {
     // Given
     vi.mocked(getAppInfo).mockReturnValue(undefined)
@@ -524,7 +546,7 @@ dev_store_url = "domain1"
 
   test('returns selected data and updates internal state, with cached state', async () => {
     // Given
-    vi.mocked(getAppInfo).mockReturnValue(CACHED1)
+    vi.mocked(getAppInfo).mockReturnValue({...CACHED1, previousAppId: APP1.apiKey})
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -252,7 +252,7 @@ function buildOutput(
       ...app,
       apiSecret: app.apiSecretKeys.length === 0 ? undefined : app.apiSecretKeys[0]!.secret,
     },
-    remoteAppUpdated: app.apiKey !== cachedInfo?.appId,
+    remoteAppUpdated: app.apiKey !== cachedInfo?.appId || app.apiKey !== cachedInfo?.previousAppId,
     storeFqdn: store.shopDomain,
     updateURLs: cachedInfo?.updateURLs,
     useCloudflareTunnels,

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -252,7 +252,7 @@ function buildOutput(
       ...app,
       apiSecret: app.apiSecretKeys.length === 0 ? undefined : app.apiSecretKeys[0]!.secret,
     },
-    remoteAppUpdated: app.apiKey !== cachedInfo?.appId || app.apiKey !== cachedInfo?.previousAppId,
+    remoteAppUpdated: app.apiKey !== cachedInfo?.previousAppId,
     storeFqdn: store.shopDomain,
     updateURLs: cachedInfo?.updateURLs,
     useCloudflareTunnels,

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -310,10 +310,10 @@ async function dev(options: DevOptions) {
       additionalProcesses,
     })
   }
+}
 
-  function setPreviousAppId(directory: string, apiKey: string) {
-    setAppInfo({directory, previousAppId: apiKey})
-  }
+function setPreviousAppId(directory: string, apiKey: string) {
+  setAppInfo({directory, previousAppId: apiKey})
 }
 
 function isWebType(web: Web, type: WebType): boolean {

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -17,6 +17,7 @@ import {ensureDeploymentIdsPresence} from './context/identifiers.js'
 import {setupConfigWatcher, setupDraftableExtensionBundler, setupFunctionWatcher} from './dev/extension/bundler.js'
 import {buildFunctionExtension} from './build/extension.js'
 import {updateExtensionDraft} from './dev/update-extension.js'
+import {setAppInfo} from './local-storage.js'
 import {
   ReverseHTTPProxyTarget,
   runConcurrentHTTPProcessesAndPathForwardTraffic,
@@ -288,6 +289,8 @@ async function dev(options: DevOptions) {
     })
   }
 
+  setPreviousAppId(options.directory, apiKey)
+
   await logMetadataForDev({devOptions: options, tunnelUrl: frontendUrl, shouldUpdateURLs, storeFqdn})
 
   await reportAnalyticsEvent({config: options.commandConfig})
@@ -306,6 +309,10 @@ async function dev(options: DevOptions) {
       proxyTargets,
       additionalProcesses,
     })
+  }
+
+  function setPreviousAppId(directory: string, apiKey: string) {
+    setAppInfo({directory, previousAppId: apiKey})
   }
 }
 

--- a/packages/app/src/cli/services/local-storage.ts
+++ b/packages/app/src/cli/services/local-storage.ts
@@ -11,6 +11,7 @@ export interface CachedAppInfo {
   storeFqdn?: string
   updateURLs?: boolean
   tunnelPlugin?: string
+  previousAppId?: string
 }
 
 // We store each app info using the directory as the key


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We want to preserve previous app switching behavior from `dev --reset` where an uninstall webhook is sent to avoid issues with local database install info.

### WHAT is this pull request doing?

Saves previous app id when switching between configurations on `use` and sets current app id as previous id on `dev`. `dev` uses this previous app id to choose when webhook is sent.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Create a new app with `pnpm create-app --local --template=node --path ~/Desktop`
2. Run `pnpm shopify app dev --path ~/Desktop/your-app` (legacy behavior)
3. Run `pnpm shopify app dev --path ~/Desktop/your-app --reset` and switch to new app
4. 👀 See how uninstall webhook is still being sent
5. Run link `pnpm shopify app config link --path ~/Desktop/your-app` 
6. Run `pnpm shopify app dev --path ~/Desktop/your-app` (new config behavior)
7. 👀 See how uninstall webhook is being sent 
8. Run link `pnpm shopify app config link --path ~/Desktop/your-app` 
9. Run `pnpm shopify app dev --path ~/Desktop/your-app` (new config behavior)
10. 👀 See how uninstall webhook is being sent 
11. Run use `pnpm shopify app config use --path ~/Desktop/your-app` 
12. Run dev again and 👀 see how uninstall webhook gets sent

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
