### PR TITLE
Fix upgrade with yarn and workspaces

### DIFF
--- a/.changeset/modern-ears-draw.md
+++ b/.changeset/modern-ears-draw.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix dependency installation for yarn with workspaces

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -433,7 +433,10 @@ export async function addNPMDependencies(
       }
       break
     case 'yarn':
-      await installDependencies(options, argumentsToAddDependenciesWithYarn(dependenciesWithVersion, options.type))
+      await installDependencies(
+        options,
+        argumentsToAddDependenciesWithYarn(dependenciesWithVersion, options.type, Boolean(options.addToRootDirectory)),
+      )
       break
     case 'pnpm':
       await installDependencies(
@@ -498,10 +501,16 @@ function argumentsToAddDependenciesWithNPM(dependency: string, type: DependencyT
  * Returns the arguments to add dependencies using Yarn.
  * @param dependencies - The list of dependencies to add
  * @param type - The dependency type.
+ * @param addAtRoot - Force to install the dependencies in the workspace root (optional, default = false)
  * @returns An array with the arguments.
  */
-function argumentsToAddDependenciesWithYarn(dependencies: string[], type: DependencyType): string[] {
+function argumentsToAddDependenciesWithYarn(dependencies: string[], type: DependencyType, addAtRoot = false): string[] {
   let command = ['add']
+
+  if (addAtRoot) {
+    command.push('-W')
+  }
+
   command = command.concat(dependencies)
   switch (type) {
     case 'dev':
@@ -521,13 +530,10 @@ function argumentsToAddDependenciesWithYarn(dependencies: string[], type: Depend
  * Returns the arguments to add dependencies using PNPM.
  * @param dependencies - The list of dependencies to add
  * @param type - The dependency type.
+ * @param addAtRoot - Force to install the dependencies in the workspace root (optional, default = false)
  * @returns An array with the arguments.
  */
-function argumentsToAddDependenciesWithPNPM(
-  dependencies: string[],
-  type: DependencyType,
-  addAtRoot: boolean,
-): string[] {
+function argumentsToAddDependenciesWithPNPM(dependencies: string[], type: DependencyType, addAtRoot = false): string[] {
   let command = ['add']
 
   if (addAtRoot) {


### PR DESCRIPTION
### WHY are these changes introduced?

`yarn shopify upgrade` is broken when the project includes workspaces:

![yarn](https://github.com/Shopify/cli/assets/14979109/87291bd6-30b0-488c-843d-74e193d64547)

Similar to https://github.com/Shopify/cli/pull/2540

### WHAT is this pull request doing?

Pass the `-W` flag to the internal `yarn add` command when workspaces is enabled to force installation in the root folder.

### How to test your changes?

`pnpm shopify upgrade --path ./old-yarn-project`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
