### PR TITLE
Fix bug in display messages and update tests

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -4,7 +4,7 @@ import {OrganizationApp} from '../../../models/organization.js'
 import {selectConfigName} from '../../../prompts/config.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {getAppConfigurationFileName, loadApp} from '../../../models/app/loader.js'
-import {AppDevCachedContext, InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../context.js'
+import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../context.js'
 import {fetchAppFromApiKey} from '../../dev/fetch.js'
 import {configurationFileNames} from '../../../constants.js'
 import {Config} from '@oclif/core'
@@ -14,7 +14,6 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 import {encodeToml} from '@shopify/cli-kit/node/toml'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {getAppInfo} from '../../local-storage.js'
 
 export interface LinkOptions {
   commandConfig: Config
@@ -23,7 +22,7 @@ export interface LinkOptions {
   configName?: string
 }
 
-export default async function link(options: LinkOptions): Promise<AppDevCachedContext> {
+export default async function link(options: LinkOptions): Promise<void> {
   const localApp = await loadAppConfigFromDefaultToml(options)
   const remoteApp = await loadRemoteApp(localApp, options.apiKey)
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
@@ -35,20 +34,12 @@ export default async function link(options: LinkOptions): Promise<AppDevCachedCo
   writeFileSync(configFilePath, encodeToml(configuration))
 
   await saveCurrentConfig({configFileName, directory: options.directory})
-  const cachedInfo = getAppInfo(options.directory)
 
   renderSuccess({
     headline: `App "${remoteApp.title}" connected to this codebase, file ${configFileName} ${
       fileAlreadyExists ? 'updated' : 'created'
     }`,
   })
-
-  return {
-    configuration: localApp.configuration,
-    configurationPath: localApp.configurationPath,
-    cachedInfo,
-    remoteApp,
-  }
 }
 
 async function loadAppConfigFromDefaultToml(options: LinkOptions): Promise<AppInterface> {

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -14,6 +14,7 @@ import {ensureDeploymentIdsPresence} from './context/identifiers.js'
 import {createExtension} from './dev/create-extension.js'
 import {CachedAppInfo, clearAppInfo, getAppInfo, setAppInfo} from './local-storage.js'
 import {DeploymentMode, resolveDeploymentMode} from './deploy/mode.js'
+import link from './app/config/link.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
 import {AppConfiguration, AppInterface, isCurrentAppSchema, appIsLaunchable} from '../models/app/app.js'
 import {Identifiers, UuidOnlyIdentifiers, updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
@@ -47,7 +48,6 @@ import {writeFileSync} from '@shopify/cli-kit/node/fs'
 import {encodeToml} from '@shopify/cli-kit/node/toml'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {basename} from '@shopify/cli-kit/node/path'
-import link from './app/config/link.js'
 import {Config} from '@oclif/core'
 
 export const InvalidApiKeyErrorMessage = (apiKey: string) => {
@@ -161,8 +161,8 @@ export async function ensureDevContext(options: DevContextOptions, token: string
   }
 
   if ((previousCachedInfo?.configFile && options.reset) || (cachedContext.cachedInfo === undefined && !options.reset)) {
-    const newCachedContext = await link(options)
-    cachedContext = {...newCachedContext}
+    await link(options)
+    cachedContext = await getAppDevCachedContext({...options, reset: false, configName: undefined, token})
   }
 
   const {configuration, configurationPath, cachedInfo, remoteApp} = cachedContext


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes: https://github.com/Shopify/internal-cli-foundations/issues/652

This PR introduces linking on first dev and whenever `--reset` is passed in and the app is opted into config in code.

### How to test your changes?

1. create an app
```bash
pnpm create-app --local --template=node --path ~/Desktop/multi-config-app
```
2. run `dev`
```bash
pnpm shopify app dev --path ~/Desktop/multi-config-app
```

  Notice that the dev process will go through linking to a new app and store the linked config in `shopify.app.toml`
3. run `dev` again to make sure that it's re-using the config from `shopify.app.toml`
4. run `dev --reset`:
```bash
pnpm shopify app dev --path ~/Desktop/multi-config-app --reset`
```
Notice that you go through the link process again and it generates a new app TOML that is used for `dev`.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
