### PR TITLE
Fix registered but not released extensions appearing in Update and Missing locally sections in deploy confirmation prompt

### DIFF
--- a/.changeset/twelve-crabs-switch.md
+++ b/.changeset/twelve-crabs-switch.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+
+The status of registered, but unreleased, CLI-managed extensions in the deploy confirmation prompt are based on their relation to the active app version (or a blank slate if there's no active version)

--- a/packages/app/src/cli/services/context/prompts.test.ts
+++ b/packages/app/src/cli/services/context/prompts.test.ts
@@ -1,144 +1,310 @@
-import {deployConfirmationPrompt} from './prompts.js'
+import {deployConfirmationPrompt, SourceSummary} from './prompts.js'
+import {RemoteSource, LocalSource} from './identifiers.js'
+import {IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
-import {InfoTableSection, renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
+import {renderConfirmationPrompt, InfoTableSection} from '@shopify/cli-kit/node/ui'
 import {describe, expect, test, vi} from 'vitest'
 
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('@shopify/cli-kit/node/api/partners')
 
 describe('deployConfirmationPrompt', () => {
-  test('when legacy deployment mode should render confirmation prompt with the source summary', async () => {
-    // Given
-    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+  describe('when legacy deployment mode', () => {
+    test('renders confirmation prompt with the source summary', async () => {
+      // Given
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
-    // When
-    const response = await deployConfirmationPrompt(buildSourceSummary(), 'legacy', 'apiKey', 'token')
+      // When
+      const response = await deployConfirmationPrompt(
+        buildSourceSummary({
+          identifiers: {...identifier1, ...identifier2},
+          toCreate: [createdExtension],
+          onlyRemote: [remoteOnlyExtension],
+          dashboardOnly: [dashboardOnlyExtension],
+        }),
+        'legacy',
+        'apiKey',
+        'token',
+      )
 
-    // Then
-    expect(response).toBe(true)
-    expect(renderConfirmationPrompt).toHaveBeenCalledWith(legacyRenderConfirmationPromptContent())
-  })
-
-  test('when unified deployment mode but without any active version should render confirmation prompt with the source summary', async () => {
-    // Given
-    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
-    vi.mocked(partnersRequest).mockResolvedValue({app: {}})
-
-    // When
-    const response = await deployConfirmationPrompt(buildSourceSummary(), 'unified', 'apiKey', 'token')
-
-    // Then
-    expect(response).toBe(true)
-    expect(renderConfirmationPrompt).toHaveBeenCalledWith(
-      legacyRenderConfirmationPromptContent('Yes, release this new version'),
-    )
-  })
-
-  test('when unified deployment mode and an active version should render confirmation prompt with the comparison between source summary and active version', async () => {
-    // Given
-    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
-    vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
-
-    // When
-    const response = await deployConfirmationPrompt(buildSourceSummary(), 'unified', 'apiKey', 'token')
-
-    // Then
-    expect(response).toBe(true)
-    expect(renderConfirmationPrompt).toHaveBeenCalledWith(
-      unifiedRenderConfirmationPromptContent('Yes, release this new version'),
-    )
-  })
-
-  test('when unified deployment mode and current extension registration and active version include same dashboard extension we should show it only in the dashboard section', async () => {
-    // Given
-    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
-    vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
-    const sourceSummary = buildSourceSummary()
-    sourceSummary.dashboardOnly.push({
-      id: 'dashboard_id1',
-      uuid: 'dashboard_uuid1',
-      title: 'dashboard_title1',
-      type: 'dashboard_type1',
+      // Then
+      expect(response).toBe(true)
+      expect(renderConfirmationPrompt).toHaveBeenCalledWith(legacyRenderConfirmationPromptContent())
     })
 
-    // When
-    const response = await deployConfirmationPrompt(sourceSummary, 'unified', 'apiKey', 'token')
+    test("doesn't call renderConfirmationPrompt() when no extensions to deploy and infoTable is empty", async () => {
+      // Given
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
-    // Then
-    // Add 'dashboard_title1' to the dashboar section
-    const expectedContent = unifiedRenderConfirmationPromptContent('Yes, release this new version')
-    expectedContent.infoTable[0]?.items?.push(['dashboard_title1', {subdued: '(from Partner Dashboard)'}])
-    // Remove 'dashboard_title1' from the deleted section
-    expectedContent.infoTable[1]?.items?.pop()
-    expect(response).toBe(true)
-    expect(renderConfirmationPrompt).toHaveBeenCalledWith(expectedContent)
+      // When
+      const response = await deployConfirmationPrompt(buildSourceSummary(), 'legacy', 'apiKey', 'token')
+
+      // Then
+      expect(response).toBe(true)
+      expect(renderConfirmationPrompt).not.toHaveBeenCalled()
+    })
   })
 
-  test('when unified deployment mode and current dashboard extension registration and non dashboard active version include same extension we should show as new, not dashboard', async () => {
-    // Given
-    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
-    vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
-    // Add dashboard extension to the current non dashboard registrations
-    let sourceSummary = buildSourceSummary()
-    sourceSummary = {
-      ...sourceSummary,
-      identifiers: {
-        ...sourceSummary.identifiers,
-        ...{dashboard_title2: 'dashboard_uuid2'},
-      },
-    }
+  describe('when unified deployment mode and app has an active version', () => {
+    test('renders confirmation prompt with the comparison between source summary and active version', async () => {
+      // Given
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
 
-    // When
-    const response = await deployConfirmationPrompt(sourceSummary, 'unified', 'apiKey', 'token')
+      // When
+      const response = await deployConfirmationPrompt(
+        buildSourceSummary({
+          identifiers: {...identifier1, ...identifier2},
+          toCreate: [createdExtension],
+          onlyRemote: [remoteOnlyExtension],
+          dashboardOnly: [dashboardOnlyExtension],
+        }),
+        'unified',
+        'apiKey',
+        'token',
+      )
 
-    // Then
-    // Remove dashboard section
-    const expectedContent = unifiedRenderConfirmationPromptContent('Yes, release this new version')
-    // Add dashboard extension to the create section
-    expectedContent.infoTable[0]?.items?.splice(1, 1)
-    expectedContent.infoTable[0]?.items?.splice(2, 1)
-    expectedContent.infoTable[0]?.items?.splice(
-      1,
-      0,
-      ['dashboard_title2', {subdued: '(new)'}],
-      ['id1', {subdued: '(new)'}],
-    )
-    expect(response).toBe(true)
-    expect(renderConfirmationPrompt).toHaveBeenCalledWith(expectedContent)
+      // Then
+      expect(response).toBe(true)
+      expect(renderConfirmationPrompt).toHaveBeenCalledWith(
+        unifiedRenderConfirmationPromptContent({
+          infoTable: [
+            {
+              header: 'Includes:',
+              items: [
+                ['extension1', {subdued: '(new)'}],
+                ['id1', {subdued: '(new)'}],
+                'extension2',
+                ['dashboard_title2', {subdued: '(from Partner Dashboard)'}],
+              ],
+              bullet: '+',
+            },
+            {
+              header: 'Removes:',
+              helperText: 'This can permanently delete app user data.',
+              items: ['title3', 'dashboard_title1'],
+              bullet: '-',
+            },
+          ],
+        }),
+      )
+    })
+
+    test('when current extension registration and active version include same dashboard extension we should show it only in the dashboard section', async () => {
+      // Given
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
+
+      const dashboardExtensionIncludedInActiveVersion = {
+        id: 'dashboard_id1',
+        uuid: 'dashboard_uuid1',
+        title: 'dashboard_title1',
+        type: 'dashboard_type1',
+      }
+
+      // When
+      const response = await deployConfirmationPrompt(
+        buildSourceSummary({
+          identifiers: {...identifier1, ...identifier2},
+          toCreate: [createdExtension],
+          onlyRemote: [remoteOnlyExtension],
+          dashboardOnly: [dashboardOnlyExtension, dashboardExtensionIncludedInActiveVersion],
+        }),
+        'unified',
+        'apiKey',
+        'token',
+      )
+
+      // Then
+      expect(response).toBe(true)
+      expect(renderConfirmationPrompt).toHaveBeenCalledWith(
+        unifiedRenderConfirmationPromptContent({
+          infoTable: [
+            {
+              header: 'Includes:',
+              items: [
+                ['extension1', {subdued: '(new)'}],
+                ['id1', {subdued: '(new)'}],
+                'extension2',
+                ['dashboard_title2', {subdued: '(from Partner Dashboard)'}],
+                ['dashboard_title1', {subdued: '(from Partner Dashboard)'}],
+              ],
+              bullet: '+',
+            },
+            {
+              header: 'Removes:',
+              helperText: 'This can permanently delete app user data.',
+              items: ['title3'],
+              bullet: '-',
+            },
+          ],
+        }),
+      )
+    })
+
+    test('when current dashboard extension registration and non dashboard active version include same extension we should show as new, not dashboard', async () => {
+      // Given
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
+      // Add dashboard extension to the current non dashboard registrations
+      const dashboardIdentifier = {dashboard_title2: 'dashboard_uuid2'}
+
+      // When
+      const response = await deployConfirmationPrompt(
+        buildSourceSummary({
+          identifiers: {...identifier1, ...identifier2, ...dashboardIdentifier},
+          toCreate: [createdExtension],
+          onlyRemote: [remoteOnlyExtension],
+          dashboardOnly: [dashboardOnlyExtension],
+        }),
+        'unified',
+        'apiKey',
+        'token',
+      )
+
+      // Then
+      expect(response).toBe(true)
+      expect(renderConfirmationPrompt).toHaveBeenCalledWith(
+        unifiedRenderConfirmationPromptContent({
+          infoTable: [
+            {
+              header: 'Includes:',
+              items: [
+                ['extension1', {subdued: '(new)'}],
+                ['dashboard_title2', {subdued: '(new)'}],
+                ['id1', {subdued: '(new)'}],
+                'extension2',
+              ],
+              bullet: '+',
+            },
+            {
+              header: 'Removes:',
+              helperText: 'This can permanently delete app user data.',
+              items: ['title3', 'dashboard_title1'],
+              bullet: '-',
+            },
+          ],
+        }),
+      )
+    })
+  })
+
+  describe("when unified deployment mode and app doesn't have an active version", () => {
+    test('renders confirmation prompt with registered, unreleased CLI extensions as new extensions', async () => {
+      // Given
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(partnersRequest).mockResolvedValue({app: {activeAppVersion: null}})
+
+      // When
+      const response = await deployConfirmationPrompt(
+        buildSourceSummary({identifiers: {...identifier1}}),
+        'unified',
+        'apiKey',
+        'token',
+      )
+
+      // Then
+      expect(response).toBe(true)
+      expect(renderConfirmationPrompt).toHaveBeenCalledWith(
+        unifiedRenderConfirmationPromptContent({
+          infoTable: [
+            {
+              header: 'Includes:',
+              items: [['extension1', {subdued: '(new)'}]],
+              bullet: '+',
+            },
+          ],
+        }),
+      )
+    })
+
+    test("doesn't render registered CLI extension in Removes section of confirmation prompt when it's missing locally", async () => {
+      // Given
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(partnersRequest).mockResolvedValue({app: {activeAppVersion: null}})
+
+      // When
+      const response = await deployConfirmationPrompt(
+        buildSourceSummary({onlyRemote: [remoteOnlyExtension]}),
+        'unified',
+        'apiKey',
+        'token',
+      )
+
+      // Then
+      expect(response).toBe(true)
+      expect(renderConfirmationPrompt).toHaveBeenCalledWith(unifiedRenderConfirmationPromptContent({infoTable: []}))
+    })
+
+    test('renders confirmation prompt with empty infoTable when no changes are being released to users', async () => {
+      // Given
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(partnersRequest).mockResolvedValue({app: {activeAppVersion: null}})
+
+      // When
+      const response = await deployConfirmationPrompt(buildSourceSummary(), 'unified', 'apiKey', 'token')
+
+      // Then
+      expect(response).toBe(true)
+      expect(renderConfirmationPrompt).toHaveBeenCalledWith(unifiedRenderConfirmationPromptContent({infoTable: []}))
+    })
+
+    test('renders confirmation prompt with empty infoTable when remote only extensions exist but are missing locally', async () => {
+      // Given
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(partnersRequest).mockResolvedValue({app: {activeAppVersion: null}})
+
+      // When
+      const response = await deployConfirmationPrompt(
+        buildSourceSummary({onlyRemote: [remoteOnlyExtension]}),
+        'unified',
+        'apiKey',
+        'token',
+      )
+
+      // Then
+      expect(response).toBe(true)
+      expect(renderConfirmationPrompt).toHaveBeenCalledWith(unifiedRenderConfirmationPromptContent({infoTable: []}))
+    })
   })
 })
 
-function buildSourceSummary() {
+const identifier1 = {extension1: 'uuid1'}
+const identifier2 = {extension2: 'uuid2'}
+const createdExtension = {
+  localIdentifier: 'id1',
+  graphQLType: 'type1',
+  type: 'type1',
+  configuration: {name: 'name1'},
+}
+const remoteOnlyExtension = {
+  id: 'remote_id1',
+  uuid: 'remote_uuid1',
+  title: 'remote_title1',
+  type: 'remote_type1',
+}
+const dashboardOnlyExtension = {
+  id: 'dashboard_id2',
+  uuid: 'dashboard_uuid2',
+  title: 'dashboard_title2',
+  type: 'dashboard_type2',
+}
+interface BuildSourceSummaryOptions {
+  identifiers?: IdentifiersExtensions
+  toCreate?: LocalSource[]
+  onlyRemote?: RemoteSource[]
+  dashboardOnly?: RemoteSource[]
+}
+
+function buildSourceSummary(options: BuildSourceSummaryOptions = {}): SourceSummary {
+  const {identifiers = {}, toCreate = [], onlyRemote = [], dashboardOnly = []} = options
+
   return {
     question: 'question',
-    identifiers: {
-      extension1: 'uuid1',
-      extension2: 'uuid2',
-    },
-    toCreate: [
-      {
-        localIdentifier: 'id1',
-        graphQLType: 'type1',
-        type: 'type1',
-        configuration: {name: 'name1'},
-      },
-    ],
-    onlyRemote: [
-      {
-        id: 'remote_id1',
-        uuid: 'remote_uuid1',
-        title: 'remote_title1',
-        type: 'remote_type1',
-      },
-    ],
-    dashboardOnly: [
-      {
-        id: 'dashboard_id2',
-        uuid: 'dashboard_uuid2',
-        title: 'dashboard_title2',
-        type: 'dashboard_type2',
-      },
-    ],
+    identifiers,
+    toCreate,
+    onlyRemote,
+    dashboardOnly,
   }
 }
 
@@ -218,28 +384,17 @@ function activeVersionContent() {
   }
 }
 
-function unifiedRenderConfirmationPromptContent(confirmationMessage = 'Yes, deploy to push changes') {
+interface UnifiedRenderConfirmationPromptContentOptions {
+  infoTable?: InfoTableSection[]
+}
+
+function unifiedRenderConfirmationPromptContent(options: UnifiedRenderConfirmationPromptContentOptions = {}) {
+  const {infoTable} = options
+
   return {
     cancellationMessage: 'No, cancel',
-    confirmationMessage,
-    infoTable: [
-      {
-        header: 'Includes:',
-        items: [
-          ['extension1', {subdued: '(new)'}],
-          ['id1', {subdued: '(new)'}],
-          'extension2',
-          ['dashboard_title2', {subdued: '(from Partner Dashboard)'}],
-        ],
-        bullet: '+',
-      },
-      {
-        header: 'Removes:',
-        helperText: 'This can permanently delete app user data.',
-        items: ['title3', 'dashboard_title1'],
-        bullet: '-',
-      },
-    ] as InfoTableSection[],
+    confirmationMessage: 'Yes, release this new version',
+    infoTable,
     message: 'question',
   }
 }

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.test.tsx
@@ -1,0 +1,201 @@
+import {PromptLayout} from './PromptLayout.js'
+import {render} from '../../../testing/ui.js'
+import {PromptState} from '../../hooks/use-prompt.js'
+import {describe, expect, test} from 'vitest'
+import React from 'react'
+import {Box, Text} from 'ink'
+
+describe('PromptLayout', async () => {
+  test("doesn't add unnecessary margins when infoTable is an empty array", async () => {
+    const items = [
+      {label: 'first', value: 'first'},
+      {label: 'second', value: 'second'},
+      {label: 'third', value: 'third'},
+      {label: 'fourth', value: 'fourth'},
+    ]
+
+    const renderInstance = render(
+      <PromptLayout
+        message="Associate your project with the org Castile Ventures?"
+        infoTable={[]}
+        state={PromptState.Idle}
+        input={
+          <Box flexDirection="column">
+            {items.map((item) => (
+              <Text key={item.value}>{item.label}</Text>
+            ))}
+          </Box>
+        }
+      />,
+    )
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?
+
+      first
+      second
+      third
+      fourth
+      "
+    `)
+  })
+
+  test("doesn't add unnecessary margins when infoTable is an empty object", async () => {
+    const items = [
+      {label: 'first', value: 'first'},
+      {label: 'second', value: 'second'},
+      {label: 'third', value: 'third'},
+      {label: 'fourth', value: 'fourth'},
+    ]
+
+    const renderInstance = render(
+      <PromptLayout
+        message="Associate your project with the org Castile Ventures?"
+        infoTable={{}}
+        state={PromptState.Idle}
+        input={
+          <Box flexDirection="column">
+            {items.map((item) => (
+              <Text key={item.value}>{item.label}</Text>
+            ))}
+          </Box>
+        }
+      />,
+    )
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?
+
+      first
+      second
+      third
+      fourth
+      "
+    `)
+  })
+
+  test("doesn't add unnecessary margins when infoTable is empty and there are other elements in the header", async () => {
+    const items = [
+      {label: 'first', value: 'first'},
+      {label: 'second', value: 'second'},
+      {label: 'third', value: 'third'},
+      {label: 'fourth', value: 'fourth'},
+    ]
+
+    const gitDiff = {
+      baselineContent: 'hello',
+      updatedContent: 'hello',
+    }
+
+    const infoMessage = {
+      title: {text: 'some title'},
+      body: 'some body',
+    }
+
+    const renderInstance = render(
+      <PromptLayout
+        message="Associate your project with the org Castile Ventures?"
+        infoTable={[]}
+        infoMessage={infoMessage}
+        gitDiff={gitDiff}
+        state={PromptState.Idle}
+        input={
+          <Box flexDirection="column">
+            {items.map((item) => (
+              <Text key={item.value}>{item.label}</Text>
+            ))}
+          </Box>
+        }
+      />,
+    )
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?
+
+         ┃  some title
+         ┃
+         ┃  some body
+         ┃
+         ┃  No changes.
+
+      first
+      second
+      third
+      fourth
+      "
+    `)
+  })
+
+  test('can have all elements visible in the header at the same time', async () => {
+    const items = [
+      {label: 'first', value: 'first'},
+      {label: 'second', value: 'second'},
+      {label: 'third', value: 'third'},
+      {label: 'fourth', value: 'fourth'},
+    ]
+
+    const gitDiff = {
+      baselineContent: 'hello',
+      updatedContent: 'hello',
+    }
+
+    const infoMessage = {
+      title: {text: 'some title'},
+      body: 'some body',
+    }
+
+    const infoTable = {
+      header1: ['item 1', 'item 2', 'item 3'],
+      header2: ['item 4', 'item 5', 'item 6'],
+      header3: ['item 7', 'item 8', 'item 9'],
+    }
+
+    const renderInstance = render(
+      <PromptLayout
+        message="Associate your project with the org Castile Ventures?"
+        infoTable={infoTable}
+        infoMessage={infoMessage}
+        gitDiff={gitDiff}
+        state={PromptState.Idle}
+        input={
+          <Box flexDirection="column">
+            {items.map((item) => (
+              <Text key={item.value}>{item.label}</Text>
+            ))}
+          </Box>
+        }
+      />,
+    )
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?
+
+         ┃  some title
+         ┃
+         ┃  some body
+         ┃
+         ┃  [1mHeader1[22m
+         ┃  • item 1
+         ┃  • item 2
+         ┃  • item 3
+         ┃
+         ┃  [1mHeader2[22m
+         ┃  • item 4
+         ┃  • item 5
+         ┃  • item 6
+         ┃
+         ┃  [1mHeader3[22m
+         ┃  • item 7
+         ┃  • item 8
+         ┃  • item 9
+         ┃
+         ┃  No changes.
+
+      first
+      second
+      third
+      fourth
+      "
+    `)
+  })
+})

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
@@ -88,6 +88,8 @@ const PromptLayout = ({
   }, [wrapperHeight, promptAreaHeight, stdout, availableLines, inputFixedAreaHeight])
 
   const {isAborted} = useAbortSignal(abortSignal)
+  // Object.keys on an array returns the indices as strings
+  const showInfoTable = infoTable && Object.keys(infoTable).length > 0
 
   return isAborted ? null : (
     <Box flexDirection="column" marginBottom={1} ref={wrapperRef}>
@@ -100,7 +102,7 @@ const PromptLayout = ({
           {header}
         </Box>
 
-        {(infoTable || infoMessage || gitDiff) && state !== PromptState.Submitted ? (
+        {(showInfoTable || infoMessage || gitDiff) && state !== PromptState.Submitted ? (
           <Box
             marginTop={1}
             marginLeft={3}
@@ -114,7 +116,7 @@ const PromptLayout = ({
             gap={1}
           >
             {infoMessage ? <InfoMessage message={infoMessage} /> : null}
-            {infoTable ? <InfoTable table={infoTable} /> : null}
+            {showInfoTable ? <InfoTable table={infoTable} /> : null}
             {gitDiff ? <GitDiff gitDiff={gitDiff} /> : null}
           </Box>
         ) : null}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-foundations/issues/168

Context: A local extension that is registered but not included in the active version and is being deployed
This extension will appear in the in the Update section of the deploy confirmation prompt. Since we want to compare changes being deployed against the active state, this extension should appear in the Add section instead. If this extension is removed locally, it currently appears in the Removed section. Instead, it should not be referenced in the confirmation prompt.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Changes to change deploy behaviour:
- The early return when an app has no active version is removed so that `deployConfirmationPrompt()` doesn't fall back to `buildLegacyDeploymentInfoPrompt()`
- Added empty array defaults for `nonDashboardRemoteRegistrations` and `onlyRemote` for when there's no active version
- `deployConfirmationPrompt()` will only early return if the extensions `infoTable` is empty and `deploymentMode` is `legacy` so that the deploy will continue for an empty version

Test changes:
- Added tests to cover the bug cases
- Added some `describe` blocks to organize the tests and break down the long test names
- Refactored `buildSourceSummary()` and `unifiedRenderConfirmationPromptContent()` to make them reusable across the different tests

**Before**
With local extension:
![with extension - main](https://github.com/Shopify/cli/assets/65420305/8c5156d1-2957-4734-8fce-64cb75044e3f)
After removing local extension:
![without extension - main](https://github.com/Shopify/cli/assets/65420305/e7535de0-53a5-4357-8f31-ce70185560b9)


**After**
With local extension:
![with-local-extension](https://github.com/Shopify/cli/assets/65420305/6ba67aaa-4ebf-4459-bed3-5b81e79070ef)
After removing local extension:
![without-local-extension](https://github.com/Shopify/cli/assets/65420305/f1313147-313d-4b95-8258-77f04f0d85a2)

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Create an app: `bin/create-test-app.js --bare`
2. Generate a web pixel extension: `pnpm shopify app generate extension`
3. Enable the `app_unified_deployment` app beta
4. Run dev: `pnpm shopify app dev`
5. Run deploy: `pnpm shopify app deploy`
6. Delete the web pixel extension locally
7. Run deploy: `pnpm shopify app deploy`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
