### PR TITLE
Fix integrated GraphiQL tool in spin

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -329,6 +329,7 @@ async function dev(options: DevOptions) {
         url: proxyUrl.replace(/^https?:\/\//, ''),
         port: graphiqlPort,
         scopes: scopesArray,
+        customShopDomain: isSpinEnvironment() ? `shopify.${await spinFqdn()}` : undefined,
       }),
     )
   }
@@ -552,6 +553,7 @@ interface DevGraphiQLTargetOptions {
   url: string
   storeFqdn: string
   scopes: string[]
+  customShopDomain: string | undefined
 }
 
 function devGraphiQLTarget(options: DevGraphiQLTargetOptions): ReverseHTTPProxyTarget {

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -15,12 +15,14 @@ function createShopify({
   apiSecret,
   scopes,
   url,
+  shopCustomDomain,
 }: {
   stdout: Writable
   apiKey: string
   apiSecret: string
   scopes: string[]
   url: string
+  shopCustomDomain?: string
 }) {
   return shopifyApi({
     apiKey,
@@ -29,6 +31,7 @@ function createShopify({
     hostName: url,
     apiVersion: LATEST_API_VERSION,
     isEmbeddedApp: false,
+    customShopDomains: shopCustomDomain ? [shopCustomDomain] : [],
     logger: {
       level: LogSeverity.Debug,
       timestamps: false,
@@ -57,6 +60,7 @@ interface SetupGraphiQLServerOptions {
   url: string
   storeFqdn: string
   scopes: string[]
+  shopCustomDomain?: string
 }
 
 export function setupGraphiQLServer({
@@ -69,10 +73,11 @@ export function setupGraphiQLServer({
   url,
   storeFqdn,
   scopes,
+  shopCustomDomain,
 }: SetupGraphiQLServerOptions): Server {
   outputDebug(`Setting up GraphiQL HTTP server...`, stdout)
 
-  const shopify = createShopify({stdout, apiKey, apiSecret, url, scopes})
+  const shopify = createShopify({stdout, apiKey, apiSecret, url, scopes, shopCustomDomain})
   const app = express()
     // Make the app accept all routes starting with /.shopify/xxx as /xxx
     .use((req, _res, next) => {

--- a/packages/app/src/cli/services/dev/processes/graphiql.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql.ts
@@ -1,6 +1,7 @@
 import {BaseProcess, DevProcessFunction} from './types.js'
 import {urlNamespaces} from '../../../constants.js'
 import {setupGraphiQLServer} from '../graphiql/server.js'
+import {isSpinEnvironment, spinFqdn} from '@shopify/cli-kit/node/context/spin'
 
 interface GraphiQLServerProcessOptions {
   appName: string
@@ -11,6 +12,7 @@ interface GraphiQLServerProcessOptions {
   url: string
   port: number
   scopes: string[]
+  shopCustomDomain: string | undefined
 }
 
 export interface GraphiQLServerProcess extends BaseProcess<GraphiQLServerProcessOptions> {
@@ -19,13 +21,15 @@ export interface GraphiQLServerProcess extends BaseProcess<GraphiQLServerProcess
 }
 
 export async function setupGraphiQLServerProcess(
-  options: Omit<GraphiQLServerProcessOptions, 'port'>,
+  options: Omit<GraphiQLServerProcessOptions, 'port' | 'shopCustomDomain'>,
 ): Promise<GraphiQLServerProcess> {
+  const shopCustomDomain = isSpinEnvironment() ? `shopify.${await spinFqdn()}` : undefined
+
   return {
     type: 'graphiql',
     prefix: `graphiql`,
     urlPrefix: `/${urlNamespaces.devTools}/graphiql`,
-    options: {...options, port: -1},
+    options: {...options, port: -1, shopCustomDomain},
     function: launchGraphiQLServer,
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Running the integrated GraphiQL toll inside spin is returning an error related to shop domains validation

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- When the app is run inside spin, set the proper `customShopDomains` when the `shopifyApi` is created from the `graphiQL server`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- The PR should be merged to test it inside `spin`
- Check that the app and the graphiQL tool is working properly as usual against the PRO environment


<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
