### PR TITLE
Lighter query for polling

### DIFF
--- a/.changeset/violet-masks-unite.md
+++ b/.changeset/violet-masks-unite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Use lighter query for polling developer preview status

--- a/packages/app/src/cli/api/graphql/find_app_custom.ts
+++ b/packages/app/src/cli/api/graphql/find_app_custom.ts
@@ -1,0 +1,9 @@
+import {gql} from 'graphql-request'
+
+export function findAppCustomQuery(fields: string) {
+  return gql`
+  query FindApp($apiKey: String!) {
+    app(apiKey: $apiKey) ${fields}
+  }
+`
+}

--- a/packages/app/src/cli/api/graphql/find_app_custom.ts
+++ b/packages/app/src/cli/api/graphql/find_app_custom.ts
@@ -1,9 +1,0 @@
-import {gql} from 'graphql-request'
-
-export function findAppCustomQuery(fields: string) {
-  return gql`
-  query FindApp($apiKey: String!) {
-    app(apiKey: $apiKey) ${fields}
-  }
-`
-}

--- a/packages/app/src/cli/api/graphql/find_app_preview_mode.ts
+++ b/packages/app/src/cli/api/graphql/find_app_preview_mode.ts
@@ -1,0 +1,15 @@
+import {gql} from 'graphql-request'
+
+export const FindAppPreviewModeQuery = gql`
+  query FindApp($apiKey: String!) {
+    app(apiKey: $apiKey) {
+      developmentStorePreviewEnabled
+    }
+  }
+`
+
+export interface FindAppPreviewModeQuerySchema {
+  app: {
+    developmentStorePreviewEnabled: boolean
+  }
+}

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -4,7 +4,7 @@ import {testApp, testOrganizationApp} from '../../../models/app/app.test-data.js
 import {selectConfigName} from '../../../prompts/config.js'
 import {loadApp} from '../../../models/app/loader.js'
 import {fetchOrCreateOrganizationApp} from '../../context.js'
-import {fetchAppFromApiKey} from '../../dev/fetch.js'
+import {fetchAppDetailsFromApiKey} from '../../dev/fetch.js'
 import {getCachedCommandInfo} from '../../local-storage.js'
 import {describe, expect, test, vi} from 'vitest'
 import {Config} from '@oclif/core'
@@ -307,14 +307,14 @@ embedded = false
       }
       vi.mocked(loadApp).mockResolvedValue(LOCAL_APP)
       vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
-      vi.mocked(fetchAppFromApiKey).mockResolvedValue(REMOTE_APP)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(REMOTE_APP)
       vi.mocked(selectConfigName).mockResolvedValue('staging')
 
       // When
       await link(options)
 
       // Then
-      expect(fetchAppFromApiKey).toHaveBeenCalledWith('api-key', 'token')
+      expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith('api-key', 'token')
     })
   })
 
@@ -328,7 +328,7 @@ embedded = false
       }
       vi.mocked(loadApp).mockResolvedValue(LOCAL_APP)
       vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
-      vi.mocked(fetchAppFromApiKey).mockResolvedValue(undefined)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(undefined)
       vi.mocked(selectConfigName).mockResolvedValue('staging')
 
       // When

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -11,7 +11,7 @@ import {selectConfigName} from '../../../prompts/config.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {getAppConfigurationFileName, loadApp} from '../../../models/app/loader.js'
 import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../context.js'
-import {fetchAppFromApiKey} from '../../dev/fetch.js'
+import {fetchAppDetailsFromApiKey} from '../../dev/fetch.js'
 import {configurationFileNames} from '../../../constants.js'
 import {writeAppConfigurationFile} from '../write-app-configuration-file.js'
 import {getCachedCommandInfo} from '../../local-storage.js'
