### PR TITLE
Fix missing query piece

### DIFF
--- a/packages/app/src/cli/api/graphql/create_app.ts
+++ b/packages/app/src/cli/api/graphql/create_app.ts
@@ -29,6 +29,9 @@ export const CreateAppQuery = gql`
         }
         appType
         grantedScopes
+        betas {
+          unifiedAppDeployment
+        }
         applicationUrl
         redirectUrlWhitelist
         requestedAccessScopes


### PR DESCRIPTION
It was in the type but not the query itself.

A note on impact: Currently, freshly created apps are identified as non-simplified deployment. This means that if we have a command that creates an app then wants to push to it, it will be using the wrong mode. Which broke a prototype for `app deploy --force-create-app`.