### PR TITLE
Don't rename graphql on generate for functions (main)

### DIFF
--- a/.changeset/cuddly-pillows-occur.md
+++ b/.changeset/cuddly-pillows-occur.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+exclude src/\*.graphql from renamed files when generating functions

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -137,7 +137,7 @@ async function functionExtensionInit({directory, url, app, name, extensionFlavor
 
       if (templateLanguage === 'javascript') {
         const srcFileExtension = getSrcFileExtension(extensionFlavor?.value || 'rust')
-        await changeIndexFileExtension(directory, srcFileExtension)
+        await changeIndexFileExtension(directory, srcFileExtension, '!(*.graphql)')
       }
     },
   })
@@ -251,8 +251,8 @@ export function getFunctionRuntimeDependencies(templateLanguage: string): Depend
   return dependencies
 }
 
-async function changeIndexFileExtension(extensionDirectory: string, fileExtension: SrcFileExtension) {
-  const srcFilePaths = await glob(joinPath(extensionDirectory, 'src', '*'))
+async function changeIndexFileExtension(extensionDirectory: string, fileExtension: SrcFileExtension, renameGlob = '*') {
+  const srcFilePaths = await glob(joinPath(extensionDirectory, 'src', renameGlob))
   const srcFileExensionsToChange = []
 
   for (const srcFilePath of srcFilePaths) {


### PR DESCRIPTION
### WHY are these changes introduced?

`main` PR as follow up to #2882 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
