### PR TITLE
Show friendlier message when JsonTemplateNormalizer fails

### DIFF
--- a/.changeset/funny-bobcats-laugh.md
+++ b/.changeset/funny-bobcats-laugh.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Show friendlier message when invalid json template format

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/file.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/file.rb
@@ -137,6 +137,8 @@ module ShopifyCLI
         end
 
         def visit_value(value)
+          return unless value.is_a?(Hash)
+
           # Reinsert settings to force the same ordering as in the backend
           settings = value.delete("settings") || {}
           value["settings"] = settings

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/file_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/file_test.rb
@@ -131,6 +131,17 @@ module ShopifyCLI
         assert_equal(expected_warnings, actual_warnings)
       end
 
+      def test_value_when_it_is_not_a_hash
+        invalid_template = { "sections": { "layout": "alt-layout" }, "order": [] }.to_json
+
+        file = fixture_file("templates/blog.json")
+        file.stubs(read: invalid_template)
+
+        assert_nothing_raised do
+          file.checksum
+        end
+      end
+
       private
 
       def fixture_file(file_path)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2720

### WHAT is this pull request doing?

When normalizing json templates, sometimes we expect a hash value but get a string instead, which causes a vague "An expected error occurred" msg. To fix that we return early if we don't get a hash value when we expect one and asset cloud is able to return a friendlier and more informative error message.

### How to test your changes?

On any template file, use this incorrect format https://github.com/Shopify/cli/issues/2720#issuecomment-1697636646 and run `shopify theme dev`. You should see this error message instead.

<img width="1251" alt="Screenshot 2023-10-16 at 10 32 08" src="https://github.com/Shopify/cli/assets/26684705/accb71b7-7563-43bf-affd-b13a035feeb2">

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
