### PR TITLE
Remove schema and return type ref from triggers

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
@@ -12,8 +12,6 @@ export const FlowTriggerExtensionSchema = BaseSchema.extend({
     .array(
       zod.object({
         type: zod.literal('flow_trigger'),
-        schema: zod.string().optional(),
-        return_type_ref: zod.string().optional(),
       }),
     )
     .min(1),
@@ -54,8 +52,6 @@ const flowTriggerSpecification = createExtensionSpecification({
       title: config.name,
       description: config.description,
       fields: serializeFields('flow_trigger', config.settings?.fields),
-      schema: extension.schema,
-      return_type_ref: extension.return_type_ref,
     }
   },
 })


### PR DESCRIPTION

### WHY are these changes introduced?

- Partially resolves https://github.com/Shopify/flow/issues/19649

### WHAT is this pull request doing?

- Removes `schema` and `return_type_ref` from flow trigger definition as they are not yet supported

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
