### PR TITLE
Use title from partnersApp in release prompts

### DIFF
--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -942,9 +942,9 @@ describe('ensureReleaseContext', () => {
       },
       command: 'release',
     })
-    const {apiSecretKeys, ...partnersAppWithoutSecretKeys} = APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA
+
     expect(got.app).toEqual(app)
-    expect(got.partnersApp).toEqual(partnersAppWithoutSecretKeys)
+    expect(got.partnersApp).toEqual(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
     expect(got.token).toEqual('token')
   })
 })

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -942,8 +942,9 @@ describe('ensureReleaseContext', () => {
       },
       command: 'release',
     })
+    const {apiSecretKeys, ...partnersAppWithoutSecretKeys} = APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA
     expect(got.app).toEqual(app)
-    expect(got.apiKey).toEqual(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA.apiKey)
+    expect(got.partnersApp).toEqual(partnersAppWithoutSecretKeys)
     expect(got.token).toEqual('token')
   })
 })

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -231,9 +231,9 @@ export interface ReleaseContextOptions {
 }
 
 interface ReleaseContextOutput {
-  apiKey: string
   token: string
   app: AppInterface
+  partnersApp: Omit<OrganizationApp, 'apiSecretKeys'>
 }
 
 interface DeployContextOutput {
@@ -407,6 +407,17 @@ export async function ensureReleaseContext(options: ReleaseContextOptions): Prom
   const result = {
     app: options.app,
     apiKey: partnersApp.apiKey,
+    partnersApp: {
+      id: partnersApp.id,
+      apiKey: partnersApp.apiKey,
+      title: partnersApp.title,
+      appType: partnersApp.appType,
+      organizationId: partnersApp.organizationId,
+      grantedScopes: partnersApp.grantedScopes,
+      betas: partnersApp.betas,
+      applicationUrl: partnersApp.applicationUrl,
+      redirectUrlWhitelist: partnersApp.redirectUrlWhitelist,
+    },
     token,
   }
 
@@ -731,6 +742,6 @@ async function logMetadataForLoadedDeployContext(env: DeployContextOutput) {
 async function logMetadataForLoadedReleaseContext(env: ReleaseContextOutput, partnerId: string) {
   await metadata.addPublicMetadata(() => ({
     partner_id: tryParseInt(partnerId),
-    api_key: env.apiKey,
+    api_key: env.partnersApp.apiKey,
   }))
 }

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -233,7 +233,7 @@ export interface ReleaseContextOptions {
 interface ReleaseContextOutput {
   token: string
   app: AppInterface
-  partnersApp: Omit<OrganizationApp, 'apiSecretKeys'>
+  partnersApp: OrganizationApp
 }
 
 interface DeployContextOutput {
@@ -407,17 +407,7 @@ export async function ensureReleaseContext(options: ReleaseContextOptions): Prom
   const result = {
     app: options.app,
     apiKey: partnersApp.apiKey,
-    partnersApp: {
-      id: partnersApp.id,
-      apiKey: partnersApp.apiKey,
-      title: partnersApp.title,
-      appType: partnersApp.appType,
-      organizationId: partnersApp.organizationId,
-      grantedScopes: partnersApp.grantedScopes,
-      betas: partnersApp.betas,
-      applicationUrl: partnersApp.applicationUrl,
-      redirectUrlWhitelist: partnersApp.redirectUrlWhitelist,
-    },
+    partnersApp,
     token,
   }
 

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -28,6 +28,7 @@ const APP = {
   grantedScopes: [],
   applicationUrl: 'https://example.com',
   redirectUrlWhitelist: [],
+  apiSecretKeys: [],
 }
 
 beforeEach(() => {
@@ -153,7 +154,7 @@ describe('release', () => {
 async function testRelease(
   app: AppInterface,
   version: string,
-  partnersApp?: Omit<OrganizationApp, 'apiSecretKeys'>,
+  partnersApp?: OrganizationApp,
   options?: {
     force?: boolean
   },

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -20,6 +20,16 @@ vi.mock('@shopify/cli-kit/node/api/partners')
 vi.mock('../api/graphql/app_release.js')
 vi.mock('./release/version-diff.js')
 
+const APP = {
+  id: 'app-id',
+  title: 'app-title',
+  apiKey: 'api-key',
+  organizationId: 'org-id',
+  grantedScopes: [],
+  applicationUrl: 'https://example.com',
+  redirectUrlWhitelist: [],
+}
+
 beforeEach(() => {
   // this is needed because using importActual to mock the ui module
   // creates a circular dependency between ui and context/local
@@ -68,7 +78,7 @@ describe('release', () => {
 
     // Then
     expect(partnersRequest).toHaveBeenCalledWith(AppRelease, 'api-token', {
-      apiKey: 'app-id',
+      apiKey: APP.apiKey,
       appVersionId: 1,
     })
     expect(renderSuccess).toHaveBeenCalledWith({
@@ -143,7 +153,7 @@ describe('release', () => {
 async function testRelease(
   app: AppInterface,
   version: string,
-  partnersApp?: Omit<OrganizationApp, 'apiSecretKeys' | 'apiKey'>,
+  partnersApp?: Omit<OrganizationApp, 'apiSecretKeys'>,
   options?: {
     force?: boolean
   },
@@ -152,7 +162,7 @@ async function testRelease(
   vi.mocked(ensureReleaseContext).mockResolvedValue({
     app,
     token: 'api-token',
-    apiKey: partnersApp?.id ?? 'app-id',
+    partnersApp: partnersApp ?? APP,
   })
 
   vi.mocked(versionDiffByVersion).mockResolvedValue({

--- a/packages/app/src/cli/services/release.ts
+++ b/packages/app/src/cli/services/release.ts
@@ -29,17 +29,17 @@ interface ReleaseOptions {
 }
 
 export async function release(options: ReleaseOptions) {
-  const {token, apiKey, app} = await ensureReleaseContext(options)
+  const {token, app, partnersApp} = await ensureReleaseContext(options)
 
-  const {versionsDiff, versionDetails} = await versionDiffByVersion(apiKey, options.version, token)
+  const {versionsDiff, versionDetails} = await versionDiffByVersion(partnersApp.apiKey, options.version, token)
 
-  await confirmReleasePrompt(app.name, versionsDiff)
+  await confirmReleasePrompt(partnersApp.title, versionsDiff)
   interface Context {
     appRelease: AppReleaseSchema
   }
 
   const variables: AppReleaseVariables = {
-    apiKey,
+    apiKey: partnersApp.apiKey,
     appVersionId: versionDetails.id,
   }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We were using the title in the local toml file as the name of the app in prompts, but that name might not match the name of the app you are deploying/releasing to.

Fixes https://github.com/Shopify/app-deploys/issues/657 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Use the name from the partners app in prompts.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
