### PR TITLE
Fix rule that detects functions that create errors

### DIFF
--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -89,7 +89,7 @@ describe('fetchOrganizations', async () => {
     const got = fetchOrganizations('token')
 
     // Then
-    await expect(got).rejects.toThrow(NoOrgError())
+    await expect(got).rejects.toThrow(new NoOrgError())
     expect(partnersRequest).toHaveBeenCalledWith(AllOrganizationsQuery, 'token')
   })
 })
@@ -115,7 +115,7 @@ describe('fetchApp', async () => {
     const got = () => fetchOrgAndApps(ORG1.id, 'token')
 
     // Then
-    await expect(got).rejects.toThrowError(NoOrgError())
+    await expect(got).rejects.toThrowError(new NoOrgError())
     expect(partnersRequest).toHaveBeenCalledWith(FindOrganizationQuery, 'token', {id: ORG1.id})
   })
 })
@@ -188,7 +188,7 @@ describe('NoOrgError', () => {
   test('renders correctly', () => {
     // Given
     const mockOutput = mockAndCaptureOutput()
-    const subject = NoOrgError('3')
+    const subject = new NoOrgError('3')
 
     // When
     renderFatalError(subject)

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -173,6 +173,7 @@ function tokenRequestErrorHandler(error: string) {
     // This means the token is invalid. We clear the session and throw an error to let the caller know.
     return new InvalidRequestError()
   }
+  // eslint-disable-next-line @shopify/cli/no-error-factory-functions
   return new AbortError(error)
 }
 

--- a/packages/cli-kit/src/public/node/dot-env.test.ts
+++ b/packages/cli-kit/src/public/node/dot-env.test.ts
@@ -1,4 +1,4 @@
-import {DotEnvNotFoundError, patchEnvFile, readAndParseDotEnv, writeDotEnv} from './dot-env.js'
+import {patchEnvFile, readAndParseDotEnv, writeDotEnv} from './dot-env.js'
 import {inTemporaryDirectory, writeFile, readFile} from './fs.js'
 import {joinPath} from './path.js'
 import {describe, expect, test} from 'vitest'
@@ -9,7 +9,7 @@ describe('readAndParseDotEnv', () => {
     const dotEnvPath = '/invalid/path/.env'
     await expect(async () => {
       await readAndParseDotEnv(dotEnvPath)
-    }).rejects.toEqual(DotEnvNotFoundError(dotEnvPath))
+    }).rejects.toThrow(/The environment file at .* does not exist./)
   })
 
   test('returns the file if it exists and the format is valid', async () => {

--- a/packages/cli-kit/src/public/node/dot-env.ts
+++ b/packages/cli-kit/src/public/node/dot-env.ts
@@ -6,15 +6,6 @@ import {outputDebug, outputContent, outputToken} from '../../public/node/output.
 import {parse, stringify} from 'envfile'
 
 /**
- * Error that's thrown when the .env is not found.
- * @param path - Path to the .env file.
- * @returns An abort error.
- */
-export const DotEnvNotFoundError = (path: string): AbortError => {
-  return new AbortError(`The environment file at ${path} does not exist.`)
-}
-
-/**
  * This interface represents a .env file.
  */
 export interface DotEnvFile {
@@ -36,7 +27,7 @@ export interface DotEnvFile {
 export async function readAndParseDotEnv(path: string): Promise<DotEnvFile> {
   outputDebug(outputContent`Reading the .env file at ${outputToken.path(path)}`)
   if (!(await fileExists(path))) {
-    throw DotEnvNotFoundError(path)
+    throw new AbortError(`The environment file at ${path} does not exist.`)
   }
   const content = await readFile(path)
   return {

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -4,7 +4,6 @@ import {
   installNodeModules,
   getDependencies,
   getPackageName,
-  PackageJsonNotFoundError,
   checkForNewVersion,
   readAndParsePackageJson,
   findUpAndReadPackageJson,
@@ -16,10 +15,11 @@ import {
   installNPMDependenciesRecursively,
   addNPMDependencies,
   DependencyVersion,
+  PackageJsonNotFoundError,
 } from './node-package-manager.js'
 import {exec} from './system.js'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from './fs.js'
-import {normalizePath as pathNormalize, joinPath, dirname} from './path.js'
+import {joinPath, dirname, normalizePath} from './path.js'
 import latestVersion from 'latest-version'
 import {vi, describe, test, expect} from 'vitest'
 
@@ -282,7 +282,9 @@ describe('getDependencies', () => {
       const packageJsonPath = joinPath(tmpDir, 'package.json')
 
       // When
-      await expect(getDependencies(packageJsonPath)).rejects.toEqual(PackageJsonNotFoundError(pathNormalize(tmpDir)))
+      await expect(getDependencies(packageJsonPath)).rejects.toEqual(
+        new PackageJsonNotFoundError(normalizePath(tmpDir)),
+      )
     })
   })
 })
@@ -590,7 +592,7 @@ describe('findUpAndReadPackageJson', () => {
 
       // When/Then
       await expect(() => findUpAndReadPackageJson(subDirectory)).rejects.toThrowError(
-        FindUpAndReadPackageJsonNotFoundError(subDirectory),
+        new FindUpAndReadPackageJsonNotFoundError(subDirectory),
       )
     })
   })
@@ -603,7 +605,7 @@ describe('addResolutionOrOverride', () => {
       const result = () => addResolutionOrOverride(tmpDir, {'@types/react': '17.0.30'})
 
       // Then
-      await expect(result).rejects.toThrow(FindUpAndReadPackageJsonNotFoundError(tmpDir))
+      await expect(result).rejects.toThrow(new FindUpAndReadPackageJsonNotFoundError(tmpDir))
     })
   })
 
