### PR TITLE
Run use to select config when current config file does not exist

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -22,7 +22,7 @@ import {
   pnpmWorkspaceFile,
 } from '@shopify/cli-kit/node/node-package-manager'
 import {inTemporaryDirectory, moveFile, mkdir, mkTmpDir, rmdir, writeFile} from '@shopify/cli-kit/node/fs'
-import {joinPath, dirname, cwd} from '@shopify/cli-kit/node/path'
+import {joinPath, dirname, cwd, normalizePath} from '@shopify/cli-kit/node/path'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
 import {outputContent} from '@shopify/cli-kit/node/output'
 // eslint-disable-next-line no-restricted-imports
@@ -1687,30 +1687,27 @@ automatically_update_urls_on_dev = true
 
   const runningOnWindows = platformAndArch().platform === 'windows'
 
-  test.skipIf(runningOnWindows)(
-    'prompts to select new config if current config file is set but does not exist',
-    async () => {
-      // Given
-      await writeConfig(linkedAppConfiguration)
-      vi.mocked(getCachedAppInfo).mockReturnValue({directory: tmpDir, configFile: 'shopify.app.non-existent.toml'})
-      vi.mocked(use).mockResolvedValue('shopify.app.toml')
+  test('prompts to select new config if current config file is set but does not exist', async () => {
+    // Given
+    await writeConfig(linkedAppConfiguration)
+    vi.mocked(getCachedAppInfo).mockReturnValue({directory: tmpDir, configFile: 'shopify.app.non-existent.toml'})
+    vi.mocked(use).mockResolvedValue('shopify.app.toml')
 
-      // When
-      await loadApp({directory: tmpDir, specifications})
+    // When
+    await loadApp({directory: tmpDir, specifications})
 
-      // Then
-      expect(use).toHaveBeenCalledWith({
-        directory: resolve(tmpDir),
-        shouldRenderSuccess: false,
-        warningContent: {
-          headline: "Couldn't find shopify.app.non-existent.toml",
-          body: [
-            "If you have multiple config files, select a new one. If you only have one config file, it's been selected as your default.",
-          ],
-        },
-      })
-    },
-  )
+    // Then
+    expect(use).toHaveBeenCalledWith({
+      directory: normalizePath(resolve(tmpDir)),
+      shouldRenderSuccess: false,
+      warningContent: {
+        headline: "Couldn't find shopify.app.non-existent.toml",
+        body: [
+          "If you have multiple config files, select a new one. If you only have one config file, it's been selected as your default.",
+        ],
+      },
+    })
+  })
 
   test.skipIf(runningOnWindows)(`updates metadata after loading a config as code application`, async () => {
     const {webDirectory} = await writeConfig(linkedAppConfiguration, {

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1702,7 +1702,12 @@ automatically_update_urls_on_dev = true
       expect(use).toHaveBeenCalledWith({
         directory: resolve(tmpDir),
         shouldRenderSuccess: false,
-        warningMessage: 'Could not find config file shopify.app.non-existent.toml, please select a new config',
+        warningContent: {
+          headline: "Couldn't find shopify.app.non-existent.toml",
+          body: [
+            "If you have multiple config files, select a new one. If you only have one config file, it's been selected as your default.",
+          ],
+        },
       })
     },
   )

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1671,23 +1671,6 @@ automatically_update_urls_on_dev = true
     })
   })
 
-  test('prompts to select new config if current config file is set but does not exist', async () => {
-    // Given
-    await writeConfig(linkedAppConfiguration)
-    vi.mocked(getCachedAppInfo).mockReturnValue({directory: tmpDir, configFile: 'shopify.app.non-existent.toml'})
-    vi.mocked(use).mockResolvedValue('shopify.app.toml')
-
-    // When
-    await loadApp({directory: tmpDir, specifications})
-
-    // Then
-    expect(use).toHaveBeenCalledWith({
-      directory: resolve(tmpDir),
-      shouldRenderSuccess: false,
-      warningMessage: 'Could not find config file shopify.app.non-existent.toml, please select a new config',
-    })
-  })
-
   test('throws error if config file is passed in but does not exist', async () => {
     // Given
     await writeConfig(linkedAppConfiguration)
@@ -1703,6 +1686,26 @@ automatically_update_urls_on_dev = true
   })
 
   const runningOnWindows = platformAndArch().platform === 'windows'
