### PR TITLE
Fix create app for apps with old templates

### DIFF
--- a/.changeset/smart-cherries-joke.md
+++ b/.changeset/smart-cherries-joke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': patch
+---
+
+Fix create app with old templates. Dev command will work just after the app is created.

--- a/packages/create-app/src/services/init.ts
+++ b/packages/create-app/src/services/init.ts
@@ -83,7 +83,7 @@ async function init(options: InitOptions) {
           packageJSON.name = hyphenizedName
           packageJSON.author = (await username()) ?? ''
           packageJSON.private = true
-          const workspacesFolders = ['extensions/*'].concat(detectAddittionalWorkspacesFolders(templateScaffoldDir))
+          const workspacesFolders = ['extensions/*'].concat(detectAdditionalWorkspacesFolders(templateScaffoldDir))
 
           switch (packageManager) {
             case 'npm':
@@ -176,7 +176,7 @@ async function ensureAppDirectoryIsAvailable(directory: string, name: string): P
     throw new AbortError(`\nA directory with this name (${name}) already exists.\nChoose a new name for your app.`)
 }
 
-function detectAddittionalWorkspacesFolders(directory: string) {
+function detectAdditionalWorkspacesFolders(directory: string) {
   return ['web', 'web/frontend'].filter((folder) => fileExistsSync(joinPath(directory, folder)))
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2866

Current default CLI templates don't include the folders `web` and `web/frontend`. For that reason the command to create an app[ was adapted ](https://github.com/Shopify/cli/pull/2523)to remove those folders from the `workspaces` setup

However the CLI supports the creation of app using the older templates using the flag `-t|--template`. Old templates include the react frontend inside the folder `web/frontend`, so after configuring the `workspaces` section and installing the dependencies, the ones for the frontend are not installed. Due to this, when the command `app dev` is run it breaks with errors similar to this one (in this case for the `node` template)

```sh
── external error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Error coming from `npm run dev`

Command failed with exit code 127: npm run dev
sh: vite: command not found

> shopify-frontend-template-react@1.0.0 dev
> vite


─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```
To reproduce the error:
- `npm init @shopify/app@latest -- --template node``
- `npm run dev`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Check if the folders  `web` and `web/frontend` exist and in that case add them to the `workspaces` setup. `remix` does not include those so it will work as for now
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- `npm run create-app -- --path /path/to/your/apps --template node`
- `npm run dev -- --path /path/to/your/apps/created-app`
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
