### PR TITLE
Change forward slash to be an invalid character for app version tag

### DIFF
--- a/.changeset/heavy-singers-speak.md
+++ b/.changeset/heavy-singers-speak.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update app version name validation to prohibit forward slashes

--- a/packages/app/src/cli/validations/version-name.test.ts
+++ b/packages/app/src/cli/validations/version-name.test.ts
@@ -4,7 +4,7 @@ import {describe, expect, test} from 'vitest'
 describe('validateVersion', () => {
   test('when version value meets all requirements should not throw any error', async () => {
     // Given
-    const version = 'AZaz09.-_/'
+    const version = 'AZaz09.-_'
 
     // When
     expect(() => validateVersion(version)).not.toThrow()
@@ -18,7 +18,7 @@ describe('validateVersion', () => {
 
   test('when version value violates unsupported characters requirements', async () => {
     // Given
-    const versionWithUnsupportedCharacters = 'AZa%&\n'
+    const versionWithUnsupportedCharacters = 'AZa%&\n/'
 
     // When
     expect(() => validateVersion(versionWithUnsupportedCharacters)).toThrowError(

--- a/packages/app/src/cli/validations/version-name.ts
+++ b/packages/app/src/cli/validations/version-name.ts
@@ -18,10 +18,10 @@ export function validateVersion(version: string | undefined) {
     )
   }
 
-  const validChars = /^[a-zA-Z0-9.\-/_]+$/
+  const validChars = /^[a-zA-Z0-9.\-_]+$/
   if (!version.match(validChars)) {
     throw new AbortError(errorMessage, [
-      "A version name must consist only of letters, numbers, and special characters '.-_/'",
+      'Version name can only contain alphanumeric characters, periods, hyphens, and underscores',
     ])
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Closes: https://github.com/Shopify/app-deploys/issues/646
Closes: https://github.com/Shopify/app-deploys/issues/649

Change the forward slash to be an invalid character for version_tag to avoid issues when used in URLs (details in [issue](https://github.com/Shopify/app-deploys/issues/646)).

### WHAT is this pull request doing?

Updates the regex, error copy, and tests to make `/` an invalid character

### How to test your changes?

Try to create an app version with a name including a forward slash.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
