### PR TITLE
Fixed CI issue due to theme check --dev-preview --version

### DIFF
--- a/.changeset/eight-days-promise.md
+++ b/.changeset/eight-days-promise.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/theme': minor
+---
+
+Fixed CI issue due to theme check --dev-preview --version implementation

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -200,6 +200,15 @@ export async function getPackageName(packageJsonPath: string): Promise<string | 
   const packageJsonContent = await readAndParsePackageJson(packageJsonPath)
   return packageJsonContent.name
 }
+/**
+ * Returns the name of the package configured in its package.json
+ * @param packageJsonPath - Path to the package.json file
+ * @returns A promise that resolves with the name.
+ */
+export async function getPackageVersion(packageJsonPath: string): Promise<string | undefined> {
+  const packageJsonContent = await readAndParsePackageJson(packageJsonPath)
+  return packageJsonContent.version
+}
 
 /**
  * Returns the list of production and dev dependencies of a package.json

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -201,9 +201,9 @@ export async function getPackageName(packageJsonPath: string): Promise<string | 
   return packageJsonContent.name
 }
 /**
- * Returns the name of the package configured in its package.json
+ * Returns the version of the package configured in its package.json
  * @param packageJsonPath - Path to the package.json file
- * @returns A promise that resolves with the name.
+ * @returns A promise that resolves with the version.
  */
 export async function getPackageVersion(packageJsonPath: string): Promise<string | undefined> {
   const packageJsonContent = await readAndParsePackageJson(packageJsonPath)

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -19,7 +19,9 @@ import {outputInfo} from '@shopify/cli-kit/node/output'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {renderInfo, renderSuccess} from '@shopify/cli-kit/node/ui'
 import {themeCheckRun} from '@shopify/theme-check-node'
-import themeCheckPackage from '@shopify/theme-check-node/package.json' assert {type: 'json'}
+import {findPathUp} from '@shopify/cli-kit/node/fs'
+import {moduleDirectory, joinPath} from '@shopify/cli-kit/node/path'
+import {getPackageVersion} from '@shopify/cli-kit/node/node-package-manager'
 
 export default class Check extends ThemeCommand {
   static description = 'Validate the theme.'
@@ -139,7 +141,17 @@ Excludes checks matching any category when specified more than once`,
       }
 
       if (flags.version) {
-        outputInfo(themeCheckPackage.version)
+        const pkgJsonPath = await findPathUp(joinPath('node_modules', '@shopify', 'theme-check-node', 'package.json'), {
+          type: 'file',
+          cwd: moduleDirectory(import.meta.url),
+        })
+
+        let version = 'unknown'
+        if (pkgJsonPath) {
+          version = (await getPackageVersion(pkgJsonPath)) || 'unknown'
+        }
+
+        outputInfo(version)
 
         // --version should not trigger full theme check operation
         return


### PR DESCRIPTION

### WHY are these changes introduced?
The previous implementation of `shopify theme check --dev-preview --version` was causing nightly CI to fail. 

### WHAT is this pull request doing?
Reimplemented the logic to get the package version of `@shopify/theme-check-node`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
