### PR TITLE
Make command token pop with magenta coloring

### DIFF
--- a/.changeset/tough-dolls-sort.md
+++ b/.changeset/tough-dolls-sort.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Make commands pop with magenta coloring

--- a/packages/cli-kit/src/private/node/ui/components/Command.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Command.test.tsx
@@ -7,6 +7,6 @@ describe('Command', async () => {
   test('renders correctly', async () => {
     const {lastFrame} = render(<Command command="npm install" />)
 
-    expect(lastFrame()).toMatchInlineSnapshot('"`npm install`"')
+    expect(lastFrame()).toMatchInlineSnapshot('"[95m`npm install`[39m"')
   })
 })

--- a/packages/cli-kit/src/private/node/ui/components/Command.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Command.tsx
@@ -9,7 +9,7 @@ interface CommandProps {
  * `Command` displays a command as non-dimmed text.
  */
 const Command: FunctionComponent<CommandProps> = ({command}): JSX.Element => {
-  return <Text>`{command}`</Text>
+  return <Text color="magentaBright">`{command}`</Text>
 }
 
 export {Command}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Make command tokens more visible
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Adds a bright magenta color to command tokens (after UX consultation with @MeredithCastile)

Before:

<img width="1136" alt="Screenshot 2023-08-28 at 19 31 39" src="https://github.com/Shopify/cli/assets/6288426/f3e5d3c3-432d-4dcd-ab19-014d53e8214f">

After:

<img width="1135" alt="Screenshot 2023-08-28 at 19 32 12" src="https://github.com/Shopify/cli/assets/6288426/893960c3-29c2-44fe-b913-27f6c6af1001">

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`$ pnpm shopify kitchen-sink static`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
