### PR TITLE
Feature: Remove app_unified_deployment_opt_in conditionals

### DIFF
--- a/.changeset/heavy-hats-protect.md
+++ b/.changeset/heavy-hats-protect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Remove rolled out beta flag

--- a/packages/app/src/cli/api/graphql/create_app.ts
+++ b/packages/app/src/cli/api/graphql/create_app.ts
@@ -78,7 +78,6 @@ export interface CreateAppQuerySchema {
       grantedScopes: string[]
       betas?: {
         unifiedAppDeployment?: boolean
-        unifiedAppDeploymentOptIn?: boolean
       }
       applicationUrl: string
       redirectUrlWhitelist: string[]

--- a/packages/app/src/cli/api/graphql/find_app.ts
+++ b/packages/app/src/cli/api/graphql/find_app.ts
@@ -14,7 +14,6 @@ export const FindAppQuery = gql`
       grantedScopes
       betas {
         unifiedAppDeployment
-        unifiedAppDeploymentOptIn
       }
       applicationUrl
       redirectUrlWhitelist
@@ -50,7 +49,6 @@ export interface FindAppQuerySchema {
     grantedScopes: string[]
     betas?: {
       unifiedAppDeployment?: boolean
-      unifiedAppDeploymentOptIn?: boolean
     }
     applicationUrl: string
     redirectUrlWhitelist: string[]

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -20,7 +20,6 @@ export type OrganizationApp = MinimalOrganizationApp & {
   grantedScopes: string[]
   betas?: {
     unifiedAppDeployment?: boolean
-    unifiedAppDeploymentOptIn?: boolean
   }
   applicationUrl: string
   redirectUrlWhitelist: string[]

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -36,7 +36,7 @@ import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {TokenItem, renderInfo, renderTasks} from '@shopify/cli-kit/node/ui'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {AbortError, AbortSilentError, BugError} from '@shopify/cli-kit/node/error'
-import {outputContent, formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+import {outputContent} from '@shopify/cli-kit/node/output'
 import {getOrganization} from '@shopify/cli-kit/node/environment'
 import {basename, joinPath} from '@shopify/cli-kit/node/path'
 import {Config} from '@oclif/core'
@@ -322,25 +322,6 @@ export interface DeployContextOptions {
 export async function ensureDeployContext(options: DeployContextOptions): Promise<DeployContextOutput> {
   const token = await ensureAuthenticatedPartners()
   const [partnersApp, envIdentifiers] = await fetchAppAndIdentifiers(options, token)
-
-  if (!partnersApp.betas?.unifiedAppDeploymentOptIn && !partnersApp.betas?.unifiedAppDeployment) {
-    renderInfo({
-      headline: [
-        'Stay tuned for changes to',
-        {command: formatPackageManagerCommand(options.app.packageManager, 'deploy')},
-        {char: '.'},
-      ],
-      body: "Soon, you'll be able to release all your extensions at the same time, directly from Shopify CLI.",
-      reference: [
-        {
-          link: {
-            url: 'https://shopify.dev/docs/apps/deployment/simplified-deployment',
-            label: 'Simplified extension deployment',
-          },
-        },
-      ],
-    })
-  }
 
   const org = await fetchOrgFromId(partnersApp.organizationId, token)
   showReusedDeployValues(org.businessName, options.app, partnersApp)

--- a/packages/app/src/cli/services/deploy/mode.test.ts
+++ b/packages/app/src/cli/services/deploy/mode.test.ts
@@ -30,7 +30,6 @@ const organizationApp = (app: AppInterface): OrganizationApp => {
     grantedScopes: [],
     betas: {
       unifiedAppDeployment: false,
-      unifiedAppDeploymentOptIn: true,
     },
   }
 }
@@ -86,24 +85,6 @@ describe('resolveDeploymentMode', () => {
       "
     `)
     expect(upgradePrompt).toHaveBeenCalled()
-  })
-
-  test("return legacy mode and don't display upcoming changes and prompt to upgrade when legacy deployment and not unified opt in", async () => {
-    // Given
-    const app = testApp()
-    const orgApp = organizationApp(app)
-    orgApp.betas!.unifiedAppDeploymentOptIn = false
-    const options = deploymentContext(app)
-    const upgradePrompt = vi.spyOn(ui, 'renderConfirmationPrompt')
-    const outputMock = mockAndCaptureOutput()
-
-    // When
-    const result = await resolveDeploymentMode(orgApp, options, TOKEN)
-
-    // Then
-    expect(result).equals('legacy')
-    expect(outputMock.info()).toMatchInlineSnapshot('""')
-    expect(upgradePrompt).not.toHaveBeenCalled()
   })
 
   test("return legacy mode and don't display upcoming changes and prompt to upgrade when legacy deployment and unified opt in but force deployments", async () => {

--- a/packages/app/src/cli/services/deploy/mode.ts
+++ b/packages/app/src/cli/services/deploy/mode.ts
@@ -81,7 +81,7 @@ function displayDeployLegacyBanner(packageManager: PackageManager) {
 async function upgradeDeploymentToUnified(app: OrganizationApp, options: DeployContextOptions, token: string) {
   let response: 'skipped' | 'confirmed' | 'cancelled' = 'skipped'
 
-  if (!app.betas?.unifiedAppDeploymentOptIn || options.force) {
+  if (options.force) {
     await metadata.addPublicMetadata(() => ({
       cmd_deploy_prompt_upgrade_to_unified_displayed: false,
       cmd_deploy_prompt_upgrade_to_unified_response: response,


### PR DESCRIPTION
### WHY are these changes introduced?

Partially Resolves: https://github.com/Shopify/develop-app-foundations/issues/97

The `app_unified_deployment_opt_in` beta flag has been fully rolled out and this is code cleanup. As a reminder, this flag governs whether a partner _can_ opt into simplified deployments, and is not the beta flag for whether a partner _is_ opted into simplified deployments (`app_unified_deployment`).

### WHAT is this pull request doing?

Cleaning up code paths regarding `app_unified_deployment_opt_in`.

### How to test your changes?
1. Clone `shopify/cli`
2. Checkout `689-remove-app-unified-deployment-opt-in`
3. Create an app using `pnpm create-app`
4. Create an extension using `pnpm shopify app generate extension --path ./app-name`
5. Deploy using `pnpm shopify app deploy --path ./app-name`
6. Verify we don't see the `Stay tuned for changes to deploy` banner.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
