### PR TITLE
Increase theme extension liquid size limit to 500kB

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -49,7 +49,7 @@ const megabytes = kilobytes * 1024
 
 const BUNDLE_SIZE_LIMIT_MB = 10
 const BUNDLE_SIZE_LIMIT = BUNDLE_SIZE_LIMIT_MB * megabytes
-const LIQUID_SIZE_LIMIT_KB = 100
+const LIQUID_SIZE_LIMIT_KB = 500
 const LIQUID_SIZE_LIMIT = LIQUID_SIZE_LIMIT_KB * kilobytes
 
 const SUPPORTED_ASSET_EXTS = ['.jpg', '.jpeg', '.js', '.css', '.png', '.svg']


### PR DESCRIPTION
This PR increases the theme extension liquid size limit to 500kB to correspond with a backend validation change.