### PR TITLE
Add automatic app unified deployment upgrade date to banner

### DIFF
--- a/.changeset/long-bees-clean.md
+++ b/.changeset/long-bees-clean.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Added automatic upgrade date to deployment availability banner

--- a/packages/app/src/cli/services/deploy/mode.test.ts
+++ b/packages/app/src/cli/services/deploy/mode.test.ts
@@ -76,6 +76,8 @@ describe('resolveDeploymentMode', () => {
       │    • Bundle all your extensions into an app version                          │
       │    • Release all your extensions to users straight from the CLI              │
       │                                                                              │
+      │  All apps will be automatically upgraded on Sept 5, 2023.                    │
+      │                                                                              │
       │  Reference                                                                   │
       │    • Simplified extension deployment [1]                                     │
       │                                                                              │
@@ -147,6 +149,8 @@ describe('resolveDeploymentMode', () => {
       │    • Bundle all your extensions into an app version                          │
       │    • Release all your extensions to users straight from the CLI              │
       │                                                                              │
+      │  All apps will be automatically upgraded on Sept 5, 2023.                    │
+      │                                                                              │
       │  Reference                                                                   │
       │    • Simplified extension deployment [1]                                     │
       │                                                                              │
@@ -195,6 +199,8 @@ describe('resolveDeploymentMode', () => {
       │                                                                              │
       │    • Bundle all your extensions into an app version                          │
       │    • Release all your extensions to users straight from the CLI              │
+      │                                                                              │
+      │  All apps will be automatically upgraded on Sept 5, 2023.                    │
       │                                                                              │
       │  Reference                                                                   │
       │    • Simplified extension deployment [1]                                     │

--- a/packages/app/src/cli/services/deploy/mode.ts
+++ b/packages/app/src/cli/services/deploy/mode.ts
@@ -60,10 +60,12 @@ function displayDeployLegacyBanner(packageManager: PackageManager) {
         list: {
           items: [
             'Bundle all your extensions into an app version',
-            'Release all your extensions to users straight from the CLI',
+            'Release all your extensions to users straight from the CLI\n',
           ],
         },
       },
+      'All apps will be automatically upgraded on',
+      {bold: 'Sept 5, 2023.'},
     ],
     reference: [
       {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/653

### WHAT is this pull request doing?

Added a new note with bolded date to indicate the on **September 5, 2023** all apps will be automatically opted into the app simplified deployment on the "Simplified deployment available now!" banner.

It would push developers to opt in earlier than later (or seemingly never).

### How to test your changes?

Create an app locally: `bin/create-test-app.js --bare`
Enable `app_unfied_deployments_opt_in` beta flag only for this app
Go to newly created app folder and deploy: `npm run deploy`

<img width="810" alt="image" src="https://github.com/Shopify/cli/assets/97697158/56fa7aaa-2dd6-408a-b834-0e19abdefa1e">


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
