### PR TITLE
Only send uninstall webhooks to launchable apps

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -106,7 +106,7 @@ async function dev(options: DevOptions) {
   const backendConfig = localApp.webs.find((web) => isWebType(web, WebType.Backend))
   const webhooksPath =
     localApp.webs.map(({configuration}) => configuration.webhooks_path).find((path) => path) || '/api/webhooks'
-  const sendUninstallWebhook = Boolean(webhooksPath) && remoteAppUpdated
+  const sendUninstallWebhook = Boolean(webhooksPath) && remoteAppUpdated && Boolean(frontendConfig || backendConfig)
 
   await validateCustomPorts(localApp.webs)
 


### PR DESCRIPTION
### WHY are these changes introduced?
The CLI `dev` command currently sends the uninstall webhooks on first `dev` regardless of whether the app has is launchable or not, which will cause it to hang for apps generated by the `none` template during `init`.

Fixes #[692](https://github.com/Shopify/develop-app-management/issues/117)

### WHAT is this pull request doing?
We are adding a check to the `sendUninstallWebhook` condition to also ensure that the app is `launchable`.

### How to test your changes?
1. Generate app with `none` template, expect to see no uninstall webhooks being sent.
2. Try again with any other template and expect to see the webhooks being sent.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
