### PR TITLE
Add name validation to flow trigger extension type

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
@@ -5,6 +5,9 @@ import {serializeFields} from '../../../services/flow/serialize-fields.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 export const FlowTriggerExtensionSchema = BaseSchemaWithHandle.extend({
+  name: zod.string().regex(/^[a-zA-Z\s]*$/, {
+    message: 'String must contain only alphabetic characters and spaces',
+  }),
   type: zod.literal('flow_trigger'),
 }).refine((config) => {
   const fields = config.settings?.fields ?? []


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves https://github.com/Shopify/flow/issues/19543

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Adds validation to the `name` field for the `flow_trigger` extension type. `flor_trigger` extension `name`s must now only contain alphabet characters and spaces

### How to test your changes?
- Pull changes
- Generate new `flow_trigger` extension
- Deploy. Observe that deployment fails because default `flow_trigger` name contains dashes (`-`)
- Remove dashes from `name` in `.toml` file
- Deploy again. Observe that deployment works as `name` field no longer contains dashes

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
