### PR TITLE
Update Extensions Dev Server 404 message to say extension targets

### DIFF
--- a/.changeset/nasty-melons-attack.md
+++ b/.changeset/nasty-melons-attack.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update 404 error message for the Extensions Dev Server to refer to extension targets

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
@@ -502,7 +502,7 @@ describe('getExtensionPointMiddleware()', () => {
     })
   })
 
-  test('returns a 404 if requested extension point target is not configured', async () => {
+  test('returns a 404 if requested extension target is not configured', async () => {
     vi.spyOn(utilities, 'sendError').mockImplementation(() => {})
 
     const extensionId = '123abc'
@@ -546,11 +546,11 @@ describe('getExtensionPointMiddleware()', () => {
 
     expect(utilities.sendError).toHaveBeenCalledWith(response, {
       statusCode: 404,
-      statusMessage: `Extension with id ${extensionId} has not configured the "${requestedExtensionPointTarget}" extension point`,
+      statusMessage: `Extension with id ${extensionId} has not configured the "${requestedExtensionPointTarget}" extension target`,
     })
   })
 
-  test('returns a 404 if requested extension point target is invalid and no redirect url can be constructed', async () => {
+  test('returns a 404 if requested extension target is invalid and no redirect url can be constructed', async () => {
     vi.spyOn(utilities, 'sendError').mockImplementation(() => {})
 
     const extensionId = '123abc'
@@ -594,11 +594,11 @@ describe('getExtensionPointMiddleware()', () => {
 
     expect(utilities.sendError).toHaveBeenCalledWith(response, {
       statusCode: 404,
-      statusMessage: `Redirect url can't be constructed for extension with id ${extensionId} and extension point "${extensionPointTarget}"`,
+      statusMessage: `Redirect url can't be constructed for extension with id ${extensionId} and extension target "${extensionPointTarget}"`,
     })
   })
 
-  test('returns the redirect URL if the requested extension point target is configured', async () => {
+  test('returns the redirect URL if the requested extension target is configured', async () => {
     vi.spyOn(utilities, 'getRedirectUrl').mockReturnValue('http://www.mock.com/redirect/url')
 
     const extensionId = '123abc'

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -222,7 +222,7 @@ export function getExtensionPointMiddleware({devOptions}: GetExtensionsMiddlewar
     if (!extension.hasExtensionPointTarget(requestedTarget)) {
       return sendError(response, {
         statusCode: 404,
-        statusMessage: `Extension with id ${extensionID} has not configured the "${requestedTarget}" extension point`,
+        statusMessage: `Extension with id ${extensionID} has not configured the "${requestedTarget}" extension target`,
       })
     }
 
@@ -230,7 +230,7 @@ export function getExtensionPointMiddleware({devOptions}: GetExtensionsMiddlewar
     if (!url) {
       return sendError(response, {
         statusCode: 404,
-        statusMessage: `Redirect url can't be constructed for extension with id ${extensionID} and extension point "${requestedTarget}"`,
+        statusMessage: `Redirect url can't be constructed for extension with id ${extensionID} and extension target "${requestedTarget}"`,
       })
     }
 


### PR DESCRIPTION
Update the 404 error messages to refer to "extension target" instead of "extension point"
