### PR TITLE
Implement our own version of tree-kill

### DIFF
--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -36,7 +36,9 @@ const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUr
     setStatusMessage('Shutting down dev ...')
     setTimeout(() => {
       if (isUnitTest()) return
-      treeKill('SIGINT')
+      treeKill(process.pid, 'SIGINT', false, () => {
+        process.exit(0)
+      })
     }, 2000)
     clearInterval(pollingInterval.current)
     await disableDeveloperPreview({apiKey, token})

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -151,7 +151,6 @@
     "tempy": "3.0.0",
     "term-size": "3.0.2",
     "terminal-link": "3.0.0",
-    "tree-kill": "1.2.2",
     "ts-error": "1.0.6",
     "unique-string": "3.0.0",
     "zod": "3.21.4"

--- a/packages/cli-kit/src/private/node/ui.tsx
+++ b/packages/cli-kit/src/private/node/ui.tsx
@@ -77,7 +77,7 @@ const renderString = (element: ReactElement, renderOptions?: RenderOptions): Ins
   }
 }
 
-export function handleCtrlC(input: string, key: Key, exit = () => treeKill('SIGINT')) {
+export function handleCtrlC(input: string, key: Key, exit = () => treeKill(process.pid, 'SIGINT')) {
   if (input === 'c' && key.ctrl) {
     // Exceptions thrown in hooks aren't caught by our errorHandler.
     exit()

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -1,9 +1,9 @@
 import {AbortSignal} from './abort.js'
 import {ExternalError} from './error.js'
 import {cwd} from './path.js'
+import {treeKill} from './tree-kill.js'
 import {shouldDisplayColors, outputDebug} from '../../public/node/output.js'
 import {execa, ExecaChildProcess} from 'execa'
-import treeKill from 'tree-kill'
 import {ReadStream} from 'tty'
 import type {Writable, Readable} from 'stream'
 
@@ -62,11 +62,9 @@ export async function exec(command: string, args: string[], options?: ExecOption
   options?.signal?.addEventListener('abort', () => {
     const pid = commandProcess.pid
     if (pid) {
-      outputDebug(`Killing process ${options.cwd} ${command} ${args.join(' ')} ${pid}...`)
+      outputDebug(`Killing process ${pid}: ${command} ${args.join(' ')}`)
       aborted = true
-      treeKill(pid, (err) => {
-        if (err) outputDebug(`Failed to kill process ${pid}: ${err}`)
-      })
+      treeKill(pid, 'SIGTERM')
     }
   })
   try {

--- a/packages/cli-kit/src/public/node/tree-kill.ts
+++ b/packages/cli-kit/src/public/node/tree-kill.ts
@@ -1,12 +1,221 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable jsdoc/require-throws */
+/* eslint-disable jsdoc/require-returns */
+/* eslint-disable no-restricted-imports */
+
+import {outputDebug} from './output.js'
 import {printEventsJson} from '../../private/node/demo-recorder.js'
-import originalTreeKill from 'tree-kill'
+import {exec, spawn} from 'child_process'
+
+interface ProcessTree {
+  [key: string]: string[]
+}
+
+type AfterKillCallback = (error?: Error) => void
 
 /**
  * Kills the process that calls the method and all its children.
  *
- * @param signal - Type of kill signal to be used.
+ * @param pid - Pid of the process to kill.
+ * @param killSignal - Type of kill signal to be used.
+ * @param killRoot - Whether to kill the root process.
+ * @param callback - Optional callback to run after killing the processes.
  */
-export function treeKill(signal: string): void {
+export function treeKill(
+  pid: number | string = process.pid,
+  killSignal = 'SIGTERM',
+  killRoot = true,
+  callback?: AfterKillCallback,
+): void {
+  const after =
+    callback ??
+    ((error?: Error) => {
+      if (error) outputDebug(`Failed to kill process ${pid}: ${error}`)
+    })
   printEventsJson()
-  originalTreeKill(process.pid, signal)
+  adaptedTreeKill(pid, killSignal, killRoot, after)
+}
+
+/**
+ * Adapted from https://github.com/pkrumins/node-tree-kill.
+ *
+ * Our implementation allows to skip killing the root process. This is useful for example when
+ * gracefully exiting the 'dev' process, as the default tree-kill implementation will cause it
+ * to exit with a non-zero code. Instead, we want to treat it as a graceful termination.
+ * In addition, we also add debug logging for better visibility in what tree-kill is doing.
+ *
+ * @param pid - Pid of the process to kill.
+ * @param killSignal - Type of kill signal to be used.
+ * @param killRoot - Whether to kill the root process.
+ * @param callback - Optional callback to run after killing the processes.
+ */
+function adaptedTreeKill(
+  pid: number | string,
+  killSignal: string,
+  killRoot: boolean,
+  callback: (error?: Error) => void,
+): void {
+  const rootPid = typeof pid === 'number' ? pid.toString() : pid
+
+  if (Number.isNaN(rootPid)) {
+    if (callback) {
+      return callback(new Error('pid must be a number'))
+    } else {
+      throw new Error('pid must be a number')
+    }
+  }
+
+  // A map from parent pid to an array of children pids
+  const tree: ProcessTree = {}
+  tree[rootPid] = []
+
+  // A set of pids to visit. We use it to recursively find all the children pids
+  const pidsToProcess: Set<string> = new Set()
+  pidsToProcess.add(rootPid)
+
+  switch (process.platform) {
+    case 'win32':
+      // @ts-ignore
+      exec(`taskkill /pid ${pid} /T /F`, callback)
+      break
+    case 'darwin':
+      buildProcessTree(
+        rootPid,
+        tree,
+        pidsToProcess,
+        function (parentPid: string) {
+          return spawn('pgrep', ['-lfP', parentPid])
+        },
+        function () {
+          killAll(tree, killSignal, rootPid, killRoot, callback)
+        },
+      )
+      break
+    // Linux
+    default:
+      buildProcessTree(
+        rootPid,
+        tree,
+        pidsToProcess,
+        function (parentPid: string) {
+          return spawn('ps', ['-o', 'pid command', '--no-headers', '--ppid', parentPid])
+        },
+        function () {
+          killAll(tree, killSignal, rootPid, killRoot, callback)
+        },
+      )
+      break
+  }
+}
+
+/**
+ * Kills all processes in the process tree.
+ *
+ * @param tree - Process tree.
+ * @param killSignal - Type of kill signal to be used.
+ * @param rootPid - Pid of the root process.
+ * @param killRoot - Whether to kill the root process.
+ * @param callback - Optional callback to run after killing the processes.
+ */
+function killAll(
+  tree: ProcessTree,
+  killSignal: string,
+  rootPid: string,
+  killRoot: boolean,
+  callback: AfterKillCallback,
+): void {
+  const killed: Set<string> = new Set()
+  try {
+    Object.keys(tree).forEach(function (pid) {
+      tree[pid]!.forEach(function (pidpid) {
+        if (!killed.has(pidpid)) {
+          killPid(pidpid, killSignal)
+          killed.add(pidpid)
+        }
+      })
+      if (pid === rootPid && killRoot && !killed.has(pid)) {
+        killPid(pid, killSignal)
+        killed.add(pid)
+      }
+    })
+  } catch (err: unknown) {
+    if (callback) {
+      // @ts-ignore
+      return callback(err)
+    } else {
+      throw err
+    }
+  }
+  if (callback) {
+    return callback()
+  }
+}
+
+/**
+ * Kills a process.
+ *
+ * @param pid - Pid of the process to kill.
+ * @param killSignal - Type of kill signal to be used.
+ */
+function killPid(pid: string, killSignal: string) {
+  try {
+    process.kill(parseInt(pid, 10), killSignal)
+  } catch (err) {
+    // @ts-ignore
+    if (err.code !== 'ESRCH') throw err
+  }
+}
+
+/**
+ * Builds a process tree.
+ *
+ * @param parentPid - Pid of the parent process.
+ * @param tree - Process tree.
+ * @param pidsToProcess - Pids to process.
+ * @param spawnChildProcessesList - Function to spawn child processes.
+ * @param cb - Callback to run after building the process tree.
+ */
+function buildProcessTree(
+  parentPid: string,
+  tree: ProcessTree,
+  pidsToProcess: Set<string>,
+  spawnChildProcessesList: (parentPid: string) => ReturnType<typeof spawn>,
+  cb: () => void,
+) {
+  const ps = spawnChildProcessesList(parentPid)
+  let allData = ''
+  ps.stdout?.on('data', function (data: Buffer) {
+    const dataStr = data.toString('ascii')
+    allData += dataStr
+  })
+
+  const onClose = (code: number) => {
+    pidsToProcess.delete(parentPid)
+
+    if (code !== 0) {
+      // no more parent processes
+      if (pidsToProcess.size === 0) {
+        return cb()
+      }
+      return
+    }
+
+    allData
+      .trim()
+      .split('\n')
+      .forEach(function (line) {
+        const match = line.match(/^(\d+)\s(.*)$/)
+        if (match) {
+          const pid = match[1]!
+          const cmd = match[2]!
+          tree[parentPid]!.push(pid)
+          tree[pid] = []
+          outputDebug(`Killing process ${pid}: ${cmd}`)
+          pidsToProcess.add(pid)
+          buildProcessTree(pid, tree, pidsToProcess, spawnChildProcessesList, cb)
+        }
+      })
+  }
+
+  ps.on('close', onClose)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -450,9 +450,6 @@ importers:
       terminal-link:
         specifier: 3.0.0
         version: 3.0.0
-      tree-kill:
-        specifier: 1.2.2
-        version: 1.2.2
       ts-error:
         specifier: 1.0.6
         version: 1.0.6
@@ -8471,7 +8468,7 @@ packages:
     resolution: {integrity: sha512-q7SeFAEFMyKxTblyVI+CsxHzfiMMP9JUDG0cRmOKEAmJiYrtrDW1YYTv129RXqfn7fMKcVc4h/LbAJvqvZIuEQ==}
     engines: {node: '>=14.16'}
     peerDependencies:
-      '@types/react': '>=18.0.0'
+      '@types/react': 17.0.2
       react: '>=18.0.0'
       react-devtools-core: ^4.19.1
     peerDependenciesMeta:
@@ -12525,6 +12522,7 @@ packages:
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+    dev: true
 
   /treeverse@1.0.4:
     resolution: {integrity: sha512-whw60l7r+8ZU8Tu/Uc2yxtc4ZTZbR/PF3u1IPNKGQ6p8EICLb3Z2lAgoqw9bqYd8IkgnsaOcLzYHFckjqNsf0g==}
@@ -13049,7 +13047,7 @@ packages:
   /vite-tsconfig-paths@3.6.0(vite@4.4.8):
     resolution: {integrity: sha512-UfsPYonxLqPD633X8cWcPFVuYzx/CMNHAjZTasYwX69sXpa4gNmQkR0XCjj82h7zhLGdTWagMjC1qfb9S+zv0A==}
     peerDependencies:
-      vite: '>2.0.0-0'
+      vite: 4.4.8
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
@@ -13713,7 +13711,6 @@ packages:
     resolution: {directory: packages/eslint-plugin-cli, type: directory}
     id: file:packages/eslint-plugin-cli
     name: '@shopify/eslint-plugin-cli'
-    version: 3.46.0
     peerDependencies:
       eslint: ^8.46.0
     dependencies:


### PR DESCRIPTION
### WHY are these changes introduced?

I’ve been unhappy with how opaque is our current way of terminating all processes spawned by the CLI:

- we can’t tell at a glance which are the processes being killed, so we can’t tell if we’re doing a good clean up job
- even when pressing q the dev process terminates with an error code, which forces automation scripts to wrap everything in a try catch

### WHAT is this pull request doing?

I’ve vendored in and refactored the `tree-kill` dependency inside `cli-kit`, so that we now have a clean exit code when exiting the program normally and also have this nice output in verbose mode:
```
$ cat log.txt | grep Killing
2023-08-31T11:22:15.331Z: Killing process 30862: npm exec remix dev
2023-08-31T11:22:15.342Z: Killing process 30870: npm exec -- graphql-code-generator --config package.json
2023-08-31T11:22:15.353Z: Killing process 30961: bundle exec ruby /Users/arkham/src/github.com/Shopify/cli/packages/cli-kit/assets/cli-ruby/bin/shopify extension serve /Users/arkham/code/shopify-apps/aug22-1552/extensions/theme-extension --api-key 7b3adc2068c1e3afd7436b4e61cb7564 --extension-id 28942303233 --extension-title theme-extension --extension-type THEME_APP_EXTENSION --theme 125112385619 --generate-tmp-theme
2023-08-31T11:22:15.362Z: Killing process 30969: npm exec -- javy compile -d -o /Users/arkham/code/shopify-apps/aug22-1552/extensions/product-discount/dist/function.wasm dist/function.js
2023-08-31T11:22:15.377Z: Killing process 31048: /Users/arkham/Library/Caches/shopify-gems-nodejs/ruby/3.1.0/gems/rb-fsevent-0.11.1/bin/fsevent_watch --format=otnetstring --latency 0.1 /Users/arkham/code/shopify-apps/aug22-1552/extensions/theme-extension
2023-08-31T11:22:15.380Z: Killing process 30916: node /Users/arkham/code/shopify-apps/aug22-1552/node_modules/.bin/../@remix-run/dev/dist/cli.js dev
2023-08-31T11:22:15.395Z: Killing process 31020: /Users/arkham/code/shopify-apps/aug22-1552/node_modules/.pnpm/@esbuild+darwin-arm64@0.17.6/node_modules/@esbuild/darwin-arm64/bin/esbuild --service=0.17.6 --ping
2023-08-31T11:22:15.397Z: Killing process 31030: node /Users/arkham/code/shopify-apps/aug22-1552/node_modules/.bin/../@remix-run/serve/dist/cli.js build/index.js
2023-08-31T11:22:17.357Z: Killing process 30725: /Users/arkham/src/github.com/Shopify/cli/packages/plugin-cloudflare/bin/cloudflared tunnel --url http://localhost:64266 --no-autoupdate
2023-08-31T11:22:17.360Z: Killing process 30878: /Users/arkham/src/github.com/Shopify/cli/node_modules/.pnpm/@esbuild+darwin-arm64@0.18.17/node_modules/@esbuild/darwin-arm64/bin/esbuild --service=0.18.17 --ping
```

### How to test your changes?

- `pnpm shopify app dev --path <path to your app>`
- press `q`
- `echo $?` should be 0
- `pnpm shopify app dev --path <path to your app> --verbose`
- wait for the output to settle and then press `q`
- you should see all the killed processes in the log


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
