### PR TITLE
Add integration tests for all of the extension tomls

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1185,6 +1185,192 @@ automatically_update_urls_on_dev = true
     }
   })
 
+  test('loads the app with a Checkout Post Purchase extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      type = "checkout_post_purchase"
+      name = "my-checkout-post-purchase"
+
+      [[metafields]]
+      namespace = "my-namespace"
+      key = "my-key"
+
+      [[metafields]]
+      namespace = "my-namespace"
+      key = "my-key-2"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-checkout-post-purchase',
+    })
+
+    const checkoutUiDirectory = joinPath(tmpDir, 'extensions', 'my-checkout-post-purchase', 'src')
+    await mkdir(checkoutUiDirectory)
+
+    const tempFilePath = joinPath(checkoutUiDirectory, 'index.js')
+    await writeFile(tempFilePath, `/** content **/`)
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        type: 'checkout_post_purchase',
+        name: 'my-checkout-post-purchase',
+        metafields: [
+          {
+            namespace: 'my-namespace',
+            key: 'my-key',
+          },
+          {
+            namespace: 'my-namespace',
+            key: 'my-key-2',
+          },
+        ],
+      })
+    }
+  })
+
+  test('loads the app with a Customer Accounts UI extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      type = "customer_accounts_ui_extension"
+      name = "my-customer-accounts-ui-extension"
+
+      categories = [ "returns" ]
+      authenticated_redirect_start_url = "https://example.com/start"
+      authenticated_redirect_redirect_urls = ["https://example.com/redirect"]
+
+      extension_points = [
+        'CustomerAccount::FullPage::RenderWithin',
+      ]
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-customer-accounts-ui-extension',
+    })
+
+    const checkoutUiDirectory = joinPath(tmpDir, 'extensions', 'my-customer-accounts-ui-extension', 'src')
+    await mkdir(checkoutUiDirectory)
+
+    const tempFilePath = joinPath(checkoutUiDirectory, 'index.js')
+    await writeFile(tempFilePath, `/** content **/`)
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        type: 'customer_accounts_ui_extension',
+        name: 'my-customer-accounts-ui-extension',
+        extension_points: ['CustomerAccount::FullPage::RenderWithin'],
+        metafields: [],
+        categories: ['returns'],
+        authenticated_redirect_start_url: 'https://example.com/start',
+        authenticated_redirect_redirect_urls: ['https://example.com/redirect'],
+      })
+    }
+  })
+
+  test('loads the app with a POS UI extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      type = "pos_ui_extension"
+      name = "my-pos-ui-extension"
+      description = "my-pos-ui-extension-description"
+
+      extension_points = [
+        'pos.home.tile.render',
+        'pos.home.modal.render'
+      ]
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-pos-ui-extension',
+    })
+
+    const checkoutUiDirectory = joinPath(tmpDir, 'extensions', 'my-pos-ui-extension', 'src')
+    await mkdir(checkoutUiDirectory)
+
+    const tempFilePath = joinPath(checkoutUiDirectory, 'index.js')
+    await writeFile(tempFilePath, `/** content **/`)
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        type: 'pos_ui_extension',
+        name: 'my-pos-ui-extension',
+        description: 'my-pos-ui-extension-description',
+        extension_points: ['pos.home.tile.render', 'pos.home.modal.render'],
+      })
+    }
+  })
+
+  test('loads the app with a Tax Calculation extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      type = "tax_calculation"
+      name = "my-tax-calculation"
+
+      production_api_base_url = "https://prod.example.com"
+      benchmark_api_base_url = "https://benchmark.example.com"
+      calculate_taxes_api_endpoint = "/calculate-taxes"
+
+      [[metafields]]
+      namespace = "my-namespace"
+      key = "my-key"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-tax-calculation',
+    })
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        type: 'tax_calculation',
+        name: 'my-tax-calculation',
+        production_api_base_url: 'https://prod.example.com',
+        benchmark_api_base_url: 'https://benchmark.example.com',
+        calculate_taxes_api_endpoint: '/calculate-taxes',
+        metafields: [
+          {
+            namespace: 'my-namespace',
+            key: 'my-key',
+          },
+        ],
+      })
+    }
+  })
+
   test('loads the app with several functions that have valid configurations', async () => {
     // Given
     await writeConfig(appConfiguration)

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -758,6 +758,290 @@ automatically_update_urls_on_dev = true
     expect(myFunction.entrySourceFilePath).toContain(joinPath(blockPath('my-function'), 'src', 'index.js'))
   })
 
