### PR TITLE
[Feature] Add metafield identifiers to be looked up by tax partner for querying

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1367,6 +1367,10 @@ automatically_update_urls_on_dev = true
       benchmark_api_base_url = "https://benchmark.example.com"
       calculate_taxes_api_endpoint = "/calculate-taxes"
 
+      [input.metafield_identifiers]
+      namespace = "taxy-tax"
+      key = "metafield-config"
+
       [[metafields]]
       namespace = "my-namespace"
       key = "my-key"
@@ -1396,6 +1400,12 @@ automatically_update_urls_on_dev = true
             key: 'my-key',
           },
         ],
+        input: {
+          metafield_identifiers: {
+            namespace: 'taxy-tax',
+            key: 'metafield-config',
+          },
+        },
       })
     }
   })

--- a/packages/app/src/cli/models/extensions/specifications/tax_calculation.ts
+++ b/packages/app/src/cli/models/extensions/specifications/tax_calculation.ts
@@ -6,6 +6,16 @@ const TaxCalculationsSchema = BaseSchema.extend({
   production_api_base_url: zod.string(),
   benchmark_api_base_url: zod.string().optional(),
   calculate_taxes_api_endpoint: zod.string(),
+  input: zod
+    .object({
+      metafield_identifiers: zod
+        .object({
+          namespace: zod.string(),
+          key: zod.string(),
+        })
+        .optional(),
+    })
+    .optional(),
 })
 
 const spec = createExtensionSpecification({
@@ -19,6 +29,7 @@ const spec = createExtensionSpecification({
       calculate_taxes_api_endpoint: config.calculate_taxes_api_endpoint,
       metafields: config.metafields,
       api_version: config.api_version,
+      metafield_identifiers: config.input?.metafield_identifiers,
     }
   },
 })


### PR DESCRIPTION
### WHY are these changes introduced?
Add a new field that a tax_calculation extension can set called `input.metafield_identifiers` which is an object containing a namespace/key pair. The field is [intended](https://docs.google.com/document/d/1ztZBtbZkNOal6GGlGF9F-xxJm7zO_vhUysdLiFQAtuA/edit#heading=h.bxzgv3ebhdbg) to be a metafield reference where the partner will store which metafields per merchant they want Shopify to query the value for come tax calculation time to passed back to the app.

Relies on https://github.com/Shopify/shopify/pull/456423 to complete.

### WHAT is this pull request doing?
Adding a new `tax_calculation` extension field called `input.metafield_identifiers` which will store a namespace/key pair. The pair will be used by Shopify at tax calculation time to lookup metafield values to pass along to the tax partner app.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
