### PR TITLE
Move descriptions in flow extension templates

### DIFF
--- a/packages/app/templates/extensions/projects/flow_action/shopify.extension.toml.liquid
+++ b/packages/app/templates/extensions/projects/flow_action/shopify.extension.toml.liquid
@@ -1,9 +1,9 @@
 name = "{{ name }}"
-description = "Your description"
 
 [[extensions]]
 type = "flow_action"
 handle = "{{ handle }}"
+description = "Your description"
 runtime_url = "https://url.com/api/execute"
 
 [settings]

--- a/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
+++ b/packages/app/templates/extensions/projects/flow_trigger/shopify.extension.toml.liquid
@@ -1,9 +1,9 @@
 name = "{{ name }}"
-description = "Your description"
 
 [[extensions]]
 type = "flow_trigger"
 handle = "{{ handle }}"
+description = "Your description"
 
 [settings]
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/flow/issues/19748

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Moves flow extensions descriptions under the `[[extension]]` header

### How to test your changes?
- Pull changes
- Generate new flow extension
- Observe that in the generated `.toml` file that `description` is nested under the `[[extension]]` header 

### Post-release steps

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
