### PR TITLE
Fix NPM separator warning for negated flags

### DIFF
--- a/.changeset/olive-vans-buy.md
+++ b/.changeset/olive-vans-buy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix NPM separator warning for negated flags

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -49,9 +49,9 @@ abstract class BaseCommand extends Command {
   protected showNpmFlagWarning(): void {
     const commandVariables = this.constructor as unknown as {_flags: JsonMap}
     const commandFlags = Object.keys(commandVariables._flags || {})
-    const possibleNpmEnvVars = commandFlags.map((key) => `npm_config_${underscore(key)}`)
+    const possibleNpmEnvVars = commandFlags.map((key) => `npm_config_${underscore(key).replace(/^no_/, '')}`)
 
-    if (possibleNpmEnvVars.some((flag) => process.env[flag])) {
+    if (possibleNpmEnvVars.some((flag) => process.env[flag] !== undefined)) {
       renderWarning({
         body: [
           'NPM scripts require an extra',


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/2348 we added a warning when using NPM and passing flags without the separator (`--`).

But it turns out that NPM removes the `no_` prefix for the flags. For example, passing `--no-release` will result in a `npm_config_release` environment variable. So our code to show the warning wasn't working in that case.

### WHAT is this pull request doing?

Ignore the `no_` prefix from the flags to show the warning in all cases

### How to test your changes?

`npm run shopify app deploy --no-release -- --path your-app`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
