### PR TITLE
Ensure [build] is not compared against remote app config

### DIFF
--- a/packages/app/src/cli/prompts/config.test.ts
+++ b/packages/app/src/cli/prompts/config.test.ts
@@ -346,4 +346,29 @@ api_version = "unstable"
       expect(result).toBeFalsy()
     })
   })
+
+  test('returns false when there are no changes to app config but there are changes to [build]', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configurationPath = joinPath(tmpDir, 'shopify.app.toml')
+      const app = testOrganizationApp() as App
+      const configuration = mergeAppConfiguration(testApp(), app as OrganizationApp)
+      const options: PushOptions = {
+        configuration: {
+          ...configuration,
+          build: {automatically_update_urls_on_dev: true, dev_store_url: 'shop1.myshopify.com'},
+        },
+        configurationPath,
+        force: false,
+      }
+      vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+
+      // When
+      const result = await confirmPushChanges(options, app)
+
+      // Then
+      expect(renderConfirmationPrompt).not.toHaveBeenCalled()
+      expect(result).toBeFalsy()
+    })
+  })
 })

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -83,8 +83,8 @@ export async function confirmPushChanges(options: PushOptions, app: App) {
     configuration.access_scopes.scopes = getAppScopesArray(configuration).join(',')
 
   const [updated, baseline] = deepDifference(
-    rewriteConfiguration(AppSchema, configuration) as object,
-    rewriteConfiguration(AppSchema, remoteConfiguration) as object,
+    {...(rewriteConfiguration(AppSchema, configuration) as object), build: undefined},
+    {...(rewriteConfiguration(AppSchema, remoteConfiguration) as object), build: undefined},
   )
 
   if (deepCompare(updated, baseline)) {


### PR DESCRIPTION
### WHY are these changes introduced?
**Steps to reproduce**
1. Ensure app has a linked config file
2. Run `shopify app dev`
3. Run `shopify app config push` and notice the following

![image](https://github.com/Shopify/cli/assets/60748788/411c4a94-afbb-4b37-93b7-1acaf5aaf4b4)

### WHAT is this pull request doing?

This ensures that we don't show the diff of `[build]` changes when pushing up app config as `[build]` is only a local CLI setting.

### How to test your changes?

1. Ensure app has a linked config file
2. Run `shopify app dev`
3. Run `shopify app config push` and notice the following
4. 
<img width="996" alt="image" src="https://github.com/Shopify/cli/assets/60748788/52a347b3-b316-47e2-897d-9ed40ed137c4">


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
