### PR TITLE
[cli-kit] fix missing / in getCIMetadata

### DIFF
--- a/packages/cli-kit/src/private/node/context/utilities.ts
+++ b/packages/cli-kit/src/private/node/context/utilities.ts
@@ -40,7 +40,7 @@ export function getCIMetadata(envName: string, envs: NodeJS.ProcessEnv): Metadat
         commitSha: envs.GITHUB_SHA,
         run: envs.GITHUB_RUN_ID,
         runNumber: envs.GITHUB_RUN_NUMBER,
-        url: `${envs.GITHUB_SERVER_URL}${envs.GITHUB_REPOSITORY}/actions/runs/${envs.GITHUB_RUN_ID}`,
+        url: `${envs.GITHUB_SERVER_URL}/${envs.GITHUB_REPOSITORY}/actions/runs/${envs.GITHUB_RUN_ID}`,
       }
     case 'gitlab':
       return {

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -309,7 +309,7 @@ describe('ciPlatform', () => {
       GITHUB_RUN_NUMBER: '789',
       GITHUB_SHA: 'abcdef',
       GITHUB_SERVER_URL: 'https://github.com',
-      GITHUB_REPOSITORY: '/user/repo',
+      GITHUB_REPOSITORY: 'user/repo',
     }
 
     // When


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Fixes a missing forward slash in the url returned from `getCIMetadata` for a Github Action workflow run. Presently this returns something like `https://github.comShopify/cli`.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