@@ -783,7 +785,7 @@ describe('getPackageManager', () => {
 
       // When/Then
       await expect(() => getPackageManager(subDirectory)).rejects.toThrowError(
-        FindUpAndReadPackageJsonNotFoundError(subDirectory),
+        new FindUpAndReadPackageJsonNotFoundError(subDirectory),
       )
     })
   })

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -45,8 +45,10 @@ export type PackageManager = (typeof packageManager)[number]
  * @param directory - The path to the directory that should contain a package.json
  * @returns An abort error.
  */
-export const PackageJsonNotFoundError = (directory: string): AbortError => {
-  return new AbortError(`The directory ${directory} doesn't have a package.json.`)
+export class PackageJsonNotFoundError extends AbortError {
+  constructor(directory: string) {
+    super(`The directory ${directory} doesn't have a package.json.`)
+  }
 }
 
 /**
@@ -55,10 +57,10 @@ export const PackageJsonNotFoundError = (directory: string): AbortError => {
  * @param directory - The directory from which the traverse has been done
  * @returns An abort error.
  */
-export const FindUpAndReadPackageJsonNotFoundError = (directory: string): BugError => {
-  return new BugError(
-    outputContent`Couldn't find a a package.json traversing directories from ${outputToken.path(directory)}`,
-  )
+export class FindUpAndReadPackageJsonNotFoundError extends BugError {
+  constructor(directory: string) {
+    super(outputContent`Couldn't find a a package.json traversing directories from ${outputToken.path(directory)}`)
+  }
 }
 
 /**
@@ -85,7 +87,7 @@ export function packageManagerUsedForCreating(env = process.env): PackageManager
 export async function getPackageManager(fromDirectory: string): Promise<PackageManager> {
   const packageJson = await findPathUp('package.json', {cwd: fromDirectory, type: 'file'})
   if (!packageJson) {
-    throw FindUpAndReadPackageJsonNotFoundError(fromDirectory)
+    throw new FindUpAndReadPackageJsonNotFoundError(fromDirectory)
   }
   const directory = dirname(packageJson)
   outputDebug(outputContent`Obtaining the dependency manager in directory ${outputToken.path(directory)}...`)
@@ -315,7 +317,7 @@ export interface PackageJson {
  */
 export async function readAndParsePackageJson(packageJsonPath: string): Promise<PackageJson> {
   if (!(await fileExists(packageJsonPath))) {
-    throw PackageJsonNotFoundError(dirname(packageJsonPath))
+    throw new PackageJsonNotFoundError(dirname(packageJsonPath))
   }
   return JSON.parse(await readFile(packageJsonPath))
 }
@@ -390,7 +392,7 @@ ${outputToken.json(options)}
   `)
   const packageJsonPath = joinPath(options.directory, 'package.json')
   if (!(await fileExists(packageJsonPath))) {
-    throw PackageJsonNotFoundError(options.directory)
+    throw new PackageJsonNotFoundError(options.directory)
   }
   const existingDependencies = Object.keys(await getDependencies(packageJsonPath))
   const dependenciesToAdd = dependencies.filter((dep) => {
@@ -549,7 +551,7 @@ export async function findUpAndReadPackageJson(fromDirectory: string): Promise<{
     const packageJson = JSON.parse(await readFile(packageJsonPath))
     return {path: packageJsonPath, content: packageJson}
   } else {
-    throw FindUpAndReadPackageJsonNotFoundError(fromDirectory)
+    throw new FindUpAndReadPackageJsonNotFoundError(fromDirectory)
   }
 }
 

--- a/packages/eslint-plugin-cli/rules/no-error-factory-functions.js
+++ b/packages/eslint-plugin-cli/rules/no-error-factory-functions.js
@@ -2,7 +2,7 @@
 const path = require('pathe')
 const file = require('fs')
 
-const errors = ['Abort', 'AbortSilent', 'Bug', 'BugSilent']
+const errors = ['AbortError', 'AbortSilentError', 'BugError', 'BugSilentError']
 
 module.exports = {
   meta: {

--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -126,7 +126,9 @@ class TunnelClientInstance implements TunnelClient {
         }
         // If already resolved, means that the CLI already received the tunnel URL.
         // Can't retry because the CLI is running with an invalid URL
-        if (resolved) throw processCrashed(error.message)
+        if (resolved) {
+          throw new BugError(`Tunnel process crashed after stablishing a connection: ${error.message}`, whatToTry())
+        }
 
         outputDebug(`Cloudflared tunnel crashed: ${error.message}, restarting...`)
 
@@ -136,10 +138,6 @@ class TunnelClientInstance implements TunnelClient {
       },
     })
   }
-}
-
-function processCrashed(message: string) {
-  return new BugError(`Tunnel process crashed after stablishing a connection: ${message}`, whatToTry())
 }
 
 function whatToTry() {


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed that the `no-error-factory-functions` rule was broken

### WHAT is this pull request doing?

- fix the eslint rule
- fix all failures, mostly by inlining the error or creating subclasses