+  test('loads the app with a Flow trigger extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      description = "Your description"
+
+      [[extensions]]
+      name = "my-flow-trigger"
+      type = "flow_trigger"
+      handle = "handle1"
+
+      [settings]
+
+        [[settings.fields]]
+        type = "customer_reference"
+
+        [[settings.fields]]
+        type = "single_line_text_field"
+        key = "your-field-key"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-flow-trigger',
+    })
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        description: 'Your description',
+        name: 'my-flow-trigger',
+        type: 'flow_trigger',
+        handle: 'handle1',
+        settings: {
+          fields: [
+            {
+              type: 'customer_reference',
+            },
+            {
+              type: 'single_line_text_field',
+              key: 'your-field-key',
+            },
+          ],
+        },
+      })
+    }
+  })
+
+  test('loads the app with a Flow action extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      description = "Your description"
+
+      [[extensions]]
+      name = "my-flow-action"
+      type = "flow_action"
+      handle = "handle2"
+      runtime_url = "https://url.com/api/execute"
+      schema = "./schema_patch.graphql"
+      return_type_ref = "Auction"
+      validation_url = "https://url.com/api/validate"
+      config_page_url = "https://url.com/config"
+      config_page_preview_url = "https://url.com/config/preview"
+
+      [settings]
+
+        [[settings.fields]]
+        type = "customer_reference"
+        required = true
+
+        [[settings.fields]]
+        type = "single_line_text_field"
+        key = "your-field-key"
+        name = "Display name"
+        description = "A description of my field"
+        required = true
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-flow-action',
+    })
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        description: 'Your description',
+        name: 'my-flow-action',
+        type: 'flow_action',
+        handle: 'handle2',
+        runtime_url: 'https://url.com/api/execute',
+        schema: './schema_patch.graphql',
+        return_type_ref: 'Auction',
+        validation_url: 'https://url.com/api/validate',
+        config_page_url: 'https://url.com/config',
+        config_page_preview_url: 'https://url.com/config/preview',
+        settings: {
+          fields: [
+            {
+              type: 'customer_reference',
+              required: true,
+            },
+            {
+              type: 'single_line_text_field',
+              key: 'your-field-key',
+              name: 'Display name',
+              description: 'A description of my field',
+              required: true,
+            },
+          ],
+        },
+      })
+    }
+  })
+
+  test('loads the app with a Function extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      name = "My function"
+      type = "product_discounts"
+      api_version = "2023-01"
+
+      [build]
+      command = "cargo wasi build --release"
+      path = "target/wasm32-wasi/release/my-function.wasm"
+      watch = [ "src/**/*.rs" ]
+
+      [ui]
+      enable_create = false
+
+      [ui.paths]
+      create = "/"
+      details = "/"
+
+      [input.variables]
+      namespace = "my-app"
+      key = "my-input-variables"
+
+      [[targeting]]
+      target = "checkout.fetch"
+      input_query = "./input_query.graphql"
+      export = "fetch"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-function',
+    })
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        name: 'My function',
+        type: 'product_discounts',
+        api_version: '2023-01',
+        build: {
+          command: 'cargo wasi build --release',
+          path: 'target/wasm32-wasi/release/my-function.wasm',
+          watch: ['src/**/*.rs'],
+        },
+        ui: {
+          enable_create: false,
+          paths: {
+            create: '/',
+            details: '/',
+          },
+        },
+        input: {
+          variables: {
+            namespace: 'my-app',
+            key: 'my-input-variables',
+          },
+        },
+        targeting: [
+          {
+            target: 'checkout.fetch',
+            input_query: './input_query.graphql',
+            export: 'fetch',
+          },
+        ],
+      })
+    }
+  })
+
+  test('loads the app with a Function extension that has a full valid configuration with unified config', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      api_version = "2023-01"
+
+      [[extensions]]
+      name = "My function"
+      handle = "my-function"
+      type = "product_discounts"
+
+      [extensions.build]
+      command = "cargo wasi build --release"
+      path = "target/wasm32-wasi/release/my-function.wasm"
+      watch = [ "src/**/*.rs" ]
+
+      [extensions.ui]
+      enable_create = false
+
+      [extensions.ui.paths]
+      create = "/"
+      details = "/"
+
+      [extensions.input.variables]
+      namespace = "my-app"
+      key = "my-input-variables"
+
+      [[extensions.targeting]]
+      target = "checkout.fetch"
+      input_query = "./input_query.graphql"
+      export = "fetch"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-function',
+    })
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        name: 'My function',
+        handle: 'my-function',
+        type: 'product_discounts',
+        api_version: '2023-01',
+        build: {
+          command: 'cargo wasi build --release',
+          path: 'target/wasm32-wasi/release/my-function.wasm',
+          watch: ['src/**/*.rs'],
+        },
+        ui: {
+          enable_create: false,
+          paths: {
+            create: '/',
+            details: '/',
+          },
+        },
+        input: {
+          variables: {
+            namespace: 'my-app',
+            key: 'my-input-variables',
+          },
+        },
+        targeting: [
+          {
+            target: 'checkout.fetch',
+            input_query: './input_query.graphql',
+            export: 'fetch',
+          },
+        ],
+      })
+    }
+  })
+
   test('loads the app with several functions that have valid configurations', async () => {
     // Given
     await writeConfig(appConfiguration)

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -763,10 +763,9 @@ automatically_update_urls_on_dev = true
     await writeConfig(appConfiguration)
 
     const blockConfiguration = `
-      description = "Your description"
-
       [[extensions]]
-      name = "my-flow-trigger"
+      name = "Auction bid placed"
+      description = "An auction bid has been placed"
       type = "flow_trigger"
       handle = "handle1"
 
@@ -777,7 +776,7 @@ automatically_update_urls_on_dev = true
 
         [[settings.fields]]
         type = "single_line_text_field"
-        key = "your-field-key"
+        key = "your_field_key"
       `
     await writeBlockConfig({
       blockConfiguration,
@@ -793,8 +792,8 @@ automatically_update_urls_on_dev = true
     expect(extension).not.toBeUndefined()
     if (extension) {
       expect(extension.configuration).toMatchObject({
-        description: 'Your description',
-        name: 'my-flow-trigger',
+        description: 'An auction bid has been placed',
+        name: 'Auction bid placed',
         type: 'flow_trigger',
         handle: 'handle1',
         settings: {
@@ -804,7 +803,7 @@ automatically_update_urls_on_dev = true
             },
             {
               type: 'single_line_text_field',
-              key: 'your-field-key',
+              key: 'your_field_key',
             },
           ],
         },
@@ -817,10 +816,9 @@ automatically_update_urls_on_dev = true
     await writeConfig(appConfiguration)
 
     const blockConfiguration = `
-      description = "Your description"
-
       [[extensions]]
-      name = "my-flow-action"
+      name = "Place a bid"
+      description = "Place a bid on an auction"
       type = "flow_action"
       handle = "handle2"
       runtime_url = "https://url.com/api/execute"
@@ -838,7 +836,7 @@ automatically_update_urls_on_dev = true
 
         [[settings.fields]]
         type = "single_line_text_field"
-        key = "your-field-key"
+        key = "your_field_key"
         name = "Display name"
         description = "A description of my field"
         required = true
@@ -857,8 +855,8 @@ automatically_update_urls_on_dev = true
     expect(extension).not.toBeUndefined()
     if (extension) {
       expect(extension.configuration).toMatchObject({
-        description: 'Your description',
-        name: 'my-flow-action',
+        description: 'Place a bid on an auction',
+        name: 'Place a bid',
         type: 'flow_action',
         handle: 'handle2',
         runtime_url: 'https://url.com/api/execute',
@@ -875,7 +873,7 @@ automatically_update_urls_on_dev = true
             },
             {
               type: 'single_line_text_field',
-              key: 'your-field-key',
+              key: 'your_field_key',
               name: 'Display name',
               description: 'A description of my field',
               required: true,

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1509,6 +1509,36 @@ automatically_update_urls_on_dev = true
     }
   })
 
+  test('loads the app with a Product Subscription extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      type = "product_subscription"
+      name = "my-product-subscription"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-product-subscription',
+    })
+
+    await writeFile(joinPath(blockPath('my-product-subscription'), 'index.js'), '')
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        type: 'product_subscription',
+        name: 'my-product-subscription',
+      })
+    }
+  })
+
   test('loads the app with several functions that have valid configurations', async () => {
     // Given
     await writeConfig(appConfiguration)

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -776,7 +776,7 @@ automatically_update_urls_on_dev = true
 
         [[settings.fields]]
         type = "single_line_text_field"
-        key = "your_field_key"
+        key = "your field key"
       `
     await writeBlockConfig({
       blockConfiguration,
@@ -803,7 +803,7 @@ automatically_update_urls_on_dev = true
             },
             {
               type: 'single_line_text_field',
-              key: 'your_field_key',
+              key: 'your field key',
             },
           ],
         },
@@ -1084,12 +1084,8 @@ automatically_update_urls_on_dev = true
       name: 'checkout-ui',
     })
 
-    const checkoutUiDirectory = joinPath(tmpDir, 'extensions', 'checkout-ui')
-    await mkdir(checkoutUiDirectory)
-
-    const tempFilePath = joinPath(checkoutUiDirectory, 'CheckoutDynamicRender.jsx')
     await writeFile(
-      tempFilePath,
+      joinPath(blockPath('checkout-ui'), 'CheckoutDynamicRender.jsx'),
       `
     import { extension, Banner } from "@shopify/ui-extensions/checkout";
 
@@ -1204,11 +1200,7 @@ automatically_update_urls_on_dev = true
       name: 'my-checkout-post-purchase',
     })
 
-    const checkoutUiDirectory = joinPath(tmpDir, 'extensions', 'my-checkout-post-purchase', 'src')
-    await mkdir(checkoutUiDirectory)
-
-    const tempFilePath = joinPath(checkoutUiDirectory, 'index.js')
-    await writeFile(tempFilePath, `/** content **/`)
+    await writeFile(joinPath(blockPath('my-checkout-post-purchase'), 'index.js'), '/** content **/')
 
     // When
     const app = await loadApp({directory: tmpDir, specifications})
@@ -1256,11 +1248,7 @@ automatically_update_urls_on_dev = true
       name: 'my-customer-accounts-ui-extension',
     })
 
-    const checkoutUiDirectory = joinPath(tmpDir, 'extensions', 'my-customer-accounts-ui-extension', 'src')
-    await mkdir(checkoutUiDirectory)
-
-    const tempFilePath = joinPath(checkoutUiDirectory, 'index.js')
-    await writeFile(tempFilePath, `/** content **/`)
+    await writeFile(joinPath(blockPath('my-customer-accounts-ui-extension'), 'index.js'), '/** content **/')
 
     // When
     const app = await loadApp({directory: tmpDir, specifications})
@@ -1365,6 +1353,71 @@ automatically_update_urls_on_dev = true
             key: 'my-key',
           },
         ],
+      })
+    }
+  })
+
+  test('loads the app with a Web Pixel extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      type = "web_pixel_extension"
+      name = "pixel"
+      runtime_context = "strict"
+
+      [settings]
+      type = "object"
+
+      [settings.fields.first]
+      name = "first"
+      description = "description"
+      type = "single_line_text_field"
+      validations = [{ choices = ["a", "b", "c"] }]
+
+      [settings.fields.second]
+      name = "second"
+      description = "description"
+      type = "single_line_text_field"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'pixel',
+    })
+    await writeFile(joinPath(blockPath('pixel'), 'index.js'), '')
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        type: 'web_pixel_extension',
+        name: 'pixel',
+        runtime_context: 'strict',
+        settings: {
+          type: 'object',
+          fields: {
+            first: {
+              description: 'description',
+              name: 'first',
+              type: 'single_line_text_field',
+              validations: [
+                {
+                  choices: ['a', 'b', 'c'],
+                },
+              ],
+            },
+            second: {
+              description: 'description',
+              name: 'second',
+              type: 'single_line_text_field',
+            },
+          },
+        },
       })
     }
   })

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1422,6 +1422,93 @@ automatically_update_urls_on_dev = true
     }
   })
 
+  test('loads the app with a Legacy Checkout UI extension that has a full valid configuration', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      type = "checkout_ui_extension"
+      name = "my-checkout-extension"
+
+      extension_points = [
+        'Checkout::Dynamic::Render'
+      ]
+
+      [[metafields]]
+      namespace = "my-namespace"
+      key = "my-key"
+
+      [[metafields]]
+      namespace = "my-namespace"
+      key = "my-other-key"
+
+      [capabilities]
+      network_access = true
+      block_progress = true
+      api_access = true
+
+      [settings]
+        [[settings.fields]]
+        key = "field_key"
+        type = "boolean"
+        name = "field-name"
+        [[settings.fields]]
+        key = "field_key_2"
+        type = "number_integer"
+        name = "field-name-2"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my-checkout-extension',
+    })
+
+    await writeFile(joinPath(blockPath('my-checkout-extension'), 'index.js'), '')
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        type: 'checkout_ui_extension',
+        name: 'my-checkout-extension',
+        extension_points: ['Checkout::Dynamic::Render'],
+        capabilities: {
+          api_access: true,
+          block_progress: true,
+          network_access: true,
+        },
+        settings: {
+          fields: [
+            {
+              key: 'field_key',
+              name: 'field-name',
+              type: 'boolean',
+            },
+            {
+              key: 'field_key_2',
+              name: 'field-name-2',
+              type: 'number_integer',
+            },
+          ],
+        },
+        metafields: [
+          {
+            key: 'my-key',
+            namespace: 'my-namespace',
+          },
+          {
+            key: 'my-other-key',
+            namespace: 'my-namespace',
+          },
+        ],
+      })
+    }
+  })
+
   test('loads the app with several functions that have valid configurations', async () => {
     // Given
     await writeConfig(appConfiguration)


### PR DESCRIPTION
### WHY are these changes introduced?

Want to make sure we have sufficient coverage over the current and new format of extension toml files so that regressions aren't introduced.

### WHAT is this pull request doing?

Testing the following
- [x] Flow trigger
- [x] Flow action
- [x] Function
- [x] UI extension
- [x] Checkout Post Purchase extension
- [x] Customer Accounts UI extension
- [x] Tax calculation extension
- [x] POS UI extension
- [x] Action extension
- [x] Web pixel
- [x] Legacy Checkout UI extension
- [x] Product subscription

### How to test your changes?

Just tests

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
