### PR TITLE
add cache for duration of command lifecycle

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -86,7 +86,7 @@
   "oclif": {
     "commands": "dist/cli/commands",
     "hooks": {
-      "clear_command_cache": "./dist/cli/hooks/clear_command_cache",
+      "init": "./dist/cli/hooks/clear_command_cache",
       "public_command_metadata": "./dist/cli/hooks/public_metadata",
       "sensitive_command_metadata": "./dist/cli/hooks/sensitive_metadata"
     },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -86,6 +86,7 @@
   "oclif": {
     "commands": "dist/cli/commands",
     "hooks": {
+      "clear_command_cache": "./dist/cli/hooks/clear_command_cache",
       "public_command_metadata": "./dist/cli/hooks/public_metadata",
       "sensitive_command_metadata": "./dist/cli/hooks/sensitive_metadata"
     },

--- a/packages/app/src/cli/hooks/clear_command_cache.ts
+++ b/packages/app/src/cli/hooks/clear_command_cache.ts
@@ -1,8 +1,10 @@
 import {clearCachedCommandInfo} from '../services/local-storage.js'
+import {randomUUID} from '@shopify/cli-kit/node/crypto'
 import {Hook} from '@oclif/core'
 
-const clearCommandCache: Hook<'init'> = async (options) => {
+const init: Hook<'init'> = async (options) => {
   clearCachedCommandInfo()
+  process.env.COMMAND_RUN_ID = randomUUID()
 }
 
-export default clearCommandCache
+export default init

--- a/packages/app/src/cli/hooks/clear_command_cache.ts
+++ b/packages/app/src/cli/hooks/clear_command_cache.ts
@@ -1,0 +1,8 @@
+import {clearCachedCommandInfo} from '../services/local-storage.js'
+import {Hook} from '@oclif/core'
+
+const clearCommandCache: Hook<'init'> = async (options) => {
+  clearCachedCommandInfo()
+}
+
+export default clearCommandCache

--- a/packages/app/src/cli/hooks/clear_command_cache.ts
+++ b/packages/app/src/cli/hooks/clear_command_cache.ts
@@ -4,6 +4,8 @@ import {Hook} from '@oclif/core'
 
 const init: Hook<'init'> = async (options) => {
   clearCachedCommandInfo()
+
+  // we want our cache to never collide when commands are running in parallel, so we set it on the current process
   process.env.COMMAND_RUN_ID = randomUUID()
 }
 

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -107,7 +107,7 @@ describe('selectApp', () => {
     })
   })
 
-  test('includes toml names when present', async () => {
+  test.only('includes toml names when present', async () => {
     vi.mocked(getTomls).mockResolvedValueOnce({
       [APP1.apiKey]: 'shopify.app.toml',
       [APP2.apiKey]: 'shopify.app.dev.toml',

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -107,7 +107,7 @@ describe('selectApp', () => {
     })
   })
 
-  test.only('includes toml names when present', async () => {
+  test('includes toml names when present', async () => {
     vi.mocked(getTomls).mockResolvedValueOnce({
       [APP1.apiKey]: 'shopify.app.toml',
       [APP2.apiKey]: 'shopify.app.dev.toml',

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -2,7 +2,6 @@ import {Organization, MinimalOrganizationApp, OrganizationStore} from '../models
 import {fetchOrgAndApps, OrganizationAppsResponse} from '../services/dev/fetch.js'
 import {getTomls} from '../utilities/app/config/getTomls.js'
 import {setCachedCommandInfo} from '../services/local-storage.js'
-import {LINK_COMMAND_ID} from '../services/app/config/link.js'
 import {renderAutocompletePrompt, renderConfirmationPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
 import {outputCompleted} from '@shopify/cli-kit/node/output'
 
@@ -28,7 +27,7 @@ export async function selectAppPrompt(
 ): Promise<string> {
   const tomls = await getTomls(apps, options?.directory)
 
-  setCachedCommandInfo(LINK_COMMAND_ID, {tomls})
+  setCachedCommandInfo({tomls})
 
   const toAnswer = (app: MinimalOrganizationApp) => {
     if (tomls[app?.apiKey]) {

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -27,7 +27,7 @@ export async function selectAppPrompt(
 ): Promise<string> {
   const tomls = await getTomls(apps, options?.directory)
 
-  setCachedCommandInfo({tomls})
+  if (tomls) setCachedCommandInfo({tomls})
 
   const toAnswer = (app: MinimalOrganizationApp) => {
     if (tomls[app?.apiKey]) {

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -1,6 +1,8 @@
 import {Organization, MinimalOrganizationApp, OrganizationStore} from '../models/organization.js'
 import {fetchOrgAndApps, OrganizationAppsResponse} from '../services/dev/fetch.js'
 import {getTomls} from '../utilities/app/config/getTomls.js'
+import {setCachedCommandInfo} from '../services/local-storage.js'
+import {LINK_COMMAND_ID} from '../services/app/config/link.js'
 import {renderAutocompletePrompt, renderConfirmationPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
 import {outputCompleted} from '@shopify/cli-kit/node/output'
 
@@ -25,6 +27,8 @@ export async function selectAppPrompt(
   },
 ): Promise<string> {
   const tomls = await getTomls(apps, options?.directory)
+
+  setCachedCommandInfo(LINK_COMMAND_ID, {tomls})
 
   const toAnswer = (app: MinimalOrganizationApp) => {
     if (tomls[app?.apiKey]) {

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -335,7 +335,7 @@ embedded = false
     })
   })
 
-  test('skips config name question if re-linking to existing current app schema', async () => {
+  test.only('skips config name question if re-linking to existing current app schema', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       const options: LinkOptions = {
@@ -370,9 +370,6 @@ embedded = false
 
       expect(selectConfigName).not.toHaveBeenCalled()
       expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.foo.toml', directory: tmp})
-      expect(renderSuccess).toHaveBeenCalledWith({
-        headline: 'App "my app" connected to this codebase, file shopify.app.foo.toml created',
-      })
     })
   })
 

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -335,7 +335,7 @@ embedded = false
     })
   })
 
-  test.only('skips config name question if re-linking to existing current app schema', async () => {
+  test('skips config name question if re-linking to existing current app schema', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       const options: LinkOptions = {

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -14,7 +14,7 @@ import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../con
 import {fetchAppFromApiKey} from '../../dev/fetch.js'
 import {configurationFileNames} from '../../../constants.js'
 import {writeAppConfigurationFile} from '../write-app-configuration-file.js'
-import {clearCachedCommandInfo, getCachedCommandInfo, setCachedCommandInfo} from '../../local-storage.js'
+import {clearCachedCommandInfo, getCachedCommandInfo} from '../../local-storage.js'
 import {Config} from '@oclif/core'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -31,7 +31,6 @@ export interface LinkOptions {
 export const LINK_COMMAND_ID = '5f2f02c6-15fd-4b7a-bde0-b033f86063c7 '
 
 export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<AppConfiguration> {
-  setCachedCommandInfo(LINK_COMMAND_ID, {data: 'my data'})
   const localApp = await loadAppConfigFromDefaultToml(options)
   const remoteApp = await loadRemoteApp(localApp, options.apiKey, options.directory)
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -20,7 +20,6 @@ import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {randomUUID} from '@shopify/cli-kit/node/crypto'
 
 export interface LinkOptions {
   commandConfig: Config
@@ -28,9 +27,6 @@ export interface LinkOptions {
   apiKey?: string
   configName?: string
 }
-
-// ensure there's a new id for each subsequent run
-export const LINK_COMMAND_ID = randomUUID()
 
 export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<AppConfiguration> {
   const localApp = await loadAppConfigFromDefaultToml(options)
@@ -104,7 +100,7 @@ async function loadConfigurationFileName(
   options: LinkOptions,
   localApp?: AppInterface,
 ): Promise<string> {
-  const {askConfigName, selectedToml} = getCachedCommandInfo(LINK_COMMAND_ID)
+  const {askConfigName, selectedToml} = getCachedCommandInfo()
 
   if (!askConfigName && selectedToml) return selectedToml as string
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -100,9 +100,9 @@ async function loadConfigurationFileName(
   options: LinkOptions,
   localApp?: AppInterface,
 ): Promise<string> {
-  const {askConfigName, selectedToml} = getCachedCommandInfo()
+  const cache = getCachedCommandInfo()
 
-  if (!askConfigName && selectedToml) return selectedToml as string
+  if (!cache?.askConfigName && cache?.selectedToml) return cache.selectedToml as string
 
   if (options.configName) {
     return getAppConfigurationFileName(options.configName)

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -14,6 +14,7 @@ import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../con
 import {fetchAppFromApiKey} from '../../dev/fetch.js'
 import {configurationFileNames} from '../../../constants.js'
 import {writeAppConfigurationFile} from '../write-app-configuration-file.js'
+import {clearCachedCommandInfo, getCachedCommandInfo, setCachedCommandInfo} from '../../local-storage.js'
 import {Config} from '@oclif/core'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -27,7 +28,10 @@ export interface LinkOptions {
   configName?: string
 }
 
+export const LINK_COMMAND_ID = '5f2f02c6-15fd-4b7a-bde0-b033f86063c7 '
+
 export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<AppConfiguration> {
+  setCachedCommandInfo(LINK_COMMAND_ID, {data: 'my data'})
   const localApp = await loadAppConfigFromDefaultToml(options)
   const remoteApp = await loadRemoteApp(localApp, options.apiKey, options.directory)
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
@@ -57,6 +61,8 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
       ],
     })
   }
+
+  clearCachedCommandInfo()
 
   return configuration
 }
@@ -99,6 +105,10 @@ async function loadConfigurationFileName(
   options: LinkOptions,
   localApp?: AppInterface,
 ): Promise<string> {
+  const {askConfigName, selectedToml} = getCachedCommandInfo(LINK_COMMAND_ID)
+
+  if (!askConfigName && selectedToml) return selectedToml as string
+
   if (options.configName) {
     return getAppConfigurationFileName(options.configName)
   }

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -14,12 +14,13 @@ import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../con
 import {fetchAppFromApiKey} from '../../dev/fetch.js'
 import {configurationFileNames} from '../../../constants.js'
 import {writeAppConfigurationFile} from '../write-app-configuration-file.js'
-import {clearCachedCommandInfo, getCachedCommandInfo} from '../../local-storage.js'
+import {getCachedCommandInfo} from '../../local-storage.js'
 import {Config} from '@oclif/core'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {randomUUID} from '@shopify/cli-kit/node/crypto'
 
 export interface LinkOptions {
   commandConfig: Config
@@ -28,7 +29,8 @@ export interface LinkOptions {
   configName?: string
 }
 
-export const LINK_COMMAND_ID = '5f2f02c6-15fd-4b7a-bde0-b033f86063c7 '
+// ensure there's a new id for each subsequent run
+export const LINK_COMMAND_ID = randomUUID()
 
 export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<AppConfiguration> {
   const localApp = await loadAppConfigFromDefaultToml(options)
@@ -60,8 +62,6 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
       ],
     })
   }
-
-  clearCachedCommandInfo()
 
   return configuration
 }

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -3,7 +3,6 @@ import {Organization, OrganizationApp} from '../../models/organization.js'
 import {fetchAppFromApiKey, OrganizationAppsResponse} from '../dev/fetch.js'
 import {CreateAppQuery, CreateAppQuerySchema} from '../../api/graphql/create_app.js'
 import {getCachedCommandInfo, setCachedCommandInfo} from '../local-storage.js'
-import {LINK_COMMAND_ID} from '../app/config/link.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputInfo} from '@shopify/cli-kit/node/output'
@@ -38,11 +37,10 @@ export async function selectOrCreateApp(
   } else {
     const selectedAppApiKey = await selectAppPrompt(apps, org.id, token, {directory: options?.directory})
 
-    const data = getCachedCommandInfo(LINK_COMMAND_ID)
+    const data = getCachedCommandInfo()
     const tomls = (data?.tomls as {[key: string]: unknown}) ?? {}
 
-    if (tomls[selectedAppApiKey])
-      setCachedCommandInfo(LINK_COMMAND_ID, {selectedToml: tomls[selectedAppApiKey], askConfigName: false})
+    if (tomls[selectedAppApiKey]) setCachedCommandInfo({selectedToml: tomls[selectedAppApiKey], askConfigName: false})
 
     const fullSelectedApp = await fetchAppFromApiKey(selectedAppApiKey, token)
     return fullSelectedApp!

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -2,6 +2,8 @@ import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompt
 import {Organization, OrganizationApp} from '../../models/organization.js'
 import {fetchAppFromApiKey, OrganizationAppsResponse} from '../dev/fetch.js'
 import {CreateAppQuery, CreateAppQuerySchema} from '../../api/graphql/create_app.js'
+import {getCachedCommandInfo, setCachedCommandInfo} from '../local-storage.js'
+import {LINK_COMMAND_ID} from '../app/config/link.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputInfo} from '@shopify/cli-kit/node/output'
@@ -35,6 +37,13 @@ export async function selectOrCreateApp(
     return createApp(org, localAppName, token, options)
   } else {
     const selectedAppApiKey = await selectAppPrompt(apps, org.id, token, {directory: options?.directory})
+
+    const data = getCachedCommandInfo(LINK_COMMAND_ID)
+    const tomls = (data?.tomls as {[key: string]: unknown}) ?? {}
+
+    if (tomls[selectedAppApiKey])
+      setCachedCommandInfo(LINK_COMMAND_ID, {selectedToml: tomls[selectedAppApiKey], askConfigName: false})
+
     const fullSelectedApp = await fetchAppFromApiKey(selectedAppApiKey, token)
     return fullSelectedApp!
   }

--- a/packages/app/src/cli/services/local-storage.ts
+++ b/packages/app/src/cli/services/local-storage.ts
@@ -92,8 +92,10 @@ function commandLocalStorage() {
 }
 
 export function setCachedCommandInfo(data: {[key: string]: unknown}): void {
-  // since we set the env var in our init hook, it will always be there
-  const id = process.env.COMMAND_RUN_ID!
+  const id = process.env.COMMAND_RUN_ID
+
+  if (!id) return
+
   const store = commandLocalStorage()
   const info = store.get(id)
 
@@ -104,8 +106,10 @@ export function setCachedCommandInfo(data: {[key: string]: unknown}): void {
 }
 
 export function getCachedCommandInfo() {
-  // since we set the env var in our init hook, it will always be there
-  const id = process.env.COMMAND_RUN_ID!
+  const id = process.env.COMMAND_RUN_ID
+
+  if (!id) return
+
   const store = commandLocalStorage()
   return store.get(id)
 }

--- a/packages/app/src/cli/services/local-storage.ts
+++ b/packages/app/src/cli/services/local-storage.ts
@@ -77,3 +77,36 @@ export function clearCurrentConfigFile(
     configFile: undefined,
   })
 }
+
+interface CommandLocalStorage {
+  [key: string]: {[key: string]: unknown}
+}
+
+let _commandLocalStorageInstance: LocalStorage<CommandLocalStorage> | undefined
+
+function commandLocalStorage() {
+  if (!_commandLocalStorageInstance) {
+    _commandLocalStorageInstance = new LocalStorage<CommandLocalStorage>({projectName: 'shopify-cli-app-command'})
+  }
+  return _commandLocalStorageInstance
+}
+
+export function setCachedCommandInfo(id: string, data: {[key: string]: unknown}): void {
+  const store = commandLocalStorage()
+  const info = store.get(id)
+
+  store.set(id, {
+    ...info,
+    ...data,
+  })
+}
+
+export function getCachedCommandInfo(id: string) {
+  const store = commandLocalStorage()
+  return store.get(id)
+}
+
+export function clearCachedCommandInfo() {
+  const store = commandLocalStorage()
+  store.clear()
+}

--- a/packages/app/src/cli/services/local-storage.ts
+++ b/packages/app/src/cli/services/local-storage.ts
@@ -91,7 +91,8 @@ function commandLocalStorage() {
   return _commandLocalStorageInstance
 }
 
-export function setCachedCommandInfo(id: string, data: {[key: string]: unknown}): void {
+export function setCachedCommandInfo(data: {[key: string]: unknown}): void {
+  const id = process.env.COMMAND_RUN_ID!
   const store = commandLocalStorage()
   const info = store.get(id)
 
@@ -101,7 +102,8 @@ export function setCachedCommandInfo(id: string, data: {[key: string]: unknown})
   })
 }
 
-export function getCachedCommandInfo(id: string) {
+export function getCachedCommandInfo() {
+  const id = process.env.COMMAND_RUN_ID!
   const store = commandLocalStorage()
   return store.get(id)
 }

--- a/packages/app/src/cli/services/local-storage.ts
+++ b/packages/app/src/cli/services/local-storage.ts
@@ -92,6 +92,7 @@ function commandLocalStorage() {
 }
 
 export function setCachedCommandInfo(data: {[key: string]: unknown}): void {
+  // since we set the env var in our init hook, it will always be there
   const id = process.env.COMMAND_RUN_ID!
   const store = commandLocalStorage()
   const info = store.get(id)
@@ -103,6 +104,7 @@ export function setCachedCommandInfo(data: {[key: string]: unknown}): void {
 }
 
 export function getCachedCommandInfo() {
+  // since we set the env var in our init hook, it will always be there
   const id = process.env.COMMAND_RUN_ID!
   const store = commandLocalStorage()
   return store.get(id)

--- a/packages/app/src/cli/utilities/app/config/getTomls.ts
+++ b/packages/app/src/cli/utilities/app/config/getTomls.ts
@@ -8,7 +8,7 @@ export async function getTomls(apps: OrganizationAppsResponse, appDirectory?: st
     return {}
   }
 
-  const regex = /^shopify\.app(\.[-\w]+)?\.toml$/g
+  const regex = /^shopify\.app(\.[-\w]+)?\.toml$/
   const clientIds: {[key: string]: string} = {}
 
   readdirSync(appDirectory).forEach((file) => {


### PR DESCRIPTION
Add a command cache to store state for the duration of the command lifecycle. Use this cache to decide whether to ask the config name.

### WHY are these changes introduced?

It's becoming exceeding less efficient to pass state around to 5+ functions to avoid using module state. The app cache serves an entirely different purpose -- there are a number of cases where we don't yet have an app at all but still need to understand what step we're at in the command and what preceded. A lightweight cache for the command itself is a useful abstraction for this.

### How to test your changes?

Run `link` and re-link a previously linked file. It should skip the command name step.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
