### PR TITLE
[cli-kit] remove full stop from outputSuccess

### DIFF
--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -263,7 +263,7 @@ export function outputInfo(content: OutputMessage, logger: Logger = consoleLog):
  * @param logger - The logging function to use to output to the user.
  */
 export function outputSuccess(content: OutputMessage, logger: Logger = consoleLog): void {
-  const message = colors.bold(`✅ Success! ${stringifyMessage(content)}.`)
+  const message = colors.bold(`✅ Success! ${stringifyMessage(content)}`)
   if (isUnitTest()) collectLog('success', content)
   outputWhereAppropriate('info', logger, message)
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

https://github.com/Shopify/oxygen-platform/issues/1373

<!--
  Context about the problem that’s being addressed.
-->
`outputSuccess` appends a full stop at the end of the success message. This causes an issue when we use it to output a deployment URL, as when a user clicks it, it will have that `.` present.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Remove the full stop. Consumers can add it as they please.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
