### PR TITLE
The `shopify theme delete` command no longer fails when some flags (`-f`, `-d`, etc.) are passed without the `-t` flag

### DIFF
--- a/.changeset/ten-pillows-attend.md
+++ b/.changeset/ten-pillows-attend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+The `shopify theme delete` command no longer fails when some flags (`-f`, `-d`, etc.) are passed without the `-t` flag

--- a/packages/theme/src/cli/services/delete.test.ts
+++ b/packages/theme/src/cli/services/delete.test.ts
@@ -42,7 +42,7 @@ describe('deleteThemes', () => {
     const confirmed = true
 
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(confirmed)
-    vi.mocked(findOrSelectTheme).mockResolvedValue(theme1)
+    vi.mocked(findThemes).mockResolvedValue([theme1])
 
     // When
     await deleteThemes(session, {...options, development: true})

--- a/packages/theme/src/cli/services/delete.ts
+++ b/packages/theme/src/cli/services/delete.ts
@@ -53,18 +53,14 @@ export async function deleteThemes(adminSession: AdminSession, options: DeleteOp
 }
 
 async function findThemesByDeleteOptions(adminSession: AdminSession, options: DeleteOptions) {
-  const isSingleThemeSelection = options.selectTheme || options.themes.length <= 1
-
-  if (!isSingleThemeSelection) {
+  if (options.selectTheme || options.themes.length > 0) {
     return findThemes(adminSession, options)
   }
 
   const store = adminSession.storeFqdn
   const theme = await findOrSelectTheme(adminSession, {
     header: `Select a theme to delete from ${store}`,
-    filter: {
-      ...options,
-    },
+    filter: {development: options.development},
   })
 
   return [theme]


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2812

### WHAT is this pull request doing?

There was an issue in the theme selection logic when the users passes some flag (such as `-f`, `-d`, etc.) but doesn't pass the `-t/--theme` flag. This PR fixes that issue.

### How to test your changes?

Run `shopify theme delete -f`

**Before**
![demo_fix_delete_before](https://github.com/Shopify/cli/assets/1079279/6eb26977-1129-49ff-83cb-f05a5b45faa2)

**After**
![demo_fix_delete_after](https://github.com/Shopify/cli/assets/1079279/472263b3-f9e6-4fb7-a0a0-10266ff099ac)

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
