### PR TITLE
Add feature test to ensure that important shared node deps are in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "fast-glob": "^3.3.1",
     "find-up": "^6.3.0",
     "fs-extra": "^11.1.0",
-    "graphql": "^15.5.1",
+    "graphql": "^16.4.0",
     "graphql-tag": "^2.12.6",
     "liquidjs": "^10.8.4",
     "node-fetch": "^3.3.1",
@@ -93,7 +93,7 @@
   "version": "0.0.0",
   "resolutions": {
     "@types/react": "17.0.2",
-    "vite": "4.3.6",
+    "vite": "4.4.8",
     "@oclif/core": "2.11.7"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -64,7 +64,7 @@
     "@types/node": "14.18.54",
     "@types/serve-static": "^1.15.2",
     "@types/ws": "^8.5.5",
-    "graphql": "^16.0.0",
+    "graphql": "^16.4.0",
     "graphql-tag": "^2.12.6",
     "@vitest/coverage-istanbul": "^0.34.1",
     "vite": "^4.4.8",

--- a/packages/features/features/node-deps.feature
+++ b/packages/features/features/node-deps.feature
@@ -1,0 +1,5 @@
+Feature: Node Dependencies
+
+Scenario: Shared node dependencies are in sync across packages
+   When I look at the package.json files in all packages
+   Then I see all shared node dependencies on the same version

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -37,7 +37,8 @@
     "fs-extra": "^9.1.0",
     "pathe": "1.1.1",
     "rimraf": "^3.0.2",
-    "tempy": "^1.0.1"
+    "tempy": "^1.0.1",
+    "fast-glob": "^3.3.1"
   },
   "engines": {
     "node": ">=14.17.0"

--- a/packages/features/steps/node-deps.steps.ts
+++ b/packages/features/steps/node-deps.steps.ts
@@ -1,0 +1,81 @@
+import {Then, When} from '@cucumber/cucumber'
+import * as path from 'pathe'
+import glob from 'fast-glob'
+import {fileURLToPath} from 'url'
+import fs from 'fs/promises'
+import {strict as assert} from 'assert'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+interface PackageJson {
+  dependencies?: {[key: string]: string}
+  devDependencies?: {[key: string]: string}
+  resolutions?: {[key: string]: string}
+}
+
+async function parsePackageJson(path: string): Promise<PackageJson> {
+  return JSON.parse(await fs.readFile(path, 'utf-8')) as PackageJson
+}
+
+When(/I look at the package.json files in all packages/, async function () {
+  this.packageJsonMap = {}
+  for (const packageJson of glob.sync(`${__dirname}/../../*/package.json`)) {
+    const packageName = path.dirname(packageJson).split('/').pop()!
+    // eslint-disable-next-line no-await-in-loop
+    this.packageJsonMap[packageName] = await parsePackageJson(packageJson)
+  }
+  this.packageJsonMap.root = await parsePackageJson(`${__dirname}/../../../package.json`)
+})
+
+const sharedDependencies = [
+  // react is not included as cli-kit uses 18, while other packages use 17
+  '@oclif/core',
+  '@shopify/cli-kit',
+  '@types/node',
+  'esbuild',
+  'execa',
+  'fast-glob',
+  'graphql',
+  'graphql-request',
+  'graphql-tag',
+  'typescript',
+  'vite',
+  'vitest',
+  'zod',
+]
+
+Then(/I see all shared node dependencies on the same version/, async function () {
+  const different: {dep: string; versions: {packageName: string; version: string}[]}[] = []
+
+  sharedDependencies.forEach((dep) => {
+    const depVersions = Object.entries(this.packageJsonMap).reduce(
+      (acc: {packageName: string; version: string}[], [packageName, json]) => {
+        const packageJson = json as PackageJson
+        const depVersion =
+          packageJson.dependencies?.[dep] ?? packageJson.devDependencies?.[dep] ?? packageJson.resolutions?.[dep]
+        if (depVersion) {
+          acc.push({packageName, version: depVersion.replace(/^\^/, '')})
+        }
+        return acc
+      },
+      [],
+    )
+
+    const allVersions = depVersions.map((pair) => pair.version)
+    const someVersionsAreDifferent = [...new Set(allVersions)].length > 1
+
+    if (someVersionsAreDifferent) {
+      different.push({dep, versions: depVersions})
+    }
+  })
+
+  const errorMessage = `The following node dependencies are on different versions across packages:\n\n${different
+    .map(
+      ({dep, versions}) =>
+        `  - ${dep}:\n${versions.map(({packageName, version}) => `    - ${packageName}: ${version}`).join('\n')}`,
+    )
+    .join('\n\n')}\n\nPlease make sure they are all on the same version.`
+
+  assert.equal(different.length, 0, errorMessage)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@types/react': 17.0.2
-  vite: 4.3.6
+  vite: 4.4.8
   '@oclif/core': 2.11.7
 
 importers:
@@ -15,7 +15,7 @@ importers:
     devDependencies:
       '@apollo/client':
         specifier: ^3.7.17
-        version: 3.7.17(graphql@15.8.0)(react@17.0.2)
+        version: 3.7.17(graphql@16.4.0)(react@17.0.2)
       '@babel/core':
         specifier: ^7.22.9
         version: 7.22.9
@@ -92,11 +92,11 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       graphql:
-        specifier: ^15.5.1
-        version: 15.8.0
+        specifier: ^16.4.0
+        version: 16.4.0
       graphql-tag:
         specifier: ^2.12.6
-        version: 2.12.6(graphql@15.8.0)
+        version: 2.12.6(graphql@16.4.0)
       liquidjs:
         specifier: ^10.8.4
         version: 10.8.4
@@ -219,14 +219,14 @@ importers:
         specifier: ^0.34.1
         version: 0.34.1(vitest@0.34.1)
       graphql:
-        specifier: ^16.0.0
+        specifier: ^16.4.0
         version: 16.4.0
       graphql-tag:
         specifier: ^2.12.6
         version: 2.12.6(graphql@16.4.0)
       vite:
-        specifier: 4.3.6
-        version: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(jsdom@20.0.3)
@@ -268,8 +268,8 @@ importers:
         specifier: ^0.34.1
         version: 0.34.1(vitest@0.34.1)
       vite:
-        specifier: 4.3.6
-        version: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(jsdom@20.0.3)
@@ -500,8 +500,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vite:
-        specifier: 4.3.6
-        version: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(jsdom@20.0.3)
@@ -519,8 +519,8 @@ importers:
         specifier: 14.18.54
         version: 14.18.54
       vite:
-        specifier: 4.3.6
-        version: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(jsdom@20.0.3)
@@ -612,6 +612,9 @@ importers:
       execa:
         specifier: ^7.2.0
         version: 7.2.0
+      fast-glob:
+        specifier: ^3.3.1
+        version: 3.3.1
       fs-extra:
         specifier: ^9.1.0
         version: 9.1.0
@@ -641,8 +644,8 @@ importers:
         version: 7.5.3
     devDependencies:
       vite:
-        specifier: 4.3.6
-        version: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(jsdom@20.0.3)
@@ -660,8 +663,8 @@ importers:
         version: 2.0.2
     devDependencies:
       vite:
-        specifier: 4.3.6
-        version: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(jsdom@20.0.3)
@@ -685,8 +688,8 @@ importers:
         specifier: ^1.15.0
         version: 1.15.0
       vite:
-        specifier: 4.3.6
-        version: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(jsdom@20.0.3)
@@ -758,11 +761,11 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vite:
-        specifier: 4.3.6
-        version: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vite-tsconfig-paths:
         specifier: ^3.3.14
-        version: 3.6.0(vite@4.3.6)
+        version: 3.6.0(vite@4.4.8)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(sass@1.64.2)
@@ -812,11 +815,11 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0
       vite:
-        specifier: 4.3.6
-        version: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vite-tsconfig-paths:
         specifier: ^3.3.14
-        version: 3.6.0(vite@4.3.6)
+        version: 3.6.0(vite@4.4.8)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(jsdom@20.0.3)
@@ -910,7 +913,7 @@ packages:
       js-yaml: 4.1.0
     dev: true
 
-  /@apollo/client@3.7.17(graphql@15.8.0)(react@17.0.2):
+  /@apollo/client@3.7.17(graphql@16.4.0)(react@17.0.2):
     resolution: {integrity: sha512-0EErSHEtKPNl5wgWikHJbKFAzJ/k11O0WO2QyqZSHpdxdAnw7UWHY4YiLbHCFG7lhrD+NTQ3Z/H9Jn4rcikoJA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -928,12 +931,12 @@ packages:
       subscriptions-transport-ws:
         optional: true
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.4.0)
       '@wry/context': 0.7.3
       '@wry/equality': 0.5.6
       '@wry/trie': 0.4.3
-      graphql: 15.8.0
-      graphql-tag: 2.12.6(graphql@15.8.0)
+      graphql: 16.4.0
+      graphql-tag: 2.12.6(graphql@16.4.0)
       hoist-non-react-statics: 3.3.2
       optimism: 0.16.2
       prop-types: 15.8.1
@@ -2832,26 +2835,10 @@ packages:
       esquery: 1.5.0
       jsdoc-type-pratt-parser: 3.1.0
 
-  /@esbuild/android-arm64@0.17.19:
-    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/android-arm64@0.18.17:
     resolution: {integrity: sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/android-arm@0.17.19:
-    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
     requiresBuild: true
     optional: true
@@ -2864,14 +2851,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-x64@0.17.19:
-    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/android-x64@0.18.17:
     resolution: {integrity: sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==}
     engines: {node: '>=12'}
@@ -2880,26 +2859,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.17.19:
-    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/darwin-arm64@0.18.17:
     resolution: {integrity: sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.17.19:
-    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
@@ -2912,26 +2875,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.17.19:
-    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/freebsd-arm64@0.18.17:
     resolution: {integrity: sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.17.19:
-    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     optional: true
@@ -2944,26 +2891,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm64@0.17.19:
-    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-arm64@0.18.17:
     resolution: {integrity: sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-arm@0.17.19:
-    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -2976,26 +2907,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ia32@0.17.19:
-    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-ia32@0.18.17:
     resolution: {integrity: sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==}
     engines: {node: '>=12'}
     cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.17.19:
-    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -3008,26 +2923,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.17.19:
-    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-mips64el@0.18.17:
     resolution: {integrity: sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==}
     engines: {node: '>=12'}
     cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.17.19:
-    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -3040,26 +2939,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.17.19:
-    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-riscv64@0.18.17:
     resolution: {integrity: sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==}
     engines: {node: '>=12'}
     cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.17.19:
-    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -3072,27 +2955,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-x64@0.17.19:
-    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-x64@0.18.17:
     resolution: {integrity: sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.17.19:
-    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
     requiresBuild: true
     optional: true
 
@@ -3104,27 +2971,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.17.19:
-    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/openbsd-x64@0.18.17:
     resolution: {integrity: sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.17.19:
-    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
     requiresBuild: true
     optional: true
 
@@ -3136,14 +2987,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-arm64@0.17.19:
-    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/win32-arm64@0.18.17:
     resolution: {integrity: sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==}
     engines: {node: '>=12'}
@@ -3152,26 +2995,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.19:
-    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/win32-ia32@0.18.17:
     resolution: {integrity: sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==}
     engines: {node: '>=12'}
     cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/win32-x64@0.17.19:
-    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
     requiresBuild: true
     optional: true
@@ -3225,21 +3052,12 @@ packages:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
 
-  /@graphql-typed-document-node/core@3.2.0(graphql@15.8.0):
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 15.8.0
-    dev: true
-
   /@graphql-typed-document-node/core@3.2.0(graphql@16.4.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.4.0
-    dev: false
 
   /@humanwhocodes/config-array@0.11.10:
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
@@ -7129,35 +6947,6 @@ packages:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
-  /esbuild@0.17.19:
-    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.17.19
-      '@esbuild/android-arm64': 0.17.19
-      '@esbuild/android-x64': 0.17.19
-      '@esbuild/darwin-arm64': 0.17.19
-      '@esbuild/darwin-x64': 0.17.19
-      '@esbuild/freebsd-arm64': 0.17.19
-      '@esbuild/freebsd-x64': 0.17.19
-      '@esbuild/linux-arm': 0.17.19
-      '@esbuild/linux-arm64': 0.17.19
-      '@esbuild/linux-ia32': 0.17.19
-      '@esbuild/linux-loong64': 0.17.19
-      '@esbuild/linux-mips64el': 0.17.19
-      '@esbuild/linux-ppc64': 0.17.19
-      '@esbuild/linux-riscv64': 0.17.19
-      '@esbuild/linux-s390x': 0.17.19
-      '@esbuild/linux-x64': 0.17.19
-      '@esbuild/netbsd-x64': 0.17.19
-      '@esbuild/openbsd-x64': 0.17.19
-      '@esbuild/sunos-x64': 0.17.19
-      '@esbuild/win32-arm64': 0.17.19
-      '@esbuild/win32-ia32': 0.17.19
-      '@esbuild/win32-x64': 0.17.19
-
   /esbuild@0.18.17:
     resolution: {integrity: sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==}
     engines: {node: '>=12'}
@@ -8354,16 +8143,6 @@ packages:
       - encoding
     dev: false
 
-  /graphql-tag@2.12.6(graphql@15.8.0):
-    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 15.8.0
-      tslib: 2.6.0
-    dev: true
-
   /graphql-tag@2.12.6(graphql@16.4.0):
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
     engines: {node: '>=10'}
@@ -8372,11 +8151,6 @@ packages:
     dependencies:
       graphql: 16.4.0
       tslib: 2.6.0
-
-  /graphql@15.8.0:
-    resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
-    engines: {node: '>= 10.x'}
-    dev: true
 
   /graphql@16.4.0:
     resolution: {integrity: sha512-tYDNcRvKCcfHREZYje3v33NSrSD/ZpbWWdPtBtUUuXx9NCo/2QDxYzNqCnMvfsrnbwRpEHMovVrPu/ERoLrIRg==}
@@ -11119,8 +10893,8 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
-  /postcss@8.4.23:
-    resolution: {integrity: sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==}
+  /postcss@8.4.27:
+    resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6
@@ -11810,8 +11584,8 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup@3.23.0:
-    resolution: {integrity: sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==}
+  /rollup@3.28.0:
+    resolution: {integrity: sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -13252,17 +13026,18 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+      vite: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
       - supports-color
       - terser
 
-  /vite-tsconfig-paths@3.6.0(vite@4.3.6):
+  /vite-tsconfig-paths@3.6.0(vite@4.4.8):
     resolution: {integrity: sha512-UfsPYonxLqPD633X8cWcPFVuYzx/CMNHAjZTasYwX69sXpa4gNmQkR0XCjj82h7zhLGdTWagMjC1qfb9S+zv0A==}
     peerDependencies:
       vite: '>2.0.0-0'
@@ -13271,18 +13046,19 @@ packages:
       globrex: 0.1.2
       recrawl-sync: 2.2.3
       tsconfig-paths: 4.2.0
-      vite: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+      vite: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite@4.3.6(@types/node@14.18.54)(sass@1.64.2):
-    resolution: {integrity: sha512-cqIyLSbA6gornMS659AXTVKF7cvSHMdKmJJwQ9DXq3lwsT1uZSdktuBRlpHQ8VnOWx0QHtjDwxPpGtyo9Fh/Qg==}
+  /vite@4.4.8(@types/node@14.18.54)(sass@1.64.2):
+    resolution: {integrity: sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
+      lightningcss: ^1.21.0
       sass: '*'
       stylus: '*'
       sugarss: '*'
@@ -13291,6 +13067,8 @@ packages:
       '@types/node':
         optional: true
       less:
+        optional: true
+      lightningcss:
         optional: true
       sass:
         optional: true
@@ -13302,9 +13080,9 @@ packages:
         optional: true
     dependencies:
       '@types/node': 14.18.54
-      esbuild: 0.17.19
-      postcss: 8.4.23
-      rollup: 3.23.0
+      esbuild: 0.18.17
+      postcss: 8.4.27
+      rollup: 3.28.0
       sass: 1.64.2
     optionalDependencies:
       fsevents: 2.3.2
@@ -13362,11 +13140,12 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+      vite: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vite-node: 0.34.1(@types/node@14.18.54)(sass@1.64.2)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -13425,11 +13204,12 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.3.6(@types/node@14.18.54)(sass@1.64.2)
+      vite: 4.4.8(@types/node@14.18.54)(sass@1.64.2)
       vite-node: 0.34.1(@types/node@14.18.54)(sass@1.64.2)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed that it was easy for dependencies shared across multiple packages to get out of sync.

### WHAT is this pull request doing?

- Add a new feature test that ensures that 'important' node deps are in sync across all workspaces
- Update some shared dependencies that were out of sync

### How to test your changes?

- Make a change in `package/app/package.json` and change the version of `vitest` to `4.6.8`
- Run `FEATURE=features/node-deps.feature p test:features` from the root of the repo
- You should see this error:
```
Feature: Node Dependencies # features/node-deps.feature:1
  Scenario: Shared node dependencies are in sync across packages # features/node-deps.feature:3
    When I look at the package.json files in all packages
    Then I see all shared node dependencies on the same version
    ✖ failed
      AssertionError [ERR_ASSERTION]: The following node dependencies are on different versions across packages:
        - vite:
          - app: 4.6.8
          - cli: 4.4.8
          - cli-kit: 4.4.8
          - create-app: 4.4.8
          - plugin-cloudflare: 4.4.8
          - plugin-did-you-mean: 4.4.8
          - theme: 4.4.8
          - ui-extensions-dev-console: 4.4.8
          - ui-extensions-server-kit: 4.4.8
          - root: 4.4.8
      Please make sure they are all on the same version.
          + expected - actual
          -1
          +0
          at World.<anonymous> (file:///Users/arkham/src/github.com/Shopify/cli/packages/features/steps/node-deps.steps.ts:80:10)
```