### PR TITLE
updated `extension generate` groupings and names

### DIFF
--- a/.changeset/rude-seals-draw.md
+++ b/.changeset/rude-seals-draw.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+minor updates to some extension names and template groupings for a better `shopify app generate extension` developer experience

--- a/packages/app/src/cli/models/templates/ui-specifications/product_subscription.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/product_subscription.ts
@@ -8,7 +8,7 @@ const productSubscriptionUIExtension: ExtensionTemplate = {
   identifier: 'subscription_ui',
   name: 'Subscription UI',
   defaultName: 'subscription-ui',
-  group: 'Merchant admin',
+  group: 'Admin',
   supportLinks: [],
   types: [
     {

--- a/packages/app/src/cli/models/templates/ui-specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/web_pixel_extension.ts
@@ -5,7 +5,7 @@ import {ExtensionTemplate} from '../../app/template.js'
  */
 const webPixelUIExtension: ExtensionTemplate = {
   identifier: 'web_pixel',
-  name: 'Web Pixel',
+  name: 'Web pixel',
   defaultName: 'web-pixel',
   group: 'Analytics',
   supportLinks: [],


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Updating extension groups + template names per @MeredithCastile's latest designs

relates to https://github.com/Shopify/partners/pull/48763 and https://github.com/Shopify/shopify-dev/pull/35237

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR updates the extension specifications in this repo. The remainder of the specifications are in `partners`, those changes are encapsulated in https://github.com/Shopify/partners/pull/48763. FWIW https://github.com/Shopify/internal-cli-foundations/issues/637 will centralize all of the specifications in `partners` which I strongly support.

**Screenshots to come once this is no longer WIP**

### How to test your changes?

**🎩  steps to come once this is no longer WIP**

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
