### PR TITLE
[Functions] Fix for Javy compile call

### DIFF
--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -136,7 +136,7 @@ export async function runJavy(
   options: JSFunctionBuildOptions,
   extra: string[] = [],
 ) {
-  const args = ['exec', '--', 'javy', 'compile', '-d', '-o', fun.outputPath, 'dist/function.js', ...extra]
+  const args = ['exec', '--', 'javy', 'compile', 'dist/function.js', '-d', '-o', fun.outputPath, ...extra];
 
   return exec('npm', args, {
     cwd: fun.directory,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [2626](https://github.com/Shopify/cli/issues/2626)

Javy call compiling JS to .wasm was called incorrectly, causing a `Command failed with exit code 1` error.

### WHAT is this pull request doing?

Updating Javy call to compile successfully.

### How to test your changes?

Deploy a new Shopify app with function, issue was occurring during [this guide](https://shopify.dev/docs/apps/selling-strategies/discounts/experience/getting-started).

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
