### PR TITLE
Support Windows line-endings in TOML files

### DIFF
--- a/packages/cli-kit/src/public/node/toml.ts
+++ b/packages/cli-kit/src/public/node/toml.ts
@@ -8,7 +8,8 @@ import * as toml from '@iarna/toml'
  * @returns JSON object.
  */
 export function decodeToml(input: string): object {
-  return toml.parse(input)
+  const normalizedInput = input.replace(/\r\n$/g, '\n')
+  return toml.parse(normalizedInput)
 }
 
 /**


### PR DESCRIPTION
Taking inspiration from https://github.com/cloudflare/workers-sdk/pull/936

Our TOML parsing code is susceptible to the same issue so I'm preventively fixing it.