### PR TITLE
Add remaining declarative fields

### DIFF
--- a/packages/app/src/cli/api/graphql/create_app.ts
+++ b/packages/app/src/cli/api/graphql/create_app.ts
@@ -21,17 +21,32 @@ export const CreateAppQuery = gql`
     ) {
       app {
         id
-        apiKey
         title
-        appType
-        applicationUrl
-        redirectUrlWhitelist
-        requestedAccessScopes
+        apiKey
+        organizationId
         apiSecretKeys {
           secret
         }
         appType
         grantedScopes
+        applicationUrl
+        redirectUrlWhitelist
+        requestedAccessScopes
+        webhookApiVersion
+        embedded
+        posEmbedded
+        preferencesUrl
+        contactEmail
+        gdprWebhooks {
+          customerDeletionUrl
+          customerDataRequestUrl
+          shopDeletionUrl
+        }
+        appProxy {
+          subPath
+          subPathPrefix
+          url
+        }
       }
       userErrors {
         field
@@ -54,17 +69,36 @@ export interface CreateAppQuerySchema {
   appCreate: {
     app: {
       id: string
-      apiKey: string
       title: string
-      applicationUrl: string
-      redirectUrlWhitelist: string[]
+      apiKey: string
       organizationId: string
       apiSecretKeys: {
         secret: string
       }[]
       appType: string
       grantedScopes: string[]
-      requestedAccessScopes: string[]
+      betas?: {
+        unifiedAppDeployment?: boolean
+        unifiedAppDeploymentOptIn?: boolean
+      }
+      applicationUrl: string
+      redirectUrlWhitelist: string[]
+      requestedAccessScopes?: string[]
+      contactEmail: string
+      webhookApiVersion: string
+      embedded: boolean
+      posEmbedded?: boolean
+      preferencesUrl?: string
+      gdprWebhooks?: {
+        customerDeletionUrl?: string
+        customerDataRequestUrl?: string
+        shopDeletionUrl?: string
+      }
+      appProxy?: {
+        proxySubPath: string
+        proxySubPathPrefix: string
+        proxyUrl: string
+      }
     }
     userErrors: {
       field: string[]

--- a/packages/app/src/cli/api/graphql/create_app.ts
+++ b/packages/app/src/cli/api/graphql/create_app.ts
@@ -95,9 +95,9 @@ export interface CreateAppQuerySchema {
         shopDeletionUrl?: string
       }
       appProxy?: {
-        proxySubPath: string
-        proxySubPathPrefix: string
-        proxyUrl: string
+        subPath: string
+        subPathPrefix: string
+        url: string
       }
     }
     userErrors: {

--- a/packages/app/src/cli/api/graphql/find_app.ts
+++ b/packages/app/src/cli/api/graphql/find_app.ts
@@ -67,9 +67,9 @@ export interface FindAppQuerySchema {
       shopDeletionUrl?: string
     }
     appProxy?: {
-      proxySubPath: string
-      proxySubPathPrefix: string
-      proxyUrl: string
+      subPath: string
+      subPathPrefix: string
+      url: string
     }
   }
 }

--- a/packages/app/src/cli/api/graphql/find_app.ts
+++ b/packages/app/src/cli/api/graphql/find_app.ts
@@ -19,6 +19,21 @@ export const FindAppQuery = gql`
       applicationUrl
       redirectUrlWhitelist
       requestedAccessScopes
