### PR TITLE
Include all extension properties when loading unified toml file

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -32,18 +32,17 @@ export const ApiVersionSchema = zod.string()
 
 export type ApiVersionSchemaType = zod.infer<typeof ApiVersionSchema>
 
+export const FieldSchema = zod.object({
+  key: zod.string().optional(),
+  name: zod.string().optional(),
+  description: zod.string().optional(),
+  required: zod.boolean().optional(),
+  type: zod.string(),
+  validations: zod.array(zod.any()).optional(),
+})
+
 export const SettingsSchema = zod.object({
-  fields: zod
-    .array(
-      zod.object({
-        key: zod.string().optional(),
-        name: zod.string().optional(),
-        description: zod.string().optional(),
-        required: zod.boolean().optional(),
-        type: zod.string(),
-      }),
-    )
-    .optional(),
+  fields: zod.array(FieldSchema).optional(),
 })
 
 export const HandleSchema = zod
@@ -77,6 +76,7 @@ export const UnifiedSchema = zod.object({
   api_version: ApiVersionSchema.optional(),
   description: zod.string().optional(),
   extensions: zod.array(zod.any()),
+  settings: SettingsSchema.optional(),
 })
 
 export type NewExtensionPointSchemaType = zod.infer<typeof NewExtensionPointSchema>


### PR DESCRIPTION
### WHY are these changes introduced?

When using the configuration parsed with the UnifiedSchema, additional properties on the extensions were omitted (ex. Flow trigger fields).

### WHAT is this pull request doing?

This change uses the decoded toml file instead which includes those properties.

### How to test your changes?

1. Generate a Flow trigger extension + deploy
2. Check the `config` of the registration record or use the trigger in a Flow workflow - the `settings.fields` from the toml file should be available

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [X] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
