### PR TITLE
Fix run config commands outside app root folder

### DIFF
--- a/.changeset/eleven-lions-eat.md
+++ b/.changeset/eleven-lions-eat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Running config commands works properly when they are run outside the app root folder

--- a/packages/app/src/cli/commands/app/config/use.ts
+++ b/packages/app/src/cli/commands/app/config/use.ts
@@ -1,4 +1,5 @@
 import {appFlags} from '../../../flags.js'
+import {loadAppConfiguration} from '../../../models/app/loader.js'
 import use from '../../../services/app/config/use.js'
 import Command from '../../../utilities/app-command.js'
 import {Args, Flags} from '@oclif/core'
@@ -32,6 +33,11 @@ export default class ConfigUse extends Command {
 
   public async run(): Promise<void> {
     const {flags, args} = await this.parse(ConfigUse)
-    await use({directory: flags.path, configName: args.config, reset: flags.reset})
+    // eslint-disable-next-line @shopify/cli/required-fields-when-loading-app
+    const localApp = await loadAppConfiguration({
+      directory: flags.path,
+    })
+
+    await use({directory: localApp.directory, configName: args.config, reset: flags.reset})
   }
 }

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -41,7 +41,7 @@ describe('link', () => {
         commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         configName: 'Default value',
       }
-      vi.mocked(loadApp).mockResolvedValue(LOCAL_APP)
+      vi.mocked(loadApp).mockResolvedValue({...LOCAL_APP, directory: tmp})
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
 
       // When
@@ -116,23 +116,22 @@ embedded = false
         directory: tmp,
         commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
       }
-      vi.mocked(loadApp).mockResolvedValue(
-        testApp({
-          configuration: {
-            path: 'shopify.app.development.toml',
-            name: 'my app',
-            client_id: '12345',
-            scopes: 'write_products',
-            webhooks: {api_version: '2023-04'},
-            application_url: 'https://myapp.com',
-            embedded: true,
-            build: {
-              automatically_update_urls_on_dev: true,
-              dev_store_url: 'my-store.myshopify.com',
-            },
+      const localApp = testApp({
+        configuration: {
+          path: 'shopify.app.development.toml',
+          name: 'my app',
+          client_id: '12345',
+          scopes: 'write_products',
+          webhooks: {api_version: '2023-04'},
+          application_url: 'https://myapp.com',
+          embedded: true,
+          build: {
+            automatically_update_urls_on_dev: true,
+            dev_store_url: 'my-store.myshopify.com',
           },
-        }),
-      )
+        },
+      })
+      vi.mocked(loadApp).mockResolvedValue({...localApp, directory: tmp})
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
         testOrganizationApp({
           apiKey: '12345',
@@ -200,7 +199,7 @@ embedded = false
         directory: tmp,
         commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
       }
-      vi.mocked(loadApp).mockResolvedValue(LOCAL_APP)
+      vi.mocked(loadApp).mockResolvedValue({...LOCAL_APP, directory: tmp})
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
 
       // When
@@ -259,7 +258,7 @@ embedded = false
         directory: tmp,
         commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
       }
-      vi.mocked(loadApp).mockResolvedValue(LOCAL_APP)
+      vi.mocked(loadApp).mockResolvedValue({...LOCAL_APP, directory: tmp})
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
 
       // When
@@ -300,7 +299,7 @@ embedded = false
         commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         apiKey: 'api-key',
       }
-      vi.mocked(loadApp).mockResolvedValue(LOCAL_APP)
+      vi.mocked(loadApp).mockResolvedValue({...LOCAL_APP, directory: tmp})
       vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
       vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(REMOTE_APP)
       vi.mocked(selectConfigName).mockResolvedValue('staging')
@@ -326,7 +325,7 @@ embedded = false
         commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         apiKey: '1234-5678',
       }
-      vi.mocked(loadApp).mockResolvedValue(LOCAL_APP)
+      vi.mocked(loadApp).mockResolvedValue({...LOCAL_APP, directory: tmp})
       vi.mocked(ensureAuthenticatedPartners).mockResolvedValue('token')
       vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(undefined)
       vi.mocked(selectConfigName).mockResolvedValue('staging')
@@ -346,19 +345,18 @@ embedded = false
         directory: tmp,
         commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
       }
