### PR TITLE
Fix extension devUUID to match remote extension UUID if exists

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -194,6 +194,7 @@ export interface AppInterface extends AppConfigurationInterface {
   hasExtensions: () => boolean
   updateDependencies: () => Promise<void>
   extensionsForType: (spec: {identifier: string; externalIdentifier: string}) => ExtensionInstance[]
+  updateExtensionUUIDS: (uuids: {[key: string]: string}) => void
 }
 
 export class App implements AppInterface {
@@ -249,6 +250,12 @@ export class App implements AppInterface {
     return this.allExtensions.filter(
       (extension) => extension.type === specification.identifier || extension.type === specification.externalIdentifier,
     )
+  }
+
+  updateExtensionUUIDS(uuids: {[key: string]: string}) {
+    this.allExtensions.forEach((extension) => {
+      extension.devUUID = uuids[extension.localIdentifier] ?? extension.devUUID
+    })
   }
 }
 

--- a/packages/app/src/cli/services/dev/processes/draftable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/draftable-extension.ts
@@ -117,7 +117,7 @@ export async function setupDraftableExtensionsProcess({
   const deploymentMode = unifiedDeployment ? 'unified' : 'legacy'
   const prodEnvIdentifiers = getAppIdentifiers({app: localApp})
 
-  const {extensionIds: remoteExtensionIds} = await ensureDeploymentIdsPresence({
+  const {extensionIds: remoteExtensionIds, extensions: extensionsUuids} = await ensureDeploymentIdsPresence({
     app: localApp,
     partnersApp: remoteApp,
     appId: apiKey,
@@ -127,6 +127,11 @@ export async function setupDraftableExtensionsProcess({
     token,
     envIdentifiers: prodEnvIdentifiers,
   })
+
+  // Update the local app with the remote extension UUIDs.
+  // Extensions are initialized with a random dev UUID when running the dev command
+  // which is sent over WS messages for live reload in dev preview of UI Extensions.
+  localApp.updateExtensionUUIDS(extensionsUuids)
 
   return {
     type: 'draftable-extension',


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes [#461](https://github.com/Shopify/app-ui/issues/461)

UI extensions, in order to have live reload, communicate with Web by web sockets. The payload of the WS does not have the uuid updated to the one in the draft. As the UUID is used for reconciliation in EH dev plugin, this results in having two extensions rendered, the one stored in the DB as a draft and the one specified by the WS payload.

### WHAT is this pull request doing?

The CLI already resolves the matching extensions, but this matching process was not updating the extension instance. To solve this:
- Added a new method to the App which updates all extension UUIDS to the ones provided in a map
- Force the update of the UUIDS after reconciliation of local and remote extensions0
- 
### How to test your changes?
- create an app with a block extension.
- dev the app and see the extension duplicated at the bottom of the order page.
- checkout this branch.
- dev the app again and see just one block extension rendered.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
