### PR TITLE
Fix ambiguity between `--editor` and `--environment` flags in the `shopify theme open` command

### DIFF
--- a/.changeset/dull-mirrors-yawn.md
+++ b/.changeset/dull-mirrors-yawn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix ambiguity between `--editor` and `--environment` flags in the `shopify theme open` command

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1147,12 +1147,12 @@ Opens the preview of your remote theme.
 
 ```
 USAGE
-  $ shopify theme open [--no-color] [--verbose] [--password <value>] [-d] [-e] [-l] [-t <value>] [-s <value>]
+  $ shopify theme open [--no-color] [--verbose] [--password <value>] [-d] [-E] [-l] [-t <value>] [-s <value>]
     [-e <value>]
 
 FLAGS
+  -E, --editor               Open the theme editor for the specified theme in the browser.
   -d, --development          Open your development theme.
-  -e, --editor               Open the theme editor for the specified theme in the browser.
   -e, --environment=<value>  The environment to apply to the current command.
   -l, --live                 Open your live (published) theme.
   -s, --store=<value>        Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -697,7 +697,7 @@
         "editor": {
           "name": "editor",
           "type": "boolean",
-          "char": "e",
+          "char": "E",
           "description": "Open the theme editor for the specified theme in the browser.",
           "allowNo": false
         },

--- a/packages/theme/src/cli/commands/theme/open.ts
+++ b/packages/theme/src/cli/commands/theme/open.ts
@@ -18,7 +18,7 @@ export default class Open extends ThemeCommand {
       env: 'SHOPIFY_FLAG_DEVELOPMENT',
     }),
     editor: Flags.boolean({
-      char: 'e',
+      char: 'E',
       description: 'Open the theme editor for the specified theme in the browser.',
       env: 'SHOPIFY_FLAG_EDITOR',
     }),


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2972

### WHAT is this pull request doing?

The aliases for `--editor` and `--environment` were conflicting. Since partners require an alias for [both](Fixes https://github.com/Shopify/cli/issues/2972) flags, `--editor` now uses `-E` instead of `-e`.

### How to test your changes?

Run: `shopify theme open -E -e <your_environment>`

![demo_fix_open_flag](https://github.com/Shopify/cli/assets/1079279/34623c1a-72a4-4e76-8f52-f81205edf6ac)


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
