### PR TITLE
Remove try catch in test script

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -123,9 +123,7 @@ program
     };
 
     const appDev = async () => {
-      try {
-        await appExec(nodePackageManager, ["run", "dev"]);
-      } catch (error) {}
+      await appExec(nodePackageManager, ["run", "dev"]);
     };
 
     const generateExtension = async (args, options = {}) => {


### PR DESCRIPTION
As now the CLI process terminates with a non-error code

### WHY are these changes introduced?

As of https://github.com/Shopify/cli/pull/2729 the CLI can terminate gracefully when pressing `q`, so we don't need to wrap the execution of `app dev` into a try/catch anymore.