### PR TITLE
Remove dates from concurrent output

### DIFF
--- a/.changeset/moody-forks-exercise.md
+++ b/.changeset/moody-forks-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Remove dates from dev and deploy logs

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
@@ -72,12 +72,12 @@ describe('ConcurrentOutput', () => {
 
     // Then
     expect(unstyled(renderInstance.lastFrame()!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
-      "0000-00-00 00:00:00 │ backend  │ first backend message
-      0000-00-00 00:00:00 │ backend  │ second backend message
-      0000-00-00 00:00:00 │ backend  │ third backend message
-      0000-00-00 00:00:00 │ frontend │ first frontend message
-      0000-00-00 00:00:00 │ frontend │ second frontend message
-      0000-00-00 00:00:00 │ frontend │ third frontend message
+      "00:00:00 │ backend  │ first backend message
+      00:00:00 │ backend  │ second backend message
+      00:00:00 │ backend  │ third backend message
+      00:00:00 │ frontend │ first frontend message
+      00:00:00 │ frontend │ second frontend message
+      00:00:00 │ frontend │ third frontend message
 
       › Press p │ preview in your browser
       › Press q │ quit
@@ -153,12 +153,12 @@ describe('ConcurrentOutput', () => {
 
     // Then
     expect(unstyled(getLastFrameAfterUnmount(renderInstance)!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
-      "0000-00-00 00:00:00 │ backend  │ first backend message
-      0000-00-00 00:00:00 │ backend  │ second backend message
-      0000-00-00 00:00:00 │ backend  │ third backend message
-      0000-00-00 00:00:00 │ frontend │ first frontend message
-      0000-00-00 00:00:00 │ frontend │ second frontend message
-      0000-00-00 00:00:00 │ frontend │ third frontend message
+      "00:00:00 │ backend  │ first backend message
+      00:00:00 │ backend  │ second backend message
+      00:00:00 │ backend  │ third backend message
+      00:00:00 │ frontend │ first frontend message
+      00:00:00 │ frontend │ second frontend message
+      00:00:00 │ frontend │ third frontend message
 
       Preview URL: https://shopify.com
       "
@@ -234,9 +234,9 @@ describe('ConcurrentOutput', () => {
     abortController.abort()
 
     expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "0000-00-00 00:00:00 │ backend │ first backend message
-      0000-00-00 00:00:00 │ backend │ second backend message
-      0000-00-00 00:00:00 │ backend │ third backend message
+      "00:00:00 │ backend │ first backend message
+      00:00:00 │ backend │ second backend message
+      00:00:00 │ backend │ third backend message
 
       Preview URL: https://shopify.com
       "
@@ -283,9 +283,9 @@ describe('ConcurrentOutput', () => {
     await expect(renderInstance.waitUntilExit()).rejects.toThrowError('something went wrong')
 
     expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "0000-00-00 00:00:00 │ backend │ first backend message
-      0000-00-00 00:00:00 │ backend │ second backend message
-      0000-00-00 00:00:00 │ backend │ third backend message
+      "00:00:00 │ backend │ first backend message
+      00:00:00 │ backend │ second backend message
+      00:00:00 │ backend │ third backend message
 
       Preview URL: https://shopify.com
       "
@@ -328,9 +328,9 @@ describe('ConcurrentOutput', () => {
     await renderInstance.waitUntilExit()
 
     expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "0000-00-00 00:00:00 │ backend │ first backend message
-      0000-00-00 00:00:00 │ backend │ second backend message
-      0000-00-00 00:00:00 │ backend │ third backend message
+      "00:00:00 │ backend │ first backend message
+      00:00:00 │ backend │ second backend message
+      00:00:00 │ backend │ third backend message
 
       Preview URL: https://shopify.com
       "
@@ -375,9 +375,9 @@ describe('ConcurrentOutput', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000))
 
     expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "0000-00-00 00:00:00 │ backend │ first backend message
-      0000-00-00 00:00:00 │ backend │ second backend message
-      0000-00-00 00:00:00 │ backend │ third backend message
+      "00:00:00 │ backend │ first backend message
+      00:00:00 │ backend │ second backend message
+      00:00:00 │ backend │ third backend message
 
       › Press p │ preview in your browser
       › Press q │ quit

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -39,6 +39,24 @@ enum ConcurrentOutputState {
   Stopped = 'stopped',
 }
 
+function addLeadingZero(number: number) {
+  if (number < 10) {
+    return `0${number}`
+  } else {
+    return number.toString()
+  }
+}
+
+function currentTime() {
+  const currentDateTime = new Date()
+
+  const hours = addLeadingZero(currentDateTime.getHours())
+  const minutes = addLeadingZero(currentDateTime.getMinutes())
+  const seconds = addLeadingZero(currentDateTime.getSeconds())
+
+  return `${hours}:${minutes}:${seconds}`
+}
+
 /**
  * Renders output from concurrent processes to the terminal.
  * Output will be divided in a three column layout
@@ -166,7 +184,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
                   <Text color={chunk.color}>
                     {showTimestamps ? (
                       <Text>
-                        {new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '')} {lineVertical}{' '}
+                        {currentTime()} {lineVertical}{' '}
                       </Text>
                     ) : null}
 

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -46,12 +46,12 @@ export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps
 /**
  * Renders output from concurrent processes to the terminal with {@link ConcurrentOutput}.
  * @example
- * 0000-00-00 00:00:00 │ backend  │ first backend message
- * 0000-00-00 00:00:00 │ backend  │ second backend message
- * 0000-00-00 00:00:00 │ backend  │ third backend message
- * 0000-00-00 00:00:00 │ frontend │ first frontend message
- * 0000-00-00 00:00:00 │ frontend │ second frontend message
- * 0000-00-00 00:00:00 │ frontend │ third frontend message
+ * 00:00:00 │ backend  │ first backend message
+ * 00:00:00 │ backend  │ second backend message
+ * 00:00:00 │ backend  │ third backend message
+ * 00:00:00 │ frontend │ first frontend message
+ * 00:00:00 │ frontend │ second frontend message
+ * 00:00:00 │ frontend │ third frontend message
  *
  * › Press p │ preview in your browser
  * › Press q │ quit.


### PR DESCRIPTION
They make the output of `dev` longer and add very little benefit.