### PR TITLE
Validate function's ui.handle matches local extension in app

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -1,11 +1,13 @@
 import {AppErrors, isWebType} from './loader.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
 import {isType} from '../../utilities/types.js'
+import {FunctionConfigType} from '../extensions/specifications/function.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify/cli-kit/node/node-package-manager'
 import {fileRealPath, findPathUp} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 export const LegacyAppSchema = zod
   .object({
@@ -195,6 +197,7 @@ export interface AppInterface extends AppConfigurationInterface {
   updateDependencies: () => Promise<void>
   extensionsForType: (spec: {identifier: string; externalIdentifier: string}) => ExtensionInstance[]
   updateExtensionUUIDS: (uuids: {[key: string]: string}) => void
+  preDeployValidation: () => Promise<void>
 }
 
 export class App implements AppInterface {
@@ -242,6 +245,21 @@ export class App implements AppInterface {
     this.nodeDependencies = nodeDependencies
   }
 
+  async preDeployValidation() {
+    const functionExtensionsWithUiHandle = this.allExtensions.filter(
+      (ext) => ext.isFunctionExtension && (ext.configuration as unknown as FunctionConfigType).ui?.handle,
+    ) as ExtensionInstance<FunctionConfigType>[]
+
+    if (functionExtensionsWithUiHandle.length > 0) {
+      const errors = validateFunctionExtensionsWithUiHandle(functionExtensionsWithUiHandle, this.allExtensions)
+      if (errors) {
+        throw new AbortError('Invalid function configuration', errors.join('\n'))
+      }
+    }
+
+    await Promise.all([this.allExtensions.map((ext) => ext.preDeployValidation())])
+  }
+
   hasExtensions(): boolean {
     return this.allExtensions.length > 0
   }
@@ -257,6 +275,32 @@ export class App implements AppInterface {
       extension.devUUID = uuids[extension.localIdentifier] ?? extension.devUUID
     })
   }
+}
+
+export function validateFunctionExtensionsWithUiHandle(
+  functionExtensionsWithUiHandle: ExtensionInstance<FunctionConfigType>[],
+  allExtensions: ExtensionInstance[],
+): string[] | undefined {
+  const errors: string[] = []
+
+  functionExtensionsWithUiHandle.forEach((extension) => {
+    const uiHandle = extension.configuration.ui!.handle!
+
+    const matchingExtension = findExtensionByHandle(allExtensions, uiHandle)
+    if (!matchingExtension) {
+      errors.push(`[${extension.name}] - Local app must contain a ui_extension with handle '${uiHandle}'`)
+    } else if (matchingExtension.configuration.type !== 'ui_extension') {
+      errors.push(
+        `[${extension.name}] - Local app must contain one extension of type 'ui_extension' and handle '${uiHandle}'`,
+      )
+    }
+  })
+
+  return errors.length > 0 ? errors : undefined
+}
+
+function findExtensionByHandle(allExtensions: ExtensionInstance[], handle: string): ExtensionInstance | undefined {
+  return allExtensions.find((ext) => ext.handle === handle)
 }
 
 export class EmptyApp extends App {

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -114,7 +114,7 @@ export async function deploy(options: DeployOptions) {
         {
           title: 'Running validation',
           task: async () => {
-            await Promise.all([app.allExtensions.map((ext) => ext.preDeployValidation())])
+            await app.preDeployValidation()
           },
         },
         {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/7308

### WHAT is this pull request doing?

This PR will add an extra validation when deploying a app that contains a function and an ui extension. 

For validating when an app that contains a function with `ui.handle`:
- The function with a `ui.handle` must contain another extension with a matching `handle` in the same local app. This will be used to link a UI extension with a function, so we can [surface that information to domains](https://github.com/Shopify/shopify/pull/452100). 
- We should ensure the matching extension is of type `ui_extension`. If we match solely on the existence of the handle, we could have a situation where partners link a function `ui_handle` to another extension type. 

This validation should check that if a function has the `ui.handle` configured, that it should match an existing extension handle. That matching extension should also be `ui_extension` type. These validation will ensure that partners are correctly linking a function with a ui_extension.

### What should reviewers focus on:
- wording of error message
- followed guidance from this [slack convo](https://shopify.slack.com/archives/C030LHFCA5T/p1694763056516339?thread_ts=1694714721.883739&cid=C030LHFCA5T) to implment

### How to test your changes?

enable `UI Extension` beta flag on organization via [partners internal](https://partners.script-service-q7k4.mehdi-salemi.us.spin.dev/internal/organizations/1).

Enable `functions_app_ui_handle` on app 

**core**
```
dev c
> api_client = ApiClient.find(1830457)
> api_client.beta.enable(:functions_app_ui_handle) 
```

Deploy an app with a function and ui Extension. The function's `ui.handle` should match the handle for the `ui extension`
```
SPIN=1 SPIN_INSTANCE=script-service-q7k4 dev spin pnpm shopify app deploy  --path=../../../../Desktop/prod-testing/product-discounts-single-ext
```
^ _updating with your spin instance urls and path to your local app_

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
