### PR TITLE
Remove next steps from deploy error banner

### DIFF
--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -1183,14 +1183,6 @@ describe('deploymentErrorsToCustomSections', () => {
       {
         body: 'First error message.',
       },
-      {
-        title: 'Next Steps',
-        body: {
-          list: {
-            items: ['View details about this version in the Partner Dashboard.'],
-          },
-        },
-      },
     ])
   })
 
@@ -1223,14 +1215,6 @@ describe('deploymentErrorsToCustomSections', () => {
         body: {
           list: {
             items: ['First error message.', 'Second error message.'],
-          },
-        },
-      },
-      {
-        title: 'Next Steps',
-        body: {
-          list: {
-            items: ['View details about this version in the Partner Dashboard.'],
           },
         },
       },

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -250,28 +250,24 @@ function generalErrorsSection(errors: AppDeploySchema['appDeploy']['userErrors']
         },
       ]
     }
-    const errorsBody =
-      errors.length === 1
-        ? errors[0]?.message
-        : {
-            list: {
-              items: errors.map((error) => error.message),
-            },
-          }
+
+    if (errors.length === 1) {
+      return [
+        {
+          body: errors[0]!.message,
+        },
+      ]
+    }
 
     return [
       {
-        body: errorsBody,
-      },
-      {
-        title: 'Next Steps',
         body: {
           list: {
-            items: ['View details about this version in the Partner Dashboard.'],
+            items: errors.map((error) => error.message),
           },
         },
       },
-    ] as ErrorCustomSection[]
+    ]
   } else {
     return []
   }


### PR DESCRIPTION
### WHY are these changes introduced?

We don't want to show the Next Steps section in the error banner when deploy because it's not very useful.

![](https://screenshot.click/06-38-jp248-lna3u.png)

### WHAT is this pull request doing?

Removes that section.