### PR TITLE
Update simplified deployment info banner 

### DIFF
--- a/.changeset/smooth-spoons-reflect.md
+++ b/.changeset/smooth-spoons-reflect.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': patch
+'@shopify/cli': patch
+---
+
+Updated the simplified deployments info banner

--- a/packages/app/src/cli/services/deploy/mode.test.ts
+++ b/packages/app/src/cli/services/deploy/mode.test.ts
@@ -75,7 +75,7 @@ describe('resolveDeploymentMode', () => {
       │    • Bundle all your extensions into an app version                          │
       │    • Release all your extensions to users straight from the CLI              │
       │                                                                              │
-      │  All apps will be automatically upgraded on Sept 5, 2023.                    │
+      │  All apps will be automatically upgraded in September 2023.                  │
       │                                                                              │
       │  Reference                                                                   │
       │    • Simplified extension deployment [1]                                     │
@@ -130,7 +130,7 @@ describe('resolveDeploymentMode', () => {
       │    • Bundle all your extensions into an app version                          │
       │    • Release all your extensions to users straight from the CLI              │
       │                                                                              │
-      │  All apps will be automatically upgraded on Sept 5, 2023.                    │
+      │  All apps will be automatically upgraded in September 2023.                  │
       │                                                                              │
       │  Reference                                                                   │
       │    • Simplified extension deployment [1]                                     │
@@ -181,7 +181,7 @@ describe('resolveDeploymentMode', () => {
       │    • Bundle all your extensions into an app version                          │
       │    • Release all your extensions to users straight from the CLI              │
       │                                                                              │
-      │  All apps will be automatically upgraded on Sept 5, 2023.                    │
+      │  All apps will be automatically upgraded in September 2023.                  │
       │                                                                              │
       │  Reference                                                                   │
       │    • Simplified extension deployment [1]                                     │

--- a/packages/app/src/cli/services/deploy/mode.ts
+++ b/packages/app/src/cli/services/deploy/mode.ts
@@ -64,8 +64,8 @@ function displayDeployLegacyBanner(packageManager: PackageManager) {
           ],
         },
       },
-      'All apps will be automatically upgraded on',
-      {bold: 'Sept 5, 2023.'},
+      'All apps will be automatically upgraded in',
+      {bold: 'September 2023.'},
     ],
     reference: [
       {


### PR DESCRIPTION
### WHY are these changes introduced?

These changes are introduced to reflect the changes how we rollout simplified deployments.


### WHAT is this pull request doing?

Updates the date from `Sept 5, 2023` to `September 2023` to match with the updated rollout plan.

### How to test your changes?

Run the `app deploy` command. Should expect to see this banner:

<img width="1887" alt="image" src="https://github.com/Shopify/cli/assets/99370588/028a98c9-ff7a-4ace-8f18-0656cae441db">


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
