### PR TITLE
Allow to pass an input JSON to 'app function run'

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -16,7 +16,8 @@
     },
     "refresh-manifests": {
       "dependsOn": [
-        "build"
+        "build",
+        "refresh-readme"
       ]
     },
     "refresh-readme": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "nx run-many --target=build --all --skip-nx-cache",
     "build:affected": "nx affected --target=build",
     "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache",
-    "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache && bin/prettify-manifests.js",
+    "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache && bin/prettify-manifests.js && pnpm refresh-readme",
     "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests && pnpm refresh-readme && pnpm refresh-documentation && bin/update-cli-kit-version.js && pnpm docs:generate",
     "refresh-documentation": "nx run-many --target=refresh-documentation --all --skip-nx-cache",
     "refresh-readme": "nx run-many --target=refresh-readme --all --skip-nx-cache"

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -968,6 +968,13 @@
           "hidden": false,
           "multiple": false
         },
+        "input": {
+          "name": "input",
+          "type": "option",
+          "char": "i",
+          "description": "The input JSON to pass to the function.",
+          "multiple": false
+        },
         "json": {
           "name": "json",
           "type": "boolean",

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -972,7 +972,7 @@
           "name": "input",
           "type": "option",
           "char": "i",
-          "description": "The input JSON to pass to the function.",
+          "description": "The input JSON to pass to the function. If omitted, standard input is used.",
           "multiple": false
         },
         "json": {

--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -12,6 +12,11 @@ export default class FunctionRun extends Command {
     ...globalFlags,
     ...appFlags,
     ...functionFlags,
+    input: Flags.string({
+      char: 'i',
+      description: 'The input JSON to pass to the function.',
+      env: 'SHOPIFY_FLAG_INPUT',
+    }),
     json: Flags.boolean({
       char: 'j',
       hidden: false,
@@ -27,7 +32,7 @@ export default class FunctionRun extends Command {
       path: flags.path,
       configName: flags.config,
       callback: async (_app, ourFunction) => {
-        await runFunctionRunner(ourFunction, {json: flags.json})
+        await runFunctionRunner(ourFunction, {input: flags.input, json: flags.json})
       },
     })
   }

--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -14,7 +14,7 @@ export default class FunctionRun extends Command {
     ...functionFlags,
     input: Flags.string({
       char: 'i',
-      description: 'The input JSON to pass to the function.',
+      description: 'The input JSON to pass to the function. If omitted, standard input is used.',
       env: 'SHOPIFY_FLAG_INPUT',
     }),
     json: Flags.boolean({

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -194,6 +194,35 @@ describe('runFunctionRunner', () => {
       },
     )
   })
+
+  test('it supports receiving an input on the command line', async () => {
+    // Given
+    const ourFunction = await testFunctionExtension()
+
+    // When
+    const got = runFunctionRunner(ourFunction, {input: 'input.json', json: false})
+
+    // Then
+    await expect(got).resolves.toBeUndefined()
+    expect(exec).toHaveBeenCalledWith(
+      'npm',
+      [
+        'exec',
+        '--',
+        'function-runner',
+        '-f',
+        joinPath(ourFunction.directory, 'dist/index.wasm'),
+        '--input',
+        'input.json',
+      ],
+      {
+        cwd: ourFunction.directory,
+        stderr: 'inherit',
+        stdin: 'inherit',
+        stdout: 'inherit',
+      },
+    )
+  })
 })
 
 describe('ExportJavyBuilder', () => {

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -147,12 +147,14 @@ export async function runJavy(
 }
 
 interface FunctionRunnerOptions {
+  input?: string
   json: boolean
 }
 
 export async function runFunctionRunner(fun: ExtensionInstance<FunctionConfigType>, options: FunctionRunnerOptions) {
   const outputAsJson = options.json ? ['--json'] : []
-  return exec('npm', ['exec', '--', 'function-runner', '-f', fun.outputPath, ...outputAsJson], {
+  const withInput = options.input ? ['--input', options.input] : []
+  return exec('npm', ['exec', '--', 'function-runner', '-f', fun.outputPath, ...withInput, ...outputAsJson], {
     cwd: fun.directory,
     stdin: 'inherit',
     stdout: 'inherit',

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -257,10 +257,11 @@ Run a Function locally for testing.
 
 ```
 USAGE
-  $ shopify app function run [--no-color] [--verbose] [--path <value>] [-c <value>] [-j]
+  $ shopify app function run [--no-color] [--verbose] [--path <value>] [-c <value>] [-i <value>] [-j]
 
 FLAGS
   -c, --config=<value>  The name of the app configuration.
+  -i, --input=<value>   The input JSON to pass to the function.
   -j, --json            Log the run result as a JSON object.
   --no-color            Disable color output.
   --path=<value>        [default: .] The path to your function directory.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -261,7 +261,7 @@ USAGE
 
 FLAGS
   -c, --config=<value>  The name of the app configuration.
-  -i, --input=<value>   The input JSON to pass to the function.
+  -i, --input=<value>   The input JSON to pass to the function. If omitted, standard input is used.
   -j, --json            Log the run result as a JSON object.
   --no-color            Disable color output.
   --path=<value>        [default: .] The path to your function directory.


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/6712

### How to test your changes?

- Create a new app with a js function
- Create a JSON like this one `{"discountNode":{"metafield":null}}` and call it `input.json`
- Run `npm run shopify app function run -i input.json`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
