### PR TITLE
Update error message unsupported version api version - unified app deployment

### DIFF
--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -198,7 +198,7 @@ export async function uploadExtensionsBundle(
       deployError = result.appDeploy.userErrors.map((error) => error.message).join(', ')
     } else {
       throw new AbortError(
-        {bold: 'Deployment failed due to a Function targetting an unsupported API.'},
+        {bold: 'Deployment failed due to a Function targeting an unsupported API.'},
         {
           subdued: 'To fix this, update the extension to target a supported version.',
         },

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -125,6 +125,22 @@ interface ErrorCustomSection extends AlertCustomSection {
   body: ErrorSectionBody
 }
 
+const API_VERSION_REFERENCE_SECTION = {
+  body: {
+    list: {
+      title: 'Reference',
+      items: [
+        {
+          link: {
+            label: 'API versioning',
+            url: 'https://shopify.dev/docs/api/usage/versioning',
+          },
+        },
+      ],
+    },
+  },
+}
+
 /**
  * Uploads a bundle.
  * @param options - The upload options
@@ -181,7 +197,14 @@ export async function uploadExtensionsBundle(
     if (result.appDeploy.appVersion) {
       deployError = result.appDeploy.userErrors.map((error) => error.message).join(', ')
     } else {
-      throw new AbortError({bold: "Version couldn't be created."}, null, [], customSections)
+      throw new AbortError(
+        {bold: 'Deployment failed due to a Function targetting an unsupported API.'},
+        {
+          subdued: 'To fix this, update the extension to target a supported version.',
+        },
+        [],
+        [...customSections, API_VERSION_REFERENCE_SECTION],
+      )
     }
   }
 
@@ -490,23 +513,7 @@ async function uploadFunctionExtension(
       const tryMessage: TokenItem = {
         subdued: `Deployment failed because one or more Functions (${variables.apiType}) is targeting an unsupported API version (${variables.apiVersion}).`,
       }
-      const customSections: AlertCustomSection[] = [
-        {
-          body: {
-            list: {
-              title: 'Reference',
-              items: [
-                {
-                  link: {
-                    label: 'API versioning',
-                    url: 'https://shopify.dev/docs/api/usage/versioning',
-                  },
-                },
-              ],
-            },
-          },
-        },
-      ]
+      const customSections: AlertCustomSection[] = [API_VERSION_REFERENCE_SECTION]
       throw new AbortError(errorMessage, tryMessage, [], customSections)
     } else {
       const errorMessage = outputContent`The deployment of functions failed with the following errors:${outputToken.json(


### PR DESCRIPTION
#gsd:35272

Addresses: https://github.com/Shopify/script-service/issues/7205
Related: https://github.com/Shopify/shopify/pull/442491

### WHY are these changes introduced?

The https://github.com/Shopify/shopify/pull/442491 PR updates core to validate api version on deploy for unified admin. Previosuly, with unified app deployment, there was no check if an api version is supported, only if it is valid or not. The PR linked address adding validation in core on api version for unified deployments.

This PR is for updating the error message that unified appl deployment displays to match the mocks - [doc here](https://docs.google.com/document/d/1LQBcgN1lncBm_3iM2yzv1KiVkTbr6sInzRY3Dux94Xs/edit)

I've included some extra content (function name + validation errors) with the error message to keep consistent with how unified app deployments was set up.

### WHAT is this pull request doing?

Unified Deployments Error Message with current pattern:
<img width="570" alt="Screenshot 2023-08-01 at 7 30 25 AM" src="https://github.com/Shopify/cli/assets/16329347/dec072b1-140d-4cac-b39f-8a4bc582de5a">

Updated error message:
<img width="596" alt="Screenshot 2023-08-01 at 7 27 27 AM" src="https://github.com/Shopify/cli/assets/16329347/e94b814a-fe62-46a7-b5b6-a1364b4b7ec1">

I've updated to match the mocks and keep consistent with current pattern in unified deployment - we can include some human readable text for the api.type and include the function name.

```
<error message in bold>
<fix message subdued>
<function name>
Validation Errors:
  - <field>: <error>
 <reference section>
```

### How to test your changes?

There a few sets you need to do to tophat this:
- In your CLI - checkout this branch: `ms.update-error-message-functions-unsupported-version`
- Run the deploy command from your CLI folder with the SPIN arguments:
```
SPIN=1 SPIN_INSTANCE=<YOUR SPIN INSTANCE NAME> dev spin pnpm shopify app deploy --path=<PATH TO YOUR APP>
```
Example:
```
SPIN=1 SPIN_INSTANCE=script-service-7brx dev spin pnpm shopify app deploy --path=../../../../Desktop/apps/delivery-app-pnpm
```

Note: Deploy against api_version `2022-07`.  (in `shopify.function.extension.toml`)


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
