### PR TITLE
Enhance the `shopify theme dev` command banner by adding the preview URL next to the preview link

### DIFF
--- a/.changeset/strange-dancers-exercise.md
+++ b/.changeset/strange-dancers-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Enhance the `shopify theme dev` command banner by adding the preview URL next to the preview link, for easy copy/pasting in terminal emulators that support hyperlinks

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -84,9 +84,12 @@ export function renderLinks(store: string, themeId: string, host = DEFAULT_HOST,
       [
         {
           link: {
-            label: 'Share your theme preview',
+            label: `Share your theme preview`,
             url: `https://${store}/?preview_theme_id=${themeId}`,
           },
+        },
+        {
+          subdued: `(https://${store}/?preview_theme_id=${themeId})`,
         },
       ],
     ],


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/2716

### WHAT is this pull request doing?

Enhance the `shopify theme dev` command banner by adding the preview URL next to the preview link, for easy copy/pasting in terminal emulators that support hyperlinks.

### How to test your changes?

Run: `shopify theme dev`

**Before**
![text_before](https://github.com/Shopify/cli/assets/1079279/1622f564-d7ca-404e-bb13-5f3965ac0b8f)

**After**
![text_after](https://github.com/Shopify/cli/assets/1079279/8dfa3313-4cd8-47c7-88f8-751f654e8411)


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
