### PR TITLE
ml/fixed import templating

### DIFF
--- a/packages/app/src/cli/services/flow/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/flow/extension-to-toml.test.ts
@@ -21,8 +21,6 @@ describe('extension-to-toml', () => {
 
     // Then
     expect(got).toEqual(`name = "action title"
-type = "flow_action"
-description = "action description"
 
 [[extensions]]
 type = "flow_action"
@@ -35,12 +33,10 @@ validation_url = "https://validation.test.dev"
 
 [[settings.fields]]
 type = "customer_reference"
-description = ""
 required = true
 
 [[settings.fields]]
 type = "product_reference"
-description = ""
 required = true
 
 [[settings.fields]]
@@ -81,8 +77,6 @@ required = true
 
     // Then
     expect(got).toEqual(`name = "trigger title"
-type = "flow_trigger"
-description = "trigger description"
 
 [[extensions]]
 type = "flow_trigger"
@@ -91,7 +85,6 @@ description = "trigger description"
 
 [[settings.fields]]
 type = "customer_reference"
-description = ""
 
 [[settings.fields]]
 key = "number property"

--- a/packages/app/src/cli/services/flow/extension-to-toml.ts
+++ b/packages/app/src/cli/services/flow/extension-to-toml.ts
@@ -36,8 +36,7 @@ export function buildTomlObject(extension: ExtensionRegistration) {
 
   const localExtensionRepresentation = {
     name: config.title,
-    type: extension.type.replace('_definition', ''),
-    description: config.description,
+
     extensions: [
       {
         type: extension.type.replace('_definition', ''),

--- a/packages/app/src/cli/services/flow/serialize-partners-fields.test.ts
+++ b/packages/app/src/cli/services/flow/serialize-partners-fields.test.ts
@@ -10,14 +10,12 @@ describe('serialize-fields', () => {
       {
         name: 'customer_id',
         label: 'Customer ID',
-        description: '',
         required: true,
         uiType: 'commerce-object-id',
       },
       {
         name: 'product_id',
         label: 'Product ID',
-        description: '',
         required: true,
         uiType: 'commerce-object-id',
       },
@@ -49,7 +47,6 @@ describe('serialize-fields', () => {
     // Given
     const fields: SerializedField[] = [
       {
-        description: '',
         name: 'customer_id',
         uiType: 'customer',
       },

--- a/packages/app/src/cli/services/flow/serialize-partners-fields.ts
+++ b/packages/app/src/cli/services/flow/serialize-partners-fields.ts
@@ -13,7 +13,7 @@ export const serializeConfigField = (field: SerializedField, type: FlowPartnersE
 
   const serializedField: ConfigField = {
     key: field.name,
-    description: field.description,
+    description: field.description ? field.description : undefined,
     type: fieldType,
   }
 
@@ -31,7 +31,6 @@ export const serializeCommerceObjectField = (field: SerializedField, type: FlowP
 
   const serializedField: ConfigField = {
     type: fieldType,
-    description: field.description,
   }
 
   if (type === 'flow_action_definition') {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixing import templating.

### WHAT is this pull request doing?

- Removing `handle` and `description` from the extension root for imported extensions.
- Removing `description` from fields when not populated.

```
name = "test action 2"

[[extensions]]
type = "flow_action"
handle = "test-action-2"
description = "asjdhlaksjd"
runtime_url = "https://url.com/api/execute"

[[settings.fields]]
type = "abandonment_reference"
required = true

[[settings.fields]]
key = "asdadasd"
type = "boolean"
name = "asdasdasdasd"
required = false
```
