### PR TITLE
Remove tunnelClient.stop()

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -349,7 +349,6 @@ async function dev(options: DevOptions) {
       previewUrl,
       app,
       abortController,
-      tunnelClient,
     })
   } else {
     await runConcurrentHTTPProcessesAndPathForwardTraffic({
@@ -359,7 +358,6 @@ async function dev(options: DevOptions) {
       additionalProcesses,
       app,
       abortController,
-      tunnelClient,
     })
   }
 }

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -13,7 +13,6 @@ import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {unstyled} from '@shopify/cli-kit/node/output'
 import {openURL} from '@shopify/cli-kit/node/system'
-import {TunnelClient} from '@shopify/cli-kit/node/plugins/tunnel'
 import {Writable} from 'stream'
 
 vi.mock('@shopify/cli-kit/node/system')
@@ -276,9 +275,6 @@ describe('Dev', () => {
   test('abortController can be used to exit from outside and should preserve static output', async () => {
     // Given
     const abortController = new AbortController()
-    const tunnelClient = {
-      stopTunnel: vi.fn(),
-    } as unknown as TunnelClient
 
     const backendProcess = {
       prefix: 'backend',
@@ -300,7 +296,6 @@ describe('Dev', () => {
         abortController={abortController}
         previewUrl="https://shopify.com"
         app={testApp}
-        tunnelClient={tunnelClient}
       />,
     )
 
@@ -331,7 +326,6 @@ describe('Dev', () => {
       00:00:00 │ backend │ third backend message
       "
     `)
-    expect(tunnelClient.stopTunnel).toHaveBeenCalledOnce()
     expect(vi.mocked(disableDeveloperPreview)).toHaveBeenNthCalledWith(1, {
       apiKey: '123',
       token: '123',

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -9,7 +9,6 @@ import {Box, Text, useInput, useStdin} from 'ink'
 import {handleCtrlC} from '@shopify/cli-kit/node/ui'
 import {openURL} from '@shopify/cli-kit/node/system'
 import figures from '@shopify/cli-kit/node/figures'
-import {TunnelClient} from '@shopify/cli-kit/node/plugins/tunnel'
 import {treeKill} from '@shopify/cli-kit/node/tree-kill'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {Writable} from 'stream'
@@ -24,18 +23,10 @@ export interface DevProps {
     apiKey: string
     token: string
   }
-  tunnelClient?: TunnelClient
   pollingTime?: number
 }
 
-const Dev: FunctionComponent<DevProps> = ({
-  abortController,
-  processes,
-  previewUrl,
-  app,
-  tunnelClient,
-  pollingTime = 5000,
-}) => {
+const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUrl, app, pollingTime = 5000}) => {
   const {apiKey, token, canEnablePreviewMode, developmentStorePreviewEnabled} = app
   const {isRawModeSupported: canUseShortcuts} = useStdin()
   const pollingInterval = useRef<NodeJS.Timeout>()
@@ -49,7 +40,6 @@ const Dev: FunctionComponent<DevProps> = ({
     }, 2000)
     clearInterval(pollingInterval.current)
     await disableDeveloperPreview({apiKey, token})
-    tunnelClient?.stopTunnel()
   })
 
   const [devPreviewEnabled, setDevPreviewEnabled] = useState<boolean>(Boolean(developmentStorePreviewEnabled))

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -2,7 +2,6 @@ import {renderDev} from '../../services/dev/ui.js'
 import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {AbortController, AbortSignal} from '@shopify/cli-kit/node/abort'
 import {OutputProcess, outputDebug, outputContent, outputToken, outputWarn} from '@shopify/cli-kit/node/output'
-import {TunnelClient} from '@shopify/cli-kit/node/plugins/tunnel'
 import {Writable} from 'stream'
 import * as http from 'http'
 
@@ -51,7 +50,6 @@ interface Options {
     token: string
   }
   abortController?: AbortController
-  tunnelClient?: TunnelClient
 }
 
 /**
@@ -70,7 +68,6 @@ export async function runConcurrentHTTPProcessesAndPathForwardTraffic({
   additionalProcesses,
   app,
   abortController,
-  tunnelClient,
 }: Options): Promise<void> {
   // Lazy-importing it because it's CJS and we don't want it
   // to block the loading of the ESM module graph.
@@ -146,7 +143,6 @@ ${outputToken.json(JSON.stringify(rules))}
       abortController: controller,
       previewUrl,
       app,
-      tunnelClient,
     }),
     server.listen(portNumber),
   ])


### PR DESCRIPTION
### WHY are these changes introduced?

We noticed that the tunnel was already getting killed by `treeKill` so there is no need to also stop it before.

### WHAT is this pull request doing?

Remove the tunnelClient handler in `abort`.

### How to test your changes?

- Run `dev`
- Check your processes for the presence of `cloudflared`
- Kill `dev` (either `q` or `ctrl+c`)
- That process should have disappeared