### PR TITLE
Add -w option to pnpm upgrade command

### DIFF
--- a/.changeset/light-fireants-share.md
+++ b/.changeset/light-fireants-share.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/cli': patch
+---
+
+Fix pnpm shopify upgrade for workspaces

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -338,6 +338,9 @@ interface AddNPMDependenciesIfNeededOptions {
 
   /** Abort signal to stop the process */
   signal?: AbortSignal
+
+  /** Whether to add the dependencies to the root package.json or to the package.json of the directory */
+  addToRootDirectory?: boolean
 }
 
 /**
@@ -421,7 +424,10 @@ export async function addNPMDependencies(
       await installDependencies(options, argumentsToAddDependenciesWithYarn(dependenciesWithVersion, options.type))
       break
     case 'pnpm':
-      await installDependencies(options, argumentsToAddDependenciesWithPNPM(dependenciesWithVersion, options.type))
+      await installDependencies(
+        options,
+        argumentsToAddDependenciesWithPNPM(dependenciesWithVersion, options.type, Boolean(options.addToRootDirectory)),
+      )
       break
   }
 }
@@ -503,9 +509,19 @@ function argumentsToAddDependenciesWithYarn(dependencies: string[], type: Depend
  * @param type - The dependency type.
  * @returns An array with the arguments.
  */
-function argumentsToAddDependenciesWithPNPM(dependencies: string[], type: DependencyType): string[] {
+function argumentsToAddDependenciesWithPNPM(
+  dependencies: string[],
+  type: DependencyType,
+  addAtRoot: boolean,
+): string[] {
   let command = ['add']
+
+  if (addAtRoot) {
+    command.push('-w')
+  }
+
   command = command.concat(dependencies)
+
   switch (type) {
     case 'dev':
       command.push('--save-dev')

--- a/packages/cli/src/cli/services/upgrade.test.ts
+++ b/packages/cli/src/cli/services/upgrade.test.ts
@@ -142,6 +142,7 @@ describe('upgrade local CLI', () => {
           directory: normalizePath(tmpDir),
           stdout: process.stdout,
           stderr: process.stderr,
+          addToRootDirectory: false,
         },
       )
       expect(outputMock.success()).toMatchInlineSnapshot(`

--- a/packages/cli/src/cli/services/upgrade.ts
+++ b/packages/cli/src/cli/services/upgrade.ts
@@ -5,6 +5,7 @@ import {
   DependencyType,
   getPackageManager,
   PackageJson,
+  usesWorkspaces,
 } from '@shopify/cli-kit/node/node-package-manager'
 import {exec} from '@shopify/cli-kit/node/system'
 import {dirname, moduleDirectory} from '@shopify/cli-kit/node/path'
@@ -144,6 +145,8 @@ async function installJsonDependencies(
       return {name: pkg, version: 'latest'}
     })
 
+  const appUsesWorkspaces = await usesWorkspaces(directory)
+
   if (packagesToUpdate.length > 0) {
     await addNPMDependencies(packagesToUpdate, {
       packageManager: await getPackageManager(directory),
@@ -151,6 +154,7 @@ async function installJsonDependencies(
       directory,
       stdout: process.stdout,
       stderr: process.stderr,
+      addToRootDirectory: appUsesWorkspaces,
     })
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Pnpm upgrade was broken
![Screenshot 2023-07-27 at 16 51 51](https://github.com/Shopify/cli/assets/151725/215c260a-e02b-4d3f-abdb-e81bc5e42662)

### WHAT is this pull request doing?

Fix the above issue.
