### PR TITLE
Require flags in non-TTY environments

### DIFF
--- a/.changeset/chatty-ghosts-compare.md
+++ b/.changeset/chatty-ghosts-compare.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/app': minor
+---
+
+Validate deploy flags in non-TTY environments

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -9,6 +9,7 @@ import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.j
 import {validateMessage} from '../../validations/message.js'
 import metadata from '../../metadata.js'
 import {Flags} from '@oclif/core'
+import {FlagOutput} from '@oclif/core/lib/interfaces/parser.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
@@ -67,6 +68,14 @@ export default class Deploy extends Command {
       description: 'URL associated with the new app version.',
       env: 'SHOPIFY_FLAG_SOURCE_CONTROL_URL',
     }),
+  }
+
+  requiredInNonTTYFlags() {
+    return {
+      force: true as const,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'client-id': (flags: FlagOutput) => !flags.config && !flags['api-key'],
+    }
   }
 
   async run(): Promise<void> {

--- a/packages/cli-kit/src/public/node/base-command.test.ts
+++ b/packages/cli-kit/src/public/node/base-command.test.ts
@@ -296,7 +296,7 @@ describe('applying environments', async () => {
     await MockCommandWithRequiredFlagInNonTTY.run(['--path', tmpDir])
 
     // Then
-    expect(unstyled(testError?.message!)).toMatch('Flag not specified:\n\nnonTTYRequiredFlag')
+    expect(unstyled(testError!.message)).toMatch('Flag not specified:\n\nnonTTYRequiredFlag')
   })
 
   runTestInTmpDir(
@@ -309,7 +309,7 @@ describe('applying environments', async () => {
       await MockCommandWithRequiredFlagInNonTTY.run(['--path', tmpDir, '--nonTTYRequiredFlag', 'stringy'])
 
       // Then
-      expect(unstyled(testError?.message!)).toMatch('Flag not specified:\n\nnonTTYFunctionDependentRequiredFlag')
+      expect(unstyled(testError!.message)).toMatch('Flag not specified:\n\nnonTTYFunctionDependentRequiredFlag')
     },
   )
 

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -81,29 +81,8 @@ abstract class BaseCommand extends Command {
     let result = await super.parse<TFlags, TGlobalFlags, TArgs>(options, argv)
     result = await this.resultWithEnvironment<TFlags, TGlobalFlags, TArgs>(result, options, argv)
     await addFromParsedFlags(result.flags)
-    const toReturn = {...result, ...{argv: result.argv as string[]}}
-    if (result?.flags && !terminalSupportsRawMode()) {
-      for (const [name, implementer] of Object.entries(this.requiredInNonTTYFlags())) {
-        if (result.flags[name] === undefined) {
-          const errorMessage = outputContent`Flag not specified:
-
-${outputToken.cyan(name)}
-
-This flag is required in non-interactive terminal environments, such as a CI environment, or when piping input from another process.`
-          const tryMessage =
-            'To resolve this, specify the option in the command, or run the command in an interactive environment such as your local terminal.'
-          switch (implementer) {
-            case true:
-              throw new AbortError(errorMessage, tryMessage)
-            default:
-              if (implementer(result.flags)) {
-                throw new AbortError(errorMessage, tryMessage)
-              }
-          }
-        }
-      }
-    }
-    return toReturn
+    this.validateNonTTYFlags(result.flags)
+    return {...result, ...{argv: result.argv as string[]}}
   }
 
   protected requiredInNonTTYFlags(): {[name: string]: true | ((flags: FlagOutput) => boolean)} {
@@ -155,6 +134,30 @@ This flag is required in non-interactive terminal environments, such as a CI env
   protected environmentsFilename(): string | undefined {
     // To be re-implemented if needed
     return undefined
+  }
+
+  private validateNonTTYFlags(flags: FlagOutput): void {
+    if (terminalSupportsRawMode()) return
+
+    for (const [name, implementer] of Object.entries(this.requiredInNonTTYFlags())) {
+      if (flags[name] === undefined) {
+        const errorMessage = outputContent`Flag not specified:
+
+${outputToken.cyan(name)}
+
+This flag is required in non-interactive terminal environments, such as a CI environment, or when piping input from another process.`
+        const tryMessage =
+          'To resolve this, specify the option in the command, or run the command in an interactive environment such as your local terminal.'
+        switch (implementer) {
+          case true:
+            throw new AbortError(errorMessage, tryMessage)
+          default:
+            if (implementer(flags)) {
+              throw new AbortError(errorMessage, tryMessage)
+            }
+        }
+      }
+    }
   }
 }
 

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -81,17 +81,29 @@ abstract class BaseCommand extends Command {
     let result = await super.parse<TFlags, TGlobalFlags, TArgs>(options, argv)
     result = await this.resultWithEnvironment<TFlags, TGlobalFlags, TArgs>(result, options, argv)
     await addFromParsedFlags(result.flags)
-    this.validateNonTTYFlags(result.flags)
     return {...result, ...{argv: result.argv as string[]}}
-  }
-
-  protected requiredInNonTTYFlags(): {[name: string]: true | ((flags: FlagOutput) => boolean)} {
-    return {}
   }
 
   protected environmentsFilename(): string | undefined {
     // To be re-implemented if needed
     return undefined
+  }
+
+  protected failMissingNonTTYFlags(flags: FlagOutput, requiredFlags: string[]): void {
+    if (terminalSupportsRawMode()) return
+
+    requiredFlags.forEach((name: string) => {
+      if (!(name in flags)) {
+        throw new AbortError(
+          outputContent`Flag not specified:
+
+${outputToken.cyan(name)}
+
+This flag is required in non-interactive terminal environments, such as a CI environment, or when piping input from another process.`,
+          'To resolve this, specify the option in the command, or run the command in an interactive environment such as your local terminal.',
+        )
+      }
+    })
   }
 
   private async resultWithEnvironment<
@@ -134,30 +146,6 @@ abstract class BaseCommand extends Command {
     )
 
     return result
-  }
-
-  private validateNonTTYFlags(flags: FlagOutput): void {
-    if (terminalSupportsRawMode()) return
-
-    for (const [name, implementer] of Object.entries(this.requiredInNonTTYFlags())) {
-      if (flags[name] === undefined) {
-        const errorMessage = outputContent`Flag not specified:
-
-${outputToken.cyan(name)}
-
-This flag is required in non-interactive terminal environments, such as a CI environment, or when piping input from another process.`
-        const tryMessage =
-          'To resolve this, specify the option in the command, or run the command in an interactive environment such as your local terminal.'
-        switch (implementer) {
-          case true:
-            throw new AbortError(errorMessage, tryMessage)
-          default:
-            if (implementer(flags)) {
-              throw new AbortError(errorMessage, tryMessage)
-            }
-        }
-      }
-    }
   }
 }
 

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -89,7 +89,12 @@ abstract class BaseCommand extends Command {
     return {}
   }
 