+      webhookApiVersion
+      embedded
+      posEmbedded
+      preferencesUrl
+      contactEmail
+      gdprWebhooks {
+        customerDeletionUrl
+        customerDataRequestUrl
+        shopDeletionUrl
+      }
+      appProxy {
+        subPath
+        subPathPrefix
+        url
+      }
     }
   }
 `
@@ -41,5 +56,20 @@ export interface FindAppQuerySchema {
     applicationUrl: string
     redirectUrlWhitelist: string[]
     requestedAccessScopes?: string[]
+    contactEmail: string
+    webhookApiVersion: string
+    embedded: boolean
+    posEmbedded?: boolean
+    preferencesUrl?: string
+    gdprWebhooks?: {
+      customerDeletionUrl?: string
+      customerDataRequestUrl?: string
+      shopDeletionUrl?: string
+    }
+    appProxy?: {
+      proxySubPath: string
+      proxySubPathPrefix: string
+      proxyUrl: string
+    }
   }
 }

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -91,6 +91,7 @@ export function testOrganizationApp(app: Partial<OrganizationApp> = {}): Organiz
     id: '1',
     title: 'app1',
     apiKey: 'api-key',
+    contactEmail: 'example@example.com',
     apiSecretKeys: [{secret: 'api-secret'}],
     organizationId: '1',
     grantedScopes: [],

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -36,9 +36,9 @@ export type OrganizationApp = MinimalOrganizationApp & {
     shopDeletionUrl?: string
   }
   appProxy?: {
-    proxySubPath: string
-    proxySubPathPrefix: string
-    proxyUrl: string
+    subPath: string
+    subPathPrefix: string
+    url: string
   }
 }
 

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -25,6 +25,21 @@ export type OrganizationApp = MinimalOrganizationApp & {
   applicationUrl: string
   redirectUrlWhitelist: string[]
   requestedAccessScopes?: string[]
+  contactEmail?: string
+  webhookApiVersion?: string
+  embedded?: boolean
+  posEmbedded?: boolean
+  preferencesUrl?: string
+  gdprWebhooks?: {
+    customerDeletionUrl?: string
+    customerDataRequestUrl?: string
+    shopDeletionUrl?: string
+  }
+  appProxy?: {
+    proxySubPath: string
+    proxySubPathPrefix: string
+    proxyUrl: string
+  }
 }
 
 export interface OrganizationStore {

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -73,13 +73,19 @@ describe('link', () => {
       const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
       const expectedContent = `client_id = "api-key"
 name = "app1"
+api_contact_email = "example@example.com"
 application_url = "https://example.com"
 embedded = true
-api_contact_email = "example@example.com"
 extension_directories = [ ]
 
 [webhooks]
-api_version = "2023-04"
+api_version = "2023-07"
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[pos]
+embedded = false
 
 [access_scopes]
 use_legacy_install_flow = true
@@ -129,12 +135,18 @@ use_legacy_install_flow = true
       const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
       const expectedContent = `client_id = "12345"
 name = "my app"
+api_contact_email = "example@example.com"
 application_url = "https://myapp.com"
 embedded = true
-api_contact_email = "example@example.com"
 
 [webhooks]
-api_version = "2023-04"
+api_version = "2023-07"
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[pos]
+embedded = false
 
 [access_scopes]
 scopes = "write_products"
@@ -168,13 +180,19 @@ scopes = "write_products"
       const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
       const expectedContent = `client_id = "api-key"
 name = "app1"
+api_contact_email = "example@example.com"
 application_url = "https://example.com"
 embedded = true
-api_contact_email = "example@example.com"
 extension_directories = [ ]
 
 [webhooks]
-api_version = "2023-04"
+api_version = "2023-07"
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[pos]
+embedded = false
 
 [access_scopes]
 use_legacy_install_flow = true
@@ -245,12 +263,18 @@ use_legacy_install_flow = true
       const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
       const expectedContent = `client_id = "api-key"
 name = "app1"
+api_contact_email = "example@example.com"
 application_url = "https://example.com"
 embedded = true
-api_contact_email = "example@example.com"
 
 [webhooks]
-api_version = "2023-04"
+api_version = "2023-07"
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[pos]
+embedded = false
 
 [access_scopes]
 use_legacy_install_flow = true
@@ -279,13 +303,19 @@ use_legacy_install_flow = true
       const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
       const expectedContent = `client_id = "api-key"
 name = "app1"
+api_contact_email = "example@example.com"
 application_url = "https://example.com"
 embedded = true
-api_contact_email = "example@example.com"
 extension_directories = [ ]
 
 [webhooks]
