### PR TITLE
Add reliability metrics to monorail tracking

### DIFF
--- a/.changeset/tough-badgers-peel.md
+++ b/.changeset/tough-badgers-peel.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+
+Add monorail config for reliability metrics

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@octokit/rest": "^19.0.13",
     "@shopify/eslint-plugin-cli": "file:packages/eslint-plugin-cli",
     "@shopify/typescript-configs": "^5.1.0",
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "@types/rimraf": "^3.0.2",
     "@types/tmp": "^0.2.3",
     "@typescript-eslint/parser": "^5.62.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,7 +68,7 @@
     "@types/express": "^4.17.17",
     "@types/http-proxy": "^1.17.11",
     "@types/lodash-es": "^4.17.9",
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "@types/react": "18.2.0",
     "@types/serve-static": "^1.15.2",
     "@types/ws": "^8.5.5",

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -172,7 +172,7 @@ async function actionsBeforeLaunchingDevProcesses(config: DevConfig) {
     deploymentMode: config.usesUnifiedDeployment ? 'unified' : 'legacy',
   })
 
-  await reportAnalyticsEvent({config: config.commandOptions.commandConfig})
+  await reportAnalyticsEvent({config: config.commandOptions.commandConfig, exitMode: 'ok'})
 }
 
 function getDevUUIDsForAllExtensions(localApp: AppInterface, apiKey: string) {

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -172,7 +172,7 @@
     "@types/git-diff": "^2.0.3",
     "@types/gradient-string": "^1.1.2",
     "@types/lodash": "4.14.195",
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "@types/react": "18.2.0",
     "@types/semver": "^7.5.2",
     "@vitest/coverage-istanbul": "^0.34.3",

--- a/packages/cli-kit/src/private/node/session/authorize.ts
+++ b/packages/cli-kit/src/private/node/session/authorize.ts
@@ -8,6 +8,7 @@ import {keypress, renderConfirmationPrompt} from '../../../public/node/ui.js'
 import {outputInfo} from '../../../public/node/output.js'
 import {checkPort as isPortAvailable} from 'get-port-please'
 import findProcess from 'find-process'
+import {runWithTimer} from '@shopify/cli-kit/node/metadata'
 
 export interface CodeAuthResult {
   code: string
@@ -44,15 +45,17 @@ export async function authorize(scopes: string[], state: string = randomHex(30))
   url = `${url}?${new URLSearchParams(params).toString()}`
   await openURL(url)
 
-  const result = await listenRedirect(host, port, url)
+  return runWithTimer('cmd_all_timing_prompts_ms')(async () => {
+    const result = await listenRedirect(host, port, url)
 
-  if (result.state !== state) {
-    throw new AbortError(
-      "The state received from the authentication doesn't match the one that initiated the authentication process.",
-    )
-  }
+    if (result.state !== state) {
+      throw new AbortError(
+        "The state received from the authentication doesn't match the one that initiated the authentication process.",
+      )
+    }
 
-  return {code: result.code, codeVerifier}
+    return {code: result.code, codeVerifier}
+  })
 }
 
 function generateRandomChallengePair() {

--- a/packages/cli-kit/src/private/node/session/authorize.ts
+++ b/packages/cli-kit/src/private/node/session/authorize.ts
@@ -6,9 +6,9 @@ import {AbortError, CancelExecution} from '../../../public/node/error.js'
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {keypress, renderConfirmationPrompt} from '../../../public/node/ui.js'
 import {outputInfo} from '../../../public/node/output.js'
+import {runWithTimer} from '../../../public/node/metadata.js'
 import {checkPort as isPortAvailable} from 'get-port-please'
 import findProcess from 'find-process'
-import {runWithTimer} from '@shopify/cli-kit/node/metadata'
 
 export interface CodeAuthResult {
   code: string

--- a/packages/cli-kit/src/public/node/error-handler.test.ts
+++ b/packages/cli-kit/src/public/node/error-handler.test.ts
@@ -111,7 +111,7 @@ describe('bugsnag metadata', () => {
 describe('send to Bugsnag', () => {
   test('processes Error instances as unhandled', async () => {
     const toThrow = new Error('In test')
-    const res = await sendErrorToBugsnag(toThrow)
+    const res = await sendErrorToBugsnag(toThrow, 'unexpected_error')
     expect(res.reported).toEqual(true)
     expect(res.unhandled).toEqual(true)
 
@@ -123,7 +123,7 @@ describe('send to Bugsnag', () => {
   })
 
   test('processes string instances', async () => {
-    const res = await sendErrorToBugsnag('In test' as any)
+    const res = await sendErrorToBugsnag('In test' as any, 'unexpected_error')
     expect(res.reported).toEqual(true)
     const {error} = res as any
     expect(error.stack).toMatch(/^Error: In test/)
@@ -131,14 +131,14 @@ describe('send to Bugsnag', () => {
   })
 
   test('processes AbortErrors as handled', async () => {
-    const res = await sendErrorToBugsnag(new error.AbortError('In test'))
+    const res = await sendErrorToBugsnag(new error.AbortError('In test'), 'expected_error')
     expect(res.reported).toEqual(true)
     expect(res.unhandled).toEqual(false)
     expect(onNotify).toHaveBeenCalledWith(res.error)
   })
 
   test.each([null, undefined, {}, {message: 'nope'}])('deals with strange things to throw %s', async (throwable) => {
-    const res = await sendErrorToBugsnag(throwable)
+    const res = await sendErrorToBugsnag(throwable, 'unexpected_error')
     expect(res.reported).toEqual(false)
     expect(onNotify).not.toHaveBeenCalled()
   })

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -8,7 +8,7 @@ import {Command, Hook} from '@oclif/core'
 // This hook is called after each successful command run. More info: https://oclif.io/docs/hooks
 export const hook: Hook.Postrun = async ({config, Command}) => {
   await detectStopCommand(Command as unknown as typeof Command)
-  await reportAnalyticsEvent({config})
+  await reportAnalyticsEvent({config, exitMode: 'ok'})
   deprecationsHook(Command)
 
   const command = Command?.id?.replace(/:/g, ' ')

--- a/packages/cli-kit/src/public/node/metadata.test.ts
+++ b/packages/cli-kit/src/public/node/metadata.test.ts
@@ -108,25 +108,11 @@ describe('runtime metadata', () => {
     // eslint-disable-next-line id-length
     const {a, b, c, d, e} = container.getAllPublicMetadata() as any
 
-    // because measurements are so small, the `.toBeCloseTo` matcher is not sufficient
-
-    // all the numbers should be between these bounds
-    const lowerBound = 8
-    const upperBound = 20
-    expect(a).toBeGreaterThanOrEqual(lowerBound)
-    expect(a).toBeLessThanOrEqual(upperBound)
-
-    expect(b).toBeGreaterThanOrEqual(lowerBound)
-    expect(b).toBeLessThanOrEqual(upperBound)
-
-    expect(c).toBeGreaterThanOrEqual(lowerBound)
-    expect(c).toBeLessThanOrEqual(upperBound)
-
-    expect(d).toBeGreaterThanOrEqual(lowerBound)
-    expect(d).toBeLessThanOrEqual(upperBound)
-
-    expect(e).toBeGreaterThanOrEqual(lowerBound)
-    expect(e).toBeLessThanOrEqual(upperBound)
+    expect(a).toBeGreaterThanOrEqual(0)
+    expect(b).toBeGreaterThanOrEqual(0)
+    expect(c).toBeGreaterThanOrEqual(0)
+    expect(d).toBeGreaterThanOrEqual(0)
+    expect(e).toBeGreaterThanOrEqual(0)
 
     const performanceEntries = performance.getEntries()
 

--- a/packages/cli-kit/src/public/node/metadata.test.ts
+++ b/packages/cli-kit/src/public/node/metadata.test.ts
@@ -110,21 +110,23 @@ describe('runtime metadata', () => {
 
     // because measurements are so small, the `.toBeCloseTo` matcher is not sufficient
 
-    // all the numbers should be between 9 and 15
-    expect(a).toBeGreaterThanOrEqual(9)
-    expect(a).toBeLessThanOrEqual(15)
+    // all the numbers should be between these bounds
+    const lowerBound = 8
+    const upperBound = 20
+    expect(a).toBeGreaterThanOrEqual(lowerBound)
+    expect(a).toBeLessThanOrEqual(upperBound)
 
-    expect(b).toBeGreaterThanOrEqual(9)
-    expect(b).toBeLessThanOrEqual(15)
+    expect(b).toBeGreaterThanOrEqual(lowerBound)
+    expect(b).toBeLessThanOrEqual(upperBound)
 
-    expect(c).toBeGreaterThanOrEqual(9)
-    expect(c).toBeLessThanOrEqual(15)
+    expect(c).toBeGreaterThanOrEqual(lowerBound)
+    expect(c).toBeLessThanOrEqual(upperBound)
 
-    expect(d).toBeGreaterThanOrEqual(9)
-    expect(d).toBeLessThanOrEqual(15)
+    expect(d).toBeGreaterThanOrEqual(lowerBound)
+    expect(d).toBeLessThanOrEqual(upperBound)
 
-    expect(e).toBeGreaterThanOrEqual(9)
-    expect(e).toBeLessThanOrEqual(15)
+    expect(e).toBeGreaterThanOrEqual(lowerBound)
+    expect(e).toBeLessThanOrEqual(upperBound)
 
     const performanceEntries = performance.getEntries()
 

--- a/packages/cli-kit/src/public/node/metadata.ts
+++ b/packages/cli-kit/src/public/node/metadata.ts
@@ -138,9 +138,9 @@ export function createRuntimeMetadataContainer<
         end = Math.max(start, end)
 
         // The top of the stack is the total time for all nested timers
-        const wallClockDuration = end - start
+        const wallClockDuration = Math.max(end - start, 0)
         const childDurations = durationStack.pop() as number
-        const duration = wallClockDuration - childDurations
+        const duration = Math.max(wallClockDuration - childDurations, 0)
 
         // If this is the topmost timer, the stack will be empty.
         if (durationStack.length > 0) {

--- a/packages/cli-kit/src/public/node/metadata.ts
+++ b/packages/cli-kit/src/public/node/metadata.ts
@@ -133,7 +133,9 @@ export function createRuntimeMetadataContainer<
         // Do the work, and time it
         const start = performance.now()
         const result = await fn()
-        const end = performance.now()
+        let end = performance.now()
+        // For very short durations, the end time can be before the start time(!) - we flatten this out to zero.
+        end = Math.max(start, end)
 
         // The top of the stack is the total time for all nested timers
         const wallClockDuration = end - start

--- a/packages/cli-kit/src/public/node/metadata.ts
+++ b/packages/cli-kit/src/public/node/metadata.ts
@@ -1,9 +1,8 @@
-import {MonorailEventPublic} from './monorail.js'
-import {sendErrorToBugsnag} from './error-handler.js'
 import {isUnitTest} from './context/local.js'
-import {PickByPrefix} from '../common/ts/pick-by-prefix.js'
-import {AnyJson} from '../../private/common/json.js'
 import {performance} from 'node:perf_hooks'
+import type {PickByPrefix} from '../common/ts/pick-by-prefix.js'
+import type {AnyJson} from '../../private/common/json.js'
+import type {MonorailEventPublic} from './monorail.js'
 
 type ProvideMetadata<T> = () => Partial<T> | Promise<Partial<T>>
 
@@ -95,6 +94,8 @@ export function createRuntimeMetadataContainer<
         await getAndSet()
         // eslint-disable-next-line no-catch-all/no-catch-all, @typescript-eslint/no-explicit-any
       } catch (error: any) {
+        // This is very prone to becoming a circular dependency, so we import it dynamically
+        const {sendErrorToBugsnag} = await import('./error-handler.js')
         await sendErrorToBugsnag(error, 'unexpected_error')
       }
     }

--- a/packages/cli-kit/src/public/node/metadata.ts
+++ b/packages/cli-kit/src/public/node/metadata.ts
@@ -3,6 +3,7 @@ import {sendErrorToBugsnag} from './error-handler.js'
 import {isUnitTest} from './context/local.js'
 import {PickByPrefix} from '../common/ts/pick-by-prefix.js'
 import {AnyJson} from '../../private/common/json.js'
+import {performance} from 'node:perf_hooks'
 
 type ProvideMetadata<T> = () => Partial<T> | Promise<Partial<T>>
 
@@ -26,6 +27,13 @@ function getMetadataErrorHandlingStrategy(): 'mute-and-report' | 'bubble' {
   return 'mute-and-report'
 }
 
+/**
+ * Any key in T that has a numeric value.
+ */
+type NumericKeyOf<T> = {
+  [K in keyof T]: T[K] extends number ? (K extends string ? K : never) : never
+}[keyof T]
+
 export interface RuntimeMetadataManager<TPublic extends AnyJson, TSensitive extends AnyJson> {
   /** Add some public metadata -- this should not contain any PII. */
   addPublicMetadata: (getData: ProvideMetadata<TPublic>, onError?: MetadataErrorHandling) => Promise<void>
@@ -38,6 +46,8 @@ export interface RuntimeMetadataManager<TPublic extends AnyJson, TSensitive exte
   getAllPublicMetadata: () => Partial<TPublic>
   /** Get a snapshot of the tracked sensitive data. */
   getAllSensitiveMetadata: () => Partial<TSensitive>
+  /** Run a function, monitoring how long it takes, and adding the elapsed time to a running total. */
+  runWithTimer: (field: NumericKeyOf<TPublic>) => <T>(fn: () => Promise<T>) => Promise<T>
 }
 
 export type PublicSchema<T> = T extends RuntimeMetadataManager<infer TPublic, infer _TSensitive> ? TPublic : never
@@ -85,10 +95,13 @@ export function createRuntimeMetadataContainer<
         await getAndSet()
         // eslint-disable-next-line no-catch-all/no-catch-all, @typescript-eslint/no-explicit-any
       } catch (error: any) {
-        await sendErrorToBugsnag(error)
+        await sendErrorToBugsnag(error, 'unexpected_error')
       }
     }
   }
+
+  // See `runWithTimer` below.
+  const durationStack: number[] = []
 
   return {
     getAllPublicMetadata: () => {
@@ -102,6 +115,55 @@ export function createRuntimeMetadataContainer<
     },
     addSensitiveMetadata: async (getData: ProvideMetadata<TSensitive>, onError: MetadataErrorHandling = 'auto') => {
       return addMetadata(addSensitive, getData, onError)
+    },
+    runWithTimer: (field: NumericKeyOf<TPublic>): (<T>(fn: () => Promise<T>) => Promise<T>) => {
+      return async (fn) => {
+        /**
+         * For nested timers, we subtract the inner timer's duration from the outer timer's. We use a stack to track the
+         * cumulative durations of nested timers. On starting a timer, we push a zero onto the stack to initialize the total
+         * duration for subsequent nested timers. Before logging, we pop the stack to get the total nested timers' duration.
+         * We subtract this from the current timer's actual duration to get its measurable duration. We then add the current
+         * timer's actual duration to the stack's top, allowing any parent timer to deduct it from its own duration.
+         */
+
+        // Initialise the running total duration for all nested timers
+        durationStack.push(0)
+
+        // Do the work, and time it
+        const start = performance.now()
+        const result = await fn()
+        const end = performance.now()
+
+        // The top of the stack is the total time for all nested timers
+        const wallClockDuration = end - start
+        const childDurations = durationStack.pop() as number
+        const duration = wallClockDuration - childDurations
+
+        // If this is the topmost timer, the stack will be empty.
+        if (durationStack.length > 0) {
+          durationStack[durationStack.length - 1] += wallClockDuration
+        }
+
+        // Log it -- we include it in the metadata, but also log via the standard performance API. The TS types for this library are not quite right, so we have to cast to `any` here.
+        performance.measure(`${field}#measurable`, {
+          start,
+          duration,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any)
+        performance.measure(`${field}#wall`, {
+          start,
+          end,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any)
+
+        // There might not be a value set, yet
+        let currentValue = (raw.public[field] || 0) as number
+        currentValue += duration
+
+        // TS is not quite smart enough to realise that raw.public[field] must be a numeric type
+        raw.public[field] = currentValue as TPublic[NumericKeyOf<TPublic>]
+        return result
+      }
     },
   }
 }
@@ -122,9 +184,10 @@ const coreData = createRuntimeMetadataContainer<
       startArgs: string[]
     }
   } & {environmentFlags: string}
->()
+>({cmd_all_timing_network_ms: 0, cmd_all_timing_prompts_ms: 0})
 
-export const {getAllPublicMetadata, getAllSensitiveMetadata, addPublicMetadata, addSensitiveMetadata} = coreData
+export const {getAllPublicMetadata, getAllSensitiveMetadata, addPublicMetadata, addSensitiveMetadata, runWithTimer} =
+  coreData
 
 export type Public = PublicSchema<typeof coreData>
 export type Sensitive = SensitiveSchema<typeof coreData>

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -10,7 +10,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 type Optional<T> = T | null
 
 // This is the topic name of the main event we log to Monorail, the command tracker
-export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.9' as const
+export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.10' as const
 
 export interface Schemas {
   [MONORAIL_COMMAND_TOPIC]: {
@@ -52,6 +52,11 @@ export interface Schemas {
       cmd_all_plugin?: Optional<string>
       cmd_all_topic?: Optional<string>
       cmd_all_verbose?: Optional<boolean>
+      cmd_all_exit?: Optional<string>
+
+      cmd_all_timing_network_ms?: Optional<number>
+      cmd_all_timing_prompts_ms?: Optional<number>
+      cmd_all_timing_active_ms?: Optional<number>
 
       // Any extension related command
       cmd_extensions_binary_from_source?: Optional<boolean>

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -3,6 +3,7 @@ import {AbortController, AbortSignal} from './abort.js'
 import {exec} from './system.js'
 import {fileExists, readFile, writeFile, findPathUp, glob} from './fs.js'
 import {dirname, joinPath} from './path.js'
+import {runWithTimer} from './metadata.js'
 import {outputToken, outputContent, outputDebug} from '../../public/node/output.js'
 import {Version} from '../../private/node/semver.js'
 import latestVersion from 'latest-version'
@@ -185,7 +186,9 @@ export async function installNodeModules(options: InstallNodeModulesOptions): Pr
   if (options.args) {
     args = args.concat(options.args)
   }
-  await exec(options.packageManager, args, execOptions)
+  await runWithTimer('cmd_all_timing_network_ms')(async () => {
+    await exec(options.packageManager, args, execOptions)
+  })
 }
 
 /**
@@ -599,7 +602,9 @@ export async function addResolutionOrOverride(directory: string, dependencies: {
  */
 async function getLatestNPMPackageVersion(name: string) {
   outputDebug(outputContent`Getting the latest version of NPM package: ${outputToken.raw(name)}`)
-  return latestVersion(name)
+  return runWithTimer('cmd_all_timing_network_ms')(() => {
+    return latestVersion(name)
+  })
 }
 
 /**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -105,7 +105,7 @@
   "devDependencies": {
     "@shopify/app": "3.49.1",
     "@shopify/theme": "3.49.1",
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "@vitest/coverage-istanbul": "^0.34.3",
     "vite": "^4.4.9",
     "vitest": "^0.34.3"

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -53,7 +53,7 @@
     "@shopify/cli-kit": "3.49.1"
   },
   "devDependencies": {
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "vite": "^4.4.9",
     "vitest": "^0.34.3"
   },

--- a/packages/eslint-plugin-cli/config.js
+++ b/packages/eslint-plugin-cli/config.js
@@ -144,6 +144,7 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         'no-restricted-syntax': 'off',
         '@shopify/cli/required-fields-when-loading-app': 'off',
+        '@typescript-eslint/ban-types': 'off',
       },
     },
   ],

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -30,7 +30,7 @@
     "@cucumber/messages": "22.0.0",
     "@cucumber/pretty-formatter": "1.0.0",
     "@types/fs-extra": "^9.0.13",
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "@types/rimraf": "^3.0.2",
     "ansi-colors": "^4.1.3",
     "execa": "^7.2.0",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -41,7 +41,7 @@
     "yaml": "2.3.2"
   },
   "devDependencies": {
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "json-schema-to-zod": "0.6.3",
     "node-stream-zip": "^1.15.0",
     "vite": "^4.4.9",

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@shopify/react-testing": "^3.0.0",
     "@shopify/ui-extensions-test-utils": "3.25.0",
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "@types/qrcode.react": "^1.0.2",
     "@types/react": "16.14.0",
     "@types/react-dom": "^16.9.11",

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@shopify/react-testing": "^3.0.0",
     "@shopify/ui-extensions-test-utils": "3.25.0",
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "@types/react": "17.0.2",
     "@types/react-dom": "^16.9.11",
     "@vitejs/plugin-react-refresh": "^1.3.6",

--- a/packages/ui-extensions-test-utils/package.json
+++ b/packages/ui-extensions-test-utils/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@shopify/react-testing": "^3.0.0",
-    "@types/node": "14.18.56",
+    "@types/node": "16.18.57",
     "@types/react": "16.14.0",
     "@types/react-dom": "^16.9.11",
     "mock-socket": "^9.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,10 +30,10 @@ importers:
         version: 16.7.4
       '@nx/eslint-plugin':
         specifier: 16.7.4
-        version: 16.7.4(@types/node@14.18.56)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2)
+        version: 16.7.4(@types/node@16.18.57)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2)
       '@nx/js':
         specifier: 16.7.4
-        version: 16.7.4(@types/node@14.18.56)(nx@16.7.4)(typescript@5.2.2)
+        version: 16.7.4(@types/node@16.18.57)(nx@16.7.4)(typescript@5.2.2)
       '@nx/workspace':
         specifier: 16.7.4
         version: 16.7.4
@@ -50,8 +50,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       '@types/rimraf':
         specifier: ^3.0.2
         version: 3.0.2
@@ -108,7 +108,7 @@ importers:
         version: 16.7.4
       oclif:
         specifier: 3.16.0
-        version: 3.16.0(@types/node@14.18.56)(typescript@5.2.2)
+        version: 3.16.0(@types/node@16.18.57)(typescript@5.2.2)
       octokit-plugin-create-pull-request:
         specifier: ^3.12.2
         version: 3.13.1
@@ -141,7 +141,7 @@ importers:
         version: 0.2.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@14.18.56)(typescript@5.2.2)
+        version: 10.9.1(@types/node@16.18.57)(typescript@5.2.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -156,7 +156,7 @@ importers:
         version: 3.8.1(esbuild@0.19.3)(graphql-tag@2.12.6)(graphql@16.8.1)
       '@oclif/core':
         specifier: 2.11.7
-        version: 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+        version: 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       '@shopify/cli-kit':
         specifier: 3.49.1
         version: link:../cli-kit
@@ -228,8 +228,8 @@ importers:
         specifier: ^4.17.9
         version: 4.17.9
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       '@types/react':
         specifier: 17.0.2
         version: 17.0.2
@@ -250,7 +250,7 @@ importers:
         version: 2.12.6(graphql@16.8.1)
       vite:
         specifier: 4.4.9
-        version: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+        version: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
       vitest:
         specifier: ^0.34.3
         version: 0.34.4(jsdom@20.0.3)
@@ -259,16 +259,16 @@ importers:
     dependencies:
       '@oclif/core':
         specifier: 2.11.7
-        version: 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+        version: 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       '@oclif/plugin-commands':
         specifier: 2.2.24
-        version: 2.2.24(@types/node@14.18.56)(typescript@5.2.2)
+        version: 2.2.24(@types/node@16.18.57)(typescript@5.2.2)
       '@oclif/plugin-help':
         specifier: 5.2.18
-        version: 5.2.18(@types/node@14.18.56)(typescript@5.2.2)
+        version: 5.2.18(@types/node@16.18.57)(typescript@5.2.2)
       '@oclif/plugin-plugins':
         specifier: 3.1.8
-        version: 3.1.8(@types/node@14.18.56)(typescript@5.2.2)
+        version: 3.1.8(@types/node@16.18.57)(typescript@5.2.2)
       '@shopify/cli-kit':
         specifier: 3.49.1
         version: link:../cli-kit
@@ -286,14 +286,14 @@ importers:
         specifier: 3.49.1
         version: link:../theme
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       '@vitest/coverage-istanbul':
         specifier: ^0.34.3
         version: 0.34.4(vitest@0.34.4)
       vite:
         specifier: 4.4.9
-        version: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+        version: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
       vitest:
         specifier: ^0.34.3
         version: 0.34.4(jsdom@20.0.3)
@@ -308,7 +308,7 @@ importers:
         version: 2.2.5
       '@oclif/core':
         specifier: 2.11.7
-        version: 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+        version: 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       '@opentelemetry/api':
         specifier: 1.6.0
         version: 1.6.0
@@ -515,8 +515,8 @@ importers:
         specifier: 4.14.195
         version: 4.14.195
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       '@types/react':
         specifier: 17.0.2
         version: 17.0.2
@@ -540,7 +540,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: 4.4.9
-        version: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+        version: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
       vitest:
         specifier: ^0.34.3
         version: 0.34.4(jsdom@20.0.3)
@@ -549,17 +549,17 @@ importers:
     dependencies:
       '@oclif/core':
         specifier: 2.11.7
-        version: 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+        version: 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       '@shopify/cli-kit':
         specifier: 3.49.1
         version: link:../cli-kit
     devDependencies:
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       vite:
         specifier: 4.4.9
-        version: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+        version: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
       vitest:
         specifier: ^0.34.3
         version: 0.34.4(jsdom@20.0.3)
@@ -640,8 +640,8 @@ importers:
         specifier: ^9.0.13
         version: 9.0.13
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       '@types/rimraf':
         specifier: ^3.0.2
         version: 3.0.2
@@ -671,7 +671,7 @@ importers:
     dependencies:
       '@oclif/core':
         specifier: 2.11.7
-        version: 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+        version: 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       '@shopify/cli-kit':
         specifier: 3.49.1
         version: link:../cli-kit
@@ -684,7 +684,7 @@ importers:
     devDependencies:
       vite:
         specifier: 4.4.9
-        version: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+        version: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
       vitest:
         specifier: ^0.34.3
         version: 0.34.4(jsdom@20.0.3)
@@ -693,7 +693,7 @@ importers:
     dependencies:
       '@oclif/core':
         specifier: 2.11.7
-        version: 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+        version: 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       '@shopify/cli-kit':
         specifier: 3.49.1
         version: link:../cli-kit
@@ -703,7 +703,7 @@ importers:
     devDependencies:
       vite:
         specifier: 4.4.9
-        version: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+        version: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
       vitest:
         specifier: ^0.34.3
         version: 0.34.4(jsdom@20.0.3)
@@ -712,7 +712,7 @@ importers:
     dependencies:
       '@oclif/core':
         specifier: 2.11.7
-        version: 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+        version: 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       '@shopify/cli-kit':
         specifier: 3.49.1
         version: link:../cli-kit
@@ -727,8 +727,8 @@ importers:
         version: 2.3.2
     devDependencies:
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       json-schema-to-zod:
         specifier: 0.6.3
         version: 0.6.3
@@ -737,7 +737,7 @@ importers:
         version: 1.15.0
       vite:
         specifier: 4.4.9
-        version: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+        version: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
       vitest:
         specifier: ^0.34.3
         version: 0.34.4(jsdom@20.0.3)
@@ -785,8 +785,8 @@ importers:
         specifier: 3.25.0
         version: link:../ui-extensions-test-utils
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       '@types/qrcode.react':
         specifier: ^1.0.2
         version: 1.0.2
@@ -804,13 +804,13 @@ importers:
         version: 1.64.2
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@14.18.56)(typescript@5.2.2)
+        version: 10.9.1(@types/node@16.18.57)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
         specifier: 4.4.9
-        version: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+        version: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
       vite-tsconfig-paths:
         specifier: ^3.3.14
         version: 3.6.0(vite@4.4.9)
@@ -827,8 +827,8 @@ importers:
         specifier: 3.25.0
         version: link:../ui-extensions-test-utils
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       '@types/react':
         specifier: 17.0.2
         version: 17.0.2
@@ -855,7 +855,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@14.18.56)(typescript@5.2.2)
+        version: 10.9.1(@types/node@16.18.57)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -864,7 +864,7 @@ importers:
         version: 0.8.0
       vite:
         specifier: 4.4.9
-        version: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+        version: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
       vite-tsconfig-paths:
         specifier: ^3.3.14
         version: 3.6.0(vite@4.4.9)
@@ -878,8 +878,8 @@ importers:
         specifier: ^3.0.0
         version: 3.3.10(react-dom@17.0.2)(react@17.0.2)
       '@types/node':
-        specifier: 14.18.56
-        version: 14.18.56
+        specifier: 16.18.57
+        version: 16.18.57
       '@types/react':
         specifier: 17.0.2
         version: 17.0.2
@@ -897,7 +897,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@14.18.56)(typescript@5.2.2)
+        version: 10.9.1(@types/node@16.18.57)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -3269,7 +3269,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
       '@types/yargs': 15.0.15
       chalk: 4.1.2
     dev: true
@@ -3612,10 +3612,10 @@ packages:
       - nx
     dev: true
 
-  /@nrwl/eslint-plugin-nx@16.7.4(@types/node@14.18.56)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2):
+  /@nrwl/eslint-plugin-nx@16.7.4(@types/node@16.18.57)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2):
     resolution: {integrity: sha512-/qN/Gn0f+7fxmxLO/mSacous3fkBXCeauKKIeJQl6uSi1aVhV/u4BddNK+d2zn5WNN/xBI+xZThM+DYJMsiXjA==}
     dependencies:
-      '@nx/eslint-plugin': 16.7.4(@types/node@14.18.56)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2)
+      '@nx/eslint-plugin': 16.7.4(@types/node@16.18.57)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3632,10 +3632,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/js@16.7.4(@types/node@14.18.56)(nx@16.7.4)(typescript@5.2.2):
+  /@nrwl/js@16.7.4(@types/node@16.18.57)(nx@16.7.4)(typescript@5.2.2):
     resolution: {integrity: sha512-7mQnzhUUSpMOnSxM10Q2XOWWEj+GdtV7HVt1s+LDvRVXSFNLWBOucjfBunbttYGO36aKk+ZPCU53SvwH2aL5eA==}
     dependencies:
-      '@nx/js': 16.7.4(@types/node@14.18.56)(nx@16.7.4)(typescript@5.2.2)
+      '@nx/js': 16.7.4(@types/node@16.18.57)(nx@16.7.4)(typescript@5.2.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3686,7 +3686,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@nx/eslint-plugin@16.7.4(@types/node@14.18.56)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2):
+  /@nx/eslint-plugin@16.7.4(@types/node@16.18.57)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2):
     resolution: {integrity: sha512-PjpXeW/Tr/y/PJSEaB9X2xNaqW6mYXzcFSAXQrlxuDNdVEtrieSj+OiAGKfaYjkcN1d/X9dupV6b/L0V+HcSlw==}
     peerDependencies:
       '@typescript-eslint/parser': ^5.60.1
@@ -3695,9 +3695,9 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      '@nrwl/eslint-plugin-nx': 16.7.4(@types/node@14.18.56)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2)
+      '@nrwl/eslint-plugin-nx': 16.7.4(@types/node@16.18.57)(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(nx@16.7.4)(typescript@5.2.2)
       '@nx/devkit': 16.7.4(nx@16.7.4)
-      '@nx/js': 16.7.4(@types/node@14.18.56)(nx@16.7.4)(typescript@5.2.2)
+      '@nx/js': 16.7.4(@types/node@16.18.57)(nx@16.7.4)(typescript@5.2.2)
       '@typescript-eslint/parser': 5.62.0(eslint@8.49.0)(typescript@5.2.2)
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.49.0)(typescript@5.2.2)
       '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.2.2)
@@ -3720,7 +3720,7 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/js@16.7.4(@types/node@14.18.56)(nx@16.7.4)(typescript@5.2.2):
+  /@nx/js@16.7.4(@types/node@16.18.57)(nx@16.7.4)(typescript@5.2.2):
     resolution: {integrity: sha512-aJnpJkgGgEt1IjsV/ywZRLZ4B5/jDkTtdVu+Wf+6UrtlWji7sq2PC96NSuKeEHjq3oAvNsBc8+u2rjB/9a+8jQ==}
     peerDependencies:
       verdaccio: ^5.0.4
@@ -3735,7 +3735,7 @@ packages:
       '@babel/preset-env': 7.22.9(@babel/core@7.22.19)
       '@babel/preset-typescript': 7.22.5(@babel/core@7.22.19)
       '@babel/runtime': 7.22.6
-      '@nrwl/js': 16.7.4(@types/node@14.18.56)(nx@16.7.4)(typescript@5.2.2)
+      '@nrwl/js': 16.7.4(@types/node@16.18.57)(nx@16.7.4)(typescript@5.2.2)
       '@nx/devkit': 16.7.4(nx@16.7.4)
       '@nx/workspace': 16.7.4
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.2.2)
@@ -3751,7 +3751,7 @@ packages:
       minimatch: 3.0.5
       semver: 7.5.3
       source-map-support: 0.5.19
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@16.18.57)(typescript@5.2.2)
       tsconfig-paths: 4.2.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -3883,7 +3883,7 @@ packages:
       supports-color: 8.1.1
       tslib: 2.6.2
 
-  /@oclif/core@2.11.7(@types/node@14.18.56)(typescript@5.2.2):
+  /@oclif/core@2.11.7(@types/node@16.18.57)(typescript@5.2.2):
     resolution: {integrity: sha512-0jbHePVekndUTd+Wee0+pnCpRhuHJrKiG9OtMqf4JSBCxp5Q8V+ACf8QKN4gNH9ppbGORfnTIYtXWh60+DcIiw==}
     engines: {node: '>=14.0.0'}
     dependencies:
@@ -3912,7 +3912,7 @@ packages:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@16.18.57)(typescript@5.2.2)
       tslib: 2.6.1
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -3923,11 +3923,11 @@ packages:
       - '@types/node'
       - typescript
 
-  /@oclif/plugin-commands@2.2.24(@types/node@14.18.56)(typescript@5.2.2):
+  /@oclif/plugin-commands@2.2.24(@types/node@16.18.57)(typescript@5.2.2):
     resolution: {integrity: sha512-bUZOBefMPR59oHngWNHDn+zGRQctVR5iMkO3qRWFUSVYt1VQtqOwAPBtpTIuIxL17/iGTG+U2b8jafn09lQNxA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+      '@oclif/core': 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       lodash: 4.17.21
     transitivePeerDependencies:
       - '@swc/core'
@@ -3936,23 +3936,23 @@ packages:
       - typescript
     dev: false
 
-  /@oclif/plugin-help@5.2.18(@types/node@14.18.56)(typescript@5.2.2):
+  /@oclif/plugin-help@5.2.18(@types/node@16.18.57)(typescript@5.2.2):
     resolution: {integrity: sha512-0JjupXUuDzlI0Ojj7/YL42btfUNuvSgZxdi8ZfeYt/uhC1/zvsSkO29KjffPxKEnbhr6jrkjOgy/Vly5JquYLg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+      '@oclif/core': 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  /@oclif/plugin-not-found@2.3.34(@types/node@14.18.56)(typescript@5.2.2):
+  /@oclif/plugin-not-found@2.3.34(@types/node@16.18.57)(typescript@5.2.2):
     resolution: {integrity: sha512-uXUpw6o2e0aqnNn+XkGL7LbL+Th2rBD1JGtFbb6anmvUvz2skiGz0o23BYmrQW8tvU92ajPOykfClKD75ptZcw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/color': 1.0.10
-      '@oclif/core': 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+      '@oclif/core': 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -3961,12 +3961,12 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-plugins@3.1.8(@types/node@14.18.56)(typescript@5.2.2):
+  /@oclif/plugin-plugins@3.1.8(@types/node@16.18.57)(typescript@5.2.2):
     resolution: {integrity: sha512-514sFBzLcR9QCSMWCHt/1XntfjJEZvb637b9YuV4kwq749pKEPF7fjCxSV1gYQCCP4TjMB5gB4AwPL4cCbe+/A==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/color': 1.0.10
-      '@oclif/core': 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+      '@oclif/core': 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       chalk: 4.1.2
       debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 9.1.0
@@ -3987,11 +3987,11 @@ packages:
       - typescript
     dev: false
 
-  /@oclif/plugin-warn-if-update-available@2.0.46(@types/node@14.18.56)(typescript@5.2.2):
+  /@oclif/plugin-warn-if-update-available@2.0.46(@types/node@16.18.57)(typescript@5.2.2):
     resolution: {integrity: sha512-TyOvPHzl1e8lLeRF8A9nhte+H9LR0arWqu+MYhNxzislx7SbG4M5yRhoH5F1MmwGxgJBbWHZVsmLjZm4S9cEog==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
+      '@oclif/core': 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
       chalk: 4.1.2
       debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 9.1.0
@@ -4738,7 +4738,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -4746,7 +4746,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
       '@types/responselike': 1.0.0
     dev: true
 
@@ -4761,7 +4761,7 @@ packages:
   /@types/cli-progress@3.11.0:
     resolution: {integrity: sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==}
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
 
   /@types/commondir@1.0.0:
     resolution: {integrity: sha512-PnpBlim0nunggueM95jRl8G3lyrcE6vPSBq6J9F2GE0o7k0ErZ26vzxdQxNnJwGX7qr/Fa0UaaChgEAZ23nanA==}
@@ -4770,7 +4770,7 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/cross-zip@4.0.0:
@@ -4788,7 +4788,7 @@ packages:
   /@types/express-serve-static-core@4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -4806,7 +4806,7 @@ packages:
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/git-diff@2.0.3:
@@ -4817,7 +4817,7 @@ packages:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/gradient-string@1.1.2:
@@ -4843,7 +4843,7 @@ packages:
   /@types/http-proxy@1.17.11:
     resolution: {integrity: sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==}
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/is-ci@3.0.0:
@@ -4881,7 +4881,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/lodash-es@4.17.9:
@@ -4918,12 +4918,12 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@14.18.56:
-    resolution: {integrity: sha512-+k+57NVS9opgrEn5l9c0gvD1r6C+PtyhVE4BTnMMRwiEA8ZO8uFcs6Yy2sXIy0eC95ZurBtRSvhZiHXBysbl6w==}
-
   /@types/node@15.14.9:
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
     dev: true
+
+  /@types/node@16.18.57:
+    resolution: {integrity: sha512-piPoDozdPaX1hNWFJQzzgWqE40gh986VvVx/QO9RU4qYRE55ld7iepDVgZ3ccGUw0R4wge0Oy1dd+3xOQNkkUQ==}
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -4965,20 +4965,20 @@ packages:
   /@types/readdir-glob@1.1.1:
     resolution: {integrity: sha512-ImM6TmoF8bgOwvehGviEj3tRdRBbQujr1N+0ypaln/GWjaerOB26jb93vsRHmdMtvVQZQebOlqt2HROark87mQ==}
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: false
 
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/rimraf@3.0.2:
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/semver@7.5.2:
@@ -4988,7 +4988,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/serve-static@1.15.2:
@@ -4996,7 +4996,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/tinycolor2@1.4.3:
@@ -5018,13 +5018,13 @@ packages:
     resolution: {integrity: sha512-4UqPv+2567NhMQuMLdKAyK4yzrfCqwaTt6bLhHEs8PFcxbHILsrxaY63n4wgE/BRLDWDQeI+WcTmkXKExh9hQg==}
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
     dev: true
 
   /@types/yargs-parser@21.0.0:
@@ -5712,8 +5712,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
       get-intrinsic: 1.2.1
 
@@ -5722,8 +5722,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
 
   /array.prototype.flatmap@1.3.1:
@@ -5731,16 +5731,16 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
 
   /array.prototype.tosorted@1.1.1:
     resolution: {integrity: sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
       get-intrinsic: 1.2.1
 
@@ -7074,13 +7074,6 @@ packages:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
 
-  /define-properties@1.2.0:
-    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-property-descriptors: 1.0.0
-      object-keys: 1.1.1
-
   /define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
@@ -7312,45 +7305,6 @@ packages:
   /error@10.4.0:
     resolution: {integrity: sha512-YxIFEJuhgcICugOUvRx5th0UM+ActZ9sjY0QJmeVwsQdvosZ7kYzc9QqS0Da3R5iUmgU5meGIxh0xBeZpMVeLw==}
     dev: true
-
-  /es-abstract@1.21.2:
-    resolution: {integrity: sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      array-buffer-byte-length: 1.0.0
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      es-set-tostringtag: 2.0.1
-      es-to-primitive: 1.2.1
-      function.prototype.name: 1.1.6
-      get-intrinsic: 1.2.1
-      get-symbol-description: 1.0.0
-      globalthis: 1.0.3
-      gopd: 1.0.1
-      has: 1.0.3
-      has-property-descriptors: 1.0.0
-      has-proto: 1.0.1
-      has-symbols: 1.0.3
-      internal-slot: 1.0.5
-      is-array-buffer: 3.0.2
-      is-callable: 1.2.7
-      is-negative-zero: 2.0.2
-      is-regex: 1.1.4
-      is-shared-array-buffer: 1.0.2
-      is-string: 1.0.7
-      is-typed-array: 1.1.12
-      is-weakref: 1.0.2
-      object-inspect: 1.12.3
-      object-keys: 1.1.1
-      object.assign: 4.1.4
-      regexp.prototype.flags: 1.5.1
-      safe-regex-test: 1.0.0
-      string.prototype.trim: 1.2.8
-      string.prototype.trimend: 1.0.7
-      string.prototype.trimstart: 1.0.7
-      typed-array-length: 1.0.4
-      unbox-primitive: 1.0.2
-      which-typed-array: 1.1.11
 
   /es-abstract@1.22.2:
     resolution: {integrity: sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==}
@@ -10991,48 +10945,48 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
 
   /object.fromentries@2.0.6:
     resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
 
   /object.groupby@1.0.0:
     resolution: {integrity: sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       get-intrinsic: 1.2.1
 
   /object.hasown@1.1.2:
     resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==}
     dependencies:
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
 
   /object.values@1.1.6:
     resolution: {integrity: sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
 
-  /oclif@3.16.0(@types/node@14.18.56)(typescript@5.2.2):
+  /oclif@3.16.0(@types/node@16.18.57)(typescript@5.2.2):
     resolution: {integrity: sha512-qbPJ9SifBDPeMnuYIyJc0+kGyXmLubJs/lOD1wjrvAiKqTWQ1xy/EFlNMgBGETCf7RQf1iSJmvf+s22ZkLc7Ow==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 2.11.7(@types/node@14.18.56)(typescript@5.2.2)
-      '@oclif/plugin-help': 5.2.18(@types/node@14.18.56)(typescript@5.2.2)
-      '@oclif/plugin-not-found': 2.3.34(@types/node@14.18.56)(typescript@5.2.2)
-      '@oclif/plugin-warn-if-update-available': 2.0.46(@types/node@14.18.56)(typescript@5.2.2)
+      '@oclif/core': 2.11.7(@types/node@16.18.57)(typescript@5.2.2)
+      '@oclif/plugin-help': 5.2.18(@types/node@16.18.57)(typescript@5.2.2)
+      '@oclif/plugin-not-found': 2.3.34(@types/node@16.18.57)(typescript@5.2.2)
+      '@oclif/plugin-warn-if-update-available': 2.0.46(@types/node@16.18.57)(typescript@5.2.2)
       async-retry: 1.3.3
       aws-sdk: 2.1383.0
       concurrently: 7.6.0
@@ -12099,14 +12053,6 @@ packages:
     hasBin: true
     dev: true
 
-  /regexp.prototype.flags@1.5.0:
-    resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
-      functions-have-names: 1.2.3
-
   /regexp.prototype.flags@1.5.1:
     resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
     engines: {node: '>= 0.4'}
@@ -12807,12 +12753,12 @@ packages:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       get-intrinsic: 1.2.1
       has-symbols: 1.0.3
       internal-slot: 1.0.5
-      regexp.prototype.flags: 1.5.0
+      regexp.prototype.flags: 1.5.1
       side-channel: 1.0.4
 
   /string.prototype.trim@1.2.8:
@@ -13243,7 +13189,7 @@ packages:
       code-block-writer: 11.0.3
     dev: true
 
-  /ts-node@10.9.1(@types/node@14.18.56)(typescript@5.2.2):
+  /ts-node@10.9.1(@types/node@16.18.57)(typescript@5.2.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -13262,7 +13208,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
       acorn: 8.9.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -13750,7 +13696,7 @@ packages:
       replace-ext: 1.0.1
     dev: true
 
-  /vite-node@0.34.4(@types/node@14.18.56)(sass@1.64.2):
+  /vite-node@0.34.4(@types/node@16.18.57)(sass@1.64.2):
     resolution: {integrity: sha512-ho8HtiLc+nsmbwZMw8SlghESEE3KxJNp04F/jPUCLVvaURwt0d+r9LxEqCX5hvrrOQ0GSyxbYr5ZfRYhQ0yVKQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -13760,7 +13706,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+      vite: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -13780,12 +13726,12 @@ packages:
       globrex: 0.1.2
       recrawl-sync: 2.2.3
       tsconfig-paths: 4.2.0
-      vite: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
+      vite: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite@4.4.9(@types/node@14.18.56)(sass@1.64.2):
+  /vite@4.4.9(@types/node@16.18.57)(sass@1.64.2):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -13813,7 +13759,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
       esbuild: 0.18.17
       postcss: 8.4.27
       rollup: 3.28.0
@@ -13854,7 +13800,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
       '@vitest/expect': 0.34.4
       '@vitest/runner': 0.34.4
       '@vitest/snapshot': 0.34.4
@@ -13874,8 +13820,8 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
-      vite-node: 0.34.4(@types/node@14.18.56)(sass@1.64.2)
+      vite: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
+      vite-node: 0.34.4(@types/node@16.18.57)(sass@1.64.2)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -13919,7 +13865,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 14.18.56
+      '@types/node': 16.18.57
       '@vitest/expect': 0.34.4
       '@vitest/runner': 0.34.4
       '@vitest/snapshot': 0.34.4
@@ -13938,8 +13884,8 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.4.9(@types/node@14.18.56)(sass@1.64.2)
-      vite-node: 0.34.4(@types/node@14.18.56)(sass@1.64.2)
+      vite: 4.4.9(@types/node@16.18.57)(sass@1.64.2)
+      vite-node: 0.34.4(@types/node@16.18.57)(sass@1.64.2)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Tracks data on CLI performance:
- command exits: ok, unexpected error, expected error
- how long spent on network calls and prompts (and infers how long the command is active for)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Introduces new monorail fields and instrumented calls.

The `runWithTimer` function wraps up another function and times how long it takes to finish. There's some complexity there in dealing with nested timers -- we essentially want to pause a timer whilst nested ones are running.

(PS: its not a decorator as decorators are for class methods only)

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Run with `--verbose` and check out the new fields.


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
