### PR TITLE
sends ui.handle as empty string instead of undefined when set

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -260,4 +260,40 @@ describe('functionConfiguration', () => {
       expect(got!.localization).toEqual(expectedLocalization)
     })
   })
+
+  test("parses ui.handle when it's an empty string", async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      extension.directory = tmpDir
+      extension.configuration.ui!.handle = ''
+
+      // When
+      const got = (await extension.deployConfig({
+        apiKey,
+        token,
+        unifiedDeployment,
+      })) as unknown as {ui: {ui_extension_handle: string}}
+
+      // Then
+      expect(got.ui?.ui_extension_handle).toStrictEqual('')
+    })
+  })
+
+  test("parses ui.handle when it's undefined", async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      extension.directory = tmpDir
+      extension.configuration.ui = undefined
+
+      // When
+      const got = (await extension.deployConfig({
+        apiKey,
+        token,
+        unifiedDeployment,
+      })) as unknown as {ui: {ui_extension_handle: string}}
+
+      // Then
+      expect(got.ui?.ui_extension_handle).toBeUndefined()
+    })
+  })
 })

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -108,7 +108,7 @@ const spec = createExtensionSpecification({
       }
     }
 
-    if (config.ui?.handle) {
+    if (config.ui?.handle !== undefined) {
       ui = {
         ...ui,
         ui_extension_handle: config.ui.handle,


### PR DESCRIPTION
### WHY are these changes introduced?

Thanks for spotting this Detla!

Right now, we are incorrectly adding `ui.handle` to the configuration of a function when `ui.handle` is set to an empty string. 

The way we add either the ui.paths or ui.handle to the config when deploying , is from setting the ui property by:

(previously)
```
    let ui: UI | undefined

    if (config.ui?.paths) {
      ui = {
        app_bridge: {
          details_path: config.ui.paths.details,
          create_path: config.ui.paths.create,
        },
      }
    }

**This check returns false when ui.handle is emptry string**
    if (config.ui?.handle) {
      ui = {
        ...ui,
        ui_extension_handle: config.ui.handle,
      }
    }
```
**thus sending ui propery as undefined when deploying**

### WHAT is this pull request doing?

Updates the check above to correctly send `ui.handle` properties when they are set to empty string. 

### How to test your changes?

Added some tests for when ui.handle is `""` or `undefined`

#### 🎩 Test deploying a function with `ui.handle` as `""`. 

<img width="349" alt="Screenshot 2023-10-04 at 9 41 39 AM" src="https://github.com/Shopify/cli/assets/16329347/998b313c-7314-45ca-b3f3-47673875d97d">

```
SPIN=1 SPIN_INSTANCE=script-service-q7k4 dev spin pnpm shopify app deploy  --path=../../../../Desktop/prod-testing/product-discounts-single-ext
```

This PR will not validate that value for `ui.handle`, only correctly set the configuration that will deployed. 

That validation is part of https://github.com/Shopify/shopify/pull/454992, and will check for an empty string in the `UiHandleValidator`.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
