### PR TITLE
Add localized description to the dev server kit

### DIFF
--- a/.changeset/angry-jars-worry.md
+++ b/.changeset/angry-jars-worry.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-server-kit': minor
+'@shopify/cli': minor
+---
+
+Added support for optional localizable description to UI extensions dev and deploy

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -21,6 +21,7 @@ describe('ui_extension', async () => {
       extension_points: extensionPoints,
       api_version: '2023-01' as const,
       name: 'UI Extension',
+      description: 'This is an ordinary test extension.',
       type: 'ui_extension',
       metafields: [],
       capabilities: {
@@ -77,6 +78,7 @@ describe('ui_extension', async () => {
         ],
         api_version: '2023-01' as const,
         name: 'UI Extension',
+        description: 'This is an ordinary test extension',
         type: 'ui_extension',
         metafields: [{namespace: 'test', key: 'test'}],
         capabilities: {
@@ -107,6 +109,7 @@ describe('ui_extension', async () => {
       const configuration = {
         api_version: '2023-01' as const,
         name: 'UI Extension',
+        description: 'This is an ordinary test extension',
         type: 'ui_extension',
         metafields: [{namespace: 'test', key: 'test'}],
         capabilities: {
@@ -224,6 +227,7 @@ Please check the configuration in ${uiExtension.configuration.path}`),
           extension_points: uiExtension.configuration.extension_points,
           capabilities: uiExtension.configuration.capabilities,
           name: uiExtension.configuration.name,
+          description: uiExtension.configuration.description,
           api_version: uiExtension.configuration.api_version,
           settings: uiExtension.configuration.settings,
         })

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -52,6 +52,7 @@ const spec = createExtensionSpecification({
       extension_points: config.extension_points,
       capabilities: config.capabilities,
       name: config.name,
+      description: config.description,
       settings: config.settings,
       localization: await loadLocalesConfig(directory, config.type),
     }

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -61,6 +61,7 @@ export async function getUIExtensionPayload(
     title: extension.configuration.name,
     handle: extension.handle,
     name: extension.configuration.name,
+    description: extension.configuration.description,
     apiVersion: extension.configuration.api_version,
     approvalScopes: options.grantedScopes,
   }

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -72,6 +72,7 @@ export interface UIExtensionPayload {
   handle: string
   // user facing name for the extension
   name: string
+  description?: string
   approvalScopes: string[]
 }
 

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
@@ -153,12 +153,15 @@ describe('ExtensionServerClient', () => {
         translations: {
           ja: {
             welcome: 'いらっしゃいませ!',
+            description: '拡張子の説明',
           },
           en: {
             welcome: 'Welcome!',
+            description: 'Extension description',
           },
           fr: {
             welcome: 'Bienvenue!',
+            description: "Description de l'extension",
           },
         },
         lastUpdated: 1684164163736,
@@ -166,7 +169,7 @@ describe('ExtensionServerClient', () => {
 
       const translatedLocalization = {
         extensionLocale: 'ja',
-        translations: '{"welcome":"いらっしゃいませ!"}',
+        translations: '{"welcome":"いらっしゃいませ!","description":"拡張子の説明"}',
         lastUpdated: localization.lastUpdated,
       }
 
@@ -177,6 +180,7 @@ describe('ExtensionServerClient', () => {
             uuid: '123',
             type: 'ui_extension',
             name: 't:welcome',
+            description: 't:description',
             localization,
             extensionPoints: [{localization}],
           },
@@ -202,11 +206,13 @@ describe('ExtensionServerClient', () => {
               uuid: '123',
               type: 'ui_extension',
               name: 'いらっしゃいませ!',
+              description: '拡張子の説明',
               localization: translatedLocalization,
               extensionPoints: [
                 {
                   localization: translatedLocalization,
                   name: 'いらっしゃいませ!',
+                  description: '拡張子の説明',
                 },
               ],
             },
@@ -285,12 +291,15 @@ describe('ExtensionServerClient', () => {
         translations: {
           ja: {
             welcome: 'いらっしゃいませ!',
+            description: '拡張子の説明',
           },
           en: {
             welcome: 'Welcome!',
+            description: 'Extension description',
           },
           fr: {
             welcome: 'Bienvenue!',
+            description: "Description de l'extension",
           },
         },
         lastUpdated: 1684164163736,
@@ -303,6 +312,7 @@ describe('ExtensionServerClient', () => {
             uuid: '123',
             type: 'ui_extension',
             name: 't:welcome',
+            description: 't:description',
             localization,
             extensionPoints: [{localization}],
           },
@@ -338,12 +348,15 @@ describe('ExtensionServerClient', () => {
         translations: {
           ja: {
             welcome: 'いらっしゃいませ!',
+            description: '拡張子の説明',
           },
           en: {
             welcome: 'Welcome!',
+            description: 'Extension description',
           },
           fr: {
             welcome: 'Bienvenue!',
+            description: "Description de l'extension",
           },
         },
         lastUpdated: 1684164163736,
@@ -351,7 +364,7 @@ describe('ExtensionServerClient', () => {
 
       const translatedLocalization = {
         extensionLocale: 'ja',
-        translations: '{"welcome":"いらっしゃいませ!"}',
+        translations: '{"welcome":"いらっしゃいませ!","description":"拡張子の説明"}',
         lastUpdated: localization.lastUpdated,
       }
 
@@ -362,6 +375,7 @@ describe('ExtensionServerClient', () => {
             uuid: '123',
             type: 'ui_extension',
             name: 't:welcome',
+            description: 't:description',
             localization,
             extensionPoints: [{localization}],
           },
@@ -369,6 +383,7 @@ describe('ExtensionServerClient', () => {
             uuid: '456',
             type: 'ui_extension',
             name: 'Extension 456',
+            description: 'This is a test extension',
             localization: null,
             extensionPoints: [{localization: null}],
           },
@@ -387,13 +402,17 @@ describe('ExtensionServerClient', () => {
               uuid: '123',
               type: 'ui_extension',
               name: 'いらっしゃいませ!',
+              description: '拡張子の説明',
               localization: translatedLocalization,
-              extensionPoints: [{localization: translatedLocalization, name: 'いらっしゃいませ!'}],
+              extensionPoints: [
+                {localization: translatedLocalization, name: 'いらっしゃいませ!', description: '拡張子の説明'},
+              ],
             },
             {
               uuid: '456',
               type: 'ui_extension',
               name: 'Extension 456',
+              description: 'This is a test extension',
               localization: null,
               extensionPoints: [{localization: null}],
             },
@@ -413,12 +432,15 @@ describe('ExtensionServerClient', () => {
         translations: {
           ja: {
             welcome: 'いらっしゃいませ!',
+            description: '拡張子の説明',
           },
           en: {
             welcome: 'Welcome!',
+            description: 'Extension description',
           },
           fr: {
             welcome: 'Bienvenue!',
+            description: "Description de l'extension",
           },
         },
         lastUpdated: 1684164163736,
@@ -426,7 +448,7 @@ describe('ExtensionServerClient', () => {
 
       const translatedLocalization = {
         extensionLocale: 'ja',
-        translations: '{"welcome":"いらっしゃいませ!"}',
+        translations: '{"welcome":"いらっしゃいませ!","description":"拡張子の説明"}',
         lastUpdated: localization.lastUpdated,
       }
 
@@ -437,6 +459,7 @@ describe('ExtensionServerClient', () => {
             uuid: '123',
             type: 'ui_extension',
             name: 't:welcome',
+            description: 't:description',
             localization,
             extensionPoints: [{localization}],
           },
@@ -444,6 +467,7 @@ describe('ExtensionServerClient', () => {
             uuid: '456',
             type: 'ui_extension',
             name: 'Extension 456',
+            description: 'This is a test extension',
             localization: null,
             extensionPoints: [{localization: null}],
           },
@@ -463,13 +487,17 @@ describe('ExtensionServerClient', () => {
               uuid: '123',
               type: 'ui_extension',
               name: 'いらっしゃいませ!',
+              description: '拡張子の説明',
               localization: translatedLocalization,
-              extensionPoints: [{localization: translatedLocalization, name: 'いらっしゃいませ!'}],
+              extensionPoints: [
+                {localization: translatedLocalization, name: 'いらっしゃいませ!', description: '拡張子の説明'},
+              ],
             },
             {
               uuid: '456',
               type: 'ui_extension',
               name: 'Extension 456',
+              description: 'This is a test extension',
               localization: null,
               extensionPoints: [{localization: null}],
             },
@@ -593,8 +621,9 @@ describe('ExtensionServerClient', () => {
             uuid: '123',
             type: 'ui_extension',
             name: 'いらっしゃいませ!',
+            description: '拡張子の説明',
             localization: {},
-            extensionPoints: [{localization: {}, name: 'いらっしゃいませ!'}],
+            extensionPoints: [{localization: {}, name: 'いらっしゃいませ!', description: '拡張子の説明'}],
           },
         ],
       })

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
@@ -87,6 +87,7 @@ export class ExtensionServerClient implements ExtensionServer.Client {
        *  extensionPoints: [{
        *    target: 'admin.product.item.action'
        *    name: 'en name'
+       *    description: 'en description'
        *    localization: {...}
        *  }],
        * }
@@ -220,8 +221,14 @@ export class ExtensionServerClient implements ExtensionServer.Client {
         localization,
         name:
           parsedTranslation && extension.name.startsWith('t:')
-            ? this._getLocalizedName(parsedTranslation, extension.name)
+            ? this._getLocalizedValue(parsedTranslation, extension.name)
             : extension.name,
+        ...(extension.description && {
+          description:
+            parsedTranslation && extension.description?.startsWith('t:')
+              ? this._getLocalizedValue(parsedTranslation, extension.description)
+              : extension.description,
+        }),
       }
 
       this.uiExtensionsByUuid[extension.uuid] = {
@@ -235,7 +242,7 @@ export class ExtensionServerClient implements ExtensionServer.Client {
 
   private _getLocalizedExtensionPoints(
     localization: FlattenedLocalization | Localization | null | undefined,
-    {extensionPoints, name}: ExtensionServer.UIExtension,
+    {extensionPoints, name, description}: ExtensionServer.UIExtension,
   ): ExtensionPoint[] {
     if (!localization || !isFlattenedTranslations(localization)) {
       return extensionPoints
@@ -246,13 +253,14 @@ export class ExtensionServerClient implements ExtensionServer.Client {
         ...extensionPoint,
         localization,
         name,
+        ...(description && {description}),
       }
     })
   }
 
-  private _getLocalizedName(translations: {[x: string]: string}, name: string): string {
-    const translationKey = name.replace('t:', '')
-    return translations[translationKey] || name
+  private _getLocalizedValue(translations: {[x: string]: string}, value: string): string {
+    const translationKey = value.replace('t:', '')
+    return translations[translationKey] || value
   }
 }
 

--- a/packages/ui-extensions-server-kit/src/i18n.ts
+++ b/packages/ui-extensions-server-kit/src/i18n.ts
@@ -67,7 +67,7 @@ export interface ExtensionTranslationMap {
   [key: string]: string
 }
 
-export const TRANSLATED_KEYS = ['localization', 'name']
+export const TRANSLATED_KEYS = ['localization', 'name', `description`]
 /**
  * From a nested dictionary like the following :
  *

--- a/packages/ui-extensions-server-kit/src/i18n.ts
+++ b/packages/ui-extensions-server-kit/src/i18n.ts
@@ -67,7 +67,7 @@ export interface ExtensionTranslationMap {
   [key: string]: string
 }
 
-export const TRANSLATED_KEYS = ['localization', 'name', `description`]
+export const TRANSLATED_KEYS = ['localization', 'name', 'description']
 /**
  * From a nested dictionary like the following :
  *

--- a/packages/ui-extensions-server-kit/src/testing/extensions.ts
+++ b/packages/ui-extensions-server-kit/src/testing/extensions.ts
@@ -16,6 +16,7 @@ export function mockExtension(obj: DeepPartial<ExtensionPayload> = {}): Extensio
   return {
     handle: 'my-extension',
     name: 'My extension',
+    description: 'My extension description',
     surface: 'admin',
     type: 'purchase_option',
     externalType: 'external_type',

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -92,6 +92,7 @@ export interface ExtensionPoint {
   root: ResourceURL
   localization?: FlattenedLocalization | Localization | null
   name: string
+  description?: string
 }
 
 export type ExtensionPoints = string[] | ExtensionPoint[] | null
@@ -115,6 +116,7 @@ export interface ExtensionPayload {
   version: string
   surface: Surface
   name: string
+  description?: string
   handle: string
   extensionPoints: ExtensionPoints
   categories?: string[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13685,6 +13685,7 @@ packages:
     resolution: {directory: packages/eslint-plugin-cli, type: directory}
     id: file:packages/eslint-plugin-cli
     name: '@shopify/eslint-plugin-cli'
+    version: 3.46.0
     peerDependencies:
       eslint: ^8.46.0
     dependencies:


### PR DESCRIPTION

### WHY are these changes introduced?

Enabling localized description for deving ui_extensions.

Fixes [#393](https://github.com/orgs/Shopify/projects/7275/views/3#:~:text=Update%20dev%2Dserver%2Dkit%20with%20localized%20description)

The optional description field is supported on the deploy flow for UI Extensions but there was this missing pice to be able to `dev` it.

### WHAT is this pull request doing?
Adding `description` and the translation logic to the websocket message payloads.

### How to test your changes?
- In the cli folder checkout this branch: `git checkout update-drafts-for-all-extensions-in-dev`
- Create a new app and admin extension (or reuse existing ones)
- Add a new locales entry for the description
- Add description to the toml file: `description: 't:new_key'`
- Run `shopify app dev --path your_app_folder_here`
- Open the dev console and navigate to the extension point of your extension
- Open the web inspector network tab and check the websocket messages contain the description

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
