### PR TITLE
Add limit to Flow template schema description length (1024 characters)

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_template.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_template.ts
@@ -9,6 +9,7 @@ import fs from 'fs'
 
 const FlowTemplateExtensionSchema = BaseSchemaWithHandle.extend({
   type: zod.literal('flow_template'),
+  description: zod.string().max(1024),
   template: zod.object({
     categories: zod.array(zod.string()),
     module: zod.string(),


### PR DESCRIPTION
### WHY are these changes introduced?
Flow stores this description in the Flow DB and the limit for that field is 1024 characters

Related: https://github.com/Shopify/shopify/pull/451488

### WHAT is this pull request doing?

Makes Flow template description not optional and limits the length to 1024 characters

### Top hat
- Confirm descriptions over 1024 characters throws a cli error prior to deploying

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
