### PR TITLE
Added --skip-store-validation for `dev`

### DIFF
--- a/.changeset/grumpy-moles-decide.md
+++ b/.changeset/grumpy-moles-decide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Add --skip-store-validation option to dev

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -242,6 +242,12 @@
           "hidden": false,
           "multiple": false
         },
+        "skip-store-validation": {
+          "name": "skip-store-validation",
+          "type": "boolean",
+          "description": "If providing a store URL, skip any checks used to validate if the store is suitable for testing.",
+          "allowNo": false
+        },
         "reset": {
           "name": "reset",
           "type": "boolean",

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -32,6 +32,11 @@ export default class Dev extends Command {
       env: 'SHOPIFY_FLAG_STORE',
       parse: async (input) => normalizeStoreFqdn(input),
     }),
+    'skip-store-validation': Flags.boolean({
+      env: 'SHOPIFY_FLAG_STORE_SKIP_VALIDATION',
+      default: false,
+      description: 'If providing a store URL, skip any checks used to validate if the store is suitable for testing.',
+    }),
     reset: Flags.boolean({
       hidden: false,
       description: 'Reset all your settings.',
@@ -123,6 +128,7 @@ export default class Dev extends Command {
       configName: flags.config,
       apiKey,
       storeFqdn: flags.store,
+      skipStoreValidation: flags['skip-store-validation'],
       reset: flags.reset,
       update: !flags['no-update'],
       skipDependenciesInstallation: flags['skip-dependencies-installation'],

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -577,11 +577,9 @@ async function fetchDevDataFromOptions(
   ])
   let selectedStore: OrganizationStore | undefined | {shopDomain: string}
 
-  if (orgWithStore?.organization !== undefined) {
-    selectedStore = orgWithStore.store
-    await convertToTestStoreIfNeeded(orgWithStore.store, orgWithStore.organization.id, token)
-  } else if (orgWithStore) {
-    selectedStore = orgWithStore.store
+  selectedStore = orgWithStore?.store
+  if (orgWithStore?.organization) {
+    await convertToTestStoreIfNeeded(selectedStore, orgWithStore.organization.id, token)
   }
 
   return {app: selectedApp, store: selectedStore}

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -43,6 +43,7 @@ export interface DevOptions {
   configName?: string
   apiKey?: string
   storeFqdn?: string
+  skipStoreValidation?: boolean
   reset: boolean
   update: boolean
   commandConfig: Config

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -180,9 +180,9 @@ Run the app.
 ```
 USAGE
   $ shopify app dev [--no-color] [--verbose] [--path <value>] [--client-id <value> | -c <value>] [-s <value>]
-    [--reset | ] [--skip-dependencies-installation] [--no-update] [--subscription-product-url <value>]
-    [--checkout-cart-url <value>] [--tunnel-url <value> |  | ] [-t <value>] [--theme-app-extension-port <value>]
-    [--notify <value>]
+    [--skip-store-validation] [--reset | ] [--skip-dependencies-installation] [--no-update] [--subscription-product-url
+    <value>] [--checkout-cart-url <value>] [--tunnel-url <value> |  | ] [-t <value>] [--theme-app-extension-port
+    <value>] [--notify <value>]
 
 FLAGS
   -c, --config=<value>                The name of the app configuration.
@@ -198,6 +198,8 @@ FLAGS
   --path=<value>                      [default: .] The path to your app directory.
   --reset                             Reset all your settings.
   --skip-dependencies-installation    Skips the installation of dependencies. Deprecated, use workspaces instead.
+  --skip-store-validation             If providing a store URL, skip any checks used to validate if the store is
+                                      suitable for testing.
   --subscription-product-url=<value>  Resource URL for subscription UI extension. Format: "/products/{productId}"
   --theme-app-extension-port=<value>  Local port of the theme app extension development server.
   --tunnel-url=<value>                Use a custom tunnel, it must be running before executing dev. Format:


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Related to https://github.com/Shopify/develop-app-management/issues/236

Fixes an issue with running the CLI against Plus development stores

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Adds the `--skip-store-validation` option. If provided, the CLI will not attempt to validate if the store is one suitable for `dev`. Plus development stores, which are not owned by the partner account, will thus be `dev`-able.

### How to test your changes?

Run `dev`, with `--store=a-plus-dev-store.myshopify.com --skip-store-validation`

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
