### PR TITLE
Fix create-app analytics throwing error in postrun hook

### DIFF
--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -1,5 +1,5 @@
 import {hashString} from '../../public/node/crypto.js'
-import {getPackageManager, packageManagerUsedForCreating} from '../../public/node/node-package-manager.js'
+import {getPackageManager, packageManagerFromUserAgent} from '../../public/node/node-package-manager.js'
 import BaseCommand from '../../public/node/base-command.js'
 import {CommandContent} from '../../public/node/hooks/prerun.js'
 import * as metadata from '../../public/node/metadata.js'
@@ -35,7 +35,7 @@ export async function startAnalytics({
   }))
 
   await metadata.addPublicMetadata(() => ({
-    cmd_all_launcher: packageManagerUsedForCreating(),
+    cmd_all_launcher: packageManagerFromUserAgent(),
     cmd_all_alias_used: commandContent.alias,
     cmd_all_topic: commandContent.topic,
     cmd_all_plugin: commandClass?.plugin?.name,

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -606,7 +606,7 @@ describe('addResolutionOrOverride', () => {
       const result = () => addResolutionOrOverride(tmpDir, {'@types/react': '17.0.30'})
 
       // Then
-      await expect(result).rejects.toThrow(new PackageJsonNotFoundError(tmpDir))
+      await expect(result).rejects.toThrow(new PackageJsonNotFoundError(normalizePath(tmpDir)))
     })
   })
 

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -16,6 +16,7 @@ import {
   addNPMDependencies,
   DependencyVersion,
   PackageJsonNotFoundError,
+  UnknownPackageManagerError,
 } from './node-package-manager.js'
 import {exec} from './system.js'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from './fs.js'
@@ -605,7 +606,7 @@ describe('addResolutionOrOverride', () => {
       const result = () => addResolutionOrOverride(tmpDir, {'@types/react': '17.0.30'})
 
       // Then
-      await expect(result).rejects.toThrow(new FindUpAndReadPackageJsonNotFoundError(tmpDir))
+      await expect(result).rejects.toThrow(new PackageJsonNotFoundError(tmpDir))
     })
   })
 
@@ -777,16 +778,16 @@ describe('getPackageManager', () => {
     })
   })
 
-  test("throws a FindUpAndReadPackageJsonNotFoundError error if it can't find a package.json", async () => {
+  test("tries to guess the package manager from the environment if it can't find a package.json", async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const subDirectory = joinPath(tmpDir, 'subdir')
       await mkdir(subDirectory)
 
       // When/Then
-      await expect(() => getPackageManager(subDirectory)).rejects.toThrowError(
-        new FindUpAndReadPackageJsonNotFoundError(subDirectory),
-      )
+      const packageManager = await getPackageManager(tmpDir)
+      // pnpm is used locally and in CI
+      expect(packageManager).toEqual('pnpm')
     })
   })
 })
@@ -858,6 +859,25 @@ describe('addNPMDependencies', () => {
       expect(mockedExec).toHaveBeenCalledWith('pnpm', ['add', 'first@0.0.1', 'second@0.0.2', '--save-prod'], {
         cwd: tmpDir,
       })
+    })
+  })
+
+  test('when the package manager is unknown an error is thrown', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const dependencies: DependencyVersion[] = [
+        {name: 'first', version: '0.0.1'},
+        {name: 'second', version: '0.0.2'},
+      ]
+
+      // When/Then
+      await expect(
+        addNPMDependencies(dependencies, {
+          type: 'prod',
+          packageManager: 'unknown',
+          directory: tmpDir,
+        }),
+      ).rejects.toThrowError(UnknownPackageManagerError)
     })
   })
 })

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -1,5 +1,5 @@
 import {
-  packageManagerUsedForCreating,
+  packageManagerFromUserAgent,
   addNPMDependenciesIfNeeded,
   installNodeModules,
   getDependencies,
@@ -59,13 +59,13 @@ describe('installNPMDependenciesRecursively', () => {
   })
 })
 
