### PR TITLE
Trigger main job only on main branch

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -58,7 +58,7 @@ jobs:
   main:
     name: "[Main] Node ${{ matrix.node }} in ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
We were getting notifications when someone merged a branch into another branch via a PR. This change makes sure that doesn't happen.