### PR TITLE
Update refresh-documentation command for node 20

### DIFF
--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -129,7 +129,7 @@
     "refresh-documentation": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "FORCE_HYPERLINK=0 pnpm ts-node-esm ./bin/refresh-documentation.ts",
+        "command": "FORCE_HYPERLINK=0 node --loader ts-node/esm ./bin/refresh-documentation.ts",
         "cwd": "packages/cli-kit"
       }
     }


### PR DESCRIPTION
The `refresh-documentation` task was failing with this error.
![Screenshot 2023-10-16 at 13 30 57](https://github.com/Shopify/cli/assets/151725/e9ab942d-cf0f-451b-ae77-8100bc0394e3)

Using `node` directly works.