### PR TITLE
Accept scopes with spaces between commas

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -10,7 +10,7 @@ import {FunctionConfigType} from '../extensions/specifications/function.js'
 import UIExtensionTemplate from '../templates/ui-specifications/ui_extension.js'
 import {OrganizationApp} from '../organization.js'
 
-const DEFAULT_CONFIG = {
+export const DEFAULT_CONFIG = {
   application_url: 'https://myapp.com',
   client_id: '12345',
   name: 'my app',

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -1,5 +1,12 @@
-import {CurrentAppConfiguration, getUIExtensionRendererVersion, isCurrentAppSchema, isLegacyAppSchema} from './app.js'
-import {testApp, testUIExtension} from './app.test-data.js'
+import {
+  CurrentAppConfiguration,
+  getAppScopes,
+  getAppScopesArray,
+  getUIExtensionRendererVersion,
+  isCurrentAppSchema,
+  isLegacyAppSchema,
+} from './app.js'
+import {DEFAULT_CONFIG, testApp, testUIExtension} from './app.test-data.js'
 import {describe, expect, test} from 'vitest'
 import {inTemporaryDirectory, mkdir, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -169,6 +176,30 @@ describe('getUIExtensionRendererVersion', () => {
       // Then
       expect(got).toEqual('not_found')
     })
+  })
+})
+
+describe('getAppScopes', () => {
+  test('returns the scopes key when schema is legacy', () => {
+    const config = {scopes: 'read_themes,read_products'}
+    expect(getAppScopes(config)).toEqual('read_themes,read_products')
+  })
+
+  test('returns the access_scopes.scopes key when schema is current', () => {
+    const config = {...DEFAULT_CONFIG, access_scopes: {scopes: 'read_themes,read_themes'}}
+    expect(getAppScopes(config)).toEqual('read_themes,read_themes')
+  })
+})
+
+describe('getAppScopesArray', () => {
+  test('returns the scopes key when schema is legacy', () => {
+    const config = {scopes: 'read_themes, read_order ,write_products'}
+    expect(getAppScopesArray(config)).toEqual(['read_themes', 'read_order', 'write_products'])
+  })
+
+  test('returns the access_scopes.scopes key when schema is current', () => {
+    const config = {...DEFAULT_CONFIG, access_scopes: {scopes: 'read_themes, read_order ,write_products'}}
+    expect(getAppScopesArray(config)).toEqual(['read_themes', 'read_order', 'write_products'])
   })
 })
 

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -102,6 +102,15 @@ export function getAppScopes(config: AppConfiguration) {
   }
 }
 
+/**
+ * Get scopes as an array from a given app.toml config file.
+ * @param config - a configuration file
+ */
+export function getAppScopesArray(config: AppConfiguration) {
+  const scopes = getAppScopes(config)
+  return scopes.length ? scopes.split(',').map((scope) => scope.trim()) : []
+}
+
 export function usesLegacyScopesBehavior(app: AppInterface | AppConfiguration) {
   const config = 'configurationPath' in app ? app.configuration : app
 

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -5,9 +5,9 @@ import {
   App,
   AppInterface,
   WebType,
-  getAppScopes,
   AppConfiguration,
   isCurrentAppSchema,
+  getAppScopesArray,
 } from './app.js'
 import {configurationFileNames, dotEnvFileNames} from '../../constants.js'
 import metadata from '../../metadata.js'
@@ -687,12 +687,7 @@ async function logMetadataForLoadedApp(
       app_extensions_ui_count: extensionUICount,
       app_name_hash: hashString(app.name),
       app_path_hash: hashString(app.directory),
-      app_scopes: JSON.stringify(
-        getAppScopes(app.configuration)
-          .split(',')
-          .map((scope) => scope.trim())
-          .sort(),
-      ),
+      app_scopes: JSON.stringify(getAppScopesArray(app.configuration).sort()),
       app_web_backend_any: webBackendCount > 0,
       app_web_backend_count: webBackendCount,
       app_web_custom_layout: loadingStrategy.usedCustomLayoutForWeb,

--- a/packages/app/src/cli/services/app/config/push.ts
+++ b/packages/app/src/cli/services/app/config/push.ts
@@ -6,6 +6,7 @@ import {
   CurrentAppConfiguration,
   isCurrentAppSchema,
   usesLegacyScopesBehavior,
+  getAppScopesArray,
 } from '../../../models/app/app.js'
 import {DeleteAppProxySchema, deleteAppProxy} from '../../../api/graphql/app_proxy_delete.js'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
@@ -89,9 +90,7 @@ const getMutationVars = (app: App, configuration: CurrentAppConfiguration) => {
   }
 
   if (!usesLegacyScopesBehavior(configuration) && configuration.access_scopes?.scopes !== undefined) {
-    variables.requestedAccessScopes = configuration.access_scopes?.scopes?.length
-      ? configuration.access_scopes.scopes.split(',')
-      : []
+    variables.requestedAccessScopes = getAppScopesArray(configuration)
   }
 
   if (configuration.app_proxy) {

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -1,6 +1,6 @@
 import {outputEnv} from './app/env/show.js'
 import {CachedAppInfo, getAppInfo} from './local-storage.js'
-import {AppInterface, getAppScopes} from '../models/app/app.js'
+import {AppInterface, getAppScopesArray} from '../models/app/app.js'
 import {configurationFileNames} from '../constants.js'
 import {ExtensionInstance} from '../models/extensions/extension-instance.js'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
@@ -204,9 +204,7 @@ class AppInfo {
 
   accessScopesSection(): [string, string] {
     const title = 'Access Scopes in Root TOML File'
-    const lines = getAppScopes(this.app.configuration)
-      .split(',')
-      .map((scope) => [scope])
+    const lines = getAppScopesArray(this.app.configuration).map((scope) => [scope])
     return [title, linesToColumns(lines)]
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Setting scopes with commas was not passing validation.

### WHAT is this pull request doing?

I added a `trim()` to the split scope names and extracted into a function and used it wherever we were splitting the scopes before.

### How to test your changes?

1. create an app
```bash
pnpm create-app --local --template=node --path ~/Desktop
```
2. link an app
```bash
pnpm shopify app config link --path ~/Desktop/scopes-app
```
3. enable the scopes betas
4. change scopes to contain a space, like `scopes = "write_products, read_themes"`
5. push config
```bash
pnpm shopify app config push --path ~/Desktop/scopes-app
```
6. 👀 see how read themes was added as a requested scope

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