-api_version = "2023-04"
+api_version = "2023-07"
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[pos]
+embedded = false
 
 [access_scopes]
 scopes = "read_products,write_orders"

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -92,12 +92,43 @@ function mergeAppConfiguration(localApp: AppInterface, remoteApp: OrganizationAp
   const configuration: AppConfiguration = {
     client_id: remoteApp.apiKey,
     name: remoteApp.title,
+    api_contact_email: remoteApp.contactEmail!,
     application_url: remoteApp.applicationUrl,
-    embedded: true,
+    embedded: remoteApp.embedded === undefined ? true : remoteApp.embedded,
     webhooks: {
-      api_version: '2023-04',
+      api_version: remoteApp.webhookApiVersion || '2023-07',
     },
-    api_contact_email: 'example@example.com',
+    auth: {
+      redirect_urls: remoteApp.redirectUrlWhitelist,
+    },
+    pos: {
+      embedded: remoteApp.posEmbedded || false,
+    },
+  }
+
+  const hasAnyPrivacyWebhook =
+    remoteApp.gdprWebhooks?.customerDataRequestUrl ||
+    remoteApp.gdprWebhooks?.customerDeletionUrl ||
+    remoteApp.gdprWebhooks?.shopDeletionUrl
+
+  if (hasAnyPrivacyWebhook) {
+    configuration.webhooks.privacy_compliance = {
+      customer_data_request_url: remoteApp.gdprWebhooks?.customerDataRequestUrl || '',
+      customer_deletion_url: remoteApp.gdprWebhooks?.customerDeletionUrl || '',
+      shop_deletion_url: remoteApp.gdprWebhooks?.shopDeletionUrl || '',
+    }
+  }
+
+  if (remoteApp.appProxy?.proxyUrl) {
+    configuration.app_proxy = {
+      url: remoteApp.appProxy.proxyUrl,
+      subpath: remoteApp.appProxy.proxySubPath,
+      prefix: remoteApp.appProxy.proxySubPathPrefix,
+    }
+  }
+
+  if (remoteApp.preferencesUrl) {
+    configuration.app_preferences = {url: remoteApp.preferencesUrl}
   }
 
   configuration.access_scopes = getAccessScopes(localApp, remoteApp)

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -119,11 +119,11 @@ function mergeAppConfiguration(localApp: AppInterface, remoteApp: OrganizationAp
     }
   }
 
-  if (remoteApp.appProxy?.proxyUrl) {
+  if (remoteApp.appProxy?.url) {
     configuration.app_proxy = {
-      url: remoteApp.appProxy.proxyUrl,
-      subpath: remoteApp.appProxy.proxySubPath,
-      prefix: remoteApp.appProxy.proxySubPathPrefix,
+      url: remoteApp.appProxy.url,
+      subpath: remoteApp.appProxy.subPath,
+      prefix: remoteApp.appProxy.subPathPrefix,
     }
   }
 

--- a/packages/app/src/cli/services/app/config/push.ts
+++ b/packages/app/src/cli/services/app/config/push.ts
@@ -42,9 +42,10 @@ export async function pushConfig({configuration, configurationPath}: Options) {
     }
 
     const shouldDeleteScopes =
-      configuration.access_scopes?.scopes?.length === 0 || usesLegacyScopesBehavior(configuration)
+      app.requestedAccessScopes &&
+      (configuration.access_scopes?.scopes === undefined || usesLegacyScopesBehavior(configuration))
 
-    if (app.requestedAccessScopes && shouldDeleteScopes) {
+    if (shouldDeleteScopes) {
       const clearResult: ClearScopesSchema = await partnersRequest(clearRequestedScopes, token, {apiKey: app.apiKey})
 
       if (clearResult.appRequestedAccessScopesClear?.userErrors?.length > 0) {
@@ -87,7 +88,7 @@ const getMutationVars = (app: App, configuration: CurrentAppConfiguration) => {
     preferencesUrl: configuration.app_preferences?.url ?? null,
   }
 
-  if (!usesLegacyScopesBehavior(configuration)) {
+  if (!usesLegacyScopesBehavior(configuration) && configuration.access_scopes?.scopes !== undefined) {
     variables.requestedAccessScopes = configuration.access_scopes?.scopes?.length
       ? configuration.access_scopes.scopes.split(',')
       : []


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds all the remaining fields to be queried and updated when running `link` and `push`, respectively.

### WHAT is this pull request doing?

This PR adds all the remaining fields to be queried and updated when running `link` and `push`, respectively. It also updates the delete logic for declared scopes.

### How to test your changes?
1. create an app
```bash
pnpm create-app --local --template=node --path ~/Desktop/multi-config-app
```
2. run `dev`
```bash
pnpm shopify app config link --path ~/Desktop/multi-config-app
```
3.  Add any of the fields on the `AppSchema` and run `push`:
```bash
pnpm shopify app config push --path ~/Desktop/multi-config-app`
```
4. Enable `access_scopes_as_configuration` for your app and remove `use_legacy_install_flow = true` from the TOML file.
 ```bash
pnpm shopify app config push --path ~/Desktop/multi-config-app`
```

5. Validate that the configurations are up to date via Partners dashboard.
6. Remove some of the clearable configs (ex: `app_proxy`, `webhooks.privacy_compliance`, `requestedAccessScopes`) from the TOML file and push
```bash
pnpm shopify app config push --path ~/Desktop/multi-config-app`
```
7. Validate that the configurations are up to date via Partners dashboard.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