+
+  test.skipIf(runningOnWindows)(
+    'prompts to select new config if current config file is set but does not exist',
+    async () => {
+      // Given
+      await writeConfig(linkedAppConfiguration)
+      vi.mocked(getCachedAppInfo).mockReturnValue({directory: tmpDir, configFile: 'shopify.app.non-existent.toml'})
+      vi.mocked(use).mockResolvedValue('shopify.app.toml')
+
+      // When
+      await loadApp({directory: tmpDir, specifications})
+
+      // Then
+      expect(use).toHaveBeenCalledWith({
+        directory: resolve(tmpDir),
+        shouldRenderSuccess: false,
+        warningMessage: 'Could not find config file shopify.app.non-existent.toml, please select a new config',
+      })
+    },
+  )
 
   test.skipIf(runningOnWindows)(`updates metadata after loading a config as code application`, async () => {
     const {webDirectory} = await writeConfig(linkedAppConfiguration, {

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1671,18 +1671,35 @@ automatically_update_urls_on_dev = true
     })
   })
 
-  test.only('prompts to select new config if current config file does not exist', async () => {
+  test('prompts to select new config if current config file is set but does not exist', async () => {
     // Given
     await writeConfig(linkedAppConfiguration)
     vi.mocked(getCachedAppInfo).mockReturnValue({directory: tmpDir, configFile: 'shopify.app.non-existent.toml'})
     vi.mocked(use).mockResolvedValue('shopify.app.toml')
 
+    // When
     await loadApp({directory: tmpDir, specifications})
+
+    // Then
     expect(use).toHaveBeenCalledWith({
       directory: resolve(tmpDir),
       shouldRenderSuccess: false,
       warningMessage: 'Could not find config file shopify.app.non-existent.toml, please select a new config',
     })
+  })
+
+  test('throws error if config file is passed in but does not exist', async () => {
+    // Given
+    await writeConfig(linkedAppConfiguration)
+    vi.mocked(getCachedAppInfo).mockReturnValue({directory: tmpDir, configFile: 'shopify.app.non-existent.toml'})
+    vi.mocked(use).mockResolvedValue('shopify.app.toml')
+
+    // When
+    const result = loadApp({directory: tmpDir, specifications, configName: 'non-existent'})
+
+    // Then
+    await expect(result).rejects.toThrow(`Couldn't find shopify.app.non-existent.toml in ${tmpDir}.`)
+    expect(use).not.toHaveBeenCalled()
   })
 
   const runningOnWindows = platformAndArch().platform === 'windows'

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -503,8 +503,13 @@ class AppConfigurationLoader {
     const cachedCurrentConfigPath = cachedCurrentConfig ? joinPath(appDirectory, cachedCurrentConfig) : null
 
     if (!this.configName && cachedCurrentConfigPath && !fileExistsSync(cachedCurrentConfigPath)) {
-      const warningMessage = `Could not find config file ${cachedCurrentConfig}, please select a new config`
-      this.configName = await use({directory: appDirectory, warningMessage, shouldRenderSuccess: false})
+      const warningContent = {
+        headline: `Couldn't find ${cachedCurrentConfig}`,
+        body: [
+          "If you have multiple config files, select a new one. If you only have one config file, it's been selected as your default.",
+        ],
+      }
+      this.configName = await use({directory: appDirectory, warningContent, shouldRenderSuccess: false})
     }
 
     this.configName = this.configName ?? cachedCurrentConfig

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -215,7 +215,7 @@ describe('use', () => {
       createConfigFile(directory, 'shopify.app.something.toml')
 
       // When
-      await use({directory, configName: 'something', warningMessage: "we're doomed. DOOMED."})
+      await use({directory, configName: 'something', warningContent: {headline: "we're doomed. DOOMED."}})
 
       // Then
       expect(renderWarning).toHaveBeenCalledWith({headline: "we're doomed. DOOMED."})

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -6,7 +6,7 @@ import {selectConfigFile} from '../../../prompts/config.js'
 import {describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {renderSuccess} from '@shopify/cli-kit/node/ui'
+import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {err, ok} from '@shopify/cli-kit/node/result'
 
 const LOCAL_APP = testApp()
@@ -115,7 +115,7 @@ describe('use', () => {
     })
   })
 
-  test('saves currentConfiguration with client_id and config name to localstorage', async () => {
+  test('saves currentConfiguration config name to localstorage', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       createConfigFile(tmp, 'shopify.app.staging.toml')
@@ -203,6 +203,40 @@ describe('use', () => {
 
       // Then
       await expect(result).rejects.toThrow(/Could not find any shopify\.app\.toml file in the directory./)
+    })
+  })
+
+  test('renders warning when warning message is specified', async () => {
+    await inTemporaryDirectory(async (directory) => {
+      // Given
+      const {configurationPath, configuration} = testApp({}, 'current')
+      vi.mocked(loadAppConfiguration).mockResolvedValue({directory, configurationPath, configuration})
+      vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.something.toml')
+      createConfigFile(directory, 'shopify.app.something.toml')
+
+      // When
+      await use({directory, configName: 'something', warningMessage: "we're doomed. DOOMED."})
+
+      // Then
+      expect(renderWarning).toHaveBeenCalledWith({headline: "we're doomed. DOOMED."})
+      expect(setCachedAppInfo).toHaveBeenCalledWith({directory, configFile: 'shopify.app.something.toml'})
+    })
+  })
+
+  test('does not render success when shouldRenderSuccess is false', async () => {
+    await inTemporaryDirectory(async (directory) => {
+      // Given
+      const {configurationPath, configuration} = testApp({}, 'current')
+      vi.mocked(loadAppConfiguration).mockResolvedValue({directory, configurationPath, configuration})
+      vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.something.toml')
+      createConfigFile(directory, 'shopify.app.something.toml')
+
+      // When
+      await use({directory, configName: 'something', shouldRenderSuccess: false})
+
+      // Then
+      expect(renderSuccess).not.toHaveBeenCalled()
+      expect(setCachedAppInfo).toHaveBeenCalledWith({directory, configFile: 'shopify.app.something.toml'})
     })
   })
 })

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -23,11 +23,6 @@ export default async function use({
   shouldRenderSuccess = true,
   reset = false,
 }: UseOptions): Promise<string | undefined> {
-  if (warningMessage) {
-    renderWarning({
-      headline: warningMessage,
-    })
-  }
   if (reset) {
     clearCurrentConfigFile(directory)
     renderSuccess({
@@ -35,6 +30,10 @@ export default async function use({
       body: ['In order to set a new current configuration, please run `shopify app config use CONFIG_NAME`.'],
     })
     return
+  }
+
+  if (warningMessage) {
+    renderWarning({headline: warningMessage})
   }
 
   const configFileName = (await getConfigFileName(directory, configName)).valueOrAbort()

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -5,21 +5,21 @@ import {isCurrentAppSchema} from '../../../models/app/app.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
+import {RenderAlertOptions, renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {Result, err, ok} from '@shopify/cli-kit/node/result'
 
 export interface UseOptions {
   directory: string
   configName?: string
   reset?: boolean
-  warningMessage?: string
+  warningContent?: RenderAlertOptions
   shouldRenderSuccess?: boolean
 }
 
 export default async function use({
   directory,
   configName,
-  warningMessage,
+  warningContent,
   shouldRenderSuccess = true,
   reset = false,
 }: UseOptions): Promise<string | undefined> {
@@ -32,8 +32,8 @@ export default async function use({
     return
   }
 
-  if (warningMessage) {
-    renderWarning({headline: warningMessage})
+  if (warningContent) {
+    renderWarning(warningContent)
   }
 
   const configFileName = (await getConfigFileName(directory, configName)).valueOrAbort()

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -5,16 +5,29 @@ import {isCurrentAppSchema} from '../../../models/app/app.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {renderSuccess} from '@shopify/cli-kit/node/ui'
+import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {Result, err, ok} from '@shopify/cli-kit/node/result'
 
 export interface UseOptions {
   directory: string
   configName?: string
   reset?: boolean
+  warningMessage?: string
+  shouldRenderSuccess?: boolean
 }
 
-export default async function use({directory, configName, reset = false}: UseOptions): Promise<void> {
+export default async function use({
+  directory,
+  configName,
+  warningMessage,
+  shouldRenderSuccess = true,
+  reset = false,
+}: UseOptions): Promise<string | undefined> {
+  if (warningMessage) {
+    renderWarning({
+      headline: warningMessage,
+    })
+  }
   if (reset) {
     clearCurrentConfigFile(directory)
     renderSuccess({
@@ -28,9 +41,13 @@ export default async function use({directory, configName, reset = false}: UseOpt
 
   await saveCurrentConfig({configFileName, directory})
 
-  renderSuccess({
-    headline: `Using configuration file ${configFileName}`,
-  })
+  if (shouldRenderSuccess) {
+    renderSuccess({
+      headline: `Using configuration file ${configFileName}`,
+    })
+  }
+
+  return configFileName
 }
 
 interface SaveCurrentConfigOptions {

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -579,7 +579,7 @@ export async function getAppContext({
 
   const {configuration, configurationPath} = await loadAppConfiguration({
     directory,
-    configName: configName || cachedInfo?.configFile,
+    configName,
   })
 
   let remoteApp


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

When a config file that was cached with `link` or `use` doesn't exist anymore, we want to allow them to choose a new file.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

When the cached file does not exist, we call `use` which will let users choose another file.

### How to test your changes?

1. Link a config file
2. Rename it
3. Run any command that uses the current config, like `dev`, `deploy`, etc
4. 👀 See how you can now choose the correct file

![image](https://github.com/Shopify/cli/assets/446046/f9dcc253-c9dc-4c58-9639-0a956315178b)

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