@@ -92,7 +92,7 @@ async function loadRemoteApp(
   if (!apiKey) {
     return fetchOrCreateOrganizationApp(localApp, token, directory)
   }
-  const app = await fetchAppFromApiKey(apiKey, token)
+  const app = await fetchAppDetailsFromApiKey(apiKey, token)
   if (!app) {
     const errorMessage = InvalidApiKeyErrorMessage(apiKey)
     throw new AbortError(errorMessage.message, errorMessage.tryMessage)

--- a/packages/app/src/cli/services/app/fetch-app-from-config-or-select.test.ts
+++ b/packages/app/src/cli/services/app/fetch-app-from-config-or-select.test.ts
@@ -2,7 +2,7 @@ import {fetchAppFromConfigOrSelect} from './fetch-app-from-config-or-select.js'
 import {selectApp} from './select-app.js'
 import {AppInterface} from '../../models/app/app.js'
 import {testApp, testAppWithConfig, testOrganizationApp} from '../../models/app/app.test-data.js'
-import {fetchAppFromApiKey} from '../dev/fetch.js'
+import {fetchAppDetailsFromApiKey} from '../dev/fetch.js'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 
@@ -21,7 +21,7 @@ beforeEach(() => {
 describe('fetchAppFromConfigOrSelect', () => {
   test('if app has config as code, fetch app from config', async () => {
     // Given
-    vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP1)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(APP1)
 
     // When
     const got = await fetchAppFromConfigOrSelect(APP_WITH_CONFIG)

--- a/packages/app/src/cli/services/app/fetch-app-from-config-or-select.ts
+++ b/packages/app/src/cli/services/app/fetch-app-from-config-or-select.ts
@@ -1,6 +1,6 @@
 import {selectApp} from './select-app.js'
 import {AppConfigurationInterface, isCurrentAppSchema} from '../../models/app/app.js'
-import {fetchAppFromApiKey} from '../dev/fetch.js'
+import {fetchAppDetailsFromApiKey} from '../dev/fetch.js'
 import {InvalidApiKeyErrorMessage} from '../context.js'
 import {OrganizationApp} from '../../models/organization.js'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
@@ -11,7 +11,7 @@ export async function fetchAppFromConfigOrSelect(app: AppConfigurationInterface)
   if (isCurrentAppSchema(app.configuration)) {
     const token = await ensureAuthenticatedPartners()
     const apiKey = app.configuration.client_id
-    organizationApp = await fetchAppFromApiKey(apiKey, token)
+    organizationApp = await fetchAppDetailsFromApiKey(apiKey, token)
     if (!organizationApp) {
       const errorMessage = InvalidApiKeyErrorMessage(apiKey)
       throw new AbortError(errorMessage.message, errorMessage.tryMessage)

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -1,6 +1,6 @@
 import {OrganizationApp} from '../../models/organization.js'
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
-import {fetchAppFromApiKey, fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
+import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 
 export async function selectApp(): Promise<OrganizationApp> {
@@ -9,6 +9,6 @@ export async function selectApp(): Promise<OrganizationApp> {
   const org = await selectOrganizationPrompt(orgs)
   const {apps} = await fetchOrgAndApps(org.id, token)
   const selectedAppApiKey = await selectAppPrompt(apps, org.id, token)
-  const fullSelectedApp = await fetchAppFromApiKey(selectedAppApiKey, token)
+  const fullSelectedApp = await fetchAppDetailsFromApiKey(selectedAppApiKey, token)
   return fullSelectedApp!
 }

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -1,6 +1,6 @@
 import {
   fetchAppExtensionRegistrations,
-  fetchAppFromApiKey,
+  fetchAppDetailsFromApiKey,
   fetchOrgAndApps,
   fetchOrganizations,
   fetchOrgFromId,
@@ -198,7 +198,7 @@ describe('ensureGenerateContext', () => {
   test('returns the provided app apiKey if valid, without cached state', async () => {
     // Given
     const input = {apiKey: 'key2', directory: '/app', reset: false, token: 'token', commandConfig: COMMAND_CONFIG}
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
 
     // When
     const got = await ensureGenerateContext(input)
@@ -210,7 +210,7 @@ describe('ensureGenerateContext', () => {
   test('returns the cached api key', async () => {
     // Given
     const input = {directory: '/app', reset: false, token: 'token', commandConfig: COMMAND_CONFIG}
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(getCachedAppInfo).mockReturnValue(CACHED1)
 
     // When
@@ -230,13 +230,13 @@ describe('ensureGenerateContext', () => {
       configuration: testAppWithConfig({config: {path: CACHED1_WITH_CONFIG.configFile, client_id: APP2.apiKey}})
         .configuration,
     })
-    vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(APP2)
 
     // When
     const got = await ensureGenerateContext(input)
 
     // Then
-    expect(fetchAppFromApiKey).toHaveBeenCalledWith(APP2.apiKey, 'token')
+    expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith(APP2.apiKey, 'token')
     expect(got).toEqual(APP2.apiKey)
   })
 
@@ -250,14 +250,14 @@ describe('ensureGenerateContext', () => {
       configuration: testAppWithConfig({config: {path: CACHED1_WITH_CONFIG.configFile, client_id: APP2.apiKey}})
         .configuration,
     })
-    vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(APP2)
 
     // When
     const got = await ensureGenerateContext(input)
 
     // Then
     expect(link).toBeCalled()
-    expect(fetchAppFromApiKey).toHaveBeenCalledWith(APP2.apiKey, 'token')
+    expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith(APP2.apiKey, 'token')
     expect(got).toEqual(APP2.apiKey)
   })
 
@@ -271,21 +271,21 @@ describe('ensureGenerateContext', () => {
       configuration: testAppWithConfig({config: {path: CACHED1_WITH_CONFIG.configFile, client_id: APP2.apiKey}})
         .configuration,
     })
-    vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(APP2)
 
     // When
     const got = await ensureGenerateContext(input)
 
     // Then
     expect(link).toBeCalled()
-    expect(fetchAppFromApiKey).toHaveBeenCalledWith(APP2.apiKey, 'token')
+    expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith(APP2.apiKey, 'token')
     expect(got).toEqual(APP2.apiKey)
   })
 
   test('selects a new app and returns the api key', async () => {
     // Given
     const input = {directory: '/app', reset: true, token: 'token', commandConfig: COMMAND_CONFIG}
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(loadAppName).mockResolvedValueOnce('my-app')
     vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
 
@@ -339,7 +339,7 @@ describe('ensureDevContext', async () => {
           },
         }).configuration,
       })
-      vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
       vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
       // When
@@ -406,7 +406,7 @@ dev_store_url = "domain1"
           },
         }).configuration,
       })
-      vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1).mockResolvedValue(APP2)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP1).mockResolvedValue(APP2)
       vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
       // When
@@ -457,7 +457,7 @@ dev_store_url = "domain1"
           embedded: true,
         },
       })
-      vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
       vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
       // When
@@ -490,7 +490,7 @@ dev_store_url = "domain1"
         configuration: testAppWithConfig({app: {}, config: {path: joinPath(tmp, 'shopify.app.dev.toml')}})
           .configuration,
       })
-      vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
 
       // When
       await ensureDevContext(
@@ -538,7 +538,7 @@ dev_store_url = "domain1"
       })
 
       vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.toml')
