### PR TITLE
[Feature] Add strong confirmation when removing extensions

### DIFF
--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -539,6 +539,7 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
       'unified',
       opt.appId,
       opt.token,
+      opt.appName,
     )
   })
 
@@ -577,6 +578,7 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
       'legacy',
       opt.appId,
       opt.token,
+      opt.appName,
     )
   })
 

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -103,6 +103,7 @@ export async function ensureExtensionsIds(
       options.deploymentMode,
       options.appId,
       options.token,
+      options.appName,
     )
     if (!confirmed) return err('user-cancelled')
   }

--- a/packages/app/src/cli/services/context/identifiers-functions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-functions.test.ts
@@ -230,6 +230,7 @@ describe('ensureFunctionsIds: matchmaking returns ok with some pending to create
       'legacy',
       opts.appId,
       opts.token,
+      opts.appName,
     )
   })
 })
@@ -358,6 +359,7 @@ describe('ensureFunctionsIds: asks user to confirm deploy', () => {
       'legacy',
       opts.appId,
       opts.token,
+      opts.appName,
     )
   })
 

--- a/packages/app/src/cli/services/context/identifiers-functions.ts
+++ b/packages/app/src/cli/services/context/identifiers-functions.ts
@@ -48,6 +48,7 @@ export async function ensureFunctionsIds(
       options.deploymentMode,
       options.appId,
       options.token,
+      options.appName,
     )
     if (!confirmed) return err('user-cancelled')
   }

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -7,6 +7,7 @@ import {
   InfoTableSection,
   renderAutocompletePrompt,
   renderConfirmationPrompt,
+  renderSternConfirmationPrompt,
   renderInfo,
 } from '@shopify/cli-kit/node/ui'
 
@@ -52,6 +53,7 @@ export async function deployConfirmationPrompt(
   deploymentMode: DeploymentMode,
   apiKey: string,
   token: string,
+  appName: string,
 ): Promise<boolean> {
   let infoTable: InfoTableSection[] = await buildUnifiedDeploymentInfoPrompt(
     apiKey,
@@ -80,12 +82,20 @@ export async function deployConfirmationPrompt(
     }
   })()
 
