### PR TITLE
Fix Thank You page redirect URLs

### DIFF
--- a/packages/app/src/cli/services/dev/extension/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.test.ts
@@ -11,9 +11,15 @@ describe('getExtensionPointTargetSurface()', () => {
     expect(getExtensionPointTargetSurface('Checkout::Dynamic::Render')).toBe('checkout')
   })
 
+  test('returns "checkout" for a UI extension targeting purchase.thank-you.*', async () => {
+    expect(getExtensionPointTargetSurface('purchase.thank-you.block.render')).toBe('checkout')
+    expect(getExtensionPointTargetSurface('purchase.thank-you.contact-information.render-after')).toBe('checkout')
+    expect(getExtensionPointTargetSurface('purchase.thank-you.cart-line-item.render-after')).toBe('checkout')
+    expect(getExtensionPointTargetSurface('purchase.thank-you.cart-line-list.render-after')).toBe('checkout')
+  })
+
   test('returns "checkout" for a UI extension targeting customer-account.order-status.*', async () => {
     expect(getExtensionPointTargetSurface('customer-account.order-status.block.render')).toBe('checkout')
-    expect(getExtensionPointTargetSurface('customer-account.order-status.timeline.render-after')).toBe('checkout')
     expect(getExtensionPointTargetSurface('customer-account.order-status.contact-information.render-after')).toBe(
       'checkout',
     )

--- a/packages/app/src/cli/services/dev/extension/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.test.ts
@@ -11,7 +11,8 @@ describe('getExtensionPointTargetSurface()', () => {
     expect(getExtensionPointTargetSurface('Checkout::Dynamic::Render')).toBe('checkout')
   })
 
-  test('returns "checkout" for a UI extension targeting purchase.thank-you.*', async () => {
+  test('returns "checkout" for a UI extension targeting purchase.* where the page is not explicitly checkout', async () => {
+    expect(getExtensionPointTargetSurface('purchase.cart-line-item.line-components.render')).toBe('checkout')
     expect(getExtensionPointTargetSurface('purchase.thank-you.block.render')).toBe('checkout')
     expect(getExtensionPointTargetSurface('purchase.thank-you.contact-information.render-after')).toBe('checkout')
     expect(getExtensionPointTargetSurface('purchase.thank-you.cart-line-item.render-after')).toBe('checkout')

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -33,6 +33,11 @@ export function getExtensionPointTargetSurface(extensionPointTarget: string) {
         return 'post_purchase'
       }
 
+      // The Thank You page is rendered as part of the checkout application
+      if (page === 'thank-you') {
+        return 'checkout'
+      }
+
       // Checkout UI extensions
       return page
     }

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -33,13 +33,8 @@ export function getExtensionPointTargetSurface(extensionPointTarget: string) {
         return 'post_purchase'
       }
 
-      // The Thank You page is rendered as part of the checkout application
-      if (page === 'thank-you') {
-        return 'checkout'
-      }
-
       // Checkout UI extensions
-      return page
+      return 'checkout'
     }
 
     // Covers Customer Accounts UI extensions (future)


### PR DESCRIPTION
Fixes errors when using the dev console with a new-style thank-you page extension target:

<img width="1451" alt="Screenshot 2023-07-25 at 1 45 41 PM" src="https://github.com/Shopify/cli/assets/3012583/03e46958-ad53-4d18-bafc-c6c1e1532ea9">

I fixed this by just treating these as "checkout" extensions, like we do for the order status page.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
