### PR TITLE
[Feature] Allow source maps in production extension builds

### DIFF
--- a/packages/app/src/cli/commands/app/build.ts
+++ b/packages/app/src/cli/commands/app/build.ts
@@ -5,6 +5,7 @@ import build from '../../services/build.js'
 import Command from '../../utilities/app-command.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
+import {extensionFlags} from '../../extension-flags.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
@@ -15,6 +16,7 @@ export default class Build extends Command {
   static flags = {
     ...globalFlags,
     ...appFlags,
+    ...extensionFlags,
     'skip-dependencies-installation': Flags.boolean({
       hidden: false,
       description: 'Skips the installation of dependencies. Deprecated, use workspaces instead.',
@@ -41,6 +43,7 @@ export default class Build extends Command {
       await showApiKeyDeprecationWarning()
     }
     const apiKey = flags['client-id'] || flags['api-key']
+    const sourceMaps = flags['source-maps']
 
     await addPublicMetadata(() => ({
       cmd_app_dependency_installation_skipped: flags['skip-dependencies-installation'],
@@ -48,6 +51,6 @@ export default class Build extends Command {
 
     const specifications = await loadLocalExtensionsSpecifications(this.config)
     const app: AppInterface = await loadApp({specifications, directory: flags.path, configName: flags.config})
-    await build({app, skipDependenciesInstallation: flags['skip-dependencies-installation'], apiKey})
+    await build({app, skipDependenciesInstallation: flags['skip-dependencies-installation'], apiKey, sourceMaps})
   }
 }

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -8,6 +8,7 @@ import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-sp
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {validateMessage} from '../../validations/message.js'
 import metadata from '../../metadata.js'
+import {extensionFlags} from '../../extension-flags.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
@@ -18,6 +19,7 @@ export default class Deploy extends Command {
   static flags = {
     ...globalFlags,
     ...appFlags,
+    ...extensionFlags,
     'api-key': Flags.string({
       hidden: true,
       description: 'The API key of your app.',
@@ -111,6 +113,7 @@ export default class Deploy extends Command {
       version: flags.version,
       commitReference: flags['source-control-url'],
       commandConfig: this.config,
+      sourceMaps: flags['source-maps'],
     })
   }
 }

--- a/packages/app/src/cli/extension-flags.ts
+++ b/packages/app/src/cli/extension-flags.ts
@@ -1,0 +1,13 @@
+import {Flags} from '@oclif/core'
+
+/**
+ * An object that contains the flags that
+ * are shared across commands that can utilize esbuild.
+ */
+export const extensionFlags = {
+  'source-maps': Flags.boolean({
+    hidden: false,
+    env: 'SHOPIFY_FLAG_SOURCE_MAPS',
+    default: false,
+  }),
+}

--- a/packages/app/src/cli/services/build.ts
+++ b/packages/app/src/cli/services/build.ts
@@ -9,6 +9,7 @@ interface BuildOptions {
   app: AppInterface
   skipDependenciesInstallation: boolean
   apiKey?: string
+  sourceMaps?: boolean
 }
 
 async function build(options: BuildOptions) {
@@ -35,7 +36,13 @@ async function build(options: BuildOptions) {
         return {
           prefix: ext.localIdentifier,
           action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
-            await ext.build({stdout, stderr, signal, app: options.app})
+            await ext.build({
+              stdout,
+              stderr,
+              signal,
+              app: options.app,
+              sourceMaps: options.sourceMaps,
+            })
           },
         }
       }),

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -38,6 +38,11 @@ export interface ExtensionBuildOptions {
    * The app that contains the extensions.
    */
   app: AppInterface
+
+  /**
+   * Whether to generate source maps. Applicable only to UI extensions.
+   */
+  sourceMaps?: boolean
 }
 
 /**
@@ -73,6 +78,7 @@ export async function buildUIExtension(extension: ExtensionInstance, options: Ex
     env: options.app.dotenv?.variables ?? {},
     stderr: options.stderr,
     stdout: options.stdout,
+    sourceMaps: options.sourceMaps,
   })
 
   await extension.buildValidation()

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -52,6 +52,9 @@ interface DeployOptions {
 
   /** The config from the Oclif command */
   commandConfig: Config
+
+  /** Whether source maps are enabled if using esbuild */
+  sourceMaps?: boolean
 }
 
 interface TasksContext {
@@ -97,7 +100,12 @@ export async function deploy(options: DeployOptions) {
         bundlePath = joinPath(tmpDir, `bundle.zip`)
         await mkdir(dirname(bundlePath))
       }
-      await bundleAndBuildExtensions({app, bundlePath, identifiers})
+      await bundleAndBuildExtensions({
+        app,
+        bundlePath,
+        identifiers,
+        sourceMaps: options.sourceMaps,
+      })
 
       const uploadTaskTitle = (() => {
         switch (deploymentMode) {

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -11,6 +11,7 @@ export interface BundleOptions {
   app: AppInterface
   bundlePath?: string
   identifiers: Identifiers
+  sourceMaps?: boolean
 }
 
 export async function bundleAndBuildExtensions(options: BundleOptions) {
@@ -25,7 +26,7 @@ export async function bundleAndBuildExtensions(options: BundleOptions) {
           prefix: extension.localIdentifier,
           action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
             await extension.buildForBundle(
-              {stderr, stdout, signal, app: options.app},
+              {stderr, stdout, signal, app: options.app, sourceMaps: options.sourceMaps},
               options.identifiers,
               bundleDirectory,
             )

--- a/packages/app/src/cli/services/extensions/bundle.test.ts
+++ b/packages/app/src/cli/services/extensions/bundle.test.ts
@@ -54,6 +54,7 @@ describe('bundleExtension()', () => {
       outputPath: extension.outputPath,
       minify: true,
       environment: 'production',
+      sourceMaps: true,
       stdin: {
         contents: 'console.log("mock stdin content")',
         resolveDir: 'mock/resolve/dir',
@@ -105,6 +106,9 @@ describe('bundleExtension()', () => {
     const plugins = options.plugins?.map(({name}) => name)
     expect(plugins).toContain('graphql-loader')
     expect(plugins).toContain('shopify:deduplicate-react')
+
+    expect(options.sourcemap).toBe(true)
+    expect(options.sourceRoot).toEqual('mock/resolve/dir/src')
   })
 
   test('can switch off React deduplication', async () => {


### PR DESCRIPTION
Resolves https://github.com/Shopify/cli/issues/2883

### WHY are these changes introduced?
Our extension is reporting errors to a service, but the stack traces are not helpful at all given that the code is heavily transformed.

### WHAT is this pull request doing?
Allow a new option to be passed to the CLI, and strings it through to the actual ESBuild command.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
