### PR TITLE
Add support for metaobject defined return types

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -32,18 +32,17 @@ export const ApiVersionSchema = zod.string()
 
 export type ApiVersionSchemaType = zod.infer<typeof ApiVersionSchema>
 
+export const FieldSchema = zod.object({
+  key: zod.string().optional(),
+  name: zod.string().optional(),
+  description: zod.string().optional(),
+  required: zod.boolean().optional(),
+  type: zod.string(),
+  validations: zod.array(zod.any()).optional(),
+})
+
 export const SettingsSchema = zod.object({
-  fields: zod
-    .array(
-      zod.object({
-        key: zod.string().optional(),
-        name: zod.string().optional(),
-        description: zod.string().optional(),
-        required: zod.boolean().optional(),
-        type: zod.string(),
-      }),
-    )
-    .optional(),
+  fields: zod.array(FieldSchema).optional(),
 })
 
 export const HandleSchema = zod
@@ -54,6 +53,15 @@ export const HandleSchema = zod
   .regex(/^[a-zA-Z0-9-]*$/, 'Handle can only contain alphanumeric characters and hyphens')
   .refine((handle) => !handle.startsWith('-') && !handle.endsWith('-'), "Handle can't start or end with a hyphen")
   .refine((handle) => [...handle].some((char) => char !== '-'), "Handle can't be all hyphens")
