### PR TITLE
Reliability metric tracking

### DIFF
--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -104,7 +104,7 @@
     "@oclif/core": "2.11.7",
     "@opentelemetry/api": "1.6.0",
     "@opentelemetry/core": "1.17.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.44.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.43.0",
     "@opentelemetry/resources": "1.17.1",
     "@opentelemetry/sdk-metrics": "1.17.1",
     "@opentelemetry/semantic-conventions": "1.17.1",

--- a/packages/cli-kit/src/private/node/__snapshots__/otel-metrics.test.ts.snap
+++ b/packages/cli-kit/src/private/node/__snapshots__/otel-metrics.test.ts.snap
@@ -1,0 +1,74 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`otel-metrics > logs metrics when activated 1`] = `
+[
+  [
+    "cli_commands_total",
+    1,
+    {
+      "cli_version": "pre",
+      "exit": "ok",
+      "job": "@shopify/app::app dev",
+    },
+  ],
+  [
+    "cli_commands_duration_ms",
+    10,
+    {
+      "cli_version": "pre",
+      "exit": "ok",
+      "job": "@shopify/app::app dev",
+    },
+  ],
+  [
+    "cli_commands_wall_clock_elapsed_ms",
+    10,
+    {
+      "cli_version": "pre",
+      "exit": "ok",
+      "job": "@shopify/app::app dev",
+      "stage": "active",
+    },
+  ],
+  [
+    "cli_commands_wall_clock_elapsed_ms",
+    20,
+    {
+      "cli_version": "pre",
+      "exit": "ok",
+      "job": "@shopify/app::app dev",
+      "stage": "network",
+    },
+  ],
+  [
+    "cli_commands_wall_clock_elapsed_ms",
+    30,
+    {
+      "cli_version": "pre",
+      "exit": "ok",
+      "job": "@shopify/app::app dev",
+      "stage": "prompt",
+    },
+  ],
+]
+`;
+
+exports[`otel-metrics > outputs debug information when deactivated 1`] = `
+"[OTEL] record cli_commands_total counter {
+  \\"labels\\": {
+    \\"exit\\": \\"ok\\",
+    \\"job\\": \\"@shopify/app::app dev\\",
+    \\"cli_version\\": \\"nightly\\"
+  }
+}
+[OTEL] record cli_commands_duration_ms histogram 10ms {
+  \\"labels\\": {
+    \\"exit\\": \\"ok\\",
+    \\"job\\": \\"@shopify/app::app dev\\",
+    \\"cli_version\\": \\"nightly\\"
+  }
+}
+[OTEL] record cli_commands_wall_clock_elapsed_ms histogram stage=\\"active\\" 10ms
+[OTEL] record cli_commands_wall_clock_elapsed_ms histogram stage=\\"network\\" 20ms
+[OTEL] record cli_commands_wall_clock_elapsed_ms histogram stage=\\"prompt\\" 30ms"
+`;

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -10,6 +10,7 @@ const cacheFolder = () => {
 
 export const environmentVariables = {
   alwaysLogAnalytics: 'SHOPIFY_CLI_ALWAYS_LOG_ANALYTICS',
+  alwaysLogMetrics: 'SHOPIFY_CLI_ALWAYS_LOG_METRICS',
   deviceAuth: 'SHOPIFY_CLI_DEVICE_AUTH',
   enableCliRedirect: 'SHOPIFY_CLI_ENABLE_CLI_REDIRECT',
   env: 'SHOPIFY_CLI_ENV',
@@ -37,6 +38,7 @@ export const environmentVariables = {
   organization: 'SHOPIFY_CLI_ORGANIZATION',
   identityToken: 'SHOPIFY_CLI_IDENTITY_TOKEN',
   refreshToken: 'SHOPIFY_CLI_REFRESH_TOKEN',
+  otelURL: 'OTEL_EXPORTER_OTLP_ENDPOINT',
 }
 
 export const systemEnvironmentVariables = {

--- a/packages/cli-kit/src/private/node/otel-metrics.test.ts
+++ b/packages/cli-kit/src/private/node/otel-metrics.test.ts
@@ -1,0 +1,56 @@
+import {recordMetrics} from './otel-metrics.js'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+import {describe, expect, test, vi} from 'vitest'
+
+describe('otel-metrics', () => {
+  test('outputs debug information when deactivated', async () => {
+    const outputMock = mockAndCaptureOutput()
+
+    await recordMetrics(
+      {
+        skipMetricAnalytics: true,
+        cliVersion: '0.0.0-nightly.1234567890',
+        owningPlugin: '@shopify/app',
+        command: 'app dev',
+        exitMode: 'ok',
+      },
+      {
+        active: 10,
+        network: 20,
+        prompt: 30,
+      },
+    )
+
+    expect(outputMock.output()).toMatchSnapshot()
+  })
+
+  test('logs metrics when activated', async () => {
+    const mockOtelRecorder = vi.fn()
+    const mockOtelCreator = vi.fn()
+    mockOtelCreator.mockReturnValue({
+      type: 'otel',
+      otel: {
+        record: mockOtelRecorder,
+      },
+    })
+
+    await recordMetrics(
+      {
+        skipMetricAnalytics: false,
+        cliVersion: '3.49.1-pre.0',
+        owningPlugin: '@shopify/app',
+        command: 'app dev',
+        exitMode: 'ok',
+      },
+      {
+        active: 10,
+        network: 20,
+        prompt: 30,
+      },
+      mockOtelCreator,
+    )
+
+    expect(mockOtelCreator).toHaveBeenCalledOnce()
+    expect(mockOtelRecorder.mock.calls).toMatchSnapshot()
+  })
+})

--- a/packages/cli-kit/src/private/node/otel-metrics.ts
+++ b/packages/cli-kit/src/private/node/otel-metrics.ts
@@ -1,0 +1,176 @@
+import {MetricInstrumentType, OtelService} from '../../public/node/vendor/otel-js/service/types.js'
+import {outputContent, outputDebug, outputToken} from '../../public/node/output.js'
+import {
+  DefaultOtelService,
+  DefaultOtelServiceOptions,
+} from '../../public/node/vendor/otel-js/service/DefaultOtelService/DefaultOtelService.js'
+import {isUnitTest, opentelemetryDomain} from '../../public/node/context/local.js'
+import {ValueType} from '@opentelemetry/api'
+
+type MetricRecorder =
+  | 'console'
+  | {
+      type: 'otel'
+      otel: Pick<OtelService, 'record'>
+    }
+
+// this should be type, not interface
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type Labels = {
+  exit: string
+  job: string
+  cli_version: string
+}
+
+interface Timing {
+  active: number
+  network: number
+  prompt: number
+}
+
+enum Name {
+  Counter = 'cli_commands_total',
+  Duration = 'cli_commands_duration_ms',
+  Elapsed = 'cli_commands_wall_clock_elapsed_ms',
+}
+
+interface CreateMetricRecorderOptions {
+  skipMetricAnalytics: boolean
+  otelOptions: Omit<DefaultOtelServiceOptions, 'env' | 'otelEndpoint'>
+}
+
+interface RecordMetricsOptions {
+  /** If true, don't log anything */
+  skipMetricAnalytics: boolean
+  /** The CLI version running the command */
+  cliVersion: string
+  /** The plug-in that owns the command */
+  owningPlugin: string
+  /** The command name, e.g. `app dev` */
+  command: string
+  /** The exit mode for the command */
+  exitMode: string
+}
+
+/**
+ * Hello, World.thing else
+ */
+export async function recordMetrics(
+  options: RecordMetricsOptions,
+  timing: Timing,
+  recorderFactory: (options: CreateMetricRecorderOptions) => MetricRecorder = createMetricRecorder,
+) {
+  const recorder = recorderFactory({
+    skipMetricAnalytics: options.skipMetricAnalytics,
+    otelOptions: defaultOtelOptions(),
+  })
+
+  let regularisedCliVersion = options.cliVersion
+
+  if (options.cliVersion.includes('nightly')) {
+    regularisedCliVersion = 'nightly'
+  } else if (options.cliVersion.includes('pre')) {
+    regularisedCliVersion = 'pre'
+  }
+  const labels = {
+    exit: options.exitMode,
+    job: `${options.owningPlugin}::${options.command}`,
+    cli_version: regularisedCliVersion,
+  }
+
+  recordCommandCounter(recorder, labels)
+  recordCommandTiming(recorder, labels, timing)
+}
+
+/**
+ * Get the default options for the OTEL service. These are the same across environments.
+ */
+function defaultOtelOptions(): Omit<DefaultOtelServiceOptions, 'env' | 'otelEndpoint'> {
+  return {
+    serviceName: 'shopify-cli',
+    throttleLimit: 1000,
+    prefixMetric: false,
+    metrics: {
+      [Name.Counter]: {
+        type: MetricInstrumentType.Counter,
+        description: 'Total number of CLI commands executed',
+        valueType: ValueType.INT,
+      },
+      [Name.Duration]: {
+        type: MetricInstrumentType.Histogram,
+        description:
+          'Total time spent in execution of CLI commands. Does not include time spent waiting for network, prompts, etc.',
+        valueType: ValueType.INT,
+        boundaries: [0, 100, 250, 500, 1000, 2000, 5000, 10_000, 20_000, 50_000],
+      },
+      [Name.Elapsed]: {
+        type: MetricInstrumentType.Histogram,
+        description:
+          'Total time elapsed from start to finish of CLI commands. Includes time spent waiting for network, prompts, etc.',
+        valueType: ValueType.INT,
+        boundaries: [0, 100, 250, 500, 1000, 2000, 5000, 10_000, 20_000, 50_000],
+      },
+    },
+  }
+}
+
+/**
+ * Create the metric recorder for this command.
+ *
+ * If metric logging is disabled, or we are running in a unit test, we record to the console.
+ *
+ */
+function createMetricRecorder(options: CreateMetricRecorderOptions): MetricRecorder {
+  let recorder: MetricRecorder = 'console'
+  if (!options.skipMetricAnalytics && !isUnitTest()) {
+    const otelEndpoint = `${opentelemetryDomain()}/v1/metrics`
+    recorder = {
+      type: 'otel',
+      otel: new DefaultOtelService({
+        ...options.otelOptions,
+        env: undefined,
+        otelEndpoint,
+      }),
+    }
+  }
+  return recorder
+}
+
+/**
+ * Log command counter metrics.
+ */
+function recordCommandCounter(recorder: MetricRecorder, labels: Labels) {
+  if (recorder === 'console') {
+    outputDebug(outputContent`[OTEL] record ${Name.Counter} counter ${outputToken.json({labels})}`)
+    return
+  }
+  recorder.otel.record(Name.Counter, 1, labels)
+}
+
+/**
+ * Log command timing metrics.
+ */
+function recordCommandTiming(recorder: MetricRecorder, labels: Labels, timing: Timing) {
+  if (recorder === 'console') {
+    outputDebug(
+      outputContent`[OTEL] record ${Name.Duration} histogram ${timing.active.toString()}ms ${outputToken.json({
+        labels,
+      })}`,
+    )
+    outputDebug(outputContent`[OTEL] record ${Name.Elapsed} histogram stage="active" ${timing.active.toString()}ms`)
+    outputDebug(outputContent`[OTEL] record ${Name.Elapsed} histogram stage="network" ${timing.network.toString()}ms`)
+    outputDebug(outputContent`[OTEL] record ${Name.Elapsed} histogram stage="prompt" ${timing.prompt.toString()}ms`)
+    return
+  }
+
+  if (timing.active > 0) {
+    recorder.otel.record(Name.Duration, timing.active, labels)
+    recorder.otel.record(Name.Elapsed, timing.active, {...labels, stage: 'active'})
+  }
+  if (timing.network > 0) {
+    recorder.otel.record(Name.Elapsed, timing.network, {...labels, stage: 'network'})
+  }
+  if (timing.prompt > 0) {
+    recorder.otel.record(Name.Elapsed, timing.prompt, {...labels, stage: 'prompt'})
+  }
+}

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -94,6 +94,16 @@ export function alwaysLogAnalytics(env = process.env): boolean {
 }
 
 /**
+ * Returns true if reporting metrics should always happen, regardless of DEBUG mode etc.
+ *
+ * @param env - The environment variables from the environment of the current process.
+ * @returns True if SHOPIFY_CLI_ALWAYS_LOG_METRICS is truthy.
+ */
+export function alwaysLogMetrics(env = process.env): boolean {
+  return isTruthy(env[environmentVariables.alwaysLogMetrics])
+}
+
+/**
  * Returns true if the CLI User is 1P.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -256,6 +266,21 @@ export function ciPlatform(
  */
 export function macAddress(): Promise<string> {
   return macaddress.one()
+}
+
+/**
+ * Get the domain to send OTEL metrics to.
+ *
+ * It can be overridden via the OTEL_EXPORTER_OTLP_ENDPOINT environment variable.
+ *
+ * @param env - The environment variables from the environment of the current process.
+ * @returns The domain to send OTEL metrics to.
+ */
+export function opentelemetryDomain(env = process.env): string | undefined {
+  if (isSet(env[environmentVariables.otelURL])) {
+    return env[environmentVariables.otelURL]
+  }
+  return 'https://otlp-http-production-cli.shopifysvc.com'
 }
 
 export type CIMetadata = Metadata

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,8 +316,8 @@ importers:
         specifier: 1.17.1
         version: 1.17.1(@opentelemetry/api@1.6.0)
       '@opentelemetry/exporter-metrics-otlp-http':
-        specifier: 0.44.0
-        version: 0.44.0(@opentelemetry/api@1.6.0)
+        specifier: 0.43.0
+        version: 0.43.0(@opentelemetry/api@1.6.0)
       '@opentelemetry/resources':
         specifier: 1.17.1
         version: 1.17.1(@opentelemetry/api@1.6.0)
@@ -4234,8 +4234,8 @@ packages:
       '@octokit/openapi-types': 17.2.0
     dev: true
 
-  /@opentelemetry/api-logs@0.44.0:
-    resolution: {integrity: sha512-OctojdKGmXHKAJa4/Ml+Nf7MD9jtYXvZyP64xTh0pNTmtgaTdWW3FURri2DdB/+l7YxRy0tYYZS3/tYEM1pj3w==}
+  /@opentelemetry/api-logs@0.43.0:
+    resolution: {integrity: sha512-0CXMOYPXgAdLM2OzVkiUfAL6QQwWVhnMfUXCqLsITY42FZ9TxAhZIHkoc4mfVxvPuXsBnRYGR8UQZX86p87z4A==}
     engines: {node: '>=14'}
     dependencies:
       '@opentelemetry/api': 1.6.0
@@ -4244,6 +4244,16 @@ packages:
   /@opentelemetry/api@1.6.0:
     resolution: {integrity: sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==}
     engines: {node: '>=8.0.0'}
+    dev: false
+
+  /@opentelemetry/core@1.17.0(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-tfnl3h+UefCgx1aeN2xtrmr6BmdWGKXypk0pflQR0urFS40aE88trnkOMc2HTJZbMrqEEl4HsaBeFhwLVXsrJg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.7.0'
+    dependencies:
+      '@opentelemetry/api': 1.6.0
+      '@opentelemetry/semantic-conventions': 1.17.0
     dev: false
 
   /@opentelemetry/core@1.17.1(@opentelemetry/api@1.6.0):
@@ -4256,43 +4266,54 @@ packages:
       '@opentelemetry/semantic-conventions': 1.17.1
     dev: false
 
-  /@opentelemetry/exporter-metrics-otlp-http@0.44.0(@opentelemetry/api@1.6.0):
-    resolution: {integrity: sha512-OiEkP9XWbh5ufjnP+xe8EQ2LShMY5f1NYBm9W/BgLaHPtlMNZnR7JB1t6Ut4gaZ7LA/yFnyrB0TnZcxntpBZ3Q==}
+  /@opentelemetry/exporter-metrics-otlp-http@0.43.0(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-k0KHKLS/xEWI4e5xrsnHpRk7Adj7JSFbFeKF4ti1d9soek3y85ZC2fTzDQC+ysUYo/lccoAXGR/gjcYgQOe7pg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
     dependencies:
       '@opentelemetry/api': 1.6.0
-      '@opentelemetry/core': 1.17.1(@opentelemetry/api@1.6.0)
-      '@opentelemetry/otlp-exporter-base': 0.44.0(@opentelemetry/api@1.6.0)
-      '@opentelemetry/otlp-transformer': 0.44.0(@opentelemetry/api@1.6.0)
-      '@opentelemetry/resources': 1.17.1(@opentelemetry/api@1.6.0)
-      '@opentelemetry/sdk-metrics': 1.17.1(@opentelemetry/api@1.6.0)
+      '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/otlp-exporter-base': 0.43.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/otlp-transformer': 0.43.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/resources': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/sdk-metrics': 1.17.0(@opentelemetry/api@1.6.0)
     dev: false
 
-  /@opentelemetry/otlp-exporter-base@0.44.0(@opentelemetry/api@1.6.0):
-    resolution: {integrity: sha512-DKQqRrfVMe96aSLZiCgIesLcMLfnWH8d4bTpLB1JbU+SAQJ7nVCAfS9U36mjFCVhvNDD7gwfCNrxqFMCHq6FUw==}
+  /@opentelemetry/otlp-exporter-base@0.43.0(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-LXNtRFVuPRXB9q0qdvrLikQ3NtT9Jmv255Idryz3RJPhOh/Fa03sBASQoj3D55OH3xazmA90KFHfhJ/d8D8y4A==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
       '@opentelemetry/api': 1.6.0
-      '@opentelemetry/core': 1.17.1(@opentelemetry/api@1.6.0)
+      '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
     dev: false
 
-  /@opentelemetry/otlp-transformer@0.44.0(@opentelemetry/api@1.6.0):
-    resolution: {integrity: sha512-1/KC+aHM1oGEsXyNy7QoxpvErxGdzt26bg9VHyNb4TDILkUFdwrnywnxPc6lXZ6h/8T8Mt718UWOKjNHC514kQ==}
+  /@opentelemetry/otlp-transformer@0.43.0(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-KXYmgzWdVBOD5NvPmGW1nEMJjyQ8gK3N8r6pi4HvmEhTp0v4T13qDSax4q0HfsqmbPJR355oqQSJUnu1dHNutw==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.7.0'
     dependencies:
       '@opentelemetry/api': 1.6.0
-      '@opentelemetry/api-logs': 0.44.0
-      '@opentelemetry/core': 1.17.1(@opentelemetry/api@1.6.0)
-      '@opentelemetry/resources': 1.17.1(@opentelemetry/api@1.6.0)
-      '@opentelemetry/sdk-logs': 0.44.0(@opentelemetry/api-logs@0.44.0)(@opentelemetry/api@1.6.0)
-      '@opentelemetry/sdk-metrics': 1.17.1(@opentelemetry/api@1.6.0)
-      '@opentelemetry/sdk-trace-base': 1.17.1(@opentelemetry/api@1.6.0)
+      '@opentelemetry/api-logs': 0.43.0
+      '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/resources': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/sdk-logs': 0.43.0(@opentelemetry/api-logs@0.43.0)(@opentelemetry/api@1.6.0)
+      '@opentelemetry/sdk-metrics': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/sdk-trace-base': 1.17.0(@opentelemetry/api@1.6.0)
+    dev: false
+
+  /@opentelemetry/resources@1.17.0(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-+u0ciVnj8lhuL/qGRBPeVYvk7fL+H/vOddfvmOeJaA1KC+5/3UED1c9KoZQlRsNT5Kw1FaK8LkY2NVLYfOVZQw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.7.0'
+    dependencies:
+      '@opentelemetry/api': 1.6.0
+      '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/semantic-conventions': 1.17.0
     dev: false
 
   /@opentelemetry/resources@1.17.1(@opentelemetry/api@1.6.0):
@@ -4306,17 +4327,29 @@ packages:
       '@opentelemetry/semantic-conventions': 1.17.1
     dev: false
 
-  /@opentelemetry/sdk-logs@0.44.0(@opentelemetry/api-logs@0.44.0)(@opentelemetry/api@1.6.0):
-    resolution: {integrity: sha512-UN3ofh9Jj54gIgrSXNRWAoaH6iPvrrjed5YAtqO9cW65U+5QPzk1Rv95vjAcY9VTrmMWvuqgEK1CYObG6Hu4OQ==}
+  /@opentelemetry/sdk-logs@0.43.0(@opentelemetry/api-logs@0.43.0)(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-JyJ2BBRKm37Mc4cSEhFmsMl5ASQn1dkGhEWzAAMSlhPtLRTv5PfvJwhR+Mboaic/eDLAlciwsgijq8IFlf6IgQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.7.0'
       '@opentelemetry/api-logs': '>=0.39.1'
     dependencies:
       '@opentelemetry/api': 1.6.0
-      '@opentelemetry/api-logs': 0.44.0
-      '@opentelemetry/core': 1.17.1(@opentelemetry/api@1.6.0)
-      '@opentelemetry/resources': 1.17.1(@opentelemetry/api@1.6.0)
+      '@opentelemetry/api-logs': 0.43.0
+      '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/resources': 1.17.0(@opentelemetry/api@1.6.0)
+    dev: false
+
+  /@opentelemetry/sdk-metrics@1.17.0(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-HlWM27yGmYuwCoVRe3yg2PqKnIsq0kEF0HQgvkeDWz2NYkq9fFaSspR6kvjxUTbghAlZrabiqbgyKoYpYaXS3w==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.7.0'
+    dependencies:
+      '@opentelemetry/api': 1.6.0
+      '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/resources': 1.17.0(@opentelemetry/api@1.6.0)
+      lodash.merge: 4.6.2
     dev: false
 
   /@opentelemetry/sdk-metrics@1.17.1(@opentelemetry/api@1.6.0):
@@ -4331,16 +4364,21 @@ packages:
       lodash.merge: 4.6.2
     dev: false
 
-  /@opentelemetry/sdk-trace-base@1.17.1(@opentelemetry/api@1.6.0):
-    resolution: {integrity: sha512-pfSJJSjZj5jkCJUQZicSpzN8Iz9UKMryPWikZRGObPnJo6cUSoKkjZh6BM3j+D47G4olMBN+YZKYqkFM1L6zNA==}
+  /@opentelemetry/sdk-trace-base@1.17.0(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-2T5HA1/1iE36Q9eg6D4zYlC4Y4GcycI1J6NsHPKZY9oWfAxWsoYnRlkPfUqyY5XVtocCo/xHpnJvGNHwzT70oQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.7.0'
     dependencies:
       '@opentelemetry/api': 1.6.0
-      '@opentelemetry/core': 1.17.1(@opentelemetry/api@1.6.0)
-      '@opentelemetry/resources': 1.17.1(@opentelemetry/api@1.6.0)
-      '@opentelemetry/semantic-conventions': 1.17.1
+      '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/resources': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/semantic-conventions': 1.17.0
+    dev: false
+
+  /@opentelemetry/semantic-conventions@1.17.0:
+    resolution: {integrity: sha512-+fguCd2d8d2qruk0H0DsCEy2CTK3t0Tugg7MhZ/UQMvmewbZLNnJ6heSYyzIZWG5IPfAXzoj4f4F/qpM7l4VBA==}
+    engines: {node: '>=14'}
     dev: false
 
   /@opentelemetry/semantic-conventions@1.17.1:


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Adds reliability metric tracking to the CLI. After running a command, report back minimal stats on command timing and exit state.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Metric tracking is disabled through `SHOPIFY_CLI_NO_ANALYTICS=1` as usual

If tracking is enabled, the same numbers currently being sent to monorail are also reported to the opentelemetry metric tracker.

### How to test your changes?

Internal instructions here: https://vault.shopify.io/snippify/snippets/2ad01d9804a0303a47f4

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
