### PR TITLE
Use handle instead of name in prompts/logs

### DIFF
--- a/packages/app/src/cli/models/app/template.ts
+++ b/packages/app/src/cli/models/app/template.ts
@@ -21,7 +21,3 @@ export interface ExtensionTemplate {
   supportLinks: string[]
   types: TemplateType[]
 }
-
-export function getTypesExternalName(templates: ExtensionTemplate[]): string[] {
-  return templates.flatMap((template) => template.name)
-}

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -180,7 +180,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   previewMessage(url: string, storeFqdn: string) {
-    const heading = outputToken.heading(`${this.name} (${this.humanName})`)
+    const heading = outputToken.heading(`${this.handle} (${this.humanName})`)
     let message = outputContent`Preview link: ${url}/extensions/${this.devUUID}`
 
     if (this.specification.previewMessage) {

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -180,7 +180,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   previewMessage(url: string, storeFqdn: string) {
-    const heading = outputToken.heading(`${this.handle} (${this.humanName})`)
+    const heading = outputToken.heading(`${this.name} (${this.humanName})`)
     let message = outputContent`Preview link: ${url}/extensions/${this.devUUID}`
 
     if (this.specification.previewMessage) {

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -120,7 +120,7 @@ const spec = createExtensionSpecification({
     const wasmExists = await fileExists(extension.outputPath)
     if (!wasmExists) {
       throw new AbortError(
-        outputContent`The function extension "${extension.name}" hasn't compiled the wasm in the expected path: ${extension.outputPath}`,
+        outputContent`The function extension "${extension.handle}" hasn't compiled the wasm in the expected path: ${extension.outputPath}`,
         `Make sure the build command outputs the wasm in the expected directory.`,
       )
     }

--- a/packages/app/src/cli/services/context/id-matching.ts
+++ b/packages/app/src/cli/services/context/id-matching.ts
@@ -21,7 +21,7 @@ export interface MatchResult {
  * Filter function to match a local and a remote source by type and name
  */
 const sameTypeAndName = (local: LocalSource, remote: RemoteSource) => {
-  return remote.type === local.graphQLType && slugify(remote.title) === slugify(local.configuration.name)
+  return remote.type === local.graphQLType && slugify(remote.title) === local.handle
 }
 
 /**
@@ -34,7 +34,7 @@ function matchByNameAndType(
   remote: RemoteSource[],
   remoteIdField: 'id' | 'uuid',
 ): {matched: IdentifiersExtensions; pending: {local: LocalSource[]; remote: RemoteSource[]}} {
-  const uniqueLocal = uniqBy(local, (elem) => [elem.graphQLType, elem.configuration.name])
+  const uniqueLocal = uniqBy(local, (elem) => [elem.graphQLType, elem.handle])
   const uniqueRemote = uniqBy(remote, (elem) => [elem.type, elem.title])
   const validMatches: IdentifiersExtensions = {}
 

--- a/packages/app/src/cli/services/context/id-matching.ts
+++ b/packages/app/src/cli/services/context/id-matching.ts
@@ -21,7 +21,7 @@ export interface MatchResult {
  * Filter function to match a local and a remote source by type and name
  */
 const sameTypeAndName = (local: LocalSource, remote: RemoteSource) => {
-  return remote.type === local.graphQLType && slugify(remote.title) === local.handle
+  return remote.type === local.graphQLType && slugify(remote.title) === slugify(local.configuration.name)
 }
 
 /**

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -135,7 +135,7 @@ async function createExtensions(extensions: LocalSource[], appId: string) {
     // Create one at a time to avoid API rate limiting issues.
     // eslint-disable-next-line no-await-in-loop
     const registration = await createExtension(appId, extension.graphQLType, extension.configuration.name, token)
-    outputCompleted(`Created extension ${extension.configuration.name}.`)
+    outputCompleted(`Created extension ${extension.handle}.`)
     result[extension.localIdentifier] = registration
   }
   return result

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -134,7 +134,7 @@ async function createExtensions(extensions: LocalSource[], appId: string) {
   for (const extension of extensions) {
     // Create one at a time to avoid API rate limiting issues.
     // eslint-disable-next-line no-await-in-loop
-    const registration = await createExtension(appId, extension.graphQLType, extension.configuration.name, token)
+    const registration = await createExtension(appId, extension.graphQLType, extension.handle, token)
     outputCompleted(`Created extension ${extension.handle}.`)
     result[extension.localIdentifier] = registration
   }

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -32,6 +32,7 @@ export interface LocalSource {
   localIdentifier: string
   graphQLType: string
   type: string
+  handle: string
   configuration: {name: string}
 }
 

--- a/packages/app/src/cli/services/context/prompts.test.ts
+++ b/packages/app/src/cli/services/context/prompts.test.ts
@@ -275,6 +275,7 @@ const createdExtension = {
   localIdentifier: 'id1',
   graphQLType: 'type1',
   type: 'type1',
+  handle: 'handle1',
   configuration: {name: 'name1'},
 }
 const remoteOnlyExtension = {

--- a/packages/app/src/cli/services/context/prompts.ts
+++ b/packages/app/src/cli/services/context/prompts.ts
@@ -18,7 +18,7 @@ export async function matchConfirmationPrompt(
   type: 'extension' | 'function' = 'extension',
 ) {
   return renderConfirmationPrompt({
-    message: `Match ${local.configuration.name} (local name) with ${remote.title} (name on Shopify Partners, ID: ${remote.id})?`,
+    message: `Match ${local.handle} (local name) with ${remote.title} (name on Shopify Partners, ID: ${remote.id})?`,
     confirmationMessage: `Yes, match to existing ${type}`,
     cancellationMessage: `No, create as a new ${type}`,
   })
@@ -35,7 +35,7 @@ export async function selectRemoteSourcePrompt(
   }))
   remoteOptions.push({label: 'Create new extension', value: 'create'})
   const uuid = await renderAutocompletePrompt({
-    message: `How would you like to deploy your "${localSource.configuration.name}"?`,
+    message: `How would you like to deploy your "${localSource.handle}"?`,
     choices: remoteOptions,
   })
   return remoteSourcesOfSameType.find((remote) => remote[remoteIdField] === uuid)!
@@ -253,7 +253,7 @@ export async function extensionMigrationPrompt(
   toMigrate: LocalRemoteSource[],
   includeRemoteType = true,
 ): Promise<boolean> {
-  const migrationNames = toMigrate.map(({local}) => `"${local.configuration.name}"`).join(', ')
+  const migrationNames = toMigrate.map(({local}) => `"${local.handle}"`).join(', ')
   const allMigrationTypes = toMigrate.map(({remote}) => remote.type.toLocaleLowerCase())
   const uniqueMigrationTypes = allMigrationTypes
     .filter((type, i) => allMigrationTypes.indexOf(type) === i)

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -1062,7 +1062,7 @@ describe('deploymentErrorsToCustomSections', () => {
         details: [
           {
             extension_id: 123,
-            extension_title: 'amortizable-marketplace-ext',
+            extension_title: 't:remote-title',
           },
         ],
       },
@@ -1073,7 +1073,7 @@ describe('deploymentErrorsToCustomSections', () => {
         details: [
           {
             extension_id: 123,
-            extension_title: 'amortizable-marketplace-ext',
+            extension_title: 't:remote-title',
           },
         ],
       },
@@ -1121,6 +1121,7 @@ describe('deploymentErrorsToCustomSections', () => {
     // Then
     expect(customSections).toEqual([
       {
+        // Uses name from identifiers and not from remote `extension_title`
         title: 'amortizable-marketplace-ext',
         body: [
           {

--- a/packages/app/src/cli/services/dev/extension/localization.ts
+++ b/packages/app/src/cli/services/dev/extension/localization.ts
@@ -57,7 +57,7 @@ export async function getLocalization(
       }),
     )
     localization.lastUpdated = Date.now()
-    outputInfo(`Parsed locales for extension ${extension.configuration.name} at ${extension.directory}`, options.stdout)
+    outputInfo(`Parsed locales for extension ${extension.handle} at ${extension.directory}`, options.stdout)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-catch-all/no-catch-all
   } catch (error: any) {
     status = 'error'
@@ -82,7 +82,7 @@ async function compileLocalizationFiles(
     localization.translations[locale] = JSON.parse(localeContent)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    const message = `Error parsing ${locale} locale for ${extension.configuration.name} at ${path}: ${error.message}`
+    const message = `Error parsing ${locale} locale for ${extension.handle} at ${path}: ${error.message}`
     outputWarn(message, options.stderr)
     throw new ExtendableError(message)
   }

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.test.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.test.ts
@@ -12,6 +12,7 @@ function getLocalExtension(attributes: Partial<LocalSource> = {}) {
   return {
     type: 'ui_extension',
     localIdentifier: 'my-extension',
+    handle: 'my-extension',
     configuration: {
       name: 'my-extension',
     },

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -21,8 +21,8 @@ export function getUIExtensionsToMigrate(
   return localSources.reduce<LocalRemoteSource[]>((accumulator, localSource) => {
     if (localSource.type === 'ui_extension') {
       const remoteSource = remoteSources.find((source) => {
-        const matchesId = source.uuid === ids[localSource.configuration.name]
-        const matchesTitle = source.title === localSource.configuration.name
+        const matchesId = source.uuid === ids[localSource.handle]
+        const matchesTitle = source.title === localSource.handle
 
         return matchesId || matchesTitle
       })

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -9,6 +9,7 @@ import {getExtensionIds, LocalRemoteSource} from '../context/id-matching.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {slugify} from '@shopify/cli-kit/common/string'
 
 export function getUIExtensionsToMigrate(
   localSources: LocalSource[],
@@ -22,7 +23,7 @@ export function getUIExtensionsToMigrate(
     if (localSource.type === 'ui_extension') {
       const remoteSource = remoteSources.find((source) => {
         const matchesId = source.uuid === ids[localSource.localIdentifier]
-        const matchesTitle = source.title === localSource.handle
+        const matchesTitle = slugify(source.title) === slugify(localSource.configuration.name)
 
         return matchesId || matchesTitle
       })

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -21,7 +21,7 @@ export function getUIExtensionsToMigrate(
   return localSources.reduce<LocalRemoteSource[]>((accumulator, localSource) => {
     if (localSource.type === 'ui_extension') {
       const remoteSource = remoteSources.find((source) => {
-        const matchesId = source.uuid === ids[localSource.handle]
+        const matchesId = source.uuid === ids[localSource.localIdentifier]
         const matchesTitle = source.title === localSource.handle
 
         return matchesId || matchesTitle

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -231,7 +231,7 @@ describe('info', () => {
     })
   })
 
-  test.only('returns errors alongside extensions when extensions have errors', async () => {
+  test('returns errors alongside extensions when extensions have errors', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       const uiExtension1 = await testUIExtension({
@@ -295,7 +295,7 @@ describe('info', () => {
       expect(result).toContain('Extensions with errors')
       // Doesn't use the type as part of the title
       expect(result).not.toContain('📂 ui_extension')
-      // Shows explicit handle in title
+      // Shows handle in title
       expect(result).toContain('📂 handle-for-extension-1')
       // Shows default handle derived from name when no handle is present
       expect(result).toContain('📂 extension-2')

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -231,12 +231,13 @@ describe('info', () => {
     })
   })
 
-  test('returns errors alongside extensions when extensions have errors', async () => {
+  test.only('returns errors alongside extensions when extensions have errors', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       const uiExtension1 = await testUIExtension({
         configuration: {
           name: 'Extension 1',
+          handle: 'handle-for-extension-1',
           type: 'ui_extension',
           metafields: [],
         },
@@ -292,7 +293,12 @@ describe('info', () => {
 
       // Then
       expect(result).toContain('Extensions with errors')
-      expect(result).toContain('📂 ui_extension')
+      // Doesn't use the type as part of the title
+      expect(result).not.toContain('📂 ui_extension')
+      // Shows explicit handle in title
+      expect(result).toContain('📂 handle-for-extension-1')
+      // Shows default handle derived from name when no handle is present
+      expect(result).toContain('📂 extension-2')
       expect(result).toContain('! Mock error with ui_extension')
       expect(result).toContain('! Mock error with checkout_ui_extension')
     })

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -177,7 +177,7 @@ class AppInfo {
   extensionSubSection(extension: ExtensionInstance): string {
     const config = extension.configuration
     const details = [
-      [`📂 ${config.handle}`, relativePath(this.app.directory, extension.directory)],
+      [`📂 ${extension.handle}`, relativePath(this.app.directory, extension.directory)],
       ['     config file', relativePath(extension.directory, extension.configurationPath)],
     ]
     if (config && config.metafields?.length) {
@@ -191,7 +191,7 @@ class AppInfo {
     const error = this.app.errors?.getError(extension.configurationPath)
     if (!error) return ''
     const details = [
-      [`📂 ${extension.configuration?.type}`, relativePath(this.app.directory, extension.directory)],
+      [`📂 ${extension.handle}`, relativePath(this.app.directory, extension.directory)],
       ['     config file', relativePath(extension.directory, extension.configurationPath)],
     ]
     const formattedError = this.formattedError(error)

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -177,7 +177,7 @@ class AppInfo {
   extensionSubSection(extension: ExtensionInstance): string {
     const config = extension.configuration
     const details = [
-      [`📂 ${config.name}`, relativePath(this.app.directory, extension.directory)],
+      [`📂 ${config.handle}`, relativePath(this.app.directory, extension.directory)],
       ['     config file', relativePath(extension.directory, extension.configurationPath)],
     ]
     if (config && config.metafields?.length) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
With the introduction of localizable names, using the extension name in prompts / logs leads to undesirable results (like showing a generig `t:name`). We should use the `handle` instead.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Use handle in all logs/prompts where the name was being used before
- Update tests
- Also update some other logic that was using the name
- Show `extensions.targeting` in errors instead of `extension_points`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- generate an admin action extension
- try to deploy
- you should see an error but with the correct namings
- run `app info` you should see the handle in the info section
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
