### PR TITLE
Use regular non-dangerous confirmation when deploying no-release

### DIFF
--- a/packages/app/src/cli/services/context/prompts.test.ts
+++ b/packages/app/src/cli/services/context/prompts.test.ts
@@ -2,7 +2,7 @@ import {deployConfirmationPrompt, SourceSummary} from './prompts.js'
 import {RemoteSource, LocalSource} from './identifiers.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
-import {renderConfirmationPrompt, InfoTableSection} from '@shopify/cli-kit/node/ui'
+import {renderConfirmationPrompt, renderDangerousConfirmationPrompt, InfoTableSection} from '@shopify/cli-kit/node/ui'
 import {describe, expect, test, vi} from 'vitest'
 
 vi.mock('@shopify/cli-kit/node/ui')
@@ -49,25 +49,57 @@ describe('deployConfirmationPrompt', () => {
     test('renders confirmation prompt with the comparison between source summary and active version', async () => {
       // Given
       vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
-      vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
+      vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent({noDelete: true}))
 
       // When
-      const response = await deployConfirmationPrompt(
-        buildSourceSummary({
-          identifiers: {...identifier1, ...identifier2},
-          toCreate: [createdExtension],
-          onlyRemote: [remoteOnlyExtension],
-          dashboardOnly: [dashboardOnlyExtension],
-        }),
-        'unified',
-        'apiKey',
-        'token',
-      )
+      const sourceSummary = buildSourceSummary({
+        identifiers: {...identifier1, ...identifier2},
+        toCreate: [createdExtension],
+        onlyRemote: [remoteOnlyExtension],
+        dashboardOnly: [dashboardOnlyExtension],
+      })
+      const response = await deployConfirmationPrompt(sourceSummary, 'unified', 'apiKey', 'token')
 
       // Then
       expect(response).toBe(true)
       expect(renderConfirmationPrompt).toHaveBeenCalledWith(
         unifiedRenderConfirmationPromptContent({
+          appTitle: sourceSummary.appTitle,
+          infoTable: [
+            {
+              header: 'Includes:',
+              items: [
+                ['extension1', {subdued: '(new)'}],
+                ['id1', {subdued: '(new)'}],
+                'extension2',
+                ['dashboard_title2', {subdued: '(from Partner Dashboard)'}],
+              ],
+              bullet: '+',
+            },
+          ],
+        }),
+      )
+    })
+
+    test('renders dangerous confirmation prompt with the comparison between source summary and active version when extensions will be deleted', async () => {
+      // Given
+      vi.mocked(renderDangerousConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
+
+      // When
+      const sourceSummary = buildSourceSummary({
+        identifiers: {...identifier1, ...identifier2},
+        toCreate: [createdExtension],
+        onlyRemote: [remoteOnlyExtension],
+        dashboardOnly: [dashboardOnlyExtension],
+      })
+      const response = await deployConfirmationPrompt(sourceSummary, 'unified', 'apiKey', 'token')
+
+      // Then
+      expect(response).toBe(true)
+      expect(renderDangerousConfirmationPrompt).toHaveBeenCalledWith(
+        unifiedRenderDangerousConfirmationPromptContent({
+          appTitle: sourceSummary.appTitle,
           infoTable: [
             {
               header: 'Includes:',
@@ -92,7 +124,7 @@ describe('deployConfirmationPrompt', () => {
 
     test('when current extension registration and active version include same dashboard extension we should show it only in the dashboard section', async () => {
       // Given
-      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(renderDangerousConfirmationPrompt).mockResolvedValue(true)
       vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
 
       const dashboardExtensionIncludedInActiveVersion = {
@@ -103,22 +135,19 @@ describe('deployConfirmationPrompt', () => {
       }
 
       // When
-      const response = await deployConfirmationPrompt(
-        buildSourceSummary({
-          identifiers: {...identifier1, ...identifier2},
-          toCreate: [createdExtension],
-          onlyRemote: [remoteOnlyExtension],
-          dashboardOnly: [dashboardOnlyExtension, dashboardExtensionIncludedInActiveVersion],
-        }),
-        'unified',
-        'apiKey',
-        'token',
-      )
+      const sourceSummary = buildSourceSummary({
+        identifiers: {...identifier1, ...identifier2},
+        toCreate: [createdExtension],
+        onlyRemote: [remoteOnlyExtension],
+        dashboardOnly: [dashboardOnlyExtension, dashboardExtensionIncludedInActiveVersion],
+      })
+      const response = await deployConfirmationPrompt(sourceSummary, 'unified', 'apiKey', 'token')
 
       // Then
       expect(response).toBe(true)
-      expect(renderConfirmationPrompt).toHaveBeenCalledWith(
-        unifiedRenderConfirmationPromptContent({
+      expect(renderDangerousConfirmationPrompt).toHaveBeenCalledWith(
+        unifiedRenderDangerousConfirmationPromptContent({
+          appTitle: sourceSummary.appTitle,
           infoTable: [
             {
               header: 'Includes:',
@@ -144,28 +173,25 @@ describe('deployConfirmationPrompt', () => {
 
     test('when current dashboard extension registration and non dashboard active version include same extension we should show as new, not dashboard', async () => {
       // Given
-      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+      vi.mocked(renderDangerousConfirmationPrompt).mockResolvedValue(true)
       vi.mocked(partnersRequest).mockResolvedValue(activeVersionContent())
       // Add dashboard extension to the current non dashboard registrations
       const dashboardIdentifier = {dashboard_title2: 'dashboard_uuid2'}
 
       // When
-      const response = await deployConfirmationPrompt(
-        buildSourceSummary({
-          identifiers: {...identifier1, ...identifier2, ...dashboardIdentifier},
-          toCreate: [createdExtension],
-          onlyRemote: [remoteOnlyExtension],
-          dashboardOnly: [dashboardOnlyExtension],
-        }),
-        'unified',
-        'apiKey',
-        'token',
-      )
+      const sourceSummary = buildSourceSummary({
+        identifiers: {...identifier1, ...identifier2, ...dashboardIdentifier},
+        toCreate: [createdExtension],
+        onlyRemote: [remoteOnlyExtension],
+        dashboardOnly: [dashboardOnlyExtension],
+      })
+      const response = await deployConfirmationPrompt(sourceSummary, 'unified', 'apiKey', 'token')
 
       // Then
       expect(response).toBe(true)
-      expect(renderConfirmationPrompt).toHaveBeenCalledWith(
-        unifiedRenderConfirmationPromptContent({
+      expect(renderDangerousConfirmationPrompt).toHaveBeenCalledWith(
+        unifiedRenderDangerousConfirmationPromptContent({
+          appTitle: sourceSummary.appTitle,
           infoTable: [
             {
               header: 'Includes:',
@@ -271,6 +297,7 @@ describe('deployConfirmationPrompt', () => {
 
 const identifier1 = {extension1: 'uuid1'}
 const identifier2 = {extension2: 'uuid2'}
+const identifier3 = {extension3: 'uuid3'}
 const createdExtension = {
   localIdentifier: 'id1',
   graphQLType: 'type1',
@@ -300,7 +327,7 @@ function buildSourceSummary(options: BuildSourceSummaryOptions = {}): SourceSumm
   const {identifiers = {}, toCreate = [], onlyRemote = [], dashboardOnly = []} = options
 
   return {
-    appTitle: undefined,
+    appTitle: 'my-app',
     question: 'question',
     identifiers,
     toCreate,
@@ -335,51 +362,54 @@ function legacyRenderConfirmationPromptContent(confirmationMessage = 'Yes, deplo
   }
 }
 
-function activeVersionContent() {
+function activeVersionContent({noDelete = false} = {}) {
+  const appModuleVersionsToDelete = [
+    {
+      registrationId: 'id3',
+      registrationUuid: 'uuid3',
+      registrationTitle: 'title3',
+      type: 'type3',
+      specification: {
+        identifier: 'spec1',
+        name: 'specName1',
+        options: {
+          managementExperience: 'cli',
+        },
+      },
+    },
+    {
+      registrationId: 'dashboard_id1',
+      registrationUuid: 'dashboard_uuid1',
+      registrationTitle: 'dashboard_title1',
+      type: 'admin-link',
+      specification: {
+        identifier: 'spec2',
+        name: 'specName2',
+        options: {
+          managementExperience: 'dashboard',
+        },
+      },
+    },
+  ]
+  const appModuleVersionsToUpdate = [
+    {
+      registrationId: 'id2',
+      registrationUuid: 'uuid2',
+      registrationTitle: 'extension2',
+      type: 'type2',
+      specification: {
+        identifier: 'spec3',
+        name: 'specName3',
+        options: {
+          managementExperience: 'cli',
+        },
+      },
+    },
+  ]
   return {
     app: {
       activeAppVersion: {
-        appModuleVersions: [
-          {
-            registrationId: 'id3',
-            registrationUuid: 'uuid3',
-            registrationTitle: 'title3',
-            type: 'type3',
-            specification: {
-              identifier: 'spec1',
-              name: 'specName1',
-              options: {
-                managementExperience: 'cli',
-              },
-            },
-          },
-          {
-            registrationId: 'id2',
-            registrationUuid: 'uuid2',
-            registrationTitle: 'extension2',
-            type: 'type2',
-            specification: {
-              identifier: 'spec3',
-              name: 'specName3',
-              options: {
-                managementExperience: 'cli',
-              },
-            },
-          },
-          {
-            registrationId: 'dashboard_id1',
-            registrationUuid: 'dashboard_uuid1',
-            registrationTitle: 'dashboard_title1',
-            type: 'admin-link',
-            specification: {
-              identifier: 'spec2',
-              name: 'specName2',
-              options: {
-                managementExperience: 'dashboard',
-              },
-            },
-          },
-        ],
+        appModuleVersions: [...appModuleVersionsToUpdate, ...(noDelete ? [] : appModuleVersionsToDelete)],
       },
     },
   }
@@ -387,6 +417,17 @@ function activeVersionContent() {
 
 interface UnifiedRenderConfirmationPromptContentOptions {
   infoTable?: InfoTableSection[]
+  appTitle?: string
+}
+
+function unifiedRenderDangerousConfirmationPromptContent(options: UnifiedRenderConfirmationPromptContentOptions = {}) {
+  const {appTitle, infoTable} = options
+
+  return {
+    confirmation: appTitle,
+    infoTable,
+    message: 'question',
+  }
 }
 
 function unifiedRenderConfirmationPromptContent(options: UnifiedRenderConfirmationPromptContentOptions = {}) {

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -73,7 +73,7 @@ export async function deployConfirmationPrompt(
 
   if (!canSkipConfirmation) {
     const appExists = Boolean(appTitle)
-    const isDangerous = appExists && removesExtension
+    const isDangerous = appExists && removesExtension && deploymentMode === 'unified'
 
     if (isDangerous) {
       confirmationResponse = await renderDangerousConfirmationPrompt({


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-foundations/issues/157

When deploying with `--no-release`, no need to render a dangerous confirmation prompt.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

The main change is going back to a regular confirmation prompt unless `deploymentMode === 'unified'` (i.e. we're releasing as well).

The tests changed a lot because I added `appTitle` so dangerous confirmation prompts would appear as appropriate, but then I needed up update many tests to `renderDangerousConfirmationPrompt` because by default we're exercising all the infoTable types.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run `shopify app deploy` when removing an extension. Normally it should use the dangerous confirmation prompt, but it should back down to a regular confirmation prompt if you add the `--no-release` flag.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
