### PR TITLE
Fix function run in create-test-app

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -52,6 +52,10 @@ program
     "-t, --template <template>",
     "template to be used for the app",
   )
+  .option(
+    "-f, --flavor <flavor>",
+    "flavor to be used for the template",
+  )
   .option("--cleanup", "delete temp app afterwards", false)
   .option("--deploy", "deploy the app to Shopify", false)
   .option("--config-as-code", "enable config as code", false)
@@ -71,6 +75,7 @@ program
 
     const appName = options.name;
     const template = options.template || "remix";
+    const flavor = options.flavor || "javascript";
     const appPath = path.join(homeDir, "Desktop", appName);
 
     switch (options.packageManager) {
@@ -145,6 +150,8 @@ program
       }
     }
 
+    const flavorFlag = template === 'remix' ? `--flavor=${flavor}` : '';
+
     switch (options.install) {
       case "local":
         log("Building latest release...");
@@ -156,6 +163,7 @@ program
           [
             "--local",
             `--template=${template}`,
+            flavorFlag,
             `--name=${appName}`,
             `--path=${path.join(homeDir, "Desktop")}`,
             `--package-manager=${nodePackageManager}`,
@@ -174,7 +182,7 @@ program
         break;
       case "nightly":
         log(`Creating new app in '${appPath}'...`);
-        let initArgs = [`--template=${template}`, `--name=${appName}`, `--path=${path.join(homeDir, "Desktop")}`];
+        let initArgs = [`--template=${template}`, flavorFlag, `--name=${appName}`, `--path=${path.join(homeDir, "Desktop")}`];
         switch (nodePackageManager) {
           case "yarn":
             // yarn doesn't support 'create @shopify/app@nightly' syntax
@@ -264,7 +272,8 @@ program
         "--flavor=typescript",
       ]);
       await appExec(nodePackageManager, ["run", "build"], { cwd: functionDir });
-      const previewProcess = execa(nodePackageManager, ["run", "preview"], {
+      const separator = nodePackageManager === "npm" ? "--" : "";
+      const previewProcess = execa(nodePackageManager, ["run", "preview", separator, "--export", "run"], {
         cwd: functionDir,
         stdout: "inherit",
       });


### PR DESCRIPTION
### WHY are these changes introduced?

The function run step in the create-test-app script was failing because it's using the default export name (`_start`), but the function template exports a function called `run`.

<img width="326" alt="25-04-591pq-paykj" src="https://github.com/Shopify/cli/assets/14979109/fe8830a5-a40b-4fba-9994-d8a114050d07">

Related to https://github.com/Shopify/develop-app-management/issues/169

### WHAT is this pull request doing?

- Add `--export run` to the function run step
- Add a default flavor for the remix template, so we don't have to manually choose between JS/TS

### How to test your changes?

`bin/create-test-app.js -i nightly`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
