### PR TITLE
Remove hardcoded string when optional webhook urls are undefined

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -136,9 +136,9 @@ function mergeAppConfiguration(localApp: AppInterface, remoteApp: OrganizationAp
 
   if (hasAnyPrivacyWebhook) {
     configuration.webhooks.privacy_compliance = {
-      customer_data_request_url: remoteApp.gdprWebhooks?.customerDataRequestUrl || '',
-      customer_deletion_url: remoteApp.gdprWebhooks?.customerDeletionUrl || '',
-      shop_deletion_url: remoteApp.gdprWebhooks?.shopDeletionUrl || '',
+      customer_data_request_url: remoteApp.gdprWebhooks?.customerDataRequestUrl,
+      customer_deletion_url: remoteApp.gdprWebhooks?.customerDeletionUrl,
+      shop_deletion_url: remoteApp.gdprWebhooks?.shopDeletionUrl,
     }
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?
If only a subset of privacy compliance webhooks are updated, then linking will trigger the following error. This is because we are setting undefined values as hardcoded empty strings, which fails the URL validation in the schema.
<img width="785" alt="image" src="https://github.com/Shopify/cli/assets/60748788/3201676d-a204-48a3-87ab-cf2e5dddd262">

### WHAT is this pull request doing?

Removes hardcoded string for privacy compliance webhook urls.

### How to test your changes?

Ensure a subset of privacy compliance webhooks are set and run link successfully.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
