### PR TITLE
Accept build_directory config for theme extensions

### DIFF
--- a/.changeset/lemon-snakes-sing.md
+++ b/.changeset/lemon-snakes-sing.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Accept a build_directory config for theme app extensions

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -202,11 +202,20 @@ export async function testUIExtension(
   return extension
 }
 
-export async function testThemeExtensions(directory = './my-extension'): Promise<ExtensionInstance> {
+interface TestThemeExtensionOptions {
+  directory?: string
+  buildDirectory?: string
+}
+
+export async function testThemeExtensions({
+  directory = './my-extension',
+  buildDirectory,
+}: TestThemeExtensionOptions = {}): Promise<ExtensionInstance> {
   const configuration = {
     name: 'theme extension name',
     type: 'theme' as const,
     metafields: [],
+    ...(buildDirectory ? {build_directory: buildDirectory} : {}),
   }
 
   const allSpecs = await loadLocalExtensionsSpecifications()

--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -110,6 +110,25 @@ describe('watchPaths', async () => {
   })
 })
 
+describe('buildDirectory', async () => {
+  test('returns the root directory by default', async () => {
+    const extensionInstance = await testThemeExtensions()
+
+    const got = extensionInstance.buildDirectory
+
+    expect(got).toBe(extensionInstance.directory)
+  })
+
+  test('returns the build directory if configured', async () => {
+    const buildDirectory = 'build'
+    const extensionInstance = await testThemeExtensions({buildDirectory})
+
+    const got = extensionInstance.buildDirectory
+
+    expect(got).toBe(joinPath(extensionInstance.directory, buildDirectory))
+  })
+})
+
 describe('isDraftable', () => {
   test('returns false for theme extensions', async () => {
     const extensionInstance = await testThemeExtensions()

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -104,6 +104,14 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     return `${this.handle}.js`
   }
 
+  get buildDirectory() {
+    if (this.configuration.build_directory) {
+      return joinPath(this.directory, this.configuration.build_directory)
+    } else {
+      return this.directory
+    }
+  }
+
   constructor(options: {
     configuration: TConfiguration
     configurationPath: string

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -70,6 +70,7 @@ export const BaseSchema = zod.object({
   capabilities: CapabilitiesSchema.optional(),
   metafields: zod.array(MetafieldSchema).optional().default([]),
   settings: SettingsSchema.optional(),
+  build_directory: zod.string().optional(),
 })
 
 export const BaseSchemaWithHandle = BaseSchema.extend({

--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -4,7 +4,7 @@ import {themeExtensionFiles} from '../../../utilities/extensions/theme.js'
 import {ExtensionInstance} from '../extension-instance.js'
 import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import {fileSize} from '@shopify/cli-kit/node/fs'
-import {dirname, relativePath} from '@shopify/cli-kit/node/path'
+import {dirname, joinPath, relativePath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 
@@ -68,11 +68,15 @@ const SUPPORTED_BUCKETS = Object.keys(SUPPORTED_EXTS)
 
 async function validateThemeExtension(extension: ExtensionInstance): Promise<void> {
   const themeFiles = await themeExtensionFiles(extension)
+  let extensionDirectory = extension.directory
+  if (extension.configuration.build_directory) {
+    extensionDirectory = joinPath(extension.directory, extension.configuration.build_directory)
+  }
   const liquidBytes: number[] = []
   const extensionBytes: number[] = []
   await Promise.all(
     themeFiles.map(async (filepath) => {
-      const relativePathName = relativePath(extension.directory, filepath)
+      const relativePathName = relativePath(extensionDirectory, filepath)
       const directoryName = dirname(relativePathName)
       validateFile(relativePathName, directoryName)
       const filesize = await fileSize(filepath)

--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -4,7 +4,7 @@ import {themeExtensionFiles} from '../../../utilities/extensions/theme.js'
 import {ExtensionInstance} from '../extension-instance.js'
 import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import {fileSize} from '@shopify/cli-kit/node/fs'
-import {dirname, joinPath, relativePath} from '@shopify/cli-kit/node/path'
+import {dirname, relativePath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 
@@ -68,15 +68,11 @@ const SUPPORTED_BUCKETS = Object.keys(SUPPORTED_EXTS)
 
 async function validateThemeExtension(extension: ExtensionInstance): Promise<void> {
   const themeFiles = await themeExtensionFiles(extension)
-  let extensionDirectory = extension.directory
-  if (extension.configuration.build_directory) {
-    extensionDirectory = joinPath(extension.directory, extension.configuration.build_directory)
-  }
   const liquidBytes: number[] = []
   const extensionBytes: number[] = []
   await Promise.all(
     themeFiles.map(async (filepath) => {
-      const relativePathName = relativePath(extensionDirectory, filepath)
+      const relativePathName = relativePath(extension.buildDirectory, filepath)
       const directoryName = dirname(relativePathName)
       validateFile(relativePathName, directoryName)
       const filesize = await fileSize(filepath)

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -57,7 +57,7 @@ export interface ExtensionBuildOptions {
  */
 export async function buildThemeExtension(extension: ExtensionInstance, options: ExtensionBuildOptions): Promise<void> {
   options.stdout.write(`Running theme check on your Theme app extension...`)
-  const offenses = await runThemeCheck(extension.directory)
+  const offenses = await runThemeCheck(extension.buildDirectory)
   options.stdout.write(offenses)
 }
 

--- a/packages/app/src/cli/services/deploy/theme-extension-config.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.ts
@@ -1,7 +1,7 @@
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {themeExtensionFiles} from '../../utilities/extensions/theme.js'
 import {readFile} from '@shopify/cli-kit/node/fs'
-import {relativePath, dirname} from '@shopify/cli-kit/node/path'
+import {joinPath, relativePath, dirname} from '@shopify/cli-kit/node/path'
 
 export interface ThemeExtensionConfig {
   theme_extension: {
@@ -12,9 +12,13 @@ export interface ThemeExtensionConfig {
 export async function themeExtensionConfig(themeExtension: ExtensionInstance): Promise<ThemeExtensionConfig> {
   const files: {[key: string]: string} = {}
   const themeFiles = await themeExtensionFiles(themeExtension)
+  let themeExtensionDirectory = themeExtension.directory
+  if (themeExtension.configuration.build_directory) {
+    themeExtensionDirectory = joinPath(themeExtension.directory, themeExtension.configuration.build_directory)
+  }
   await Promise.all(
     themeFiles.map(async (filepath) => {
-      const relativePathName = relativePath(themeExtension.directory, filepath)
+      const relativePathName = relativePath(themeExtensionDirectory, filepath)
       const directoryName = dirname(relativePathName)
       const encoding = directoryName === 'assets' ? 'binary' : 'utf8'
       const fileContents = await readFile(filepath, {encoding})

--- a/packages/app/src/cli/services/deploy/theme-extension-config.ts
+++ b/packages/app/src/cli/services/deploy/theme-extension-config.ts
@@ -1,7 +1,7 @@
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {themeExtensionFiles} from '../../utilities/extensions/theme.js'
 import {readFile} from '@shopify/cli-kit/node/fs'
-import {joinPath, relativePath, dirname} from '@shopify/cli-kit/node/path'
+import {relativePath, dirname} from '@shopify/cli-kit/node/path'
 
 export interface ThemeExtensionConfig {
   theme_extension: {
@@ -12,13 +12,9 @@ export interface ThemeExtensionConfig {
 export async function themeExtensionConfig(themeExtension: ExtensionInstance): Promise<ThemeExtensionConfig> {
   const files: {[key: string]: string} = {}
   const themeFiles = await themeExtensionFiles(themeExtension)
-  let themeExtensionDirectory = themeExtension.directory
-  if (themeExtension.configuration.build_directory) {
-    themeExtensionDirectory = joinPath(themeExtension.directory, themeExtension.configuration.build_directory)
-  }
   await Promise.all(
     themeFiles.map(async (filepath) => {
-      const relativePathName = relativePath(themeExtensionDirectory, filepath)
+      const relativePathName = relativePath(themeExtension.buildDirectory, filepath)
       const directoryName = dirname(relativePathName)
       const encoding = directoryName === 'assets' ? 'binary' : 'utf8'
       const fileContents = await readFile(filepath, {encoding})

--- a/packages/app/src/cli/services/dev/theme-extension-args.test.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.test.ts
@@ -10,7 +10,7 @@ describe('themeExtensionArgs', async () => {
     const apiKey = 'api_key_0000_1111_2222'
     const developerPlatformClient = testDeveloperPlatformClient()
     const options = {themeExtensionPort: 8282, theme: 'theme ID'}
-    const extension = await testThemeExtensions()
+    const extension = await testThemeExtensions({buildDirectory: 'build'})
 
     const registration = {
       id: 'extension ID',
@@ -24,7 +24,7 @@ describe('themeExtensionArgs', async () => {
     const args = await themeExtensionArgs(extension, apiKey, developerPlatformClient, options)
 
     expect(args).toEqual([
-      './my-extension',
+      'my-extension/build',
       '--api-key',
       'api_key_0000_1111_2222',
 

--- a/packages/app/src/cli/services/dev/theme-extension-args.ts
+++ b/packages/app/src/cli/services/dev/theme-extension-args.ts
@@ -10,7 +10,7 @@ export async function themeExtensionArgs(
 ) {
   const extensionRegistration = await ensureThemeExtensionDevContext(extension, apiKey, developerPlatformClient)
   const extensionId = extensionRegistration.id
-  const directory = extension.directory
+  const directory = extension.buildDirectory
   const extensionTitle = extension.localIdentifier
   const extensionType = extension.graphQLType
 

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -81,14 +81,10 @@ export async function bundleThemeExtension(
 ): Promise<void> {
   options.stdout.write(`Bundling theme extension ${extension.localIdentifier}...`)
   const files = await themeExtensionFiles(extension)
-  let extensionDirectory = extension.directory
-  if (extension.configuration.build_directory) {
-    extensionDirectory = joinPath(extensionDirectory, extension.configuration.build_directory)
-  }
 
   await Promise.all(
     files.map(function (filepath) {
-      const relativePathName = relativePath(extensionDirectory, filepath)
+      const relativePathName = relativePath(extension.buildDirectory, filepath)
       const outputFile = joinPath(extension.outputPath, relativePathName)
       return copyFile(filepath, outputFile)
     }),

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -81,10 +81,14 @@ export async function bundleThemeExtension(
 ): Promise<void> {
   options.stdout.write(`Bundling theme extension ${extension.localIdentifier}...`)
   const files = await themeExtensionFiles(extension)
+  let extensionDirectory = extension.directory
+  if (extension.configuration.build_directory) {
+    extensionDirectory = joinPath(extensionDirectory, extension.configuration.build_directory)
+  }
 
   await Promise.all(
     files.map(function (filepath) {
-      const relativePathName = relativePath(extension.directory, filepath)
+      const relativePathName = relativePath(extensionDirectory, filepath)
       const outputFile = joinPath(extension.outputPath, relativePathName)
       return copyFile(filepath, outputFile)
     }),

--- a/packages/app/src/cli/utilities/extensions/theme.ts
+++ b/packages/app/src/cli/utilities/extensions/theme.ts
@@ -23,12 +23,8 @@ const ignoredFilePatterns = [
 ]
 
 export async function themeExtensionFiles(themeExtension: ExtensionInstance): Promise<string[]> {
-  let themeExtensionDirectory = themeExtension.directory
-  if (themeExtension.configuration.build_directory) {
-    themeExtensionDirectory = joinPath(themeExtensionDirectory, themeExtension.configuration.build_directory)
-  }
   const filename = '.shopifyignore'
-  const filepath = joinPath(themeExtensionDirectory, filename)
+  const filepath = joinPath(themeExtension.buildDirectory, filename)
   const ignore = ignoredFilePatterns.map((pattern) => joinPath('*', pattern))
 
   if (fileExistsSync(filepath)) {
@@ -38,7 +34,7 @@ export async function themeExtensionFiles(themeExtension: ExtensionInstance): Pr
 
   return glob('*/*', {
     absolute: true,
-    cwd: themeExtensionDirectory,
+    cwd: themeExtension.buildDirectory,
     ignore,
   })
 }

--- a/packages/app/src/cli/utilities/extensions/theme.ts
+++ b/packages/app/src/cli/utilities/extensions/theme.ts
@@ -23,8 +23,12 @@ const ignoredFilePatterns = [
 ]
 
 export async function themeExtensionFiles(themeExtension: ExtensionInstance): Promise<string[]> {
+  let themeExtensionDirectory = themeExtension.directory
+  if (themeExtension.configuration.build_directory) {
+    themeExtensionDirectory = joinPath(themeExtensionDirectory, themeExtension.configuration.build_directory)
+  }
   const filename = '.shopifyignore'
-  const filepath = joinPath(themeExtension.directory, filename)
+  const filepath = joinPath(themeExtensionDirectory, filename)
   const ignore = ignoredFilePatterns.map((pattern) => joinPath('*', pattern))
 
   if (fileExistsSync(filepath)) {
@@ -34,7 +38,7 @@ export async function themeExtensionFiles(themeExtension: ExtensionInstance): Pr
 
   return glob('*/*', {
     absolute: true,
-    cwd: themeExtension.directory,
+    cwd: themeExtensionDirectory,
     ignore,
   })
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #867
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Accepts a `build_directory` config in the extension config file. This can be used to have a `src`/`dist` directory setup for theme extensions.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Move your theme files to a build directory, and configure `build_directory` in your theme app extension's TOML file. Things should work as usual.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->
Need to document this!

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
