### PR TITLE
Fix dev behavior with reset and client-id flags

### DIFF
--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -585,7 +585,7 @@ dev_store_url = "domain1"
           list: {
             items: [
               'Org:          org1',
-              'App:          undefined',
+              'App:          app1',
               'Dev store:    domain1',
               'Update URLs:  Not yet configured',
             ],

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -368,6 +368,77 @@ describe('ensureDevContext', async () => {
     })
   })
 
+  test('returns context from client-id flag rather than config in cache', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+name = "my app"
+client_id = "12345"
+application_url = "https://myapp.com"
+embedded = true
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+scopes = "read_products"
+
+[webhooks]
+api_version = "2023-04"
+
+[build]
+dev_store_url = "domain1"
+`
+      const filePath = joinPath(tmp, 'shopify.app.toml')
+      writeFileSync(filePath, expectedContent)
+      vi.mocked(getCachedAppInfo).mockReturnValue(CACHED1_WITH_CONFIG)
+      vi.mocked(loadAppConfiguration).mockReset()
+      vi.mocked(loadAppConfiguration).mockResolvedValue({
+        directory: tmp,
+        configurationPath: joinPath(tmp, CACHED1_WITH_CONFIG.configFile!),
+        configuration: testAppWithConfig({
+          config: {
+            name: APP1.apiKey,
+            client_id: APP1.apiKey,
+            build: {
+              automatically_update_urls_on_dev: true,
+              dev_store_url: STORE1.shopDomain,
+            },
+          },
+        }).configuration,
+      })
+      vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1).mockResolvedValue(APP2)
+      vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
+
+      // When
+      const got = await ensureDevContext(
+        {
+          directory: 'app_directory',
+          reset: false,
+          commandConfig: COMMAND_CONFIG,
+          apiKey: APP2.apiKey,
+        },
+        'token',
+      )
+
+      // Then
+      expect(got).toEqual({
+        remoteApp: {...APP2, apiSecret: 'secret2'},
+        storeFqdn: STORE1.shopDomain,
+        remoteAppUpdated: true,
+        updateURLs: true,
+        configName: CACHED1_WITH_CONFIG.configFile,
+      })
+      expect(setCachedAppInfo).not.toHaveBeenCalled()
+
+      expect(metadata.getAllPublicMetadata()).toMatchObject({
+        api_key: APP2.apiKey,
+        partner_id: 1,
+      })
+
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      expect(content).toEqual(expectedContent)
+    })
+  })
+
   test('loads the correct file when config flag is passed in', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -148,6 +148,7 @@ async function dev(options: DevOptions) {
         cachedUpdateURLs,
         newApp: remoteApp.newApp,
         localApp,
+        apiKey,
       })
       if (shouldUpdateURLs) await updateURLs(newURLs, apiKey, token, localApp)
       await outputUpdateURLsResult(shouldUpdateURLs, newURLs, remoteApp, localApp)

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -160,7 +160,7 @@ export async function updateURLs(
     throw new AbortError(errors)
   }
 
-  if (localApp && isCurrentAppSchema(localApp.configuration)) {
+  if (localApp && isCurrentAppSchema(localApp.configuration) && localApp.configuration.client_id === apiKey) {
     const localConfiguration: AppConfiguration = {
       ...localApp.configuration,
       application_url: urls.applicationUrl,
@@ -186,9 +186,11 @@ export interface ShouldOrPromptUpdateURLsOptions {
   cachedUpdateURLs?: boolean
   newApp?: boolean
   localApp?: AppInterface
+  apiKey: string
 }
 
 export async function shouldOrPromptUpdateURLs(options: ShouldOrPromptUpdateURLsOptions): Promise<boolean> {
+  if (options.localApp && options.localApp.configuration.client_id !== options.apiKey) return true
   if (options.newApp || !terminalSupportsRawMode()) return true
   let shouldUpdateURLs: boolean = options.cachedUpdateURLs === true
 


### PR DESCRIPTION
### WHY are these changes introduced?

When running `shopify app dev --client-id <app-client-id>`, if there is a current linked configuration, the changes to the app URLs and configuration get updated to the file even if the config file is linked to a different app.

### WHAT is this pull request doing?

Ensures that the loaded configuration file does not get updated if the `client_id` on file does not match with the app that is fetched from the `--client-id` flag.

### How to test your changes?

**1st scenario**
1. Run `shopify app config link` to link a `shopify.app.toml` to an app upstream.
1. Run `shopify app dev --client-id <different-id-than-linked>` and see that `different-id-than-linked` URLs are updated upstream, with no changes to `shopify.app.toml`.

**2nd scenario**
1. Run `shopify app config link` to link a `shopify.app.toml` to an app upstream.
1. Run `shopify app dev --reset` up until the first prompt (org selection prompt) and terminate the process.
1. Run `shopify app dev --client-id <different-id-than-linked>` and see that `different-id-than-linked` URLs are updated upstream, with no changes to `shopify.app.toml`.

**3rd scenario**
1. Run `shopify app config link` to link a `shopify.app.toml` to an app upstream.
1. Run `shopify app config link` to link a `shopify.app.prod.toml` to an app upstream.
1. Run `shopify app dev --client-id <different-id-than-linked>` and see that `different-id-than-linked` URLs are updated upstream, with no changes to `shopify.app.toml` or `shopify.app.prod.toml`.

**legacy scenario**
1. Run `npm init @shopify/app@latest` to generate a new app template
2. `cd` into app and run `npm run dev`
1. Run `shopify app dev --client-id <different-app-id>` and see that `different-app-id` URLs are updated upstream, with no changes to `shopify.app.toml`.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
