### PR TITLE
Fix redirection issue for customer account ui extension.

### DIFF
--- a/.changeset/unlucky-lizards-pretend.md
+++ b/.changeset/unlucky-lizards-pretend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix redirection issue for customer account ui extension

--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -105,6 +105,23 @@ describe('getExtensionPointRedirectUrl()', () => {
     expect(result).toBe('https://example.myshopify.com/mock/cart/url?dev=https%3A%2F%2Flocalhost%3A8081%2Fextensions')
   })
 
+  test('returns customer account server URL if the extension point targets customer account', () => {
+    const extension = {
+      devUUID: '123abc',
+    } as ExtensionInstance
+
+    const options = {
+      storeFqdn: 'example.myshopify.com',
+      url: 'https://localhost:8081',
+    } as unknown as ExtensionDevOptions
+
+    const result = getExtensionPointRedirectUrl('customer-account.page.render', extension, options)
+
+    expect(result).toBe(
+      'https://example.account.myshopify.com/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc',
+    )
+  })
+
   test('returns undefined if the extension point surface is not supported', () => {
     const extension = {
       devUUID: '123abc',

--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -14,14 +14,7 @@ export function getRedirectUrl(extension: ExtensionInstance, options: ExtensionD
 
     return rawUrl.toString()
   } else if (extension.surface === 'customer_accounts') {
-    const [storeName, ...storeDomainParts] = options.storeFqdn.split('.')
-    const accountsUrl = `${storeName}.account.${storeDomainParts.join('.')}`
-    const origin = `${options.url}/extensions`
-
-    const rawUrl = new URL(`https://${accountsUrl}/extensions-development`)
-    rawUrl.searchParams.append('origin', origin)
-    rawUrl.searchParams.append('extensionId', extension.devUUID)
-
+    const rawUrl = getCustomerAccountsRedirectUrl(extension, options)
     return rawUrl.toString()
   } else {
     const rawUrl = new URL(`https://${options.storeFqdn}/`)
@@ -38,7 +31,7 @@ export function getExtensionPointRedirectUrl(
   options: ExtensionDevOptions,
 ): string | undefined {
   const surface = getExtensionPointTargetSurface(requestedTarget)
-  const rawUrl = new URL(`https://${options.storeFqdn}/`)
+  let rawUrl = new URL(`https://${options.storeFqdn}/`)
 
   switch (surface) {
     case 'checkout':
@@ -52,11 +45,25 @@ export function getExtensionPointRedirectUrl(
       rawUrl.searchParams.append('url', getExtensionUrl(extension, options))
       rawUrl.searchParams.append('target', requestedTarget)
       break
+    case 'customer-accounts':
+      rawUrl = getCustomerAccountsRedirectUrl(extension, options)
+      break
     default:
       return undefined
   }
 
   return rawUrl.toString()
+}
+
+function getCustomerAccountsRedirectUrl(extension: ExtensionInstance, options: ExtensionDevOptions): URL {
+  const [storeName, ...storeDomainParts] = options.storeFqdn.split('.')
+  const accountsUrl = `${storeName}.account.${storeDomainParts.join('.')}`
+  const origin = `${options.url}/extensions`
+
+  const rawUrl = new URL(`https://${accountsUrl}/extensions-development`)
+  rawUrl.searchParams.append('origin', origin)
+  rawUrl.searchParams.append('extensionId', extension.devUUID)
+  return rawUrl
 }
 
 export function getExtensionUrl(extension: ExtensionInstance, options: ExtensionDevOptions): string {


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves: https://github.com/Shopify/core-issues/issues/59586


### WHAT is this pull request doing?
1. Set the correct redirection url for new customer account ui extension.
2. Refactor the redirection url for leagacy customer account ui extension.

### How to test your changes?
1. Enable customer account and ui extension flags for your partner account.
2. Create a new customer account ui extension locally.
3. `dev clone cli` and checkout to this branch.
4. ` pnpm shopify app dev --path your_extension_app_path --reset`
5. Click the link. Check if you will be redirect to customer account url.

See this video to tophat. https://videobin.shopify.io/v/NqGQqv

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
