### PR TITLE
Fix duplicate react

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -54,11 +54,9 @@
     "esbuild": "0.18.17",
     "express": "4.18.2",
     "graphql-request": "5.2.0",
-    "ink": "4.4.1",
     "h3": "0.7.21",
     "http-proxy": "1.18.1",
     "javy-cli": "0.1.8",
-    "react": "18.2.0",
     "serve-static": "1.15.0",
     "ws": "8.13.0"
   },
@@ -77,6 +75,10 @@
     "graphql-tag": "^2.12.6",
     "vite": "^4.4.8",
     "vitest": "^0.34.1"
+  },
+  "peerDependencies": {
+    "ink": "4.4.1",
+    "react": "18.2.0"
   },
   "engines": {
     "node": ">=14.17.0"

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -13,7 +13,6 @@ export const dotEnvFileNames = {
 }
 
 export const versions = {
-  react: '^17.0.0',
   reactTypes: '17.0.30',
 } as const
 

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -203,14 +203,6 @@ async function uiExtensionInit({directory, url, app, name, extensionFlavor}: Ext
       task: async () => {
         const packageManager = app.packageManager
         if (app.usesWorkspaces) {
-          // NPM doesn't resolve the react dependency properly with extensions depending on React 17 and cli-kit on React 18
-          if (extensionFlavor?.value.includes('react') && packageManager === 'npm') {
-            await addNPMDependenciesIfNeeded([{name: 'react', version: versions.react}], {
-              packageManager,
-              type: 'prod',
-              directory: app.directory,
-            })
-          }
           // Only install dependencies if the extension is javascript
           if (getTemplateLanguage(extensionFlavor?.value) === 'javascript') {
             await installNodeModules({

--- a/packages/features/steps/node-deps.steps.ts
+++ b/packages/features/steps/node-deps.steps.ts
@@ -11,6 +11,7 @@ const __dirname = path.dirname(__filename)
 interface PackageJson {
   dependencies?: {[key: string]: string}
   devDependencies?: {[key: string]: string}
+  peerDependencies?: {[key: string]: string}
   resolutions?: {[key: string]: string}
 }
 
@@ -54,7 +55,10 @@ Then(/I see all shared node dependencies on the same version/, async function ()
       (acc: {packageName: string; version: string}[], [packageName, json]) => {
         const packageJson = json as PackageJson
         const depVersion =
-          packageJson.dependencies?.[dep] ?? packageJson.devDependencies?.[dep] ?? packageJson.resolutions?.[dep]
+          packageJson.dependencies?.[dep] ??
+          packageJson.devDependencies?.[dep] ??
+          packageJson.peerDependencies?.[dep] ??
+          packageJson.resolutions?.[dep]
         if (depVersion) {
           acc.push({packageName, version: depVersion.replace(/^\^/, '')})
         }


### PR DESCRIPTION
### WHY are these changes introduced?

A PR targeting main that backports changes from https://github.com/Shopify/cli/pull/2822

### WHAT is this pull request doing?

- Make it so the `app` package only declares `ink` and `react` as peer dependencies
- In this way, the only copy of those deps come from the `cli-kit` package
- Stop adding `react` as a top level dependency

### How to test your changes?

- `npm init @shopify/app@experimental` choose none
- `npm run generate extension` choose checkout
- `npm run dev` runs successfully
- `npm ls react` prints this:
```
├─┬ @shopify/app@0.0.0-experimental-20230913134317
│ ├─┬ @shopify/cli-kit@0.0.0-experimental-20230913134317
│ │ └── react@18.2.0 deduped
│ ├─┬ ink@4.4.1
│ │ ├─┬ react-reconciler@0.29.0
│ │ │ └── react@18.2.0 deduped
│ │ └── react@18.2.0 deduped
│ └── react@18.2.0
└─┬ checkout-ui@1.0.0 -> ./extensions/checkout-ui
  ├─┬ @shopify/ui-extensions-react@2023.7.2
  │ ├─┬ @remote-ui/react@4.5.14
  │ │ └─┬ react-reconciler@0.26.2
  │ │   └── react@17.0.2
  │ └── react@17.0.2 deduped
  └── react@17.0.2
  ```
(only two active copies of react, 17 for extensions and 18 for cli-kit and app)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
