### PR TITLE
Report any kind of error to Bugsnag as handled/unhandled

### DIFF
--- a/.changeset/eighty-pets-approve.md
+++ b/.changeset/eighty-pets-approve.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Do not report "not found" errors

--- a/.changeset/empty-cobras-do.md
+++ b/.changeset/empty-cobras-do.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add verbose logs for Bugsnag reporting

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -40,7 +40,7 @@ import {tryParseInt} from '@shopify/cli-kit/common/string'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {TokenItem, renderError, renderInfo, renderTasks} from '@shopify/cli-kit/node/ui'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {AbortError, AbortSilentError, BugError} from '@shopify/cli-kit/node/error'
+import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import {outputContent} from '@shopify/cli-kit/node/output'
 import {getOrganization} from '@shopify/cli-kit/node/environment'
 import {basename, joinPath} from '@shopify/cli-kit/node/path'
@@ -214,7 +214,7 @@ const resetHelpMessage = ['You can pass', {command: '--reset'}, 'to your command
 
 const appFromId = async (appId: string, token: string): Promise<OrganizationApp> => {
   const app = await fetchAppDetailsFromApiKey(appId, token)
-  if (!app) throw new BugError([`Couldn't find the app with Client ID`, {command: appId}], resetHelpMessage)
+  if (!app) throw new AbortError([`Couldn't find the app with Client ID`, {command: appId}], resetHelpMessage)
   return app
 }
 
@@ -224,7 +224,7 @@ const storeFromFqdn = async (storeFqdn: string, orgId: string, token: string): P
     await convertToTestStoreIfNeeded(result.store, orgId, token)
     return result.store
   } else {
-    throw new BugError(`Couldn't find the store with domain "${storeFqdn}". ${resetHelpMessage}`)
+    throw new AbortError(`Couldn't find the store with domain "${storeFqdn}". ${resetHelpMessage}`)
   }
 }
 
@@ -549,11 +549,11 @@ async function fetchDevDataFromOptions(
     (async () => {
       if (options.storeFqdn) {
         const orgWithStore = await fetchStoreByDomain(orgId, token, options.storeFqdn)
-        if (!orgWithStore) throw new BugError(`Could not find Organization for id ${orgId}.`)
+        if (!orgWithStore) throw new AbortError(`Could not find Organization for id ${orgId}.`)
         if (!orgWithStore.store) {
           const partners = await partnersFqdn()
           const org = orgWithStore.organization
-          throw new BugError(
+          throw new AbortError(
             `Could not find ${options.storeFqdn} in the Organization ${org.businessName} as a valid store.`,
             `Visit https://${partners}/${org.id}/stores to create a new development or Shopify Plus sandbox store in your organization`,
           )

--- a/packages/cli-kit/src/public/node/error-handler.test.ts
+++ b/packages/cli-kit/src/public/node/error-handler.test.ts
@@ -121,10 +121,11 @@ describe('bugsnag metadata', () => {
 })
 
 describe('send to Bugsnag', () => {
-  test('processes Error instances', async () => {
+  test('processes Error instances as unhandled', async () => {
     const toThrow = new Error('In test')
     const res = await sendErrorToBugsnag(toThrow)
     expect(res.reported).toEqual(true)
+    expect(res.unhandled).toEqual(true)
 
     const {error} = res as any
 
@@ -141,10 +142,11 @@ describe('send to Bugsnag', () => {
     expect(onNotify).toHaveBeenCalledWith(res.error)
   })
 
-  test('ignores fatals', async () => {
+  test('processes AbortErrors as handled', async () => {
     const res = await sendErrorToBugsnag(new error.AbortError('In test'))
-    expect(res.reported).toEqual(false)
-    expect(onNotify).not.toHaveBeenCalled()
+    expect(res.reported).toEqual(true)
+    expect(res.unhandled).toEqual(false)
+    expect(onNotify).toHaveBeenCalledWith(res.error)
   })
 
   test.each([null, undefined, {}, {message: 'nope'}])('deals with strange things to throw %s', async (throwable) => {

--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -65,7 +65,10 @@ const reportError = async (error: unknown, config?: Interfaces.Config): Promise<
 export async function sendErrorToBugsnag(
   error: unknown,
 ): Promise<{reported: false; error: unknown} | {error: Error; reported: true}> {
-  if (settings.debug || !shouldReportError(error)) return {reported: false, error}
+  if (settings.debug || !shouldReportError(error)) {
+    outputDebug(`Skipping Bugsnag report`)
+    return {reported: false, error}
+  }
 
   let reportableError: Error
   let stacktrace: string | undefined
@@ -104,9 +107,8 @@ export async function sendErrorToBugsnag(
   if (report) {
     initializeBugsnag()
     await new Promise((resolve, reject) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      Bugsnag.notify(reportableError, undefined, (error, event) => {
+      outputDebug(`Reporting error to Bugsnag: ${reportableError.message}`)
+      Bugsnag.notify(reportableError, undefined, (error: unknown) => {
         if (error) {
           reject(error)
         } else {

--- a/packages/cli-kit/src/public/node/error.ts
+++ b/packages/cli-kit/src/public/node/error.ts
@@ -178,7 +178,7 @@ function isFatal(error: unknown): error is FatalError {
 }
 
 /**
- * A function that checks if an error should be reported.
+ * A function that checks if an error should be reported as unhandled.
  *
  * @param error - Error to be checked.
  * @returns A boolean indicating if the error should be reported.


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-management/issues/195

We are reporting to Bugsnag user errors (like "App not found") mixed with unexpected errors.

Example: https://app.bugsnag.com/shopify/cli/errors/64b0140d6b457e000847a018

### WHAT is this pull request doing?

- Set `unhandled = true` for all bugs and unexpected errors
- Set `unhandled = false` for controlled errors (like AbortError), and always report
- Replace a few BugError with AbortError
- Add verbose logs to know when the error is reported as handled, unhandled or skipped

Example of handled error report: https://app.bugsnag.com/shopify/cli/errors/64f70a3fe74a7000083d69d7?filters[event.unhandled]=false&filters[event.severity]=error

### How to test your changes?

- Update the client ID in your `shopify.app.toml` with an invalid value
- `p shopify app dev --path ~/your-app --verbose | grep Bugsnag` (it should skip the report in dev environment)
- `SHOPIFY_CLI_ENV=production p shopify app dev --path ~/your-app --verbose | grep Bugsnag` (it should report as handled)
- Add `throw new BugError('boom!')` in `commands/app/dev.ts`
- `SHOPIFY_CLI_ENV=production p shopify app dev --path ~/your-app --verbose | grep Bugsnag` (it should report as unhandled)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
