### PR TITLE
Show developer preview state change immediately

### DIFF
--- a/.changeset/four-walls-report.md
+++ b/.changeset/four-walls-report.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+
+Remove dev preview enabled flickering status

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -693,9 +693,12 @@ describe('Dev', () => {
     `)
 
     // wait for useEffect callbacks to be run
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 500))
 
-    expect(vi.mocked(enableDeveloperPreview)).toHaveBeenCalled()
+    expect(vi.mocked(enableDeveloperPreview)).toHaveBeenNthCalledWith(1, {
+      apiKey: '123',
+      token: '123',
+    })
 
     // unmount so that polling is cleared after every test
     renderInstance.unmount()

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -87,7 +87,7 @@ describe('Dev', () => {
 
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -266,7 +266,7 @@ describe('Dev', () => {
 
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -321,7 +321,7 @@ describe('Dev', () => {
 
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -409,7 +409,7 @@ describe('Dev', () => {
 
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -426,7 +426,7 @@ describe('Dev', () => {
 
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✖ off
+      › Press d │ toggle development store preview: ✖ off
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -521,7 +521,7 @@ describe('Dev', () => {
 
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -546,7 +546,7 @@ describe('Dev', () => {
       "
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -568,7 +568,7 @@ describe('Dev', () => {
       "
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✖ off
+      › Press d │ toggle development store preview: ✖ off
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -614,7 +614,7 @@ describe('Dev', () => {
 
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -661,7 +661,7 @@ describe('Dev', () => {
 
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -684,7 +684,7 @@ describe('Dev', () => {
       "
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -715,7 +715,7 @@ describe('Dev', () => {
       "
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✖ off
+      › Press d │ toggle development store preview: ✖ off
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -740,7 +740,7 @@ describe('Dev', () => {
       "
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 
@@ -757,7 +757,7 @@ describe('Dev', () => {
       "
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
-      › Press d │ development store preview: ✔ on
+      › Press d │ toggle development store preview: ✔ on
       › Press p │ preview in your browser
       › Press q │ quit
 

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -94,6 +94,9 @@ describe('Dev', () => {
       Preview URL: https://shopify.com
       "
     `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test("doesn't render shortcuts if the stdin is not a TTY", async () => {
@@ -163,6 +166,9 @@ describe('Dev', () => {
       Preview URL: https://shopify.com
       "
     `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('opens the previewUrl when p is pressed', async () => {
@@ -175,6 +181,8 @@ describe('Dev', () => {
     renderInstance.stdin.write('p')
     // Then
     expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://shopify.com')
+
+    renderInstance.unmount()
   })
 
   test('quits when q is pressed', async () => {
@@ -215,6 +223,9 @@ describe('Dev', () => {
     await promise
     // Then
     expect(abort).toHaveBeenCalledOnce()
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('abortController can be used to exit from outside and should preserve static output', async () => {
@@ -275,6 +286,9 @@ describe('Dev', () => {
       apiKey: '123',
       token: '123',
     })
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('accepts inputs when the processes resolve', async () => {
@@ -318,6 +332,9 @@ describe('Dev', () => {
     await waitForInputsToBeReady()
     renderInstance.stdin.write('p')
     expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://shopify.com')
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('when a process throws an error it calls abort on the abortController', async () => {
@@ -344,6 +361,9 @@ describe('Dev', () => {
 
     await renderInstance.waitUntilExit()
     expect(abort).toHaveBeenCalledOnce()
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('polls for preview mode', async () => {
@@ -413,6 +433,9 @@ describe('Dev', () => {
       Preview URL: https://shopify.com
       "
     `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test("doesn't poll for preview mode when the app does not support it", async () => {
@@ -461,6 +484,9 @@ describe('Dev', () => {
 
     renderInstance.stdin.write('d')
     expect(vi.mocked(developerPreviewUpdate)).not.toHaveBeenCalled()
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('shows an error message when polling for preview mode fails', async () => {
@@ -503,6 +529,9 @@ describe('Dev', () => {
       Failed to fetch the latest status of the development store preview, trying again in 5 seconds.
       "
     `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('enables preview mode when pressing d', async () => {
@@ -546,6 +575,9 @@ describe('Dev', () => {
       Preview URL: https://shopify.com
       "
     `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test("shows an error message if enabling preview mode by pressing d doesn't succeed", async () => {
@@ -590,6 +622,9 @@ describe('Dev', () => {
       Failed to turn off development store preview.
       "
     `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('shows an error message if enabling preview mode by pressing d throws an exception', async () => {
@@ -634,6 +669,9 @@ describe('Dev', () => {
       Failed to turn off development store preview.
       "
     `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('enables preview mode at startup', async () => {
@@ -657,10 +695,10 @@ describe('Dev', () => {
     // wait for useEffect callbacks to be run
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(vi.mocked(enableDeveloperPreview)).toHaveBeenNthCalledWith(1, {
-      apiKey: '123',
-      token: '123',
-    })
+    expect(vi.mocked(enableDeveloperPreview)).toHaveBeenCalled()
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('shows an error message if enabling preview mode at startup fails', async () => {
@@ -686,6 +724,9 @@ describe('Dev', () => {
       Try turning it on manually by pressing \`d\`.
       "
     `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 
   test('shows an error if handling input throws an error', async () => {
@@ -724,5 +765,8 @@ describe('Dev', () => {
       Failed to handle your input.
       "
     `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
   })
 })

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -173,7 +173,8 @@ const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUr
             <Box flexDirection="column">
               {canEnablePreviewMode ? (
                 <Text>
-                  {figures.pointerSmall} Press <Text bold>d</Text> {figures.lineVertical} development store preview: {}
+                  {figures.pointerSmall} Press <Text bold>d</Text> {figures.lineVertical} toggle development store
+                  preview: {}
                   {devPreviewEnabled ? <Text color="green">✔ on</Text> : <Text color="red">✖ off</Text>}
                 </Text>
               ) : null}

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -110,25 +110,28 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
   )
 
   useEffect(() => {
-    ;(() => {
-      return Promise.all(
-        processes.map(async (process, index) => {
-          const stdout = writableStream(process, index)
-          const stderr = writableStream(process, index)
-          await process.action(stdout, stderr, abortSignal)
-        }),
-      )
-    })()
-      .then(() => {
+    const runProcesses = async () => {
+      try {
+        await Promise.all(
+          processes.map(async (process, index) => {
+            const stdout = writableStream(process, index)
+            const stderr = writableStream(process, index)
+            await process.action(stdout, stderr, abortSignal)
+          }),
+        )
         if (!keepRunningAfterProcessesResolve) {
           unmountInk()
         }
-      })
-      .catch((error) => {
+        // eslint-disable-next-line no-catch-all/no-catch-all
+      } catch (error: unknown) {
         if (!keepRunningAfterProcessesResolve) {
-          unmountInk(error)
+          unmountInk(error as Error | undefined)
         }
-      })
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    runProcesses()
   }, [abortSignal, processes, writableStream, unmountInk, keepRunningAfterProcessesResolve])
 
   const {lineVertical} = figures


### PR DESCRIPTION
### WHY are these changes introduced?

There are currently 2 UX issues with dev preview in `dev`.
- At the start the status flickers from "off" to "on" because in the beginning dev preview is turned off and gets automatically turned on
- When pressing `d` there is a delay so the user might think that nothing is happening

By showing the real value in the backend we're optimizing for the failure state. What I mean is that if turning on/off dev preview fails then the status will be correctly displayed without extra effort.
What I propose instead is to "lie" to the user by showing instant change and only revert back if the operation fails.

### WHAT is this pull request doing?

- At startup we immediately show `dev` preview as turned on. If turning it on fails we show an error message AND the correct "off" status.
- When pressing `d` we immediately toggle the state, reverting it to the previous value (with an error message) only when there is a problem.

### How to test your changes?

- Run `dev`
- Dev preview should be immediately on
- Press `d`
- Dev preview should immediately toggle