-describe('packageManagerUsedForCreating', () => {
+describe('packageManagerFromUserAgent', () => {
   test('returns pnpm if the npm_config_user_agent variable contains yarn', () => {
     // Given
     const env = {npm_config_user_agent: 'yarn/1.22.17'}
 
     // When
-    const got = packageManagerUsedForCreating(env)
+    const got = packageManagerFromUserAgent(env)
 
     // Then
     expect(got).toBe('yarn')
@@ -76,7 +76,7 @@ describe('packageManagerUsedForCreating', () => {
     const env = {npm_config_user_agent: 'pnpm'}
 
     // When
-    const got = packageManagerUsedForCreating(env)
+    const got = packageManagerFromUserAgent(env)
 
     // Then
     expect(got).toBe('pnpm')
@@ -87,7 +87,7 @@ describe('packageManagerUsedForCreating', () => {
     const env = {npm_config_user_agent: 'npm'}
 
     // When
-    const got = packageManagerUsedForCreating(env)
+    const got = packageManagerFromUserAgent(env)
 
     // Then
     expect(got).toBe('npm')
@@ -95,7 +95,7 @@ describe('packageManagerUsedForCreating', () => {
 
   test('returns unknown when the package manager cannot be detected', () => {
     // When
-    const got = packageManagerUsedForCreating({})
+    const got = packageManagerFromUserAgent({})
 
     // Then
     expect(got).toBe('unknown')

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -57,7 +57,7 @@ export class UnknownPackageManagerError extends AbortError {
  */
 export class PackageJsonNotFoundError extends AbortError {
   constructor(directory: string) {
-    super(`The directory ${directory} doesn't have a package.json.`)
+    super(outputContent`The directory ${outputToken.path(directory)} doesn't have a package.json.`)
   }
 }
 

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -36,8 +36,18 @@ export type DependencyType = 'dev' | 'prod' | 'peer'
 /**
  * A union that represents the package managers available.
  */
-export const packageManager = ['yarn', 'npm', 'pnpm'] as const
+export const packageManager = ['yarn', 'npm', 'pnpm', 'unknown'] as const
 export type PackageManager = (typeof packageManager)[number]
+
+/**
+ * Returns an abort error that's thrown when the package manager can't be determined.
+ * @returns An abort error.
+ */
+export class UnknownPackageManagerError extends AbortError {
+  constructor() {
+    super('Unknown package manager')
+  }
+}
 
 /**
  * Returns an abort error that's thrown when a directory that's expected to have
@@ -68,7 +78,7 @@ export class FindUpAndReadPackageJsonNotFoundError extends BugError {
  * @param env - The environment variables of the process in which the CLI runs.
  * @returns The dependency manager
  */
-export function packageManagerFromUserAgent(env = process.env): PackageManager | 'unknown' {
+export function packageManagerFromUserAgent(env = process.env): PackageManager {
   if (env.npm_config_user_agent?.includes('yarn')) {
     return 'yarn'
   } else if (env.npm_config_user_agent?.includes('pnpm')) {
@@ -84,7 +94,7 @@ export function packageManagerFromUserAgent(env = process.env): PackageManager |
  * @param fromDirectory - The starting directory
  * @returns The dependency manager
  */
-export async function getPackageManager(fromDirectory: string): Promise<PackageManager | 'unknown'> {
+export async function getPackageManager(fromDirectory: string): Promise<PackageManager> {
   const packageJson = await findPathUp('package.json', {cwd: fromDirectory, type: 'file'})
   if (!packageJson) {
     return packageManagerFromUserAgent()
@@ -431,6 +441,8 @@ export async function addNPMDependencies(
         argumentsToAddDependenciesWithPNPM(dependenciesWithVersion, options.type, Boolean(options.addToRootDirectory)),
       )
       break
+    case 'unknown':
+      throw new UnknownPackageManagerError()
   }
 }
 

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -68,7 +68,7 @@ export class FindUpAndReadPackageJsonNotFoundError extends BugError {
  * @param env - The environment variables of the process in which the CLI runs.
  * @returns The dependency manager
  */
-export function packageManagerUsedForCreating(env = process.env): PackageManager | 'unknown' {
+export function packageManagerFromUserAgent(env = process.env): PackageManager | 'unknown' {
   if (env.npm_config_user_agent?.includes('yarn')) {
     return 'yarn'
   } else if (env.npm_config_user_agent?.includes('pnpm')) {
@@ -80,14 +80,14 @@ export function packageManagerUsedForCreating(env = process.env): PackageManager
 }
 
 /**
- * Returns the dependency manager used by an existing project.
+ * Returns the dependency manager used in a directory.
  * @param fromDirectory - The starting directory
  * @returns The dependency manager
  */
-export async function getPackageManager(fromDirectory: string): Promise<PackageManager> {
+export async function getPackageManager(fromDirectory: string): Promise<PackageManager | 'unknown'> {
   const packageJson = await findPathUp('package.json', {cwd: fromDirectory, type: 'file'})
   if (!packageJson) {
-    throw new FindUpAndReadPackageJsonNotFoundError(fromDirectory)
+    return packageManagerFromUserAgent()
   }
   const directory = dirname(packageJson)
   outputDebug(outputContent`Obtaining the dependency manager in directory ${outputToken.path(directory)}...`)

--- a/packages/cli-kit/src/public/node/output.test.ts
+++ b/packages/cli-kit/src/public/node/output.test.ts
@@ -15,11 +15,13 @@ describe('Output helpers', () => {
     expect(outputToken.packagejsonScript('yarn', 'dev', '--reset').value).toEqual('yarn dev --reset')
     expect(outputToken.packagejsonScript('npm', 'dev', '--reset').value).toEqual('npm run dev -- --reset')
     expect(outputToken.packagejsonScript('pnpm', 'dev', '--reset').value).toEqual('pnpm dev --reset')
+    expect(outputToken.packagejsonScript('unknown', 'dev', '--reset').value).toEqual('dev --reset')
   })
   test('can format dependency manager commands without flags', () => {
     expect(outputToken.packagejsonScript('yarn', 'dev').value).toEqual('yarn dev')
     expect(outputToken.packagejsonScript('npm', 'dev').value).toEqual('npm run dev')
     expect(outputToken.packagejsonScript('pnpm', 'dev').value).toEqual('pnpm dev')
+    expect(outputToken.packagejsonScript('unknown', 'dev').value).toEqual('dev')
   })
 })
 

--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -115,6 +115,10 @@ export function formatPackageManagerCommand(
       }
       return pieces.join(' ')
     }
+    case 'unknown': {
+      const pieces = [scriptName, ...scriptArgs]
+      return pieces.join(' ')
+    }
   }
 }
 
@@ -442,10 +446,7 @@ export function shouldDisplayColors(_process = process): boolean {
  * @param version - The version to update to.
  * @returns The message to remind the user to update the CLI.
  */
-export function getOutputUpdateCLIReminder(
-  packageManager: PackageManager | 'unknown' | undefined,
-  version: string,
-): string {
+export function getOutputUpdateCLIReminder(packageManager: PackageManager | undefined, version: string): string {
   const versionMessage = `💡 Version ${version} available!`
   if (!packageManager || packageManager === 'unknown') return versionMessage
 

--- a/packages/cli/src/cli/services/commands/version.test.ts
+++ b/packages/cli/src/cli/services/commands/version.test.ts
@@ -1,6 +1,6 @@
 import {versionService} from './version.js'
 import {afterEach, describe, expect, vi, test} from 'vitest'
-import {checkForNewVersion, packageManagerUsedForCreating} from '@shopify/cli-kit/node/node-package-manager'
+import {checkForNewVersion, packageManagerFromUserAgent} from '@shopify/cli-kit/node/node-package-manager'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 
 vi.mock('@shopify/cli-kit/node/node-package-manager')
@@ -15,7 +15,7 @@ describe('check CLI version', () => {
     // Given
     const outputMock = mockAndCaptureOutput()
     vi.mocked(checkForNewVersion).mockResolvedValue('3.0.10')
-    vi.mocked(packageManagerUsedForCreating).mockReturnValue('yarn')
+    vi.mocked(packageManagerFromUserAgent).mockReturnValue('yarn')
 
     // When
     await versionService()
@@ -31,7 +31,7 @@ describe('check CLI version', () => {
     // Given
     const outputMock = mockAndCaptureOutput()
     vi.mocked(checkForNewVersion).mockResolvedValue('3.0.10')
-    vi.mocked(packageManagerUsedForCreating).mockReturnValue('pnpm')
+    vi.mocked(packageManagerFromUserAgent).mockReturnValue('pnpm')
 
     // When
     await versionService()
@@ -47,7 +47,7 @@ describe('check CLI version', () => {
     // Given
     const outputMock = mockAndCaptureOutput()
     vi.mocked(checkForNewVersion).mockResolvedValue('3.0.10')
-    vi.mocked(packageManagerUsedForCreating).mockReturnValue('npm')
+    vi.mocked(packageManagerFromUserAgent).mockReturnValue('npm')
 
     // When
     await versionService()

--- a/packages/cli/src/cli/services/commands/version.ts
+++ b/packages/cli/src/cli/services/commands/version.ts
@@ -1,5 +1,5 @@
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
-import {checkForNewVersion, packageManagerUsedForCreating} from '@shopify/cli-kit/node/node-package-manager'
+import {checkForNewVersion, packageManagerFromUserAgent} from '@shopify/cli-kit/node/node-package-manager'
 import {outputInfo, outputContent, outputToken, getOutputUpdateCLIReminder} from '@shopify/cli-kit/node/output'
 
 export async function versionService(): Promise<void> {
@@ -8,7 +8,7 @@ export async function versionService(): Promise<void> {
   outputInfo(outputContent`Current Shopify CLI version: ${outputToken.yellow(currentVersion)}`.value)
   const lastVersion = await checkForNewVersion(cliDependency, currentVersion)
   if (lastVersion) {
-    const packageManager = packageManagerUsedForCreating()
+    const packageManager = packageManagerFromUserAgent()
     outputInfo(getOutputUpdateCLIReminder(packageManager, lastVersion))
   }
 }

--- a/packages/create-app/src/services/init.ts
+++ b/packages/create-app/src/services/init.ts
@@ -4,7 +4,7 @@ import {
   findUpAndReadPackageJson,
   packageManager,
   PackageManager,
-  packageManagerUsedForCreating,
+  packageManagerFromUserAgent,
   writePackageJSON,
 } from '@shopify/cli-kit/node/node-package-manager'
 import {renderSuccess, renderTasks, Task} from '@shopify/cli-kit/node/ui'
@@ -152,7 +152,7 @@ function inferPackageManager(optionsPackageManager: string | undefined): Package
   if (optionsPackageManager && packageManager.includes(optionsPackageManager as PackageManager)) {
     return optionsPackageManager as PackageManager
   }
-  const usedPackageManager = packageManagerUsedForCreating()
+  const usedPackageManager = packageManagerFromUserAgent()
   return usedPackageManager === 'unknown' ? 'npm' : usedPackageManager
 }
 

--- a/packages/create-app/src/services/init.ts
+++ b/packages/create-app/src/services/init.ts
@@ -5,6 +5,7 @@ import {
   packageManager,
   PackageManager,
   packageManagerFromUserAgent,
+  UnknownPackageManagerError,
   writePackageJSON,
 } from '@shopify/cli-kit/node/node-package-manager'
 import {renderSuccess, renderTasks, Task} from '@shopify/cli-kit/node/ui'
@@ -86,6 +87,8 @@ async function init(options: InitOptions) {
               // pnpm due to missing peerDependencies.
               await appendFile(joinPath(templateScaffoldDir, '.npmrc'), `auto-install-peers=true\n`)
               break
+            case 'unknown':
+              throw new UnknownPackageManagerError()
           }
 
           await updateCLIDependencies({packageJSON, local: options.local, directory: templateScaffoldDir})


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-management/issues/15

Analytics reporting in `create-app` was throwing an error in the postrun hook because `getPackageManager` was trying to guess the package manager from a folder which, because it's the app's parent folder, doesn't have a package.json.

### WHAT is this pull request doing?

If there is no package.json we can try to use the existing function `packageManagerFromUserAgent` to guess it.

### How to test your changes?

Unless we publish this it won't be easy to test because if you run `pnpm create-app --verbose` from the root `cli` folder there is going to be a package.json there and you won't see the exception.

Once this is merged we can test `npm init` with nightly.
