### PR TITLE
Improve error message for invalid configuration files

### DIFF
--- a/.changeset/fuzzy-oranges-juggle.md
+++ b/.changeset/fuzzy-oranges-juggle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Improve error message for invalid configuration files

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -25,7 +25,7 @@ export async function selectAppPrompt(
     directory?: string
   },
 ): Promise<string> {
-  const tomls = await getTomls(apps, options?.directory)
+  const tomls = await getTomls(options?.directory)
 
   if (tomls) setCachedCommandInfo({tomls})
 

--- a/packages/app/src/cli/services/dev/update-extension.test.ts
+++ b/packages/app/src/cli/services/dev/update-extension.test.ts
@@ -10,7 +10,14 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 
 vi.mock('@shopify/cli-kit/node/api/partners')
 vi.mock('@shopify/cli-kit/node/output')
-vi.mock('../../models/app/loader.js')
+vi.mock('../../models/app/loader.js', async () => {
+  const actual: any = await vi.importActual('../../models/app/loader.js')
+  return {
+    ...actual,
+    parseConfigurationFile: vi.fn(),
+    parseConfigurationObject: vi.fn(),
+  }
+})
 
 const token = 'mock-token'
 const apiKey = 'mock-api-key'

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -3,7 +3,7 @@ import {
   ExtensionUpdateDraftMutation,
   ExtensionUpdateSchema,
 } from '../../api/graphql/update_draft.js'
-import {parseConfigurationFile, parseConfigurationObject} from '../../models/app/loader.js'
+import {loadConfigurationFile, parseConfigurationFile, parseConfigurationObject} from '../../models/app/loader.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {ExtensionsArraySchema, UnifiedSchema} from '../../models/extensions/schemas.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
@@ -11,7 +11,6 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {readFile} from '@shopify/cli-kit/node/fs'
 import {OutputMessage, outputInfo} from '@shopify/cli-kit/node/output'
 import {relativizePath} from '@shopify/cli-kit/node/path'
-import {decodeToml} from '@shopify/cli-kit/node/toml'
 import {Writable} from 'stream'
 
 interface UpdateExtensionDraftOptions {
@@ -86,8 +85,7 @@ export async function updateExtensionConfig({
     throw new AbortError(errorMessage)
   }
 
-  const fileContent = await readFile(extension.configurationPath)
-  let configObject = decodeToml(fileContent)
+  let configObject = await loadConfigurationFile(extension.configurationPath)
   const {extensions} = ExtensionsArraySchema.parse(configObject)
 
   if (extensions) {

--- a/packages/app/src/cli/utilities/app/config/getTomls.ts
+++ b/packages/app/src/cli/utilities/app/config/getTomls.ts
@@ -1,9 +1,8 @@
-import {OrganizationAppsResponse} from '../../../services/dev/fetch.js'
+import {loadConfigurationFile} from '../../../models/app/loader.js'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {decodeToml} from '@shopify/cli-kit/node/toml'
-import {readFileSync, readdirSync} from 'fs'
+import {readdirSync} from 'fs'
 
-export async function getTomls(apps: OrganizationAppsResponse, appDirectory?: string) {
+export async function getTomls(appDirectory?: string) {
   if (!appDirectory) {
     return {}
   }
@@ -11,18 +10,20 @@ export async function getTomls(apps: OrganizationAppsResponse, appDirectory?: st
   const regex = /^shopify\.app(\.[-\w]+)?\.toml$/
   const clientIds: {[key: string]: string} = {}
 
-  readdirSync(appDirectory).forEach((file) => {
-    if (regex.test(file)) {
-      const filePath = joinPath(appDirectory, file)
-      const fileContent = readFileSync(filePath, 'utf8')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const parsedToml: {[key: string]: any} = decodeToml(fileContent)
+  const files = readdirSync(appDirectory)
+  await Promise.all(
+    files.map(async (file) => {
+      if (regex.test(file)) {
+        const filePath = joinPath(appDirectory, file)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const parsedToml = (await loadConfigurationFile(filePath)) as {[key: string]: any}
 
-      if (parsedToml.client_id) {
-        clientIds[parsedToml.client_id] = file
+        if (parsedToml.client_id) {
+          clientIds[parsedToml.client_id] = file
+        }
       }
-    }
-  })
+    }),
+  )
 
   return clientIds
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1118,7 +1118,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
-      resolve: 1.22.2
+      resolve: 1.22.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2482,7 +2482,7 @@ packages:
   /@changesets/apply-release-plan@6.1.4:
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       '@changesets/config': 2.3.1
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 2.0.0
@@ -2500,7 +2500,7 @@ packages:
   /@changesets/assemble-release-plan@5.2.4:
     resolution: {integrity: sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.6
       '@changesets/types': 5.2.1
@@ -2584,7 +2584,7 @@ packages:
   /@changesets/get-release-plan@3.0.17:
     resolution: {integrity: sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       '@changesets/assemble-release-plan': 5.2.4
       '@changesets/config': 2.3.1
       '@changesets/pre': 1.0.14
@@ -2600,7 +2600,7 @@ packages:
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -2625,7 +2625,7 @@ packages:
   /@changesets/pre@1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -2635,7 +2635,7 @@ packages:
   /@changesets/read@0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.16
@@ -2656,7 +2656,7 @@ packages:
   /@changesets/write@0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -3397,7 +3397,7 @@ packages:
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -5701,7 +5701,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.6
       cosmiconfig: 6.0.0
-      resolve: 1.22.2
+      resolve: 1.22.3
     dev: true
 
   /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.22.9):
@@ -6426,7 +6426,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   /concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -6938,7 +6938,7 @@ packages:
   /dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       csstype: 3.1.2
     dev: false
 
@@ -7238,7 +7238,7 @@ packages:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.12.1
-      resolve: 1.22.2
+      resolve: 1.22.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7412,7 +7412,7 @@ packages:
       eslint-utils: 2.1.0
       ignore: 5.2.4
       minimatch: 3.1.2
-      resolve: 1.22.2
+      resolve: 1.22.3
       semver: 6.3.1
 
   /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.46.0)(prettier@2.8.8):
@@ -10185,7 +10185,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.2
+      resolve: 1.22.3
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true
@@ -11484,7 +11484,7 @@ packages:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
     engines: {node: '>= 0.10'}
     dependencies:
-      resolve: 1.22.2
+      resolve: 1.22.3
 
   /recrawl-sync@2.2.3:
     resolution: {integrity: sha512-vSaTR9t+cpxlskkdUFrsEpnf67kSmPk66yAGT1fZPrDudxQjoMzPgQhSMImQ0pAw5k0NPirefQfhopSjhdUtpQ==}
@@ -11657,6 +11657,7 @@ packages:
       is-core-module: 2.12.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: false
 
   /resolve@1.22.3:
     resolution: {integrity: sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==}
@@ -13803,7 +13804,7 @@ packages:
     resolution: {integrity: sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/runtime': 7.21.5
+      '@babel/runtime': 7.22.6
       '@types/lodash': 4.14.195
       lodash: 4.17.21
       lodash-es: 4.17.21
@@ -13847,6 +13848,7 @@ packages:
     resolution: {directory: packages/eslint-plugin-cli, type: directory}
     id: file:packages/eslint-plugin-cli
     name: '@shopify/eslint-plugin-cli'
+    version: 3.46.0
     peerDependencies:
       eslint: ^8.46.0
     dependencies:


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2623

### WHAT is this pull request doing?

Improve the error message when a configuration file is invalid, showing the file path and exact problem.

**Before**:
<img width="896" alt="before2" src="https://github.com/Shopify/cli/assets/14979109/d95b9660-5cf0-41b1-b4c2-c573b18784e4">

**After**:
<img width="898" alt="after2" src="https://github.com/Shopify/cli/assets/14979109/7023e9a4-ddd4-403c-a654-c35b00c90f04">

### How to test your changes?

- Create an app with an extension
- Put a wrong value (like `asdf`) for any field in shopify.extension.toml
- `p shopify app dev`
- Revert the change in shopify.extension.toml
- Put a wrong value (like `asdf`) for any field in shopify.app.toml
- `p shopify app dev --reset` and choose to use an existing app

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
