### PR TITLE
Added back GQL for enabling developer preview, updated renderDev footer to include toggle for developer preview

### DIFF
--- a/.changeset/rotten-mirrors-march.md
+++ b/.changeset/rotten-mirrors-march.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+- Enable dev preview mode on startup.
+- Add dev log footer shortcut to toggle dev preview mode on/off.
+- Disabke dev preview mode when exit

--- a/packages/app/src/cli/api/graphql/development_preview.ts
+++ b/packages/app/src/cli/api/graphql/development_preview.ts
@@ -1,0 +1,36 @@
+import {gql} from 'graphql-request'
+
+export const DevelopmentStorePreviewUpdateQuery = gql`
+  mutation DevelopmentStorePreviewUpdate($input: DevelopmentStorePreviewUpdateInput!) {
+    developmentStorePreviewUpdate(input: $input) {
+      app {
+        id
+        developmentStorePreviewEnabled
+      }
+      userErrors {
+        message
+        field
+      }
+    }
+  }
+`
+
+export interface DevelopmentStorePreviewUpdateInput {
+  input: {
+    apiKey: string
+    enabled: boolean
+  }
+}
+
+export interface DevelopmentStorePreviewUpdateSchema {
+  developmentStorePreviewUpdate: {
+    app: {
+      id: string
+      developmentStorePreviewEnabled: boolean
+    }
+    userErrors: {
+      field: string[]
+      message: string
+    }[]
+  }
+}

--- a/packages/app/src/cli/api/graphql/find_app.ts
+++ b/packages/app/src/cli/api/graphql/find_app.ts
@@ -33,6 +33,7 @@ export const FindAppQuery = gql`
         subPathPrefix
         url
       }
+      developmentStorePreviewEnabled
     }
   }
 `
@@ -69,5 +70,6 @@ export interface FindAppQuerySchema {
       subPathPrefix: string
       url: string
     }
+    developmentStorePreviewEnabled: boolean
   }
 }

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -93,6 +93,10 @@ export default class Dev extends Command {
     }),
   }
 
