### PR TITLE
Refactor AutocompletePrompt and SelectPrompt

### DIFF
--- a/packages/app/src/cli/prompts/config.test.ts
+++ b/packages/app/src/cli/prompts/config.test.ts
@@ -83,9 +83,7 @@ describe('selectConfigName', () => {
       expect(renderTextPrompt).toHaveBeenCalledWith({
         defaultValue: 'My app',
         message: 'Configuration file name:',
-        previewPrefix: expect.any(Function),
-        previewSuffix: expect.any(Function),
-        previewValue: expect.any(Function),
+        preview: expect.any(Function),
         validate: expect.any(Function),
       })
     })

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -9,6 +9,7 @@ import {fileExists, glob} from '@shopify/cli-kit/node/fs'
 import {basename, joinPath} from '@shopify/cli-kit/node/path'
 import {slugify} from '@shopify/cli-kit/common/string'
 import {err, ok, Result} from '@shopify/cli-kit/node/result'
+import colors from '@shopify/cli-kit/node/colors'
 
 export async function selectConfigName(directory: string, defaultName = ''): Promise<string> {
   const namePromptOptions = buildTextPromptOptions(defaultName)
@@ -52,9 +53,7 @@ function buildTextPromptOptions(defaultValue: string): RenderTextPromptOptions {
     message: 'Configuration file name:',
     defaultValue,
     validate,
-    previewPrefix: () => 'shopify.app.',
-    previewValue: (value: string) => slugify(value),
-    previewSuffix: () => '.toml will be generated in your root directory\n',
+    preview: (value) => `shopify.app.${colors.cyan(slugify(value))}.toml will be generated in your root directory`,
   }
 }
 

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -104,7 +104,7 @@ describe('AutocompletePrompt', async () => {
 
     const renderInstance = render(
       <AutocompletePrompt
-        message="Associate your project with the org Castile Ventures?"
+        message={['Associate your project with the org', {userInput: 'Castile Ventures?'}]}
         choices={items}
         infoTable={infoTable}
         onSubmit={onEnter}
@@ -121,7 +121,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWaitForChange(renderInstance, ENTER)
 
     expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
-      "?  Associate your project with the org Castile Ventures?
+      "?  Associate your project with the org [36mCastile Ventures?[39m
       [36m✔[39m  [36msecond[39m
       "
     `)
@@ -212,6 +212,46 @@ describe('AutocompletePrompt', async () => {
          ┃  \u001b[1mRemove\u001b[22m
          ┃  • integrated-demand-ext
          ┃  • order-discount
+
+      [36m>[39m  [36mfirst[39m
+         second
+         third
+         fourth
+
+         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+      "
+    `)
+  })
+
+  test('supports a git diff', async () => {
+    const items = [
+      {label: 'first', value: 'first'},
+      {label: 'second', value: 'second'},
+      {label: 'third', value: 'third'},
+      {label: 'fourth', value: 'fourth'},
+    ]
+
+    const gitDiff = {
+      baselineContent: 'hello\n',
+      updatedContent: 'world\n',
+    }
+
+    const renderInstance = render(
+      <AutocompletePrompt
+        message="Associate your project with the org Castile Ventures?"
+        choices={items}
+        gitDiff={gitDiff}
+        onSubmit={() => {}}
+        search={() => Promise.resolve({data: []} as SearchResults<string>)}
+      />,
+    )
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?
+
+         ┃  [36m  @@ -1 +1 @@[m
+         ┃  [31m- hello[m
+         ┃  [32m+ [m[32mworld[m
 
       [36m>[39m  [36mfirst[39m
          second

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -104,7 +104,7 @@ describe('AutocompletePrompt', async () => {
 
     const renderInstance = render(
       <AutocompletePrompt
-        message={['Associate your project with the org', {userInput: 'Castile Ventures?'}]}
+        message={['Associate your project with the org', {userInput: 'Castile Ventures'}, {char: '?'}]}
         choices={items}
         infoTable={infoTable}
         onSubmit={onEnter}
@@ -121,7 +121,7 @@ describe('AutocompletePrompt', async () => {
     await sendInputAndWaitForChange(renderInstance, ENTER)
 
     expect(getLastFrameAfterUnmount(renderInstance)).toMatchInlineSnapshot(`
-      "?  Associate your project with the org [36mCastile Ventures?[39m
+      "?  Associate your project with the org [36mCastile Ventures[39m?
       [36m✔[39m  [36msecond[39m
       "
     `)

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -43,13 +43,14 @@ function AutocompletePrompt<T>({
   infoMessage,
   gitDiff,
 }: React.PropsWithChildren<AutocompletePromptProps<T>>): ReactElement | null {
-  const [answer, setAnswer] = useState<SelectItem<T> | undefined>(choices[0])
   const {exit: unmountInk} = useApp()
   const [searchTerm, setSearchTerm] = useState('')
   const [searchResults, setSearchResults] = useState<SelectItem<T>[]>(choices)
   const canSearch = choices.length > MIN_NUMBER_OF_ITEMS_FOR_SEARCH
   const [hasMorePages, setHasMorePages] = useState(initialHasMorePages)
-  const {state, setState} = usePrompt()
+  const {state, setState, answer, setAnswer} = usePrompt<SelectItem<T> | undefined>({
+    initialAnswer: choices[0],
+  })
 
   const paginatedSearch = useCallback(
     async (term: string) => {
@@ -69,7 +70,7 @@ function AutocompletePrompt<T>({
         onSubmit(answer.value)
       }
     },
-    [state, onSubmit, unmountInk, setState],
+    [state, setAnswer, setState, unmountInk, onSubmit],
   )
 
   const setLoadingWhenSlow = useRef<NodeJS.Timeout>()

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -49,7 +49,7 @@ function AutocompletePrompt<T>({
   const canSearch = choices.length > MIN_NUMBER_OF_ITEMS_FOR_SEARCH
   const [hasMorePages, setHasMorePages] = useState(initialHasMorePages)
   const {state, setState, answer, setAnswer} = usePrompt<SelectItem<T> | undefined>({
-    initialAnswer: choices[0],
+    initialAnswer: undefined,
   })
 
   const paginatedSearch = useCallback(

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/GitDiff.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/GitDiff.test.tsx
@@ -1,6 +1,6 @@
 import {GitDiff} from './GitDiff.js'
-import {render} from '../../testing/ui.js'
-import {unstyled} from '../../../../public/node/output.js'
+import {render} from '../../../testing/ui.js'
+import {unstyled} from '../../../../../public/node/output.js'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import React from 'react'
 
@@ -10,13 +10,23 @@ afterEach(async () => {
 
 describe('GitDiff', async () => {
   test('renders correctly when no changes exist', async () => {
-    const {lastFrame} = render(<GitDiff baselineContent="hello" updatedContent="hello" />)
+    const gitDiff = {
+      baselineContent: 'hello',
+      updatedContent: 'hello',
+    }
+
+    const {lastFrame} = render(<GitDiff gitDiff={gitDiff} />)
 
     expect(lastFrame()).toEqual('No changes.')
   })
 
   test('renders correctly when changes exist', async () => {
-    const {lastFrame} = render(<GitDiff baselineContent="hello\n" updatedContent="world\n" />)
+    const gitDiff = {
+      baselineContent: 'hello\n',
+      updatedContent: 'world\n',
+    }
+
+    const {lastFrame} = render(<GitDiff gitDiff={gitDiff} />)
 
     expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
       "  @@ -1 +1 @@
@@ -26,7 +36,12 @@ describe('GitDiff', async () => {
   })
 
   test('renders correctly when changes exist and are several lines long', async () => {
-    const {lastFrame} = render(<GitDiff baselineContent="hello\nworld\n" updatedContent="world\nhello\n" />)
+    const gitDiff = {
+      baselineContent: 'hello\nworld\n',
+      updatedContent: 'world\nhello\n',
+    }
+
+    const {lastFrame} = render(<GitDiff gitDiff={gitDiff} />)
 
     expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
       "  @@ -1,2 +1,2 @@
@@ -37,7 +52,12 @@ describe('GitDiff', async () => {
   })
 
   test('displays color correctly', async () => {
-    const {lastFrame} = render(<GitDiff baselineContent="hello\nworld\n" updatedContent="world\nhello\n" />)
+    const gitDiff = {
+      baselineContent: 'hello\nworld\n',
+      updatedContent: 'world\nhello\n',
+    }
+
+    const {lastFrame} = render(<GitDiff gitDiff={gitDiff} />)
 
     expect(lastFrame()).toMatchInlineSnapshot(`
       "\u001b[36m  @@ -1,2 +1,2 @@\u001b[m
@@ -49,7 +69,12 @@ describe('GitDiff', async () => {
 
   test('respects no-color mode', async () => {
     vi.stubGlobal('process', {...process, env: {...process.env, FORCE_COLOR: '0'}})
-    const {lastFrame} = render(<GitDiff baselineContent="hello\nworld\n" updatedContent="world\nhello\n" />)
+    const gitDiff = {
+      baselineContent: 'hello\nworld\n',
+      updatedContent: 'world\nhello\n',
+    }
+
+    const {lastFrame} = render(<GitDiff gitDiff={gitDiff} />)
 
     expect(lastFrame()!).toMatchInlineSnapshot(`
       "  @@ -1,2 +1,2 @@
@@ -66,13 +91,19 @@ describe('GitDiff', async () => {
         world
       + hello"
     `
+
+    const gitDiff = {
+      baselineContent: 'hello\nworld\n',
+      updatedContent: 'world\nhello',
+    }
+
     // Removing a newline
 
-    const {lastFrame} = render(<GitDiff baselineContent="hello\nworld\n" updatedContent="world\nhello" />)
+    const {lastFrame} = render(<GitDiff gitDiff={gitDiff} />)
 
     expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(expectedDiff)
 
-    const lastFrame2 = render(<GitDiff baselineContent="hello\nworld\n" updatedContent="world\nhello" />).lastFrame
+    const lastFrame2 = render(<GitDiff gitDiff={gitDiff} />).lastFrame
 
     expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(expectedDiff)
   })
@@ -97,7 +128,13 @@ sit
 amet
 foo
 qux`
-    const {lastFrame} = render(<GitDiff baselineContent={baselineContent} updatedContent={updatedContent} />)
+
+    const gitDiff = {
+      baselineContent,
+      updatedContent,
+    }
+
+    const {lastFrame} = render(<GitDiff gitDiff={gitDiff} />)
 
     expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
       "  @@ -1,3 +1,3 @@

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/GitDiff.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/GitDiff.tsx
@@ -1,4 +1,4 @@
-import {unstyled, shouldDisplayColors} from '../../../../public/node/output.js'
+import {unstyled, shouldDisplayColors} from '../../../../../public/node/output.js'
 import {Text} from 'ink'
 import React, {FunctionComponent} from 'react'
 import {createRequire} from 'module'
@@ -7,8 +7,10 @@ const require = createRequire(import.meta.url)
 const gitDiff = require('git-diff')
 
 export interface GitDiffProps {
-  baselineContent: string
-  updatedContent: string
+  gitDiff: {
+    baselineContent: string
+    updatedContent: string
+  }
 }
 
 /**
@@ -19,7 +21,7 @@ export interface GitDiffProps {
  *   unchanged line
  * + added line
  */
-const GitDiff: FunctionComponent<GitDiffProps> = ({baselineContent, updatedContent}): JSX.Element => {
+const GitDiff: FunctionComponent<GitDiffProps> = ({gitDiff: {baselineContent, updatedContent}}): JSX.Element => {
   const rawDiffContents = gitDiff(baselineContent, updatedContent, {
     color: shouldDisplayColors(),
     // Show minimal context to accommodate small terminals.

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoMessage.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoMessage.test.tsx
@@ -1,0 +1,26 @@
+import {InfoMessage} from './InfoMessage.js'
+import {render} from '../../../testing/ui.js'
+import {describe, expect, test} from 'vitest'
+import React from 'react'
+
+describe('InfoMessage', async () => {
+  test('renders a message with title and body', async () => {
+    const {lastFrame} = render(
+      <InfoMessage
+        message={{
+          title: {
+            color: 'red',
+            text: "This can't be undone.",
+          },
+          body: "Once you upgrade this app, you can't go back to the old way of deploying extensions",
+        }}
+      />,
+    )
+
+    expect(lastFrame()).toMatchInlineSnapshot(`
+      "[31mThis can't be undone.[39m
+
+      Once you upgrade this app, you can't go back to the old way of deploying extensions"
+    `)
+  })
+})

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoMessage.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoMessage.tsx
@@ -12,13 +12,18 @@ export interface InfoMessageProps {
   }
 }
 
-const InfoMessage: FunctionComponent<InfoMessageProps> = ({message}) => {
+const InfoMessage: FunctionComponent<InfoMessageProps> = ({
+  message: {
+    title: {color, text: title},
+    body,
+  },
+}) => {
   return (
     <Box flexDirection="column" gap={1}>
-      <Text color={message.title.color}>
-        <TokenizedText item={message.title.text} />
+      <Text color={color}>
+        <TokenizedText item={title} />
       </Text>
-      <TokenizedText item={message.body} />
+      <TokenizedText item={body} />
     </Box>
   )
 }

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/InfoMessage.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/InfoMessage.tsx
@@ -1,0 +1,26 @@
+import {InlineToken, LinkToken, TokenItem, TokenizedText, UserInputToken} from '../TokenizedText.js'
+import {Box, Text, TextProps} from 'ink'
+import React, {FunctionComponent} from 'react'
+
+export interface InfoMessageProps {
+  message: {
+    title: {
+      color?: TextProps['color']
+      text: TokenItem<Exclude<InlineToken, UserInputToken | LinkToken>>
+    }
+    body: TokenItem
+  }
+}
+
+const InfoMessage: FunctionComponent<InfoMessageProps> = ({message}) => {
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text color={message.title.color}>
+        <TokenizedText item={message.title.text} />
+      </Text>
+      <TokenizedText item={message.body} />
+    </Box>
+  )
+}
+
+export {InfoMessage}

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
@@ -1,0 +1,129 @@
+import {GitDiff, GitDiffProps} from './GitDiff.js'
+import {InfoMessage, InfoMessageProps} from './InfoMessage.js'
+import {InfoTable, InfoTableProps} from './InfoTable.js'
+import {InlineToken, LinkToken, TokenItem, TokenizedText} from '../TokenizedText.js'
+import {messageWithPunctuation} from '../../utilities.js'
+import {AbortSignal} from '../../../../../public/node/abort.js'
+import useAbortSignal from '../../hooks/use-abort-signal.js'
+import React, {ReactElement, cloneElement, useCallback, useLayoutEffect, useState} from 'react'
+import {Box, measureElement, Text, useStdout} from 'ink'
+import figures from 'figures'
+
+export type Message = TokenItem<Exclude<InlineToken, LinkToken>>
+
+export interface PromptLayoutProps {
+  message: Message
+  infoTable?: InfoTableProps['table']
+  abortSignal?: AbortSignal
+  infoMessage?: InfoMessageProps['message']
+  gitDiff?: GitDiffProps['gitDiff']
+  header?: ReactElement | null
+  submitted: boolean
+  submittedAnswerLabel?: string
+  input: ReactElement
+}
+
+const SELECT_INPUT_FOOTER_HEIGHT = 4
+
+const PromptLayout = ({
+  message,
+  infoTable,
+  abortSignal,
+  infoMessage,
+  gitDiff,
+  header,
+  submitted,
+  input,
+  submittedAnswerLabel,
+}: PromptLayoutProps): ReactElement | null => {
+  const {stdout} = useStdout()
+  const [wrapperHeight, setWrapperHeight] = useState(0)
+  const [promptAreaHeight, setPromptAreaHeight] = useState(0)
+  const currentAvailableLines = stdout.rows - promptAreaHeight - SELECT_INPUT_FOOTER_HEIGHT
+  const [availableLines, setAvailableLines] = useState(currentAvailableLines)
+  const inputComponent = cloneElement(input, {availableLines})
+
+  const wrapperRef = useCallback(
+    (node) => {
+      if (node !== null) {
+        const {height} = measureElement(node)
+        if (wrapperHeight !== height) {
+          setWrapperHeight(height)
+        }
+      }
+    },
+    [wrapperHeight],
+  )
+
+  const promptAreaRef = useCallback((node) => {
+    if (node !== null) {
+      const {height} = measureElement(node)
+      setPromptAreaHeight(height)
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    function onResize() {
+      const newAvailableLines = stdout.rows - promptAreaHeight - SELECT_INPUT_FOOTER_HEIGHT
+      if (newAvailableLines !== availableLines) {
+        setAvailableLines(newAvailableLines)
+      }
+    }
+
+    onResize()
+
+    stdout.on('resize', onResize)
+    return () => {
+      stdout.off('resize', onResize)
+    }
+  }, [wrapperHeight, promptAreaHeight, stdout, availableLines])
+
+  const {isAborted} = useAbortSignal(abortSignal)
+
+  return isAborted ? null : (
+    <Box flexDirection="column" marginBottom={1} ref={wrapperRef}>
+      <Box ref={promptAreaRef} flexDirection="column">
+        <Box>
+          <Box marginRight={2}>
+            <Text>?</Text>
+          </Box>
+          <TokenizedText item={messageWithPunctuation(message)} />
+          {header}
+        </Box>
+
+        {(infoTable || infoMessage || gitDiff) && !submitted ? (
+          <Box
+            marginTop={1}
+            marginLeft={3}
+            paddingLeft={2}
+            borderStyle="bold"
+            borderLeft
+            borderRight={false}
+            borderTop={false}
+            borderBottom={false}
+            flexDirection="column"
+            gap={1}
+          >
+            {infoMessage ? <InfoMessage message={infoMessage} /> : null}
+            {infoTable ? <InfoTable table={infoTable} /> : null}
+            {gitDiff ? <GitDiff gitDiff={gitDiff} /> : null}
+          </Box>
+        ) : null}
+      </Box>
+
+      {submitted && submittedAnswerLabel ? (
+        <Box>
+          <Box marginRight={2}>
+            <Text color="cyan">{figures.tick}</Text>
+          </Box>
+
+          <Text color="cyan">{submittedAnswerLabel}</Text>
+        </Box>
+      ) : (
+        <Box marginTop={1}>{inputComponent}</Box>
+      )}
+    </Box>
+  )
+}
+
+export {PromptLayout}

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
@@ -24,8 +24,6 @@ export interface PromptLayoutProps {
   input: ReactElement
 }
 
-const FOOTER_HEIGHT = 4
-
 const PromptLayout = ({
   message,
   infoTable,
@@ -40,9 +38,9 @@ const PromptLayout = ({
   const {stdout} = useStdout()
   const [wrapperHeight, setWrapperHeight] = useState(0)
   const [promptAreaHeight, setPromptAreaHeight] = useState(0)
-  const currentAvailableLines = stdout.rows - promptAreaHeight - FOOTER_HEIGHT
+  const [inputFixedAreaHeight, setInputFixedAreaHeight] = useState(0)
+  const currentAvailableLines = stdout.rows - promptAreaHeight - inputFixedAreaHeight
   const [availableLines, setAvailableLines] = useState(currentAvailableLines)
-  const inputComponent = cloneElement(input, {availableLines})
 
   const wrapperRef = useCallback(
     (node) => {
@@ -63,9 +61,19 @@ const PromptLayout = ({
     }
   }, [])
 
+  const inputFixedAreaRef = useCallback((node) => {
+    if (node !== null) {
+      const {height} = measureElement(node)
+      // + 3 accounts for the margins inside the input elements and the last empty line of the terminal
+      setInputFixedAreaHeight(height + 3)
+    }
+  }, [])
+
+  const inputComponent = cloneElement(input, {availableLines, inputFixedAreaRef})
+
   useLayoutEffect(() => {
     function onResize() {
-      const newAvailableLines = stdout.rows - promptAreaHeight - FOOTER_HEIGHT
+      const newAvailableLines = stdout.rows - promptAreaHeight - inputFixedAreaHeight
       if (newAvailableLines !== availableLines) {
         setAvailableLines(newAvailableLines)
       }
@@ -77,7 +85,7 @@ const PromptLayout = ({
     return () => {
       stdout.off('resize', onResize)
     }
-  }, [wrapperHeight, promptAreaHeight, stdout, availableLines])
+  }, [wrapperHeight, promptAreaHeight, stdout, availableLines, inputFixedAreaHeight])
 
   const {isAborted} = useAbortSignal(abortSignal)
 

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
@@ -24,7 +24,7 @@ export interface PromptLayoutProps {
   input: ReactElement
 }
 
-const SELECT_INPUT_FOOTER_HEIGHT = 4
+const FOOTER_HEIGHT = 4
 
 const PromptLayout = ({
   message,
@@ -40,7 +40,7 @@ const PromptLayout = ({
   const {stdout} = useStdout()
   const [wrapperHeight, setWrapperHeight] = useState(0)
   const [promptAreaHeight, setPromptAreaHeight] = useState(0)
-  const currentAvailableLines = stdout.rows - promptAreaHeight - SELECT_INPUT_FOOTER_HEIGHT
+  const currentAvailableLines = stdout.rows - promptAreaHeight - FOOTER_HEIGHT
   const [availableLines, setAvailableLines] = useState(currentAvailableLines)
   const inputComponent = cloneElement(input, {availableLines})
 
@@ -65,7 +65,7 @@ const PromptLayout = ({
 
   useLayoutEffect(() => {
     function onResize() {
-      const newAvailableLines = stdout.rows - promptAreaHeight - SELECT_INPUT_FOOTER_HEIGHT
+      const newAvailableLines = stdout.rows - promptAreaHeight - FOOTER_HEIGHT
       if (newAvailableLines !== availableLines) {
         setAvailableLines(newAvailableLines)
       }

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
@@ -5,6 +5,7 @@ import {InlineToken, LinkToken, TokenItem, TokenizedText} from '../TokenizedText
 import {messageWithPunctuation} from '../../utilities.js'
 import {AbortSignal} from '../../../../../public/node/abort.js'
 import useAbortSignal from '../../hooks/use-abort-signal.js'
+import {PromptState} from '../../hooks/use-prompt.js'
 import React, {ReactElement, cloneElement, useCallback, useLayoutEffect, useState} from 'react'
 import {Box, measureElement, Text, useStdout} from 'ink'
 import figures from 'figures'
@@ -18,7 +19,7 @@ export interface PromptLayoutProps {
   infoMessage?: InfoMessageProps['message']
   gitDiff?: GitDiffProps['gitDiff']
   header?: ReactElement | null
-  submitted: boolean
+  state: PromptState
   submittedAnswerLabel?: string
   input: ReactElement
 }
@@ -32,7 +33,7 @@ const PromptLayout = ({
   infoMessage,
   gitDiff,
   header,
-  submitted,
+  state,
   input,
   submittedAnswerLabel,
 }: PromptLayoutProps): ReactElement | null => {
@@ -91,7 +92,7 @@ const PromptLayout = ({
           {header}
         </Box>
 
-        {(infoTable || infoMessage || gitDiff) && !submitted ? (
+        {(infoTable || infoMessage || gitDiff) && state !== PromptState.Submitted ? (
           <Box
             marginTop={1}
             marginLeft={3}
@@ -111,7 +112,7 @@ const PromptLayout = ({
         ) : null}
       </Box>
 
-      {submitted && submittedAnswerLabel ? (
+      {state === PromptState.Submitted && submittedAnswerLabel ? (
         <Box>
           <Box marginRight={2}>
             <Text color="cyan">{figures.tick}</Text>

--- a/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
@@ -30,6 +30,7 @@ export interface SelectInputProps<T> {
   morePagesMessage?: string
   availableLines?: number
   onSubmit?: (item: Item<T>) => void
+  inputFixedAreaRef?: React.RefObject<DOMElement>
 }
 
 export interface Item<T> {
@@ -140,6 +141,7 @@ function SelectInputInner<T>(
     morePagesMessage,
     availableLines = MAX_AVAILABLE_LINES,
     onSubmit,
+    inputFixedAreaRef,
   }: SelectInputProps<T>,
   ref: React.ForwardedRef<DOMElement>,
 ): JSX.Element | null {
@@ -281,25 +283,27 @@ function SelectInputInner<T>(
           ) : null}
         </Box>
 
-        {noItems ? (
-          <Box marginLeft={3}>
-            <Text dimColor>Try again with a different keyword.</Text>
-          </Box>
-        ) : (
-          <Box marginLeft={3} flexDirection="column">
-            <Text dimColor>
-              {`Press ${figures.arrowUp}${figures.arrowDown} arrows to select, enter ${
-                itemsHaveKeys ? 'or a shortcut ' : ''
-              }to confirm.`}
-            </Text>
-            {hasMorePages ? (
-              <Text>
-                <Text bold>1-{items.length} of many</Text>
-                {morePagesMessage ? `  ${morePagesMessage}` : null}
+        <Box ref={inputFixedAreaRef}>
+          {noItems ? (
+            <Box marginLeft={3}>
+              <Text dimColor>Try again with a different keyword.</Text>
+            </Box>
+          ) : (
+            <Box marginLeft={3} flexDirection="column">
+              <Text dimColor>
+                {`Press ${figures.arrowUp}${figures.arrowDown} arrows to select, enter ${
+                  itemsHaveKeys ? 'or a shortcut ' : ''
+                }to confirm.`}
               </Text>
-            ) : null}
-          </Box>
-        )}
+              {hasMorePages ? (
+                <Text>
+                  <Text bold>1-{items.length} of many</Text>
+                  {morePagesMessage ? `  ${morePagesMessage}` : null}
+                </Text>
+              ) : null}
+            </Box>
+          )}
+        </Box>
       </Box>
     )
   }

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
@@ -161,6 +161,45 @@ describe('SelectPrompt', async () => {
     `)
   })
 
+  test('supports a git diff', async () => {
+    const items = [
+      {label: 'first', value: 'first'},
+      {label: 'second', value: 'second'},
+      {label: 'third', value: 'third'},
+      {label: 'fourth', value: 'fourth'},
+    ]
+
+    const gitDiff = {
+      baselineContent: 'hello\n',
+      updatedContent: 'world\n',
+    }
+
+    const renderInstance = render(
+      <SelectPrompt
+        message="Associate your project with the org Castile Ventures?"
+        choices={items}
+        gitDiff={gitDiff}
+        onSubmit={() => {}}
+      />,
+    )
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "?  Associate your project with the org Castile Ventures?
+
+         ┃  [36m  @@ -1 +1 @@[m
+         ┃  [31m- hello[m
+         ┃  [32m+ [m[32mworld[m
+
+      [36m>[39m  [36mfirst[39m
+         second
+         third
+         fourth
+
+         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+      "
+    `)
+  })
+
   test('supports an info message', async () => {
     const items = [
       {label: 'first', value: 'first'},

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -5,7 +5,7 @@ import {InfoMessageProps} from './Prompts/InfoMessage.js'
 import {Message, PromptLayout} from './Prompts/PromptLayout.js'
 import {AbortSignal} from '../../../../public/node/abort.js'
 import usePrompt, {PromptState} from '../hooks/use-prompt.js'
-import React, {ReactElement, useCallback, useState} from 'react'
+import React, {ReactElement, useCallback} from 'react'
 import {useApp} from 'ink'
 
 export interface SelectPromptProps<T> {
@@ -33,9 +33,10 @@ function SelectPrompt<T>({
   if (choices.length === 0) {
     throw new Error('SelectPrompt requires at least one choice')
   }
-  const [answer, setAnswer] = useState<SelectItem<T> | undefined>(undefined)
   const {exit: unmountInk} = useApp()
-  const {state, setState} = usePrompt()
+  const {state, setState, answer, setAnswer} = usePrompt<SelectItem<T> | undefined>({
+    initialAnswer: undefined,
+  })
 
   const submitAnswer = useCallback(
     (answer: SelectItem<T>) => {
@@ -44,7 +45,7 @@ function SelectPrompt<T>({
       unmountInk()
       onSubmit(answer.value)
     },
-    [unmountInk, onSubmit, setState],
+    [setAnswer, setState, unmountInk, onSubmit],
   )
 
   return (

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -1,33 +1,28 @@
 import {SelectInput, SelectInputProps, Item as SelectItem} from './SelectInput.js'
 import {InfoTable, InfoTableProps} from './Prompts/InfoTable.js'
-import {InlineToken, LinkToken, TokenItem, TokenizedText, UserInputToken} from './TokenizedText.js'
-import {GitDiff, GitDiffProps} from './GitDiff.js'
+import {InlineToken, LinkToken, TokenItem, TokenizedText} from './TokenizedText.js'
+import {GitDiff, GitDiffProps} from './Prompts/GitDiff.js'
+import {InfoMessage, InfoMessageProps} from './Prompts/InfoMessage.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {AbortSignal} from '../../../../public/node/abort.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
 import React, {ReactElement, useCallback, useLayoutEffect, useState} from 'react'
-import {Box, measureElement, Text, useApp, useStdout, TextProps} from 'ink'
+import {Box, measureElement, Text, useApp, useStdout} from 'ink'
 import figures from 'figures'
 import ansiEscapes from 'ansi-escapes'
-
-export interface InfoMessage {
-  title: {
-    color?: TextProps['color']
-    text: TokenItem<Exclude<InlineToken, UserInputToken | LinkToken>>
-  }
-  body: TokenItem
-}
 
 export interface SelectPromptProps<T> {
   message: TokenItem<Exclude<InlineToken, LinkToken>>
   choices: SelectInputProps<T>['items']
   onSubmit: (value: T) => void
   infoTable?: InfoTableProps['table']
-  gitDiff?: GitDiffProps
+  gitDiff?: GitDiffProps['gitDiff']
   defaultValue?: T
   abortSignal?: AbortSignal
-  infoMessage?: InfoMessage
+  infoMessage?: InfoMessageProps['message']
 }
+
+const SELECT_INPUT_FOOTER_HEIGHT = 4
 
 // eslint-disable-next-line react/function-component-definition
 function SelectPrompt<T>({
@@ -68,7 +63,7 @@ function SelectPrompt<T>({
 
   useLayoutEffect(() => {
     function onResize() {
-      const newAvailableLines = stdout.rows - promptAreaHeight - 4
+      const newAvailableLines = stdout.rows - promptAreaHeight - SELECT_INPUT_FOOTER_HEIGHT
       if (newAvailableLines !== availableLines) {
         setAvailableLines(newAvailableLines)
       }
@@ -119,16 +114,9 @@ function SelectPrompt<T>({
             flexDirection="column"
             gap={1}
           >
-            {infoMessage ? (
-              <Box flexDirection="column" gap={1}>
-                <Text color={infoMessage.title.color}>
-                  <TokenizedText item={infoMessage.title.text} />
-                </Text>
-                <TokenizedText item={infoMessage.body} />
-              </Box>
-            ) : null}
+            {infoMessage ? <InfoMessage message={infoMessage} /> : null}
             {infoTable ? <InfoTable table={infoTable} /> : null}
-            {gitDiff ? <GitDiff {...gitDiff} /> : null}
+            {gitDiff ? <GitDiff gitDiff={gitDiff} /> : null}
           </Box>
         ) : null}
       </Box>

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -4,6 +4,7 @@ import {GitDiffProps} from './Prompts/GitDiff.js'
 import {InfoMessageProps} from './Prompts/InfoMessage.js'
 import {Message, PromptLayout} from './Prompts/PromptLayout.js'
 import {AbortSignal} from '../../../../public/node/abort.js'
+import usePrompt, {PromptState} from '../hooks/use-prompt.js'
 import React, {ReactElement, useCallback, useState} from 'react'
 import {useApp} from 'ink'
 
@@ -34,22 +35,22 @@ function SelectPrompt<T>({
   }
   const [answer, setAnswer] = useState<SelectItem<T> | undefined>(undefined)
   const {exit: unmountInk} = useApp()
-  const [submitted, setSubmitted] = useState(false)
+  const {state, setState} = usePrompt()
 
   const submitAnswer = useCallback(
     (answer: SelectItem<T>) => {
       setAnswer(answer)
-      setSubmitted(true)
+      setState(PromptState.Submitted)
       unmountInk()
       onSubmit(answer.value)
     },
-    [unmountInk, onSubmit],
+    [unmountInk, onSubmit, setState],
   )
 
   return (
     <PromptLayout
       message={message}
-      submitted={submitted}
+      state={state}
       submittedAnswerLabel={answer?.label}
       infoTable={infoTable}
       infoMessage={infoMessage}

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -34,24 +34,24 @@ function SelectPrompt<T>({
     throw new Error('SelectPrompt requires at least one choice')
   }
   const {exit: unmountInk} = useApp()
-  const {state, setState, answer, setAnswer} = usePrompt<SelectItem<T> | undefined>({
+  const {promptState, setPromptState, answer, setAnswer} = usePrompt<SelectItem<T> | undefined>({
     initialAnswer: undefined,
   })
 
   const submitAnswer = useCallback(
     (answer: SelectItem<T>) => {
       setAnswer(answer)
-      setState(PromptState.Submitted)
+      setPromptState(PromptState.Submitted)
       unmountInk()
       onSubmit(answer.value)
     },
-    [setAnswer, setState, unmountInk, onSubmit],
+    [setAnswer, setPromptState, unmountInk, onSubmit],
   )
 
   return (
     <PromptLayout
       message={message}
-      state={state}
+      state={promptState}
       submittedAnswerLabel={answer?.label}
       infoTable={infoTable}
       infoMessage={infoMessage}

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.tsx
@@ -1,18 +1,14 @@
 import {SelectInput, SelectInputProps, Item as SelectItem} from './SelectInput.js'
-import {InfoTable, InfoTableProps} from './Prompts/InfoTable.js'
-import {InlineToken, LinkToken, TokenItem, TokenizedText} from './TokenizedText.js'
-import {GitDiff, GitDiffProps} from './Prompts/GitDiff.js'
-import {InfoMessage, InfoMessageProps} from './Prompts/InfoMessage.js'
-import {messageWithPunctuation} from '../utilities.js'
+import {InfoTableProps} from './Prompts/InfoTable.js'
+import {GitDiffProps} from './Prompts/GitDiff.js'
+import {InfoMessageProps} from './Prompts/InfoMessage.js'
+import {Message, PromptLayout} from './Prompts/PromptLayout.js'
 import {AbortSignal} from '../../../../public/node/abort.js'
-import useAbortSignal from '../hooks/use-abort-signal.js'
-import React, {ReactElement, useCallback, useLayoutEffect, useState} from 'react'
-import {Box, measureElement, Text, useApp, useStdout} from 'ink'
-import figures from 'figures'
-import ansiEscapes from 'ansi-escapes'
+import React, {ReactElement, useCallback, useState} from 'react'
+import {useApp} from 'ink'
 
 export interface SelectPromptProps<T> {
-  message: TokenItem<Exclude<InlineToken, LinkToken>>
+  message: Message
   choices: SelectInputProps<T>['items']
   onSubmit: (value: T) => void
   infoTable?: InfoTableProps['table']
@@ -21,8 +17,6 @@ export interface SelectPromptProps<T> {
   abortSignal?: AbortSignal
   infoMessage?: InfoMessageProps['message']
 }
-
-const SELECT_INPUT_FOOTER_HEIGHT = 4
 
 // eslint-disable-next-line react/function-component-definition
 function SelectPrompt<T>({
@@ -41,105 +35,28 @@ function SelectPrompt<T>({
   const [answer, setAnswer] = useState<SelectItem<T> | undefined>(undefined)
   const {exit: unmountInk} = useApp()
   const [submitted, setSubmitted] = useState(false)
-  const {stdout} = useStdout()
-  const [wrapperHeight, setWrapperHeight] = useState(0)
-  const [promptAreaHeight, setPromptAreaHeight] = useState(0)
-  const currentAvailableLines = stdout.rows - promptAreaHeight - 5
-  const [availableLines, setAvailableLines] = useState(currentAvailableLines)
-
-  const wrapperRef = useCallback((node) => {
-    if (node !== null) {
-      const {height} = measureElement(node)
-      setWrapperHeight(height)
-    }
-  }, [])
-
-  const promptAreaRef = useCallback((node) => {
-    if (node !== null) {
-      const {height} = measureElement(node)
-      setPromptAreaHeight(height)
-    }
-  }, [])
-
-  useLayoutEffect(() => {
-    function onResize() {
-      const newAvailableLines = stdout.rows - promptAreaHeight - SELECT_INPUT_FOOTER_HEIGHT
-      if (newAvailableLines !== availableLines) {
-        setAvailableLines(newAvailableLines)
-      }
-    }
-
-    onResize()
-
-    stdout.on('resize', onResize)
-    return () => {
-      stdout.off('resize', onResize)
-    }
-  }, [wrapperHeight, promptAreaHeight, choices.length, stdout, availableLines])
 
   const submitAnswer = useCallback(
     (answer: SelectItem<T>) => {
-      if (stdout && wrapperHeight >= stdout.rows) {
-        stdout.write(ansiEscapes.clearTerminal)
-      }
       setAnswer(answer)
       setSubmitted(true)
       unmountInk()
       onSubmit(answer.value)
     },
-    [stdout, wrapperHeight, unmountInk, onSubmit],
+    [unmountInk, onSubmit],
   )
 
-  const {isAborted} = useAbortSignal(abortSignal)
-
-  return isAborted ? null : (
-    <Box flexDirection="column" marginBottom={1} ref={wrapperRef}>
-      <Box ref={promptAreaRef} flexDirection="column">
-        <Box>
-          <Box marginRight={2}>
-            <Text>?</Text>
-          </Box>
-          <TokenizedText item={messageWithPunctuation(message)} />
-        </Box>
-        {(infoTable || infoMessage || gitDiff) && !submitted ? (
-          <Box
-            marginTop={1}
-            marginLeft={3}
-            paddingLeft={2}
-            borderStyle="bold"
-            borderLeft
-            borderRight={false}
-            borderTop={false}
-            borderBottom={false}
-            flexDirection="column"
-            gap={1}
-          >
-            {infoMessage ? <InfoMessage message={infoMessage} /> : null}
-            {infoTable ? <InfoTable table={infoTable} /> : null}
-            {gitDiff ? <GitDiff gitDiff={gitDiff} /> : null}
-          </Box>
-        ) : null}
-      </Box>
-
-      {submitted ? (
-        <Box>
-          <Box marginRight={2}>
-            <Text color="cyan">{figures.tick}</Text>
-          </Box>
-
-          <Text color="cyan">{answer!.label}</Text>
-        </Box>
-      ) : (
-        <Box marginTop={1}>
-          <SelectInput
-            defaultValue={defaultValue}
-            items={choices}
-            availableLines={availableLines}
-            onSubmit={submitAnswer}
-          />
-        </Box>
-      )}
-    </Box>
+  return (
+    <PromptLayout
+      message={message}
+      submitted={submitted}
+      submittedAnswerLabel={answer?.label}
+      infoTable={infoTable}
+      infoMessage={infoMessage}
+      gitDiff={gitDiff}
+      abortSignal={abortSignal}
+      input={<SelectInput defaultValue={defaultValue} items={choices} onSubmit={submitAnswer} />}
+    />
   )
 }
 

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
@@ -4,6 +4,7 @@ import {unstyled} from '../../../../public/node/output.js'
 import {AbortController} from '../../../../public/node/abort.js'
 import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
+import colors from '@shopify/cli-kit/node/colors'
 
 const ENTER = '\r'
 
@@ -209,9 +210,7 @@ describe('TextPrompt', () => {
       <TextPrompt
         onSubmit={() => {}}
         message="How tall are you in cm?"
-        previewPrefix={() => 'You are '}
-        previewValue={(value) => String(Number(value) / 100)}
-        previewSuffix={() => 'm tall.'}
+        preview={(value) => `You are ${colors.cyan(String(Number(value) / 100))}m tall.`}
       />,
     )
 
@@ -232,11 +231,11 @@ describe('TextPrompt', () => {
       <TextPrompt
         onSubmit={() => {}}
         message="How tall are you?"
-        previewPrefix={() => 'You are '}
-        previewValue={(value) =>
-          `incredibly humongously savagely unnaturally monstrously pathetically arrogantly ${value}`
+        preview={(value) =>
+          `You are ${colors.cyan(
+            `incredibly humongously savagely unnaturally monstrously pathetically arrogantly ${value}`,
+          )} tall.`
         }
-        previewSuffix={() => ' tall.'}
       />,
     )
 

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -1,5 +1,5 @@
 import {TextInput} from './TextInput.js'
-import {TokenizedText} from './TokenizedText.js'
+import {InlineToken, TokenItem, TokenizedText} from './TokenizedText.js'
 import {handleCtrlC} from '../../ui.js'
 import useLayout from '../hooks/use-layout.js'
 import {messageWithPunctuation} from '../utilities.js'
@@ -18,9 +18,7 @@ export interface TextPromptProps {
   allowEmpty?: boolean
   emptyDisplayedValue?: string
   abortSignal?: AbortSignal
-  previewPrefix?: (value: string) => string | undefined
-  previewValue?: (value: string) => string | undefined
-  previewSuffix?: (value: string) => string | undefined
+  preview?: (value: string) => TokenItem<InlineToken>
 }
 
 const TextPrompt: FunctionComponent<TextPromptProps> = ({
@@ -32,9 +30,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   allowEmpty = false,
   emptyDisplayedValue = '(empty)',
   abortSignal,
-  previewPrefix,
-  previewValue,
-  previewSuffix,
+  preview,
 }) => {
   if (password && defaultValue) {
     throw new Error("Can't use defaultValue with password")
@@ -128,17 +124,13 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
               <Text color={color}>{error}</Text>
             </Box>
           ) : null}
+          {!shouldShowError && preview ? (
+            <Box marginLeft={3}>
+              <TokenizedText item={preview(answerOrDefault)} />
+            </Box>
+          ) : null}
         </Box>
       )}
-      {previewValue && !submitted ? (
-        <Box marginLeft={3}>
-          <Text>
-            <Text>{previewPrefix ? previewPrefix(answerOrDefault) : null}</Text>
-            <Text color={color}>{previewValue(answerOrDefault)}</Text>
-            <Text>{previewSuffix ? previewSuffix(answerOrDefault) : null}</Text>
-          </Text>
-        </Box>
-      ) : null}
     </Box>
   )
 }

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -5,6 +5,7 @@ import useLayout from '../hooks/use-layout.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {AbortSignal} from '../../../../public/node/abort.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
+import usePrompt, {PromptState} from '../hooks/use-prompt.js'
 import React, {FunctionComponent, useCallback, useState} from 'react'
 import {Box, useApp, useInput, Text} from 'ink'
 import figures from 'figures'
@@ -50,14 +51,15 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   )
 
   const {oneThird} = useLayout()
-  const [answer, setAnswer] = useState<string>('')
+  const {state, setState, answer, setAnswer} = usePrompt<string>({
+    initialAnswer: '',
+  })
   const answerOrDefault = answer.length > 0 ? answer : defaultValue
   const displayEmptyValue = answerOrDefault === ''
   const displayedAnswer = displayEmptyValue ? emptyDisplayedValue : answerOrDefault
   const {exit: unmountInk} = useApp()
-  const [submitted, setSubmitted] = useState(false)
   const [error, setError] = useState<string | undefined>(undefined)
-  const shouldShowError = submitted && error
+  const shouldShowError = state === PromptState.Submitted && error
   const color = shouldShowError ? 'red' : 'cyan'
   const underline = new Array(oneThird - 3).fill('▔')
   const {isAborted} = useAbortSignal(abortSignal)
@@ -66,7 +68,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
     handleCtrlC(input, key)
 
     if (key.return) {
-      setSubmitted(true)
+      setState(PromptState.Submitted)
       const error = validateAnswer(answerOrDefault)
       setError(error)
 
@@ -85,7 +87,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
         </Box>
         <TokenizedText item={messageWithPunctuation(message)} />
       </Box>
-      {submitted && !error ? (
+      {state === PromptState.Submitted && !error ? (
         <Box>
           <Box marginRight={2}>
             <Text color="cyan">{figures.tick}</Text>
@@ -108,7 +110,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
                 value={answer}
                 onChange={(answer) => {
                   setAnswer(answer)
-                  setSubmitted(false)
+                  setState(PromptState.Submitted)
                 }}
                 defaultValue={defaultValue}
                 color={color}

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -51,7 +51,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   )
 
   const {oneThird} = useLayout()
-  const {state, setState, answer, setAnswer} = usePrompt<string>({
+  const {promptState, setPromptState, answer, setAnswer} = usePrompt<string>({
     initialAnswer: '',
   })
   const answerOrDefault = answer.length > 0 ? answer : defaultValue
@@ -59,7 +59,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   const displayedAnswer = displayEmptyValue ? emptyDisplayedValue : answerOrDefault
   const {exit: unmountInk} = useApp()
   const [error, setError] = useState<string | undefined>(undefined)
-  const shouldShowError = state === PromptState.Submitted && error
+  const shouldShowError = promptState === PromptState.Submitted && error
   const color = shouldShowError ? 'red' : 'cyan'
   const underline = new Array(oneThird - 3).fill('▔')
   const {isAborted} = useAbortSignal(abortSignal)
@@ -68,7 +68,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
     handleCtrlC(input, key)
 
     if (key.return) {
-      setState(PromptState.Submitted)
+      setPromptState(PromptState.Submitted)
       const error = validateAnswer(answerOrDefault)
       setError(error)
 
@@ -87,7 +87,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
         </Box>
         <TokenizedText item={messageWithPunctuation(message)} />
       </Box>
-      {state === PromptState.Submitted && !error ? (
+      {promptState === PromptState.Submitted && !error ? (
         <Box>
           <Box marginRight={2}>
             <Text color="cyan">{figures.tick}</Text>
@@ -110,7 +110,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
                 value={answer}
                 onChange={(answer) => {
                   setAnswer(answer)
-                  setState(PromptState.Submitted)
+                  setPromptState(PromptState.Idle)
                 }}
                 defaultValue={defaultValue}
                 color={color}

--- a/packages/cli-kit/src/private/node/ui/hooks/use-prompt.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-prompt.ts
@@ -12,12 +12,12 @@ interface UsePromptProps<T> {
 }
 
 export default function usePrompt<T>({initialAnswer}: UsePromptProps<T>) {
-  const [state, setState] = useState<PromptState>(PromptState.Idle)
+  const [promptState, setPromptState] = useState<PromptState>(PromptState.Idle)
   const [answer, setAnswer] = useState<T>(initialAnswer)
 
   return {
-    state,
-    setState,
+    promptState,
+    setPromptState,
     answer,
     setAnswer,
   }

--- a/packages/cli-kit/src/private/node/ui/hooks/use-prompt.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-prompt.ts
@@ -1,0 +1,17 @@
+import {useState} from 'react'
+
+export enum PromptState {
+  Idle = 'idle',
+  Loading = 'loading',
+  Submitted = 'submitted',
+  Error = 'error',
+}
+
+export default function usePrompt() {
+  const [promptState, setPromptState] = useState<PromptState>(PromptState.Idle)
+
+  return {
+    state: promptState,
+    setState: setPromptState,
+  }
+}

--- a/packages/cli-kit/src/private/node/ui/hooks/use-prompt.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-prompt.ts
@@ -7,11 +7,18 @@ export enum PromptState {
   Error = 'error',
 }
 
-export default function usePrompt() {
-  const [promptState, setPromptState] = useState<PromptState>(PromptState.Idle)
+interface UsePromptProps<T> {
+  initialAnswer: T
+}
+
+export default function usePrompt<T>({initialAnswer}: UsePromptProps<T>) {
+  const [state, setState] = useState<PromptState>(PromptState.Idle)
+  const [answer, setAnswer] = useState<T>(initialAnswer)
 
   return {
-    state: promptState,
-    setState: setPromptState,
+    state,
+    setState,
+    answer,
+    setAnswer,
   }
 }

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -28,12 +28,13 @@ import {
   ListToken,
   TokenItem,
 } from '../../private/node/ui/components/TokenizedText.js'
-import {SelectPrompt, SelectPromptProps, InfoMessage} from '../../private/node/ui/components/SelectPrompt.js'
+import {SelectPrompt, SelectPromptProps} from '../../private/node/ui/components/SelectPrompt.js'
 import {Tasks, Task} from '../../private/node/ui/components/Tasks.js'
 import {TextPrompt, TextPromptProps} from '../../private/node/ui/components/TextPrompt.js'
 import {AutocompletePromptProps, AutocompletePrompt} from '../../private/node/ui/components/AutocompletePrompt.js'
 import {InfoTableSection} from '../../private/node/ui/components/Prompts/InfoTable.js'
 import {recordUIEvent, resetRecordedSleep} from '../../private/node/demo-recorder.js'
+import {InfoMessageProps} from '../../private/node/ui/components/Prompts/InfoMessage.js'
 import React from 'react'
 import {Key as InkKey, RenderOptions} from 'ink'
 
@@ -604,4 +605,5 @@ This usually happens when running a command non-interactively, for example in a 
 }
 
 export type Key = InkKey
-export {Task, TokenItem, InlineToken, LinkToken, TableColumn, InfoTableSection, ListToken, InfoMessage}
+export type InfoMessage = InfoMessageProps['message']
+export {Task, TokenItem, InlineToken, LinkToken, TableColumn, InfoTableSection, ListToken}


### PR DESCRIPTION
In order to create a multi-select prompt we first need to refactor prompts so that a large part of their code can be reused to build other prompts. This is also going to be useful for text prompt and the work that @amcaplan is doing in https://github.com/Shopify/cli/pull/2451