### PR TITLE
Retain previous proxy url subpath

### DIFF
--- a/.changeset/little-nails-jog.md
+++ b/.changeset/little-nails-jog.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Retain previuos proxy url subpath

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -595,6 +595,28 @@ describe('generatePartnersURLs', () => {
       },
     })
   })
+
+  test('Returns app proxy section changing only the host of the proxy url', () => {
+    const applicationUrl = 'http://my-base-url'
+    const proxyUrl = 'http://old-base-url/subpath'
+
+    const got = generatePartnersURLs(applicationUrl, [], {url: proxyUrl, subpath: 'subpath', prefix: 'prefix'})
+
+    expect(got).toMatchObject({
+      applicationUrl,
+      redirectUrlWhitelist: [
+        `${applicationUrl}/auth/callback`,
+        `${applicationUrl}/auth/shopify/callback`,
+        `${applicationUrl}/api/auth/callback`,
+        `${applicationUrl}/${urlNamespaces.devTools}/graphiql/auth/callback`,
+      ],
+      appProxy: {
+        proxyUrl: 'http://my-base-url/subpath',
+        proxySubPath: 'subpath',
+        proxySubPathPrefix: 'prefix',
+      },
+    })
+  })
 })
 
 describe('validatePartnersURLs', () => {

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -147,7 +147,13 @@ export function generatePartnersURLs(
   }
 
   const appProxy = proxyFields
-    ? {appProxy: {proxyUrl: baseURL, proxySubPath: proxyFields.subpath, proxySubPathPrefix: proxyFields.prefix}}
+    ? {
+        appProxy: {
+          proxyUrl: replaceHost(proxyFields.url, baseURL),
+          proxySubPath: proxyFields.subpath,
+          proxySubPathPrefix: proxyFields.prefix,
+        },
+      }
     : {}
 
   return {
@@ -155,6 +161,13 @@ export function generatePartnersURLs(
     redirectUrlWhitelist,
     ...appProxy,
   }
+}
+
+function replaceHost(oldUrl: string, newUrl: string): string {
+  const oldUrlObject = new URL(oldUrl)
+  const newUrlObject = new URL(newUrl)
+  oldUrlObject.host = newUrlObject.host
+  return oldUrlObject.toString().replace(/\/$/, '')
 }
 
 export async function updateURLs(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2905

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- When the dev command is run, in case there's a previous configuration for the proxy url, its host part is replaced with the one used for the dev command. That way the old `path` is not lost
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Add proxy configuration in the remote app. Add a path to the url

<img src="https://github.com/Shopify/cli/assets/105213827/7c868ec5-57d3-4af0-a929-0329e5f17604" width=400/>

- Run the `dev` command using the modified remote app
- Check that in the `shopify.app.toml` and in the remote configuration, the proxy url contains the new host and the previous path


<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
