### PR TITLE
Remove changesets already released

### DIFF
--- a/.changeset/cuddly-pillows-occur.md
+++ b/.changeset/cuddly-pillows-occur.md
@@ -1,5 +1,0 @@
----
-'@shopify/app': patch
----
-
-exclude src/\*.graphql from renamed files when generating functions

--- a/.changeset/friendly-nails-listen.md
+++ b/.changeset/friendly-nails-listen.md
@@ -1,5 +1,0 @@
----
-'@shopify/app': patch
----
-
-Read SHOPIFY_API_KEY env var for dev/deploy instead of warning because API key wasn't passed

--- a/.changeset/fuzzy-toys-enjoy.md
+++ b/.changeset/fuzzy-toys-enjoy.md
@@ -1,5 +1,0 @@
----
-'@shopify/app': patch
----
-
-- New extension capability `collect_buyer_consent` with nested capability `sms_marketing`

--- a/.changeset/light-pianos-perform.md
+++ b/.changeset/light-pianos-perform.md
@@ -1,5 +1,0 @@
----
-'@shopify/plugin-cloudflare': patch
----
-
-Support new cloudfare error message and add a default error message for unknown returned errors

--- a/.changeset/modern-ears-draw.md
+++ b/.changeset/modern-ears-draw.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Fix dependency installation for yarn with workspaces

--- a/.changeset/nasty-numbers-vanish.md
+++ b/.changeset/nasty-numbers-vanish.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Fix local font urls


### PR DESCRIPTION
### WHY are these changes introduced?

There are changesets in main about fixes that were already released as patches.

### WHAT is this pull request doing?

Remove changesets already released

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
