### PR TITLE
Default to npm when running create-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "graph": "nx graph",
     "shopify": "nx build cli && node packages/cli/bin/dev.js",
     "shopify:run": "node packages/cli/bin/dev.js",
-    "create-app": "nx build create-app && node packages/create-app/bin/dev.js",
+    "create-app": "nx build create-app && node packages/create-app/bin/dev.js --package-manager npm",
     "clean": "nx run-many --target=clean --all --skip-nx-cache && nx reset",
     "docs:generate": "nx run-many --target=docs:generate --all --skip-nx-cache",
     "lint": "nx run-many --target=lint --all --skip-nx-cache",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This reflects most users' experiences and is expected to surface bugs that we wouldn't see using pnpm (especially regarding peer dependencies)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Adds a default package manager `npm` to `create-app`.

You can still override passing e.g. `--package-manager pnpm`

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run `create-app` and see it uses npm. Run again with `--package-manager pnpm` and see it uses pnpm.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
