### PR TITLE
Support template branches when creating apps

### DIFF
--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -46,6 +46,12 @@
           "description": "The app template. Accepts one of the following:\n       - <remix|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
           "multiple": false
         },
+        "flavor": {
+          "name": "flavor",
+          "type": "option",
+          "description": "Which flavor of the given template to use.",
+          "multiple": false
+        },
         "package-manager": {
           "name": "package-manager",
           "type": "option",

--- a/packages/create-app/src/commands/init.test.ts
+++ b/packages/create-app/src/commands/init.test.ts
@@ -41,6 +41,14 @@ describe('create app command', () => {
     expect(initService).toHaveBeenCalledOnce()
   })
 
+  test('executes correctly when using a flavor for the remix template', async () => {
+    // When
+    await Init.run(['--template', 'remix', '--flavor', 'javascript'])
+
+    // Then
+    expect(initService).toHaveBeenCalledOnce()
+  })
+
   test('executes correctly when using a non-visible template alias name', async () => {
     // When
     await Init.run(['--template', 'node'])
@@ -83,6 +91,18 @@ describe('create app command', () => {
     const expectedError = new AbortError(
       'Only GitHub repository references are supported, ' +
         'e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]',
+    )
+    expect(errorHandler).toHaveBeenCalledWith(expectedError, anyConfig)
+  })
+
+  test('throw an error when using a flavor for a template that has no branches set up', async () => {
+    // When
+    await Init.run(['--template', 'node', '--flavor', 'javascript'])
+
+    // Then
+    const anyConfig = expect.any(Config)
+    const expectedError = new AbortError(
+      outputContent`The ${outputToken.yellow('node')} template does not support flavors`,
     )
     expect(errorHandler).toHaveBeenCalledWith(expectedError, anyConfig)
   })

--- a/packages/create-app/src/commands/init.ts
+++ b/packages/create-app/src/commands/init.ts
@@ -1,4 +1,4 @@
-import initPrompt, {allTemplates, visibleTemplates} from '../prompts/init.js'
+import initPrompt, {isPredefinedTemplate, visibleTemplates} from '../prompts/init.js'
 import initService from '../services/init.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -83,7 +83,7 @@ export default class Init extends Command {
         'Only GitHub repository references are supported, ' +
           'e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]',
       )
-    if (!url && !allTemplates.includes(template))
+    if (!url && !isPredefinedTemplate(template))
       throw new AbortError(
         outputContent`Only ${visibleTemplates
           .map((alias) => outputContent`${outputToken.yellow(alias)}`.value)

--- a/packages/create-app/src/commands/init.ts
+++ b/packages/create-app/src/commands/init.ts
@@ -128,9 +128,11 @@ export default class Init extends Command {
 
     if (!templateConfig.branches.options[flavor]) {
       throw new AbortError(
-        outputContent`Only ${Object.keys(templateConfig.branches.options)
+        outputContent`Invalid option for ${outputToken.yellow('--flavor')}\nThe ${outputToken.yellow(
+          '--flavor',
+        )} flag for ${outputToken.yellow(template)} accepts only ${Object.keys(templateConfig.branches.options)
           .map((alias) => outputContent`${outputToken.yellow(alias)}`.value)
-          .join(', ')} template flavors are supported for ${outputToken.yellow(template)}`,
+          .join(', ')}`,
       )
     }
   }

--- a/packages/create-app/src/prompts/init.test.ts
+++ b/packages/create-app/src/prompts/init.test.ts
@@ -101,7 +101,7 @@ describe('init', () => {
         {label: 'JavaScript', value: 'javascript'},
         {label: 'TypeScript', value: 'main'},
       ],
-      message: 'Which template would you like to use?',
+      message: 'For your Remix template, which language do you prefer?',
     })
     expect(got).toEqual({...options, ...answers, templateType: 'remix'})
   })

--- a/packages/create-app/src/prompts/init.test.ts
+++ b/packages/create-app/src/prompts/init.test.ts
@@ -101,7 +101,7 @@ describe('init', () => {
         {label: 'JavaScript', value: 'javascript'},
         {label: 'TypeScript', value: 'main'},
       ],
-      message: 'For your Remix template, which language do you prefer?',
+      message: 'For your Remix template, which language do you want?',
     })
     expect(got).toEqual({...options, ...answers, templateType: 'remix'})
   })

--- a/packages/create-app/src/prompts/init.test.ts
+++ b/packages/create-app/src/prompts/init.test.ts
@@ -71,4 +71,38 @@ describe('init', () => {
     })
     expect(got).toEqual({...options, ...answers, templateType: 'none'})
   })
+
+  test('it renders branches for templates that have them', async () => {
+    const answers = {
+      name: 'app',
+      template: 'https://github.com/Shopify/shopify-app-template-remix#javascript',
+    }
+    const options = {directory: '/'}
+
+    // Given
+    vi.mocked(renderTextPrompt).mockResolvedValueOnce(answers.name)
+    vi.mocked(renderSelectPrompt).mockResolvedValueOnce('remix')
+    vi.mocked(renderSelectPrompt).mockResolvedValueOnce('javascript')
+
+    // When
+    const got = await init(options)
+
+    // Then
+    expect(renderSelectPrompt).toHaveBeenCalledWith({
+      choices: [
+        {label: 'Start with Remix (recommended)', value: 'remix'},
+        {label: 'Start by adding your first extension', value: 'none'},
+      ],
+      message: 'Get started building your app:',
+      defaultValue: 'remix',
+    })
+    expect(renderSelectPrompt).toHaveBeenCalledWith({
+      choices: [
+        {label: 'JavaScript', value: 'javascript'},
+        {label: 'TypeScript', value: 'main'},
+      ],
+      message: 'Which template would you like to use?',
+    })
+    expect(got).toEqual({...options, ...answers, templateType: 'remix'})
+  })
 })

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -37,7 +37,7 @@ export const templates = {
     label: 'Start with Remix (recommended)',
     visible: true,
     branches: {
-      prompt: 'For your Remix template, which language do you prefer?',
+      prompt: 'For your Remix template, which language do you want?',
       options: {
         javascript: {branch: 'javascript', label: 'JavaScript'},
         typescript: {branch: 'main', label: 'TypeScript'},

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -125,7 +125,7 @@ const init = async (options: InitOptions): Promise<InitOutput> => {
 
     if (selectedTemplate.branches) {
       const templateBranch = await renderSelectPrompt({
-        message: 'Which template would you like to use?',
+        message: 'For your Remix template, which language do you prefer?',
         choices: selectedTemplate.branches.map((branch) => ({value: branch.branch, label: branch.label})),
       })
 

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -10,27 +10,56 @@ interface InitOptions {
 interface InitOutput {
   name: string
   template: string
-  // e.g. 'Remix'
-  templateType: keyof typeof templateURLMap | 'custom'
+  // e.g. 'remix'
+  templateType: PredefinedTemplate | 'custom'
+}
+
+interface TemplateBranch {
+  branch: string
+  label: string
+}
+interface Template {
+  url: string
+  label?: string
+  visible: boolean
+  branches?: TemplateBranch[]
 }
 
 // Eventually this list should be taken from a remote location
 // That way we don't have to update the CLI every time we add a template
-export const templateURLMap = {
-  remix: {url: 'https://github.com/Shopify/shopify-app-template-remix', visible: true},
-  none: {url: 'https://github.com/Shopify/shopify-app-template-none', visible: true},
-  node: {url: 'https://github.com/Shopify/shopify-app-template-node', visible: false},
-  php: {url: 'https://github.com/Shopify/shopify-app-template-php', visible: false},
-  ruby: {url: 'https://github.com/Shopify/shopify-app-template-ruby', visible: false},
+export const templates = {
+  remix: {
+    url: 'https://github.com/Shopify/shopify-app-template-remix',
+    label: 'Start with Remix (recommended)',
+    visible: true,
+    branches: [
+      {branch: 'javascript', label: 'JavaScript'},
+      {branch: 'main', label: 'TypeScript'},
+    ],
+  } as Template,
+  none: {
+    url: 'https://github.com/Shopify/shopify-app-template-none',
+    label: 'Start by adding your first extension',
+    visible: true,
+  } as Template,
+  node: {
+    url: 'https://github.com/Shopify/shopify-app-template-node',
+    visible: false,
+  } as Template,
+  php: {
+    url: 'https://github.com/Shopify/shopify-app-template-php',
+    visible: false,
+  } as Template,
+  ruby: {
+    url: 'https://github.com/Shopify/shopify-app-template-ruby',
+    visible: false,
+  } as Template,
 } as const
+export type PredefinedTemplate = keyof typeof templates
 
-export const allTemplates = Object.keys(templateURLMap)
-export const visibleTemplates = allTemplates.filter((key) => templateURLMap[key as keyof typeof templateURLMap].visible)
+export const allTemplates = Object.keys(templates) as Readonly<PredefinedTemplate[]>
+export const visibleTemplates = allTemplates.filter((key) => templates[key].visible) as Readonly<PredefinedTemplate[]>
 
-const templateLabels = {
-  remix: 'Start with Remix (recommended)',
-  none: 'Start by adding your first extension',
-} as const
 const templateOptionsInOrder = ['remix', 'none'] as const
 
 const init = async (options: InitOptions): Promise<InitOutput> => {
@@ -39,7 +68,7 @@ const init = async (options: InitOptions): Promise<InitOutput> => {
 
   const defaults = {
     name: await generateRandomNameForSubdirectory({suffix: 'app', directory: options.directory}),
-    template: templateURLMap.remix.url,
+    template: templates.remix.url,
   } as const
 
   let welcomed = false
@@ -72,29 +101,45 @@ const init = async (options: InitOptions): Promise<InitOutput> => {
     template = await renderSelectPrompt({
       choices: templateOptionsInOrder.map((key) => {
         return {
-          label: templateLabels[key] || key,
+          label: templates[key].label || key,
           value: key,
         }
       }),
       message: 'Get started building your app:',
-      defaultValue: allTemplates.find(
-        (key) => templateURLMap[key as keyof typeof templateURLMap].url === defaults.template,
-      ),
+      defaultValue: allTemplates.find((key) => templates[key].url === defaults.template),
     })
   }
 
-  const templateIsPredefined = Object.prototype.hasOwnProperty.call(templateURLMap, template)
   const answers: InitOutput = {
     ...options,
     name,
     template,
-    templateType: templateIsPredefined ? (template as keyof typeof templateURLMap) : 'custom',
+    templateType: isPredefinedTemplate(template) ? template : 'custom',
   }
 
-  const selectedTemplate = templateURLMap[answers.template as keyof typeof templateURLMap]
-  answers.template = selectedTemplate?.url || answers.template || defaults.template
+  let selectedUrl: string | undefined
+  if (answers.templateType !== 'custom') {
+    const selectedTemplate = templates[answers.templateType]
+
+    selectedUrl = selectedTemplate.url
+
+    if (selectedTemplate.branches) {
+      const templateBranch = await renderSelectPrompt({
+        message: 'Which template would you like to use?',
+        choices: selectedTemplate.branches.map((branch) => ({value: branch.branch, label: branch.label})),
+      })
+
+      selectedUrl += `#${templateBranch}`
+    }
+  }
+
+  answers.template = selectedUrl || answers.template || defaults.template
 
   return answers
 }
 
 export default init
+
+export function isPredefinedTemplate(template: string): template is PredefinedTemplate {
+  return allTemplates.includes(template as PredefinedTemplate)
+}


### PR DESCRIPTION
### WHY are these changes introduced?

We'll have multiple options of the Remix app template going forward, and we want users to be able to select between a TS or JS version of the template.

### WHAT is this pull request doing?

Setting up the form so it asks a second question for the remix template, so the user can select a branch.

I implemented this as a generic way of adding branch options so that other templates can benefit from this in the future.

### How to test your changes?

- Run `dev create-app`, and select the remix template
- OR run `dev create-app --template remix`

![image](https://github.com/Shopify/cli/assets/64600052/102ccff6-de7a-481e-8710-540a1a79d075)

### Post-release steps

Merge [this template PR](https://github.com/Shopify/shopify-app-template-remix/pull/372) which makes `main` the TS version of the code.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition, since I'm just altering the template string we use in the end.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