-      vi.mocked(loadApp).mockResolvedValue(
-        testApp({
-          configuration: {
-            path: 'shopify.app.foo.toml',
-            name: 'my app',
-            client_id: '12345',
-            scopes: 'write_products',
-            webhooks: {api_version: '2023-04'},
-            application_url: 'https://myapp.com',
-            embedded: true,
-          },
-        }),
-      )
+      const localApp = testApp({
+        configuration: {
+          path: 'shopify.app.foo.toml',
+          name: 'my app',
+          client_id: '12345',
+          scopes: 'write_products',
+          webhooks: {api_version: '2023-04'},
+          application_url: 'https://myapp.com',
+          embedded: true,
+        },
+      })
+      vi.mocked(loadApp).mockResolvedValue({...localApp, directory: tmp})
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
         testOrganizationApp({
           apiKey: '12345',
@@ -423,7 +421,7 @@ embedded = false
         directory: tmp,
         commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
       }
-      vi.mocked(loadApp).mockResolvedValue(LOCAL_APP)
+      vi.mocked(loadApp).mockResolvedValue({...LOCAL_APP, directory: tmp})
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({
         ...REMOTE_APP,
         requestedAccessScopes: ['read_products', 'write_orders'],

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -35,16 +35,17 @@ export interface LinkOptions {
 
 export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<AppConfiguration> {
   const localApp = await loadAppConfigFromDefaultToml(options)
-  const remoteApp = await loadRemoteApp(localApp, options.apiKey, options.directory)
+  const directory = localApp.directory && localApp.directory !== '' ? localApp.directory : options.directory
+  const remoteApp = await loadRemoteApp(localApp, options.apiKey, directory)
 
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
-  const configFilePath = joinPath(options.directory, configFileName)
+  const configFilePath = joinPath(directory, configFileName)
 
   const configuration = mergeAppConfiguration({...localApp.configuration, path: configFilePath}, remoteApp)
 
   await writeAppConfigurationFile(configuration)
 
-  await saveCurrentConfig({configFileName, directory: options.directory})
+  await saveCurrentConfig({configFileName, directory})
 
   if (shouldRenderSuccess) {
     renderSuccess({
@@ -123,7 +124,7 @@ async function loadConfigurationFileName(
     return configurationFileNames.app
   }
 
-  const configName = await selectConfigName(options.directory, remoteApp.title)
+  const configName = await selectConfigName(localApp.directory ?? options.directory, remoteApp.title)
   return `shopify.app.${configName}.toml`
 }
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -35,7 +35,7 @@ export interface LinkOptions {
 
 export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<AppConfiguration> {
   const localApp = await loadAppConfigFromDefaultToml(options)
-  const directory = localApp.directory && localApp.directory !== '' ? localApp.directory : options.directory
+  const directory = localApp?.directory || options.directory
   const remoteApp = await loadRemoteApp(localApp, options.apiKey, directory)
 
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
@@ -110,7 +110,7 @@ async function loadRemoteApp(
 async function loadConfigurationFileName(
   remoteApp: OrganizationApp,
   options: LinkOptions,
-  localApp?: AppInterface,
+  localApp: AppInterface,
 ): Promise<string> {
   const cache = getCachedCommandInfo()
 
@@ -120,11 +120,11 @@ async function loadConfigurationFileName(
     return getAppConfigurationFileName(options.configName)
   }
 
-  if (!localApp?.configuration || (localApp && isLegacyAppSchema(localApp.configuration))) {
+  if (!localApp.configuration || (localApp && isLegacyAppSchema(localApp.configuration))) {
     return configurationFileNames.app
   }
 
-  const configName = await selectConfigName(localApp.directory ?? options.directory, remoteApp.title)
+  const configName = await selectConfigName(localApp.directory || options.directory, remoteApp.title)
   return `shopify.app.${configName}.toml`
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When you run either `app config link` or `app config use` inside an app subfolder, the folder used to search/create app toml is not correct.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Use the commands `path` flag to load the app. Once it's loaded, the logic uses the app directory

### How to test your changes?
- Run `shopify app config link` outside the root app folder
```
npm run shopify app config link --path /your/app/path/extensions --reset
```
- Select a different app so a new toml file is created

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
