### PR TITLE
Fix create-test-app script default template

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -70,7 +70,7 @@ program
       : new Set(options.extensions.split(","));
 
     const appName = options.name;
-    const template = options.template || "node";
+    const template = options.template || "remix";
     const appPath = path.join(homeDir, "Desktop", appName);
 
     switch (options.packageManager) {


### PR DESCRIPTION
The create-test-app script is broken if we don't pass a `--template` flag explicitly.