### PR TITLE
Fix config link when there is no shopify.app.toml

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -249,6 +249,13 @@ export class App implements AppInterface {
   }
 }
 
+export class EmptyApp extends App {
+  constructor() {
+    const configuration = {scopes: '', extension_directories: []}
+    super('', '', '', 'npm', configuration, '', {}, [], [], false)
+  }
+}
+
 type RendererVersionResult = {name: string; version: string} | undefined | 'not_found'
 
 /**

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -63,7 +63,7 @@ describe('link', () => {
         directory: tmp,
         commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
       }
-      vi.mocked(loadApp).mockResolvedValue(LOCAL_APP)
+      vi.mocked(loadApp).mockRejectedValue('App not found')
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
 
       // When
@@ -266,6 +266,7 @@ name = "app1"
 api_contact_email = "example@example.com"
 application_url = "https://example.com"
 embedded = true
+extension_directories = [ ]
 
 [webhooks]
 api_version = "2023-07"

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -1,5 +1,11 @@
 import {saveCurrentConfig} from './use.js'
-import {AppConfiguration, AppInterface, isCurrentAppSchema, isLegacyAppSchema} from '../../../models/app/app.js'
+import {
+  AppConfiguration,
+  AppInterface,
+  EmptyApp,
+  isCurrentAppSchema,
+  isLegacyAppSchema,
+} from '../../../models/app/app.js'
 import {OrganizationApp} from '../../../models/organization.js'
 import {selectConfigName} from '../../../prompts/config.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
@@ -54,7 +60,7 @@ async function loadAppConfigFromDefaultToml(options: LinkOptions): Promise<AppIn
     return app
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
-    return {name: ''} as AppInterface
+    return new EmptyApp()
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

@alvaro-shopify realized that the link command was crashing when there is no shopify.app.toml.

![image (1)](https://github.com/Shopify/cli/assets/14979109/4fd764fd-f5df-47ca-9908-9b530992beae)

### WHAT is this pull request doing?

Fixes it so the command works anyway

### How to test your changes?

- Remove shopify.app.toml
- `p shopify app config link`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
