### PR TITLE
Fix internal server error in the `shopify theme dev` command

### DIFF
--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy_param_builder.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy_param_builder.rb
@@ -55,6 +55,8 @@ module ShopifyCLI
 
         def cookie_sections
           CGI::Cookie.parse(cookie)["hot_reload_files"].join.split(",") || []
+        rescue StandardError
+          []
         end
 
         def core?(path)


### PR DESCRIPTION
### WHY are these changes introduced?

Ruby 3.2 relies on CGI 0.3.6, and since CGI 0.34 errors are raised for invalid Cookies. This was not happening on Ruby 3.1 because it relies on CGI 0.3.1.

### WHAT is this pull request doing?

In case an invalid cookie is encounter, the proxy skips the parsing of the `hot_reload_files` cookie, as cosequency users with invalid cookie might experience instability if they try the hot-reload feature with multiple tabs open

### How to test your changes?

- Run `shopify theme dev` using Ruby 3.2
- Open the localhost URL
- Set cookie unsupported by Ruby CGI in the Chrome Console (`document.cookie = "visitor UUID=@1; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/"`)
- Refresh the browser

**Before**
![before](https://github.com/Shopify/cli/assets/1079279/e254fc33-a62c-4c6b-9e37-b9864ba2bcf1)

**After**
![Monosnap screencast 2023-08-11 08-07-40](https://github.com/Shopify/cli/assets/1079279/834122a7-42fc-4d3c-a695-202d161b2f96)


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
