### PR TITLE
Fix checkout-cart-url flag

### DIFF
--- a/packages/app/src/cli/services/dev/extension.test.ts
+++ b/packages/app/src/cli/services/dev/extension.test.ts
@@ -1,4 +1,3 @@
-import * as utilities from './extension/utilities.js'
 import * as store from './extension/payload/store.js'
 import * as server from './extension/server.js'
 import * as websocket from './extension/websocket.js'
@@ -20,10 +19,10 @@ describe('devUIExtensions()', () => {
     signal: {addEventListener: vi.fn()},
     stdout: process.stdout,
     stderr: process.stderr,
+    checkoutCartUrl: 'mock/path/from/extensions',
   } as unknown as ExtensionDevOptions
 
   function spyOnEverything() {
-    vi.spyOn(utilities, 'getCartPathFromExtensions').mockResolvedValue('mock/path/from/extensions')
     vi.spyOn(store, 'getExtensionsPayloadStoreRawPayload').mockResolvedValue({
       mock: 'payload',
     } as unknown as ExtensionsEndpointPayload)
@@ -53,7 +52,7 @@ describe('devUIExtensions()', () => {
     // THEN
     expect(store.ExtensionsPayloadStore).toHaveBeenCalledWith(
       {mock: 'payload'},
-      {...options, checkoutCartUrl: 'mock/path/from/extensions', websocketURL: 'wss://mock.url/extensions'},
+      {...options, websocketURL: 'wss://mock.url/extensions'},
     )
   })
 
@@ -66,10 +65,7 @@ describe('devUIExtensions()', () => {
 
     // THEN
     expect(server.setupHTTPServer).toHaveBeenCalledWith({
-      devOptions: {
-        ...options,
-        checkoutCartUrl: 'mock/path/from/extensions',
-      },
+      devOptions: options,
       payloadStore: {mock: 'payload-store'},
     })
   })
@@ -98,10 +94,7 @@ describe('devUIExtensions()', () => {
 
     // THEN
     expect(bundler.setupBundlerAndFileWatcher).toHaveBeenCalledWith({
-      devOptions: {
-        ...options,
-        checkoutCartUrl: 'mock/path/from/extensions',
-      },
+      devOptions: options,
       payloadStore: {mock: 'payload-store'},
     })
   })

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -1,4 +1,3 @@
-import {getCartPathFromExtensions} from './extension/utilities.js'
 import {setupWebsocketConnection} from './extension/websocket.js'
 import {setupBundlerAndFileWatcher} from './extension/bundler.js'
 import {setupHTTPServer} from './extension/server.js'
@@ -100,25 +99,20 @@ export interface ExtensionDevOptions {
 }
 
 export async function devUIExtensions(options: ExtensionDevOptions): Promise<void> {
-  const devOptions: ExtensionDevOptions = {
-    ...options,
-    checkoutCartUrl: await getCartPathFromExtensions(options.extensions, options.storeFqdn, options.checkoutCartUrl),
-  }
-
   const payloadStoreOptions = {
-    ...devOptions,
+    ...options,
     websocketURL: getWebSocketUrl(options.url),
   }
   const payloadStoreRawPayload = await getExtensionsPayloadStoreRawPayload(payloadStoreOptions)
   const payloadStore = new ExtensionsPayloadStore(payloadStoreRawPayload, payloadStoreOptions)
 
   outputDebug(`Setting up the UI extensions HTTP server...`, options.stdout)
-  const httpServer = setupHTTPServer({devOptions, payloadStore})
+  const httpServer = setupHTTPServer({devOptions: options, payloadStore})
 
   outputDebug(`Setting up the UI extensions Websocket server...`, options.stdout)
   const websocketConnection = setupWebsocketConnection({...options, httpServer, payloadStore})
   outputDebug(`Setting up the UI extensions bundler and file watching...`, options.stdout)
-  const fileWatcher = await setupBundlerAndFileWatcher({devOptions, payloadStore})
+  const fileWatcher = await setupBundlerAndFileWatcher({devOptions: options, payloadStore})
 
   options.signal.addEventListener('abort', () => {
     outputDebug('Closing the UI extensions dev server...')

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -14,11 +14,7 @@ const CUSTOMER_ACCOUNT_CHECKOUT_RENDERED_TARGETS = new Set([
  * @param extensions - The UI Extensions to dev
  * @param store - The store FQDN
  */
-export async function getCartPathFromExtensions(
-  extensions: ExtensionInstance[],
-  store: string,
-  checkoutCartUrl?: string,
-) {
+export async function buildCartURLIfNeeded(extensions: ExtensionInstance[], store: string, checkoutCartUrl?: string) {
   const hasUIExtension = extensions.filter((extension) => extension.shouldFetchCartUrl()).length > 0
   if (!hasUIExtension) return undefined
   if (checkoutCartUrl) return checkoutCartUrl

--- a/packages/app/src/cli/services/dev/processes/previewable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/previewable-extension.ts
@@ -1,7 +1,7 @@
 import {BaseProcess, DevProcessFunction} from './types.js'
 import {devUIExtensions} from '../extension.js'
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
-import {fetchProductVariant} from '../../../utilities/extensions/fetch-product-variant.js'
+import {buildCartURLIfNeeded} from '../extension/utilities.js'
 import {DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 
 export const MANIFEST_VERSION = '3'
@@ -92,17 +92,4 @@ export async function setupPreviewableExtensionsProcess({
       ...options,
     },
   }
-}
-
-/**
- * To prepare Checkout UI Extensions for dev'ing we need to retrieve a valid product variant ID
- * @param extensions - The UI Extensions to dev
- * @param store - The store FQDN
- */
-export async function buildCartURLIfNeeded(extensions: ExtensionInstance[], store: string, checkoutCartUrl?: string) {
-  const hasUIExtension = extensions.map((ext) => ext.type).includes('checkout_ui_extension')
-  if (!hasUIExtension) return undefined
-  if (checkoutCartUrl) return checkoutCartUrl
-  const variantId = await fetchProductVariant(store)
-  return `/cart/${variantId}:1`
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Running the `dev` command with the flag `checkout-cart-url` is not working with checkout ui extensions generated from the new template. The product shown when you visit the checkout extension preview url is different to the one you set in the flag 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Remove the old method that built the url. It was receiving the cart url flag value and in case there are no `checkout_ui_extension`  type it returned `undefined` as the cart url. New checkout ui extensions have the generic `ui-extension` type, so we should filter them using the method `shouldFetchCartUrl` which applies to the old and new checkout ui extensions
- Remove duplicate call to the cart url build method inside the execution of the dev ui process.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Run the `dev` command with one product variant
```sh
p shopify app dev --path /path/to/your/app  --checkout-cart-url /cart/43823180349462:1
```
- Visit the checkout ui extension preview url and the product variant displayed in the cart should match the one you set in the flag

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
