### PR TITLE
Fix upgrade command using a non default app config file

### DIFF
--- a/.changeset/young-birds-yell.md
+++ b/.changeset/young-birds-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Upgrade command works with a valid app config file different from the default shopify.app.toml

--- a/packages/cli/src/cli/services/upgrade.test.ts
+++ b/packages/cli/src/cli/services/upgrade.test.ts
@@ -85,6 +85,26 @@ describe('upgrade global CLI', () => {
 })
 
 describe('upgrade local CLI', () => {
+  test('throws an error if a valid app config file is missing', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      await Promise.all([
+        writeFile(
+          joinPath(tmpDir, 'package.json'),
+          JSON.stringify({dependencies: {'@shopify/cli': currentCliVersion, '@shopify/app': currentCliVersion}}),
+        ),
+        touchFile(joinPath(tmpDir, 'shopify.wrongapp.toml')),
+      ])
+      const outputMock = mockAndCaptureOutput()
+      vi.spyOn(nodePackageManager as any, 'checkForNewVersion').mockResolvedValue(undefined)
+
+      // When // Then
+      await expect(upgrade(tmpDir, currentCliVersion, {env: {npm_config_user_agent: 'npm'}})).rejects.toBeInstanceOf(
+        AbortError,
+      )
+    })
+  })
+
   test('does not upgrade locally if the latest version is found', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
@@ -160,7 +180,7 @@ describe('upgrade local CLI', () => {
           joinPath(tmpDir, 'package.json'),
           JSON.stringify({dependencies: {'@shopify/cli': currentCliVersion, '@shopify/app': oldCliVersion}}),
         ),
-        touchFile(joinPath(tmpDir, 'shopify.app.toml')),
+        touchFile(joinPath(tmpDir, 'shopify.app.nondefault.toml')),
       ])
       const outputMock = mockAndCaptureOutput()
       const checkMock = vi.spyOn(nodePackageManager as any, 'checkForNewVersion')

--- a/packages/cli/src/cli/services/upgrade.ts
+++ b/packages/cli/src/cli/services/upgrade.ts
@@ -8,8 +8,8 @@ import {
   usesWorkspaces,
 } from '@shopify/cli-kit/node/node-package-manager'
 import {exec} from '@shopify/cli-kit/node/system'
-import {dirname, moduleDirectory} from '@shopify/cli-kit/node/path'
-import {findPathUp} from '@shopify/cli-kit/node/fs'
+import {dirname, joinPath, moduleDirectory} from '@shopify/cli-kit/node/path'
+import {findPathUp, glob} from '@shopify/cli-kit/node/fs'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputInfo, outputSuccess, outputToken, outputWarn} from '@shopify/cli-kit/node/output'
 
@@ -48,7 +48,12 @@ export async function upgrade(
 }
 
 async function getProjectDir(directory: string): Promise<string | undefined> {
-  const configFile = await findPathUp(['shopify.app.toml', 'hydrogen.config.js', 'hydrogen.config.ts'], {
+  const configFiles = ['shopify.app{,.*}.toml', 'hydrogen.config.js', 'hydrogen.config.ts']
+  const existsConfigFile = async (directory: string) => {
+    const configPaths = await glob(configFiles.map((file) => joinPath(directory, file)))
+    return configPaths.length > 0 ? configPaths[0] : undefined
+  }
+  const configFile = await findPathUp(existsConfigFile, {
     cwd: directory,
     type: 'file',
   })


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
If your app includes a valid app config file `shopify.app.production.toml` but does not the default one  `shopify.app.toml`  this error is shown when you run the `upgrade` command

```
╭─ error ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                        │
│  Couldn't find the configuration file for /your/app/path, are you in a Shopify project directory?                          │
│                                                                                                                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Detect as app valid path those that includes
  - `shopify.app.toml`
  - `shopify.app.*.toml`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Modify the name of your default app config to something similar to `shopify.invalidapp.toml`, run the command `p shopify upgrade --path /path/to/your/app` and you should see an error
- Modify the name of your default app config to its default value `shopify.app.toml`, run the command `p shopify upgrade --path /path/to/your/app` and the command should run properly
-  Modify the name of your default app config to something similar to `shopify.app.production.toml`, run the command `p shopify upgrade --path /path/to/your/app` and the command should run properly
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
