### PR TITLE
Add more metadata for the config commands

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -10,7 +10,11 @@ import {OrganizationApp} from '../../../models/organization.js'
 import {selectConfigName} from '../../../prompts/config.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {getAppConfigurationFileName, loadApp} from '../../../models/app/loader.js'
-import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../context.js'
+import {
+  InvalidApiKeyErrorMessage,
+  fetchOrCreateOrganizationApp,
+  logMetadataForLoadedConfigContext,
+} from '../../context.js'
 import {fetchAppDetailsFromApiKey} from '../../dev/fetch.js'
 import {configurationFileNames} from '../../../constants.js'
 import {writeAppConfigurationFile} from '../write-app-configuration-file.js'
@@ -63,6 +67,8 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
       ],
     })
   }
+
+  await logMetadataForLoadedConfigContext(remoteApp)
 
   return configuration
 }

--- a/packages/app/src/cli/services/app/config/push.ts
+++ b/packages/app/src/cli/services/app/config/push.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../models/app/app.js'
 import {DeleteAppProxySchema, deleteAppProxy} from '../../../api/graphql/app_proxy_delete.js'
 import {confirmPushChanges} from '../../../prompts/config.js'
-import {renderCurrentlyUsedConfigInfo} from '../../context.js'
+import {logMetadataForLoadedConfigContext, renderCurrentlyUsedConfigInfo} from '../../context.js'
 import {fetchOrgFromId} from '../../dev/fetch.js'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
@@ -94,6 +94,8 @@ export async function pushConfig(options: PushOptions) {
         abort(errors)
       }
     }
+
+    await logMetadataForLoadedConfigContext(app)
 
     renderSuccess({
       headline: `Updated your app config for ${configuration.name}`,

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -3,6 +3,7 @@ import {testApp, testAppWithConfig, testOrganizationApp} from '../../../models/a
 import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
 import {clearCurrentConfigFile, setCachedAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
+import {logMetadataForLoadedConfigContext} from '../../context.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -17,12 +18,13 @@ vi.mock('../../../models/app/loader.js')
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('@shopify/cli-kit/node/session')
 vi.mock('@shopify/cli-kit/node/api/partners')
+vi.mock('../../context.js')
 
 const REMOTE_APP = testOrganizationApp()
 
 beforeEach(() => {
   vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
-  vi.mocked(partnersRequest).mockResolvedValue(REMOTE_APP)
+  vi.mocked(partnersRequest).mockResolvedValue({app: REMOTE_APP})
 })
 
 describe('use', () => {
@@ -248,6 +250,22 @@ describe('use', () => {
       // Then
       expect(renderSuccess).not.toHaveBeenCalled()
       expect(setCachedAppInfo).toHaveBeenCalledWith({directory, configFile: 'shopify.app.something.toml'})
+    })
+  })
+
+  test('logs metadata', async () => {
+    await inTemporaryDirectory(async (directory) => {
+      // Given
+      const {configuration} = testApp({}, 'current')
+      vi.mocked(loadAppConfiguration).mockResolvedValue({directory, configuration})
+      vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.something.toml')
+      createConfigFile(directory, 'shopify.app.something.toml')
+
+      // When
+      await use({directory, configName: 'something'})
+
+      // Then
+      expect(logMetadataForLoadedConfigContext).toHaveBeenNthCalledWith(1, REMOTE_APP)
     })
   })
 })

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -1,20 +1,29 @@
 import use, {UseOptions} from './use.js'
-import {testApp, testAppWithConfig} from '../../../models/app/app.test-data.js'
+import {testApp, testAppWithConfig, testOrganizationApp} from '../../../models/app/app.test-data.js'
 import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
 import {clearCurrentConfigFile, setCachedAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {err, ok} from '@shopify/cli-kit/node/result'
-
-const LOCAL_APP = testApp()
+import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 
 vi.mock('../../../prompts/config.js')
 vi.mock('../../local-storage.js')
 vi.mock('../../../models/app/loader.js')
 vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('@shopify/cli-kit/node/session')
+vi.mock('@shopify/cli-kit/node/api/partners')
+
+const REMOTE_APP = testOrganizationApp()
+
+beforeEach(() => {
+  vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
+  vi.mocked(partnersRequest).mockResolvedValue(REMOTE_APP)
+})
 
 describe('use', () => {
   test('clears currentConfiguration when reset is true', async () => {

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -1,14 +1,18 @@
 import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
 import {clearCurrentConfigFile, setCachedAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
-import {isCurrentAppSchema} from '../../../models/app/app.js'
+import {AppConfiguration, isCurrentAppSchema} from '../../../models/app/app.js'
+import {logMetadataForLoadedConfigContext} from '../../context.js'
+import {GetConfigQuerySchema, GetConfig} from '../../../api/graphql/get_config.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {RenderAlertOptions, renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {Result, err, ok} from '@shopify/cli-kit/node/result'
 import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager'
-import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+import {formatPackageManagerCommand, outputDebug} from '@shopify/cli-kit/node/output'
+import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 
 export interface UseOptions {
   directory: string
@@ -45,13 +49,15 @@ export default async function use({
 
   const configFileName = (await getConfigFileName(directory, configName)).valueOrAbort()
 
-  await saveCurrentConfig({configFileName, directory})
+  const configuration = await saveCurrentConfig({configFileName, directory})
 
   if (shouldRenderSuccess) {
     renderSuccess({
       headline: `Using configuration file ${configFileName}`,
     })
   }
+
+  await logMetadata(configuration)
 
   return configFileName
 }
@@ -69,6 +75,8 @@ export async function saveCurrentConfig({configFileName, directory}: SaveCurrent
       directory,
       configFile: configFileName,
     })
+
+    return configuration
   } else {
     throw new AbortError(`Configuration file ${configFileName} needs a client_id.`)
   }
@@ -84,4 +92,18 @@ async function getConfigFileName(directory: string, configName?: string): Promis
     }
   }
   return selectConfigFile(directory)
+}
+
+async function logMetadata(configuration: AppConfiguration) {
+  const token = await ensureAuthenticatedPartners()
+  const queryVariables = {apiKey: configuration.client_id}
+  const queryResult: GetConfigQuerySchema = await partnersRequest(GetConfig, token, queryVariables)
+
+  if (queryResult.app) {
+    const {app} = queryResult
+
+    await logMetadataForLoadedConfigContext(app)
+  } else {
+    outputDebug("Couldn't find app for analytics. Make sure you have a valid client ID.")
+  }
 }

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -777,6 +777,13 @@ async function logMetadataForLoadedDeployContext(env: DeployContextOutput) {
   }))
 }
 
+export async function logMetadataForLoadedConfigContext(app: {organizationId: string; apiKey: string}) {
+  await metadata.addPublicMetadata(() => ({
+    partner_id: tryParseInt(app.organizationId),
+    api_key: app.apiKey,
+  }))
+}
+
 export async function enableDeveloperPreview({apiKey, token}: {apiKey: string; token: string}) {
   return developerPreviewUpdate({apiKey, token, enabled: true})
 }


### PR DESCRIPTION
### WHY are these changes introduced?

As per https://github.com/Shopify/develop-app-management/issues/40 we want to track more metadata for `config` commands as well.

### WHAT is this pull request doing?

This PR adds a new function called `logMetadataForLoadedConfigContext` that tracks `partner_id` and `api_key`.
