### PR TITLE
Use env var on codespaces to detect the correct port forwarding domain

### DIFF
--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -21,7 +21,7 @@ import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {isSpin, spinFqdn, appPort, appHost} from '@shopify/cli-kit/node/context/spin'
-import {codespaceURL, gitpodURL, isUnitTest} from '@shopify/cli-kit/node/context/local'
+import {codespacePortForwardingDomain, codespaceURL, gitpodURL, isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {renderConfirmationPrompt, renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 import {terminalSupportsRawMode} from '@shopify/cli-kit/node/system'
 
@@ -467,13 +467,14 @@ describe('generateFrontendURL', () => {
   test('Returns a codespace url if we are in a codespace environment', async () => {
     // Given
     vi.mocked(codespaceURL).mockReturnValue('codespace.url.fqdn.com')
+    vi.mocked(codespacePortForwardingDomain).mockReturnValue('app.github.dev')
 
     // When
     const got = await generateFrontendURL(defaultOptions)
 
     // Then
     expect(got).toEqual({
-      frontendUrl: 'https://codespace.url.fqdn.com-4040.githubpreview.dev',
+      frontendUrl: 'https://codespace.url.fqdn.com-4040.app.github.dev',
       frontendPort: 4040,
       usingLocalhost: false,
     })

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -11,7 +11,7 @@ import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {isValidURL} from '@shopify/cli-kit/common/url'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {appHost, appPort, isSpin, spinFqdn} from '@shopify/cli-kit/node/context/spin'
-import {codespaceURL, gitpodURL} from '@shopify/cli-kit/node/context/local'
+import {codespaceURL, codespacePortForwardingDomain, gitpodURL} from '@shopify/cli-kit/node/context/local'
 import {fanoutHooks} from '@shopify/cli-kit/node/plugins'
 import {terminalSupportsRawMode} from '@shopify/cli-kit/node/system'
 import {TunnelClient} from '@shopify/cli-kit/node/plugins/tunnel'
@@ -54,7 +54,7 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
   let usingLocalhost = false
 
   if (codespaceURL()) {
-    frontendUrl = `https://${codespaceURL()}-${frontendPort}.githubpreview.dev`
+    frontendUrl = `https://${codespaceURL()}-${frontendPort}.${codespacePortForwardingDomain()}`
     return {frontendUrl, frontendPort, usingLocalhost}
   }
 

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -26,8 +26,9 @@ export const environmentVariables = {
   noThemeBundling: 'SHOPIFY_CLI_NO_THEME_BUNDLING',
   bundledThemeCLI: 'SHOPIFY_CLI_BUNDLED_THEME_CLI',
   // Variables to detect if the CLI is running in a cloud environment
-  codespaceName: 'CODESPACE_NAME',
   codespaces: 'CODESPACES',
+  codespaceName: 'CODESPACE_NAME',
+  codespacePortForwardingDomain: 'GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN',
   gitpod: 'GITPOD_WORKSPACE_URL',
   cloudShell: 'CLOUD_SHELL',
   spin: 'SPIN',

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -156,6 +156,17 @@ export function codespaceURL(env = process.env): string | undefined {
 }
 
 /**
+ * Return codespacePortForwardingDomain if we are running in codespaces.
+ * Https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace#list-of-default-environment-variables.
+ *
+ * @param env - The environment variables from the environment of the current process.
+ * @returns The codespace port forwarding domain.
+ */
+export function codespacePortForwardingDomain(env = process.env): string | undefined {
+  return env[environmentVariables.codespacePortForwardingDomain]
+}
+
+/**
  * Checks if the CLI is run from a cloud environment.
  *
  * @param env - Environment variables used when the cli is launched.


### PR DESCRIPTION
### WHY are these changes introduced?

Github codespaces have changed their domain for forwarding apps from:

> https://myapp-4040.githubpreview.dev

to

> https://myapp-4040.app.github.dev

they've announced it here https://github.blog/changelog/2023-07-14-codespaces-port-forwarding-domain-name-updates/

### WHAT is this pull request doing?

Use the suggested env var to construct the codespaces url

### How to test your changes?

- try creating a shopify app on github codespaces and then open the preview url


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
