### PR TITLE
Fix link command when no default config file

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -259,7 +259,7 @@ export class App implements AppInterface {
 
 export class EmptyApp extends App {
   constructor() {
-    const configuration = {scopes: '', extension_directories: []}
+    const configuration = {scopes: ''}
     super('', '', '', 'npm', configuration, '', {}, [], [], false)
   }
 }

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -75,7 +75,6 @@ describe('link', () => {
 name = "app1"
 application_url = "https://example.com"
 embedded = true
-extension_directories = [ ]
 
 [webhooks]
 api_version = "2023-07"
@@ -343,7 +342,6 @@ use_legacy_install_flow = true
 name = "app1"
 application_url = "https://example.com"
 embedded = true
-extension_directories = [ ]
 
 [webhooks]
 api_version = "2023-07"
@@ -423,7 +421,6 @@ scopes = "read_products,write_orders"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
-extension_directories = [ ]
 
 [webhooks]
 api_version = "2023-07"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When you run the `app config link` using a local that does not include any `shopify.app.toml` file, the new file generated is invalid to run the `dev` command if the app contains extensions
The file is created with the attribute `extension_directories: []`, this attribute is used by the app loader to take the relative root paths where the extensions are located. In this case it's an empty array so the extensions generated inside the default relative `extensions` folder are not loaded

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Creates the default app config file without the attribute `extension_directories: []`

### How to test your changes?
- Delete the file `shopify.app.toml` from the root folder of your app
- Run the command `p shopify app config link --path /your/app/path`
- Run the `dev` command with an app that includes some extensions
- The extensions should be loaded
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
