### PR TITLE
Fix issue of redirecting customer account ui extension to checkout

### DIFF
--- a/packages/app/src/cli/services/dev/extension/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.test.ts
@@ -19,9 +19,9 @@ describe('getExtensionPointTargetSurface()', () => {
     expect(getExtensionPointTargetSurface('purchase.thank-you.cart-line-list.render-after')).toBe('checkout')
   })
 
-  test('returns "checkout" for a UI extension targeting customer-account.order-status.*', async () => {
+  test('returns "checkout" for a checkout UI extension target that starts with customer-account', async () => {
     expect(getExtensionPointTargetSurface('customer-account.order-status.block.render')).toBe('checkout')
-    expect(getExtensionPointTargetSurface('customer-account.order-status.contact-information.render-after')).toBe(
+    expect(getExtensionPointTargetSurface('customer-account.order-status.customer-information.render-after')).toBe(
       'checkout',
     )
     expect(getExtensionPointTargetSurface('customer-account.order-status.cart-line-item.render-after')).toBe('checkout')

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -40,8 +40,7 @@ export function getExtensionPointTargetSurface(extensionPointTarget: string) {
     // Covers Customer Accounts UI extensions (future)
     case 'customeraccount':
     case 'customer-account': {
-      // These targets are rendered by Checkout
-      if (page === 'order-status') {
+      if (isCheckoutRenderedCustomerAccountTarget(extensionPointTarget)) {
         return 'checkout'
       }
 
@@ -57,4 +56,15 @@ export function getExtensionPointTargetSurface(extensionPointTarget: string) {
       // Covers Admin UI extensions
       return domain
   }
+}
+
+function isCheckoutRenderedCustomerAccountTarget(extensionPointTarget: string) {
+  const customerAccountCheckoutRenderedTargets = new Set([
+    'customer-account.order-status.cart-line-item.render-after',
+    'customer-account.order-status.cart-line-list.render-after',
+    'customer-account.order-status.customer-information.render-after',
+    'customer-account.order-status.block.render',
+  ])
+
+  return customerAccountCheckoutRenderedTargets.has(extensionPointTarget)
 }

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -2,6 +2,13 @@ import {ExtensionInstance} from '../../../models/extensions/extension-instance.j
 
 import {fetchProductVariant} from '../../../utilities/extensions/fetch-product-variant.js'
 
+const CUSTOMER_ACCOUNT_CHECKOUT_RENDERED_TARGETS = new Set([
+  'customer-account.order-status.cart-line-item.render-after',
+  'customer-account.order-status.cart-line-list.render-after',
+  'customer-account.order-status.customer-information.render-after',
+  'customer-account.order-status.block.render',
+])
+
 /**
  * To prepare UI Extensions targeting Checkout for dev'ing we need to retrieve a valid product variant ID
  * @param extensions - The UI Extensions to dev
@@ -40,7 +47,7 @@ export function getExtensionPointTargetSurface(extensionPointTarget: string) {
     // Covers Customer Accounts UI extensions (future)
     case 'customeraccount':
     case 'customer-account': {
-      if (isCheckoutRenderedCustomerAccountTarget(extensionPointTarget)) {
+      if (CUSTOMER_ACCOUNT_CHECKOUT_RENDERED_TARGETS.has(extensionPointTarget)) {
         return 'checkout'
       }
 
@@ -56,15 +63,4 @@ export function getExtensionPointTargetSurface(extensionPointTarget: string) {
       // Covers Admin UI extensions
       return domain
   }
-}
-
-function isCheckoutRenderedCustomerAccountTarget(extensionPointTarget: string) {
-  const customerAccountCheckoutRenderedTargets = new Set([
-    'customer-account.order-status.cart-line-item.render-after',
-    'customer-account.order-status.cart-line-list.render-after',
-    'customer-account.order-status.customer-information.render-after',
-    'customer-account.order-status.block.render',
-  ])
-
-  return customerAccountCheckoutRenderedTargets.has(extensionPointTarget)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves: https://github.com/Shopify/core-issues/issues/60345

### WHAT is this pull request doing?
In cli, it redirects all targets start from `customer-account.order-status` to checkout. [Code is here.](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/services/dev/extension/utilities.ts#L44)

We should only redirect [these 4 checkout targets](https://github.com/Shopify/shopify/blob/main/components/apps/app/services/apps/models/ui_extension/schema/groups/checkout_ui.rb#L222-L227) to checkout instead of all of them

### How to test your changes?
1. Enable customer account and ui extension flags for your partner account.
2. Create a new customer account ui extension locally.
3. dev clone cli and checkout to this branch.
 `pnpm shopify app dev --path your_extension_app_path --reset`
4. Test different targets in your extension (by updating `shopify.extension.toml` and changing the target in the corresponding module.)
5. Ensure that the `customer-account.order-status...` targets specified in the PR redirect to checkout when you attempt to preview, while other targets redirect to customer accounts.
 
You can also check this video for 🎩  https://videobin.shopify.io/v/9gvo8P

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
