### PR TITLE
Remove workflow path filtering

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -36,8 +36,6 @@ on:
       - main
       - stable/3.*
   pull_request:
-    paths-ignore:
-      - '**.md'
   merge_group:
 
 concurrency:


### PR DESCRIPTION
### WHY are these changes introduced?

We were skipping CI when the PR only contained changes in *.md files, but now the workflow is required to merge.

Example PR: https://github.com/Shopify/cli/pull/2785

GitHub note found by @alvaro-shopify:

![image](https://github.com/Shopify/cli/assets/14979109/5933d687-4ef8-43ff-82e2-160e4564e24c)

### WHAT is this pull request doing?

Always run CI, no matter the changes

### How to test your changes?

Merge and create a PR with a single change in README.md 🤷 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
