### PR TITLE
Remove distribution percentage and rollout progress references

### DIFF
--- a/.changeset/hot-carrots-confess.md
+++ b/.changeset/hot-carrots-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Remove distribution percentage info from versions list

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -514,13 +514,6 @@ describe('deploy', () => {
         },
         '',
       ],
-      nextSteps: [
-        [
-          'Run',
-          {command: formatPackageManagerCommand(app.packageManager, 'shopify app versions list')},
-          'to see rollout progress.',
-        ],
-      ],
     })
   })
 

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -302,13 +302,6 @@ async function outputUnifiedCompletionMessage(
       : renderSuccess({
           headline: 'New version released to users.',
           body: linkAndMessage,
-          nextSteps: [
-            [
-              'Run',
-              {command: formatPackageManagerCommand(app.packageManager, 'shopify app versions list')},
-              'to see rollout progress.',
-            ],
-          ],
         })
   }
 

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -82,15 +82,6 @@ describe('release', () => {
         '\nmessage',
       ],
       headline: 'Version released to users.',
-      nextSteps: [
-        [
-          'Run',
-          {
-            command: 'yarn shopify app versions list',
-          },
-          'to see rollout progress.',
-        ],
-      ],
     })
   })
 

--- a/packages/app/src/cli/services/release.ts
+++ b/packages/app/src/cli/services/release.ts
@@ -5,7 +5,6 @@ import {AppRelease, AppReleaseSchema, AppReleaseVariables} from '../api/graphql/
 import {confirmReleasePrompt} from '../prompts/release.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {renderError, renderSuccess, renderTasks, TokenItem} from '@shopify/cli-kit/node/ui'
-import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 import {Config} from '@oclif/core'
 
 interface ReleaseOptions {
@@ -73,13 +72,6 @@ export async function release(options: ReleaseOptions) {
     renderSuccess({
       headline: 'Version released to users.',
       body: linkAndMessage,
-      nextSteps: [
-        [
-          'Run',
-          {command: formatPackageManagerCommand(app.packageManager, 'shopify app versions list')},
-          'to see rollout progress.',
-        ],
-      ],
     })
   }
 }

--- a/packages/app/src/cli/services/versions-list.test.ts
+++ b/packages/app/src/cli/services/versions-list.test.ts
@@ -133,11 +133,11 @@ describe('versions-list', () => {
 
     // Then
     expect(mockOutput.info())
-      .toMatchInlineSnapshot(`"VERSION       STATUS           MESSAGE        DATE CREATED         CREATED BY
-────────────  ───────────────  ─────────────  ───────────────────  ───────────
-versionTag    ★ active (100%)  message        2021-01-01 00:00:00  createdBy
-versionTag 2  released         message 2      2021-01-01 00:00:00  createdBy 2
-versionTag 3  released         long messa...  2021-01-01 00:00:00  createdBy 3
+      .toMatchInlineSnapshot(`"VERSION       STATUS    MESSAGE        DATE CREATED         CREATED BY
+────────────  ────────  ─────────────  ───────────────────  ───────────
+versionTag    ★ active  message        2021-01-01 00:00:00  createdBy
+versionTag 2  released  message 2      2021-01-01 00:00:00  createdBy 2
+versionTag 3  released  long messa...  2021-01-01 00:00:00  createdBy 3
 
 View all 31 app versions in the Partner Dashboard ( https://partners.shopify.com/orgId/apps/appId/versions )"`)
   })

--- a/packages/app/src/cli/services/versions-list.ts
+++ b/packages/app/src/cli/services/versions-list.ts
@@ -33,10 +33,7 @@ async function fetchAppVersions(
     const message = appVersion.message ?? ''
     return {
       ...appVersion,
-      status:
-        appVersion.status === 'active'
-          ? colors.green(`★ ${appVersion.status} (${appVersion.distributionPercentage}%)`)
-          : appVersion.status,
+      status: appVersion.status === 'active' ? colors.green(`★ ${appVersion.status}`) : appVersion.status,
       createdBy: appVersion.createdBy?.displayName ?? '',
       createdAt: formatDate(new Date(appVersion.createdAt)),
       message,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-deploys/issues/659
Removes the distribution percentage from app versions list in order to not confuse the users.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Removes the distributionPercentage info

### How to test your changes?

**Before changes:**
1. From the `main` branch create an app by running `bin/create-test-app.js --bare` 
2. Create a deployable app module `pnpm shopify app generate extension --type=subscriptions-ui`
3. Run run through the various deployments-related commands (`deploy`,  `release`, and `versions list`)
4. Check that `deploy` success message shows `Next steps`,  and references "rollout progress"

<img width="700" alt="Screenshot 2023-07-21 at 19 29 59" src="https://github.com/Shopify/cli/assets/4012836/61b1bed0-2fbd-46ca-ae5c-a831aa7c2e81">

5. Check that distribution percentage is visible for active app version

<img width="667" alt="Screenshot 2023-07-21 at 18 44 56" src="https://github.com/Shopify/cli/assets/4012836/1b10ca56-001d-4431-81fe-e7a74169acc4">

6. Check that `release` success message shows `Next steps`,  and references "rollout progress"

<img width="675" alt="Screenshot 2023-07-21 at 19 30 13" src="https://github.com/Shopify/cli/assets/4012836/ae78baa7-a925-41c9-a7b4-fd00a156733f">

**After changes:**
(Switch on `remove-distribution-bar` branch.)

1. Check that `deploy` success message does not show `Next steps`

<img width="668" alt="Screenshot 2023-07-21 at 19 33 49" src="https://github.com/Shopify/cli/assets/4012836/13404f28-a373-447a-8dde-bcfd86996a5f">

2. Check that distribution percentage is not visible for active app version.

<img width="586" alt="Screenshot 2023-07-21 at 18 57 14" src="https://github.com/Shopify/cli/assets/4012836/6b3b77e0-ff7d-4504-b15e-7763c624dac5">

3. Check that `release` success message does not show `Next steps`

<img width="666" alt="Screenshot 2023-07-21 at 19 34 41" src="https://github.com/Shopify/cli/assets/4012836/b741a251-c21b-4c0f-9c8f-420ce644ee80">


### Post-release steps

n/a

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