+  public static analyticsStopCommand(): string | undefined {
+    return 'app dev stop'
+  }
+
   public async run(): Promise<void> {
     const {flags} = await this.parse(Dev)
     if (flags['api-key']) {

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -39,6 +39,7 @@ export type OrganizationApp = MinimalOrganizationApp & {
     subPathPrefix: string
     url: string
   }
+  developmentStorePreviewEnabled?: boolean
 }
 
 export interface OrganizationStore {

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -31,6 +31,11 @@ import {getAppConfigurationFileName, loadAppConfiguration, loadAppName} from '..
 import {ExtensionInstance} from '../models/extensions/extension-instance.js'
 
 import {ExtensionRegistration} from '../api/graphql/all_app_extension_registrations.js'
+import {
+  DevelopmentStorePreviewUpdateInput,
+  DevelopmentStorePreviewUpdateQuery,
+  DevelopmentStorePreviewUpdateSchema,
+} from '../api/graphql/development_preview.js'
 import {tryParseInt} from '@shopify/cli-kit/common/string'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {TokenItem, renderInfo, renderTasks} from '@shopify/cli-kit/node/ui'
@@ -41,6 +46,7 @@ import {getOrganization} from '@shopify/cli-kit/node/environment'
 import {basename, joinPath} from '@shopify/cli-kit/node/path'
 import {Config} from '@oclif/core'
 import {glob} from '@shopify/cli-kit/node/fs'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 
 export const InvalidApiKeyErrorMessage = (apiKey: string) => {
   return {
@@ -757,6 +763,43 @@ async function logMetadataForLoadedDeployContext(env: DeployContextOutput) {
     partner_id: tryParseInt(env.partnersApp.organizationId),
     api_key: env.identifiers.app,
   }))
+}
+
+export async function enableDeveloperPreview({apiKey, token}: {apiKey: string; token: string}) {
+  return developerPreviewUpdate({apiKey, token, enabled: true})
+}
+
+export async function disableDeveloperPreview({apiKey, token}: {apiKey: string; token: string}) {
+  await developerPreviewUpdate({apiKey, token, enabled: false})
+}
+
+export async function developerPreviewUpdate({
+  apiKey,
+  token,
+  enabled,
+}: {
+  apiKey: string
+  token: string
+  enabled: boolean
+}) {
+  let result: DevelopmentStorePreviewUpdateSchema | undefined
+  try {
+    const query = DevelopmentStorePreviewUpdateQuery
+    const variables: DevelopmentStorePreviewUpdateInput = {
+      input: {
+        apiKey,
+        enabled,
+      },
+    }
+
+    result = await partnersRequest(query, token, variables)
+    const userErrors = result?.developmentStorePreviewUpdate?.userErrors
+    return !userErrors || userErrors.length === 0
+
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (error: unknown) {
+    return false
+  }
 }
 
 async function logMetadataForLoadedReleaseContext(env: ReleaseContextOutput, partnerId: string) {

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -111,6 +111,7 @@ export async function devUIExtensions(options: ExtensionDevOptions): Promise<voi
   const fileWatcher = await setupBundlerAndFileWatcher({devOptions, payloadStore})
 
   options.signal.addEventListener('abort', () => {
+    outputDebug('Closing the UI extensions dev server...')
     fileWatcher.close()
     websocketConnection.close()
     httpServer.close()

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -1,12 +1,15 @@
 import {PartnersURLs} from './urls.js'
+import {fetchAppFromApiKey} from './fetch.js'
 import {AppInterface, isCurrentAppSchema} from '../../models/app/app.js'
 import {OrganizationApp} from '../../models/organization.js'
 import {getAppConfigurationShorthand} from '../../models/app/loader.js'
+import {developerPreviewUpdate, enableDeveloperPreview} from '../context.js'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {renderConcurrent, RenderConcurrentOptions, renderInfo} from '@shopify/cli-kit/node/ui'
+import {FooterContext, renderConcurrent, RenderConcurrentOptions, renderInfo} from '@shopify/cli-kit/node/ui'
 import {openURL} from '@shopify/cli-kit/node/system'
 import {basename} from '@shopify/cli-kit/node/path'
-import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+import {formatPackageManagerCommand, outputContent, outputDebug, outputToken} from '@shopify/cli-kit/node/output'
+import {AbortController} from '@shopify/cli-kit/node/abort'
 
 export async function outputUpdateURLsResult(
   updated: boolean,
@@ -58,22 +61,67 @@ export async function outputUpdateURLsResult(
   }
 }
 
-export function renderDev(renderConcurrentOptions: RenderConcurrentOptions, previewUrl: string) {
+export async function renderDev(
+  renderConcurrentOptions: RenderConcurrentOptions,
+  previewUrl: string,
+  app: {
+    canEnablePreviewMode: boolean
+    developmentStorePreviewEnabled?: boolean
+    apiKey: string
+    token: string
+  },
+) {
   let options = renderConcurrentOptions
+
+  const {apiKey, token, canEnablePreviewMode, developmentStorePreviewEnabled} = app
+
+  const shortcuts = []
+  if (canEnablePreviewMode) {
+    // Enable dev preview on app dev start
+    const enablingDevPreviewSucceeds = await enableDeveloperPreview({apiKey, token})
+
+    const devPreviewStatus = enablingDevPreviewSucceeds ? true : developmentStorePreviewEnabled
+
+    buildDevPreviewShortcut({devPreviewStatus, apiKey, token})
+
+    shortcuts.push(buildDevPreviewShortcut({devPreviewStatus, apiKey, token}))
+  }
+
+  const subTitle = `Preview URL: ${previewUrl}`
 
   if (previewUrl) {
     options = {
       ...options,
-      onInput: (input, _key, exit) => {
+      onInputAsync: async (input, _key, exit, footerContext) => {
         if (input === 'p' && previewUrl) {
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          openURL(previewUrl)
+          await openURL(previewUrl)
         } else if (input === 'q') {
           exit()
+        } else if (input === 'd' && canEnablePreviewMode) {
+          if (!footerContext) return
+          const currentShortcutAction = footerContext.footer?.shortcuts.find((shortcut) => shortcut.key === 'd')
+          if (!currentShortcutAction) return
+          const newDevPreviewStatus = !currentShortcutAction.state?.devPreviewStatus
+          const newShortcutAction = buildDevPreviewShortcut({devPreviewStatus: newDevPreviewStatus, apiKey, token})
+          const developerPreviewUpdateValue = await developerPreviewUpdate({
+            apiKey,
+            token,
+            enabled: newDevPreviewStatus,
+          })
+          if (developerPreviewUpdateValue) {
+            footerContext.updateShortcut(currentShortcutAction, newShortcutAction)
+            footerContext.updateSubTitle(subTitle)
+          } else {
+            const newSubTitle = outputContent`${subTitle}\n\n${outputToken.errorText(
+              'There was an error turning on developer preview mode',
+            )}`.value
+            footerContext.updateSubTitle(newSubTitle)
+          }
         }
       },
       footer: {
         shortcuts: [
+          ...shortcuts,
           {
             key: 'p',
             action: 'preview in your browser',
@@ -83,11 +131,31 @@ export function renderDev(renderConcurrentOptions: RenderConcurrentOptions, prev
             action: 'quit',
           },
         ],
-        subTitle: `Preview URL: ${previewUrl}`,
+        subTitle,
       },
     }
   }
   return renderConcurrent({...options, keepRunningAfterProcessesResolve: true})
+}
+
+function buildDevPreviewShortcut({
+  devPreviewStatus,
+  apiKey,
+  token,
+}: {
+  devPreviewStatus?: boolean
+  apiKey: string
+  token: string
+}) {
+  const outputStatus = devPreviewStatus ? outputToken.green('✔ on') : outputToken.errorText('✖ off')
+  return {
+    key: 'd',
+    action: outputContent`development store preview: ${outputStatus}`.value,
+    state: {
+      devPreviewStatus,
+    },
+    syncer: buildPollForDevPreviewMode(apiKey, token),
+  }
 }
 
 async function partnersURL(organizationId: string, appId: string) {
@@ -96,5 +164,37 @@ async function partnersURL(organizationId: string, appId: string) {
       label: 'Partners Dashboard',
       url: `https://${await partnersFqdn()}/${organizationId}/apps/${appId}/edit`,
     },
+  }
+}
+
+function buildPollForDevPreviewMode(apiKey: string, token: string, interval = 5) {
+  return (footerContext: FooterContext, abortController: AbortController) => {
+    const currentIntervalInSeconds = interval
+
+    return new Promise<void>((_resolve, _reject) => {
+      const onPoll = async () => {
+        const app = await fetchAppFromApiKey(apiKey, token)
+        const currentShortcutAction = footerContext.footer?.shortcuts.find((shortcut) => shortcut.key === 'd')
+        if (!currentShortcutAction) return
+        const newShortcutAction = buildDevPreviewShortcut({
+          devPreviewStatus: app?.developmentStorePreviewEnabled ?? false,
+          apiKey,
+          token,
+        })
+        footerContext.updateShortcut(currentShortcutAction, newShortcutAction)
+      }
+
+      const startPolling = () => {
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        return setInterval(onPoll, currentIntervalInSeconds * 1000)
+      }
+
+      const pollId = startPolling()
+
+      abortController.signal.addEventListener('abort', async () => {
+        outputDebug('Stopping poll for dev preview mode...')
+        clearInterval(pollId)
+      })
+    })
   }
 }

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
@@ -47,6 +47,12 @@ describe('runConcurrentHTTPProcessesAndPathForwardTraffic', () => {
         },
       ],
       additionalProcesses: [],
+      app: {
+        canEnablePreviewMode: false,
+        developmentStorePreviewEnabled: false,
+        apiKey: '',
+        token: '',
+      },
     })
 
     // Then

--- a/packages/cli-kit/src/private/node/tree-kill.ts
+++ b/packages/cli-kit/src/private/node/tree-kill.ts
@@ -1,7 +1,0 @@
-import {printEventsJson} from './demo-recorder.js'
-import originalTreeKill from 'tree-kill'
-
-export function treeKill(signal: string) {
-  printEventsJson()
-  originalTreeKill(process.pid, signal)
-}

--- a/packages/cli-kit/src/private/node/ui.tsx
+++ b/packages/cli-kit/src/private/node/ui.tsx
@@ -1,6 +1,6 @@
-import {treeKill} from './tree-kill.js'
 import {collectLog, consoleLog, Logger, LogLevel, outputWhereAppropriate} from '../../public/node/output.js'
 import {isUnitTest} from '../../public/node/context/local.js'
+import {treeKill} from '../../public/node/tree-kill.js'
 import {ReactElement} from 'react'
 import {Key, render as inkRender, RenderOptions} from 'ink'
 import {EventEmitter} from 'events'
@@ -77,9 +77,9 @@ const renderString = (element: ReactElement, renderOptions?: RenderOptions): Ins
   }
 }
 
-export function handleCtrlC(input: string, key: Key) {
+export function handleCtrlC(input: string, key: Key, exit = () => treeKill('SIGINT')) {
   if (input === 'c' && key.ctrl) {
     // Exceptions thrown in hooks aren't caught by our errorHandler.
-    treeKill('SIGINT')
+    exit()
   }
 }

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
@@ -51,7 +51,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess, frontendProcess]}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
         footer={{
           shortcuts: [
             {
@@ -133,7 +133,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess, frontendProcess]}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
         footer={{
           shortcuts: [
             {
@@ -185,7 +185,7 @@ describe('ConcurrentOutput', () => {
       <ConcurrentOutput
         processes={[neverEndingProcess]}
         onInput={(input, key) => onInput(input, key)}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
       />,
     )
 
@@ -216,7 +216,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortSignal={abortController.signal}
+        abortController={abortController}
         footer={{
           shortcuts: [
             {
@@ -241,10 +241,6 @@ describe('ConcurrentOutput', () => {
       "00:00:00 │ backend │ first backend message
       00:00:00 │ backend │ second backend message
       00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      Preview URL: https://shopify.com
       "
     `)
 
@@ -269,7 +265,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
         footer={{
           shortcuts: [
             {
@@ -316,7 +312,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
         footer={{
           shortcuts: [
             {
@@ -363,7 +359,7 @@ describe('ConcurrentOutput', () => {
     const renderInstance = render(
       <ConcurrentOutput
         processes={[backendProcess]}
-        abortSignal={new AbortController().signal}
+        abortController={new AbortController()}
         footer={{
           shortcuts: [
             {

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -1,8 +1,8 @@
 import {OutputProcess} from '../../../../public/node/output.js'
-import {AbortSignal} from '../../../../public/node/abort.js'
+import {AbortController} from '../../../../public/node/abort.js'
+import {treeKill} from '../../../../public/node/tree-kill.js'
 import {handleCtrlC} from '../../ui.js'
 import {addOrUpdateConcurrentUIEventOutput} from '../../demo-recorder.js'
-import {treeKill} from '../../tree-kill.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
 import React, {FunctionComponent, useCallback, useEffect, useMemo, useState} from 'react'
 import {Box, Key, Static, Text, useInput, TextProps, useStdin, useApp} from 'ink'
@@ -12,19 +12,32 @@ import {Writable} from 'stream'
 
 export type WritableStream = (process: OutputProcess, index: number) => Writable
 
+export interface Footer {
+  shortcuts: Shortcut[]
+  subTitle?: string
+}
+
+export interface FooterContext {
+  footer?: Footer
+  updateShortcut: (prevShortcut: Shortcut, newShortcut: Shortcut) => void
+  updateSubTitle: (subTitle: string) => void
+}
+
 interface Shortcut {
   key: string
   action: string
+  syncer?: (footerContext: FooterContext, abortController: AbortController) => void
+  state?: {
+    [key: string]: unknown
+  }
 }
 export interface ConcurrentOutputProps {
   processes: OutputProcess[]
-  abortSignal: AbortSignal
+  abortController: AbortController
   showTimestamps?: boolean
   onInput?: (input: string, key: Key, exit: () => void) => void
-  footer?: {
-    shortcuts: Shortcut[]
-    subTitle?: string
-  }
+  onInputAsync?: (input: string, key: Key, exit: () => void, footerContext: FooterContext) => Promise<void>
+  footer?: Footer
   // If set, the component is not automatically unmounted once the processes have all finished
   keepRunningAfterProcessesResolve?: boolean
 }
@@ -33,12 +46,10 @@ interface Chunk {
   prefix: string
   lines: string[]
 }
-
 enum ConcurrentOutputState {
   Running = 'running',
   Stopped = 'stopped',
 }
-
 function addLeadingZero(number: number) {
   if (number < 10) {
     return `0${number}`
@@ -46,17 +57,13 @@ function addLeadingZero(number: number) {
     return number.toString()
   }
 }
-
 function currentTime() {
   const currentDateTime = new Date()
-
   const hours = addLeadingZero(currentDateTime.getHours())
   const minutes = addLeadingZero(currentDateTime.getMinutes())
   const seconds = addLeadingZero(currentDateTime.getSeconds())
-
   return `${hours}:${minutes}:${seconds}`
 }
-
 /**
  * Renders output from concurrent processes to the terminal.
  * Output will be divided in a three column layout
@@ -92,9 +99,10 @@ function currentTime() {
  */
 const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
   processes,
-  abortSignal,
+  abortController,
   showTimestamps = true,
   onInput,
+  onInputAsync,
   footer,
   keepRunningAfterProcessesResolve,
 }) => {
@@ -103,6 +111,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
   const prefixColumnSize = Math.max(...processes.map((process) => process.prefix.length))
   const {isRawModeSupported} = useStdin()
   const [state, setState] = useState<ConcurrentOutputState>(ConcurrentOutputState.Running)
+  const [footerContent, setFooterContent] = useState<Footer | undefined>(footer)
   const concurrentColors: TextProps['color'][] = useMemo(() => ['yellow', 'cyan', 'magenta', 'green', 'blue'], [])
   const lineColor = useCallback(
     (index: number) => {
@@ -111,14 +120,12 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
     },
     [concurrentColors],
   )
-
   const writableStream = useCallback(
     (process: OutputProcess, index: number) => {
       return new Writable({
         write(chunk, _encoding, next) {
           const lines = stripAnsi(chunk.toString('utf8').replace(/(\n)$/, '')).split(/\n/)
           addOrUpdateConcurrentUIEventOutput({prefix: process.prefix, index, output: lines.join('\n')}, {footer})
-
           setProcessOutput((previousProcessOutput) => [
             ...previousProcessOutput,
             {
@@ -127,25 +134,64 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
               lines,
             },
           ])
-
           next()
         },
       })
     },
     [footer, lineColor],
   )
-
-  const {isAborted} = useAbortSignal(abortSignal)
+  const {isAborted} = useAbortSignal(abortController.signal)
   const useShortcuts = isRawModeSupported && state === ConcurrentOutputState.Running && !isAborted
+
+  const updateShortcut = (prevShortcut: Shortcut, newShortcut: Shortcut) => {
+    if (!footerContent) return
+    const newFooterContent = {...footerContent}
+
+    newFooterContent.shortcuts.map((short) => {
+      if (short.key === prevShortcut.key) {
+        short.action = newShortcut.action
+        short.key = newShortcut.key
+        short.state = newShortcut.state
+      }
+    })
+    setFooterContent(newFooterContent)
+  }
+
+  const updateSubTitle = (subTitle: string) => {
+    if (!footerContent) return
+
+    setFooterContent({...footerContent, subTitle})
+  }
+
+  const runShortcutSyncs = () => {
+    footerContent?.shortcuts?.forEach((shortcut) => {
+      if (shortcut.syncer) shortcut.syncer({footer: footerContent, updateShortcut, updateSubTitle}, abortController)
+    })
+  }
 
   useInput(
     (input, key) => {
-      handleCtrlC(input, key)
+      const exit = abortController ? () => abortController.abort() : () => treeKill('SIGINT')
 
-      onInput!(input, key, () => treeKill('SIGINT'))
+      handleCtrlC(input, key, exit)
+
+      const triggerOnInput = async () => {
+        if (onInput) {
+          onInput(input, key, exit)
+        } else if (onInputAsync) {
+          await onInputAsync(input, key, exit, {footer: footerContent, updateShortcut, updateSubTitle})
+        }
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      triggerOnInput()
     },
-    {isActive: typeof onInput !== 'undefined' && useShortcuts},
+    {isActive: (typeof onInput !== 'undefined' || typeof onInputAsync !== 'undefined') && useShortcuts},
   )
+
+  useEffect(() => {
+    runShortcutSyncs()
+  }, [])
 
   useEffect(() => {
     ;(() => {
@@ -153,8 +199,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
         processes.map(async (process, index) => {
           const stdout = writableStream(process, index)
           const stderr = writableStream(process, index)
-
-          await process.action(stdout, stderr, abortSignal)
+          await process.action(stdout, stderr, abortController.signal)
         }),
       )
     })()
@@ -168,10 +213,8 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
         setState(ConcurrentOutputState.Stopped)
         unmountInk(error)
       })
-  }, [abortSignal, processes, writableStream, unmountInk, keepRunningAfterProcessesResolve])
-
+  }, [abortController, processes, writableStream, unmountInk, keepRunningAfterProcessesResolve])
   const {lineVertical} = figures
-
   return (
     <>
       <Static items={processOutput}>
@@ -187,7 +230,6 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
                         {currentTime()} {lineVertical}{' '}
                       </Text>
                     ) : null}
-
                     <Text>
                       {chunk.prefix}
                       {prefixBuffer} {lineVertical} {line}
@@ -199,7 +241,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
           )
         }}
       </Static>
-      {footer ? (
+      {footerContent && !isAborted ? (
         <Box
           marginY={1}
           paddingTop={1}
@@ -213,16 +255,16 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
         >
           {useShortcuts ? (
             <Box flexDirection="column">
-              {footer.shortcuts.map((shortcut, index) => (
+              {footerContent.shortcuts.map((shortcut, index) => (
                 <Text key={index}>
                   {figures.pointerSmall} Press <Text bold>{shortcut.key}</Text> {figures.lineVertical} {shortcut.action}
                 </Text>
               ))}
             </Box>
           ) : null}
-          {footer.subTitle ? (
+          {footerContent.subTitle ? (
             <Box marginTop={useShortcuts ? 1 : 0}>
-              <Text>{footer.subTitle}</Text>
+              <Text>{footerContent.subTitle}</Text>
             </Box>
           ) : null}
         </Box>
@@ -230,5 +272,4 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
     </>
   )
 }
-
 export {ConcurrentOutput}

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -22,6 +22,10 @@ abstract class BaseCommand extends Command {
     return undefined
   }
 
+  public static analyticsStopCommand(): string | undefined {
+    return undefined
+  }
+
   async catch(error: Error & {exitCode?: number | undefined}): Promise<void> {
     errorHandler(error, this.config)
   }

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -1,13 +1,38 @@
 import {postrun as deprecationsHook} from './deprecations.js'
 import {reportAnalyticsEvent} from '../analytics.js'
 import {outputDebug} from '../../../public/node/output.js'
-import {Hook} from '@oclif/core'
+import BaseCommand from '../base-command.js'
+import * as metadata from '../../../public/node/metadata.js'
+import {Command, Hook} from '@oclif/core'
 
 // This hook is called after each successful command run. More info: https://oclif.io/docs/hooks
 export const hook: Hook.Postrun = async ({config, Command}) => {
+  await detectStopCommand(Command as unknown as typeof Command)
   await reportAnalyticsEvent({config})
   deprecationsHook(Command)
 
   const command = Command?.id?.replace(/:/g, ' ')
   outputDebug(`Completed command ${command}`)
+}
+
+/**
+ * Override the command name with the stop one for analytics purposes.
+ *
+ * @param commandClass - Oclif command class.
+ */
+async function detectStopCommand(commandClass: Command.Class | typeof BaseCommand): Promise<void> {
+  const currentTime = new Date().getTime()
+  if (commandClass && Object.prototype.hasOwnProperty.call(commandClass, 'analyticsStopCommand')) {
+    const stopCommand = (commandClass as typeof BaseCommand).analyticsStopCommand()
+    if (stopCommand) {
+      const {commandStartOptions} = metadata.getAllSensitiveMetadata()
+      await metadata.addSensitiveMetadata(() => ({
+        commandStartOptions: {
+          ...commandStartOptions!,
+          startTime: currentTime,
+          startCommand: stopCommand,
+        },
+      }))
+    }
+  }
 }

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -62,7 +62,7 @@ export async function exec(command: string, args: string[], options?: ExecOption
   options?.signal?.addEventListener('abort', () => {
     const pid = commandProcess.pid
     if (pid) {
-      outputDebug(`Abort signal received, killing process ${pid}`)
+      outputDebug(`Killing process ${options.cwd} ${command} ${args.join(' ')} ${pid}...`)
       aborted = true
       treeKill(pid, (err) => {
         if (err) outputDebug(`Failed to kill process ${pid}: ${err}`)

--- a/packages/cli-kit/src/public/node/tree-kill.ts
+++ b/packages/cli-kit/src/public/node/tree-kill.ts
@@ -1,0 +1,12 @@
+import {printEventsJson} from '../../private/node/demo-recorder.js'
+import originalTreeKill from 'tree-kill'
+
+/**
+ * Kills the process that calls the method and all its children.
+ *
+ * @param signal - Type of kill signal to be used.
+ */
+export function treeKill(signal: string): void {
+  printEventsJson()
+  originalTreeKill(process.pid, signal)
+}

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -44,9 +44,11 @@ import {Key as InkKey, RenderOptions} from 'ink'
 
 type PartialBy<T, TKey extends keyof T> = Omit<T, TKey> & Partial<Pick<T, TKey>>
 
-export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps, 'abortSignal'> {
+export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps, 'abortController'> {
   renderOptions?: RenderOptions
 }
+
+export {FooterContext} from '../../private/node/ui/components/ConcurrentOutput.js'
 
 /**
  * Renders output from concurrent processes to the terminal with {@link ConcurrentOutput}.
@@ -67,17 +69,17 @@ export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps
  *
  */
 export async function renderConcurrent({renderOptions, ...props}: RenderConcurrentOptions) {
-  const abortSignal = props.abortSignal ?? new AbortController().signal
+  const abortController = props.abortController ?? new AbortController()
 
   if (terminalSupportsRawMode(renderOptions?.stdin)) {
-    return render(<ConcurrentOutput {...props} abortSignal={abortSignal} />, {
+    return render(<ConcurrentOutput {...props} abortController={abortController} />, {
       ...renderOptions,
-      exitOnCtrlC: typeof props.onInput === 'undefined',
+      exitOnCtrlC: typeof props.onInput === 'undefined' && typeof props.onInputAsync === 'undefined',
     })
   } else {
     return Promise.all(
       props.processes.map(async (concurrentProcess) => {
-        await concurrentProcess.action(process.stdout, process.stderr, abortSignal)
+        await concurrentProcess.action(process.stdout, process.stderr, abortController.signal)
       }),
     )
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/internal-cli-foundations/issues/713

Implements solution agreed upon in this [doc discussing Dev Preview](https://docs.google.com/document/d/1pJiB-ZWFP7ieKTVAhmC6hEtI2ZuIoNGH7iFhqO-zhXA/edit?usp=sharing).

IMPORTANT!!!! This [PR](https://github.com/Shopify/cli/pull/2637) should be merged or rejected first. Other alternative is rebase this branch to the PR's one and then merge this PR

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

**Previously**, when running `shopify app dev`, if you have at least one `draftable` extension you are prompted to turn on Developer Preview in your store via the green underlined link to "Partner Dashboard".

<img width="1033" alt="Screenshot 2023-08-03 at 4 03 26 PM" src="https://github.com/Shopify/cli/assets/1966327/46caa535-69b7-457f-81e0-944eca1cca25">

**After this PR,** when running `shopify app dev`, it will automatically set dev preview to 'on' and render another shortcut in the footer that will allow you to toggle the developer preview mode with `d`. 

![](https://screenshot.click/03-17-f4bpx-jjumx.gif)



### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

- Clone Shopify/cli
- Checkout the `add-dev-preview-toggle` branch
- Create an app using `pnpm create-app`
- cd into app folder `cd ./name-of-app`
- Generate a draftable extension like admin-action or admin-block with `pnpm shopify app generate extension`
- cd into cli folder `cd ..`
- Run app dev command on newly created app with `pnpm shopify app dev --path ./name-of-app`
- Install app on your development store
- You should see the new toggle for turning off/on developer preview 🎉 

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