-      vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
       vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
       // When
@@ -609,7 +609,7 @@ dev_store_url = "domain1"
     // Given
     vi.mocked(getCachedAppInfo).mockReturnValue({...CACHED1_WITH_CONFIG, previousAppId: APP2.apiKey})
     // vi.mocked(fetchOrgFromId).mockResolvedValueOnce(ORG2)
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP1)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
     // When
@@ -628,7 +628,7 @@ dev_store_url = "domain1"
   test('returns selected data and updates internal state, with cached state', async () => {
     // Given
     vi.mocked(getCachedAppInfo).mockReturnValue({...CACHED1, previousAppId: APP1.apiKey})
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP1)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
     // When
@@ -678,7 +678,7 @@ dev_store_url = "domain1"
     // Given
     vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
     vi.mocked(convertToTestStoreIfNeeded).mockResolvedValueOnce()
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
 
     // When
@@ -708,7 +708,7 @@ dev_store_url = "domain1"
   test('throws if the store input is not valid', async () => {
     // Given
     vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: undefined})
 
     // When
@@ -720,7 +720,7 @@ dev_store_url = "domain1"
   test('resets cached state if reset is true', async () => {
     // When
     vi.mocked(getCachedAppInfo).mockReturnValueOnce(CACHED1)
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
 
     await ensureDevContext({...INPUT, reset: true}, 'token')
 
@@ -746,7 +746,7 @@ dev_store_url = "domain1"
           embedded: true,
         },
       })
