### PR TITLE
Allow enabling and disabling dev store preview mode with dashboard managed extensions

### DIFF
--- a/.changeset/modern-snakes-occur.md
+++ b/.changeset/modern-snakes-occur.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Allow enabling and disabling dev store preview mode with dashboard managed extensions.

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -15,9 +15,9 @@ import {DevConfig, DevProcesses, setupDevProcesses} from './dev/processes/setup-
 import {frontAndBackendConfig} from './dev/processes/utils.js'
 import {outputUpdateURLsResult, renderDev} from './dev/ui.js'
 import {DevProcessFunction} from './dev/processes/types.js'
-import {canEnablePreviewMode} from './extensions/common.js'
 import {DeploymentMode} from './deploy/mode.js'
 import {setCachedAppInfo} from './local-storage.js'
+import {canEnablePreviewMode} from './extensions/common.js'
 import {loadApp} from '../models/app/loader.js'
 import {Web, isCurrentAppSchema, getAppScopesArray, AppInterface} from '../models/app/app.js'
 import {getAppIdentifiers} from '../models/app/identifiers.js'
@@ -289,7 +289,12 @@ async function launchDevProcesses({
   })
 
   const app = {
-    canEnablePreviewMode: canEnablePreviewMode(config.remoteApp, config.localApp),
+    canEnablePreviewMode: await canEnablePreviewMode({
+      remoteApp: config.remoteApp,
+      localApp: config.localApp,
+      token: config.token,
+      apiKey: config.remoteApp.apiKey,
+    }),
     developmentStorePreviewEnabled: config.remoteApp.developmentStorePreviewEnabled,
     apiKey: config.remoteApp.apiKey,
     token: config.token,

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -28,7 +28,14 @@ export interface DevProps {
   pollingTime?: number
 }
 
-const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUrl, graphiqlUrl, app, pollingTime = 5000}) => {
+const Dev: FunctionComponent<DevProps> = ({
+  abortController,
+  processes,
+  previewUrl,
+  graphiqlUrl,
+  app,
+  pollingTime = 5000,
+}) => {
   const {apiKey, token, canEnablePreviewMode, developmentStorePreviewEnabled} = app
   const {isRawModeSupported: canUseShortcuts} = useStdin()
   const pollingInterval = useRef<NodeJS.Timeout>()
@@ -132,7 +139,7 @@ const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUr
             await metadata.addPublicMetadata(() => ({
               cmd_dev_graphiql_opened: true,
             }))
-            openURL(graphiqlUrl)
+            await openURL(graphiqlUrl)
           } else if (input === 'q') {
             abortController.abort()
           } else if (input === 'd' && canEnablePreviewMode) {
@@ -199,7 +206,8 @@ const Dev: FunctionComponent<DevProps> = ({abortController, processes, previewUr
               ) : null}
               {graphiqlUrl ? (
                 <Text>
-                  {figures.pointerSmall} Press <Text bold>g</Text> {figures.lineVertical} open the GraphiQL Explorer in your browser
+                  {figures.pointerSmall} Press <Text bold>g</Text> {figures.lineVertical} open the GraphiQL Explorer in
+                  your browser
                 </Text>
               ) : null}
               <Text>

--- a/packages/app/src/cli/services/extensions/common.ts
+++ b/packages/app/src/cli/services/extensions/common.ts
@@ -2,6 +2,7 @@ import {AppInterface} from '../../models/app/app.js'
 import {blocks} from '../../constants.js'
 import {ExtensionFlavor} from '../../models/app/template.js'
 import {OrganizationApp} from '../../models/organization.js'
+import {fetchAppExtensionRegistrations} from '../dev/fetch.js'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {fileExists, findPathUp, mkdir} from '@shopify/cli-kit/node/fs'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -47,7 +48,19 @@ export async function ensureExtensionDirectoryExists({name, app}: {name: string;
   return extensionDirectory
 }
 
-export function canEnablePreviewMode(remoteApp: Partial<OrganizationApp>, localApp: AppInterface) {
+export async function canEnablePreviewMode({
+  remoteApp,
+  localApp,
+  token,
+  apiKey,
+}: {
+  remoteApp: Partial<OrganizationApp>
+  localApp: AppInterface
+  token: string
+  apiKey: string
+}) {
+  const {dashboardManagedExtensionRegistrations} = (await fetchAppExtensionRegistrations({token, apiKey})).app
+  if (dashboardManagedExtensionRegistrations.length > 0) return true
   const themeExtensions = localApp.allExtensions.filter((ext) => ext.isThemeExtension)
   if (themeExtensions.length > 0) return true
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-management/issues/1475

There are cases, like when developers only have dashboard managed extensions, when we weren't showing the dev preview toggle.

### WHAT is this pull request doing?

Allow enabling and disabling dev store preview mode with dashboard managed extensions when running `dev`.

### How to test your changes?

- Add a dashboard managed extension (e.g. admin link)
- Run `dev`
- Dev preview should be enabled and the toggling should be possible with `d`