### PR TITLE
Remove api contact email from configuration file

### DIFF
--- a/packages/app/src/cli/api/graphql/create_app.ts
+++ b/packages/app/src/cli/api/graphql/create_app.ts
@@ -36,7 +36,6 @@ export const CreateAppQuery = gql`
         embedded
         posEmbedded
         preferencesUrl
-        contactEmail
         gdprWebhooks {
           customerDeletionUrl
           customerDataRequestUrl
@@ -84,7 +83,6 @@ export interface CreateAppQuerySchema {
       applicationUrl: string
       redirectUrlWhitelist: string[]
       requestedAccessScopes?: string[]
-      contactEmail: string
       webhookApiVersion: string
       embedded: boolean
       posEmbedded?: boolean

--- a/packages/app/src/cli/api/graphql/find_app.ts
+++ b/packages/app/src/cli/api/graphql/find_app.ts
@@ -23,7 +23,6 @@ export const FindAppQuery = gql`
       embedded
       posEmbedded
       preferencesUrl
-      contactEmail
       gdprWebhooks {
         customerDeletionUrl
         customerDataRequestUrl
@@ -56,7 +55,6 @@ export interface FindAppQuerySchema {
     applicationUrl: string
     redirectUrlWhitelist: string[]
     requestedAccessScopes?: string[]
-    contactEmail: string
     webhookApiVersion: string
     embedded: boolean
     posEmbedded?: boolean

--- a/packages/app/src/cli/api/graphql/get_config.ts
+++ b/packages/app/src/cli/api/graphql/get_config.ts
@@ -11,7 +11,6 @@ export const GetConfig = gql`
       applicationUrl
       redirectUrlWhitelist
       preferencesUrl
-      contactEmail
       webhookApiVersion
       embedded
       posEmbedded
@@ -38,7 +37,6 @@ export interface App {
   grantedScopes: string[]
   applicationUrl: string
   redirectUrlWhitelist: string[]
-  contactEmail: string
   webhookApiVersion: string
   embedded: boolean
   posEmbedded?: boolean

--- a/packages/app/src/cli/api/graphql/push_config.ts
+++ b/packages/app/src/cli/api/graphql/push_config.ts
@@ -7,7 +7,6 @@ export const PushConfig = gql`
     $applicationUrl: Url
     $redirectUrlAllowlist: [Url]
     $requestedAccessScopes: [String!]
-    $contactEmail: String!
     $webhookApiVersion: String!
     $gdprWebhooks: GdprWebhooksInput
     $appProxy: AppProxyInput
@@ -19,7 +18,6 @@ export const PushConfig = gql`
       input: {
         title: $title
         apiKey: $apiKey
-        contactEmail: $contactEmail
         applicationUrl: $applicationUrl
         redirectUrlWhitelist: $redirectUrlAllowlist
         requestedAccessScopes: $requestedAccessScopes
@@ -58,7 +56,6 @@ export interface PushConfigVariables {
   redirectUrlAllowlist?: string[] | null
   requestedAccessScopes?: string[]
   webhookApiVersion?: string
-  contactEmail?: string
   gdprWebhooks?: GdprWebhooks
   appProxy?: AppProxy
   posEmbedded?: boolean

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -14,7 +14,6 @@ export const DEFAULT_CONFIG = {
   application_url: 'https://myapp.com',
   client_id: '12345',
   name: 'my app',
-  api_contact_email: 'wils@bahan-lee.com',
   webhooks: {
     api_version: '2023-04',
   },
@@ -94,7 +93,6 @@ export function testOrganizationApp(app: Partial<OrganizationApp> = {}): Organiz
     id: '1',
     title: 'app1',
     apiKey: 'api-key',
-    contactEmail: 'example@example.com',
     apiSecretKeys: [{secret: 'api-secret'}],
     organizationId: '1',
     grantedScopes: [],

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -15,7 +15,6 @@ const DEFAULT_APP = testApp()
 
 const CORRECT_CURRENT_APP_SCHEMA: CurrentAppConfiguration = {
   name: 'app 1',
-  api_contact_email: 'ryan@shopify.com',
   client_id: '12345',
   webhooks: {
     api_version: '2023-04',

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -28,7 +28,6 @@ const validateUrl = (zodType: zod.ZodString) => {
 export const AppSchema = zod
   .object({
     name: zod.string().max(30),
-    api_contact_email: zod.string().email(),
     client_id: zod.string(),
     application_url: validateUrl(zod.string()),
     embedded: zod.boolean(),

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -33,7 +33,6 @@ scopes = "read_products"
 `
   const linkedAppConfiguration = `
 name = "for-testing"
-api_contact_email = "me@example.com"
 client_id = "1234567890"
 application_url = "https://example.com/lala"
 embedded = true

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -25,7 +25,6 @@ export type OrganizationApp = MinimalOrganizationApp & {
   applicationUrl: string
   redirectUrlWhitelist: string[]
   requestedAccessScopes?: string[]
-  contactEmail?: string
   webhookApiVersion?: string
   embedded?: boolean
   posEmbedded?: boolean

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -126,7 +126,7 @@ describe('selectStore', () => {
     // Then
     expect(got).toEqual(STORE1)
     expect(renderAutocompletePrompt).not.toBeCalled()
-    expect(outputMock.output()).toMatch('Using your default dev store (store1) to preview your project')
+    expect(outputMock.output()).toMatch('Using your default dev store, store1, to preview your project')
   })
 
   test('returns store if user selects one', async () => {

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -39,7 +39,7 @@ export async function selectAppPrompt(apps: OrganizationAppsResponse, orgId: str
 export async function selectStorePrompt(stores: OrganizationStore[]): Promise<OrganizationStore | undefined> {
   if (stores.length === 0) return undefined
   if (stores.length === 1) {
-    outputCompleted(`Using your default dev store (${stores[0]!.shopName}) to preview your project.`)
+    outputCompleted(`Using your default dev store, ${stores[0]!.shopName}, to preview your project.`)
     return stores[0]
   }
   const storeList = stores.map((store) => ({label: store.shopName, value: store.shopId}))

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -73,7 +73,6 @@ describe('link', () => {
       const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
       const expectedContent = `client_id = "api-key"
 name = "app1"
-api_contact_email = "example@example.com"
 application_url = "https://example.com"
 embedded = true
 extension_directories = [ ]
@@ -110,7 +109,6 @@ use_legacy_install_flow = true
           configurationPath: 'shopify.app.development.toml',
           configuration: {
             name: 'my app',
-            api_contact_email: 'example@example.com',
             client_id: '12345',
             scopes: 'write_products',
             webhooks: {api_version: '2023-04'},
@@ -136,7 +134,6 @@ use_legacy_install_flow = true
       const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
       const expectedContent = `client_id = "12345"
 name = "my app"
-api_contact_email = "example@example.com"
 application_url = "https://myapp.com"
 embedded = true
 
@@ -181,7 +178,6 @@ scopes = "write_products"
       const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
       const expectedContent = `client_id = "api-key"
 name = "app1"
-api_contact_email = "example@example.com"
 application_url = "https://example.com"
 embedded = true
 extension_directories = [ ]
@@ -264,7 +260,6 @@ use_legacy_install_flow = true
       const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
       const expectedContent = `client_id = "api-key"
 name = "app1"
-api_contact_email = "example@example.com"
 application_url = "https://example.com"
 embedded = true
 extension_directories = [ ]
@@ -305,7 +300,6 @@ use_legacy_install_flow = true
       const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
       const expectedContent = `client_id = "api-key"
 name = "app1"
-api_contact_email = "example@example.com"
 application_url = "https://example.com"
 embedded = true
 extension_directories = [ ]

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -98,7 +98,6 @@ function mergeAppConfiguration(localApp: AppInterface, remoteApp: OrganizationAp
   const configuration: AppConfiguration = {
     client_id: remoteApp.apiKey,
     name: remoteApp.title,
-    api_contact_email: remoteApp.contactEmail!,
     application_url: remoteApp.applicationUrl,
     embedded: remoteApp.embedded === undefined ? true : remoteApp.embedded,
     webhooks: {

--- a/packages/app/src/cli/services/app/config/push.test.ts
+++ b/packages/app/src/cli/services/app/config/push.test.ts
@@ -30,7 +30,6 @@ describe('pushConfig', () => {
     expect(vi.mocked(partnersRequest).mock.calls[1]![2]!).toEqual({
       apiKey: '12345',
       applicationUrl: 'https://myapp.com',
-      contactEmail: 'wils@bahan-lee.com',
       embedded: true,
       gdprWebhooks: {
         customerDataRequestUrl: undefined,
@@ -74,7 +73,6 @@ describe('pushConfig', () => {
     expect(vi.mocked(partnersRequest).mock.calls[1]![2]!).toEqual({
       apiKey: '12345',
       applicationUrl: 'https://myapp.com',
-      contactEmail: 'wils@bahan-lee.com',
       embedded: true,
       gdprWebhooks: {
         customerDataRequestUrl: undefined,
@@ -120,7 +118,6 @@ describe('pushConfig', () => {
     expect(vi.mocked(partnersRequest).mock.calls[1]![2]!).toEqual({
       apiKey: '12345',
       applicationUrl: 'https://myapp.com',
-      contactEmail: 'wils@bahan-lee.com',
       embedded: true,
       gdprWebhooks: {
         customerDataRequestUrl: undefined,
@@ -166,7 +163,6 @@ describe('pushConfig', () => {
     expect(vi.mocked(partnersRequest).mock.calls[1]![2]!).toEqual({
       apiKey: '12345',
       applicationUrl: 'https://myapp.com',
-      contactEmail: 'wils@bahan-lee.com',
       embedded: true,
       gdprWebhooks: {
         customerDataRequestUrl: undefined,
@@ -211,7 +207,6 @@ describe('pushConfig', () => {
     expect(vi.mocked(partnersRequest).mock.calls[1]![2]!).toEqual({
       apiKey: '12345',
       applicationUrl: 'https://myapp.com',
-      contactEmail: 'wils@bahan-lee.com',
       embedded: true,
       gdprWebhooks: {
         customerDataRequestUrl: undefined,
@@ -277,7 +272,6 @@ describe('pushConfig', () => {
         userErrors: [
           {message: "I don't like this name", field: ['input', 'title']},
           {message: 'funny api key', field: ['input', 'api_key']},
-          {message: 'cannot include shopify', field: ['input', 'partner_email']},
           {message: 'this url is blocked', field: ['input', 'application_url']},
           {message: 'suspicious', field: ['input', 'redirect_url_whitelist']},
           {message: 'invalid scope: read_minds', field: ['input', 'requested_access_scopes']},
@@ -300,7 +294,6 @@ describe('pushConfig', () => {
     // Then
     await expect(result).rejects.toThrow(`name: I don't like this name
 client_id: funny api key
-api_contact_email: cannot include shopify
 application_url: this url is blocked
 auth > redirect_urls: suspicious
 access_scopes > scopes: invalid scope: read_minds
@@ -346,7 +339,6 @@ app_preferences > url: this url is blocked 6`)
       apiKey: '12345',
       title: 'my app',
       applicationUrl: 'https://myapp.com',
-      contactEmail: 'wils@bahan-lee.com',
       gdprWebhooks: {
         customerDataRequestUrl: undefined,
         customerDeletionUrl: undefined,

--- a/packages/app/src/cli/services/app/config/push.ts
+++ b/packages/app/src/cli/services/app/config/push.ts
@@ -24,7 +24,6 @@ export interface Options {
 const FIELD_NAMES: {[key: string]: string} = {
   title: 'name',
   api_key: 'client_id',
-  partner_email: 'api_contact_email',
   redirect_url_whitelist: 'auth > redirect_urls',
   requested_access_scopes: 'access_scopes > scopes',
   webhook_api_version: 'webhooks > api_version',
@@ -100,7 +99,6 @@ const getMutationVars = (app: App, configuration: CurrentAppConfiguration) => {
     apiKey: configuration.client_id,
     title: configuration.name,
     applicationUrl: configuration.application_url,
-    contactEmail: configuration.api_contact_email,
     webhookApiVersion: configuration.webhooks?.api_version,
     redirectUrlAllowlist: configuration.auth?.redirect_urls ?? null,
     embedded: configuration.embedded ?? app.embedded,

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -129,7 +129,6 @@ describe('use', () => {
         config: {
           name: 'something',
           client_id: 'something',
-          api_contact_email: 'bob@bob.com',
           webhooks: {api_version: '2023-04'},
           application_url: 'https://example.com',
         },
@@ -166,7 +165,6 @@ describe('use', () => {
       const app = testAppWithConfig({
         config: {
           name: 'something',
-          api_contact_email: 'bob@bob.com',
           application_url: 'https://example.com',
           client_id: 'something',
           webhooks: {api_version: '2023-04'},

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -371,7 +371,6 @@ describe('ensureDevContext', async () => {
         configurationPath: joinPath(tmp, 'shopify.app.dev.toml'),
         configuration: {
           name: 'my app',
-          api_contact_email: 'example@example.com',
           client_id: '12345',
           scopes: 'write_products',
           webhooks: {api_version: '2023-04'},
@@ -431,7 +430,6 @@ describe('ensureDevContext', async () => {
       const expectedContent = `application_url = "https://myapp.com"
 client_id = "12345"
 name = "my app"
-api_contact_email = "wils@bahan-lee.com"
 embedded = true
 
 [webhooks]
@@ -663,7 +661,6 @@ dev_store_url = "domain1"
           client_id: APP2.apiKey,
           name: APP2.apiKey,
           application_url: APP2.applicationUrl,
-          api_contact_email: 'wils@bahan-lee.com',
           webhooks: {api_version: '2023-04'},
           embedded: true,
         },

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -45,7 +45,6 @@ describe('info', () => {
       // Given
       const testConfig = `
       name = "my app"
-      api_contact_email = "me@example.com"
       client_id = "12345"
       application_url = "https://example.com/lala"
       embedded = true
@@ -66,7 +65,6 @@ describe('info', () => {
           configurationPath: joinPath(tmp, 'shopify.app.toml'),
           configuration: {
             name: 'my app',
-            api_contact_email: 'me@example.com',
             client_id: '12345',
             application_url: 'https://example.com/lala',
             embedded: true,


### PR DESCRIPTION
### WHY are these changes introduced?

We are removing `api_contact_email` for the following reasons:
- Storing the `api_contact_email` could possibly store PII about developers in source control. 
- Updating `api_contact_email` is not an active part of the development loop.
- It is already pre-configured when a new app is created upstream and is very rarely changed.
- We'll want to be more careful as to how we expose emails and will be worth taking more time and looking into better alternatives post-Editions.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Removes `api_contact_email` as a declarative configuration.

### How to test your changes?

Run `dev`, `link` and `push` to make sure that `api_contact_email` is no longer declarative.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
