### PR TITLE
Add `local_pickup_delivery_option_generator` extension type

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -117,6 +117,7 @@
           "cart_transform",
           "tax_calculation",
           "fulfillment_constraints",
+          "local_pickup_delivery_option_generator",
         ],
         "default": "checkout_ui_extension",
     },

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -62,6 +62,7 @@ const spec = createExtensionSpecification({
     'shipping_discounts',
     'fulfillment_constraints',
     'order_routing_location_rule',
+    'local_pickup_delivery_option_generator',
   ],
   schema: FunctionExtensionSchema,
   appModuleFeatures: (_) => ['function'],


### PR DESCRIPTION
### WHY are these changes introduced?

Issue: https://github.com/Shopify/shopify/issues/446570

These changes will allow us use the main cli repo to deploy local_pickup_delivery_option_generator functions.

### WHAT is this pull request doing?

Exposes the local_pickup_delivery_option_generator extension type and allows us to deploy local_pickup_delivery_option_generator functions.

### How to test your changes?

I am able deploy a function to spin with these changes on my branch.

<img width="1008" alt="image" src="https://github.com/Shopify/cli/assets/12888080/3c00faf1-5448-4e7b-992d-13e10d1d1597">

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
