### PR TITLE
ml/toml and validation updates

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_action.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_action.ts
@@ -1,9 +1,10 @@
 import {BaseSchemaWithHandle} from '../schemas.js'
 import {createExtensionSpecification} from '../specification.js'
 import {
-  validateNonCommerceObjectShape,
+  validateFieldShape,
   startsWithHttps,
   validateCustomConfigurationPageConfig,
+  validateReturnTypeConfig,
 } from '../../../services/flow/validation.js'
 import {serializeFields} from '../../../services/flow/serialize-fields.js'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -25,8 +26,12 @@ export const FlowActionExtensionSchema = BaseSchemaWithHandle.extend({
     config.validation_url,
   )
   const fields = config.settings?.fields ?? []
-  const settingsFieldsAreValid = fields.every((field) => validateNonCommerceObjectShape(field, 'flow_action'))
-  return configurationPageIsValid && settingsFieldsAreValid
+  const settingsFieldsAreValid = fields.every((field, index) =>
+    validateFieldShape(field, 'flow_action', config.handle, index),
+  )
+  const returnTypeIsValid = validateReturnTypeConfig(config.return_type_ref, config.schema)
+
+  return configurationPageIsValid && settingsFieldsAreValid && returnTypeIsValid
 })
 
 /**

--- a/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
@@ -1,6 +1,6 @@
 import {BaseSchemaWithHandle} from '../schemas.js'
 import {createExtensionSpecification} from '../specification.js'
-import {validateNonCommerceObjectShape} from '../../../services/flow/validation.js'
+import {validateFieldShape} from '../../../services/flow/validation.js'
 import {serializeFields} from '../../../services/flow/serialize-fields.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -8,7 +8,9 @@ export const FlowTriggerExtensionSchema = BaseSchemaWithHandle.extend({
   type: zod.literal('flow_trigger'),
 }).refine((config) => {
   const fields = config.settings?.fields ?? []
-  const settingsFieldsAreValid = fields.every((field) => validateNonCommerceObjectShape(field, 'flow_trigger'))
+  const settingsFieldsAreValid = fields.every((field, index) =>
+    validateFieldShape(field, 'flow_trigger', config.handle, index),
+  )
   return settingsFieldsAreValid
 })
 

--- a/packages/app/src/cli/services/flow/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/flow/extension-to-toml.test.ts
@@ -34,17 +34,13 @@ config_page_preview_url = "https://previewurl.test.dev"
 validation_url = "https://validation.test.dev"
 
 [[settings.fields]]
-key = "customer_id"
 type = "customer_reference"
 description = ""
-name = "Customer ID"
 required = true
 
 [[settings.fields]]
-key = "product_id"
 type = "product_reference"
 description = ""
-name = "Product ID"
 required = true
 
 [[settings.fields]]
@@ -94,7 +90,6 @@ handle = "trigger-ext"
 description = "trigger description"
 
 [[settings.fields]]
-key = "customer_id"
 type = "customer_reference"
 description = ""
 

--- a/packages/app/src/cli/services/flow/serialize-partners-fields.ts
+++ b/packages/app/src/cli/services/flow/serialize-partners-fields.ts
@@ -30,13 +30,11 @@ export const serializeCommerceObjectField = (field: SerializedField, type: FlowP
   const fieldType = isAction ? `${field.name.replace('_id', '')}_reference` : `${field.uiType}_reference`
 
   const serializedField: ConfigField = {
-    key: field.name,
     type: fieldType,
     description: field.description,
   }
 
   if (type === 'flow_action_definition') {
-    serializedField.name = field.label
     serializedField.required = field.required
   }
 

--- a/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
+++ b/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
@@ -1,4 +1,5 @@
 name = "{{ name }}"
+description = "Your description"
 
 [[extensions]]
 type = "flow_trigger"

--- a/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
+++ b/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
@@ -1,5 +1,4 @@
 name = "{{ name }}"
-handle = "{{ handle }}"
 
 [[extensions]]
 type = "flow_trigger"

--- a/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
+++ b/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
@@ -1,6 +1,5 @@
 name = "{{ name }}"
 handle = "{{ handle }}"
-description = "Your description"
 
 [[extensions]]
 type = "flow_trigger"
@@ -13,4 +12,4 @@ handle = "{{ handle }}"
 
   [[settings.fields]]
   type = "single_line_text_field"
-  key = "your-field-key"
+  key = "Your field key"


### PR DESCRIPTION
### WHY are these changes introduced?

Did a bug bash, noticed some inconsistencies in the TOML files and validation. [Issue](https://github.com/Shopify/flow/issues/19690).

### WHAT is this pull request doing?

- Standardize the description property so that it is located at the extension level
- Update the generate command to generate the handle at the extension level
- Throw an error when a partner adds a key to a commerce object field
- Update trigger template to include a valid key for field
- Update the validation schema for flow actions

### How to test your changes?

Pull down the branch and create an action/trigger. Check that the generated files are correct. Test the updated validation. Deploy.
