### PR TITLE
[ShopifyVM] Store `ui.handle` as part of a functions config on deploy

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -81,7 +81,7 @@ describe('functionConfiguration', () => {
             details_path: extension.configuration.ui!.paths!.details,
             create_path: extension.configuration.ui!.paths!.create,
           },
-          handle: extension.configuration.ui!.handle,
+          ui_extension_handle: extension.configuration.ui!.handle,
         },
         input_query: inputQuery,
         input_query_variables: {
@@ -115,7 +115,7 @@ describe('functionConfiguration', () => {
         module_id: moduleId,
         enable_creation_ui: true,
         input_query: undefined,
-        input_query_variabels: undefined,
+        input_query_variables: undefined,
         ui: undefined,
       })
     })

--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -44,6 +44,7 @@ describe('functionConfiguration', () => {
             details: '/details/:id',
           },
           enable_create: true,
+          handle: 'linked-ext-handle',
         },
         configuration_ui: false,
         api_version: '2022-07',
@@ -80,6 +81,7 @@ describe('functionConfiguration', () => {
             details_path: extension.configuration.ui!.paths!.details,
             create_path: extension.configuration.ui!.paths!.create,
           },
+          handle: extension.configuration.ui!.handle,
         },
         input_query: inputQuery,
         input_query_variables: {

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -6,6 +6,14 @@ import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent} from '@shopify/cli-kit/node/output'
 
+interface UI {
+  app_bridge?: {
+    create_path: string
+    details_path: string
+  }
+  ui_extension_handle?: string
+}
+
 export type FunctionConfigType = zod.infer<typeof FunctionExtensionSchema>
 export const FunctionExtensionSchema = BaseSchema.extend({
   build: zod.object({
@@ -88,6 +96,24 @@ const spec = createExtensionSpecification({
         }),
       ))
 
+    let ui: UI | undefined
+
+    if (config.ui?.paths) {
+      ui = {
+        app_bridge: {
+          details_path: config.ui.paths.details,
+          create_path: config.ui.paths.create,
+        },
+      }
+    }
+
+    if (config.ui?.handle) {
+      ui = {
+        ...ui,
+        ui_extension_handle: config.ui.handle,
+      }
+    }
+
     return {
       title: config.name,
       module_id: moduleId,
@@ -101,15 +127,7 @@ const spec = createExtensionSpecification({
             single_json_metafield: config.input.variables,
           }
         : undefined,
-      ui: config.ui?.paths
-        ? {
-            app_bridge: {
-              details_path: config.ui.paths.details,
-              create_path: config.ui.paths.create,
-            },
-            handle: config.ui?.handle,
-          }
-        : undefined,
+      ui,
       enable_creation_ui: config.ui?.enable_create ?? true,
       targets,
     }

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -26,6 +26,7 @@ export const FunctionExtensionSchema = BaseSchema.extend({
           details: zod.string(),
         })
         .optional(),
+      handle: zod.string().optional(),
     })
     .optional(),
   api_version: zod.string(),
@@ -106,6 +107,7 @@ const spec = createExtensionSpecification({
               details_path: config.ui.paths.details,
               create_path: config.ui.paths.create,
             },
+            handle: config.ui?.handle,
           }
         : undefined,
       enable_creation_ui: config.ui?.enable_create ?? true,


### PR DESCRIPTION
In order to establish a connection between a UI extension and a function, we will provide partners with the ability to define a ui.handle string within their TOML file. This specific value will be directly associated with the handle value of their UI extension within the local app.

During the deployment, the `ui.handle` needs to be stored as part of the functions config. This ensures that the value can be easily accessed and retrieved at a later point in time.

### WHY are these changes introduced?

Addresses: https://github.com/Shopify/script-service/issues/7307

https://github.com/Shopify/shopify/pull/449584 will be merged prior to this PR.

### Summary 
- **Commit 1**: Updates `function.ts` so that it can parse `ui.linkedExtensions.handle` _(cleaned needed, left comments in for now)_


### How to test your changes?

- Add `ui.linkedExtension.handle` to your function's `shopify.extension.toml`
- deploy from this branch on CLI:
```
SPIN=1 SPIN_INSTANCE=script-service-gnes dev spin pnpm shopify app deploy  --path=../../../../Desktop/prod-testing/diversified-sponsorship-app
```
_^ replacing with your spin instance's fqdn_
- Check config to ensure handle was stored, to do this, first in your [spins service internal](https://app.shopify.script-service-gnes.mehdi-salemi.us.spin.dev/services/internal/queries/new?q=select%20er.uuid%2C%20er.title%2C%20HEX(e.config)%2C%20er.active_version_id%20%3D%20e.id%20as%20%22is_active%22%0Afrom%20app_extension_registrations%20er%0Ainner%20join%20app_static_extension_configs%20e%20on%20er.active_version_id%20%3D%20e.id%20or%20er.draft_version_id%20%3D%20e.id%0Awhere%20specification_identifier%3D%27function%27%20and%20api_client_id%3D1830457&shard_by=master), and copy the **Hex(e.config)** value.  You can use the following query:
```
select er.uuid, er.title, HEX(e.config), er.active_version_id = e.id as "is_active"
from app_extension_registrations er
inner join app_static_extension_configs e on er.active_version_id = e.id or er.draft_version_id = e.id
where specification_identifier='function' and api_client_id=1830457
```
- Then `unpack` the config to see it correctly stored the handle. 
```
> dev c
> config = "value from services internal"
> VersionedSerializer.snappy_pack_column(Hash).load([config].pack("H*"))
```

<img width="660" alt="Screenshot 2023-09-06 at 9 24 09 AM" src="https://github.com/Shopify/cli/assets/16329347/a1b5a332-c1a7-41be-b754-b40bb701d4e5">

**The `ui.handle` should be stored in the function's config.** 

### Note to self
Where im at:
- ~~figure out how the toml gets parsed~~
- ~~updated function.ts so that it correctly parses the `ui.handle`~~
- ~~not getting stored as part of function config, look into this next~~
- ~~add beta flag in cli to allow usage of `ui.handle`~~ - **in core**
- https://github.com/Shopify/shopify/pull/449584 - Core's FunctionExtension should accept the `ui.handle` and store as part of function config (components/apps/app/services/apps/shopify_vm/function_extension.rb) 
- ~~update tests~~
- This PR will need to be merged after https://github.com/Shopify/shopify/pull/449584
- ~~add something for changeset~~ not adding to changeset as these are not user facing

## Next Steps
- https://github.com/Shopify/script-service/issues/7308  - _Add validation when `ui.handle` is present. This should check other local extensions in app, and ensure that the `ui.handle` matches the `extension.handle` for another extension in the app._ 
- https://github.com/Shopify/script-service/issues/7309 - _Surface handle to domains_ 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
