### PR TITLE
Correct typo in multi_line_text_field mapping

### DIFF
--- a/packages/app/src/cli/services/flow/constants.ts
+++ b/packages/app/src/cli/services/flow/constants.ts
@@ -29,7 +29,7 @@ export const ACTION_SUPPORTED_COMMERCE_OBJECTS = [
 export const uiTypesMap: [string, string][] = [
   ['boolean', 'checkbox'],
   ['email', 'email'],
-  ['multi_line_text_field', 'text-multi-lines'],
+  ['multi_line_text_field', 'text-multi-line'],
   ['number_integer', 'int'],
   ['single_line_text_field', 'text-single-line'],
   ['url', 'url'],


### PR DESCRIPTION
### WHY are these changes introduced?

Typo is causing task not to sync to Flow when `multi_line_text_field` is used.

### WHAT is this pull request doing?

Corrects the typo.

### How to test your changes?

Create a Flow extension that uses a `multi_line_text_field` field

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
