### PR TITLE
Fix concurrent github workflows for merge groups

### DIFF
--- a/.github/workflows/cli-ruby.yml
+++ b/.github/workflows/cli-ruby.yml
@@ -8,7 +8,7 @@ on:
   merge_group:
 
 concurrency:
-  group: shopify-${{ github.head_ref }}
+  group: shopify-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - stable/3.*
 
 concurrency:
-  group: changeset-${{ github.head_ref }}
+  group: changeset-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed that adding two PRs to the merge queue make things fail because of these concurrency checks. This is because in that case we don't have a `head_ref` property.

### WHAT is this pull request doing?

Make sure the concurrency checks work with multiple queued PRs.