### PR TITLE
Render DangerousConfirmationPrompt when removing an extension

### DIFF
--- a/.changeset/sixty-pumpkins-sleep.md
+++ b/.changeset/sixty-pumpkins-sleep.md
@@ -1,0 +1,6 @@
+---
+'@shopify/eslint-plugin-cli': minor
+'@shopify/app': minor
+---
+
+Add DangerousConfirmationPrompt component to call developer attention to dangerous yes/no decisions

--- a/packages/app/src/cli/prompts/release.test.ts
+++ b/packages/app/src/cli/prompts/release.test.ts
@@ -1,6 +1,6 @@
 import {confirmReleasePrompt} from './release.js'
 import {describe, expect, vi, test} from 'vitest'
-import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
+import {renderConfirmationPrompt, renderDangerousConfirmationPrompt} from '@shopify/cli-kit/node/ui'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
 
 vi.mock('@shopify/cli-kit/node/ui')
@@ -34,7 +34,7 @@ describe('confirmReleasePrompt', () => {
 
   test('shows removed extensions in the infoTable if the diff contains removed extensions', async () => {
     // Given
-    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+    vi.mocked(renderDangerousConfirmationPrompt).mockResolvedValue(true)
 
     // When / Then
     await expect(
@@ -45,7 +45,7 @@ describe('confirmReleasePrompt', () => {
       }),
     ).resolves
 
-    expect(renderConfirmationPrompt).toHaveBeenCalledWith({
+    expect(renderDangerousConfirmationPrompt).toHaveBeenCalledWith({
       message: 'Release this version of test app?',
       infoTable: [
         {
@@ -55,14 +55,13 @@ describe('confirmReleasePrompt', () => {
           bullet: '-',
         },
       ],
-      confirmationMessage: 'Yes, release this version',
-      cancellationMessage: 'No, cancel',
+      confirmation: 'test app',
     })
   })
 
   test('throws a silent exception in case the user rejects the release prompt', async () => {
     // Given
-    vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
+    vi.mocked(renderDangerousConfirmationPrompt).mockResolvedValue(false)
 
     // When/ Then
     await expect(

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -527,6 +527,7 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
     // Then
     expect(deployConfirmationPrompt).toBeCalledWith(
       {
+        appTitle: 'app1',
         question: `Release a new version of ${PARTNERS_APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA.title}?`,
         identifiers: {
           EXTENSION_A: 'UUID_A',
@@ -565,6 +566,7 @@ describe('ensureExtensionsIds: asks user to confirm deploy', () => {
     // Then
     expect(deployConfirmationPrompt).toBeCalledWith(
       {
+        appTitle: 'app1',
         question: 'Make the following changes to your extensions in Shopify Partners?',
         identifiers: {
           EXTENSION_A: 'UUID_A',

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -91,6 +91,7 @@ export async function ensureExtensionsIds(
 
     const confirmed = await deployConfirmationPrompt(
       {
+        appTitle: options.partnersApp?.title,
         question,
         identifiers: validMatches,
         toCreate: extensionsToCreate,

--- a/packages/app/src/cli/services/context/identifiers-functions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-functions.test.ts
@@ -221,6 +221,7 @@ describe('ensureFunctionsIds: matchmaking returns ok with some pending to create
     expect(got).toEqual(ok({}))
     expect(deployConfirmationPrompt).toHaveBeenCalledWith(
       {
+        appTitle: 'my-app',
         question: 'Make the following changes to your functions in Shopify Partners?',
         identifiers: {},
         onlyRemote: [],
@@ -285,6 +286,7 @@ describe('ensureFunctionsIds: matchmaking returns ok with some pending confirmat
     expect(got).toEqual(ok({}))
     expect(deployConfirmationPrompt).toHaveBeenCalledWith(
       {
+        appTitle: 'my-app',
         question: 'Make the following changes to your functions in Shopify Partners?',
         identifiers: {},
         onlyRemote: [],
@@ -346,6 +348,7 @@ describe('ensureFunctionsIds: asks user to confirm deploy', () => {
     // Then
     expect(deployConfirmationPrompt).toBeCalledWith(
       {
+        appTitle: 'my-app',
         question: 'Make the following changes to your functions in Shopify Partners?',
         identifiers: {
           FUNCTION_A: 'ID_A',

--- a/packages/app/src/cli/services/context/identifiers-functions.ts
+++ b/packages/app/src/cli/services/context/identifiers-functions.ts
@@ -39,6 +39,7 @@ export async function ensureFunctionsIds(
   if (!options.force) {
     const confirmed = await deployConfirmationPrompt(
       {
+        appTitle: options.app.name,
         question: 'Make the following changes to your functions in Shopify Partners?',
         identifiers: validMatches,
         toCreate: functionsToCreate,

--- a/packages/app/src/cli/services/context/prompts.test.ts
+++ b/packages/app/src/cli/services/context/prompts.test.ts
@@ -300,6 +300,7 @@ function buildSourceSummary(options: BuildSourceSummaryOptions = {}): SourceSumm
   const {identifiers = {}, toCreate = [], onlyRemote = [], dashboardOnly = []} = options
 
   return {
+    appTitle: undefined,
     question: 'question',
     identifiers,
     toCreate,

--- a/packages/eslint-plugin-cli/rules/prompt-message-format.js
+++ b/packages/eslint-plugin-cli/rules/prompt-message-format.js
@@ -23,6 +23,7 @@ module.exports = {
           functionName === 'renderSelectPrompt' ||
           functionName === 'renderAutocompletePrompt' ||
           functionName === 'renderConfirmationPrompt' ||
+          functionName === 'renderDangerousConfirmationPrompt' ||
           functionName === 'renderTextPrompt'
         ) {
           const firstArgument = node.arguments[0]


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/628

We want to warn more strongly when deploying dangerously.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Regular deploys are as before.

<img width="656" alt="Screenshot 2023-07-19 at 12 56 26" src="https://github.com/Shopify/cli/assets/6288426/30f3bc31-ade5-48a2-83e3-06746e6e348a">

Deploys that remove extensions are prompted in a way that requires a more deliberate response.

<img width="833" alt="Screenshot 2023-07-19 at 12 55 46" src="https://github.com/Shopify/cli/assets/6288426/80f6dcda-17ff-4922-948e-78d37f2965e7">

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Deploy an app with an extension, then remove the extension and deploy again. You should see the dangerous prompt.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