+
+export const FlowReturnObject = SettingsSchema.extend({
+  description: zod.string().optional(),
+  key: zod.string(),
+})
+
+export const FlowReturnSchema = zod.object({
+  objects: zod.array(FlowReturnObject).optional(),
+})
 
 export const BaseSchema = zod.object({
   name: zod.string(),
@@ -77,6 +85,8 @@ export const UnifiedSchema = zod.object({
   api_version: ApiVersionSchema.optional(),
   description: zod.string().optional(),
   extensions: zod.array(zod.any()),
+  settings: SettingsSchema.optional(),
+  return: FlowReturnSchema.optional(),
 })
 
 export type NewExtensionPointSchemaType = zod.infer<typeof NewExtensionPointSchema>

--- a/packages/app/src/cli/services/flow/serialize-metafield-to-sdl.test.ts
+++ b/packages/app/src/cli/services/flow/serialize-metafield-to-sdl.test.ts
@@ -1,0 +1,388 @@
+import {getFieldType, generateGraphQLField, loadSchemaPatchFromReturns} from './serialize-metafield-to-sdl.js'
+import {FieldSchema, FlowReturnSchema} from '../../models/extensions/schemas.js'
+import {describe, expect, test} from 'vitest'
+
+describe('getFieldType', () => {
+  test('should handle single_line_text_field type correctly', () => {
+    // Given
+    const field = {
+      type: 'single_line_text_field',
+    }
+
+    // When
+    const result = getFieldType(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual({
+      enumType: undefined,
+      fieldType: 'String',
+    })
+  })
+
+  test('should handle a required field correctly', () => {
+    // Given
+    const field = {
+      type: 'single_line_text_field',
+      required: true,
+    }
+
+    // When
+    const result = getFieldType(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual({
+      enumType: undefined,
+      fieldType: 'String!',
+    })
+  })
+
+  test('should handle boolean type correctly', () => {
+    // Given
+    const field = {
+      type: 'boolean',
+    }
+
+    // When
+    const result = getFieldType(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual({
+      enumType: undefined,
+      fieldType: 'Boolean',
+    })
+  })
+
+  test('should handle number_integer type correctly', () => {
+    // Given
+    const field = {
+      type: 'number_integer',
+    }
+
+    // When
+    const result = getFieldType(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual({
+      enumType: undefined,
+      fieldType: 'Int',
+    })
+  })
+
+  test('should handle metaobject_reference type correctly', () => {
+    // Given
+    const field = {
+      type: 'metaobject_reference<limits>',
+    }
+
+    // When
+    const result = getFieldType(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual({
+      enumType: undefined,
+      fieldType: 'Limits',
+    })
+  })
+
+  test('should handle list.metaobject_reference type correctly', () => {
+    // Given
+    const field = {
+      type: 'list.metaobject_reference<attachments>',
+    }
+
+    // When
+    const result = getFieldType(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual({
+      enumType: undefined,
+      fieldType: '[Attachments]',
+    })
+  })
+
+  test('should handle single_line_text_field with choices correctly', () => {
+    // Given
+    const field = {
+      key: 'status',
+      type: 'single_line_text_field',
+      validations: [
+        {
+          choices: ['ok', 'warn', 'disable'],
+        },
+      ],
+    }
+
+    // When
+    const result = getFieldType(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual({
+      enumType: `enum ObjectKeyStatusEnum {
+  ok
+  warn
+  disable
+}`,
+      fieldType: 'ObjectKeyStatusEnum',
+    })
+  })
+
+  test('should handle a field that is a list of single_line_text_field', () => {
+    // Given
+    const field = {
+      type: 'list.single_line_text_field',
+    }
+
+    // When
+    const result = getFieldType(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual({
+      enumType: undefined,
+      fieldType: '[String]',
+    })
+  })
+})
+
+test('should handle a field that is a list of single_line_text_field with choices', () => {
+  // Given
+  const field = {
+    key: 'statuses',
+    type: 'list.single_line_text_field',
+    validations: [
+      {
+        choices: ['ok', 'warn', 'disable'],
+      },
+    ],
+  }
+
+  // When
+  const result = getFieldType(FieldSchema.parse(field), 'object_key')
+
+  // Then
+  expect(result).toEqual({
+    enumType: `enum ObjectKeyStatusesEnum {
+  ok
+  warn
+  disable
+}`,
+    fieldType: '[ObjectKeyStatusesEnum]',
+  })
+})
+
+describe('generateGraphQLField', () => {
+  test('should generate GraphQL field with description', () => {
+    // Given
+    const field = {
+      key: 'status',
+      type: 'single_line_text_field',
+      description: 'Status of the object',
+    }
+
+    // When
+    const result = generateGraphQLField(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual('  # Status of the object\n  status: String\n')
+  })
+
+  test('should generate GraphQL field without description', () => {
+    // Given
+    const field = {
+      key: 'status',
+      type: 'single_line_text_field',
+    }
+
+    // When
+    const result = generateGraphQLField(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual('  status: String\n')
+  })
+
+  test('should generate GraphQL field with choices', () => {
+    // Given
+    const field = {
+      key: 'status',
+      type: 'single_line_text_field',
+      validations: [
+        {
+          choices: ['ok', 'warn', 'disable'],
+        },
+      ],
+    }
+
+    // When
+    const result = generateGraphQLField(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual('  status: ObjectKeyStatusEnum\n')
+  })
+
+  test('should generate GraphQL field with required flag', () => {
+    // Given
+    const field = {
+      key: 'status',
+      type: 'single_line_text_field',
+      required: true,
+    }
+
+    // When
+    const result = generateGraphQLField(FieldSchema.parse(field), 'object_key')
+
+    // Then
+    expect(result).toEqual('  status: String!\n')
+  })
+})
+
+describe('loadSchemaPatchFromReturns', () => {
+  test('should load schema patch from returns correctly', () => {
+    // Given
+    const returns = {
+      objects: [
+        {
+          description: 'object description',
+          key: 'object_key',
+          fields: [
+            {
+              description: 'field description',
+              key: 'field_key',
+              type: 'single_line_text_field',
+              required: true,
+              validations: [
+                {
+                  choices: ['choice1', 'choice2'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    // When
+    const result = loadSchemaPatchFromReturns(FlowReturnSchema.parse(returns))
+
+    // Then
+    const expected = `# object description\ntype ObjectKey {\n  # field description\n  field_key: ObjectKeyFieldKeyEnum!\n}\nenum ObjectKeyFieldKeyEnum {\n  choice1\n  choice2\n}\n`
+    expect(result).toEqual(expected)
+  })
+
+  test('should handle an object that has a field that is another object', () => {
+    // Given
+    const returns = {
+      objects: [
+        {
+          key: 'card',
+          fields: [
+            {
+              key: 'limits',
+              type: 'metaobject_reference<limits>',
+            },
+          ],
+        },
+        {
+          key: 'limits',
+          fields: [
+            {
+              key: 'attachments',
+              type: 'number_integer',
+            },
+          ],
+        },
+      ],
+    }
+
+    // When
+    const result = loadSchemaPatchFromReturns(FlowReturnSchema.parse(returns))
+
+    // Then
+    const expected = `type Card {\n  limits: Limits\n}\ntype Limits {\n  attachments: Int\n}\n`
+    expect(result).toEqual(expected)
+  })
+
+  test('should handle a field that is a list of another object', () => {
+    // Given
+    const returns = {
+      objects: [
+        {
+          key: 'card',
+          fields: [
+            {
+              key: 'attachments',
+              type: 'list.metaobject_reference<attachments>',
+            },
+          ],
+        },
+        {
+          key: 'attachments',
+          fields: [
+            {
+              key: 'status',
+              type: 'single_line_text_field',
+            },
+          ],
+        },
+      ],
+    }
+
+    // When
+    const result = loadSchemaPatchFromReturns(FlowReturnSchema.parse(returns))
+
+    // Then
+    const expected = `type Card {\n  attachments: [Attachments]\n}\ntype Attachments {\n  status: String\n}\n`
+    expect(result).toEqual(expected)
+  })
+
+  test('should handle a field that is a list of single_line_text_field with choices', () => {
+    // Given
+    const returns = {
+      objects: [
+        {
+          key: 'card',
+          fields: [
+            {
+              key: 'statuses',
+              type: 'list.single_line_text_field',
+              validations: [
+                {
+                  choices: ['ok', 'warn', 'disable'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    // When
+    const result = loadSchemaPatchFromReturns(FlowReturnSchema.parse(returns))
+
+    // Then
+    const expected = `type Card {\n  statuses: [CardStatusesEnum]\n}\nenum CardStatusesEnum {\n  ok\n  warn\n  disable\n}\n`
+    expect(result).toEqual(expected)
+  })
+
+  test('should handle a field that is a list of single_line_text_field', () => {
+    // Given
+    const returns = {
+      objects: [
+        {
+          key: 'card',
+          fields: [
+            {
+              key: 'names',
+              type: 'list.single_line_text_field',
+            },
+          ],
+        },
+      ],
+    }
+
+    // When
+    const result = loadSchemaPatchFromReturns(FlowReturnSchema.parse(returns))
+
+    // Then
+    const expected = `type Card {\n  names: [String]\n}\n`
+    expect(result).toEqual(expected)
+  })
+})

--- a/packages/app/src/cli/services/flow/serialize-metafield-to-sdl.ts
+++ b/packages/app/src/cli/services/flow/serialize-metafield-to-sdl.ts
@@ -1,0 +1,100 @@
+import {FlowReturnSchema, FieldSchema, FlowReturnObject} from '../../models/extensions/schemas.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+import {capitalize, camelize} from '@shopify/cli-kit/common/string'
+
+export const getFieldType = (field: zod.infer<typeof FieldSchema>, objectKey: string) => {
+  let choices
+  if (field.validations) {
+    const validation = field.validations.find((validation) => validation.choices)
+    if (validation) {
+      choices = validation.choices
+    }
+  }
+
+  let fieldType
+  let enumType
+  if (field.type.includes('<') && field.type.includes('>')) {
+    const itemType = capitalize(field.type.slice(field.type.indexOf('<') + 1, field.type.indexOf('>')))
+    fieldType = field.type.startsWith('list.') ? `[${itemType}]` : itemType
+  } else if (field.type.startsWith('list.')) {
+    const itemType = field.type.slice(field.type.indexOf('.') + 1)
+    if (['number_decimal', 'number_integer'].includes(itemType)) {
+      fieldType = '[Int]'
+    } else if (itemType === 'single_line_text_field') {
+      if (choices && field.key) {
+        fieldType = `[${capitalize(camelize(objectKey))}${capitalize(camelize(field.key))}Enum]`
+        enumType = `enum ${fieldType.slice(1, -1)} {\n  ${choices.join('\n  ')}\n}`
+      } else {
+        fieldType = '[String]'
+      }
+    } else {
+      fieldType = `[${capitalize(itemType)}]`
+    }
+  } else if (field.type === 'number_decimal' || field.type === 'number_integer') {
+    fieldType = 'Int'
+  } else if (field.type === 'single_line_text_field') {
+    if (choices && field.key) {
+      fieldType = `${capitalize(camelize(objectKey))}${capitalize(camelize(field.key))}Enum`
+      enumType = `enum ${fieldType} {\n  ${choices.join('\n  ')}\n}`
+    } else {
+      fieldType = 'String'
+    }
+  } else {
+    fieldType = capitalize(field.type)
+  }
+
+  fieldType = field.required ? `${fieldType}!` : fieldType
+
+  return {fieldType, enumType}
+}
+
+export const generateGraphQLField = (field: zod.infer<typeof FieldSchema>, objectKey: string) => {
+  const {fieldType} = getFieldType(field, objectKey)
+  let fieldSDL = ''
+  if (field.description) {
+    fieldSDL += `  # ${field.description}\n`
+  }
+  if (field.key) {
+    fieldSDL += `  ${field.key}: ${fieldType}\n`
+  }
+  return fieldSDL
+}
+
+export const generateGraphQLType = (object: zod.infer<typeof FlowReturnObject>) => {
+  let typeSDL = ''
+  let enumSDL = ''
+  if (object.description) {
+    typeSDL += `# ${object.description}\n`
+  }
+  if (object.key) {
+    typeSDL += `type ${capitalize(camelize(object.key))} {\n`
+    if (object.fields) {
+      object.fields.forEach((field) => {
+        const {enumType} = getFieldType(field, object.key)
+        if (enumType) {
+          enumSDL += `${enumType}\n`
+        }
+        typeSDL += generateGraphQLField(field, object.key)
+      })
+    }
+    typeSDL += '}\n'
+  }
+  return {typeSDL, enumSDL}
+}
+
+export const loadSchemaPatchFromReturns = (returns: zod.infer<typeof FlowReturnSchema>) => {
+  let graphqlSDL = ''
+  let enumSDL = ''
+
+  if (!returns || !returns.objects) {
+    return graphqlSDL
+  }
+
+  returns.objects.forEach((object) => {
+    const {typeSDL, enumSDL: objectEnumSDL} = generateGraphQLType(object)
+    graphqlSDL += typeSDL
+    enumSDL += objectEnumSDL
+  })
+
+  return graphqlSDL + enumSDL
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Adds support for inlining return objects for Flow actions.

### WHAT is this pull request doing?

Converts metafield type definitions into a GraphQL SDL.

Object references
```
  [[return.objects.fields]]
  key = "limits"
  description = "The limits of the card"
  type = "metaobject_reference<limits>"
```
  
List references
```
  [[return.objects.fields]]
  key = "attachments"
  description = "The attachments limits of the card"
  type = "list.metaobject_reference<attachments>"
```

Enums
```
  [[return.objects.fields]]
  key = "status"
  description = "The status of the per board limits for attachments"
  type = "single_line_text_field"
  validations = [ { choices = ["ok", "warn", "disable"] } ]
```
### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
