### PR TITLE
Unify Cloudflare errors

### DIFF
--- a/.changeset/empty-actors-bow.md
+++ b/.changeset/empty-actors-bow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/plugin-cloudflare': patch
+---
+
+Unify Cloudflare errors

--- a/packages/plugin-cloudflare/src/tunnel.test.ts
+++ b/packages/plugin-cloudflare/src/tunnel.test.ts
@@ -52,7 +52,7 @@ describe('hookStart', () => {
     const result = tunnelClient.valueOrAbort().getTunnelStatus()
 
     // Then
-    expect(result).toEqual({status: 'error', message: 'Could not find tunnel url'})
+    expect(result).toEqual({status: 'error', message: 'Could not start Cloudflare tunnel: URL not found.'})
   })
 
   test('returns starting status if a URL is detected but there is no connection yet', async () => {
@@ -105,7 +105,7 @@ describe('hookStart', () => {
     expect(exec).toBeCalledTimes(5)
     expect(result).toEqual({
       status: 'error',
-      message: 'Could not start Cloudflare tunnel, max retries reached.',
+      message: 'Could not start Cloudflare tunnel: max retries reached.',
       tryMessage: expect.anything(),
     })
   })

--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -64,7 +64,7 @@ class TunnelClientInstance implements TunnelClient {
       resolved = true
       this.currentStatus = {
         status: 'error',
-        message: 'Could not start Cloudflare tunnel, max retries reached.',
+        message: 'Could not start Cloudflare tunnel: max retries reached.',
         tryMessage: whatToTry(),
       }
       return
@@ -84,11 +84,11 @@ class TunnelClientInstance implements TunnelClient {
         if (lastErrors === '') {
           this.currentStatus = {
             status: 'error',
-            message: 'Could not start Cloudflare tunnel, unknown error.',
+            message: 'Could not start Cloudflare tunnel: unknown error.',
             tryMessage: whatToTry(),
           }
         } else {
-          this.currentStatus = {status: 'error', message: lastErrors}
+          this.currentStatus = {status: 'error', message: lastErrors, tryMessage: whatToTry()}
         }
         this.abortController?.abort()
       }
@@ -107,7 +107,7 @@ class TunnelClientInstance implements TunnelClient {
             resolved = true
             self.currentStatus = {status: 'connected', url}
           } else {
-            self.currentStatus = {status: 'error', message: 'Could not find tunnel url'}
+            self.currentStatus = {status: 'error', message: 'Could not start Cloudflare tunnel: URL not found.'}
           }
         }
         const errorMessage = findError(chunk)
@@ -127,7 +127,7 @@ class TunnelClientInstance implements TunnelClient {
           // Cloudflare crashed because Rosetta 2 is not installed
           this.currentStatus = {
             status: 'error',
-            message: `Error starting cloudflared tunnel: Missing Rosetta 2.`,
+            message: `Could not start Cloudflare tunnel: Missing Rosetta 2.`,
             tryMessage: "Install it by running 'softwareupdate --install-rosetta' and try again",
           }
           return
@@ -135,10 +135,13 @@ class TunnelClientInstance implements TunnelClient {
         // If already resolved, means that the CLI already received the tunnel URL.
         // Can't retry because the CLI is running with an invalid URL
         if (resolved) {
-          throw new BugError(`Tunnel process crashed after stablishing a connection: ${error.message}`, whatToTry())
+          throw new BugError(
+            `Could not start Cloudflare tunnel: process crashed after stablishing a connection: ${error.message}`,
+            whatToTry(),
+          )
         }
 
-        outputDebug(`Cloudflared tunnel crashed: ${error.message}, restarting...`)
+        outputDebug(`Cloudflare tunnel crashed: ${error.message}, restarting...`)
 
         // wait 1 second before restarting the tunnel, to avoid rate limiting
         if (!isUnitTest()) await sleep(1)
@@ -179,7 +182,14 @@ function findError(data: Buffer): string | undefined {
     /ERR Failed to create new quic connection error/,
   ]
   const match = knownErrors.some((error) => error.test(data.toString()))
-  return match ? data.toString() : undefined
+  if (!match) return undefined
+
+  return `Could not start Cloudflare tunnel: ${cleanCloudflareLog(data.toString())}`
+}
+
+function cleanCloudflareLog(input: string): string {
+  const prefixRegex = /^[0-9TZ:-]+ (ERR )?/g
+  return input.replace(prefixRegex, '')
 }
 
 function findConnection(data: Buffer): string | undefined {

--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -80,7 +80,7 @@ class TunnelClientInstance implements TunnelClient {
     setTimeout(() => {
       if (!resolved) {
         resolved = true
-        const lastErrors = errors.slice(-5).join('\n')
+        const lastErrors = [...new Set(errors)].slice(-5).join('\n')
         if (lastErrors === '') {
           this.currentStatus = {
             status: 'error',
@@ -189,7 +189,8 @@ function findError(data: Buffer): string | undefined {
 
 function cleanCloudflareLog(input: string): string {
   const prefixRegex = /^[0-9TZ:-]+ (ERR )?/g
-  return input.replace(prefixRegex, '')
+  const suffixRegex = /connIndex.*/g
+  return input.replace(prefixRegex, '').replace(suffixRegex, '')
 }
 
 function findConnection(data: Buffer): string | undefined {


### PR DESCRIPTION
### WHY are these changes introduced?

We are re-throwing some errors directly from Cloudflare, and it may be not very useful. Also, they differ too much, so it's hard to group them in Bugsnag ([example](https://app.bugsnag.com/shopify/cli/errors/6524ea64e7bfa100077025f9)).

### WHAT is this pull request doing?
- Prefix all Cloudflare errors with the same phrase: `Could not start Cloudflare tunnel: xxx`
- Always show some `What to try` options
- Remove some noise from Cloudflare errors, like `2023-10-10T06:07:59Z ERR` or the IPs

Before:
```
╭─ error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                           │
│  2023-10-10T06:07:59Z ERR Failed to serve quic connection error="Unauthorized: Failed to get tunnel" connIndex=0 event=0 ip=198.41.200.113                │
│                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```

After:

```
╭─ error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                           │
│  Could not start Cloudflare tunnel: Failed to serve quic connection error="Unauthorized: Failed to get tunnel"                                            │
│                                                                                                                                                           │
│  What to try:                                                                                                                                             │
│    • Run the command again                                                                                                                                │
│    • Add the flag `--tunnel-url {URL}` to use a custom tunnel URL                                                                                         │
│                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

### How to test your changes?

- Add another item [here](https://github.com/Shopify/cli/blob/516893d447b472ec648006c29532ca08e5582db5/packages/plugin-cloudflare/src/tunnel.ts#L175) like `Requesting new quick Tunnel`, which is always shown in cloudflared log
- Comment out [this line](https://github.com/Shopify/cli/blob/516893d447b472ec648006c29532ca08e5582db5/packages/plugin-cloudflare/src/tunnel.ts#L104)
- `p shopify app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
