### PR TITLE
Reorder UI extension flavors select

### DIFF
--- a/packages/app/src/cli/models/templates/common.ts
+++ b/packages/app/src/cli/models/templates/common.ts
@@ -3,8 +3,8 @@ import {ExtensionFlavor} from '../app/template.js'
 export function uiFlavors(path: string): ExtensionFlavor[] {
   return [
     {
-      name: 'TypeScript',
-      value: 'typescript',
+      name: 'JavaScript React',
+      value: 'react',
       path,
     },
     {
@@ -18,8 +18,8 @@ export function uiFlavors(path: string): ExtensionFlavor[] {
       path,
     },
     {
-      name: 'JavaScript React',
-      value: 'react',
+      name: 'TypeScript',
+      value: 'typescript',
       path,
     },
   ]


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-management/issues/29

We want to reorder the list of UI extension flavors so that the default is our recommended choice. The issue contains screenshots that explain the problem and solution.

### WHAT is this pull request doing?

Reorder them.

### How to test your changes?

Try to generate a UI extension and the order of the flavors should be the one explained in the issue.

### Post-release steps

- Merge https://github.com/Shopify/shopify-dev/pull/37540
