### PR TITLE
Clarify `SHOPIFY_CLI_BUNDLED_THEME_CLI` environment variable should not be used, yet resolve its compatibility issue

### DIFF
--- a/.changeset/sour-toys-scream.md
+++ b/.changeset/sour-toys-scream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Clarify `SHOPIFY_CLI_BUNDLED_THEME_CLI` environment variable should not be used, yet resolve its compatibility issue

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -4,6 +4,7 @@ import ThemeCommand from '../../utilities/theme-command.js'
 import {dev, refreshTokens, showDeprecationWarnings} from '../../services/dev.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
 import {findOrSelectTheme} from '../../utilities/theme-selector.js'
+import {showEmbeddedCLIWarning} from '../../utilities/embedded-cli-warning.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
@@ -103,6 +104,7 @@ export default class Dev extends ThemeCommand {
    * Every 110 minutes, it will refresh the session token.
    */
   async run(): Promise<void> {
+    showEmbeddedCLIWarning()
     showDeprecationWarnings(this.argv)
 
     let {flags} = await this.parse(Dev)

--- a/packages/theme/src/cli/commands/theme/pull.test.ts
+++ b/packages/theme/src/cli/commands/theme/pull.test.ts
@@ -6,11 +6,15 @@ import {Config} from '@oclif/core'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {Theme} from '@shopify/cli-kit/node/themes/models/theme'
+import {useEmbeddedThemeCLI} from '@shopify/cli-kit/node/context/local'
+import {renderWarning} from '@shopify/cli-kit/node/ui'
 
 vi.mock('../../utilities/development-theme-manager.js')
 vi.mock('../../utilities/theme-store.js')
 vi.mock('@shopify/cli-kit/node/ruby')
 vi.mock('@shopify/cli-kit/node/session')
+vi.mock('@shopify/cli-kit/node/context/local')
+vi.mock('@shopify/cli-kit/node/ui')
 
 describe('Pull', () => {
   describe('run', () => {
@@ -18,6 +22,7 @@ describe('Pull', () => {
     const path = '/my-theme'
 
     async function run(argv: string[], theme?: Theme) {
+      vi.mocked(renderWarning).mockReturnValue('shhh!')
       vi.mocked(ensureThemeStore).mockReturnValue('example.myshopify.com')
       vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(adminSession)
       if (theme) {
@@ -39,6 +44,8 @@ describe('Pull', () => {
     }
 
     test('should pass development theme from local storage to CLI 2', async () => {
+      vi.mocked(useEmbeddedThemeCLI).mockReturnValue(true)
+
       const theme = new Theme(1, 'Theme', 'development')
       await run([], theme)
 
@@ -48,6 +55,8 @@ describe('Pull', () => {
     })
 
     test('should pass theme and development theme from local storage to CLI 2', async () => {
+      vi.mocked(useEmbeddedThemeCLI).mockReturnValue(true)
+
       const themeId = 2
       const theme = new Theme(3, 'Theme', 'development')
       await run([`--theme=${themeId}`], theme)
@@ -55,7 +64,18 @@ describe('Pull', () => {
       expectCLI2ToHaveBeenCalledWith(`theme pull ${path} --theme ${themeId} --development-theme-id ${theme.id}`)
     })
 
+    test("should not pass development theme to CLI 2 when user isn't using the embedded CLI", async () => {
+      vi.mocked(useEmbeddedThemeCLI).mockReturnValue(false)
+
+      const themeId = 2
+      const theme = new Theme(3, 'Theme', 'development')
+      await run([`--theme=${themeId}`], theme)
+
+      expectCLI2ToHaveBeenCalledWith(`theme pull ${path} --theme ${themeId}`)
+    })
+
     test('should not pass development theme to CLI 2 if local storage is empty', async () => {
+      vi.mocked(useEmbeddedThemeCLI).mockReturnValue(true)
       await run([])
 
       expect(DevelopmentThemeManager.prototype.find).not.toHaveBeenCalled()
@@ -64,6 +84,7 @@ describe('Pull', () => {
     })
 
     test('should pass theme and development theme to CLI 2', async () => {
+      vi.mocked(useEmbeddedThemeCLI).mockReturnValue(true)
       const theme = new Theme(4, 'Theme', 'development')
       await run(['--development'], theme)
 

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -2,10 +2,12 @@ import {themeFlags} from '../../flags.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
+import {showEmbeddedCLIWarning} from '../../utilities/embedded-cli-warning.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
+import {useEmbeddedThemeCLI} from '@shopify/cli-kit/node/context/local'
 
 export default class Pull extends ThemeCommand {
   static description = 'Download your remote theme files locally.'
@@ -56,6 +58,8 @@ export default class Pull extends ThemeCommand {
   static cli2Flags = ['theme', 'development', 'live', 'nodelete', 'only', 'ignore', 'force', 'development-theme-id']
 
   async run(): Promise<void> {
+    showEmbeddedCLIWarning()
+
     const {flags} = await this.parse(Pull)
     const store = ensureThemeStore(flags)
     const adminSession = await ensureAuthenticatedThemes(store, flags.password)
@@ -67,7 +71,9 @@ export default class Pull extends ThemeCommand {
         flags.theme = `${theme.id}`
         flags.development = false
       }
-      flags['development-theme-id'] = theme.id
+      if (useEmbeddedThemeCLI()) {
+        flags['development-theme-id'] = theme.id
+      }
     }
 
     const flagsToPass = this.passThroughFlags(flags, {allowedFlags: Pull.cli2Flags})

--- a/packages/theme/src/cli/utilities/embedded-cli-warning.test.ts
+++ b/packages/theme/src/cli/utilities/embedded-cli-warning.test.ts
@@ -1,0 +1,48 @@
+import {showEmbeddedCLIWarning} from './embedded-cli-warning.js'
+import {renderWarning} from '@shopify/cli-kit/node/ui'
+import {useEmbeddedThemeCLI} from '@shopify/cli-kit/node/context/local'
+import {test, describe, expect, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('@shopify/cli-kit/node/context/local')
+
+describe('#showEmbeddedCLIWarning', () => {
+  test("shows warning message when the user isn't using the embedded CLI", async () => {
+    // Given
+    vi.mocked(useEmbeddedThemeCLI).mockReturnValue(false)
+
+    // When
+    showEmbeddedCLIWarning()
+
+    // Then
+    expect(renderWarning).toBeCalledWith({
+      headline: ['`SHOPIFY_CLI_BUNDLED_THEME_CLI` is deprecated.'],
+      body: [
+        'The',
+        {
+          command: 'SHOPIFY_CLI_BUNDLED_THEME_CLI',
+        },
+        'environment variable has been deprecated and should be used for debugging purposes only. If this variable is essential to your workflow, please report an issue at',
+        {
+          link: {
+            url: 'https://github.com/Shopify/cli/issues',
+          },
+        },
+        {
+          char: '.',
+        },
+      ],
+    })
+  })
+
+  test("doesn't show warning message when the user is using the embedded CLI", async () => {
+    // Given
+    vi.mocked(useEmbeddedThemeCLI).mockReturnValue(true)
+
+    // When
+    showEmbeddedCLIWarning()
+
+    // Then
+    expect(renderWarning).not.toBeCalled()
+  })
+})

--- a/packages/theme/src/cli/utilities/embedded-cli-warning.ts
+++ b/packages/theme/src/cli/utilities/embedded-cli-warning.ts
@@ -1,0 +1,25 @@
+import {useEmbeddedThemeCLI} from '@shopify/cli-kit/node/context/local'
+import {renderWarning} from '@shopify/cli-kit/node/ui'
+
+export function showEmbeddedCLIWarning() {
+  if (!useEmbeddedThemeCLI()) {
+    renderWarning({
+      headline: ['`SHOPIFY_CLI_BUNDLED_THEME_CLI` is deprecated.'],
+      body: [
+        'The',
+        {
+          command: 'SHOPIFY_CLI_BUNDLED_THEME_CLI',
+        },
+        'environment variable has been deprecated and should be used for debugging purposes only. If this variable is essential to your workflow, please report an issue at',
+        {
+          link: {
+            url: 'https://github.com/Shopify/cli/issues',
+          },
+        },
+        {
+          char: '.',
+        },
+      ],
+    })
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

These changes fix an issue related to https://github.com/Shopify/cli/issues/2665.

### WHAT is this pull request doing?

The `SHOPIFY_CLI_BUNDLED_THEME_CLI` environment variable should not be used, as it points to the legacy/unsupported Shopify CLI 2.0 (`shopify/shopify-cli`) commands. Instead, theme commands should execute the Ruby classes at `shopify/cli`.

This PR introduces a warning with a call to action for users who currently rely on `SHOPIFY_CLI_BUNDLED_THEME_CLI`. It also resolves a compatibility issue for users who currently activate the `SHOPIFY_CLI_BUNDLED_THEME_CLI`.

### How to test your changes?

- Run `export SHOPIFY_CLI_BUNDLED_THEME_CLI=1`
- Run `shopify theme pull -d`

**Before**
<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/933f2833-1207-4a35-89ba-6f84fba9ac48"/>

**After**
<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/e104f0a9-b923-4e11-b350-98a3b0c5a520"/>


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
