### PR TITLE
Update dev.yml since homebrew got deprecated

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -8,11 +8,9 @@ up:
       version: 3.1.2
   - bundler:
       gemfile: packages/cli-kit/assets/cli-ruby/Gemfile
-  - homebrew:
+  - packages:
     - jq
-    - delve
-    - pnpm:
-        version: 8.6.11
+    - pnpm
   - custom:
       name: 'Install PNPM dependencies'
       # we flip these two conditions to always run `pnpm install`


### PR DESCRIPTION
### WHY are these changes introduced?

The `homebrew` section in `dev.yml` was deprecated in favour of `packages`.
