### PR TITLE
Fix issue with multiple copies of react being loaded

### DIFF
--- a/.changeset/clever-socks-sort.md
+++ b/.changeset/clever-socks-sort.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+
+Fix issue caused by cli-kit and app providing multiple copies of react.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -51,11 +51,9 @@
     "diff": "5.1.0",
     "esbuild": "0.18.17",
     "graphql-request": "5.2.0",
-    "ink": "4.2.0",
     "h3": "0.7.21",
     "http-proxy": "1.18.1",
     "javy-cli": "0.1.8",
-    "react": "18.2.0",
     "serve-static": "1.15.0",
     "ws": "8.13.0"
   },
@@ -72,6 +70,10 @@
     "graphql-tag": "^2.12.6",
     "vite": "^4.4.8",
     "vitest": "^0.34.1"
+  },
+  "peerDependencies": {
+    "ink": "4.2.0",
+    "react": "18.2.0"
   },
   "engines": {
     "node": ">=14.17.0"

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -203,14 +203,6 @@ async function uiExtensionInit({directory, url, app, name, extensionFlavor}: Ext
       task: async () => {
         const packageManager = app.packageManager
         if (app.usesWorkspaces) {
-          // NPM doesn't resolve the react dependency properly with extensions depending on React 17 and cli-kit on React 18
-          if (extensionFlavor?.value.includes('react') && packageManager === 'npm') {
-            await addNPMDependenciesIfNeeded([{name: 'react', version: versions.react}], {
-              packageManager,
-              type: 'prod',
-              directory: app.directory,
-            })
-          }
           // Only install dependencies if the extension is javascript
           if (getTemplateLanguage(extensionFlavor?.value) === 'javascript') {
             await installNodeModules({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -8464,7 +8464,7 @@ packages:
     resolution: {integrity: sha512-q7SeFAEFMyKxTblyVI+CsxHzfiMMP9JUDG0cRmOKEAmJiYrtrDW1YYTv129RXqfn7fMKcVc4h/LbAJvqvZIuEQ==}
     engines: {node: '>=14.16'}
     peerDependencies:
-      '@types/react': '>=18.0.0'
+      '@types/react': 17.0.2
       react: '>=18.0.0'
       react-devtools-core: ^4.19.1
     peerDependenciesMeta:
@@ -13043,7 +13043,7 @@ packages:
   /vite-tsconfig-paths@3.6.0(vite@4.4.8):
     resolution: {integrity: sha512-UfsPYonxLqPD633X8cWcPFVuYzx/CMNHAjZTasYwX69sXpa4gNmQkR0XCjj82h7zhLGdTWagMjC1qfb9S+zv0A==}
     peerDependencies:
-      vite: '>2.0.0-0'
+      vite: 4.4.8
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
@@ -13707,7 +13707,6 @@ packages:
     resolution: {directory: packages/eslint-plugin-cli, type: directory}
     id: file:packages/eslint-plugin-cli
     name: '@shopify/eslint-plugin-cli'
-    version: 3.46.0
     peerDependencies:
       eslint: ^8.46.0
     dependencies:


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2809

### WHAT is this pull request doing?

- Make it so the `app` package only declares `ink` and `react` as peer dependencies
- In this way, the only copy of those deps come from the `cli-kit` package
- Stop adding `react` as a top level dependency

### How to test your changes?

- `npm init @shopify/app@experimental` choose none
- `npm run generate extension` choose checkout
- `npm run dev` runs successfully
- `npm ls react` prints this:
```
├─┬ @shopify/app@0.0.0-experimental-20230913134317
│ ├─┬ @shopify/cli-kit@0.0.0-experimental-20230913134317
│ │ └── react@18.2.0 deduped
│ ├─┬ ink@4.4.1
│ │ ├─┬ react-reconciler@0.29.0
│ │ │ └── react@18.2.0 deduped
│ │ └── react@18.2.0 deduped
│ └── react@18.2.0
└─┬ checkout-ui@1.0.0 -> ./extensions/checkout-ui
  ├─┬ @shopify/ui-extensions-react@2023.7.2
  │ ├─┬ @remote-ui/react@4.5.14
  │ │ └─┬ react-reconciler@0.26.2
  │ │   └── react@17.0.2
  │ └── react@17.0.2 deduped
  └── react@17.0.2
  ```
(only two active copies of react, 17 for extensions and 18 for cli-kit and app)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
