### PR TITLE
Remove show/hide button for extensions

### DIFF
--- a/.changeset/purple-trees-sin.md
+++ b/.changeset/purple-trees-sin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-dev-console-app': patch
+---
+
+Remove the show/hide button from console

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/Extensions.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/Extensions.tsx
@@ -7,10 +7,7 @@ import {useExtensionServerOptions} from './hooks/useExtensionServerOptions'
 import {useApp} from './hooks/useApp'
 import {useI18n} from '@shopify/react-i18n'
 import React from 'react'
-import {QuestionMarkMajor} from '@shopify/polaris-icons'
-import {Icon} from '@/components/Icon'
 import {isEmbedded} from '@/utilities/embedded'
-import {Tooltip} from '@/components/Tooltip'
 
 export function Extensions() {
   const [i18n] = useI18n({

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/Extensions.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/Extensions.tsx
@@ -47,14 +47,6 @@ export function Extensions() {
             <th>{i18n.translate('extensionList.handle')}</th>
             <th>{i18n.translate('extensionList.preview')}</th>
             <th>{i18n.translate('extensionList.mobile')}</th>
-            <th>
-              <span className={styles.WithIcon}>
-                {i18n.translate('extensionList.view')}
-                <Tooltip text={i18n.translate('tooltips.viewColumnHeader')}>
-                  <Icon source={QuestionMarkMajor} muted />
-                </Tooltip>
-              </span>
-            </th>
             <th>{i18n.translate('extensionList.status')}</th>
           </Row>
         </thead>

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/AppHomeRow/AppHomeRow.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/AppHomeRow/AppHomeRow.tsx
@@ -52,9 +52,6 @@ export function AppHomeRow() {
       <td>
         <NotApplicable />
       </td>
-      <td>
-        <NotApplicable />
-      </td>
     </Row>
   )
 }

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.test.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.test.tsx
@@ -17,7 +17,6 @@ vi.mock('..', () => ({
   QRCodeModal: () => null,
   Row: (props: any) => props.children,
   Status: () => null,
-  NotApplicable: () => null,
 }))
 
 mockI18n(en)

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.test.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.test.tsx
@@ -17,7 +17,7 @@ vi.mock('..', () => ({
   QRCodeModal: () => null,
   Row: (props: any) => props.children,
   Status: () => null,
-  View: () => null,
+  NotApplicable: () => null,
 }))
 
 mockI18n(en)

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
@@ -2,7 +2,7 @@ import * as styles from './ExtensionRow.module.scss'
 import en from './translations/en.json'
 
 import {PreviewLinks} from './components'
-import {QRCodeModal, Row, Status, View} from '..'
+import {NotApplicable, QRCodeModal, Row, Status, View} from '..'
 import {useExtension} from '../../hooks/useExtension'
 import React, {useState} from 'react'
 import {useI18n} from '@shopify/react-i18n'
@@ -63,7 +63,7 @@ export function ExtensionRow({uuid}: Props) {
         />
       </td>
       <td>
-        <View show={show} hide={hide} hidden={extension.development.hidden} />
+        <NotApplicable />
       </td>
       <td>
         <Status status={extension.development.status} />

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
@@ -2,7 +2,7 @@ import * as styles from './ExtensionRow.module.scss'
 import en from './translations/en.json'
 
 import {PreviewLinks} from './components'
-import {NotApplicable, QRCodeModal, Row, Status, View} from '..'
+import {NotApplicable, QRCodeModal, Row, Status} from '..'
 import {useExtension} from '../../hooks/useExtension'
 import React, {useState} from 'react'
 import {useI18n} from '@shopify/react-i18n'

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
@@ -2,7 +2,7 @@ import * as styles from './ExtensionRow.module.scss'
 import en from './translations/en.json'
 
 import {PreviewLinks} from './components'
-import {NotApplicable, QRCodeModal, Row, Status} from '..'
+import {QRCodeModal, Row, Status} from '..'
 import {useExtension} from '../../hooks/useExtension'
 import React, {useState} from 'react'
 import {useI18n} from '@shopify/react-i18n'

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
@@ -63,9 +63,6 @@ export function ExtensionRow({uuid}: Props) {
         />
       </td>
       <td>
-        <NotApplicable />
-      </td>
-      <td>
         <Status status={extension.development.status} />
       </td>
     </Row>

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/PostPurchaseRow/PostPurchaseRow.test.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/PostPurchaseRow/PostPurchaseRow.test.tsx
@@ -20,7 +20,6 @@ vi.mock('..', async () => {
     ...{
       Row: (props: any) => props.children,
       Status: () => null,
-      View: () => null,
     },
   }
 })

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/PostPurchaseRow/PostPurchaseRow.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/PostPurchaseRow/PostPurchaseRow.tsx
@@ -2,7 +2,7 @@ import * as styles from './PostPurchaseRow.module.scss'
 import en from './translations/en.json'
 
 import {PostPurchaseModal} from './components'
-import {Row, Status, View} from '..'
+import {Row, Status} from '..'
 import {useExtension} from '../../hooks/useExtension.js'
 import React, {useState} from 'react'
 import {useI18n} from '@shopify/react-i18n'
@@ -39,9 +39,6 @@ export function PostPurchaseRow({uuid}: Props) {
         <PostPurchaseModal onClose={() => setShowModal(false)} url={extension.development.root.url} open={showModal} />
       </td>
       <td></td>
-      <td>
-        <View hidden={extension.development.hidden} show={show} hide={hide} />
-      </td>
       <td>
         <Status status={extension.development.status} />
       </td>


### PR DESCRIPTION
With the introduction of automatic draft updates during dev for extensions, toggling between local and a deployed no longer provide any value and results in a confusing experience.

### WHY are these changes introduced?

Closes https://github.com/Shopify/app-ui/issues/407

### WHAT is this pull request doing?

Remove show/hide button for extensions

### 🎩 instructions

- Follow steps to run the console locally here https://github.com/Shopify/cli/tree/main/packages/ui-extensions-dev-console
- Confirm that the show/hide button isn't present for extensions