### PR TITLE
Move configurationPath to be a property of the Configuration object

### DIFF
--- a/packages/app/src/cli/commands/app/config/push.ts
+++ b/packages/app/src/cli/commands/app/config/push.ts
@@ -22,11 +22,11 @@ export default class ConfigPush extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(ConfigPush)
-    const {configuration, configurationPath} = await loadAppConfiguration({
+    const {configuration} = await loadAppConfiguration({
       configName: flags.config,
       directory: flags.path,
     })
 
-    await pushConfig({configuration, configurationPath, force: flags.force})
+    await pushConfig({configuration, force: flags.force})
   }
 }

--- a/packages/app/src/cli/commands/app/env/pull.ts
+++ b/packages/app/src/cli/commands/app/env/pull.ts
@@ -31,7 +31,7 @@ export default class EnvPull extends Command {
       configName: flags.config,
       mode: 'report',
     })
-    const envFile = joinPath(app.directory, flags['env-file'] ?? getDotEnvFileName(app.configurationPath))
+    const envFile = joinPath(app.directory, flags['env-file'] ?? getDotEnvFileName(app.configuration.path))
     outputInfo(await pullEnv(app, {envFile}))
   }
 }

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -10,6 +10,7 @@ import productSubscriptionUIExtension from '../templates/ui-specifications/produ
 import webPixelUIExtension from '../templates/ui-specifications/web_pixel_extension.js'
 
 export const DEFAULT_CONFIG = {
+  path: '/tmp/project/shopify.app.toml',
   application_url: 'https://myapp.com',
   client_id: '12345',
   name: 'my app',
@@ -25,7 +26,7 @@ export const DEFAULT_CONFIG = {
 export function testApp(app: Partial<AppInterface> = {}, schemaType: 'current' | 'legacy' = 'legacy'): AppInterface {
   const getConfig = () => {
     if (schemaType === 'legacy') {
-      return {scopes: '', extension_directories: []}
+      return {scopes: '', extension_directories: [], path: ''}
     } else {
       return DEFAULT_CONFIG
     }
@@ -37,7 +38,6 @@ export function testApp(app: Partial<AppInterface> = {}, schemaType: 'current' |
     app.directory ?? '/tmp/project',
     app.packageManager ?? 'yarn',
     app.configuration ?? getConfig(),
-    app.configurationPath ?? '/tmp/project/shopify.app.toml',
     app.nodeDependencies ?? {},
     app.webs ?? [
       {
@@ -69,6 +69,7 @@ interface TestAppWithConfigOptions {
 
 export function testAppWithLegacyConfig({app = {}, config = {}}: TestAppWithConfigOptions): AppInterface {
   const configuration: AppConfiguration = {
+    path: '',
     scopes: '',
     name: 'name',
     extension_directories: [],

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -8,6 +8,7 @@ import {FunctionConfigType} from '../extensions/specifications/function.js'
 import {OrganizationApp} from '../organization.js'
 import productSubscriptionUIExtension from '../templates/ui-specifications/product_subscription.js'
 import webPixelUIExtension from '../templates/ui-specifications/web_pixel_extension.js'
+import {BaseConfigType} from '../extensions/schemas.js'
 
 export const DEFAULT_CONFIG = {
   path: '/tmp/project/shopify.app.toml',
@@ -102,7 +103,11 @@ export function testOrganizationApp(app: Partial<OrganizationApp> = {}): Organiz
   return {...defaultApp, ...app}
 }
 
-export async function testUIExtension(uiExtension: Partial<ExtensionInstance> = {}): Promise<ExtensionInstance> {
+export async function testUIExtension(
+  uiExtension: Omit<Partial<ExtensionInstance>, 'configuration'> & {
+    configuration?: Partial<BaseConfigType> & {path?: string}
+  } = {},
+): Promise<ExtensionInstance> {
   const directory = uiExtension?.directory ?? '/tmp/project/extensions/test-ui-extension'
 
   const configuration = uiExtension?.configuration ?? {
@@ -115,14 +120,14 @@ export async function testUIExtension(uiExtension: Partial<ExtensionInstance> = 
       api_access: false,
     },
   }
-  const configurationPath = uiExtension?.configurationPath ?? `${directory}/shopify.ui.extension.toml`
+  const configurationPath = uiExtension?.configuration?.path ?? `${directory}/shopify.ui.extension.toml`
   const entryPath = uiExtension?.entrySourceFilePath ?? `${directory}/src/index.js`
 
   const allSpecs = await loadFSExtensionsSpecifications()
   const specification = allSpecs.find((spec) => spec.identifier === configuration.type)!
 
   const extension = new ExtensionInstance({
-    configuration,
+    configuration: configuration as BaseConfigType,
     configurationPath,
     entryPath,
     directory,

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -1,5 +1,6 @@
 import {
   CurrentAppConfiguration,
+  LegacyAppConfiguration,
   getAppScopes,
   getAppScopesArray,
   getUIExtensionRendererVersion,
@@ -14,6 +15,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 const DEFAULT_APP = testApp()
 
 const CORRECT_CURRENT_APP_SCHEMA: CurrentAppConfiguration = {
+  path: '',
   name: 'app 1',
   client_id: '12345',
   webhooks: {
@@ -46,7 +48,8 @@ const CORRECT_CURRENT_APP_SCHEMA: CurrentAppConfiguration = {
   },
 }
 
-const CORRECT_LEGACY_APP_SCHEMA = {
+const CORRECT_LEGACY_APP_SCHEMA: LegacyAppConfiguration = {
+  path: '',
   extension_directories: [],
   web_directories: [],
   scopes: 'write_products',
@@ -175,7 +178,7 @@ describe('getUIExtensionRendererVersion', () => {
 
 describe('getAppScopes', () => {
   test('returns the scopes key when schema is legacy', () => {
-    const config = {scopes: 'read_themes,read_products'}
+    const config = {path: '', scopes: 'read_themes,read_products'}
     expect(getAppScopes(config)).toEqual('read_themes,read_products')
   })
 
@@ -187,7 +190,7 @@ describe('getAppScopes', () => {
 
 describe('getAppScopesArray', () => {
   test('returns the scopes key when schema is legacy', () => {
-    const config = {scopes: 'read_themes, read_order ,write_products'}
+    const config = {path: '', scopes: 'read_themes, read_order ,write_products'}
     expect(getAppScopesArray(config)).toEqual(['read_themes', 'read_order', 'write_products'])
   })
 

--- a/packages/app/src/cli/models/app/identifiers.test.ts
+++ b/packages/app/src/cli/models/app/identifiers.test.ts
@@ -1,5 +1,5 @@
 import {updateAppIdentifiers, getAppIdentifiers} from './identifiers.js'
-import {testApp, testUIExtension} from './app.test-data.js'
+import {testApp, testAppWithConfig, testUIExtension} from './app.test-data.js'
 import {describe, expect, test} from 'vitest'
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env'
 import {fileExists, inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
@@ -40,10 +40,14 @@ describe('updateAppIdentifiers', () => {
     await inTemporaryDirectory(async (tmpDir: string) => {
       // Given
       const uiExtension = await testUIExtension()
-      const app = testApp({
-        directory: tmpDir,
-        allExtensions: [uiExtension],
-        configurationPath: joinPath(tmpDir, 'shopify.app.staging.toml'),
+      const app = testAppWithConfig({
+        app: {
+          directory: tmpDir,
+          allExtensions: [uiExtension],
+        },
+        config: {
+          path: joinPath(tmpDir, 'shopify.app.staging.toml'),
+        },
       })
 
       // When

--- a/packages/app/src/cli/models/app/identifiers.ts
+++ b/packages/app/src/cli/models/app/identifiers.ts
@@ -45,7 +45,7 @@ export async function updateAppIdentifiers(
 
   if (!dotenvFile) {
     dotenvFile = {
-      path: joinPath(app.directory, getDotEnvFileName(app.configurationPath)),
+      path: joinPath(app.directory, getDotEnvFileName(app.configuration.path)),
       variables: {},
     }
   }

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2091,7 +2091,9 @@ describe('parseConfigurationObject', () => {
     ]
     const expectedFormatted = outputContent`Fix a schema error in tmp:\n${JSON.stringify(errorObject, null, 2)}`
     const abortOrReport = vi.fn()
-    await parseConfigurationObject(AppSchema, 'tmp', configurationObject, abortOrReport)
+
+    const {path, ...toParse} = configurationObject
+    await parseConfigurationObject(AppSchema, 'tmp', toParse, abortOrReport)
 
     expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
   })

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -406,7 +406,7 @@ class AppLoader {
         this.abortOrReport(
           outputContent`Duplicated handle "${handle}" in extensions ${result}. Handle needs to be unique per extension.`,
           undefined,
-          extension.configurationPath,
+          extension.configuration.path,
         )
       } else if (extension.handle) {
         handles.add(extension.handle)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -97,7 +97,7 @@ export async function parseConfigurationFile<TSchema extends zod.ZodType>(
     throw new AbortError(errorMessage)
   },
   decode: (input: string) => object = decodeToml,
-): Promise<zod.TypeOf<TSchema>> {
+): Promise<zod.TypeOf<TSchema> & {path: string}> {
   const fallbackOutput = {} as zod.TypeOf<TSchema>
 
   const configurationObject = await loadConfigurationFile(filepath, abortOrReport, decode)
@@ -112,7 +112,7 @@ export async function parseConfigurationObject<TSchema extends zod.ZodType>(
   filepath: string,
   configurationObject: unknown,
   abortOrReport: AbortOrReport,
-): Promise<zod.TypeOf<TSchema>> {
+): Promise<zod.TypeOf<TSchema> & {path: string}> {
   const fallbackOutput = {} as zod.TypeOf<TSchema>
 
   const parseResult = schema.safeParse(configurationObject)
@@ -124,7 +124,7 @@ export async function parseConfigurationObject<TSchema extends zod.ZodType>(
       filepath,
     )
   }
-  return parseResult.data
+  return {...parseResult.data, path: filepath}
 }
 
 export function findSpecificationForType(specifications: ExtensionSpecification[], type: string) {
@@ -218,13 +218,8 @@ class AppLoader {
       directory: this.directory,
       configName: this.configName,
     })
-    const {
-      directory: appDirectory,
-      configurationPath,
-      configuration,
-      configurationLoadResultMetadata,
-    } = await configurationLoader.loaded()
-    const dotenv = await loadDotEnv(appDirectory, configurationPath)
+    const {directory: appDirectory, configuration, configurationLoadResultMetadata} = await configurationLoader.loaded()
+    const dotenv = await loadDotEnv(appDirectory, configuration.path)
 
     const {allExtensions, usedCustomLayout} = await this.loadExtensions(
       appDirectory,
@@ -247,7 +242,6 @@ class AppLoader {
       appDirectory,
       packageManager,
       configuration,
-      configurationPath,
       nodeDependencies,
       webs,
       allExtensions,
@@ -507,7 +501,6 @@ type ConfigurationLoadResultMetadata = {
 class AppConfigurationLoader {
   private directory: string
   private configName?: string
-  private configurationPath = ''
 
   constructor({directory, configName}: AppConfigurationLoaderConstructorArgs) {
     this.directory = directory
@@ -571,7 +564,7 @@ class AppConfigurationLoader {
       }
     }
 
-    return {directory: appDirectory, configuration, configurationPath, configurationLoadResultMetadata}
+    return {directory: appDirectory, configuration, configurationLoadResultMetadata}
   }
 
   // Sometimes we want to run app commands from a nested folder (for example within an extension). So we need to

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -36,8 +36,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   localIdentifier: string
   idEnvironmentVariableName: string
   directory: string
-  configuration: TConfiguration
-  configurationPath: string
+  configuration: TConfiguration & {path: string}
   outputPath: string
   handle: string
   specification: ExtensionSpecification
@@ -113,8 +112,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     directory: string
     specification: ExtensionSpecification
   }) {
-    this.configuration = options.configuration
-    this.configurationPath = options.configurationPath
+    this.configuration = {...options.configuration, path: options.configurationPath}
     this.entrySourceFilePath = options.entryPath ?? ''
     this.directory = options.directory
     this.specification = options.specification
@@ -159,7 +157,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
   validate() {
     if (!this.specification.validate) return Promise.resolve(ok(undefined))
-    return this.specification.validate(this.configuration, this.directory, this.configurationPath)
+    return this.specification.validate(this.configuration, this.directory)
   }
 
   preDeployValidation(): Promise<void> {

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -36,7 +36,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
     apiKey: string,
     moduleId?: string,
   ) => Promise<{[key: string]: unknown} | undefined>
-  validate?: (config: TConfiguration, directory: string, configurationPath: string) => Promise<Result<unknown, string>>
+  validate?: (config: TConfiguration & {path: string}, directory: string) => Promise<Result<unknown, string>>
   preDeployValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   buildValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   hasExtensionPointTarget?(config: TConfiguration, target: string): boolean

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -152,7 +152,7 @@ describe('ui_extension', async () => {
           err(`Couldn't find ${notFoundPath}
 Please check the module path for EXTENSION::POINT::A
 
-Please check the configuration in ${uiExtension.configurationPath}`),
+Please check the configuration in ${uiExtension.configuration.path}`),
         )
       })
     })
@@ -185,7 +185,7 @@ Please check the configuration in ${uiExtension.configurationPath}`),
           err(`Duplicate targets found: EXTENSION::POINT::A
 Extension point targets must be unique
 
-Please check the configuration in ${uiExtension.configurationPath}`),
+Please check the configuration in ${uiExtension.configuration.path}`),
         )
       })
     })

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -43,8 +43,8 @@ const spec = createExtensionSpecification({
       }) !== undefined
     return needsCart ? [...basic, 'cart_url'] : basic
   },
-  validate: async (config, directory, configPath) => {
-    return validateUIExtensionPointConfig(directory, config.extension_points, configPath)
+  validate: async (config, directory) => {
+    return validateUIExtensionPointConfig(directory, config.extension_points, config.path)
   },
   deployConfig: async (config, directory) => {
     return {

--- a/packages/app/src/cli/prompts/config.test.ts
+++ b/packages/app/src/cli/prompts/config.test.ts
@@ -177,7 +177,6 @@ describe('confirmPushChanges', () => {
     // Given
     const options: PushOptions = {
       configuration: testAppWithConfig().configuration,
-      configurationPath: 'shopify.app.toml',
       force: true,
     }
     const app = testOrganizationApp() as App
@@ -198,6 +197,7 @@ describe('confirmPushChanges', () => {
       vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
       const configuration = mergeAppConfiguration(
+        configurationPath,
         testApp({}, 'current'),
         app as OrganizationApp,
       ) as CurrentAppConfiguration
@@ -208,7 +208,6 @@ describe('confirmPushChanges', () => {
 
       const options: PushOptions = {
         configuration,
-        configurationPath,
         force: false,
       }
 
@@ -249,10 +248,9 @@ api_version = "unstable"
       // Given
       const configurationPath = joinPath(tmpDir, 'shopify.app.toml')
       const app = testOrganizationApp() as App
-      const configuration = mergeAppConfiguration(testApp(), app as OrganizationApp)
+      const configuration = mergeAppConfiguration(configurationPath, testApp(), app as OrganizationApp)
       const options: PushOptions = {
         configuration,
-        configurationPath,
         force: false,
       }
       vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
@@ -293,7 +291,6 @@ api_version = "unstable"
       const configuration = decodeToml(updatedContent) as AppConfiguration
       const options: PushOptions = {
         configuration,
-        configurationPath,
         force: false,
       }
       // When
@@ -334,7 +331,6 @@ api_version = "unstable"
       const configuration = decodeToml(updatedContent) as AppConfiguration
       const options: PushOptions = {
         configuration,
-        configurationPath,
         force: false,
       }
 
@@ -352,13 +348,12 @@ api_version = "unstable"
       // Given
       const configurationPath = joinPath(tmpDir, 'shopify.app.toml')
       const app = testOrganizationApp() as App
-      const configuration = mergeAppConfiguration(testApp(), app as OrganizationApp)
+      const configuration = mergeAppConfiguration(configurationPath, testApp(), app as OrganizationApp)
       const options: PushOptions = {
         configuration: {
           ...configuration,
           build: {automatically_update_urls_on_dev: true, dev_store_url: 'shop1.myshopify.com'},
         },
-        configurationPath,
         force: false,
       }
       vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)

--- a/packages/app/src/cli/prompts/config.test.ts
+++ b/packages/app/src/cli/prompts/config.test.ts
@@ -1,6 +1,6 @@
 import {confirmPushChanges, selectConfigFile, selectConfigName, validate} from './config.js'
 import {PushOptions} from '../services/app/config/push.js'
-import {testOrganizationApp, testAppWithConfig, testApp} from '../models/app/app.test-data.js'
+import {testOrganizationApp, testAppWithConfig, DEFAULT_CONFIG} from '../models/app/app.test-data.js'
 import {App} from '../api/graphql/get_config.js'
 import {mergeAppConfiguration} from '../services/app/config/link.js'
 import {OrganizationApp} from '../models/organization.js'
@@ -197,8 +197,7 @@ describe('confirmPushChanges', () => {
       vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
       const configuration = mergeAppConfiguration(
-        configurationPath,
-        testApp({}, 'current'),
+        {...DEFAULT_CONFIG, path: configurationPath},
         app as OrganizationApp,
       ) as CurrentAppConfiguration
 
@@ -248,7 +247,7 @@ api_version = "unstable"
       // Given
       const configurationPath = joinPath(tmpDir, 'shopify.app.toml')
       const app = testOrganizationApp() as App
-      const configuration = mergeAppConfiguration(configurationPath, testApp(), app as OrganizationApp)
+      const configuration = mergeAppConfiguration({...DEFAULT_CONFIG, path: configurationPath}, app as OrganizationApp)
       const options: PushOptions = {
         configuration,
         force: false,
@@ -348,7 +347,7 @@ api_version = "unstable"
       // Given
       const configurationPath = joinPath(tmpDir, 'shopify.app.toml')
       const app = testOrganizationApp() as App
-      const configuration = mergeAppConfiguration(configurationPath, testApp(), app as OrganizationApp)
+      const configuration = mergeAppConfiguration({...DEFAULT_CONFIG, path: configurationPath}, app as OrganizationApp)
       const options: PushOptions = {
         configuration: {
           ...configuration,

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -77,7 +77,11 @@ export async function confirmPushChanges(options: PushOptions, app: App) {
   if (options.force) return true
 
   const configuration = options.configuration as CurrentAppConfiguration
-  const remoteConfiguration = mergeAppConfiguration({configuration} as AppInterface, app as OrganizationApp)
+  const remoteConfiguration = mergeAppConfiguration(
+    configuration.path,
+    {configuration} as AppInterface,
+    app as OrganizationApp,
+  )
 
   if (configuration.access_scopes?.scopes)
     configuration.access_scopes.scopes = getAppScopesArray(configuration).join(',')

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import {PushOptions} from '../services/app/config/push.js'
-import {AppInterface, AppSchema, CurrentAppConfiguration, getAppScopesArray} from '../models/app/app.js'
+import {AppSchema, CurrentAppConfiguration, getAppScopesArray} from '../models/app/app.js'
 import {mergeAppConfiguration} from '../services/app/config/link.js'
 import {OrganizationApp} from '../models/organization.js'
 import {App} from '../api/graphql/get_config.js'
@@ -77,11 +77,7 @@ export async function confirmPushChanges(options: PushOptions, app: App) {
   if (options.force) return true
 
   const configuration = options.configuration as CurrentAppConfiguration
-  const remoteConfiguration = mergeAppConfiguration(
-    configuration.path,
-    {configuration} as AppInterface,
-    app as OrganizationApp,
-  )
+  const remoteConfiguration = mergeAppConfiguration(configuration, app as OrganizationApp)
 
   if (configuration.access_scopes?.scopes)
     configuration.access_scopes.scopes = getAppScopesArray(configuration).join(',')

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -123,8 +123,8 @@ embedded = false
       }
       vi.mocked(loadApp).mockResolvedValue(
         testApp({
-          configurationPath: 'shopify.app.development.toml',
           configuration: {
+            path: 'shopify.app.development.toml',
             name: 'my app',
             client_id: '12345',
             scopes: 'write_products',
@@ -348,8 +348,8 @@ embedded = false
       }
       vi.mocked(loadApp).mockResolvedValue(
         testApp({
-          configurationPath: 'shopify.app.foo.toml',
           configuration: {
+            path: 'shopify.app.foo.toml',
             name: 'my app',
             client_id: '12345',
             scopes: 'write_products',

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -34,7 +34,7 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
   const configFilePath = joinPath(options.directory, configFileName)
 
-  const configuration = mergeAppConfiguration(localApp, remoteApp)
+  const configuration = mergeAppConfiguration(configFilePath, localApp, remoteApp)
 
   await writeAppConfigurationFile(configFilePath, configuration)
 
@@ -116,8 +116,13 @@ async function loadConfigurationFileName(
   return `shopify.app.${configName}.toml`
 }
 
-export function mergeAppConfiguration(localApp: AppInterface, remoteApp: OrganizationApp): AppConfiguration {
+export function mergeAppConfiguration(
+  configPath: string,
+  localApp: AppInterface,
+  remoteApp: OrganizationApp,
+): AppConfiguration {
   const configuration: AppConfiguration = {
+    path: configPath,
     client_id: remoteApp.apiKey,
     name: remoteApp.title,
     application_url: remoteApp.applicationUrl.replace(/\/$/, ''),

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -36,7 +36,7 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
 
   const configuration = mergeAppConfiguration(configFilePath, localApp, remoteApp)
 
-  await writeAppConfigurationFile(configFilePath, configuration)
+  await writeAppConfigurationFile(configuration)
 
   await saveCurrentConfig({configFileName, directory: options.directory})
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -31,10 +31,11 @@ export interface LinkOptions {
 export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<AppConfiguration> {
   const localApp = await loadAppConfigFromDefaultToml(options)
   const remoteApp = await loadRemoteApp(localApp, options.apiKey, options.directory)
+
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
   const configFilePath = joinPath(options.directory, configFileName)
 
-  const configuration = mergeAppConfiguration(configFilePath, localApp, remoteApp)
+  const configuration = mergeAppConfiguration({...localApp.configuration, path: configFilePath}, remoteApp)
 
   await writeAppConfigurationFile(configuration)
 
@@ -117,12 +118,11 @@ async function loadConfigurationFileName(
 }
 
 export function mergeAppConfiguration(
-  configPath: string,
-  localApp: AppInterface,
+  appConfiguration: AppConfiguration,
   remoteApp: OrganizationApp,
 ): AppConfiguration {
-  const configuration: AppConfiguration = {
-    path: configPath,
+  const result: AppConfiguration = {
+    path: appConfiguration.path,
     client_id: remoteApp.apiKey,
     name: remoteApp.title,
     application_url: remoteApp.applicationUrl.replace(/\/$/, ''),
@@ -144,7 +144,7 @@ export function mergeAppConfiguration(
     remoteApp.gdprWebhooks?.shopDeletionUrl
 
   if (hasAnyPrivacyWebhook) {
-    configuration.webhooks.privacy_compliance = {
+    result.webhooks.privacy_compliance = {
       customer_data_request_url: remoteApp.gdprWebhooks?.customerDataRequestUrl,
       customer_deletion_url: remoteApp.gdprWebhooks?.customerDeletionUrl,
       shop_deletion_url: remoteApp.gdprWebhooks?.shopDeletionUrl,
@@ -152,7 +152,7 @@ export function mergeAppConfiguration(
   }
 
   if (remoteApp.appProxy?.url) {
-    configuration.app_proxy = {
+    result.app_proxy = {
       url: remoteApp.appProxy.url,
       subpath: remoteApp.appProxy.subPath,
       prefix: remoteApp.appProxy.subPathPrefix,
@@ -160,37 +160,37 @@ export function mergeAppConfiguration(
   }
 
   if (remoteApp.preferencesUrl) {
-    configuration.app_preferences = {url: remoteApp.preferencesUrl}
+    result.app_preferences = {url: remoteApp.preferencesUrl}
   }
 
-  configuration.access_scopes = getAccessScopes(localApp, remoteApp)
+  result.access_scopes = getAccessScopes(appConfiguration, remoteApp)
 
-  if (localApp.configuration?.extension_directories) {
-    configuration.extension_directories = localApp.configuration.extension_directories
+  if (appConfiguration.extension_directories) {
+    result.extension_directories = appConfiguration.extension_directories
   }
 
-  if (localApp.configuration?.web_directories) {
-    configuration.web_directories = localApp.configuration.web_directories
+  if (appConfiguration.web_directories) {
+    result.web_directories = appConfiguration.web_directories
   }
 
-  return configuration
+  return result
 }
 
-const getAccessScopes = (localApp: AppInterface, remoteApp: OrganizationApp) => {
+const getAccessScopes = (appConfiguration: AppConfiguration, remoteApp: OrganizationApp) => {
   // if we have upstream scopes, use them
   if (remoteApp.requestedAccessScopes) {
     return {
       scopes: remoteApp.requestedAccessScopes.join(','),
     }
     // if we have scopes locally and not upstream, preserve them but don't push them upstream (legacy is true)
-  } else if (isLegacyAppSchema(localApp.configuration) && localApp.configuration.scopes) {
+  } else if (isLegacyAppSchema(appConfiguration) && appConfiguration.scopes) {
     return {
-      scopes: localApp.configuration.scopes,
+      scopes: appConfiguration.scopes,
       use_legacy_install_flow: true,
     }
-  } else if (isCurrentAppSchema(localApp.configuration) && localApp.configuration.access_scopes?.scopes) {
+  } else if (isCurrentAppSchema(appConfiguration) && appConfiguration.access_scopes?.scopes) {
     return {
-      scopes: localApp.configuration.access_scopes.scopes,
+      scopes: appConfiguration.access_scopes.scopes,
       use_legacy_install_flow: true,
     }
     // if we can't find scopes or have to fall back, omit setting a scope and set legacy to true

--- a/packages/app/src/cli/services/app/config/push.test.ts
+++ b/packages/app/src/cli/services/app/config/push.test.ts
@@ -31,7 +31,6 @@ describe('pushConfig', () => {
     const app = testApp({}, 'current')
     const options: PushOptions = {
       configuration: app.configuration,
-      configurationPath: app.configurationPath,
       force: true,
     }
 
@@ -82,7 +81,6 @@ describe('pushConfig', () => {
     app.configuration = {...app.configuration, access_scopes: {scopes: 'write_products', use_legacy_install_flow: true}}
     const options: PushOptions = {
       configuration: app.configuration,
-      configurationPath: app.configurationPath,
       force: true,
     }
 
@@ -127,7 +125,6 @@ describe('pushConfig', () => {
     app.configuration = {...app.configuration, access_scopes: {scopes: 'write_products', use_legacy_install_flow: true}}
     const options: PushOptions = {
       configuration: app.configuration,
-      configurationPath: app.configurationPath,
       force: true,
     }
 
@@ -174,7 +171,6 @@ describe('pushConfig', () => {
 
     const options: PushOptions = {
       configuration: app.configuration,
-      configurationPath: app.configurationPath,
       force: true,
     }
 
@@ -218,7 +214,6 @@ describe('pushConfig', () => {
 
     const options: PushOptions = {
       configuration: app.configuration,
-      configurationPath: app.configurationPath,
       force: true,
     }
 
@@ -260,8 +255,8 @@ describe('pushConfig', () => {
 
   test('returns error when client id cannot be found', async () => {
     // Given
-    const {configuration, configurationPath} = testApp({}, 'current')
-    const options: PushOptions = {configuration, configurationPath, force: true}
+    const {configuration} = testApp({}, 'current')
+    const options: PushOptions = {configuration, force: true}
 
     vi.mocked(partnersRequest).mockResolvedValue({app: null})
 
@@ -276,7 +271,6 @@ describe('pushConfig', () => {
     const app = testApp({}, 'current')
     const options: PushOptions = {
       configuration: app.configuration,
-      configurationPath: app.configurationPath,
       force: true,
     }
 
@@ -296,8 +290,8 @@ describe('pushConfig', () => {
 
   test('returns error with field names when update mutation fails and userErrors includes field', async () => {
     // Given
-    const {configuration, configurationPath} = testApp({}, 'current')
-    const options: PushOptions = {configuration, configurationPath, force: true}
+    const {configuration} = testApp({}, 'current')
+    const options: PushOptions = {configuration, force: true}
 
     vi.mocked(partnersRequest).mockResolvedValue({
       app: {id: 1, apiKey: DEFAULT_CONFIG.client_id},
@@ -354,7 +348,6 @@ app_preferences > url: this url is blocked 6`)
 
     const options: PushOptions = {
       configuration: app.configuration,
-      configurationPath: app.configurationPath,
       force: true,
     }
 
@@ -401,7 +394,6 @@ app_preferences > url: this url is blocked 6`)
     const app = testApp({}, 'current')
     const options: PushOptions = {
       configuration: app.configuration,
-      configurationPath: app.configurationPath,
       force: false,
     }
     vi.mocked(confirmPushChanges).mockReset()

--- a/packages/app/src/cli/services/app/config/push.ts
+++ b/packages/app/src/cli/services/app/config/push.ts
@@ -21,7 +21,6 @@ import {basename} from '@shopify/cli-kit/node/path'
 
 export interface PushOptions {
   configuration: AppConfiguration
-  configurationPath: string
   force: boolean
 }
 
@@ -42,10 +41,10 @@ const FIELD_NAMES: {[key: string]: string} = {
 }
 
 export async function pushConfig(options: PushOptions) {
-  const {configuration, configurationPath} = options
+  const {configuration} = options
   if (isCurrentAppSchema(configuration)) {
     const token = await ensureAuthenticatedPartners()
-    const configFileName = isCurrentAppSchema(configuration) ? basename(configurationPath) : undefined
+    const configFileName = isCurrentAppSchema(configuration) ? basename(configuration.path) : undefined
 
     const queryVariables = {apiKey: configuration.client_id}
     const queryResult: GetConfigQuerySchema = await partnersRequest(GetConfig, token, queryVariables)

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -71,7 +71,6 @@ describe('use', () => {
       const appWithoutClientID = testApp()
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: appWithoutClientID.configurationPath,
         configuration: appWithoutClientID.configuration,
       })
 
@@ -135,7 +134,6 @@ describe('use', () => {
       })
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: app.configurationPath,
         configuration: app.configuration,
       })
 
@@ -172,7 +170,6 @@ describe('use', () => {
       })
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: app.configurationPath,
         configuration: app.configuration,
       })
 
@@ -209,8 +206,8 @@ describe('use', () => {
   test('renders warning when warning message is specified', async () => {
     await inTemporaryDirectory(async (directory) => {
       // Given
-      const {configurationPath, configuration} = testApp({}, 'current')
-      vi.mocked(loadAppConfiguration).mockResolvedValue({directory, configurationPath, configuration})
+      const {configuration} = testApp({}, 'current')
+      vi.mocked(loadAppConfiguration).mockResolvedValue({directory, configuration})
       vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.something.toml')
       createConfigFile(directory, 'shopify.app.something.toml')
 
@@ -226,8 +223,8 @@ describe('use', () => {
   test('does not render success when shouldRenderSuccess is false', async () => {
     await inTemporaryDirectory(async (directory) => {
       // Given
-      const {configurationPath, configuration} = testApp({}, 'current')
-      vi.mocked(loadAppConfiguration).mockResolvedValue({directory, configurationPath, configuration})
+      const {configuration} = testApp({}, 'current')
+      vi.mocked(loadAppConfiguration).mockResolvedValue({directory, configuration})
       vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.something.toml')
       createConfigFile(directory, 'shopify.app.something.toml')
 

--- a/packages/app/src/cli/services/app/env/pull.test.ts
+++ b/packages/app/src/cli/services/app/env/pull.test.ts
@@ -101,8 +101,8 @@ function mockApp(currentVersion = '2.2.2'): AppInterface {
   return testApp({
     name: 'myapp',
     directory: '/',
-    configurationPath: joinPath('/', 'shopify.app.toml'),
     configuration: {
+      path: joinPath('/', 'shopify.app.toml'),
       scopes: 'my-scope',
       extension_directories: ['extensions/*'],
     },

--- a/packages/app/src/cli/services/app/env/show.test.ts
+++ b/packages/app/src/cli/services/app/env/show.test.ts
@@ -7,8 +7,8 @@ import {testApp, testOrganizationApp} from '../../../models/app/app.test-data.js
 import {describe, expect, vi, test} from 'vitest'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import * as file from '@shopify/cli-kit/node/fs'
-import {joinPath} from '@shopify/cli-kit/node/path'
 import {stringifyMessage, unstyled} from '@shopify/cli-kit/node/output'
+import {joinPath} from '@shopify/cli-kit/node/path'
 
 vi.mock('../../dev/fetch.js')
 vi.mock('../fetch-app-from-config-or-select.js')
@@ -63,8 +63,8 @@ function mockApp(currentVersion = '2.2.2'): AppInterface {
   return testApp({
     name: 'myapp',
     directory: '/',
-    configurationPath: joinPath('/', 'shopify.app.toml'),
     configuration: {
+      path: joinPath('/', 'shopify.app.toml'),
       scopes: 'my-scope',
     },
     nodeDependencies,

--- a/packages/app/src/cli/services/app/update-url.test.ts
+++ b/packages/app/src/cli/services/app/update-url.test.ts
@@ -12,8 +12,9 @@ vi.mock('../../prompts/update-url.js')
 vi.mock('@shopify/cli-kit/node/session')
 
 const APP1 = testAppWithConfig({
-  app: {configurationPath: 'my-app/shopify.app.development.toml'},
+  app: {},
   config: {
+    path: 'my-app/shopify.app.development.toml',
     client_id: 'api-key',
     application_url: 'https://myapp.com',
   },

--- a/packages/app/src/cli/services/app/write-app-configuration-file.test.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.test.ts
@@ -39,7 +39,7 @@ describe('writeAppConfigurationFile', () => {
       const filePath = joinPath(tmp, 'shopify.app.toml')
 
       // When
-      const got = await writeAppConfigurationFile(filePath, FULL_CONFIGURATION)
+      const got = await writeAppConfigurationFile({...FULL_CONFIGURATION, path: filePath})
 
       // Then
       const content = await readFile(filePath)
@@ -93,8 +93,9 @@ dev_store_url = "example.myshopify.com"
       const filePath = joinPath(tmp, 'shopify.app.toml')
 
       // When
-      const got = await writeAppConfigurationFile(filePath, {
+      const got = await writeAppConfigurationFile({
         ...FULL_CONFIGURATION,
+        path: filePath,
         build: undefined,
         app_preferences: undefined,
         pos: undefined,

--- a/packages/app/src/cli/services/app/write-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.ts
@@ -5,7 +5,7 @@ import {zod} from '@shopify/cli-kit/node/schema'
 
 // toml does not support comments and there aren't currently any good/maintained libs for this,
 // so for now, we manually add comments
-export async function writeAppConfigurationFile(configFilePath: string, configuration: AppConfiguration) {
+export async function writeAppConfigurationFile(configuration: AppConfiguration) {
   const initialComment = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration\n`
   const scopesComment = `\n# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes`
 
@@ -23,7 +23,7 @@ export async function writeAppConfigurationFile(configFilePath: string, configur
 
   const file = fileSplit.join('')
 
-  writeFileSync(configFilePath, file)
+  writeFileSync(configuration.path, file)
 }
 
 export const rewriteConfiguration = <T extends zod.ZodTypeAny>(schema: T, config: unknown): unknown => {

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -187,8 +187,8 @@ describe('ensureGenerateContext', () => {
   beforeEach(() => {
     vi.mocked(loadAppConfiguration).mockResolvedValue({
       directory: '/app',
-      configurationPath: '/app/shopify.app.toml',
       configuration: {
+        path: '/app/shopify.app.toml',
         scopes: 'read_products',
       },
     })
@@ -226,8 +226,8 @@ describe('ensureGenerateContext', () => {
     vi.mocked(loadAppConfiguration).mockReset()
     vi.mocked(loadAppConfiguration).mockResolvedValueOnce({
       directory: '/app',
-      configurationPath: CACHED1_WITH_CONFIG.configFile!,
-      configuration: testAppWithConfig({config: {client_id: APP2.apiKey}}).configuration,
+      configuration: testAppWithConfig({config: {path: CACHED1_WITH_CONFIG.configFile, client_id: APP2.apiKey}})
+        .configuration,
     })
     vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP2)
 
@@ -246,8 +246,8 @@ describe('ensureGenerateContext', () => {
     vi.mocked(loadAppConfiguration).mockReset()
     vi.mocked(loadAppConfiguration).mockResolvedValueOnce({
       directory: '/app',
-      configurationPath: CACHED1_WITH_CONFIG.configFile!,
-      configuration: testAppWithConfig({config: {client_id: APP2.apiKey}}).configuration,
+      configuration: testAppWithConfig({config: {path: CACHED1_WITH_CONFIG.configFile, client_id: APP2.apiKey}})
+        .configuration,
     })
     vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP2)
 
@@ -267,8 +267,8 @@ describe('ensureGenerateContext', () => {
     vi.mocked(loadAppConfiguration).mockReset()
     vi.mocked(loadAppConfiguration).mockResolvedValueOnce({
       directory: '/app',
-      configurationPath: CACHED1_WITH_CONFIG.configFile!,
-      configuration: testAppWithConfig({config: {client_id: APP2.apiKey}}).configuration,
+      configuration: testAppWithConfig({config: {path: CACHED1_WITH_CONFIG.configFile, client_id: APP2.apiKey}})
+        .configuration,
     })
     vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP2)
 
@@ -312,8 +312,8 @@ describe('ensureDevContext', async () => {
   beforeEach(() => {
     vi.mocked(loadAppConfiguration).mockResolvedValue({
       directory: '/app',
-      configurationPath: '/app/shopify.app.toml',
       configuration: {
+        path: '/app/shopify.app.toml',
         scopes: 'read_products',
       },
     })
@@ -326,9 +326,9 @@ describe('ensureDevContext', async () => {
       vi.mocked(loadAppConfiguration).mockReset()
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: joinPath(tmp, CACHED1_WITH_CONFIG.configFile!),
         configuration: testAppWithConfig({
           config: {
+            path: joinPath(tmp, CACHED1_WITH_CONFIG.configFile!),
             name: APP2.apiKey,
             client_id: APP2.apiKey,
             build: {
@@ -393,9 +393,9 @@ dev_store_url = "domain1"
       vi.mocked(loadAppConfiguration).mockReset()
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: joinPath(tmp, CACHED1_WITH_CONFIG.configFile!),
         configuration: testAppWithConfig({
           config: {
+            path: joinPath(tmp, CACHED1_WITH_CONFIG.configFile!),
             name: APP1.apiKey,
             client_id: APP1.apiKey,
             build: {
@@ -446,8 +446,8 @@ dev_store_url = "domain1"
       vi.mocked(loadAppConfiguration).mockReset()
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: joinPath(tmp, 'shopify.app.dev.toml'),
         configuration: {
+          path: joinPath(tmp, 'shopify.app.dev.toml'),
           name: 'my app',
           client_id: '12345',
           scopes: 'write_products',
@@ -486,8 +486,8 @@ dev_store_url = "domain1"
       vi.mocked(loadAppConfiguration).mockReset()
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: joinPath(tmp, 'shopify.app.dev.toml'),
-        configuration: testApp({}, 'current').configuration,
+        configuration: testAppWithConfig({app: {}, config: {path: joinPath(tmp, 'shopify.app.dev.toml')}})
+          .configuration,
       })
       vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
 
@@ -533,8 +533,7 @@ dev_store_url = "domain1"
       vi.mocked(loadAppConfiguration).mockReset()
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: joinPath(tmp, 'shopify.app.toml'),
-        configuration: testApp({}, 'current').configuration,
+        configuration: testAppWithConfig({config: {path: joinPath(tmp, 'shopify.app.toml')}}).configuration,
       })
 
       vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.toml')
@@ -737,8 +736,8 @@ dev_store_url = "domain1"
       const filePath = joinPath(tmp, 'shopify.app.dev.toml')
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: filePath,
         configuration: {
+          path: filePath,
           client_id: APP2.apiKey,
           name: APP2.apiKey,
           application_url: APP2.applicationUrl,
@@ -776,8 +775,8 @@ dev_store_url = "domain1"
       const filePath = joinPath(tmp, 'shopify.app.toml')
       vi.mocked(loadAppConfiguration).mockResolvedValue({
         directory: tmp,
-        configurationPath: filePath,
         configuration: {
+          path: filePath,
           client_id: APP2.apiKey,
           name: APP2.apiKey,
           application_url: APP2.applicationUrl,

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -133,7 +133,7 @@ export async function ensureGenerateContext(options: {
  * @returns The selected org, app and dev store
  */
 export async function ensureDevContext(options: DevContextOptions, token: string): Promise<DevContextOutput> {
-  const {configuration, configurationPath, cachedInfo, remoteApp} = await getAppContext({
+  const {configuration, cachedInfo, remoteApp} = await getAppContext({
     ...options,
     token,
     promptLinkingApp: !options.apiKey,
@@ -181,7 +181,7 @@ export async function ensureDevContext(options: DevContextOptions, token: string
         dev_store_url: selectedStore?.shopDomain,
       },
     }
-    await writeAppConfigurationFile(configurationPath, newConfiguration)
+    await writeAppConfigurationFile(configuration.path, newConfiguration)
   } else if (!cachedInfo || rightApp) {
     setCachedAppInfo({
       appId: selectedApp.apiKey,
@@ -554,7 +554,6 @@ async function fetchDevDataFromOptions(
 
 export interface AppContext {
   configuration: AppConfiguration
-  configurationPath: string
   cachedInfo?: CachedAppInfo
   remoteApp?: OrganizationApp
 }
@@ -596,7 +595,7 @@ export async function getAppContext({
 
   let cachedInfo = getCachedAppInfo(directory)
 
-  const {configuration, configurationPath} = await loadAppConfiguration({
+  const {configuration} = await loadAppConfiguration({
     directory,
     configName,
   })
@@ -607,7 +606,7 @@ export async function getAppContext({
     cachedInfo = {
       ...cachedInfo,
       directory,
-      configFile: basename(configurationPath),
+      configFile: basename(configuration.path),
       orgId: remoteApp.organizationId,
       appId: remoteApp.apiKey,
       title: remoteApp.title,
@@ -618,7 +617,6 @@ export async function getAppContext({
 
   return {
     configuration,
-    configurationPath,
     cachedInfo,
     remoteApp,
   }
@@ -723,7 +721,7 @@ export function showReusedDeployValues(
     org,
     appName: remoteApp.title,
     appDotEnv: app.dotenv?.path,
-    configFile: isCurrentAppSchema(app.configuration) ? basename(app.configurationPath) : undefined,
+    configFile: isCurrentAppSchema(app.configuration) ? basename(app.configuration.path) : undefined,
     resetMessage: resetHelpMessage,
   })
 }

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -181,7 +181,7 @@ export async function ensureDevContext(options: DevContextOptions, token: string
         dev_store_url: selectedStore?.shopDomain,
       },
     }
-    await writeAppConfigurationFile(configuration.path, newConfiguration)
+    await writeAppConfigurationFile(newConfiguration)
   } else if (!cachedInfo || rightApp) {
     setCachedAppInfo({
       appId: selectedApp.apiKey,

--- a/packages/app/src/cli/services/context/id-manual-matching.test.ts
+++ b/packages/app/src/cli/services/context/id-manual-matching.test.ts
@@ -28,7 +28,6 @@ let EXTENSION_B: ExtensionInstance
 
 beforeAll(async () => {
   EXTENSION_A = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_A',
     configuration: {
       name: 'EXTENSION A',
@@ -41,7 +40,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_A_2 = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_A_2',
     configuration: {
       name: 'EXTENSION A 2',
@@ -54,7 +52,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_B = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_B',
     configuration: {
       name: 'EXTENSION B',

--- a/packages/app/src/cli/services/context/id-matching.test.ts
+++ b/packages/app/src/cli/services/context/id-matching.test.ts
@@ -94,7 +94,6 @@ let FUNCTION_A: ExtensionInstance
 
 beforeAll(async () => {
   EXTENSION_A = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_A',
     configuration: {
       name: 'EXTENSION A',
@@ -107,7 +106,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_A_2 = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_A_2',
     configuration: {
       name: 'EXTENSION A 2',
@@ -120,7 +118,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_B = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_B',
     configuration: {
       name: 'EXTENSION B',
@@ -133,7 +130,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_B_2 = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_B_2',
     configuration: {
       name: 'EXTENSION B 2',
@@ -146,7 +142,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_C = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_C',
     configuration: {
       name: 'EXTENSION C',
@@ -159,7 +154,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_D = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_D',
     configuration: {
       name: 'EXTENSION D',

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -112,7 +112,6 @@ vi.mock('../dev/migrate-to-ui-extension')
 
 beforeAll(async () => {
   EXTENSION_A = await testUIExtension({
-    configurationPath: '',
     directory: 'EXTENSION_A',
     type: 'checkout_post_purchase',
     configuration: {
@@ -125,7 +124,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_A_2 = await testUIExtension({
-    configurationPath: '',
     directory: 'EXTENSION_A_2',
     type: 'checkout_post_purchase',
     configuration: {
@@ -139,7 +137,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_B = await testUIExtension({
-    configurationPath: '',
     directory: 'EXTENSION_B',
     type: 'checkout_post_purchase',
     configuration: {

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -65,8 +65,7 @@ const LOCAL_APP = (uiExtensions: ExtensionInstance[], functionExtensions: Extens
   return testApp({
     name: 'my-app',
     directory: '/app',
-    configurationPath: '/shopify.app.toml',
-    configuration: {scopes: 'read_products', extension_directories: ['extensions/*']},
+    configuration: {path: '/shopify.app.toml', scopes: 'read_products', extension_directories: ['extensions/*']},
     allExtensions: [...uiExtensions, ...functionExtensions],
   })
 }

--- a/packages/app/src/cli/services/context/identifiers-functions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-functions.test.ts
@@ -41,8 +41,7 @@ const LOCAL_APP = (functionExtensions: ExtensionInstance[]): AppInterface => {
   return testApp({
     name: 'my-app',
     directory: '/app',
-    configurationPath: '/shopify.app.toml',
-    configuration: {scopes: 'read_products', extension_directories: ['extensions/*']},
+    configuration: {path: '/shopify.app.toml', scopes: 'read_products', extension_directories: ['extensions/*']},
     allExtensions: functionExtensions,
   })
 }

--- a/packages/app/src/cli/services/context/identifiers.test.ts
+++ b/packages/app/src/cli/services/context/identifiers.test.ts
@@ -76,7 +76,6 @@ vi.mock('./identifiers-functions')
 
 beforeAll(async () => {
   EXTENSION_A = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_A',
     configuration: {
       name: 'EXTENSION A',
@@ -89,7 +88,6 @@ beforeAll(async () => {
   })
 
   EXTENSION_A_2 = await testUIExtension({
-    configurationPath: '',
     directory: '/EXTENSION_A_2',
     configuration: {
       name: 'EXTENSION A 2',

--- a/packages/app/src/cli/services/context/identifiers.test.ts
+++ b/packages/app/src/cli/services/context/identifiers.test.ts
@@ -37,8 +37,7 @@ const LOCAL_APP = (uiExtensions: ExtensionInstance[], functionExtensions: Extens
   return testApp({
     name: 'my-app',
     directory: '/app',
-    configurationPath: '/shopify.app.toml',
-    configuration: {scopes: 'read_products', extension_directories: ['extensions/*']},
+    configuration: {path: '/shopify.app.toml', scopes: 'read_products', extension_directories: ['extensions/*']},
     allExtensions: [...uiExtensions, ...functionExtensions],
   })
 }

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -300,7 +300,6 @@ describe('deploy', () => {
       [
         expect.objectContaining({
           configuration: functionExtension.configuration,
-          configurationPath: functionExtension.configurationPath,
           directory: functionExtension.directory,
           entrySourceFilePath: functionExtension.entrySourceFilePath,
           idEnvironmentVariableName: functionExtension.idEnvironmentVariableName,

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -119,7 +119,7 @@ async function dev(options: DevOptions) {
     renderWarning({
       headline: [`The scopes in your TOML don't match the scopes in your Partner Dashboard`],
       body: [
-        `Scopes in ${basename(localApp.configurationPath)}:`,
+        `Scopes in ${basename(localApp.configuration.path)}:`,
         scopesMessage(getAppScopesArray(localApp.configuration)),
         '\n',
         'Scopes in Partner Dashboard:',

--- a/packages/app/src/cli/services/dev/extension/bundler.test.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.test.ts
@@ -269,7 +269,7 @@ describe('setupConfigWatcher()', async () => {
       unifiedDeployment: true,
     })
 
-    expect(chokidar.watch).toHaveBeenCalledWith(mockExtension.configurationPath)
+    expect(chokidar.watch).toHaveBeenCalledWith(mockExtension.configuration.path)
     expect(chokidarOnSpy).toHaveBeenCalledWith('change', expect.any(Function))
   })
 
@@ -304,7 +304,7 @@ describe('setupConfigWatcher()', async () => {
       token: 'mock-token',
       unifiedDeployment: true,
     })
-    expect(outputInfo).toHaveBeenCalledWith(`Config file at path ${mockExtension.configurationPath} changed`, stdout)
+    expect(outputInfo).toHaveBeenCalledWith(`Config file at path ${mockExtension.configuration.path} changed`, stdout)
   })
 
   test('stops watching the config file when the signal aborts and close resolves', async () => {

--- a/packages/app/src/cli/services/dev/extension/bundler.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.ts
@@ -188,8 +188,8 @@ export async function setupConfigWatcher({
 }: SetupConfigWatcherOptions) {
   const {default: chokidar} = await import('chokidar')
 
-  const configWatcher = chokidar.watch(extension.configurationPath).on('change', (_event, _path) => {
-    outputInfo(`Config file at path ${extension.configurationPath} changed`, stdout)
+  const configWatcher = chokidar.watch(extension.configuration.path).on('change', (_event, _path) => {
+    outputInfo(`Config file at path ${extension.configuration.path} changed`, stdout)
     updateExtensionConfig({
       extension,
       token,

--- a/packages/app/src/cli/services/dev/extension/localization.test.ts
+++ b/packages/app/src/cli/services/dev/extension/localization.test.ts
@@ -12,6 +12,7 @@ async function testGetLocalization(tmpDir: string, currentLocalization?: Localiz
 
   const extension = await testUIExtension({
     configuration: {
+      path: `${tmpDir}/shopify.ui.extension.toml`,
       name: 'mock-name',
       type: 'checkout_ui_extension',
       metafields: [],
@@ -23,7 +24,6 @@ async function testGetLocalization(tmpDir: string, currentLocalization?: Localiz
     },
     idEnvironmentVariableName: 'mockId',
     localIdentifier: 'localIdentifier',
-    configurationPath: `${tmpDir}/shopify.ui.extension.toml`,
     directory: tmpDir,
     type: 'checkout_ui_extension',
     graphQLType: 'graphQLType',

--- a/packages/app/src/cli/services/dev/output.test.ts
+++ b/packages/app/src/cli/services/dev/output.test.ts
@@ -8,8 +8,8 @@ import {
 } from '../../models/app/app.test-data.js'
 import {AppInterface} from '../../models/app/app.js'
 import {afterEach, describe, expect, test} from 'vitest'
-import {joinPath} from '@shopify/cli-kit/node/path'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+import {joinPath} from '@shopify/cli-kit/node/path'
 
 afterEach(() => {
   mockAndCaptureOutput().clear()
@@ -123,17 +123,18 @@ async function mockApp(newConfig = false): Promise<AppInterface> {
   const functionExtension = await testFunctionExtension()
   const themeExtension = await testThemeExtensions()
   const uiExtension = await testUIExtension()
-
   const configurationPath = joinPath('/', newConfig ? 'shopify.app.staging.toml' : 'shopify.app.toml')
 
-  return testApp(
+  const result = testApp(
     {
       name: 'my-super-customer-accounts-app',
       directory: '/',
-      configurationPath,
       nodeDependencies,
       allExtensions: [functionExtension, themeExtension, uiExtension],
     },
     newConfig ? 'current' : 'legacy',
   )
+  result.configuration.path = configurationPath
+
+  return result
 }

--- a/packages/app/src/cli/services/dev/output.ts
+++ b/packages/app/src/cli/services/dev/output.ts
@@ -26,7 +26,7 @@ export async function outputUpdateURLsResult(
     })
   } else if (!updated) {
     if (isCurrentAppSchema(localApp.configuration)) {
-      const fileName = basename(localApp.configurationPath)
+      const fileName = basename(localApp.configuration.path)
       const configName = getAppConfigurationShorthand(fileName)
       const pushCommandArgs = configName ? [`--config=${configName}`] : []
 

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -14,8 +14,7 @@ vi.mock('@shopify/cli-kit/node/session')
 
 const LOCAL_APP: AppInterface = testApp({
   directory: '',
-  configurationPath: '/shopify.app.toml',
-  configuration: {scopes: 'read_products', extension_directories: ['extensions/*']},
+  configuration: {path: '/shopify.app.toml', scopes: 'read_products', extension_directories: ['extensions/*']},
   webs: [
     {
       directory: '',

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -85,19 +85,19 @@ export async function updateExtensionConfig({
     throw new AbortError(errorMessage)
   }
 
-  let configObject = await loadConfigurationFile(extension.configurationPath)
+  let configObject = await loadConfigurationFile(extension.configuration.path)
   const {extensions} = ExtensionsArraySchema.parse(configObject)
 
   if (extensions) {
     // If the config has an array, find our extension using the handle.
-    const configuration = await parseConfigurationFile(UnifiedSchema, extension.configurationPath, abort)
+    const configuration = await parseConfigurationFile(UnifiedSchema, extension.configuration.path, abort)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const extensionConfig = configuration.extensions.find((config: any) => config.handle === extension.handle)
     if (!extensionConfig) {
       abort(
         `ERROR: Invalid handle
   - Expected handle: "${extension.handle}"
-  - Configuration file path: ${relativizePath(extension.configurationPath)}.
+  - Configuration file path: ${relativizePath(extension.configuration.path)}.
   - Handles are immutable, you can't change them once they are set.`,
       )
     }
@@ -107,7 +107,7 @@ export async function updateExtensionConfig({
 
   const newConfig = await parseConfigurationObject(
     extension.specification.schema,
-    extension.configurationPath,
+    extension.configuration.path,
     configObject,
     abort,
   )

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -98,7 +98,8 @@ describe('updateURLs', () => {
     await updateURLs(urls, apiKey, 'token', appWithConfig)
 
     // Then
-    expect(writeAppConfigurationFile).toHaveBeenCalledWith(appWithConfig.configurationPath, {
+    expect(writeAppConfigurationFile).toHaveBeenCalledWith(appWithConfig.configuration.path, {
+      path: '/tmp/project/shopify.app.toml',
       access_scopes: {
         scopes: 'read_products',
       },
@@ -187,7 +188,8 @@ describe('updateURLs', () => {
     await updateURLs(urls, apiKey, 'token', appWithConfig)
 
     // Then
-    expect(writeAppConfigurationFile).toHaveBeenCalledWith(appWithConfig.configurationPath, {
+    expect(writeAppConfigurationFile).toHaveBeenCalledWith(appWithConfig.configuration.path, {
+      path: '/tmp/project/shopify.app.toml',
       access_scopes: {
         scopes: 'read_products',
       },
@@ -371,7 +373,7 @@ describe('shouldOrPromptUpdateURLs', () => {
     // Then
     expect(result).toBe(true)
     expect(setCachedAppInfo).not.toHaveBeenCalled()
-    expect(writeAppConfigurationFile).toHaveBeenCalledWith(localApp.configurationPath, localApp.configuration)
+    expect(writeAppConfigurationFile).toHaveBeenCalledWith(localApp.configuration.path, localApp.configuration)
   })
 })
 

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -98,8 +98,8 @@ describe('updateURLs', () => {
     await updateURLs(urls, apiKey, 'token', appWithConfig)
 
     // Then
-    expect(writeAppConfigurationFile).toHaveBeenCalledWith(appWithConfig.configuration.path, {
-      path: '/tmp/project/shopify.app.toml',
+    expect(writeAppConfigurationFile).toHaveBeenCalledWith({
+      path: appWithConfig.configuration.path,
       access_scopes: {
         scopes: 'read_products',
       },
@@ -188,8 +188,8 @@ describe('updateURLs', () => {
     await updateURLs(urls, apiKey, 'token', appWithConfig)
 
     // Then
-    expect(writeAppConfigurationFile).toHaveBeenCalledWith(appWithConfig.configuration.path, {
-      path: '/tmp/project/shopify.app.toml',
+    expect(writeAppConfigurationFile).toHaveBeenCalledWith({
+      path: appWithConfig.configuration.path,
       access_scopes: {
         scopes: 'read_products',
       },
@@ -373,7 +373,7 @@ describe('shouldOrPromptUpdateURLs', () => {
     // Then
     expect(result).toBe(true)
     expect(setCachedAppInfo).not.toHaveBeenCalled()
-    expect(writeAppConfigurationFile).toHaveBeenCalledWith(localApp.configuration.path, localApp.configuration)
+    expect(writeAppConfigurationFile).toHaveBeenCalledWith(localApp.configuration)
   })
 })
 

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -188,7 +188,7 @@ export async function updateURLs(
       }
     }
 
-    await writeAppConfigurationFile(localApp.configurationPath, localConfiguration)
+    await writeAppConfigurationFile(localApp.configuration.path, localConfiguration)
   }
 }
 
@@ -238,7 +238,7 @@ export async function shouldOrPromptUpdateURLs(options: ShouldOrPromptUpdateURLs
         automatically_update_urls_on_dev: shouldUpdateURLs,
       }
 
-      await writeAppConfigurationFile(options.localApp.configurationPath, localConfiguration)
+      await writeAppConfigurationFile(options.localApp.configuration.path, localConfiguration)
     } else {
       setCachedAppInfo({directory: options.appDirectory, updateURLs: shouldUpdateURLs})
     }

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -188,7 +188,7 @@ export async function updateURLs(
       }
     }
 
-    await writeAppConfigurationFile(localApp.configuration.path, localConfiguration)
+    await writeAppConfigurationFile(localConfiguration)
   }
 }
 
@@ -238,7 +238,7 @@ export async function shouldOrPromptUpdateURLs(options: ShouldOrPromptUpdateURLs
         automatically_update_urls_on_dev: shouldUpdateURLs,
       }
 
-      await writeAppConfigurationFile(options.localApp.configuration.path, localConfiguration)
+      await writeAppConfigurationFile(localConfiguration)
     } else {
       setCachedAppInfo({directory: options.appDirectory, updateURLs: shouldUpdateURLs})
     }

--- a/packages/app/src/cli/services/generate.test.ts
+++ b/packages/app/src/cli/services/generate.test.ts
@@ -3,7 +3,7 @@ import {ensureGenerateContext} from './context.js'
 import {generateExtensionTemplate} from './generate/extension.js'
 import {loadApp} from '../models/app/loader.js'
 import {
-  testApp,
+  testAppWithConfig,
   testFunctionExtension,
   testLocalExtensionTemplates,
   testRemoteSpecifications,
@@ -170,11 +170,13 @@ describe('generate', () => {
 
 async function mockSuccessfulCommandExecution(identifier: string, existingExtensions: ExtensionInstance[] = []) {
   const appRoot = '/'
-  const app = testApp({
-    directory: appRoot,
-    configurationPath: joinPath(appRoot, 'shopify.app.toml'),
-    extensionsForType: (_spec: {identifier: string; externalIdentifier: string}) => existingExtensions,
-    allExtensions: existingExtensions,
+  const app = testAppWithConfig({
+    app: {
+      directory: appRoot,
+      extensionsForType: (_spec: {identifier: string; externalIdentifier: string}) => existingExtensions,
+      allExtensions: existingExtensions,
+    },
+    config: {path: joinPath(appRoot, 'shopify.app.toml')},
   })
 
   const allExtensionTemplates = testRemoteExtensionTemplates.concat(testLocalExtensionTemplates)

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -236,25 +236,25 @@ describe('info', () => {
       // Given
       const uiExtension1 = await testUIExtension({
         configuration: {
+          path: 'extension/path/1',
           name: 'Extension 1',
           handle: 'handle-for-extension-1',
           type: 'ui_extension',
           metafields: [],
         },
-        configurationPath: 'extension/path/1',
       })
       const uiExtension2 = await testUIExtension({
         configuration: {
+          path: 'extension/path/2',
           name: 'Extension 2',
           type: 'checkout_ui_extension',
           metafields: [],
         },
-        configurationPath: 'extension/path/2',
       })
 
       const errors = new AppErrors()
-      errors.addError(uiExtension1.configurationPath, 'Mock error with ui_extension')
-      errors.addError(uiExtension2.configurationPath, 'Mock error with checkout_ui_extension')
+      errors.addError(uiExtension1.configuration.path, 'Mock error with ui_extension')
+      errors.addError(uiExtension2.configuration.path, 'Mock error with checkout_ui_extension')
 
       const app = mockApp({
         directory: tmp,

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -62,8 +62,8 @@ describe('info', () => {
         app: testApp({
           name: 'my app',
           directory: tmp,
-          configurationPath: joinPath(tmp, 'shopify.app.toml'),
           configuration: {
+            path: joinPath(tmp, 'shopify.app.toml'),
             name: 'my app',
             client_id: '12345',
             application_url: 'https://example.com/lala',
@@ -324,8 +324,8 @@ function mockApp({
   return testApp({
     name: 'my app',
     directory,
-    configurationPath: joinPath(directory, 'shopify.app.toml'),
     configuration: {
+      path: joinPath(directory, 'shopify.app.toml'),
       scopes: 'my-scope',
       extension_directories: ['extensions/*'],
     },

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -178,7 +178,7 @@ class AppInfo {
     const config = extension.configuration
     const details = [
       [`📂 ${extension.handle}`, relativePath(this.app.directory, extension.directory)],
-      ['     config file', relativePath(extension.directory, extension.configurationPath)],
+      ['     config file', relativePath(extension.directory, extension.configuration.path)],
     ]
     if (config && config.metafields?.length) {
       details.push(['     metafields', `${config.metafields.length}`])
@@ -188,11 +188,11 @@ class AppInfo {
   }
 
   invalidExtensionSubSection(extension: ExtensionInstance): string {
-    const error = this.app.errors?.getError(extension.configurationPath)
+    const error = this.app.errors?.getError(extension.configuration.path)
     if (!error) return ''
     const details = [
       [`📂 ${extension.handle}`, relativePath(this.app.directory, extension.directory)],
-      ['     config file', relativePath(extension.directory, extension.configurationPath)],
+      ['     config file', relativePath(extension.directory, extension.configuration.path)],
     ]
     const formattedError = this.formattedError(error)
     return `\n${linesToColumns(details)}\n${formattedError}`

--- a/packages/app/src/cli/services/versions-list.ts
+++ b/packages/app/src/cli/services/versions-list.ts
@@ -105,7 +105,7 @@ export default async function versionList(options: VersionListOptions) {
   renderCurrentlyUsedConfigInfo({
     org,
     appName: app.title,
-    configFile: isCurrentAppSchema(options.app.configuration) ? basename(options.app.configurationPath) : undefined,
+    configFile: isCurrentAppSchema(options.app.configuration) ? basename(options.app.configuration.path) : undefined,
   })
 
   if (appVersions.length === 0) {


### PR DESCRIPTION

### WHY are these changes introduced?

I noticed that we were storing and passing around `configuration` and `configurationPath` separately in both app and extension configs. Instead I really liked the design of the `DotEnv` data structure, where the data structure itself includes the path of there the data is stored.

### WHAT is this pull request doing?

- Merge in path inside `AppConfiguration`
- Merge in path inside `ExtensionInstance`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
