### PR TITLE
Recognize surface for legacy customer account extension targets

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -122,6 +122,23 @@ describe('getExtensionPointRedirectUrl()', () => {
     )
   })
 
+  test('returns customer account server URL if the extension point uses legacy customer account target', () => {
+    const extension = {
+      devUUID: '123abc',
+    } as ExtensionInstance
+
+    const options = {
+      storeFqdn: 'example.myshopify.com',
+      url: 'https://localhost:8081',
+    } as unknown as ExtensionDevOptions
+
+    const result = getExtensionPointRedirectUrl('CustomerAccount::FullPage::RenderWithin', extension, options)
+
+    expect(result).toBe(
+      'https://example.account.myshopify.com/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc',
+    )
+  })
+
   test('returns undefined if the extension point surface is not supported', () => {
     const extension = {
       devUUID: '123abc',

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -38,6 +38,7 @@ export function getExtensionPointTargetSurface(extensionPointTarget: string) {
     }
 
     // Covers Customer Accounts UI extensions (future)
+    case 'customeraccount':
     case 'customer-account': {
       // These targets are rendered by Checkout
       if (page === 'order-status') {


### PR DESCRIPTION
### WHY are these changes introduced?

When inferring a surface from a target, only targets prefixed with `customer-account` are currently recognized as customer account extensions.

We are in the process of migrating 1p apps from the legacy format to the new format so we need to support the legacy targets (that are prefixed with `CustomerAccount`) in the interim.

### WHAT is this pull request doing?

Adds a fallthrough case statement for handling `customeraccount` in addition to `customer-account`.

### How to test your changes?

* Follow up to step 7 from [this doc](https://docs.google.com/document/d/1T5yHuJxGPg37IQhT7uNOcJb8Ned5GXc_y-rCOJDRcJU/edit#heading=h.ua5trnf4kn9g) to generate a new customer account extension
* Navigate to the app directory and use `pwd` to find the path
* Return to the `cli` directory and run `pnpm shopify app dev --path {path_to_your_app}`
* Once the dev server is running, press `p` to preview. Click on the extension (with the old target name) and ensure that the preview loads properly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
