### PR TITLE
Fix ink dependency error and only extension apps using yarn

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -58,7 +58,9 @@
     "http-proxy": "1.18.1",
     "javy-cli": "0.1.8",
     "serve-static": "1.15.0",
-    "ws": "8.13.0"
+    "ws": "8.13.0",
+    "ink": "4.4.1",
+    "react": "18.2.0"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.2",


### PR DESCRIPTION
### WHY are these changes introduced?
Moved to `main` this [PR](https://github.com/Shopify/cli/pull/2944) from `stable`

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
