### PR TITLE
Fix automatic matching for extensions with localized names

### DIFF
--- a/packages/app/src/cli/services/context/id-matching.test.ts
+++ b/packages/app/src/cli/services/context/id-matching.test.ts
@@ -291,7 +291,7 @@ describe('automaticMatchmaking: some local of the same type, only one remote', (
   })
 })
 
-describe('automaticMatchmaking: some local of the same type, a remote with same type but different name', () => {
+describe('automaticMatchmaking: some local of the same type, a remote with same type but a remote name that doesnt match a local handle', () => {
   test('prompts for manual matching', async () => {
     // When
     const got = await automaticMatchmaking([EXTENSION_A, EXTENSION_A_2], [REGISTRATION_A_3], {}, 'uuid')

--- a/packages/app/src/cli/services/context/id-matching.ts
+++ b/packages/app/src/cli/services/context/id-matching.ts
@@ -18,16 +18,16 @@ export interface MatchResult {
 }
 
 /**
- * Filter function to match a local and a remote source by type and name
+ * Filter function to match a local and a remote source by type and handle
  */
 const sameTypeAndName = (local: LocalSource, remote: RemoteSource) => {
-  return remote.type === local.graphQLType && slugify(remote.title) === slugify(local.configuration.name)
+  return remote.type === local.graphQLType && slugify(remote.title) === slugify(local.handle)
 }
 
 /**
- * Automatically match local and remote sources if they have the same type and name
+ * Automatically match local and remote sources if they have the same type and handle
  *
- * If multiple local or remote sources have the same type and name, they can't be matched automatically
+ * If multiple local or remote sources have the same type and handle, they can't be matched automatically
  */
 function matchByNameAndType(
   local: LocalSource[],
@@ -36,6 +36,7 @@ function matchByNameAndType(
 ): {matched: IdentifiersExtensions; pending: {local: LocalSource[]; remote: RemoteSource[]}} {
   const uniqueLocal = uniqBy(local, (elem) => [elem.graphQLType, elem.handle])
   const uniqueRemote = uniqBy(remote, (elem) => [elem.type, elem.title])
+
   const validMatches: IdentifiersExtensions = {}
 
   uniqueLocal.forEach((localSource) => {

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -35,7 +35,6 @@ export interface LocalSource {
   graphQLType: string
   type: string
   handle: string
-  configuration: {name: string}
 }
 
 export type MatchingError = 'pending-remote' | 'invalid-environment' | 'user-cancelled'

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.test.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.test.ts
@@ -139,7 +139,7 @@ describe('getExtensionsToMigrate()', () => {
       // Given
       const localExtension = getLocalExtension({
         type: 'ui_extension',
-        configuration: {name: 'a-different-extension'},
+        handle: 'a-different-extension',
       })
       const remoteExtension = getRemoteExtension({type: 'CHECKOUT_UI_EXTENSION', title: 'does-not-match', uuid: '5678'})
 

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -23,7 +23,7 @@ export function getUIExtensionsToMigrate(
     if (localSource.type === 'ui_extension') {
       const remoteSource = remoteSources.find((source) => {
         const matchesId = source.uuid === ids[localSource.localIdentifier]
-        const matchesTitle = slugify(source.title) === slugify(localSource.configuration.name)
+        const matchesTitle = slugify(source.title) === slugify(localSource.handle)
 
         return matchesId || matchesTitle
       })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8902,7 +8902,7 @@ packages:
     resolution: {integrity: sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA==}
     engines: {node: '>=14.16'}
     peerDependencies:
-      '@types/react': 17.0.2
+      '@types/react': '>=18.0.0'
       react: '>=18.0.0'
       react-devtools-core: ^4.19.1
     peerDependenciesMeta:
@@ -13675,7 +13675,7 @@ packages:
   /vite-tsconfig-paths@3.6.0(vite@4.4.9):
     resolution: {integrity: sha512-UfsPYonxLqPD633X8cWcPFVuYzx/CMNHAjZTasYwX69sXpa4gNmQkR0XCjj82h7zhLGdTWagMjC1qfb9S+zv0A==}
     peerDependencies:
-      vite: 4.4.9
+      vite: '>2.0.0-0'
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We were using `handle` to match extensions, but not in every part of the flow, we missed a key comparison and this caused all matching to fail when the local extension has a localized name.
It started to fail now because before introducing localized names, the `name` and `handle` were always the same initially.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Compare local `handle` with remote `title`. 
(When we create an extension, we use the initial `handle` to populate the `title`)
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Create a new app with a few extensions using unified-config and localized names (admin block for instance)
Try to `dev` multiple times (without deploying first, to avoid caching UUIDs)
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
