### PR TITLE
Adapt group and extensions names and sorting displayed with the exten…

### DIFF
--- a/.changeset/tasty-laws-rush.md
+++ b/.changeset/tasty-laws-rush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Adapt group and extensions names and sorting displayed with the extensions prompt

--- a/packages/app/src/cli/api/graphql/template_specifications.ts
+++ b/packages/app/src/cli/api/graphql/template_specifications.ts
@@ -8,6 +8,7 @@ export const RemoteTemplateSpecificationsQuery = gql`
       name
       defaultName
       group
+      sortPriority
       supportLinks
       types {
         url

--- a/packages/app/src/cli/models/app/template.ts
+++ b/packages/app/src/cli/models/app/template.ts
@@ -17,6 +17,7 @@ export interface ExtensionTemplate {
   identifier: string
   name: string
   defaultName: string
+  sortPriority?: number
   group: string
   supportLinks: string[]
   types: TemplateType[]

--- a/packages/app/src/cli/models/templates/ui-specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/checkout_ui_extension.ts
@@ -9,6 +9,7 @@ const checkoutUIExtension: ExtensionTemplate = {
   name: 'Checkout UI',
   defaultName: 'checkout-ui',
   group: 'Discounts and checkout',
+  sortPriority: 1,
   supportLinks: [],
   types: [
     {

--- a/packages/app/src/cli/models/templates/ui-specifications/product_subscription.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/product_subscription.ts
@@ -8,7 +8,7 @@ const productSubscriptionUIExtension: ExtensionTemplate = {
   identifier: 'subscription_ui',
   name: 'Subscription UI',
   defaultName: 'subscription-ui',
-  group: 'Merchant admin',
+  group: 'Admin',
   supportLinks: [],
   types: [
     {

--- a/packages/app/src/cli/models/templates/ui-specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/templates/ui-specifications/web_pixel_extension.ts
@@ -5,7 +5,7 @@ import {ExtensionTemplate} from '../../app/template.js'
  */
 const webPixelUIExtension: ExtensionTemplate = {
   identifier: 'web_pixel',
-  name: 'Web Pixel',
+  name: 'Web pixel',
   defaultName: 'web-pixel',
   group: 'Analytics',
   supportLinks: [],

--- a/packages/app/src/cli/prompts/generate/extension.test.ts
+++ b/packages/app/src/cli/prompts/generate/extension.test.ts
@@ -4,6 +4,9 @@ import {testApp, testLocalExtensionTemplates, testRemoteExtensionTemplates} from
 import {ExtensionTemplate} from '../../models/app/template.js'
 import {ExtensionFlavorValue} from '../../services/generate/extension.js'
 import themeExtension from '../../models/templates/theme-specifications/theme.js'
+import checkoutUIExtension from '../../models/templates/ui-specifications/checkout_ui_extension.js'
+import productSubscriptionUIExtension from '../../models/templates/ui-specifications/product_subscription.js'
+import webPixelUIExtension from '../../models/templates/ui-specifications/web_pixel_extension.js'
 import {describe, expect, vi, beforeEach, test} from 'vitest'
 import {isShopify, isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {renderAutocompletePrompt, renderSelectPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
@@ -208,6 +211,76 @@ describe('extension prompt', async () => {
       extensionTemplate,
       extensionContent: [{name: 'my-product-discount', index: 0, flavor: 'rust'}],
     })
+  })
+})
+
+describe('build choices', async () => {
+  test('when none of the extensions has sortPriority then choices should be sorted ok', async () => {
+    // Given
+    const checkOut = {...checkoutUIExtension, sortPriority: undefined}
+    const productSubscription = {...productSubscriptionUIExtension, sortPriority: undefined}
+    const webPixel = {...webPixelUIExtension, sortPriority: undefined}
+    const extensions = [checkOut, productSubscription, webPixel]
+
+    // When
+    const got = buildChoices(extensions)
+
+    // Then
+    expect(got.length).equals(3)
+    expect(got[0]?.label).equals(checkOut.name)
+    expect(got[1]?.label).equals(productSubscription.name)
+    expect(got[2]?.label).equals(webPixel.name)
+  })
+
+  test('when some of the extensions has sortPriority then choices should be sorted ok', async () => {
+    // Given
+    const checkOut = {...checkoutUIExtension, sortPriority: undefined}
+    const productSubscription = {...productSubscriptionUIExtension, sortPriority: undefined}
+    const webPixel = {...webPixelUIExtension, sortPriority: 1}
+    const extensions = [checkOut, productSubscription, webPixel]
+
+    // When
+    const got = buildChoices(extensions)
+
+    // Then
+    expect(got.length).equals(3)
+    expect(got[0]?.label).equals(webPixel.name)
+    expect(got[1]?.label).equals(checkOut.name)
+    expect(got[2]?.label).equals(productSubscription.name)
+  })
+
+  test('when some of the extensions has the same sortPriority then choices should be sorted ok', async () => {
+    // Given
+    const checkOut = {...checkoutUIExtension, sortPriority: undefined}
+    const productSubscription = {...productSubscriptionUIExtension, sortPriority: 1}
+    const webPixel = {...webPixelUIExtension, sortPriority: 1}
+    const extensions = [checkOut, productSubscription, webPixel]
+
+    // When
+    const got = buildChoices(extensions)
+
+    // Then
+    expect(got.length).equals(3)
+    expect(got[0]?.label).equals(productSubscription.name)
+    expect(got[1]?.label).equals(webPixel.name)
+    expect(got[2]?.label).equals(checkOut.name)
+  })
+
+  test('when all the extensions has different sortPriority then choices should be sorted ok', async () => {
+    // Given
+    const checkOut = {...checkoutUIExtension, sortPriority: 3}
+    const productSubscription = {...productSubscriptionUIExtension, sortPriority: 2}
+    const webPixel = {...webPixelUIExtension, sortPriority: 1}
+    const extensions = [checkOut, productSubscription, webPixel]
+
+    // When
+    const got = buildChoices(extensions)
+
+    // Then
+    expect(got.length).equals(3)
+    expect(got[0]?.label).equals(webPixel.name)
+    expect(got[1]?.label).equals(productSubscription.name)
+    expect(got[2]?.label).equals(checkOut.name)
   })
 })
 


### PR DESCRIPTION
…sions prompt

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Raname some of the current templates specifications to match [this proposal](https://docs.google.com/presentation/d/1OGYNwdI-C7l9yLqBpTrFCeTcbCC7xIdTE0_FtoxuDxQ/edit#slide=id.g257c65c73d8_0_10)


NOTE: This PR should not be merged until the [partners one](https://github.com/Shopify/partners/pull/49078) has been shipped
NOTE: A nightly should be generated once this PR is merged
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Rename some group names according with the proposal
- Integrate the new template specification API field `sortPriority`
- Integrate the new  optional sorting criteria `sortPriority` in the extensions prompt so `checkout` and `postpurchase` are displayed the first ones under the `Discounts and checkout` group regardless their alphabetical position.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new spin instance `spin up partners -c partners.branch=rename-extension-groups`
- Run the command `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name) p shopify app generate extension --path /path/to/your/app`
<img src="https://github.com/Shopify/cli/assets/105213827/82a4d018-1357-49fc-9f66-afb3d2dda77b" width="400"/>





<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
