### PR TITLE
Always assign only 1 port to a monolith

### DIFF
--- a/.changeset/dry-moose-raise.md
+++ b/.changeset/dry-moose-raise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Only assign a single port when frontend and backend are the same web

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -328,7 +328,7 @@ function isWebType(web: Web, type: WebType): boolean {
 interface DevWebOptions {
   web: Web
   backendPort: number
-  frontendServerPort: number
+  frontendServerPort: number | undefined
   hmrServerPort?: number
   apiKey: string
   apiSecret?: string

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -118,17 +118,15 @@ async function dev(options: DevOptions) {
 
   await validateCustomPorts(localApp.webs)
 
-  const [{frontendUrl, frontendPort, usingLocalhost}, backendPort, currentURLs] = await Promise.all(
-    [
-      generateFrontendURL({
-        ...options,
-        app: localApp,
-        tunnelClient,
-      }),
-      getBackendPort() || backendConfig?.configuration.port || getAvailableTCPPort(),
-      getURLs(apiKey, token),
-    ],
-  )
+  const [{frontendUrl, frontendPort, usingLocalhost}, backendPort, currentURLs] = await Promise.all([
+    generateFrontendURL({
+      ...options,
+      app: localApp,
+      tunnelClient,
+    }),
+    getBackendPort() || backendConfig?.configuration.port || getAvailableTCPPort(),
+    getURLs(apiKey, token),
+  ])
   let frontendServerPort = frontendConfig?.configuration.port
   if (frontendConfig) {
     if (!frontendServerPort) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

When a single `web` has both frontend and backend roles, it gets assigned 2 ports, which doesn't make sense.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Ensures that a monolithic app will have only 1 port assigned. This is first felt in terms of webhooks.

Before:

![Screenshot 2023-07-09 at 13 59 17](https://github.com/Shopify/cli/assets/6288426/74bb5b3d-26a6-437c-9b90-963b37f84a05)

After:

![Screenshot 2023-07-09 at 13 59 53](https://github.com/Shopify/cli/assets/6288426/e5a5230f-914b-4c0c-95a8-c930c49b4c43)

### How to test your changes?

1. Run `dev`, open the preview link, install the app.
2. Kill dev and change [this line](https://github.com/Shopify/cli/blob/45f52b1530b11f98bdf821b922b0968075992a78/packages/app/src/cli/services/dev.ts#L117C1-L117C1) to `const sendUninstallWebhook = true`
3. Run `dev` again and watch what happens with the webhook.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
