### PR TITLE
Omit descriptions to Flow commerce fields on import

### DIFF
--- a/packages/app/src/cli/services/flow/serialize-partners-fields.ts
+++ b/packages/app/src/cli/services/flow/serialize-partners-fields.ts
@@ -32,7 +32,6 @@ export const serializeCommerceObjectField = (field: SerializedField, type: FlowP
   const serializedField: ConfigField = {
     key: field.name,
     type: fieldType,
-    description: field.description,
   }
 
   if (type === 'flow_action_definition') {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/flow/issues/19750

### WHAT is this pull request doing?

Removes description when generating TOML entries for commerce object fields for imported Flow trigger and action extensions.

### How to test your changes?

- Created a trigger and action in the partners dashboard
- Ran import command
- Got the following outputs (note the lack of description on the commmerce objects

```
name = "Dashboard Action"
type = "flow_action"
description = "some desc"

[[extensions]]
type = "flow_action"
handle = "dashboard-action"
description = "some desc"
runtime_url = "https://google.com"

[[settings.fields]]
key = "customer_id"
type = "customer_reference"
name = "Customer ID"
required = true

[[settings.fields]]
key = "email"
description = "my email field"
type = "email"
name = "email"
required = false
```
```
name = "Dashboard Trigger"
type = "flow_trigger"
description = "some desc"

[[extensions]]
type = "flow_trigger"
handle = "dashboard-trigger"
description = "some desc"

[[settings.fields]]
key = "Number"
description = "some number"
type = "number_decimal"

[[settings.fields]]
key = "order_id"
type = "order_reference"
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
