### PR TITLE
Allow using alias for templates that are not listed as options

### DIFF
--- a/.changeset/strong-beers-tickle.md
+++ b/.changeset/strong-beers-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': patch
+---
+
+Allow using template aliases that are not displayed as options in the prompt when creating apps

--- a/packages/create-app/src/commands/init.test.ts
+++ b/packages/create-app/src/commands/init.test.ts
@@ -1,5 +1,5 @@
 import Init from './init.js'
-import initPrompt, {templateURLMap} from '../prompts/init.js'
+import initPrompt, {visibleTemplates} from '../prompts/init.js'
 import initService from '../services/init.js'
 import {describe, expect, vi, beforeEach, test} from 'vitest'
 import {errorHandler} from '@shopify/cli-kit/node/error-handler'
@@ -32,6 +32,14 @@ describe('create app command', () => {
     expect(initService).toHaveBeenCalledOnce()
   })
 
+  test('executes correctly when using a non-visible template alias name', async () => {
+    // When
+    await Init.run(['--template', 'node'])
+
+    // Then
+    expect(initService).toHaveBeenCalledOnce()
+  })
+
   test('executes correctly when using a github url as a template alias name', async () => {
     // When
     await Init.run(['--template', 'https://github.com/myrepo'])
@@ -50,7 +58,7 @@ describe('create app command', () => {
     // Then
     const anyConfig = expect.any(Config)
     const expectedError = new AbortError(
-      outputContent`Only ${Object.keys(templateURLMap)
+      outputContent`Only ${visibleTemplates
         .map((alias) => outputContent`${outputToken.yellow(alias)}`.value)
         .join(', ')} template aliases are supported`,
     )

--- a/packages/create-app/src/commands/init.ts
+++ b/packages/create-app/src/commands/init.ts
@@ -1,4 +1,4 @@
-import initPrompt, {templateURLMap} from '../prompts/init.js'
+import initPrompt, {templateURLMap, visibleTemplates} from '../prompts/init.js'
 import initService from '../services/init.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -29,7 +29,7 @@ export default class Init extends Command {
     }),
     template: Flags.string({
       description: `The app template. Accepts one of the following:
-       - <${Object.keys(templateURLMap).join('|')}>
+       - <${visibleTemplates.join('|')}>
        - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]`,
       env: 'SHOPIFY_FLAG_TEMPLATE',
     }),
@@ -85,7 +85,7 @@ export default class Init extends Command {
       )
     if (!url && !Object.keys(templateURLMap).includes(template))
       throw new AbortError(
-        outputContent`Only ${Object.keys(templateURLMap)
+        outputContent`Only ${visibleTemplates
           .map((alias) => outputContent`${outputToken.yellow(alias)}`.value)
           .join(', ')} template aliases are supported`,
       )

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -17,9 +17,15 @@ interface InitOutput {
 // Eventually this list should be taken from a remote location
 // That way we don't have to update the CLI every time we add a template
 export const templateURLMap = {
-  remix: 'https://github.com/Shopify/shopify-app-template-remix',
-  none: 'https://github.com/Shopify/shopify-app-template-none',
+  remix: {url: 'https://github.com/Shopify/shopify-app-template-remix', visible: true},
+  none: {url: 'https://github.com/Shopify/shopify-app-template-none', visible: true},
+  node: {url: 'https://github.com/Shopify/shopify-app-template-node', visible: false},
+  php: {url: 'https://github.com/Shopify/shopify-app-template-php', visible: false},
+  ruby: {url: 'https://github.com/Shopify/shopify-app-template-ruby', visible: false},
 } as const
+export const visibleTemplates = Object.keys(templateURLMap).filter(
+  (key) => templateURLMap[key as keyof typeof templateURLMap].visible,
+)
 
 const templateLabels = {
   remix: 'Start with Remix (recommended)',
@@ -33,7 +39,7 @@ const init = async (options: InitOptions): Promise<InitOutput> => {
 
   const defaults = {
     name: await generateRandomNameForSubdirectory({suffix: 'app', directory: options.directory}),
-    template: templateURLMap.remix,
+    template: templateURLMap.remix.url,
   } as const
 
   let welcomed = false
@@ -72,7 +78,7 @@ const init = async (options: InitOptions): Promise<InitOutput> => {
       }),
       message: 'Get started building your app:',
       defaultValue: Object.keys(templateURLMap).find(
-        (key) => templateURLMap[key as keyof typeof templateURLMap] === defaults.template,
+        (key) => templateURLMap[key as keyof typeof templateURLMap].url === defaults.template,
       ),
     })
   }
@@ -85,8 +91,8 @@ const init = async (options: InitOptions): Promise<InitOutput> => {
     templateType: templateIsPredefined ? (template as keyof typeof templateURLMap) : 'custom',
   }
 
-  const templateURL = templateURLMap[answers.template as keyof typeof templateURLMap]
-  answers.template = templateURL || answers.template || defaults.template
+  const selectedTemplate = templateURLMap[answers.template as keyof typeof templateURLMap]
+  answers.template = selectedTemplate?.url || answers.template || defaults.template
 
   return answers
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We've updated the template options we display to the user when creating a new app, but we still want to allow some aliases that were previously available.

### WHAT is this pull request doing?

Adding a distinction between visible and non-visible aliases to make life easier when creating apps.

### How to test your changes?

- Success cases
  - `dev create-app --template <aliases>`
  - `dev create-app --template <URL>`
  - `dev create-app`
- Failure case: `dev create-app --template <invalid-alias>`

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
