### PR TITLE
Add missing Manage app permission to the organization not found error banner

### DIFF
--- a/.changeset/rich-zebras-suffer.md
+++ b/.changeset/rich-zebras-suffer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Add missing Manage app permission to the organization not found error banner

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -201,6 +201,8 @@ describe('NoOrgError', () => {
       │                                                                              │
       │  Next steps                                                                  │
       │    • Have you created a Shopify Partners organization [1]?                   │
+      │    • Does your account include Manage app permissions?, please contact the   │
+      │      owner of the organization to grant you access.                          │
       │    • Have you confirmed your accounts from the emails you received?          │
       │    • Need to connect to a different App or organization? Run the command     │
       │      again with \`--reset\`                                                    │

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -32,6 +32,13 @@ export class NoOrgError extends AbortError {
           char: '?',
         },
       ],
+      [
+        'Does your account include',
+        {
+          subdued: 'Manage app',
+        },
+        'permissions?, please contact the owner of the organization to grant you access.',
+      ],
       'Have you confirmed your accounts from the emails you received?',
       [
         'Need to connect to a different App or organization? Run the command again with',


### PR DESCRIPTION
### WHY are these changes introduced?
When a user authenticates using an staff account that does not include `Manage app` permission an error banner is displayed with some `try with` suggestions. However none of them references the problem with the permission.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add a this suggestion about missing `Manage app` permission to the error banner
```
 Does your account include  Manage app  permissions?, please contact the owner of the organization to grant you access. 
```
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Run the `dev` command
- Authenticate using a staff account without `Manage app` permissions
- Output
```
╭─ error ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                        │
│  No Organization found                                                                                                                 │
│                                                                                                                                        │
│  Next steps                                                                                                                            │
│    • Have you created a Shopify Partners organization?                                                                                 │
│    • Does your account include Manage app permissions?, please contact the owner of the organization to grant you access.              │
│    • Have you confirmed your accounts from the emails you received?                                                                    │
│    • Need to connect to a different App or organization? Run the command again with `--reset`                                          │
│                                                                                                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
