### PR TITLE
Reuse getAppScopesArray function while selecting an app

### DIFF
--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -159,7 +159,7 @@ const FETCH_RESPONSE = {
 const DEFAULT_SELECT_APP_OPTIONS = {
   directory: undefined,
   isLaunchable: true,
-  scopes: '',
+  scopesArray: [],
 }
 
 const options = (app: AppInterface): DeployContextOptions => {

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -17,7 +17,13 @@ import {DeploymentMode, resolveDeploymentMode} from './deploy/mode.js'
 import link from './app/config/link.js'
 import {writeAppConfigurationFile} from './app/write-app-configuration-file.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
-import {AppConfiguration, AppInterface, isCurrentAppSchema, appIsLaunchable} from '../models/app/app.js'
+import {
+  AppConfiguration,
+  AppInterface,
+  isCurrentAppSchema,
+  appIsLaunchable,
+  getAppScopesArray,
+} from '../models/app/app.js'
 import {Identifiers, UuidOnlyIdentifiers, updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
 import metadata from '../metadata.js'
@@ -430,10 +436,12 @@ export async function fetchOrCreateOrganizationApp(
   const orgId = await selectOrg(token)
   const {organization, apps} = await fetchOrgsAppsAndStores(orgId, token)
   const isLaunchable = appIsLaunchable(app)
-  const scopes = isCurrentAppSchema(app.configuration)
-    ? app.configuration?.access_scopes?.scopes
-    : app.configuration?.scopes
-  const partnersApp = await selectOrCreateApp(app.name, apps, organization, token, {isLaunchable, scopes, directory})
+  const scopesArray = getAppScopesArray(app.configuration)
+  const partnersApp = await selectOrCreateApp(app.name, apps, organization, token, {
+    isLaunchable,
+    scopesArray,
+    directory,
+  })
   return partnersApp
 }
 

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -71,7 +71,7 @@ describe('createApp', () => {
     }
 
     // When
-    const got = await createApp(ORG2, localApp.name, 'token', {scopes: 'write_products', isLaunchable: true})
+    const got = await createApp(ORG2, localApp.name, 'token', {scopesArray: ['write_products'], isLaunchable: true})
     expect(got).toEqual(APP1)
 
     // Then

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -23,7 +23,7 @@ export async function selectOrCreateApp(
   token: string,
   options?: {
     isLaunchable?: boolean
-    scopes?: string
+    scopesArray?: string[]
     directory?: string
   },
 ): Promise<OrganizationApp> {
@@ -51,14 +51,24 @@ export async function selectOrCreateApp(
 // read more here: https://vault.shopify.io/gsd/projects/31406
 const MAGIC_URL = 'https://shopify.dev/apps/default-app-home'
 const MAGIC_REDIRECT_URL = 'https://shopify.dev/apps/default-app-home/api/auth'
-const getAppVars = (org: Organization, name: string, isLaunchable = true, scopes: string) => {
+
+interface AppVars {
+  org: number
+  title: string
+  appUrl: string
+  redir: string[]
+  requestedAccessScopes: string[]
+  type: string
+}
+
+function getAppVars(org: Organization, name: string, isLaunchable = true, scopesArray?: string[]): AppVars {
   if (isLaunchable) {
     return {
       org: parseInt(org.id, 10),
       title: `${name}`,
       appUrl: 'https://example.com',
       redir: ['https://example.com/api/auth'],
-      requestedAccessScopes: scopes?.length ? scopes.split(',') : [],
+      requestedAccessScopes: scopesArray ?? [],
       type: 'undecided',
     }
   } else {
@@ -79,13 +89,13 @@ export async function createApp(
   token: string,
   options?: {
     isLaunchable?: boolean
-    scopes?: string
+    scopesArray?: string[]
     directory?: string
   },
 ): Promise<OrganizationApp> {
   const name = await appNamePrompt(appName)
 
-  const variables = getAppVars(org, name, options?.isLaunchable, options?.scopes ?? '')
+  const variables = getAppVars(org, name, options?.isLaunchable, options?.scopesArray)
 
   const query = CreateAppQuery
   const result: CreateAppQuerySchema = await partnersRequest(query, token, variables)


### PR DESCRIPTION
In this way we also fix a bug in handling scopes with whitespaces.

### WHY are these changes introduced?

Currently trying to create a new app with these scopes `write_products, write_discounts` fails.

### WHAT is this pull request doing?

Reuse `getAppScopesArray` so we can take advantage of the trimming logic.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
