### PR TITLE
Replace esbuild variables that have letters/numbers only

### DIFF
--- a/.changeset/six-windows-enjoy.md
+++ b/.changeset/six-windows-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Javascript functions/extensions now support environment variable sustitution.

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -31,3 +31,5 @@ export const blocks = {
 export const urlNamespaces = {
   devTools: '.shopify',
 } as const
+
+export const EsbuildEnvVarPrefix = 'SHOPIFY_'

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -32,4 +32,4 @@ export const urlNamespaces = {
   devTools: '.shopify',
 } as const
 
-export const EsbuildEnvVarPrefix = 'SHOPIFY_'
+export const EsbuildEnvVarRegex = /^([a-zA-Z0-9_])*$/

--- a/packages/app/src/cli/services/extensions/bundle.test.ts
+++ b/packages/app/src/cli/services/extensions/bundle.test.ts
@@ -63,7 +63,7 @@ describe('bundleExtension()', () => {
         stdout,
         stderr,
       },
-      {VAR_FROM_RUNTIME: 'runtime_var'},
+      {VAR_FROM_RUNTIME: 'runtime_var', SHOPIFY_VAR_FROM_RUNTIME: 'runtime_var'},
     )
 
     // Then
@@ -94,7 +94,7 @@ describe('bundleExtension()', () => {
     expect(options.define).toEqual({
       'process.env.FOO': JSON.stringify('BAR'),
       'process.env.NODE_ENV': JSON.stringify('production'),
-      'process.env.VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
+      'process.env.SHOPIFY_VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
     })
     expect(vi.mocked(stdout.write).mock.calls[0][0]).toMatchInlineSnapshot(`
       "▲ [WARNING] warning text [plugin plugin]

--- a/packages/app/src/cli/services/extensions/bundle.test.ts
+++ b/packages/app/src/cli/services/extensions/bundle.test.ts
@@ -63,7 +63,7 @@ describe('bundleExtension()', () => {
         stdout,
         stderr,
       },
-      {VAR_FROM_RUNTIME: 'runtime_var', SHOPIFY_VAR_FROM_RUNTIME: 'runtime_var'},
+      {VAR_FROM_RUNTIME: 'runtime_var', 'INVALID(VAR)': 'invalid_var'},
     )
 
     // Then
@@ -94,7 +94,7 @@ describe('bundleExtension()', () => {
     expect(options.define).toEqual({
       'process.env.FOO': JSON.stringify('BAR'),
       'process.env.NODE_ENV': JSON.stringify('production'),
-      'process.env.SHOPIFY_VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
+      'process.env.VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
     })
     expect(vi.mocked(stdout.write).mock.calls[0][0]).toMatchInlineSnapshot(`
       "▲ [WARNING] warning text [plugin plugin]

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -1,7 +1,7 @@
 import {ExtensionBuildOptions} from '../build/extension.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {themeExtensionFiles} from '../../utilities/extensions/theme.js'
-import {environmentVariableNames} from '../../constants.js'
+import {EsbuildEnvVarRegex, environmentVariableNames} from '../../constants.js'
 import {context as esContext, BuildResult, formatMessagesSync} from 'esbuild'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {copyFile} from '@shopify/cli-kit/node/fs'
@@ -109,7 +109,7 @@ function onResult(result: Awaited<ReturnType<typeof esBuild>> | null, options: B
 }
 
 function getESBuildOptions(options: BundleOptions, processEnv = process.env): Parameters<typeof esContext>[0] {
-  const validEnvs = pickBy(processEnv, (value, key) => key.startsWith('SHOPIFY_') && value)
+  const validEnvs = pickBy(processEnv, (value, key) => EsbuildEnvVarRegex.test(key) && value)
 
   const env: {[variable: string]: string | undefined} = {...options.env, ...validEnvs}
   const define = Object.keys(env || {}).reduce(

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -11,6 +11,7 @@ import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {Writable} from 'stream'
 import {createRequire} from 'module'
 import type {StdinOptions, build as esBuild, Plugin} from 'esbuild'
+import {pickBy} from '@shopify/cli-kit/common/object'
 
 const require = createRequire(import.meta.url)
 
@@ -108,7 +109,9 @@ function onResult(result: Awaited<ReturnType<typeof esBuild>> | null, options: B
 }
 
 function getESBuildOptions(options: BundleOptions, processEnv = process.env): Parameters<typeof esContext>[0] {
-  const env: {[variable: string]: string | undefined} = {...options.env, ...processEnv}
+  const validEnvs = pickBy(processEnv, (value, key) => key.startsWith('SHOPIFY_') && value)
+
+  const env: {[variable: string]: string | undefined} = {...options.env, ...validEnvs}
   const define = Object.keys(env || {}).reduce(
     (acc, key) => ({
       ...acc,

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -8,10 +8,10 @@ import {copyFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, relativePath} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
+import {pickBy} from '@shopify/cli-kit/common/object'
 import {Writable} from 'stream'
 import {createRequire} from 'module'
 import type {StdinOptions, build as esBuild, Plugin} from 'esbuild'
-import {pickBy} from '@shopify/cli-kit/common/object'
 
 const require = createRequire(import.meta.url)
 

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -77,7 +77,7 @@ describe('bundleExtension', () => {
       const got = bundleExtension(
         ourFunction,
         {stdout, stderr, signal, app},
-        {VAR_FROM_RUNTIME: 'runtime_var', SHOPIFY_VAR_FROM_RUNTIME: 'runtime_var'},
+        {VAR_FROM_RUNTIME: 'runtime_var', 'INVALID_(VAR)': 'invalid_var'},
       )
 
       // Then
@@ -85,7 +85,7 @@ describe('bundleExtension', () => {
       expect(esBuild).toHaveBeenCalledWith({
         outfile: joinPath(tmpDir, 'dist/function.js'),
         define: {
-          'process.env.SHOPIFY_VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
+          'process.env.VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
           'process.env.VAR_FROM_ENV_FILE': JSON.stringify('env_file_var'),
         },
         entryPoints: [shopifyFunction],
@@ -271,7 +271,7 @@ describe('ExportJavyBuilder', () => {
         const got = builder.bundle(
           ourFunction,
           {stdout, stderr, signal, app},
-          {VAR_FROM_RUNTIME: 'runtime_var', SHOPIFY_VAR_FROM_RUNTIME: 'runtime_var'},
+          {VAR_FROM_RUNTIME: 'runtime_var', 'INVALID_(VAR)': 'invalid_var'},
         )
 
         // Then
@@ -279,7 +279,7 @@ describe('ExportJavyBuilder', () => {
         expect(esBuild).toHaveBeenCalledWith({
           outfile: joinPath(tmpDir, 'dist/function.js'),
           define: {
-            'process.env.SHOPIFY_VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
+            'process.env.VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
             'process.env.VAR_FROM_ENV_FILE': JSON.stringify('env_file_var'),
           },
           stdin: {

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -74,14 +74,18 @@ describe('bundleExtension', () => {
       const shopifyFunction = await installShopifyLibrary(tmpDir)
 
       // When
-      const got = bundleExtension(ourFunction, {stdout, stderr, signal, app}, {VAR_FROM_RUNTIME: 'runtime_var'})
+      const got = bundleExtension(
+        ourFunction,
+        {stdout, stderr, signal, app},
+        {VAR_FROM_RUNTIME: 'runtime_var', SHOPIFY_VAR_FROM_RUNTIME: 'runtime_var'},
+      )
 
       // Then
       await expect(got).resolves.toBeUndefined()
       expect(esBuild).toHaveBeenCalledWith({
         outfile: joinPath(tmpDir, 'dist/function.js'),
         define: {
-          'process.env.VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
+          'process.env.SHOPIFY_VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
           'process.env.VAR_FROM_ENV_FILE': JSON.stringify('env_file_var'),
         },
         entryPoints: [shopifyFunction],
@@ -264,14 +268,18 @@ describe('ExportJavyBuilder', () => {
         ourFunction.entrySourceFilePath = joinPath(tmpDir, 'src/index.ts')
 
         // When
-        const got = builder.bundle(ourFunction, {stdout, stderr, signal, app}, {VAR_FROM_RUNTIME: 'runtime_var'})
+        const got = builder.bundle(
+          ourFunction,
+          {stdout, stderr, signal, app},
+          {VAR_FROM_RUNTIME: 'runtime_var', SHOPIFY_VAR_FROM_RUNTIME: 'runtime_var'},
+        )
 
         // Then
         await expect(got).resolves.toBeUndefined()
         expect(esBuild).toHaveBeenCalledWith({
           outfile: joinPath(tmpDir, 'dist/function.js'),
           define: {
-            'process.env.VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
+            'process.env.SHOPIFY_VAR_FROM_RUNTIME': JSON.stringify('runtime_var'),
             'process.env.VAR_FROM_ENV_FILE': JSON.stringify('env_file_var'),
           },
           stdin: {

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -11,7 +11,7 @@ import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {Writable} from 'stream'
 import {pickBy} from '@shopify/cli-kit/common/object'
-import {EsbuildEnvVarPrefix} from '../../constants.js'
+import {EsbuildEnvVarRegex} from '../../constants.js'
 
 interface JSFunctionBuildOptions {
   stdout: Writable
@@ -131,7 +131,7 @@ function getESBuildOptions(
   appEnv: {[variable: string]: string | undefined},
   processEnv = process.env,
 ): Parameters<typeof esBuild>[0] {
-  const validEnvs = pickBy(processEnv, (value, key) => key.startsWith(EsbuildEnvVarPrefix) && value)
+  const validEnvs = pickBy(processEnv, (value, key) => EsbuildEnvVarRegex.test(key) && value)
 
   const env: {[variable: string]: string | undefined} = {...appEnv, ...validEnvs}
   const define = Object.keys(env || {}).reduce(

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -10,6 +10,7 @@ import {findPathUp, inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {Writable} from 'stream'
+import {pickBy} from '@shopify/cli-kit/common/object'
 
 interface JSFunctionBuildOptions {
   stdout: Writable
@@ -129,7 +130,9 @@ function getESBuildOptions(
   appEnv: {[variable: string]: string | undefined},
   processEnv = process.env,
 ): Parameters<typeof esBuild>[0] {
-  const env: {[variable: string]: string | undefined} = {...appEnv, ...processEnv}
+  const validEnvs = pickBy(processEnv, (value, key) => key.startsWith('SHOPIFY_') && value)
+
+  const env: {[variable: string]: string | undefined} = {...appEnv, ...validEnvs}
   const define = Object.keys(env || {}).reduce(
     (acc, key) => ({
       ...acc,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -1,6 +1,7 @@
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {AppInterface} from '../../models/app/app.js'
+import {EsbuildEnvVarRegex} from '../../constants.js'
 import {hyphenate, camelize} from '@shopify/cli-kit/common/string'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {exec} from '@shopify/cli-kit/node/system'
@@ -9,9 +10,8 @@ import {build as esBuild, BuildResult, BuildOptions} from 'esbuild'
 import {findPathUp, inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
-import {Writable} from 'stream'
 import {pickBy} from '@shopify/cli-kit/common/object'
-import {EsbuildEnvVarRegex} from '../../constants.js'
+import {Writable} from 'stream'
 
 interface JSFunctionBuildOptions {
   stdout: Writable

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -11,6 +11,7 @@ import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {Writable} from 'stream'
 import {pickBy} from '@shopify/cli-kit/common/object'
+import {EsbuildEnvVarPrefix} from '../../constants.js'
 
 interface JSFunctionBuildOptions {
   stdout: Writable
@@ -130,7 +131,7 @@ function getESBuildOptions(
   appEnv: {[variable: string]: string | undefined},
   processEnv = process.env,
 ): Parameters<typeof esBuild>[0] {
-  const validEnvs = pickBy(processEnv, (value, key) => key.startsWith('SHOPIFY_') && value)
+  const validEnvs = pickBy(processEnv, (value, key) => key.startsWith(EsbuildEnvVarPrefix) && value)
 
   const env: {[variable: string]: string | undefined} = {...appEnv, ...validEnvs}
   const define = Object.keys(env || {}).reduce(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We introduced a feature to sustitute environment variables in extensions/functions at build time. But we need to validate that they are supported by esbuild first.

This PR filters variables to keep the ones having just letters/numbers/underscores

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
