### PR TITLE
Use env var on codespaces to detect the correct port forwarding domain

### DIFF
--- a/.changeset/fair-rabbits-cheat.md
+++ b/.changeset/fair-rabbits-cheat.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+
+Fix support for github codespaces

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -20,7 +20,7 @@ import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {isSpin, spinFqdn, appPort, appHost} from '@shopify/cli-kit/node/context/spin'
-import {codespaceURL, gitpodURL, isUnitTest} from '@shopify/cli-kit/node/context/local'
+import {codespacePortForwardingDomain, codespaceURL, gitpodURL, isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {renderConfirmationPrompt, renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 import {terminalSupportsRawMode} from '@shopify/cli-kit/node/system'
 
@@ -466,13 +466,14 @@ describe('generateFrontendURL', () => {
   test('Returns a codespace url if we are in a codespace environment', async () => {
     // Given
     vi.mocked(codespaceURL).mockReturnValue('codespace.url.fqdn.com')
+    vi.mocked(codespacePortForwardingDomain).mockReturnValue('app.github.dev')
 
     // When
     const got = await generateFrontendURL(defaultOptions)
 
     // Then
     expect(got).toEqual({
-      frontendUrl: 'https://codespace.url.fqdn.com-4040.githubpreview.dev',
+      frontendUrl: 'https://codespace.url.fqdn.com-4040.app.github.dev',
       frontendPort: 4040,
       usingLocalhost: false,
     })

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -10,7 +10,7 @@ import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {isValidURL} from '@shopify/cli-kit/common/url'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {appHost, appPort, isSpin, spinFqdn} from '@shopify/cli-kit/node/context/spin'
-import {codespaceURL, gitpodURL} from '@shopify/cli-kit/node/context/local'
+import {codespaceURL, codespacePortForwardingDomain, gitpodURL} from '@shopify/cli-kit/node/context/local'
 import {fanoutHooks} from '@shopify/cli-kit/node/plugins'
 import {terminalSupportsRawMode} from '@shopify/cli-kit/node/system'
 import {TunnelClient} from '@shopify/cli-kit/node/plugins/tunnel'
@@ -53,7 +53,7 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
   let usingLocalhost = false
 
   if (codespaceURL()) {
-    frontendUrl = `https://${codespaceURL()}-${frontendPort}.githubpreview.dev`
+    frontendUrl = `https://${codespaceURL()}-${frontendPort}.${codespacePortForwardingDomain()}`
     return {frontendUrl, frontendPort, usingLocalhost}
   }
 

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -26,8 +26,9 @@ export const environmentVariables = {
   noThemeBundling: 'SHOPIFY_CLI_NO_THEME_BUNDLING',
   bundledThemeCLI: 'SHOPIFY_CLI_BUNDLED_THEME_CLI',
   // Variables to detect if the CLI is running in a cloud environment
-  codespaceName: 'CODESPACE_NAME',
   codespaces: 'CODESPACES',
+  codespaceName: 'CODESPACE_NAME',
+  codespacePortForwardingDomain: 'GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN',
   gitpod: 'GITPOD_WORKSPACE_URL',
   cloudShell: 'CLOUD_SHELL',
   spin: 'SPIN',

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -156,6 +156,17 @@ export function codespaceURL(env = process.env): string | undefined {
 }
 
 /**
+ * Return codespacePortForwardingDomain if we are running in codespaces.
+ * Https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace#list-of-default-environment-variables.
+ *
+ * @param env - The environment variables from the environment of the current process.
+ * @returns The codespace port forwarding domain.
+ */
+export function codespacePortForwardingDomain(env = process.env): string | undefined {
+  return env[environmentVariables.codespacePortForwardingDomain]
+}
+
+/**
  * Checks if the CLI is run from a cloud environment.
  *
  * @param env - Environment variables used when the cli is launched.


### PR DESCRIPTION
### WHY are these changes introduced?

Backports https://github.com/Shopify/cli/pull/2824 to the 3.49 stable branch