-  protected async resultWithEnvironment<
+  protected environmentsFilename(): string | undefined {
+    // To be re-implemented if needed
+    return undefined
+  }
+
+  private async resultWithEnvironment<
     TFlags extends FlagOutput & {path?: string; verbose?: boolean},
     TGlobalFlags extends FlagOutput,
     TArgs extends ArgOutput,
@@ -129,11 +134,6 @@ abstract class BaseCommand extends Command {
     )
 
     return result
-  }
-
-  protected environmentsFilename(): string | undefined {
-    // To be re-implemented if needed
-    return undefined
   }
 
   private validateNonTTYFlags(flags: FlagOutput): void {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We [already throw an error](https://github.com/Shopify/cli/pull/1964) when prompting in non-TTY environments. However, the errors are thrown a bit too late. Sometimes it's hard to understand what's the required action, especially for something like `--force`. Or even something like `client-id` which ends up initially prompting for a choice of Partner org. So we want to allow the command itself to define required flags for non-TTY environments.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

We've added the ability to define a required flag set for non-TTY environments in the command, with the format:

```ts
{

  // Requires `as const` because only `true` not `false` is valid
  force: true as const,

  // A function taking the parsed flags as input, and returning a boolean.
  // In this case, `client-id` is only required to be passed if we haven't specified a config.
  'client-id': (flags: FlagOutput) => !flags.config

}
```

Before:

<img width="1150" alt="Screenshot 2023-08-07 at 20 44 03" src="https://github.com/Shopify/cli/assets/6288426/382008c7-9077-428d-8c41-11ea99376966">

After:

<img width="1170" alt="Screenshot 2023-08-07 at 20 44 48" src="https://github.com/Shopify/cli/assets/6288426/6428d7bc-13fe-41e2-8a82-64cd207ad4af">

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
```
$ echo | pnpm shopify app deploy --path /path/to/your/app
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
