### PR TITLE
Fix generates default app config file when there is no one

### DIFF
--- a/.changeset/rich-elephants-shave.md
+++ b/.changeset/rich-elephants-shave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix generates default app config file when there is no one

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -54,7 +54,7 @@ async function loadAppConfigFromDefaultToml(options: LinkOptions): Promise<AppIn
     return app
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
-    return {name: ''} as AppInterface
+    return {configuration: {scopes: ''}} as AppInterface
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
You receive an unexpected error when you run the command `app config link` without an existing `shopify.app.toml` 

![image](https://github.com/Shopify/cli/assets/105213827/1f32ba0a-f416-42b0-8047-71275d80740f)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Build a default in-memory empty app config so the flow to create the `shopify.app.toml` works as excepected
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Delete the `shopify.app.toml` config file from an existing local app
- Run `p shopify app config link --path /path/to/your/app` 
- The command should finish successfully and a new `shopify.app.toml`  with the content of the selected remote app
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->


<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
