### PR TITLE
Fix concurrent function builds

### DIFF
--- a/.changeset/sixty-crews-enjoy.md
+++ b/.changeset/sixty-crews-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix concurrent function builds


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2877

We are building the functions in parallel and when the `javy-cli` binary is not present, all of them will try to download and run it at the same time, causing an error sometimes.

### WHAT is this pull request doing?

When the deploy includes functions, pre-download the javy binary (by running a simple javy command, which automatically downloads it when it's not present) to avoid issues when running build concurrently, which might cause multiple downloads in parallel.

Alternatives:
- Do not build functions in parallel when there are several
- Try to make javy more robust by preventing multiple processes from downloading/accessing the binary simultaneously

### How to test your changes?

- Generate 3+ functions (more likely to crash)
- Remove the javy binary, so that it has to be downloaded again: `rm ~/Library/Caches/binarycache/javy*`
- `p shopify app deploy`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
