### PR TITLE
Update Partner community link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Shopify Partners Community 🙌
-    url: https://www.shopify.com/partners/community#conversation
+    url: https://community.shopify.com/c/partners-and-developers/ct-p/appdev
     about: Connect with Shopify and other Shopify Partners through our online communities!
   - name: Shopify CLI 2.0 issues 📝
     url: https://www.github.com/Shopify/shopify-cli/issues/new/choose


### PR DESCRIPTION
### WHY are these changes introduced?

See https://github.com/Shopify/partners/issues/45465

The shopify.com/partners/community page is being sunset. Update the Partner Community link to the new page.

### WHAT is this pull request doing?

Updating the link to the Partners community in the issue tempate.

### How to test your changes?

Test after deploy, issues template previews not enabled for this repo.

### Post-release steps

Ensure issue template updated. 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
