### PR TITLE
Add flow trigger field name validation

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
@@ -1,11 +1,25 @@
-import {BaseSchemaWithHandle} from '../schemas.js'
+import {BaseSchemaWithHandle, FieldSchema} from '../schemas.js'
 import {createExtensionSpecification} from '../specification.js'
 import {validateFieldShape} from '../../../services/flow/validation.js'
 import {serializeFields} from '../../../services/flow/serialize-fields.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
+const FlowTriggerSettingsSchema = FieldSchema.extend({
+  name: zod
+    .string()
+    .regex(/^[a-zA-Z\s]*$/, {
+      message: 'String must contain only alphabetic characters and spaces',
+    })
+    .optional(),
+})
+
 export const FlowTriggerExtensionSchema = BaseSchemaWithHandle.extend({
   type: zod.literal('flow_trigger'),
+  settings: zod
+    .object({
+      fields: zod.array(FlowTriggerSettingsSchema).optional(),
+    })
+    .optional(),
 }).refine((config) => {
   const fields = config.settings?.fields ?? []
   const settingsFieldsAreValid = fields.every((field, index) =>

--- a/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
@@ -5,7 +5,7 @@ import {serializeFields} from '../../../services/flow/serialize-fields.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const FlowTriggerSettingsSchema = FieldSchema.extend({
-  name: zod
+  key: zod
     .string()
     .regex(/^[a-zA-Z\s]*$/, {
       message: 'String must contain only alphabetic characters and spaces',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/flow/issues/19543

### WHAT is this pull request doing?
This PR adds extra validation to `flow_trigger` field `key`s. This validation is currently present in core and is being replicated here to offer app developers better error messaging

### How to test your changes?
- Pull in changes
- Create a new `flow_trigger` extension
- Change field `key` value to include a non-alpha or space character
- Deploy and observe that validation error pops up in CLI

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
