### PR TITLE
Support new cloudfare error message

### DIFF
--- a/.changeset/light-pianos-perform.md
+++ b/.changeset/light-pianos-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/plugin-cloudflare': patch
+---
+
+Support new cloudfare error message and add a default error message for unknown returned errors

--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -81,7 +81,15 @@ class TunnelClientInstance implements TunnelClient {
       if (!resolved) {
         resolved = true
         const lastErrors = errors.slice(-5).join('\n')
-        this.currentStatus = {status: 'error', message: lastErrors}
+        if (lastErrors === '') {
+          this.currentStatus = {
+            status: 'error',
+            message: 'Could not start Cloudflare tunnel, unknown error.',
+            tryMessage: whatToTry(),
+          }
+        } else {
+          this.currentStatus = {status: 'error', message: lastErrors}
+        }
         this.abortController?.abort()
       }
     }, TUNNEL_TIMEOUT * 1000)

--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -168,6 +168,7 @@ function findError(data: Buffer): string | undefined {
     /failed to provision routing/,
     /ERR Couldn't start tunnel/,
     /ERR Failed to serve quic connection/,
+    /ERR Failed to create new quic connection error/,
   ]
   const match = knownErrors.some((error) => error.test(data.toString()))
   return match ? data.toString() : undefined


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
There is a different error message returned by the cloudfare binary when the default `quic` used is not supported by the user. The CLI displays an empty error message like this:

![image](https://github.com/Shopify/cli/assets/105213827/7583d7c0-c864-49f0-b575-8a06d989b3a4)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add the new error message to the list of supported cloudfare error messages, so it's detected as a known message and the error banner could display it.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Not possible to reproduce locally without blocking the required `udp` port against the cloudfare servers. More info [here](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/install-and-setup/ports-and-ips/)
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