-  return renderConfirmationPrompt({
-    message: question,
-    infoTable,
-    confirmationMessage,
-    cancellationMessage: 'No, cancel',
-  })
+  if (onlyRemote.length) {
+    return renderSternConfirmationPrompt({
+      message: question,
+      answer: appName,
+      infoTable,
+    })
+  } else {
+    return renderConfirmationPrompt({
+      message: question,
+      infoTable,
+      confirmationMessage,
+      cancellationMessage: 'No, cancel',
+    })
+  }
 }
 
 function buildLegacyDeploymentInfoPrompt({

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
@@ -252,4 +252,54 @@ describe('TextPrompt', () => {
       "
     `)
   })
+
+  test('shows an instruction when provided', async () => {
+    const renderInstance = render(
+      <TextPrompt onSubmit={() => {}} message="Do something serious?" instruction="Type `yolo` to confirm:" />,
+    )
+
+    await waitForInputsToBeReady()
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "?  Do something serious?
+
+         Type \`yolo\` to confirm:
+      >
+         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+      "
+    `)
+  })
+
+  test('shows an info table when provided', async () => {
+    const infoTable = [
+      {
+        header: 'Includes:',
+        items: ['new-ext'],
+        bullet: '+',
+      },
+      {
+        header: 'Removes:',
+        items: ['integrated-demand-ext', ['order-discount', {subdued: '(1)'}]],
+        bullet: '-',
+      },
+    ]
+
+    const renderInstance = render(<TextPrompt onSubmit={() => {}} message="Test question" infoTable={infoTable} />)
+
+    await waitForInputsToBeReady()
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "?  Test question:
+
+         ┃  Includes:
+         ┃  + new-ext
+         ┃
+         ┃  Removes:
+         ┃  - integrated-demand-ext
+         ┃  - order-discount (1)
+      >
+         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+      "
+    `)
+  })
 })

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -1,4 +1,5 @@
 import {TextInput} from './TextInput.js'
+import {InfoTable, InfoTableProps} from './Prompts/InfoTable.js'
 import {TokenizedText} from './TokenizedText.js'
 import {handleCtrlC} from '../../ui.js'
 import useLayout from '../hooks/use-layout.js'
@@ -11,6 +12,7 @@ import figures from 'figures'
 
 export interface TextPromptProps {
   message: string
+  instruction?: string
   onSubmit: (value: string) => void
   defaultValue?: string
   password?: boolean
@@ -21,10 +23,12 @@ export interface TextPromptProps {
   previewPrefix?: (value: string) => string | undefined
   previewValue?: (value: string) => string | undefined
   previewSuffix?: (value: string) => string | undefined
+  infoTable?: InfoTableProps['table']
 }
 
 const TextPrompt: FunctionComponent<TextPromptProps> = ({
   message,
+  instruction,
   onSubmit,
   validate,
   defaultValue = '',
@@ -35,6 +39,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   previewPrefix,
   previewValue,
   previewSuffix,
+  infoTable,
 }) => {
   if (password && defaultValue) {
     throw new Error("Can't use defaultValue with password")
@@ -89,6 +94,29 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
         </Box>
         <TokenizedText item={messageWithPunctuation(message)} />
       </Box>
+      {infoTable ? (
+        <Box
+          marginTop={1}
+          marginLeft={3}
+          paddingLeft={2}
+          borderStyle="bold"
+          borderLeft
+          borderRight={false}
+          borderTop={false}
+          borderBottom={false}
+          flexDirection="column"
+          gap={1}
+        >
+          <InfoTable table={infoTable} />
+        </Box>
+      ) : null}
+      {instruction ? (
+        <Box>
+          <Box marginTop={1} marginLeft={3}>
+            <TokenizedText item={messageWithPunctuation(instruction)} />
+          </Box>
+        </Box>
+      ) : null}
       {submitted && !error ? (
         <Box>
           <Box marginRight={2}>

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -380,6 +380,50 @@ export async function renderConfirmationPrompt({
   })
 }
 
+export interface RenderSternConfirmationPromptOptions
+  extends Pick<TextPromptProps, 'message' | 'infoTable' | 'abortSignal'> {
+  answer: string
+  renderOptions?: RenderOptions
+}
+
+/**
+ * Renders a stern confirmation prompt to the console.
+ * @example
+ * ?  Delete the following themes from the store?
+ *
+ *    ┃  Includes:
+ *    ┃  + new-ext
+ *    ┃
+ *    ┃  Removes:
+ *    ┃  - integrated-demand-ext
+ *    ┃  - order-discount (1)
+ *
+ *    Type `Mega App` to confirm:
+ * >
+ *    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+ *
+ */
+export async function renderSternConfirmationPrompt({
+  message,
+  answer,
+  renderOptions,
+  abortSignal,
+  infoTable,
+}: RenderSternConfirmationPromptOptions): Promise<boolean> {
+  // eslint-disable-next-line prefer-rest-params
+  recordUIEvent({type: 'sternConfirmationPrompt', properties: arguments[0]})
+
+  const result = await renderTextPrompt({
+    message,
+    instruction: `Type \`${answer}\` to confirm`,
+    renderOptions,
+    validate: (val) => (val === answer ? undefined : `"${val}" does not match ${answer}`),
+    abortSignal,
+    infoTable,
+  })
+  return result === answer
+}
+
 export interface RenderAutocompleteOptions<T>
   extends PartialBy<Omit<AutocompletePromptProps<T>, 'onSubmit'>, 'search'> {
   renderOptions?: RenderOptions


### PR DESCRIPTION
Closes: https://github.com/Shopify/develop-app-foundations/issues/157

### WHY are these changes introduced?

We want to add a strong confirmation prompt when creating a release with removed extensions.

### WHAT is this pull request doing?

<img width="1286" alt="Screenshot 2023-07-14 at 2 44 04 PM" src="https://github.com/Shopify/cli/assets/6545515/5005ace7-84f9-4e58-a113-fe6d2bd61217">
<img width="1283" alt="Screenshot 2023-07-14 at 2 43 07 PM" src="https://github.com/Shopify/cli/assets/6545515/656ac06e-31b6-4fdb-8fda-c04046d466d3">
<img width="1284" alt="Screenshot 2023-07-14 at 2 44 44 PM" src="https://github.com/Shopify/cli/assets/6545515/d4447818-4ec4-40ce-b0d1-6ea3d76a941e">
<img width="1306" alt="Screenshot 2023-07-14 at 2 45 21 PM" src="https://github.com/Shopify/cli/assets/6545515/10ba7c01-6536-49ad-a1ad-dcd4f99dc6c9">


### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
