### PR TITLE
Exclude client-id/api-key flags from being run with --config except in link

### DIFF
--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -51,14 +51,20 @@
           "type": "option",
           "description": "Application's API key that will be exposed at build time.",
           "hidden": true,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "client-id": {
           "name": "client-id",
           "type": "option",
           "description": "Application's Client ID that will be exposed at build time.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         }
       },
       "args": {}
@@ -213,14 +219,20 @@
           "type": "option",
           "description": "The API key of your app.",
           "hidden": true,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "client-id": {
           "name": "client-id",
           "type": "option",
           "description": "The Client ID of your app.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "store": {
           "name": "store",
@@ -357,7 +369,10 @@
           "type": "option",
           "description": "The Client ID of your app.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         }
       },
       "args": {}
@@ -460,14 +475,20 @@
           "type": "option",
           "description": "The API key of your app.",
           "hidden": true,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "client-id": {
           "name": "client-id",
           "type": "option",
           "description": "The Client ID of your app.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "reset": {
           "name": "reset",
@@ -1002,14 +1023,20 @@
           "type": "option",
           "description": "The API key to fetch the schema with.",
           "hidden": true,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "client-id": {
           "name": "client-id",
           "type": "option",
           "description": "The Client ID to fetch the schema with.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "stdout": {
           "name": "stdout",
@@ -1158,14 +1185,20 @@
           "type": "option",
           "description": "The API key of your app.",
           "hidden": true,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "client-id": {
           "name": "client-id",
           "type": "option",
           "description": "The Client ID of your app.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         }
       },
       "args": {
@@ -1218,14 +1251,20 @@
           "type": "option",
           "description": "The API key to fetch the schema with.",
           "hidden": true,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "client-id": {
           "name": "client-id",
           "type": "option",
           "description": "The Client ID to fetch the schema with.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "stdout": {
           "name": "stdout",
@@ -1333,14 +1372,20 @@
           "type": "option",
           "description": "The API key of your app.",
           "hidden": true,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "client-id": {
           "name": "client-id",
           "type": "option",
           "description": "The Client ID of your app.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         }
       },
       "args": {
@@ -1395,14 +1440,20 @@
           "type": "option",
           "description": "Application's API key to fetch versions for.",
           "hidden": true,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         },
         "client-id": {
           "name": "client-id",
           "type": "option",
           "description": "The Client ID to fetch versions for.",
           "hidden": false,
-          "multiple": false
+          "multiple": false,
+          "exclusive": [
+            "config"
+          ]
         }
       },
       "args": {

--- a/packages/app/src/cli/commands/app/build.ts
+++ b/packages/app/src/cli/commands/app/build.ts
@@ -25,11 +25,13 @@ export default class Build extends Command {
       hidden: true,
       description: "Application's API key that will be exposed at build time.",
       env: 'SHOPIFY_FLAG_API_KEY',
+      exclusive: ['config'],
     }),
     'client-id': Flags.string({
       hidden: false,
       description: "Application's Client ID that will be exposed at build time.",
       env: 'SHOPIFY_FLAG_CLIENT_ID',
+      exclusive: ['config'],
     }),
   }
 

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -17,11 +17,13 @@ export default class Dev extends Command {
       hidden: true,
       description: 'The API key of your app.',
       env: 'SHOPIFY_FLAG_APP_API_KEY',
+      exclusive: ['config'],
     }),
     'client-id': Flags.string({
       hidden: false,
       description: 'The Client ID of your app.',
       env: 'SHOPIFY_FLAG_CLIENT_ID',
+      exclusive: ['config'],
     }),
     store: Flags.string({
       hidden: false,

--- a/packages/app/src/cli/commands/app/function/schema.ts
+++ b/packages/app/src/cli/commands/app/function/schema.ts
@@ -18,11 +18,13 @@ export default class FetchSchema extends Command {
       name: 'API key',
       description: 'The API key to fetch the schema with.',
       env: 'SHOPIFY_FLAG_APP_API_KEY',
+      exclusive: ['config'],
     }),
     'client-id': Flags.string({
       hidden: false,
       description: 'The Client ID to fetch the schema with.',
       env: 'SHOPIFY_FLAG_CLIENT_ID',
+      exclusive: ['config'],
     }),
     stdout: Flags.boolean({
       description: 'Output the schema to stdout instead of writing to a file.',

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -49,11 +49,13 @@ export default class AppGenerateExtension extends Command {
       hidden: true,
       description: 'The API key of your app.',
       env: 'SHOPIFY_FLAG_APP_API_KEY',
+      exclusive: ['config'],
     }),
     'client-id': Flags.string({
       hidden: false,
       description: 'The Client ID of your app.',
       env: 'SHOPIFY_FLAG_CLIENT_ID',
+      exclusive: ['config'],
     }),
   }
 

--- a/packages/app/src/cli/commands/app/import-flow-legacy-extensions.ts
+++ b/packages/app/src/cli/commands/app/import-flow-legacy-extensions.ts
@@ -17,6 +17,7 @@ export default class AppImportFlowExtension extends Command {
       hidden: false,
       description: 'The Client ID of your app.',
       env: 'SHOPIFY_FLAG_CLIENT_ID',
+      exclusive: ['config'],
     }),
   }
 

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -19,11 +19,13 @@ export default class Release extends Command {
       hidden: true,
       description: 'The API key of your app.',
       env: 'SHOPIFY_FLAG_APP_API_KEY',
+      exclusive: ['config'],
     }),
     'client-id': Flags.string({
       hidden: false,
       description: 'The Client ID of your app.',
       env: 'SHOPIFY_FLAG_CLIENT_ID',
+      exclusive: ['config'],
     }),
     reset: Flags.boolean({
       hidden: false,

--- a/packages/app/src/cli/commands/app/versions/list.ts
+++ b/packages/app/src/cli/commands/app/versions/list.ts
@@ -19,11 +19,13 @@ export default class VersionsList extends Command {
       hidden: true,
       description: "Application's API key to fetch versions for.",
       env: 'SHOPIFY_FLAG_API_KEY',
+      exclusive: ['config'],
     }),
     'client-id': Flags.string({
       hidden: false,
       description: 'The Client ID to fetch versions for.',
       env: 'SHOPIFY_FLAG_CLIENT_ID',
+      exclusive: ['config'],
     }),
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

`--client-id`/`--api-key` can't be used with `--config` for most `shopify app` commands

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
