### PR TITLE
Dont rename graphql on generate for functions

### DIFF
--- a/.changeset/cuddly-pillows-occur.md
+++ b/.changeset/cuddly-pillows-occur.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+exclude src/\*.graphql from renamed files when generating functions

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -137,7 +137,7 @@ async function functionExtensionInit({directory, url, app, name, extensionFlavor
 
       if (templateLanguage === 'javascript') {
         const srcFileExtension = getSrcFileExtension(extensionFlavor?.value || 'rust')
-        await changeIndexFileExtension(directory, srcFileExtension)
+        await changeIndexFileExtension(directory, srcFileExtension, '!(*.graphql)')
       }
     },
   })
@@ -251,8 +251,8 @@ export function getFunctionRuntimeDependencies(templateLanguage: string): Depend
   return dependencies
 }
 
-async function changeIndexFileExtension(extensionDirectory: string, fileExtension: SrcFileExtension) {
-  const srcFilePaths = await glob(joinPath(extensionDirectory, 'src', '*'))
+async function changeIndexFileExtension(extensionDirectory: string, fileExtension: SrcFileExtension, renameGlob = '*') {
+  const srcFilePaths = await glob(joinPath(extensionDirectory, 'src', renameGlob))
   const srcFileExensionsToChange = []
 
   for (const srcFilePath of srcFilePaths) {


### PR DESCRIPTION
### WHY are these changes introduced?

New templates being released for functions will include `.graphql` files under `src`. Without this change, the CLI will attempt to rename them.

### WHAT is this pull request doing?

Excludes `src/*.graphql` from the rename operation for functions.

### How to test your changes?

Unit test, and on a local app against the [new templates](https://github.com/Shopify/function-examples/pull/347).

```
pnpm shopify app generate extension --path /Users/nickwesselman/src/scratch/luxury-capital-app --clone-url https://github.com/Shopify/function-examples#template-updates-2023-10 --template product_discounts --name another-discount-ts
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
