### PR TITLE
Fix lint issues

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -7,7 +7,6 @@ import {getAppConfigurationFileName, loadApp} from '../../../models/app/loader.j
 import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../context.js'
 import {fetchAppFromApiKey} from '../../dev/fetch.js'
 import {configurationFileNames} from '../../../constants.js'
-import {getAppInfo} from '../../local-storage.js'
 import {Config} from '@oclif/core'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {fileExists, writeFileSync} from '@shopify/cli-kit/node/fs'

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -134,7 +134,7 @@ describe('release', () => {
         '\nmessage',
         '\n\nsome kind of error 1, some kind of error 2',
       ],
-      headline: "Version couldn't be released",
+      headline: "Version couldn't be released.",
     })
   })
 })

--- a/packages/app/src/cli/services/release.ts
+++ b/packages/app/src/cli/services/release.ts
@@ -59,7 +59,7 @@ export async function release(options: ReleaseOptions) {
 
   if (release.userErrors?.length > 0) {
     renderError({
-      headline: "Version couldn't be released",
+      headline: "Version couldn't be released.",
       body: [
         ...linkAndMessage,
         `${linkAndMessage.length > 0 ? '\n\n' : ''}${release.userErrors.map((error) => error.message).join(', ')}`,

--- a/packages/app/src/cli/services/release/version-diff.test.ts
+++ b/packages/app/src/cli/services/release/version-diff.test.ts
@@ -17,7 +17,7 @@ describe('versionDiffByVersion', () => {
     expect(outputMock.error()).toMatchInlineSnapshot(`
       "╭─ error ──────────────────────────────────────────────────────────────────────╮
       │                                                                              │
-      │  Version couldn't be released                                                │
+      │  Version couldn't be released.                                               │
       │                                                                              │
       │  Version version could not be found.                                         │
       │                                                                              │

--- a/packages/app/src/cli/services/release/version-diff.ts
+++ b/packages/app/src/cli/services/release/version-diff.ts
@@ -34,7 +34,7 @@ async function versionDetailsByVersion(apiKey: string, version: string, token: s
     return deployment
   } catch (err) {
     renderError({
-      headline: "Version couldn't be released",
+      headline: "Version couldn't be released.",
       body: ['Version', {userInput: version}, 'could not be found.'],
     })
     throw new AbortSilentError()


### PR DESCRIPTION
### WHY are these changes introduced?

CI is [failing for main](https://github.com/Shopify/cli/actions/runs/5517272912/jobs/10059663582)

```
> nx run app:lint


/home/runner/work/cli/cli/packages/app/src/cli/services/app/config/link.ts
  10:9  error  'getAppInfo' is defined but never used  unused-imports/no-unused-imports

/home/runner/work/cli/cli/packages/app/src/cli/services/release.ts
  62:7  warning  The headline attribute should end with punctuation  @shopify/cli/banner-headline-format

/home/runner/work/cli/cli/packages/app/src/cli/services/release/version-diff.ts
  37:7  warning  The headline attribute should end with punctuation  @shopify/cli/banner-headline-format

✖ 3 problems (1 error, 2 warnings)
```

### WHAT is this pull request doing?

Fix them

### How to test your changes?

CI

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
