### PR TITLE
Generate source maps in dev

### DIFF
--- a/.changeset/fast-bobcats-bathe.md
+++ b/.changeset/fast-bobcats-bathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Generate sourcemaps when running dev

--- a/packages/app/src/cli/services/dev/extension/bundler.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.ts
@@ -68,6 +68,7 @@ export async function setupBundlerAndFileWatcher(options: FileWatcherOptions) {
             // ESBuild handles error output
           }
         },
+        sourceMaps: true,
       }),
     )
 

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -44,6 +44,11 @@ export interface BundleOptions {
    * with a migration plan.
    */
   environment: 'development' | 'production'
+
+  /**
+   * Whether or not to generate source maps.
+   */
+  sourceMaps?: boolean
 }
 
 /**
@@ -138,6 +143,11 @@ function getESBuildOptions(options: BundleOptions, processEnv = process.env): Pa
         })
       },
     })
+  }
+
+  if (options.sourceMaps) {
+    esbuildOptions.sourcemap = true
+    esbuildOptions.sourceRoot = `${options.stdin.resolveDir}/src`
   }
   return esbuildOptions
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-management/issues/34

Source maps provide a better developer experience.

### WHAT is this pull request doing?

Adding sourcemaps to the output of esbuild when running `dev`.

### How to test your changes?

- Generate a subscription UI extension in JS
- Add a debugger statement
- Go to the test product page with the Chome dev tools open
- It should stop at the debugger and provide clean code to read

Before this change this is the code on a fresh subscription UI extension

```js
(() => {
  // node_modules/.pnpm/@shopify+admin-ui-extensions@1.1.0/node_modules/@shopify/admin-ui-extensions/build/esm/api.mjs
  function extend(extensionPoint, callback) {
    return self.shopify.extend(extensionPoint, callback);
  }

  // node_modules/.pnpm/@remote-ui+core@2.1.17/node_modules/@remote-ui/core/build/esm/component.mjs
  function createRemoteComponent(componentType) {
    return componentType;
  }

  // node_modules/.pnpm/@shopify+admin-ui-extensions@1.1.0/node_modules/@shopify/admin-ui-extensions/build/esm/components/Text/Text.mjs
  var Text = createRemoteComponent("Text");

  // extensions/subscription-ui/src/index.js
  extend("Admin::Product::SubscriptionPlan::Add", App);
  extend("Admin::Product::SubscriptionPlan::Create", App);
  extend("Admin::Product::SubscriptionPlan::Remove", App);
  extend("Admin::Product::SubscriptionPlan::Edit", App);
  function App(root, { extensionPoint }) {
    debugger;
    root.appendChild(
      root.createComponent(
        Text,
        {},
        `Welcome to the ${extensionPoint} extension!`
      )
    );
    root.mount();
  }
})();
```

After
```js
import { Text, extend } from "@shopify/admin-ui-extensions";

// Your extension must render all four modes
extend("Admin::Product::SubscriptionPlan::Add", App);
extend("Admin::Product::SubscriptionPlan::Create", App);
extend("Admin::Product::SubscriptionPlan::Remove", App);
extend("Admin::Product::SubscriptionPlan::Edit", App);

function App(root, { extensionPoint }) {
  debugger
  root.appendChild(
    root.createComponent(
      Text,
      {},
      `Welcome to the ${extensionPoint} extension!`
    )
  );
  root.mount();
}
```