### PR TITLE
Get rid of the concept of an App Dev Cached Context

### DIFF
--- a/packages/app/src/cli/commands/app/info.ts
+++ b/packages/app/src/cli/commands/app/info.ts
@@ -36,7 +36,14 @@ export default class AppInfo extends Command {
       configName: flags.config,
       mode: 'report',
     })
-    outputInfo(await info(app, {format: (flags.json ? 'json' : 'text') as Format, webEnv: flags['web-env']}))
+    outputInfo(
+      await info(app, {
+        format: (flags.json ? 'json' : 'text') as Format,
+        webEnv: flags['web-env'],
+        configName: flags.config,
+        commandConfig: this.config,
+      }),
+    )
     if (app.errors) process.exit(2)
   }
 }

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -14,7 +14,7 @@ import metadata from '../../metadata.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
 import {ExtensionsArraySchema, TypeSchema, UnifiedSchema} from '../extensions/schemas.js'
 import {ExtensionSpecification} from '../extensions/specification.js'
-import {getAppInfo} from '../../services/local-storage.js'
+import {getCachedAppInfo} from '../../services/local-storage.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {fileExists, readFile, glob, findPathUp} from '@shopify/cli-kit/node/fs'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
@@ -483,7 +483,7 @@ class AppConfigurationLoader {
   async loaded() {
     const appDirectory = await this.getAppDirectory()
     let configSource: LinkedConfigurationSource = this.configName ? 'flag' : 'cached'
-    this.configName = this.configName ?? getAppInfo(appDirectory)?.configFile
+    this.configName = this.configName ?? getCachedAppInfo(appDirectory)?.configFile
     if (this.configName === undefined) {
       configSource = 'default'
     }

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -1,7 +1,7 @@
 import use, {UseOptions} from './use.js'
 import {testApp, testAppWithConfig} from '../../../models/app/app.test-data.js'
 import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
-import {clearCurrentConfigFile, setAppInfo} from '../../local-storage.js'
+import {clearCurrentConfigFile, setCachedAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
 import {describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
@@ -31,7 +31,7 @@ describe('use', () => {
 
       // Then
       expect(clearCurrentConfigFile).toHaveBeenCalledWith(tmp)
-      expect(setAppInfo).not.toHaveBeenCalled()
+      expect(setCachedAppInfo).not.toHaveBeenCalled()
       expect(loadAppConfiguration).not.toHaveBeenCalled()
 
       expect(renderSuccess).toHaveBeenCalledWith({
@@ -144,7 +144,7 @@ describe('use', () => {
       await use(options)
 
       // Then
-      expect(setAppInfo).toHaveBeenCalledWith({
+      expect(setCachedAppInfo).toHaveBeenCalledWith({
         directory: tmp,
         configFile: 'shopify.app.staging.toml',
       })
@@ -182,7 +182,7 @@ describe('use', () => {
       await use(options)
 
       // Then
-      expect(setAppInfo).toHaveBeenCalledWith({
+      expect(setCachedAppInfo).toHaveBeenCalledWith({
         directory: tmp,
         configFile: 'shopify.app.local.toml',
       })

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -1,5 +1,5 @@
 import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
-import {clearCurrentConfigFile, setAppInfo} from '../../local-storage.js'
+import {clearCurrentConfigFile, setCachedAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
 import {isCurrentAppSchema} from '../../../models/app/app.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -42,7 +42,7 @@ export async function saveCurrentConfig({configFileName, directory}: SaveCurrent
   const {configuration} = await loadAppConfiguration({configName: configFileName, directory})
 
   if (isCurrentAppSchema(configuration) && configuration.client_id) {
-    setAppInfo({
+    setCachedAppInfo({
       directory,
       configFile: configFileName,
     })

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -19,7 +19,7 @@ import {
   ensureReleaseContext,
 } from './context.js'
 import {createExtension} from './dev/create-extension.js'
-import {CachedAppInfo, clearAppInfo, getAppInfo, setAppInfo} from './local-storage.js'
+import {CachedAppInfo, clearCachedAppInfo, getCachedAppInfo, setCachedAppInfo} from './local-storage.js'
 import {resolveDeploymentMode} from './deploy/mode.js'
 import link from './app/config/link.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
@@ -207,7 +207,7 @@ describe('ensureGenerateContext', () => {
     // Given
     const input = {directory: '/app', reset: false, token: 'token', commandConfig: COMMAND_CONFIG}
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(getAppInfo).mockReturnValue(CACHED1)
+    vi.mocked(getCachedAppInfo).mockReturnValue(CACHED1)
 
     // When
     const got = await ensureGenerateContext(input)
@@ -219,7 +219,7 @@ describe('ensureGenerateContext', () => {
   test('returns the api key from the current config', async () => {
     // Given
     const input = {directory: '/app', reset: false, token: 'token', commandConfig: COMMAND_CONFIG}
-    vi.mocked(getAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
+    vi.mocked(getCachedAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
     vi.mocked(loadAppConfiguration).mockReset()
     vi.mocked(loadAppConfiguration).mockResolvedValueOnce({
       appDirectory: '/app',
@@ -239,7 +239,7 @@ describe('ensureGenerateContext', () => {
   test('links an app on first command run', async () => {
     // Given
     const input = {directory: '/app', reset: false, token: 'token', commandConfig: COMMAND_CONFIG}
-    vi.mocked(getAppInfo).mockReturnValueOnce(undefined).mockReturnValue(CACHED1_WITH_CONFIG)
+    vi.mocked(getCachedAppInfo).mockReturnValueOnce(undefined).mockReturnValue(CACHED1_WITH_CONFIG)
     vi.mocked(loadAppConfiguration).mockReset()
     vi.mocked(loadAppConfiguration).mockResolvedValueOnce({
       appDirectory: '/app',
@@ -260,7 +260,7 @@ describe('ensureGenerateContext', () => {
   test('links an app on reset if already opted into config in code', async () => {
     // Given
     const input = {directory: '/app', reset: true, token: 'token', commandConfig: COMMAND_CONFIG}
-    vi.mocked(getAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
+    vi.mocked(getCachedAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
     vi.mocked(loadAppConfiguration).mockReset()
     vi.mocked(loadAppConfiguration).mockResolvedValueOnce({
       appDirectory: '/app',
@@ -283,7 +283,7 @@ describe('ensureGenerateContext', () => {
     const input = {directory: '/app', reset: true, token: 'token', commandConfig: COMMAND_CONFIG}
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(loadAppName).mockResolvedValueOnce('my-app')
-    vi.mocked(getAppInfo).mockReturnValue(undefined)
+    vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
 
     // When
     const got = await ensureGenerateContext(input)
@@ -296,7 +296,7 @@ describe('ensureGenerateContext', () => {
       ORG1,
       'token',
     )
-    expect(setAppInfo).toHaveBeenCalledWith({
+    expect(setCachedAppInfo).toHaveBeenCalledWith({
       appId: APP1.apiKey,
       title: APP1.title,
       directory: '/app',
@@ -319,7 +319,7 @@ describe('ensureDevContext', async () => {
   test('returns selected data using config file set in cache', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
-      vi.mocked(getAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
+      vi.mocked(getCachedAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
       vi.mocked(loadAppConfiguration).mockReset()
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         appDirectory: tmp,
@@ -357,7 +357,7 @@ describe('ensureDevContext', async () => {
         configName: CACHED1_WITH_CONFIG.configFile,
         deploymentMode: 'legacy',
       })
-      expect(setAppInfo).not.toHaveBeenCalled()
+      expect(setCachedAppInfo).not.toHaveBeenCalled()
 
       expect(metadata.getAllPublicMetadata()).toMatchObject({
         api_key: APP2.apiKey,
@@ -369,7 +369,7 @@ describe('ensureDevContext', async () => {
   test('loads the correct file when config flag is passed in', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
-      vi.mocked(getAppInfo).mockReturnValue(undefined)
+      vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
       vi.mocked(loadAppConfiguration).mockReset()
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         appDirectory: tmp,
@@ -459,7 +459,7 @@ dev_store_url = "domain1"
   test('shows the correct banner content when running for the first time with linked config file', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
-      vi.mocked(getAppInfo).mockReturnValue(undefined)
+      vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
       vi.mocked(loadAppConfiguration).mockReset()
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         appDirectory: tmp,
@@ -509,7 +509,7 @@ dev_store_url = "domain1"
 
   test('returns selected data and updates internal state, without cached state', async () => {
     // Given
-    vi.mocked(getAppInfo).mockReturnValue(undefined)
+    vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
 
     // When
     const got = await ensureDevContext(INPUT, 'token')
@@ -522,7 +522,7 @@ dev_store_url = "domain1"
       updateURLs: undefined,
       deploymentMode: 'legacy',
     })
-    expect(setAppInfo).toHaveBeenNthCalledWith(1, {
+    expect(setCachedAppInfo).toHaveBeenNthCalledWith(1, {
       appId: APP1.apiKey,
       title: APP1.title,
       storeFqdn: STORE1.shopDomain,
@@ -538,7 +538,7 @@ dev_store_url = "domain1"
 
   test('returns remoteAppUpdated true when previous app id is different', async () => {
     // Given
-    vi.mocked(getAppInfo).mockReturnValue({...CACHED1_WITH_CONFIG, previousAppId: APP2.apiKey})
+    vi.mocked(getCachedAppInfo).mockReturnValue({...CACHED1_WITH_CONFIG, previousAppId: APP2.apiKey})
     // vi.mocked(fetchOrgFromId).mockResolvedValueOnce(ORG2)
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
@@ -559,7 +559,7 @@ dev_store_url = "domain1"
 
   test('returns selected data and updates internal state, with cached state', async () => {
     // Given
-    vi.mocked(getAppInfo).mockReturnValue({...CACHED1, previousAppId: APP1.apiKey})
+    vi.mocked(getCachedAppInfo).mockReturnValue({...CACHED1, previousAppId: APP1.apiKey})
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
@@ -576,7 +576,7 @@ dev_store_url = "domain1"
     })
     expect(fetchOrganizations).not.toBeCalled()
     expect(selectOrganizationPrompt).not.toBeCalled()
-    expect(setAppInfo).toHaveBeenNthCalledWith(1, {
+    expect(setCachedAppInfo).toHaveBeenNthCalledWith(1, {
       appId: APP1.apiKey,
       title: APP1.title,
       storeFqdn: STORE1.shopDomain,
@@ -609,7 +609,7 @@ dev_store_url = "domain1"
 
   test('returns selected data and updates internal state, with inputs from flags', async () => {
     // Given
-    vi.mocked(getAppInfo).mockReturnValue(undefined)
+    vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
     vi.mocked(convertToTestStoreIfNeeded).mockResolvedValueOnce()
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
@@ -625,7 +625,7 @@ dev_store_url = "domain1"
       updateURLs: undefined,
       deploymentMode: 'legacy',
     })
-    expect(setAppInfo).toHaveBeenNthCalledWith(1, {
+    expect(setCachedAppInfo).toHaveBeenNthCalledWith(1, {
       appId: APP2.apiKey,
       directory: INPUT_WITH_DATA.directory,
       storeFqdn: STORE1.shopDomain,
@@ -641,7 +641,7 @@ dev_store_url = "domain1"
 
   test('throws if the store input is not valid', async () => {
     // Given
-    vi.mocked(getAppInfo).mockReturnValue(undefined)
+    vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: undefined})
 
@@ -653,13 +653,13 @@ dev_store_url = "domain1"
 
   test('resets cached state if reset is true', async () => {
     // When
-    vi.mocked(getAppInfo).mockReturnValueOnce(CACHED1)
+    vi.mocked(getCachedAppInfo).mockReturnValueOnce(CACHED1)
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
 
     await ensureDevContext({...INPUT, reset: true}, 'token')
 
     // Then
-    expect(clearAppInfo).toHaveBeenCalledWith(BAD_INPUT_WITH_DATA.directory)
+    expect(clearCachedAppInfo).toHaveBeenCalledWith(BAD_INPUT_WITH_DATA.directory)
     expect(fetchOrgAndApps).toBeCalled()
     expect(link).not.toBeCalled()
   })
@@ -667,7 +667,7 @@ dev_store_url = "domain1"
   test('reset triggers link if opted into config in code', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
-      vi.mocked(getAppInfo).mockReturnValueOnce(CACHED1_WITH_CONFIG)
+      vi.mocked(getCachedAppInfo).mockReturnValueOnce(CACHED1_WITH_CONFIG)
       const filePath = joinPath(tmp, 'shopify.app.dev.toml')
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         appDirectory: tmp,
@@ -706,7 +706,7 @@ dev_store_url = "domain1"
 
   test('dev enables automatically the development store preview if the unified deployments beta is enabled', async () => {
     // Given
-    vi.mocked(getAppInfo).mockReturnValueOnce(undefined)
+    vi.mocked(getCachedAppInfo).mockReturnValueOnce(undefined)
     vi.mocked(fetchOrgFromId).mockResolvedValueOnce(ORG2)
     vi.mocked(selectOrCreateApp).mockResolvedValue(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
     vi.mocked(partnersRequest).mockResolvedValueOnce({
@@ -733,7 +733,7 @@ dev_store_url = "domain1"
 
   test('display an error to enable dev preview if the beta is enabled in partners but an error is returned', async () => {
     // Given
-    vi.mocked(getAppInfo).mockReturnValue(undefined)
+    vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
     vi.mocked(fetchOrgFromId).mockResolvedValueOnce(ORG2)
     vi.mocked(selectOrCreateApp).mockResolvedValue(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
     vi.mocked(partnersRequest).mockRejectedValue(new AbortError('error enabling'))
@@ -795,7 +795,7 @@ describe('ensureDeployContext', () => {
       extensionIds: {},
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
-    vi.mocked(getAppInfo).mockReturnValue(CACHED1)
+    vi.mocked(getCachedAppInfo).mockReturnValue(CACHED1)
     vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
     vi.mocked(reuseDevConfigPrompt).mockResolvedValueOnce(true)

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -558,18 +558,20 @@ export interface AppContext {
  * @param directory - The directory containing the app.
  * @param token - The partners token.
  */
-async function getAppContext({
+export async function getAppContext({
   reset,
   directory,
   token,
   configName,
   commandConfig,
+  promptLinkingApp = true,
 }: {
   reset: boolean
   directory: string
   token: string
-  configName?: string
   commandConfig: Config
+  configName?: string
+  promptLinkingApp?: boolean
 }): Promise<AppContext> {
   const previousCachedInfo = getCachedAppInfo(directory)
 
@@ -577,7 +579,7 @@ async function getAppContext({
 
   // if this is the first time we are setting up this app, or
   // if we had config-as-code enabled and we're resetting
-  if (previousCachedInfo === undefined || (previousCachedInfo.configFile && reset)) {
+  if (promptLinkingApp && (previousCachedInfo === undefined || (previousCachedInfo.configFile && reset))) {
     await link({directory, commandConfig})
   }
 

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -12,7 +12,7 @@ import {
 import {convertToTestStoreIfNeeded, selectStore} from './dev/select-store.js'
 import {ensureDeploymentIdsPresence} from './context/identifiers.js'
 import {createExtension} from './dev/create-extension.js'
-import {CachedAppInfo, clearAppInfo, getAppInfo, setAppInfo} from './local-storage.js'
+import {CachedAppInfo, clearCachedAppInfo, getCachedAppInfo, setCachedAppInfo} from './local-storage.js'
 import {DeploymentMode, resolveDeploymentMode} from './deploy/mode.js'
 import link from './app/config/link.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
@@ -116,7 +116,7 @@ export async function ensureGenerateContext(options: {
     const {organization, apps} = await fetchOrgAndApps(orgId, options.token)
     const localAppName = await loadAppName(options.directory)
     const selectedApp = await selectOrCreateApp(localAppName, apps, organization, options.token)
-    setAppInfo({
+    setCachedAppInfo({
       appId: selectedApp.apiKey,
       title: selectedApp.title,
       directory: options.directory,
@@ -184,7 +184,7 @@ export async function ensureDevContext(options: DevContextOptions, token: string
     }
     writeFileSync(configurationPath, encodeToml(newConfiguration))
   } else {
-    setAppInfo({
+    setCachedAppInfo({
       appId: selectedApp.apiKey,
       title: selectedApp.title,
       directory: options.directory,
@@ -283,7 +283,7 @@ interface DeployContextOutput {
  * undefined if there is no cached value or the user doesn't want to use it.
  */
 export async function fetchDevAppAndPrompt(app: AppInterface, token: string): Promise<OrganizationApp | undefined> {
-  const devAppId = getAppInfo(app.directory)?.appId
+  const devAppId = getCachedAppInfo(app.directory)?.appId
   if (!devAppId) return undefined
 
   const partnersResponse = await fetchAppFromApiKey(devAppId, token)
@@ -570,15 +570,15 @@ async function getAppDevCachedContext({
   configName?: string
   commandConfig: Config
 }): Promise<AppDevCachedContext> {
-  const previousCachedInfo = getAppInfo(directory)
+  const previousCachedInfo = getCachedAppInfo(directory)
 
-  if (reset) clearAppInfo(directory)
+  if (reset) clearCachedAppInfo(directory)
 
-  let cachedInfo = getAppInfo(directory)
+  let cachedInfo = getCachedAppInfo(directory)
 
   if ((previousCachedInfo?.configFile && reset) || previousCachedInfo === undefined) {
     await link({directory, commandConfig})
-    cachedInfo = getAppInfo(directory)
+    cachedInfo = getCachedAppInfo(directory)
   }
 
   const {configuration, configurationPath} = await loadAppConfiguration({

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -17,7 +17,7 @@ import {ensureDeploymentIdsPresence} from './context/identifiers.js'
 import {setupConfigWatcher, setupDraftableExtensionBundler, setupFunctionWatcher} from './dev/extension/bundler.js'
 import {buildFunctionExtension} from './build/extension.js'
 import {updateExtensionDraft} from './dev/update-extension.js'
-import {setAppInfo} from './local-storage.js'
+import {setCachedAppInfo} from './local-storage.js'
 import {
   ReverseHTTPProxyTarget,
   runConcurrentHTTPProcessesAndPathForwardTraffic,
@@ -311,7 +311,7 @@ async function dev(options: DevOptions) {
 }
 
 function setPreviousAppId(directory: string, apiKey: string) {
-  setAppInfo({directory, previousAppId: apiKey})
+  setCachedAppInfo({directory, previousAppId: apiKey})
 }
 
 function isWebType(web: Web, type: WebType): boolean {

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -11,7 +11,7 @@ import {
 import {testApp} from '../../models/app/app.test-data.js'
 import {UpdateURLsQuery} from '../../api/graphql/update_urls.js'
 import {GetURLsQuery} from '../../api/graphql/get_urls.js'
-import {setAppInfo} from '../local-storage.js'
+import {setCachedAppInfo} from '../local-storage.js'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {Config} from '@oclif/core'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -232,7 +232,7 @@ describe('shouldOrPromptUpdateURLs', () => {
     await shouldOrPromptUpdateURLs(options)
 
     // Then
-    expect(setAppInfo).toHaveBeenNthCalledWith(1, {
+    expect(setCachedAppInfo).toHaveBeenNthCalledWith(1, {
       directory: '/path',
       updateURLs: true,
     })
@@ -322,7 +322,7 @@ describe('generateFrontendURL', () => {
 
     // Then
     expect(got).toEqual({frontendUrl: 'https://4040-gitpod.url.fqdn.com', frontendPort: 4040, usingLocalhost: false})
-    expect(setAppInfo).not.toBeCalled()
+    expect(setCachedAppInfo).not.toBeCalled()
     expect(renderSelectPrompt).not.toBeCalled()
   })
 
@@ -339,7 +339,7 @@ describe('generateFrontendURL', () => {
       frontendPort: 4040,
       usingLocalhost: false,
     })
-    expect(setAppInfo).not.toBeCalled()
+    expect(setCachedAppInfo).not.toBeCalled()
     expect(renderSelectPrompt).not.toBeCalled()
   })
 
@@ -359,7 +359,7 @@ describe('generateFrontendURL', () => {
       frontendPort: 4040,
       usingLocalhost: false,
     })
-    expect(setAppInfo).not.toBeCalled()
+    expect(setCachedAppInfo).not.toBeCalled()
     expect(renderSelectPrompt).not.toBeCalled()
   })
 
@@ -378,7 +378,7 @@ describe('generateFrontendURL', () => {
       frontendPort: 1234,
       usingLocalhost: false,
     })
-    expect(setAppInfo).not.toBeCalled()
+    expect(setCachedAppInfo).not.toBeCalled()
     expect(renderSelectPrompt).not.toBeCalled()
   })
 

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -2,7 +2,7 @@ import {updateURLsPrompt} from '../../prompts/dev.js'
 import {AppConfiguration, AppInterface, isCurrentAppSchema} from '../../models/app/app.js'
 import {UpdateURLsQuery, UpdateURLsQuerySchema, UpdateURLsQueryVariables} from '../../api/graphql/update_urls.js'
 import {GetURLsQuery, GetURLsQuerySchema, GetURLsQueryVariables} from '../../api/graphql/get_urls.js'
-import {setAppInfo} from '../local-storage.js'
+import {setCachedAppInfo} from '../local-storage.js'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
 import {Config} from '@oclif/core'
 import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
@@ -221,7 +221,7 @@ export async function shouldOrPromptUpdateURLs(options: ShouldOrPromptUpdateURLs
 
       writeFileSync(options.localApp.configurationPath, encodeToml(localConfiguration))
     } else {
-      setAppInfo({directory: options.appDirectory, updateURLs: newUpdateURLs})
+      setCachedAppInfo({directory: options.appDirectory, updateURLs: newUpdateURLs})
     }
   }
   return shouldUpdate

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -1,6 +1,6 @@
 import {info} from './info.js'
 import {fetchOrgAndApps, fetchOrganizations} from './dev/fetch.js'
-import {getAppInfo} from './local-storage.js'
+import {getCachedAppInfo} from './local-storage.js'
 import {fetchAppFromConfigOrSelect} from './app/fetch-app-from-config-or-select.js'
 import {AppInterface} from '../models/app/app.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
@@ -34,7 +34,7 @@ describe('info', () => {
 
   test('returns the current config when present', async () => {
     // Given
-    vi.mocked(getAppInfo).mockReturnValue(undefined)
+    vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
     const app = testAppWithConfig()
 
     // When
@@ -58,7 +58,7 @@ describe('info', () => {
       storeFqdn: 'my-app.example.com',
       updateURLs: true,
     }
-    vi.mocked(getAppInfo).mockReturnValue(cachedAppInfo)
+    vi.mocked(getCachedAppInfo).mockReturnValue(cachedAppInfo)
     const app = mockApp()
 
     // When

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -1,16 +1,18 @@
-import {info} from './info.js'
-import {fetchOrgAndApps, fetchOrganizations} from './dev/fetch.js'
+import {InfoOptions, info} from './info.js'
+import {fetchAppFromApiKey, fetchOrgAndApps, fetchOrganizations} from './dev/fetch.js'
 import {getCachedAppInfo} from './local-storage.js'
 import {fetchAppFromConfigOrSelect} from './app/fetch-app-from-config-or-select.js'
 import {AppInterface} from '../models/app/app.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
-import {testApp, testAppWithConfig, testOrganizationApp, testUIExtension} from '../models/app/app.test-data.js'
+import {testApp, testOrganizationApp, testUIExtension} from '../models/app/app.test-data.js'
 import {AppErrors} from '../models/app/loader.js'
 import {describe, expect, vi, test} from 'vitest'
 import {checkForNewVersion} from '@shopify/cli-kit/node/node-package-manager'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {stringifyMessage, unstyled} from '@shopify/cli-kit/node/output'
+import {Config} from '@oclif/core'
+import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
 
 vi.mock('./local-storage.js')
 vi.mock('./dev/fetch.js')
@@ -19,240 +21,308 @@ vi.mock('../prompts/dev.js')
 vi.mock('@shopify/cli-kit/node/session')
 vi.mock('@shopify/cli-kit/node/node-package-manager')
 
+const infoOptions: InfoOptions = {
+  format: 'text',
+  webEnv: false,
+  commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+}
+
 describe('info', () => {
   test('returns update shopify cli reminder when last version is greater than current version', async () => {
-    // Given
-    const latestVersion = '2.2.3'
-    const app = mockApp()
-    vi.mocked(checkForNewVersion).mockResolvedValue(latestVersion)
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const latestVersion = '2.2.3'
+      const app = mockApp({directory: tmp})
+      vi.mocked(checkForNewVersion).mockResolvedValue(latestVersion)
 
-    // When
-    const result = stringifyMessage(await info(app, {format: 'text', webEnv: false}))
-    // Then
-    expect(unstyled(result)).toMatch('Shopify CLI       2.2.2 💡 Version 2.2.3 available! Run yarn shopify upgrade')
+      // When
+      const result = stringifyMessage(await info(app, infoOptions))
+      // Then
+      expect(unstyled(result)).toMatch('Shopify CLI       2.2.2 💡 Version 2.2.3 available! Run yarn shopify upgrade')
+    })
   })
 
   test('returns the current config when present', async () => {
-    // Given
-    vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
-    const app = testAppWithConfig()
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const testConfig = `
+      name = "my app"
+      api_contact_email = "me@example.com"
+      client_id = "12345"
+      application_url = "https://example.com/lala"
+      embedded = true
 
-    // When
-    const result = stringifyMessage(await info(app, {format: 'text', webEnv: false}))
+      [webhooks]
+      api_version = "2023-07"
+      `
+      vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
+      vi.mocked(fetchAppFromApiKey).mockResolvedValue(
+        testOrganizationApp({id: '123', title: 'my app', apiKey: '12345'}),
+      )
 
-    // Then
-    expect(unstyled(result)).toMatch(/Configuration file\s*\/tmp\/project\/shopify.app.toml/)
-    expect(unstyled(result)).toMatch(/App name\s*my app/)
-    expect(unstyled(result)).toMatch(/Client ID\s*12345/)
-    expect(unstyled(result)).toMatch(/Access scopes\s*read_products/)
-    expect(unstyled(result)).toMatch(/Dev store\s*Not yet configured/)
-    expect(unstyled(result)).toMatch(/Update URLs\s*Not yet configured/)
+      const app = mockApp({
+        directory: tmp,
+        app: testApp({
+          name: 'my app',
+          directory: tmp,
+          configurationPath: joinPath(tmp, 'shopify.app.toml'),
+          configuration: {
+            name: 'my app',
+            api_contact_email: 'me@example.com',
+            client_id: '12345',
+            application_url: 'https://example.com/lala',
+            embedded: true,
+            webhooks: {api_version: '2023-07'},
+            access_scopes: {scopes: 'read_products'},
+          },
+        }),
+        configContents: testConfig,
+      })
+
+      // When
+      const result = stringifyMessage(await info(app, infoOptions))
+
+      // Then
+      expect(unstyled(result)).toMatch(/Configuration file\s*shopify.app.toml/)
+      expect(unstyled(result)).toMatch(/App name\s*my app/)
+      expect(unstyled(result)).toMatch(/Client ID\s*12345/)
+      expect(unstyled(result)).toMatch(/Access scopes\s*read_products/)
+      expect(unstyled(result)).toMatch(/Dev store\s*Not yet configured/)
+      expect(unstyled(result)).toMatch(/Update URLs\s*Not yet configured/)
+    })
   })
 
   test('returns the current cache from dev when present', async () => {
-    // Given
-    const cachedAppInfo = {
-      directory: '/path',
-      title: 'My App',
-      appId: '123',
-      storeFqdn: 'my-app.example.com',
-      updateURLs: true,
-    }
-    vi.mocked(getCachedAppInfo).mockReturnValue(cachedAppInfo)
-    const app = mockApp()
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const cachedAppInfo = {
+        directory: '/path',
+        title: 'My App',
+        appId: '123',
+        storeFqdn: 'my-app.example.com',
+        updateURLs: true,
+      }
+      vi.mocked(getCachedAppInfo).mockReturnValue(cachedAppInfo)
+      const app = mockApp({directory: tmp})
 
-    // When
-    const result = stringifyMessage(await info(app, {format: 'text', webEnv: false}))
+      // When
+      const result = stringifyMessage(await info(app, infoOptions))
 
-    // Then
-    expect(unstyled(result)).toMatch(/Configuration file\s*Not yet configured/)
-    expect(unstyled(result)).toMatch(/App name\s*My App/)
-    expect(unstyled(result)).toMatch(/Client ID\s*123/)
-    expect(unstyled(result)).toMatch(/Access scopes\s*my-scope/)
-    expect(unstyled(result)).toMatch(/Dev store\s*my-app.example.com/)
-    expect(unstyled(result)).toMatch(/Update URLs\s*Always/)
+      // Then
+      expect(unstyled(result)).toMatch(/Configuration file\s*shopify.app.toml/)
+      expect(unstyled(result)).toMatch(/App name\s*My App/)
+      expect(unstyled(result)).toMatch(/Client ID\s*123/)
+      expect(unstyled(result)).toMatch(/Access scopes\s*my-scope/)
+      expect(unstyled(result)).toMatch(/Dev store\s*my-app.example.com/)
+      expect(unstyled(result)).toMatch(/Update URLs\s*Always/)
+    })
   })
 
   test('returns empty configs for dev when not present', async () => {
-    // Given
-    const app = mockApp()
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const app = mockApp({directory: tmp})
 
-    // When
-    const result = stringifyMessage(await info(app, {format: 'text', webEnv: false}))
+      // When
+      const result = stringifyMessage(await info(app, infoOptions))
 
-    // Then
-    expect(unstyled(result)).toMatch(/App name\s*Not yet configured/)
-    expect(unstyled(result)).toMatch(/Dev store\s*Not yet configured/)
-    expect(unstyled(result)).toMatch(/Client ID\s*Not yet configured/)
-    expect(unstyled(result)).toMatch(/Update URLs\s*Not yet configured/)
+      // Then
+      expect(unstyled(result)).toMatch(/App name\s*Not yet configured/)
+      expect(unstyled(result)).toMatch(/Dev store\s*Not yet configured/)
+      expect(unstyled(result)).toMatch(/Client ID\s*Not yet configured/)
+      expect(unstyled(result)).toMatch(/Update URLs\s*Not yet configured/)
+    })
   })
 
   test('returns update shopify cli reminder when last version lower or equals to current version', async () => {
-    // Given
-    const app = mockApp()
-    vi.mocked(checkForNewVersion).mockResolvedValue(undefined)
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const app = mockApp({directory: tmp})
+      vi.mocked(checkForNewVersion).mockResolvedValue(undefined)
 
-    // When
-    const result = stringifyMessage(await info(app, {format: 'text', webEnv: false}))
-    // Then
-    expect(unstyled(result)).toMatch('Shopify CLI       2.2.2')
-    expect(unstyled(result)).not.toMatch('CLI reminder')
+      // When
+      const result = stringifyMessage(await info(app, infoOptions))
+      // Then
+      expect(unstyled(result)).toMatch('Shopify CLI       2.2.2')
+      expect(unstyled(result)).not.toMatch('CLI reminder')
+    })
   })
 
   test('returns the web environment as a text when webEnv is true', async () => {
-    // Given
-    const app = mockApp()
-    const organization = {
-      id: '123',
-      betas: {},
-      businessName: 'test',
-      website: '',
-      apps: {nodes: []},
-    }
-    const organizationApp = testOrganizationApp({
-      id: '123',
-      title: 'Test app',
-      appType: 'custom',
-    })
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const app = mockApp({directory: tmp})
+      const organization = {
+        id: '123',
+        betas: {},
+        businessName: 'test',
+        website: '',
+        apps: {nodes: []},
+      }
+      const organizationApp = testOrganizationApp({
+        id: '123',
+        title: 'Test app',
+        appType: 'custom',
+      })
 
-    vi.mocked(fetchOrganizations).mockResolvedValue([organization])
-    vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)
-    vi.mocked(fetchOrgAndApps).mockResolvedValue({
-      organization,
-      stores: [],
-      apps: {
-        nodes: [organizationApp],
-        pageInfo: {hasNextPage: false},
-      },
-    })
-    vi.mocked(fetchAppFromConfigOrSelect).mockResolvedValue(organizationApp)
-    vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
+      vi.mocked(fetchOrganizations).mockResolvedValue([organization])
+      vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)
+      vi.mocked(fetchOrgAndApps).mockResolvedValue({
+        organization,
+        stores: [],
+        apps: {
+          nodes: [organizationApp],
+          pageInfo: {hasNextPage: false},
+        },
+      })
+      vi.mocked(fetchAppFromConfigOrSelect).mockResolvedValue(organizationApp)
+      vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
 
-    // When
-    const result = await info(app, {format: 'text', webEnv: true})
+      // When
+      const result = await info(app, {...infoOptions, webEnv: true})
 
-    // Then
-    expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
-    "
-        SHOPIFY_API_KEY=api-key
-        SHOPIFY_API_SECRET=api-secret
-        SCOPES=my-scope
+      // Then
+      expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
       "
-    `)
+          SHOPIFY_API_KEY=api-key
+          SHOPIFY_API_SECRET=api-secret
+          SCOPES=my-scope
+        "
+      `)
+    })
   })
 
   test('returns the web environment as a json when webEnv is true', async () => {
-    // Given
-    const app = mockApp()
-    const organization = {
-      id: '123',
-      betas: {},
-      businessName: 'test',
-      website: '',
-      apps: {nodes: []},
-    }
-    const organizationApp = testOrganizationApp({
-      id: '123',
-      title: 'Test app',
-      appType: 'custom',
-    })
-    vi.mocked(fetchOrganizations).mockResolvedValue([organization])
-    vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)
-    vi.mocked(fetchOrgAndApps).mockResolvedValue({
-      organization,
-      stores: [],
-      apps: {
-        nodes: [organizationApp],
-        pageInfo: {hasNextPage: false},
-      },
-    })
-    vi.mocked(fetchAppFromConfigOrSelect).mockResolvedValue(organizationApp)
-    vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const app = mockApp({directory: tmp})
+      const organization = {
+        id: '123',
+        betas: {},
+        businessName: 'test',
+        website: '',
+        apps: {nodes: []},
+      }
+      const organizationApp = testOrganizationApp({
+        id: '123',
+        title: 'Test app',
+        appType: 'custom',
+      })
+      vi.mocked(fetchOrganizations).mockResolvedValue([organization])
+      vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)
+      vi.mocked(fetchOrgAndApps).mockResolvedValue({
+        organization,
+        stores: [],
+        apps: {
+          nodes: [organizationApp],
+          pageInfo: {hasNextPage: false},
+        },
+      })
+      vi.mocked(fetchAppFromConfigOrSelect).mockResolvedValue(organizationApp)
+      vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
 
-    // When
-    const result = await info(app, {format: 'json', webEnv: true})
+      // When
+      const result = await info(app, {...infoOptions, format: 'json', webEnv: true})
 
-    // Then
-    expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
-      "{
-        \\"SHOPIFY_API_KEY\\": \\"api-key\\",
-        \\"SHOPIFY_API_SECRET\\": \\"api-secret\\",
-        \\"SCOPES\\": \\"my-scope\\"
-      }"
-    `)
+      // Then
+      expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
+        "{
+          \\"SHOPIFY_API_KEY\\": \\"api-key\\",
+          \\"SHOPIFY_API_SECRET\\": \\"api-secret\\",
+          \\"SCOPES\\": \\"my-scope\\"
+        }"
+      `)
+    })
   })
 
   test('returns errors alongside extensions when extensions have errors', async () => {
-    // Given
-    const uiExtension1 = await testUIExtension({
-      configuration: {
-        name: 'Extension 1',
-        type: 'ui_extension',
-        metafields: [],
-      },
-      configurationPath: 'extension/path/1',
-    })
-    const uiExtension2 = await testUIExtension({
-      configuration: {
-        name: 'Extension 2',
-        type: 'checkout_ui_extension',
-        metafields: [],
-      },
-      configurationPath: 'extension/path/2',
-    })
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const uiExtension1 = await testUIExtension({
+        configuration: {
+          name: 'Extension 1',
+          type: 'ui_extension',
+          metafields: [],
+        },
+        configurationPath: 'extension/path/1',
+      })
+      const uiExtension2 = await testUIExtension({
+        configuration: {
+          name: 'Extension 2',
+          type: 'checkout_ui_extension',
+          metafields: [],
+        },
+        configurationPath: 'extension/path/2',
+      })
 
-    const errors = new AppErrors()
-    errors.addError(uiExtension1.configurationPath, 'Mock error with ui_extension')
-    errors.addError(uiExtension2.configurationPath, 'Mock error with checkout_ui_extension')
+      const errors = new AppErrors()
+      errors.addError(uiExtension1.configurationPath, 'Mock error with ui_extension')
+      errors.addError(uiExtension2.configurationPath, 'Mock error with checkout_ui_extension')
 
-    const app = mockApp(undefined, {
-      errors,
-      allExtensions: [uiExtension1, uiExtension2],
-    })
-    const organization = {
-      id: '123',
-      betas: {},
-      businessName: 'test',
-      website: '',
-      apps: {nodes: []},
-    }
-    const organizationApp = testOrganizationApp({
-      id: '123',
-      title: 'Test app',
-      appType: 'custom',
-    })
-    vi.mocked(fetchOrganizations).mockResolvedValue([organization])
-    vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)
-    vi.mocked(fetchOrgAndApps).mockResolvedValue({
-      organization,
-      stores: [],
-      apps: {
-        nodes: [organizationApp],
-        pageInfo: {hasNextPage: false},
-      },
-    })
-    vi.mocked(fetchAppFromConfigOrSelect).mockResolvedValue(organizationApp)
-    vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
+      const app = mockApp({
+        directory: tmp,
+        app: {
+          errors,
+          allExtensions: [uiExtension1, uiExtension2],
+        },
+      })
+      const organization = {
+        id: '123',
+        betas: {},
+        businessName: 'test',
+        website: '',
+        apps: {nodes: []},
+      }
+      const organizationApp = testOrganizationApp({
+        id: '123',
+        title: 'Test app',
+        appType: 'custom',
+      })
+      vi.mocked(fetchOrganizations).mockResolvedValue([organization])
+      vi.mocked(selectOrganizationPrompt).mockResolvedValue(organization)
+      vi.mocked(fetchOrgAndApps).mockResolvedValue({
+        organization,
+        stores: [],
+        apps: {
+          nodes: [organizationApp],
+          pageInfo: {hasNextPage: false},
+        },
+      })
+      vi.mocked(fetchAppFromConfigOrSelect).mockResolvedValue(organizationApp)
+      vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
 
-    // When
-    const result = await info(app, {format: 'text', webEnv: false})
+      // When
+      const result = await info(app, infoOptions)
 
-    // Then
-    expect(result).toContain('Extensions with errors')
-    expect(result).toContain('📂 ui_extension')
-    expect(result).toContain('! Mock error with ui_extension')
-    expect(result).toContain('! Mock error with checkout_ui_extension')
+      // Then
+      expect(result).toContain('Extensions with errors')
+      expect(result).toContain('📂 ui_extension')
+      expect(result).toContain('! Mock error with ui_extension')
+      expect(result).toContain('! Mock error with checkout_ui_extension')
+    })
   })
 })
 
-function mockApp(currentVersion = '2.2.2', app?: Partial<AppInterface>): AppInterface {
+function mockApp({
+  directory,
+  currentVersion = '2.2.2',
+  configContents = 'scopes = "read_products"',
+  app,
+}: {
+  directory: string
+  currentVersion?: string
+  configContents?: string
+  app?: Partial<AppInterface>
+}): AppInterface {
   const nodeDependencies: {[key: string]: string} = {}
   nodeDependencies['@shopify/cli'] = currentVersion
 
+  writeFileSync(joinPath(directory, 'shopify.app.toml'), configContents)
+
   return testApp({
-    name: 'myapp',
-    directory: '/',
-    configurationPath: joinPath('/', 'shopify.app.toml'),
+    name: 'my app',
+    directory,
+    configurationPath: joinPath(directory, 'shopify.app.toml'),
     configuration: {
       scopes: 'my-scope',
       extension_directories: ['extensions/*'],

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -1,6 +1,6 @@
 import {outputEnv} from './app/env/show.js'
-import {getCachedAppInfo} from './local-storage.js'
-import {AppInterface, getAppScopes, isCurrentAppSchema} from '../models/app/app.js'
+import {getAppContext} from './context.js'
+import {AppInterface, getAppScopes} from '../models/app/app.js'
 import {configurationFileNames} from '../constants.js'
 import {ExtensionInstance} from '../models/extensions/extension-instance.js'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
@@ -15,10 +15,14 @@ import {
   stringifyMessage,
   getOutputUpdateCLIReminder,
 } from '@shopify/cli-kit/node/output'
+import {Config} from '@oclif/core'
+import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 
 export type Format = 'json' | 'text'
-interface InfoOptions {
+export interface InfoOptions {
   format: Format
+  commandConfig: Config
+  configName?: string
   /** When true the command outputs the env. variables necessary to deploy and run web/ */
   webEnv: boolean
 }
@@ -27,23 +31,23 @@ interface Configurable {
   externalType: string
 }
 
-export async function info(app: AppInterface, {format, webEnv}: InfoOptions): Promise<OutputMessage> {
-  if (webEnv) {
-    return infoWeb(app, {format})
+export async function info(app: AppInterface, options: InfoOptions): Promise<OutputMessage> {
+  if (options.webEnv) {
+    return infoWeb(app, options)
   } else {
-    return infoApp(app, {format})
+    return infoApp(app, options)
   }
 }
 
-export async function infoWeb(app: AppInterface, {format}: Omit<InfoOptions, 'webEnv'>): Promise<OutputMessage> {
+export async function infoWeb(app: AppInterface, {format}: InfoOptions): Promise<OutputMessage> {
   return outputEnv(app, format)
 }
 
-export async function infoApp(app: AppInterface, {format}: Omit<InfoOptions, 'webEnv'>): Promise<OutputMessage> {
-  if (format === 'json') {
+export async function infoApp(app: AppInterface, options: InfoOptions): Promise<OutputMessage> {
+  if (options.format === 'json') {
     return outputContent`${JSON.stringify(app, null, 2)}`
   } else {
-    const appInfo = new AppInfo(app)
+    const appInfo = new AppInfo(app, options)
     return appInfo.output()
   }
 }
@@ -53,14 +57,16 @@ const NOT_CONFIGURED_TEXT = outputContent`${outputToken.italic('Not yet configur
 
 class AppInfo {
   private app: AppInterface
+  private options: InfoOptions
 
-  constructor(app: AppInterface) {
+  constructor(app: AppInterface, options: InfoOptions) {
     this.app = app
+    this.options = options
   }
 
   async output(): Promise<string> {
     const sections: [string, string][] = [
-      this.devConfigsSection(),
+      await this.devConfigsSection(),
       this.projectSettingsSection(),
       await this.appComponentsSection(),
       await this.systemInfoSection(),
@@ -68,46 +74,38 @@ class AppInfo {
     return sections.map((sectionContents: [string, string]) => formatSection(...sectionContents)).join('\n\n')
   }
 
-  devConfigsSection(): [string, string] {
+  async devConfigsSection(): Promise<[string, string]> {
     const title = `Current app configuration`
+    const token = await ensureAuthenticatedPartners()
+    const {cachedInfo} = await getAppContext({
+      token,
+      directory: this.app.directory,
+      reset: false,
+      configName: this.options.configName,
+      commandConfig: this.options.commandConfig,
+      promptLinkingApp: false,
+    })
 
-    let configName = NOT_CONFIGURED_TEXT
-    let appName = NOT_CONFIGURED_TEXT
-    let storeDescription = NOT_CONFIGURED_TEXT
-    let apiKey = NOT_CONFIGURED_TEXT
-    let updateURLs = NOT_CONFIGURED_TEXT
-    let postscript = outputContent`💡 These will be populated when you run ${outputToken.packagejsonScript(
+    const postscript = outputContent`💡 To change these, run ${outputToken.packagejsonScript(
       this.app.packageManager,
       'dev',
+      '--reset',
     )}`.value
-    const cachedAppInfo = getCachedAppInfo(this.app.directory)
-    if (isCurrentAppSchema(this.app.configuration)) {
-      configName = this.app.configurationPath
-      appName = this.app.configuration.name
-      apiKey = this.app.configuration.client_id
-      if (this.app.configuration.build?.dev_store_url) storeDescription = this.app.configuration.build.dev_store_url
-      if (this.app.configuration.build?.automatically_update_urls_on_dev) {
-        updateURLs = this.app.configuration.build.automatically_update_urls_on_dev ? 'Always' : 'Never'
-      }
-      postscript = outputContent`💡 To change these, use the '--config' flag.`.value
-    } else if (cachedAppInfo) {
-      if (cachedAppInfo.title) appName = cachedAppInfo.title
-      if (cachedAppInfo.storeFqdn) storeDescription = cachedAppInfo.storeFqdn
-      if (cachedAppInfo.appId) apiKey = cachedAppInfo.appId
-      if (cachedAppInfo.updateURLs !== undefined) updateURLs = cachedAppInfo.updateURLs ? 'Always' : 'Never'
-      postscript = outputContent`💡 To change these, run ${outputToken.packagejsonScript(
-        this.app.packageManager,
-        'dev',
-        '--reset',
-      )}`.value
+
+    let updateUrls
+    if (cachedInfo?.updateURLs === undefined) {
+      updateUrls = NOT_CONFIGURED_TEXT
+    } else {
+      updateUrls = cachedInfo.updateURLs ? 'Always' : 'Never'
     }
+
     const lines = [
-      ['Configuration file', configName],
-      ['App name', appName],
-      ['Client ID', apiKey],
+      ['Configuration file', cachedInfo?.configFile || configurationFileNames.app],
+      ['App name', cachedInfo?.title || NOT_CONFIGURED_TEXT],
+      ['Client ID', cachedInfo?.appId || NOT_CONFIGURED_TEXT],
       ['Access scopes', getAppScopes(this.app.configuration)],
-      ['Dev store', storeDescription],
-      ['Update URLs', updateURLs],
+      ['Dev store', cachedInfo?.storeFqdn || NOT_CONFIGURED_TEXT],
+      ['Update URLs', updateUrls],
     ]
     return [title, `${linesToColumns(lines)}\n\n${postscript}`]
   }

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -1,5 +1,5 @@
 import {outputEnv} from './app/env/show.js'
-import {getAppInfo} from './local-storage.js'
+import {getCachedAppInfo} from './local-storage.js'
 import {AppInterface, getAppScopes, isCurrentAppSchema} from '../models/app/app.js'
 import {configurationFileNames} from '../constants.js'
 import {ExtensionInstance} from '../models/extensions/extension-instance.js'
@@ -80,7 +80,7 @@ class AppInfo {
       this.app.packageManager,
       'dev',
     )}`.value
-    const cachedAppInfo = getAppInfo(this.app.directory)
+    const cachedAppInfo = getCachedAppInfo(this.app.directory)
     if (isCurrentAppSchema(this.app.configuration)) {
       configName = this.app.configurationPath
       appName = this.app.configuration.name

--- a/packages/app/src/cli/services/local-storage.test.ts
+++ b/packages/app/src/cli/services/local-storage.test.ts
@@ -1,4 +1,10 @@
-import {AppLocalStorageSchema, clearAppInfo, clearCurrentConfigFile, getAppInfo, setAppInfo} from './local-storage.js'
+import {
+  AppLocalStorageSchema,
+  clearCachedAppInfo,
+  clearCurrentConfigFile,
+  getCachedAppInfo,
+  setCachedAppInfo,
+} from './local-storage.js'
 import {describe, expect, test} from 'vitest'
 import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
 import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
@@ -13,10 +19,10 @@ describe('getAppInfo', async () => {
     await inTemporaryDirectory(async (cwd) => {
       // Given
       const storage = new LocalStorage<AppLocalStorageSchema>({cwd})
-      setAppInfo(APP1, storage)
+      setCachedAppInfo(APP1, storage)
 
       // When
-      const got = getAppInfo(APP1.directory, storage)
+      const got = getCachedAppInfo(APP1.directory, storage)
 
       // Then
       expect(got).toEqual(APP1)
@@ -29,7 +35,7 @@ describe('getAppInfo', async () => {
       const storage = new LocalStorage<AppLocalStorageSchema>({cwd})
 
       // When
-      const got = getAppInfo('app3', storage)
+      const got = getCachedAppInfo('app3', storage)
 
       // Then
       expect(got).toEqual(undefined)
@@ -45,7 +51,7 @@ describe('setAppInfo', async () => {
       storage.set(APP1.directory, APP1)
 
       // When
-      setAppInfo(APP1Updated, storage)
+      setCachedAppInfo(APP1Updated, storage)
       const got = storage.get(APP1.directory)
 
       // Then
@@ -59,7 +65,7 @@ describe('setAppInfo', async () => {
       const storage = new LocalStorage<AppLocalStorageSchema>({cwd})
 
       // When
-      setAppInfo({appId: 'app2', directory: '/app2', storeFqdn: APP2.storeFqdn, orgId: APP2.orgId}, storage)
+      setCachedAppInfo({appId: 'app2', directory: '/app2', storeFqdn: APP2.storeFqdn, orgId: APP2.orgId}, storage)
       const got = storage.get(APP2.directory)
 
       // Then
@@ -73,7 +79,10 @@ describe('setAppInfo', async () => {
       const storage = new LocalStorage<AppLocalStorageSchema>({cwd})
 
       // When
-      setAppInfo({appId: 'app2', directory: '\\app2\\something', storeFqdn: APP2.storeFqdn, orgId: APP2.orgId}, storage)
+      setCachedAppInfo(
+        {appId: 'app2', directory: '\\app2\\something', storeFqdn: APP2.storeFqdn, orgId: APP2.orgId},
+        storage,
+      )
       const got = storage.get('/app2/something')
 
       // Then
@@ -91,8 +100,8 @@ describe('clearAppInfo', async () => {
       storage.set(APP2.directory, APP2)
 
       // When
-      clearAppInfo(APP1.directory, storage)
-      const got = getAppInfo(APP1.directory, storage)
+      clearCachedAppInfo(APP1.directory, storage)
+      const got = getCachedAppInfo(APP1.directory, storage)
 
       // Then
       expect(got).toEqual(undefined)
@@ -105,11 +114,11 @@ describe('clearCurrentConfigFile', async () => {
     await inTemporaryDirectory(async (cwd) => {
       // Given
       const storage = new LocalStorage<AppLocalStorageSchema>({cwd})
-      setAppInfo({directory: APP1_WITH_CONFIG_FILE.directory, configFile: 'shopify.app.staging.toml'})
+      setCachedAppInfo({directory: APP1_WITH_CONFIG_FILE.directory, configFile: 'shopify.app.staging.toml'})
 
       // When
       clearCurrentConfigFile(APP1_WITH_CONFIG_FILE.directory, storage)
-      const got = getAppInfo(APP1_WITH_CONFIG_FILE.directory, storage)
+      const got = getCachedAppInfo(APP1_WITH_CONFIG_FILE.directory, storage)
 
       // Then
       expect(got?.configFile).toBeUndefined()

--- a/packages/app/src/cli/services/local-storage.ts
+++ b/packages/app/src/cli/services/local-storage.ts
@@ -27,7 +27,7 @@ function appLocalStorage() {
   return _appLocalStorageInstance
 }
 
-export function getAppInfo(
+export function getCachedAppInfo(
   directory: string,
   config: LocalStorage<AppLocalStorageSchema> = appLocalStorage(),
 ): CachedAppInfo | undefined {
@@ -36,18 +36,16 @@ export function getAppInfo(
   return config.get(normalized)
 }
 
-export function clearAppInfo(directory: string, config: LocalStorage<AppLocalStorageSchema> = appLocalStorage()): void {
+export function clearCachedAppInfo(
+  directory: string,
+  config: LocalStorage<AppLocalStorageSchema> = appLocalStorage(),
+): void {
   const normalized = normalizePath(directory)
   outputDebug(outputContent`Clearing app information for directory ${outputToken.path(normalized)}...`)
   config.delete(normalized)
 }
 
-export function clearAllAppInfo(config: LocalStorage<AppLocalStorageSchema> = appLocalStorage()): void {
-  outputDebug(outputContent`Clearing all app information...`)
-  config.clear()
-}
-
-export function setAppInfo(
+export function setCachedAppInfo(
   options: CachedAppInfo,
   config: LocalStorage<AppLocalStorageSchema> = appLocalStorage(),
 ): void {


### PR DESCRIPTION
### WHY are these changes introduced?

We used to have an idea of an AppDevCachedContext, but with config-as-code the app context can either come from the cache or from the config. 

### WHAT is this pull request doing?

Makes functions in the local storage module self-evident: `getCachedAppInfo` instead of `getAppInfo`
Rename `getAppDevCachedContext` to `getAppContext`
Make it so the `app info` command reuses the `getAppContext` helper