### PR TITLE
Rename `run` import to `__runFunction` to avoid naming collisions

### DIFF
--- a/.changeset/proud-lemons-dress.md
+++ b/.changeset/proud-lemons-dress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Avoid naming collision in JS function exports

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -349,11 +349,11 @@ describe('ExportJavyBuilder', () => {
     const got = builder.entrypointContents
 
     // Then
-    expect(got).toContain('import run from "@shopify/shopify_function/run"')
+    expect(got).toContain('import __runFunction from "@shopify/shopify_function/run"')
     expect(got).toContain('import { fooBar as runFooBar } from "user-function"')
-    expect(got).toContain('export function fooBar() { return run(runFooBar) }')
+    expect(got).toContain('export function fooBar() { return __runFunction(runFooBar) }')
     expect(got).toContain('import { fooBaz as runFooBaz } from "user-function"')
-    expect(got).toContain('export function fooBaz() { return run(runFooBaz) }')
+    expect(got).toContain('export function fooBaz() { return __runFunction(runFooBaz) }')
   })
 })
 

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -240,14 +240,14 @@ world ${JAVY_WORLD} {
 
   get entrypointContents() {
     const prelude = `
-import run from "@shopify/shopify_function/run"`
+import __runFunction from "@shopify/shopify_function/run"`
 
     const exports = this.exports.map((name) => {
       const identifier = camelize(name)
       const alias = camelize(`run-${name}`)
       return `
 import { ${identifier} as ${alias} } from "user-function"
-export function ${identifier}() { return run(${alias}) }`
+export function ${identifier}() { return __runFunction(${alias}) }`
     })
 
     return `${prelude}\n${exports.join('\n')}`


### PR DESCRIPTION
### WHY are these changes introduced?

The prelude for building a JS function collides with exports using the name `run`. 

### WHAT is this pull request doing?

This PR updates the prelude import to `__runFunction` so that it's less likely to collide with an export name.

### How to test your changes?

Deploy a JS function that has a `run` export against a `run` target and ensure it doesn't stack overflow.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
