### PR TITLE
Add versioning to Liquid Console remote theme

### DIFF
--- a/.changeset/chilly-brooms-allow.md
+++ b/.changeset/chilly-brooms-allow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Add versioning to Liquid Console remote theme, allowing users to try different versions of Liquid Console in the same store without facing compatibility issues

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/console.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/console.rb
@@ -8,13 +8,15 @@ module Theme
       options do |parser, flags|
         parser.on("--url=URL") { |url| flags[:url] = url }
         parser.on("--port=PORT") { |port| flags[:port] = port }
+        parser.on("--theme=THEME") { |theme| flags[:theme] = theme }
       end
 
       def call(_args, _name)
         url = options.flags[:url]
         port = options.flags[:port]
+        theme = options.flags[:theme]
 
-        ShopifyCLI::Theme::Repl.new(@ctx, url, port).run
+        ShopifyCLI::Theme::Repl.new(@ctx, url, port, theme).run
       end
     end
   end

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl.rb
@@ -17,12 +17,13 @@ require_relative "repl/snippet"
 module ShopifyCLI
   module Theme
     class Repl
-      attr_reader :ctx, :url, :port, :session, :storefront_digest, :secure_session_id
+      attr_reader :ctx, :url, :port, :theme, :session, :storefront_digest, :secure_session_id
 
-      def initialize(ctx, url, port)
+      def initialize(ctx, url, port, theme)
         @ctx = ctx
         @url = url
         @port = port
+        @theme = theme
         @session = []
       end
 
@@ -76,7 +77,7 @@ module ShopifyCLI
       def authenticate!
         # Currently, Shopify CLI can't bypass the store password, so the
         # `AuthDevServer` gets the session to perform requests at the SFR.
-        ShopifyCLI::Theme::Repl::AuthDevServer.start(ctx, self, port)
+        ShopifyCLI::Theme::Repl::AuthDevServer.start(ctx, self, port, theme)
       end
 
       def api

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_dev_server.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_dev_server.rb
@@ -6,13 +6,11 @@ module ShopifyCLI
       class AuthDevServer < ShopifyCLI::Theme::DevServer
         attr_accessor :app, :repl
 
-        REPL_THEME = "liquid-console-repl"
-
         class << self
-          def start(ctx, repl, port)
+          def start(ctx, repl, port, theme = "liquid-console-repl")
             instance.repl = repl
 
-            super(ctx, nil, port: port, theme: REPL_THEME)
+            super(ctx, nil, port: port, theme: theme)
           end
         end
 

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/remote_evaluator.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/remote_evaluator.rb
@@ -131,6 +131,9 @@ module ShopifyCLI
 
         def extract_body(response)
           response.body.lines[1..-2].join.strip
+        rescue StandardError
+          # Handle malformed body gracefully
+          "{}"
         end
 
         def not_found?(response)

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/repl/auth_dev_server_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/repl/auth_dev_server_test.rb
@@ -78,7 +78,7 @@ module ShopifyCLI
         def dev_server
           AuthDevServer.instance.tap do |server|
             server.stubs(:ctx).returns(ctx)
-            server.stubs(:theme_identifier).returns(AuthDevServer::REPL_THEME)
+            server.stubs(:theme_identifier).returns("liquid-console-repl")
           end
         end
 

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -6,6 +6,7 @@ import {ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
 import {Flags} from '@oclif/core'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 
 export default class Console extends ThemeCommand {
   static description = 'Shopify Liquid REPL (read-eval-print loop) tool'
@@ -31,6 +32,8 @@ export default class Console extends ThemeCommand {
     const {flags} = await this.parse(Console)
     const store = ensureThemeStore(flags)
     const {password, url, port} = flags
+    const cliVersion = CLI_KIT_VERSION
+    const theme = `liquid-console-repl-${cliVersion}`
 
     const adminSession = await ensureAuthenticatedThemes(store, password, [], true)
     const storefrontToken = await ensureAuthenticatedStorefront([], password)
@@ -44,7 +47,7 @@ export default class Console extends ThemeCommand {
       ],
     })
 
-    return execCLI2(['theme', 'console', '--url', url, '--port', port], {
+    return execCLI2(['theme', 'console', '--url', url, '--port', port, '--theme', theme], {
       store,
       adminToken: adminSession.token,
       storefrontToken,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2811.

The `shopify theme console` relies on a tiny hidden theme named `liquid-console-repl` to remotely evaluate Liquid snippets. However, users who tested the beta version of `shopify theme console` ended up with an outdated version of `liquid-console-repl` in their stores.

Currently, users facing this issue need to manually remove the remote theme (`liquid-console-repl`) so that the Liquid Console can automatically create a new, valid one.

### WHAT is this pull request doing?

This PR couples the CLI version with the Liquid Console by appending the CLI version to the theme name. So, instead of `liquid-console-repl`, the theme is now called `liquid-console-repl-3.49.1`. This allows us to modify the theme's structure even during patch releases without introducing compatibility issues.

### How to test your changes?

- Run `shopify theme console`
- Run `shopify theme list`
- Notice the REPL theme name has the CLI version now

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
