### PR TITLE
Analytics for dev hotkeys

### DIFF
--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -1,3 +1,4 @@
+import metadata from '../../../../metadata.js'
 import {developerPreviewUpdate, disableDeveloperPreview, enableDeveloperPreview} from '../../../context.js'
 import {fetchAppPreviewMode} from '../../fetch.js'
 import {OutputProcess} from '@shopify/cli-kit/node/output'
@@ -123,12 +124,21 @@ const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUr
           setError('')
 
           if (input === 'p' && previewUrl) {
+            await metadata.addPublicMetadata(() => ({
+              cmd_dev_preview_url_opened: true,
+            }))
             await openURL(previewUrl)
           } else if (input === 'g' && graphiqlUrl) {
+            await metadata.addPublicMetadata(() => ({
+              cmd_dev_graphiql_opened: true,
+            }))
             openURL(graphiqlUrl)
           } else if (input === 'q') {
             abortController.abort()
           } else if (input === 'd' && canEnablePreviewMode) {
+            await metadata.addPublicMetadata(() => ({
+              cmd_dev_dev_preview_toggle_used: true,
+            }))
             const newDevPreviewEnabled = !devPreviewEnabled
             setDevPreviewEnabled(newDevPreviewEnabled)
             try {

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -83,6 +83,9 @@ export interface Schemas {
       cmd_dev_tunnel_type?: Optional<string>
       cmd_dev_tunnel_custom_hash?: Optional<string>
       cmd_dev_urls_updated?: Optional<boolean>
+      cmd_dev_preview_url_opened?: Optional<boolean>
+      cmd_dev_graphiql_opened?: Optional<boolean>
+      cmd_dev_dev_preview_toggle_used?: Optional<boolean>
 
       // Create-app related commands
       cmd_create_app_template?: Optional<string>

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -10,7 +10,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 type Optional<T> = T | null
 
 // This is the topic name of the main event we log to Monorail, the command tracker
-export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.7' as const
+export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.9' as const
 
 export interface Schemas {
   [MONORAIL_COMMAND_TOPIC]: {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

To know what people are using `dev` for.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Adds tracking to hotkeys used in `dev` to launch GraphiQL, launch preview, or toggle development preview mode.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

1. Checkout this branch
2. Run `app dev` in verbose mode, and use some hotkeys
3. See that the event sent at the end includes the correct keys with `true` as the value
4. For bonus points, run with `SHOPIFY_CLI_ALWAYS_LOG_ANALYTICS=1`, check when the events appear in monorail, and confirm the data is there (I've done this already)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
