### PR TITLE
[stable] Generate schema from targets if present

### DIFF
--- a/packages/app/src/cli/api/graphql/functions/target_schema_definition.ts
+++ b/packages/app/src/cli/api/graphql/functions/target_schema_definition.ts
@@ -1,0 +1,17 @@
+import {gql} from 'graphql-request'
+
+export const TargetSchemaDefinitionQuery = gql`
+  query TargetSchemaDefinitionQuery($apiKey: String!, $version: String!, $target: String!) {
+    definition: functionTargetSchemaDefinition(apiKey: $apiKey, version: $version, target: $target)
+  }
+`
+
+export interface TargetSchemaDefinitionQuerySchema {
+  definition: string | null
+}
+
+export interface TargetSchemaDefinitionQueryVariables {
+  apiKey: string
+  version: string
+  target: string
+}


### PR DESCRIPTION
### WHY are these changes introduced?

With target support, the generate schema command for functions no longer works.

Related issue: https://github.com/Shopify/script-service/issues/7327

Stable release of #2899

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
