### PR TITLE
Sanitize tokens in verbose mode

### DIFF
--- a/packages/cli-kit/src/private/node/api.ts
+++ b/packages/cli-kit/src/private/node/api.ts
@@ -1,4 +1,5 @@
 import {sanitizedHeadersOutput} from './api/headers.js'
+import {sanitizeURL} from './api/urls.js'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {Headers} from 'form-data'
 import {ClientError} from 'graphql-request'
@@ -43,7 +44,7 @@ export async function debugLogResponseInfo<T extends {headers: Headers; status: 
     }
   } finally {
     const t1 = performance.now()
-    outputDebug(`Request to ${url} completed in ${Math.round(t1 - t0)} ms
+    outputDebug(`Request to ${sanitizeURL(url)} completed in ${Math.round(t1 - t0)} ms
 With response headers:
 ${sanitizedHeadersOutput(responseHeaders)}
     `)

--- a/packages/cli-kit/src/private/node/api/graphql.ts
+++ b/packages/cli-kit/src/private/node/api/graphql.ts
@@ -11,10 +11,18 @@ export function debugLogRequestInfo<T>(
 ) {
   outputDebug(outputContent`Sending ${outputToken.json(api)} GraphQL request:
   ${outputToken.raw(query.toString().trim())}
-${variables ? `\nWith variables:\n${JSON.stringify(variables, null, 2)}\n` : ''}
+${variables ? `\nWith variables:\n${sanitizeVariables(variables)}\n` : ''}
 With request headers:
 ${sanitizedHeadersOutput(headers)}
 `)
+}
+
+function sanitizeVariables(variables: Variables): string {
+  const result: Variables = {...variables}
+  if ('apiKey' in result) {
+    result.apiKey = '*****'
+  }
+  return JSON.stringify(result, null, 2)
 }
 
 export function errorHandler<T>(api: string): (error: unknown) => Error | unknown {

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -29,7 +29,7 @@ export class GraphQLClientError extends RequestClientError {
  */
 export function sanitizedHeadersOutput(headers: {[key: string]: string}): string {
   const sanitized: {[key: string]: string} = {}
-  const keywords = ['token', 'authorization']
+  const keywords = ['token', 'authorization', 'subject_token']
   Object.keys(headers).forEach((header) => {
     if (keywords.find((keyword) => header.toLocaleLowerCase().includes(keyword)) === undefined) {
       sanitized[header] = headers[header]!

--- a/packages/cli-kit/src/private/node/api/urls.test.ts
+++ b/packages/cli-kit/src/private/node/api/urls.test.ts
@@ -1,0 +1,48 @@
+import {sanitizeURL} from './urls.js'
+import {test, expect, describe} from 'vitest'
+
+describe('sanitizeURL', () => {
+  test('sanitizes subject_token query parameter', () => {
+    // Given
+    const url = 'https://example.com?subject_token=abc123'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://example.com/?subject_token=****')
+  })
+
+  test('sanitizes token query parameter', () => {
+    // Given
+    const url = 'https://example.com?token=abc123'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://example.com/?token=****')
+  })
+
+  test('sanitizes multiple query parameters', () => {
+    // Given
+    const url = 'https://example.com?subject_token=abc123&token=def456'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://example.com/?subject_token=****&token=****')
+  })
+
+  test('leaves other query parameters unchanged', () => {
+    // Given
+    const url = 'https://example.com?subject_token=abc123&other_param=def456'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://example.com/?subject_token=****&other_param=def456')
+  })
+})

--- a/packages/cli-kit/src/private/node/api/urls.ts
+++ b/packages/cli-kit/src/private/node/api/urls.ts
@@ -1,0 +1,15 @@
+/**
+ * Removes the sensitive data from the url and outputs them as a string.
+ * @param url - HTTP headers.
+ * @returns A sanitized version of the url as a string.
+ */
+export function sanitizeURL(url: string): string {
+  const parsedUrl = new URL(url)
+  if (parsedUrl.searchParams.has('subject_token')) {
+    parsedUrl.searchParams.set('subject_token', '****')
+  }
+  if (parsedUrl.searchParams.has('token')) {
+    parsedUrl.searchParams.set('token', '****')
+  }
+  return parsedUrl.toString()
+}

--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -1,6 +1,7 @@
 import {dirname} from './path.js'
 import {createFileWriteStream, fileExistsSync, mkdirSync, unlinkFileSync} from './fs.js'
 import {buildHeaders, httpsAgent, sanitizedHeadersOutput} from '../../private/node/api/headers.js'
+import {sanitizeURL} from '../../private/node/api/urls.js'
 import {outputContent, outputDebug} from '../../public/node/output.js'
 import {debugLogResponseInfo} from '../../private/node/api.js'
 import FormData from 'form-data'
@@ -45,6 +46,7 @@ export async function fetch(url: RequestInfo, init?: RequestInit): Response {
  * @returns A promise that resolves with the response.
  */
 export async function shopifyFetch(url: RequestInfo, init?: RequestInit): Response {
+  const sanitizedUrl = sanitizeURL(url.toString())
   const options: RequestInit = {
     ...(init ?? {}),
     headers: {
@@ -53,7 +55,7 @@ export async function shopifyFetch(url: RequestInfo, init?: RequestInit): Respon
     },
   }
 
-  outputDebug(outputContent`Sending ${options.method ?? 'GET'} request to URL ${url.toString()}
+  outputDebug(outputContent`Sending ${options.method ?? 'GET'} request to URL ${sanitizedUrl}
 With request headers:
 ${sanitizedHeadersOutput((options?.headers ?? {}) as {[header: string]: string})}
 `)
@@ -68,7 +70,8 @@ ${sanitizedHeadersOutput((options?.headers ?? {}) as {[header: string]: string})
  * @returns - A promise that resolves with the local path.
  */
 export function downloadFile(url: string, to: string): Promise<string> {
-  outputDebug(`Downloading ${url} to ${to}`)
+  const sanitizedUrl = sanitizeURL(url)
+  outputDebug(`Downloading ${sanitizedUrl} to ${to}`)
 
   return new Promise<string>((resolve, reject) => {
     if (!fileExistsSync(dirname(to))) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

Noticed that tokens are being logged to console in `--verbose` mode

### WHAT is this pull request doing?

Sanitizes the URL parameters where they are printed.

### How to test your changes?

Unit tests and did a 🎩 

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
