### PR TITLE
Read SHOPIFY_API_KEY as a way to specify --api-key

### DIFF
--- a/.changeset/friendly-nails-listen.md
+++ b/.changeset/friendly-nails-listen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Read SHOPIFY_API_KEY env var for dev/deploy instead of warning because API key wasn't passed

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -80,6 +80,11 @@ export default class Deploy extends Command {
     validateVersion(flags.version)
     validateMessage(flags.message)
 
+    if (!flags['api-key']) {
+      if (process.env.SHOPIFY_API_KEY) {
+        flags['api-key'] = process.env.SHOPIFY_API_KEY
+      }
+    }
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
     }

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -99,6 +99,12 @@ export default class Dev extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(Dev)
+
+    if (!flags['api-key']) {
+      if (process.env.SHOPIFY_API_KEY) {
+        flags['api-key'] = process.env.SHOPIFY_API_KEY
+      }
+    }
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
     }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #2841

We [recommend](https://shopify.dev/docs/apps/tools/cli/ci-cd#github-actions) for CI/CD to specify the `SHOPIFY_API_KEY` env variable. But it's not taken into account when requiring `client-id` for non-TTY environments.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Considers `SHOPIFY_API_KEY` as though `--api-key` has been specified. We also consider it deprecated because `client ID` is now the preferred terminology (we should update the docs as well to reflect this).

### How to test your changes?

```
echo | SHOPIFY_API_KEY=SOME-API-KEY pnpm shopify app deploy --path /path/to/your/app -f
```

Before: fails
After: passes, warns that the `api-key` flag is deprecated

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
