### PR TITLE
Fix wrong version flag definition

### DIFF
--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -473,10 +473,7 @@
           "description": "The name of the app version to release.",
           "hidden": false,
           "required": true,
-          "multiple": false,
-          "exclusive": [
-            "app-version-id"
-          ]
+          "multiple": false
         }
       },
       "args": {}

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -35,7 +35,6 @@ export default class Release extends Command {
       hidden: false,
       description: 'The name of the app version to release.',
       env: 'SHOPIFY_FLAG_VERSION',
-      exclusive: ['app-version-id'],
       required: true,
     }),
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a wrong definition for the `release` command `version` flag.
### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