-      vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP2)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(APP2)
 
       // When
       const got = await ensureDevContext({...INPUT, reset: true}, 'token')
@@ -785,7 +785,7 @@ dev_store_url = "domain1"
           embedded: true,
         },
       })
-      vi.mocked(fetchAppFromApiKey).mockResolvedValue(APP2)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(APP2)
 
       // When
       const got = await ensureDevContext({...INPUT}, 'token')
@@ -808,7 +808,7 @@ describe('ensureDeployContext', () => {
       extensionIds: {},
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
 
     // When
@@ -835,7 +835,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(getCachedAppInfo).mockReturnValue(CACHED1)
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
     vi.mocked(reuseDevConfigPrompt).mockResolvedValueOnce(true)
 
@@ -861,7 +861,7 @@ describe('ensureDeployContext', () => {
       extensionIds: {},
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
 
     // When
@@ -870,7 +870,7 @@ describe('ensureDeployContext', () => {
     // Then
     expect(selectOrCreateApp).not.toHaveBeenCalled()
     expect(reuseDevConfigPrompt).not.toHaveBeenCalled()
-    expect(fetchAppFromApiKey).toHaveBeenCalledWith(APP2.apiKey, 'token')
+    expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith(APP2.apiKey, 'token')
     expect(got.partnersApp.id).toEqual(APP2.id)
     expect(got.partnersApp.title).toEqual(APP2.title)
     expect(got.partnersApp.appType).toEqual(APP2.appType)
@@ -887,7 +887,7 @@ describe('ensureDeployContext', () => {
       extensionIds: {},
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
     // When
     const got = await ensureDeployContext(options(app))
@@ -917,7 +917,7 @@ describe('ensureDeployContext', () => {
     // Given
     const app = testApp()
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP1.apiKey})
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(undefined)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(undefined)
 
     // When
     await expect(ensureDeployContext(options(app))).rejects.toThrow(/Couldn't find the app with Client ID key1/)
@@ -934,7 +934,7 @@ describe('ensureDeployContext', () => {
 
     // There is a cached app but it will be ignored
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
 
     const opts = options(app)
@@ -975,7 +975,7 @@ describe('ensureDeployContext', () => {
 
     // There is a cached app but it will be ignored
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
 
     const opts = options(app)
@@ -1003,7 +1003,7 @@ describe('ensureReleaseContext', () => {
     // Given
     const app = testApp()
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP1.apiKey})
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP1)
 
     // When/Then
     await expect(() =>
@@ -1033,7 +1033,7 @@ describe('ensureReleaseContext', () => {
     // Given
     const app = testApp()
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA.apiKey})
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
     vi.mocked(updateAppIdentifiers).mockResolvedValue(app)
 
     // When
@@ -1129,7 +1129,7 @@ describe('ensureVersionsListContext', () => {
   test('returns the partners token and app', async () => {
     // Given
     const app = testApp()
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP_WITH_UNIFIED_APP_DEPLOYMENTS_BETA)
 
     // When
     const got = await ensureVersionsListContext({
@@ -1149,7 +1149,7 @@ describe('ensureVersionsListContext', () => {
   test('throws an error if the deployments beta is disabled', async () => {
     // Given
     const app = testApp()
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce(APP1)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP1)
 
     // When/Then
     await expect(() =>

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -1,7 +1,7 @@
 import {selectOrCreateApp} from './dev/select-app.js'
 import {
   fetchAllDevStores,
-  fetchAppFromApiKey,
+  fetchAppDetailsFromApiKey,
   fetchOrgAndApps,
   fetchOrganizations,
   fetchOrgFromId,
@@ -91,7 +91,7 @@ export async function ensureGenerateContext(options: {
   configName?: string
 }): Promise<string> {
   if (options.apiKey) {
-    const app = await fetchAppFromApiKey(options.apiKey, options.token)
+    const app = await fetchAppDetailsFromApiKey(options.apiKey, options.token)
     if (!app) {
       const errorMessage = InvalidApiKeyErrorMessage(options.apiKey)
       throw new AbortError(errorMessage.message, errorMessage.tryMessage)
@@ -103,7 +103,7 @@ export async function ensureGenerateContext(options: {
 
   if (cachedInfo?.appId && cachedInfo?.orgId) {
     const org = await fetchOrgFromId(cachedInfo.orgId, options.token)
-    const app = remoteApp || (await fetchAppFromApiKey(cachedInfo.appId, options.token))
+    const app = remoteApp || (await fetchAppDetailsFromApiKey(cachedInfo.appId, options.token))
     if (!app || !org) {
       const errorMessage = InvalidApiKeyErrorMessage(cachedInfo.appId)
       throw new AbortError(errorMessage.message, errorMessage.tryMessage)
@@ -213,7 +213,7 @@ export async function ensureDevContext(options: DevContextOptions, token: string
 const resetHelpMessage = ['You can pass', {command: '--reset'}, 'to your command to reset your app configuration.']
 
 const appFromId = async (appId: string, token: string): Promise<OrganizationApp> => {
-  const app = await fetchAppFromApiKey(appId, token)
+  const app = await fetchAppDetailsFromApiKey(appId, token)
   if (!app) throw new BugError([`Couldn't find the app with Client ID`, {command: appId}], resetHelpMessage)
   return app
 }
@@ -275,7 +275,7 @@ export async function fetchDevAppAndPrompt(app: AppInterface, token: string): Pr
   const devAppId = getCachedAppInfo(app.directory)?.appId
   if (!devAppId) return undefined
 
-  const partnersResponse = await fetchAppFromApiKey(devAppId, token)
+  const partnersResponse = await fetchAppDetailsFromApiKey(devAppId, token)
   if (!partnersResponse) return undefined
 
   const org = await fetchOrgFromId(partnersResponse.organizationId, token)
@@ -538,7 +538,7 @@ async function fetchDevDataFromOptions(
     (async () => {
       let selectedApp: OrganizationApp | undefined
       if (options.apiKey) {
-        selectedApp = await fetchAppFromApiKey(options.apiKey, token)
+        selectedApp = await fetchAppDetailsFromApiKey(options.apiKey, token)
         if (!selectedApp) {
           const errorMessage = InvalidApiKeyErrorMessage(options.apiKey)
           throw new AbortError(errorMessage.message, errorMessage.tryMessage)

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -123,7 +123,7 @@ export async function fetchOrgAndApps(orgId: string, token: string, title?: stri
   return {organization: parsedOrg, apps: org.apps, stores: []}
 }
 
-export async function fetchAppFromApiKey(apiKey: string, token: string): Promise<OrganizationApp | undefined> {
+export async function fetchAppDetailsFromApiKey(apiKey: string, token: string): Promise<OrganizationApp | undefined> {
   const res: FindAppQuerySchema = await partnersRequest(FindAppQuery, token, {
     apiKey,
   })

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -6,6 +6,7 @@ import {
 import {AllOrganizationsQuery, AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
 import {FindOrganizationQuery, FindOrganizationQuerySchema} from '../../api/graphql/find_org.js'
 import {FindAppQuery, FindAppQuerySchema} from '../../api/graphql/find_app.js'
+import {findAppCustomQuery} from '../../api/graphql/find_app_custom.js'
 import {FindOrganizationBasicQuery, FindOrganizationBasicQuerySchema} from '../../api/graphql/find_org_basic.js'
 import {
   AllDevStoresByOrganizationQuery,
@@ -125,6 +126,21 @@ export async function fetchOrgAndApps(orgId: string, token: string, title?: stri
 
 export async function fetchAppDetailsFromApiKey(apiKey: string, token: string): Promise<OrganizationApp | undefined> {
   const res: FindAppQuerySchema = await partnersRequest(FindAppQuery, token, {
+    apiKey,
+  })
+  return res.app
+}
+
+interface FetchAppFromApiKeyOptions {
+  fields: string
+}
+
+export async function fetchAppFromApiKey<TAppSchema extends {app: unknown}>(
+  apiKey: string,
+  token: string,
+  {fields = '{id}'}: FetchAppFromApiKeyOptions,
+): Promise<TAppSchema['app'] | undefined> {
+  const res: TAppSchema = await partnersRequest(findAppCustomQuery(fields), token, {
     apiKey,
   })
   return res.app

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -6,7 +6,7 @@ import {
 import {AllOrganizationsQuery, AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
 import {FindOrganizationQuery, FindOrganizationQuerySchema} from '../../api/graphql/find_org.js'
 import {FindAppQuery, FindAppQuerySchema} from '../../api/graphql/find_app.js'
-import {findAppCustomQuery} from '../../api/graphql/find_app_custom.js'
+import {FindAppPreviewModeQuery, FindAppPreviewModeQuerySchema} from '../../api/graphql/find_app_preview_mode.js'
 import {FindOrganizationBasicQuery, FindOrganizationBasicQuerySchema} from '../../api/graphql/find_org_basic.js'
 import {
   AllDevStoresByOrganizationQuery,
@@ -131,19 +131,11 @@ export async function fetchAppDetailsFromApiKey(apiKey: string, token: string): 
   return res.app
 }
 
-interface FetchAppFromApiKeyOptions {
-  fields: string
-}
-
-export async function fetchAppFromApiKey<TAppSchema extends {app: unknown}>(
-  apiKey: string,
-  token: string,
-  {fields = '{id}'}: FetchAppFromApiKeyOptions,
-): Promise<TAppSchema['app'] | undefined> {
-  const res: TAppSchema = await partnersRequest(findAppCustomQuery(fields), token, {
+export async function fetchAppPreviewMode(apiKey: string, token: string): Promise<boolean | undefined> {
+  const res: FindAppPreviewModeQuerySchema = await partnersRequest(FindAppPreviewModeQuery, token, {
     apiKey,
   })
-  return res.app
+  return res.app?.developmentStorePreviewEnabled
 }
 
 export async function fetchOrgFromId(id: string, token: string): Promise<Organization> {

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -1,6 +1,6 @@
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {Organization, OrganizationApp} from '../../models/organization.js'
-import {fetchAppFromApiKey, OrganizationAppsResponse} from '../dev/fetch.js'
+import {fetchAppDetailsFromApiKey, OrganizationAppsResponse} from '../dev/fetch.js'
 import {CreateAppQuery, CreateAppQuerySchema} from '../../api/graphql/create_app.js'
 import {getCachedCommandInfo, setCachedCommandInfo} from '../local-storage.js'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
@@ -42,7 +42,7 @@ export async function selectOrCreateApp(
 
     if (tomls[selectedAppApiKey]) setCachedCommandInfo({selectedToml: tomls[selectedAppApiKey], askConfigName: false})
 
-    const fullSelectedApp = await fetchAppFromApiKey(selectedAppApiKey, token)
+    const fullSelectedApp = await fetchAppDetailsFromApiKey(selectedAppApiKey, token)
     return fullSelectedApp!
   }
 }

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -1,6 +1,6 @@
 import {Dev} from './Dev.js'
 import {developerPreviewUpdate, disableDeveloperPreview, enableDeveloperPreview} from '../../../context.js'
-import {fetchAppFromApiKey} from '../../fetch.js'
+import {fetchAppDetailsFromApiKey} from '../../fetch.js'
 import {
   getLastFrameAfterUnmount,
   render,
@@ -442,7 +442,7 @@ describe('Dev', () => {
       "
     `)
 
-    expect(vi.mocked(fetchAppFromApiKey)).not.toHaveBeenCalled()
+    expect(vi.mocked(fetchAppDetailsFromApiKey)).not.toHaveBeenCalled()
     expect(vi.mocked(enableDeveloperPreview)).not.toHaveBeenCalled()
 
     renderInstance.stdin.write('d')
@@ -451,7 +451,7 @@ describe('Dev', () => {
 
   test('shows an error message when polling for preview mode fails', async () => {
     // Given
-    vi.mocked(fetchAppFromApiKey).mockRejectedValueOnce(new Error('something went wrong'))
+    vi.mocked(fetchAppDetailsFromApiKey).mockRejectedValueOnce(new Error('something went wrong'))
 
     const backendProcess = {
       prefix: 'backend',
@@ -580,7 +580,7 @@ describe('Dev', () => {
 
   test('polls for preview mode', async () => {
     // Given
-    vi.mocked(fetchAppFromApiKey).mockResolvedValueOnce({
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce({
       developmentStorePreviewEnabled: false,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -1,5 +1,5 @@
 import {developerPreviewUpdate, disableDeveloperPreview, enableDeveloperPreview} from '../../../context.js'
-import {fetchAppFromApiKey} from '../../fetch.js'
+import {fetchAppDetailsFromApiKey} from '../../fetch.js'
 import {OutputProcess} from '@shopify/cli-kit/node/output'
 import {ConcurrentOutput} from '@shopify/cli-kit/node/ui/components'
 import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
@@ -60,7 +60,7 @@ const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUr
 
   useEffect(() => {
     const pollDevPreviewMode = async () => {
-      const app = await fetchAppFromApiKey(apiKey, token)
+      const app = await fetchAppDetailsFromApiKey(apiKey, token)
       setDevPreviewEnabled(app?.developmentStorePreviewEnabled ?? false)
     }
 

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -1,5 +1,5 @@
 import {developerPreviewUpdate, disableDeveloperPreview, enableDeveloperPreview} from '../../../context.js'
-import {fetchAppFromApiKey} from '../../fetch.js'
+import {fetchAppPreviewMode} from '../../fetch.js'
 import {OutputProcess} from '@shopify/cli-kit/node/output'
 import {ConcurrentOutput} from '@shopify/cli-kit/node/ui/components'
 import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
@@ -60,10 +60,8 @@ const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUr
 
   useEffect(() => {
     const pollDevPreviewMode = async () => {
-      const app = await fetchAppFromApiKey<
-        {app: { developmentStorePreviewEnabled: boolean }}
-      >(apiKey, token, {fields: '{ developmentStorePreviewEnabled }'})
-      setDevPreviewEnabled(app?.developmentStorePreviewEnabled ?? false)
+      const enabled = await fetchAppPreviewMode(apiKey, token)
+      setDevPreviewEnabled(enabled ?? false)
     }
 
     const enablePreviewMode = async () => {

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -1,5 +1,5 @@
 import {developerPreviewUpdate, disableDeveloperPreview, enableDeveloperPreview} from '../../../context.js'
-import {fetchAppDetailsFromApiKey} from '../../fetch.js'
+import {fetchAppFromApiKey} from '../../fetch.js'
 import {OutputProcess} from '@shopify/cli-kit/node/output'
 import {ConcurrentOutput} from '@shopify/cli-kit/node/ui/components'
 import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
@@ -60,7 +60,9 @@ const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUr
 
   useEffect(() => {
     const pollDevPreviewMode = async () => {
-      const app = await fetchAppDetailsFromApiKey(apiKey, token)
+      const app = await fetchAppFromApiKey<
+        {app: { developmentStorePreviewEnabled: boolean }}
+      >(apiKey, token, {fields: '{ developmentStorePreviewEnabled }'})
       setDevPreviewEnabled(app?.developmentStorePreviewEnabled ?? false)
     }
 

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -1,5 +1,5 @@
 import {InfoOptions, info} from './info.js'
-import {fetchAppFromApiKey, fetchOrgAndApps, fetchOrganizations} from './dev/fetch.js'
+import {fetchAppDetailsFromApiKey, fetchOrgAndApps, fetchOrganizations} from './dev/fetch.js'
 import {getCachedAppInfo} from './local-storage.js'
 import {fetchAppFromConfigOrSelect} from './app/fetch-app-from-config-or-select.js'
 import {AppInterface} from '../models/app/app.js'
@@ -53,7 +53,7 @@ describe('info', () => {
       api_version = "2023-07"
       `
       vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
-      vi.mocked(fetchAppFromApiKey).mockResolvedValue(
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(
         testOrganizationApp({id: '123', title: 'my app', apiKey: '12345'}),
       )
 

--- a/packages/app/src/cli/services/webhook/find-app-info.test.ts
+++ b/packages/app/src/cli/services/webhook/find-app-info.test.ts
@@ -1,6 +1,6 @@
 import {findInEnv, findApiKey, requestAppInfo} from './find-app-info.js'
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
-import {fetchAppFromApiKey, fetchOrganizations, fetchOrgAndApps, FetchResponse} from '../dev/fetch.js'
+import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps, FetchResponse} from '../dev/fetch.js'
 import {MinimalOrganizationApp} from '../../models/organization.js'
 import {testOrganizationApp} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
@@ -131,7 +131,7 @@ describe('findApiKey', () => {
 describe('requestAppInfo', () => {
   test('no app found', async () => {
     // Given
-    vi.mocked(fetchAppFromApiKey).mockResolvedValue(undefined)
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(undefined)
 
     // When
     const credentials = await requestAppInfo(aToken, anApiKey)
@@ -142,7 +142,7 @@ describe('requestAppInfo', () => {
 
   test('no secrets available', async () => {
     // Given
-    vi.mocked(fetchAppFromApiKey).mockResolvedValue(
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(
       testOrganizationApp({
         apiKey: anApiKey,
         apiSecretKeys: [],
@@ -158,7 +158,7 @@ describe('requestAppInfo', () => {
 
   test('secrets available', async () => {
     // Given
-    vi.mocked(fetchAppFromApiKey).mockResolvedValue(
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(
       testOrganizationApp({
         apiKey: anApiKey,
       }),

--- a/packages/app/src/cli/services/webhook/find-app-info.ts
+++ b/packages/app/src/cli/services/webhook/find-app-info.ts
@@ -1,5 +1,5 @@
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
-import {fetchAppFromApiKey, fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
+import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env'
 import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath, basename, cwd} from '@shopify/cli-kit/node/path'
@@ -69,7 +69,7 @@ export async function findApiKey(token: string): Promise<string | undefined> {
  * @returns client_id, client_secret, client_api_key
  */
 export async function requestAppInfo(token: string, apiKey: string): Promise<AppCredentials> {
-  const fullSelectedApp = await fetchAppFromApiKey(apiKey, token)
+  const fullSelectedApp = await fetchAppDetailsFromApiKey(apiKey, token)
   const credentials: AppCredentials = {}
   if (fullSelectedApp === undefined) {
     return credentials


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-management/issues/170

We're running an expensive (~1s) query just to fetch 1 field. Let's limit to what we need!

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
1. Adds a new query just for this purpose, which only fetches developer preview mode.
2. Uses that for polling.
3. Renames `fetchAppFromApiKey` to `fetchAppDetailsFromApiKey` to mark the operation as expensive so we won't be so quick to use it outright in the future.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`app dev` and dev preview toggling should still work

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
