### PR TITLE
Fix windows theme package

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -5,7 +5,7 @@ import { stdin as input, stdout as output } from "node:process";
 import { createRequire } from "module";
 import { fileURLToPath } from "url";
 import { Readable } from "stream";
-import execa, { node } from "execa";
+import { execa } from "execa";
 import path from "path";
 import os from "os";
 import fs from "fs";

--- a/bin/create-test-theme.js
+++ b/bin/create-test-theme.js
@@ -4,7 +4,7 @@ import * as readline from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 import { createRequire } from "module"
 import { fileURLToPath } from "url"
-import {execa} from "execa"
+import { execa } from "execa"
 import path from "path"
 import os from "os"
 import fs from "fs"

--- a/bin/create-test-theme.js
+++ b/bin/create-test-theme.js
@@ -4,7 +4,7 @@ import * as readline from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 import { createRequire } from "module"
 import { fileURLToPath } from "url"
-import execa from "execa"
+import {execa} from "execa"
 import path from "path"
 import os from "os"
 import fs from "fs"
@@ -124,6 +124,9 @@ program
 
     log(`Checking your theme...`)
     await shopifyExec(["theme", "check"])
+
+    log(`Packaging your theme...`)
+    await shopifyExec(["theme", "package"])
 
     log(`Serving your theme on store ${options.store}...`)
     const devProcess = shopifyExec(["theme", "dev", "--store", options.store])

--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -139,5 +139,5 @@ export function moduleDirectory(moduleURL: string | URL): string {
  */
 export function cwd(): string {
   // eslint-disable-next-line @shopify/cli/no-process-cwd
-  return process.env.INIT_CWD ? normalize(process.env.INIT_CWD) : process.cwd()
+  return normalize(process.env.INIT_CWD ? process.env.INIT_CWD : process.cwd())
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When running `theme package` without the `--path` flag we use `cwd()` as the default directory.
That's correct,  but on windows this path is not normalized to be used with `glob` which is what we use to find the files we need to package.

Fixes https://github.com/Shopify/cli/issues/2634

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Normalize the result of `cwd()`
- Add a `theme package` step to the `create-test-theme` script
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- run `shopify theme package` in windows from a theme folder, it should produce a valid `.zip` file
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
