### PR TITLE
Do not report tunnel errors to Bugsnag

### DIFF
--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -105,7 +105,7 @@ async function pollTunnelURL(tunnelClient: TunnelClient): Promise<string> {
     const pollTunnelStatus = async () => {
       const result = tunnelClient.getTunnelStatus()
       outputDebug(`Polling tunnel status for ${tunnelClient.provider} (attempt ${retries}): ${result.status}`)
-      if (result.status === 'error') return reject(new BugError(result.message, result.tryMessage))
+      if (result.status === 'error') return reject(new AbortError(result.message, result.tryMessage))
       if (result.status === 'connected') {
         resolve(result.url)
       } else {


### PR DESCRIPTION
### WHY are these changes introduced?

We get too many [Cloudflare errors in Bugsnag](https://app.bugsnag.com/shopify/cli/errors/64ad52e6b5b94700090d19e3) (mostly timeouts), and we are being rate-limited because of that.

### WHAT is this pull request doing?

Avoid reporting tunnel errors to Bugsnag, as the message and possible solutions are already clear enough.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
