### PR TITLE
Add note about node installation

### DIFF
--- a/docs/cli/cross-os-compatibility.md
+++ b/docs/cli/cross-os-compatibility.md
@@ -52,7 +52,7 @@ node bin/create-test-app.js -e ui
 After you've installed Parallels and virtualized the Windows environment, you need to install the following software:
 
 - [Git](https://git-scm.com/download/win)
-- [Node](https://nodejs.org/en/download/)
+- [Node](https://nodejs.org/en/download/) (remember to also install chocolatey)
 - [Ruby](https://rubyinstaller.org/downloads/) (needed for themes, Ruby+DevKit 3.0.x is recommended)
 - [PNPM](https://pnpm.io/installation)
   - You will need to enable [long paths](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell) support on windows:


### PR DESCRIPTION
A small addition to your cross os testing docs.
Without installing chocolatey and visual studio code tools 2019, I wasn't able to run `pnpm install`