### PR TITLE
Prevent link success banner from showing up when linking on dev

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -28,7 +28,7 @@ export interface LinkOptions {
   configName?: string
 }
 
-export default async function link(options: LinkOptions): Promise<void> {
+export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<void> {
   const localApp = await loadAppConfigFromDefaultToml(options)
   const remoteApp = await loadRemoteApp(localApp, options.apiKey)
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
@@ -41,11 +41,13 @@ export default async function link(options: LinkOptions): Promise<void> {
 
   await saveCurrentConfig({configFileName, directory: options.directory})
 
-  renderSuccess({
-    headline: `App "${remoteApp.title}" connected to this codebase, file ${configFileName} ${
-      fileAlreadyExists ? 'updated' : 'created'
-    }`,
-  })
+  if (shouldRenderSuccess) {
+    renderSuccess({
+      headline: `App "${remoteApp.title}" connected to this codebase, file ${configFileName} ${
+        fileAlreadyExists ? 'updated' : 'created'
+      }`,
+    })
+  }
 }
 
 async function loadAppConfigFromDefaultToml(options: LinkOptions): Promise<AppInterface> {

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -557,7 +557,7 @@ export async function getAppContext({
   const firstTimeSetup = previousCachedInfo === undefined
   const usingConfigAndResetting = previousCachedInfo?.configFile && reset
   if (promptLinkingApp && commandConfig && (firstTimeSetup || usingConfigAndResetting)) {
-    await link({directory, commandConfig})
+    await link({directory, commandConfig}, false)
   }
 
   let cachedInfo = getCachedAppInfo(directory)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Ensures that we don't have a success banner from the `link` process in the middle of running `dev`.
<img width="792" alt="image" src="https://github.com/Shopify/cli/assets/60748788/7feded35-58c4-4a00-ab68-a274d8039825">

### WHAT is this pull request doing?

![image](https://github.com/Shopify/cli/assets/60748788/052f330a-da3b-4c4d-ac37-b5fb6d50da7b)

### How to test your changes?

Generate and app template and run `dev` for the first time. The success banner shouldn't be there anymore.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
