### PR TITLE
Fix dev for 1P devs using app with a theme app extension

### DIFF
--- a/.changeset/yellow-jeans-beam.md
+++ b/.changeset/yellow-jeans-beam.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Fix dev for 1P devs using app with a theme app extension

--- a/.changeset/yellow-jeans-beam.md
+++ b/.changeset/yellow-jeans-beam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix dev for 1P devs using app with a theme app extension

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/extension/dev_server.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/extension/dev_server.rb
@@ -159,7 +159,7 @@ module ShopifyCLI
 
         def preview_message
           if Shopifolk.acting_as_shopify_organization?
-            parsed_uri = URI.parse(extension.preview_message)
+            parsed_uri = URI.parse(extension.location)
             shopify_org_url = "#{parsed_uri.scheme}://#{parsed_uri.host}/9082/impersonate"
             if ShopifyCLI::Environment.unified_deployment?
               ctx.message("serve.preview_message_1p_unified", shopify_org_url, theme.editor_url, address)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Command `dev` is not working for 1P dev using an app with a theme app extension. After the theme content is pushed to the server by the TAE and error is returned when the instructions should be displayed

```sh
┃ Pushing theme...    80%
┃ Pushing theme...    90%
┃ Pushing theme...   100%
┃ ------------------
┃ --------- Viewing extension…
┃ ✗ An unexpected error occurred.
```


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Fix a typo error in this [PR](https://github.com/Shopify/cli/pull/2171), `extension.preview_message` does not exist and `extension.location` should be used instead
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create an app with a theme app extension
- Create a partners spin instance `spin up partners`
- Run the command `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name) SHOPIFY_CLI_1P_DEV=1 p shopify app dev --path /path/to/your/app`
- Select `Shopify` organization
- Command should run as expected
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
