### PR TITLE
Fix generate context not logging relevant metadata

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -10,11 +10,7 @@ import {OrganizationApp} from '../../../models/organization.js'
 import {selectConfigName} from '../../../prompts/config.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {getAppConfigurationFileName, loadApp} from '../../../models/app/loader.js'
-import {
-  InvalidApiKeyErrorMessage,
-  fetchOrCreateOrganizationApp,
-  logMetadataForLoadedConfigContext,
-} from '../../context.js'
+import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp, logMetadataForLoadedContext} from '../../context.js'
 import {fetchAppDetailsFromApiKey} from '../../dev/fetch.js'
 import {configurationFileNames} from '../../../constants.js'
 import {writeAppConfigurationFile} from '../write-app-configuration-file.js'
@@ -68,7 +64,7 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
     })
   }
 
-  await logMetadataForLoadedConfigContext(remoteApp)
+  await logMetadataForLoadedContext(remoteApp)
 
   return configuration
 }

--- a/packages/app/src/cli/services/app/config/push.ts
+++ b/packages/app/src/cli/services/app/config/push.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../models/app/app.js'
 import {DeleteAppProxySchema, deleteAppProxy} from '../../../api/graphql/app_proxy_delete.js'
 import {confirmPushChanges} from '../../../prompts/config.js'
-import {logMetadataForLoadedConfigContext, renderCurrentlyUsedConfigInfo} from '../../context.js'
+import {logMetadataForLoadedContext, renderCurrentlyUsedConfigInfo} from '../../context.js'
 import {fetchOrgFromId} from '../../dev/fetch.js'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
@@ -95,7 +95,7 @@ export async function pushConfig(options: PushOptions) {
       }
     }
 
-    await logMetadataForLoadedConfigContext(app)
+    await logMetadataForLoadedContext(app)
 
     renderSuccess({
       headline: `Updated your app config for ${configuration.name}`,

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -3,7 +3,7 @@ import {testApp, testAppWithConfig, testOrganizationApp} from '../../../models/a
 import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models/app/loader.js'
 import {clearCurrentConfigFile, setCachedAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
-import {logMetadataForLoadedConfigContext} from '../../context.js'
+import {logMetadataForLoadedContext} from '../../context.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -265,7 +265,7 @@ describe('use', () => {
       await use({directory, configName: 'something'})
 
       // Then
-      expect(logMetadataForLoadedConfigContext).toHaveBeenNthCalledWith(1, REMOTE_APP)
+      expect(logMetadataForLoadedContext).toHaveBeenNthCalledWith(1, REMOTE_APP)
     })
   })
 })

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -2,7 +2,7 @@ import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models
 import {clearCurrentConfigFile, setCachedAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
 import {AppConfiguration, isCurrentAppSchema} from '../../../models/app/app.js'
-import {logMetadataForLoadedConfigContext} from '../../context.js'
+import {logMetadataForLoadedContext} from '../../context.js'
 import {GetConfigQuerySchema, GetConfig} from '../../../api/graphql/get_config.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {fileExists} from '@shopify/cli-kit/node/fs'
@@ -102,7 +102,7 @@ async function logMetadata(configuration: AppConfiguration) {
   if (queryResult.app) {
     const {app} = queryResult
 
-    await logMetadataForLoadedConfigContext(app)
+    await logMetadataForLoadedContext(app)
   } else {
     outputDebug("Couldn't find app for analytics. Make sure you have a valid client ID.")
   }

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -121,6 +121,10 @@ export async function ensureGenerateContext(options: {
       directory: options.directory,
       orgId,
     })
+    await logMetadataForLoadedContext({
+      organizationId: selectedApp.organizationId,
+      apiKey: selectedApp.apiKey,
+    })
     return selectedApp.apiKey
   }
 }
@@ -206,7 +210,10 @@ export async function ensureDevContext(options: DevContextOptions, token: string
   })
 
   const result = buildOutput(selectedApp, selectedStore, cachedInfo)
-  await logMetadataForLoadedDevContext(result)
+  await logMetadataForLoadedContext({
+    organizationId: result.remoteApp.organizationId,
+    apiKey: result.remoteApp.apiKey,
+  })
   return result
 }
 
@@ -374,7 +381,10 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
     deploymentMode,
   }
 
-  await logMetadataForLoadedDeployContext(result)
+  await logMetadataForLoadedContext({
+    organizationId: result.partnersApp.organizationId,
+    apiKey: result.identifiers.app,
+  })
   return result
 }
 
@@ -408,7 +418,7 @@ export async function ensureReleaseContext(options: ReleaseContextOptions): Prom
     token,
   }
 
-  await logMetadataForLoadedReleaseContext(result, partnersApp.organizationId)
+  await logMetadataForLoadedContext({organizationId: partnersApp.organizationId, apiKey: partnersApp.apiKey})
   return result
 }
 
@@ -763,21 +773,7 @@ function showDevValues(org: string, appName: string) {
   })
 }
 
-async function logMetadataForLoadedDevContext(env: DevContextOutput) {
-  await metadata.addPublicMetadata(() => ({
-    partner_id: tryParseInt(env.remoteApp.organizationId),
-    api_key: env.remoteApp.apiKey,
-  }))
-}
-
-async function logMetadataForLoadedDeployContext(env: DeployContextOutput) {
-  await metadata.addPublicMetadata(() => ({
-    partner_id: tryParseInt(env.partnersApp.organizationId),
-    api_key: env.identifiers.app,
-  }))
-}
-
-export async function logMetadataForLoadedConfigContext(app: {organizationId: string; apiKey: string}) {
+export async function logMetadataForLoadedContext(app: {organizationId: string; apiKey: string}) {
   await metadata.addPublicMetadata(() => ({
     partner_id: tryParseInt(app.organizationId),
     api_key: app.apiKey,
@@ -819,13 +815,6 @@ export async function developerPreviewUpdate({
   } catch (error: unknown) {
     return false
   }
-}
-
-async function logMetadataForLoadedReleaseContext(env: ReleaseContextOutput, partnerId: string) {
-  await metadata.addPublicMetadata(() => ({
-    partner_id: tryParseInt(partnerId),
-    api_key: env.partnersApp.apiKey,
-  }))
 }
 
 function checkDeploymentsBeta(command: string, partnersApp: OrganizationApp) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-management/issues/1463

### WHAT is this pull request doing?

We weren't logging `partner_id` and `api_key` for the `generate command, this fixes that.

### How to test your changes?

- Run generate command with `--verbose`
- See that those attributes are present in the metadata
