### PR TITLE
Adding support for function localizations

### DIFF
--- a/.changeset/poor-cameras-heal.md
+++ b/.changeset/poor-cameras-heal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Function extensions are now able to provide a `locales` directory, and translate name and description

--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -2,7 +2,7 @@ import {FunctionConfigType} from './function.js'
 import {testFunctionExtension} from '../../app/app.test-data.js'
 import {ExtensionInstance} from '../extension-instance.js'
 import * as upload from '../../../services/deploy/upload.js'
-import {inTemporaryDirectory, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, touchFile, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
@@ -90,6 +90,8 @@ describe('functionConfiguration', () => {
         },
         enable_creation_ui: true,
         module_id: moduleId,
+        localization: {},
+        targets: undefined,
       })
     })
   })
@@ -113,8 +115,10 @@ describe('functionConfiguration', () => {
         module_id: moduleId,
         enable_creation_ui: true,
         input_query: undefined,
-        input_query_variabels: undefined,
+        input_query_variables: undefined,
         ui: undefined,
+        localization: {},
+        targets: undefined,
       })
     })
   })
@@ -148,5 +152,35 @@ describe('functionConfiguration', () => {
 
     // When & Then
     await expect(() => extension.deployConfig({apiKey, token, unifiedDeployment})).rejects.toThrowError(AbortError)
+  })
+
+  test('parses locales', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      extension.directory = tmpDir
+      const enLocale = {
+        extension: {
+          title: 'English Title',
+          description: 'English Description',
+        },
+      }
+
+      const localesDir = joinPath(extension.directory, 'locales')
+      await mkdir(localesDir)
+      await writeFile(joinPath(localesDir, 'en.default.json'), JSON.stringify(enLocale))
+
+      // When
+      const got = await extension.deployConfig({apiKey, token, unifiedDeployment})
+
+      // Then
+      const expectedLocalization = {
+        default_locale: 'en',
+        translations: {
+          en: 'eyJleHRlbnNpb24iOnsidGl0bGUiOiJFbmdsaXNoIFRpdGxlIiwiZGVzY3JpcHRpb24iOiJFbmdsaXNoIERlc2NyaXB0aW9uIn19',
+        },
+      }
+
+      expect(got!.localization).toEqual(expectedLocalization)
+    })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -1,5 +1,6 @@
 import {createExtensionSpecification} from '../specification.js'
 import {BaseSchema} from '../schemas.js'
+import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
@@ -109,6 +110,7 @@ const spec = createExtensionSpecification({
           }
         : undefined,
       enable_creation_ui: config.ui?.enable_create ?? true,
+      localization: await loadLocalesConfig(directory, 'function'),
       targets,
     }
   },

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -337,6 +337,7 @@ describe('deploy', () => {
       api_type: functionExtension.configuration.type,
       api_version: functionExtension.configuration.api_version,
       enable_creation_ui: true,
+      localization: {},
     }
     vi.mocked(uploadWasmBlob).mockResolvedValue({url: 'url', moduleId})
 
@@ -378,6 +379,7 @@ describe('deploy', () => {
       api_type: functionExtension.configuration.type,
       api_version: functionExtension.configuration.api_version,
       enable_creation_ui: true,
+      localization: {},
     }
     vi.mocked(uploadWasmBlob).mockResolvedValue({url: 'url', moduleId})
 


### PR DESCRIPTION
### WHY are these changes introduced?

Adding support for defining a locales directory in your app to supply localized strings. Use t: prefix for your titles and description field (if applicable) in your .toml file to use the localized strings. (Basically rebasing DC's [PR](https://github.com/Shopify/cli/pull/2226) to stable/3.49 branch)

Pushing to stable/3.49 branch

### WHAT is this pull request doing?
Leveraging the existing helpers for localization.


### How to test your changes?
- Test with companion PR in core on branch `func-loc`.
- Create a script-service spin instance with shopify branch `func-loc`
- create an app with discounts function
- make the following changes
```
./app/extension/discoutn_function
  ├── ...
  ├── locales // Create this dir and add locales
  │   ├── en.default.json // The default locale for the extension
  │   └── fr.json // The French language translations for the extension
  ├── package.json
  ├── shopify.extension.toml // The config file for the extension
  ├── ...
```

- update shopify.extension.toml to have:
```toml
name = "t:title"
description = "t:description"
```
- example en.default.json
```json
{
  "title": "English title",
  "description": "English description"
}

```



### Post-release steps
NOTE: Will have another PR soon to incorporate these changes in cli/main as well.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
