### PR TITLE
Always show the footer in dev, by keeping the task display running

### DIFF
--- a/.changeset/silent-pigs-wonder.md
+++ b/.changeset/silent-pigs-wonder.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+
+Keep showing the footer when running dev with extension only apps

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -133,11 +133,11 @@ async function dev(options: DevOptions) {
   const proxyUrl = usingLocalhost ? `${frontendUrl}:${proxyPort}` : frontendUrl
   const hmrServerPort = frontendConfig?.configuration.hmr_server ? await getAvailableTCPPort() : undefined
 
-  let previewUrl
+  // By default, preview goes to the direct URL for the app.
+  let previewUrl = buildAppURLForWeb(storeFqdn, apiKey)
   let shouldUpdateURLs = false
 
   if (frontendConfig || backendConfig) {
-    previewUrl = buildAppURLForWeb(storeFqdn, apiKey)
     if (options.update) {
       const newURLs = generatePartnersURLs(
         exposedUrl,
@@ -203,6 +203,7 @@ async function dev(options: DevOptions) {
   const draftableExtensions = localApp.allExtensions.filter((ext) => ext.isDraftable(unifiedDeployment))
 
   if (previewableExtensions.length > 0) {
+    // If any previewable extensions, the preview URL should be the dev console approach
     previewUrl = `${proxyUrl}/extensions/dev-console`
     const devExt = await devUIExtensionsTarget({
       app: localApp,

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -57,7 +57,7 @@ export function outputExtensionsMessages(app: AppInterface) {
   outputThemeExtensionsMessage(app.allExtensions.filter((ext) => ext.isThemeExtension))
 }
 
-export function renderDev(renderConcurrentOptions: RenderConcurrentOptions, previewUrl: string | undefined) {
+export function renderDev(renderConcurrentOptions: RenderConcurrentOptions, previewUrl: string) {
   let options = renderConcurrentOptions
 
   if (previewUrl) {
@@ -86,7 +86,7 @@ export function renderDev(renderConcurrentOptions: RenderConcurrentOptions, prev
       },
     }
   }
-  return renderConcurrent(options)
+  return renderConcurrent({...options, keepOpenAfterStopping: true})
 }
 
 function outputThemeExtensionsMessage(extensions: ExtensionInstance[]) {

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -86,7 +86,7 @@ export function renderDev(renderConcurrentOptions: RenderConcurrentOptions, prev
       },
     }
   }
-  return renderConcurrent({...options, keepOpenAfterStopping: true})
+  return renderConcurrent({...options, keepRunningAfterProcessesResolve: true})
 }
 
 function outputThemeExtensionsMessage(extensions: ExtensionInstance[]) {

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -40,7 +40,7 @@ export interface ReverseHTTPProxyTarget {
 }
 
 interface Options {
-  previewUrl: string | undefined
+  previewUrl: string
   portNumber: number
   proxyTargets: ReverseHTTPProxyTarget[]
   additionalProcesses: OutputProcess[]


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Ensures that we are consistent in showing the preview footer in dev

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Keeps the dev task list open, with its footer, even when the tasks have completed running.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Init a "none" app, and add a subscription ui extension. Run dev and observe that the footer is displayed and can be previewed with (p)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
