### PR TITLE
Fix support for legacy theme check configuration identifiers

### DIFF
--- a/.changeset/purple-birds-film.md
+++ b/.changeset/purple-birds-film.md
@@ -3,4 +3,4 @@
 '@shopify/cli': minor
 ---
 
-Added fix to support `:theme_app_extension` for theme check.
+Added fix to support `:theme_app_extension` for dev-preview theme check.

--- a/.changeset/purple-birds-film.md
+++ b/.changeset/purple-birds-film.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme': minor
+'@shopify/cli': minor
+---
+
+Added fix to support `:theme_app_extension` for theme check.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -899,7 +899,9 @@ USAGE
 
 FLAGS
   -C, --config=<value>            Use the config provided, overriding .theme-check.yml if present
-                                  Use :theme_app_extension to use default checks for theme app extensions
+                                  Supports all theme-check: config values, e.g., theme-check:theme-app-extension,
+                                  theme-check:recommended, theme-check:all
+                                  For backwards compatibility, :theme_app_extension is also supported
   -a, --auto-correct              Automatically fix offenses
   -c, --category=<value>          Only run this category of checks
                                   Runs checks matching all categories when specified more than once

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -58,7 +58,7 @@
           "name": "config",
           "type": "option",
           "char": "C",
-          "description": "Use the config provided, overriding .theme-check.yml if present\nUse :theme_app_extension to use default checks for theme app extensions",
+          "description": "Use the config provided, overriding .theme-check.yml if present\n      Supports all theme-check: config values, e.g., theme-check:theme-app-extension,\n      theme-check:recommended, theme-check:all\n      For backwards compatibility, :theme_app_extension is also supported ",
           "required": false,
           "multiple": false
         },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -36,8 +36,8 @@
   "dependencies": {
     "@oclif/core": "2.11.7",
     "@shopify/cli-kit": "3.50.0",
-    "@shopify/theme-check-node": "1.16.1",
-    "@shopify/theme-language-server-node": "1.3.2",
+    "@shopify/theme-check-node": "1.20.1",
+    "@shopify/theme-language-server-node": "1.5.1",
     "yaml": "2.3.2"
   },
   "devDependencies": {

--- a/packages/theme/src/cli/commands/theme/check.test.ts
+++ b/packages/theme/src/cli/commands/theme/check.test.ts
@@ -1,0 +1,83 @@
+import Check from './check.js'
+import {describe, vi, expect, test, beforeEach, afterAll, SpyInstance} from 'vitest'
+import {Config} from '@oclif/core'
+import {themeCheckRun, Theme, Config as ThemeConfig, Offense} from '@shopify/theme-check-node'
+
+vi.mock('@shopify/theme-check-node')
+
+describe('Check', () => {
+  let exitSpy: SpyInstance
+
+  beforeEach(() => {
+    // Create a spy on process.exit
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(vi.fn())
+  })
+
+  afterAll(() => {
+    // Restore the original process.exit function after each test
+    exitSpy.mockRestore()
+  })
+
+  describe('run', () => {
+    const path = '/my-theme'
+
+    async function run(argv: string[]) {
+      const config = {} as Config
+      const check = new Check(['--dev-preview', `--path=${path}`, ...argv], config)
+
+      await check.run()
+    }
+
+    test('should change config to "theme-check:recommended" when ":default" is inputted', async () => {
+      const mockTheme: Theme = []
+      const mockConfig: ThemeConfig = {
+        settings: {},
+        checks: [],
+        root: '',
+      }
+      const mockOffenses: Offense[] = []
+
+      vi.mocked(themeCheckRun).mockImplementation(async (path, config) => {
+        expect(config).toBe('theme-check:recommended')
+        return {offenses: mockOffenses, theme: mockTheme, config: mockConfig}
+      })
+
+      await run(['--config=:default'])
+    })
+
+    test('should change config to "theme-check:theme-app-extension" when ":theme_app_extensions" is inputted', async () => {
+      const mockTheme: Theme = []
+      const mockConfig: ThemeConfig = {
+        settings: {},
+        checks: [],
+        root: '',
+      }
+      const mockOffenses: Offense[] = []
+
+      vi.mocked(themeCheckRun).mockImplementation(async (path, config) => {
+        expect(config).toBe('theme-check:theme-app-extension')
+        return {offenses: mockOffenses, theme: mockTheme, config: mockConfig}
+      })
+
+      await run(['--config=:theme_app_extensions'])
+    })
+
+    test('should not change config when ":theme_app_extension" is not inputted', async () => {
+      const expectedConfig = 'some-config'
+      const mockTheme: Theme = []
+      const mockConfig: ThemeConfig = {
+        settings: {},
+        checks: [],
+        root: '',
+      }
+      const mockOffenses: Offense[] = []
+
+      vi.mocked(themeCheckRun).mockImplementation(async (path, config) => {
+        expect(config).toBe(expectedConfig)
+        return {offenses: mockOffenses, theme: mockTheme, config: mockConfig}
+      })
+
+      await run([`--config=${expectedConfig}`])
+    })
+  })
+})

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -49,7 +49,9 @@ Runs checks matching all categories when specified more than once`,
       char: 'C',
       required: false,
       description: `Use the config provided, overriding .theme-check.yml if present
-Use :theme_app_extension to use default checks for theme app extensions`,
+      Supports all theme-check: config values, e.g., theme-check:theme-app-extension,
+      theme-check:recommended, theme-check:all
+      For backwards compatibility, :theme_app_extension is also supported `,
       env: 'SHOPIFY_FLAG_CONFIG',
     }),
     // Typescript theme check no longer uses `--exclude-categories`
@@ -171,7 +173,11 @@ Excludes checks matching any category when specified more than once`,
         return
       }
 
-      const {offenses, theme} = await themeCheckRun(path, flags.config)
+      // To support backwards compatibility for :theme_app_extension
+      const isLegacyTAEConfig = flags.config === ':theme_app_extension'
+      const config = isLegacyTAEConfig ? 'theme-check:theme-app-extension' : flags.config
+
+      const {offenses, theme} = await themeCheckRun(path, config)
 
       const offensesByFile = sortOffenses(offenses)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,11 +717,11 @@ importers:
         specifier: 3.50.0
         version: link:../cli-kit
       '@shopify/theme-check-node':
-        specifier: 1.16.1
-        version: 1.16.1
+        specifier: 1.20.1
+        version: 1.20.1
       '@shopify/theme-language-server-node':
-        specifier: 1.3.2
-        version: 1.3.2
+        specifier: 1.5.1
+        version: 1.5.1
       yaml:
         specifier: 2.3.2
         version: 2.3.2
@@ -4586,8 +4586,8 @@ packages:
     engines: {node: '>=12.14.0'}
     dev: false
 
-  /@shopify/liquid-html-parser@1.0.0:
-    resolution: {integrity: sha512-z64n4gbS41tHsvuB6JoC8cxnsgLXWtauiBzB0pOsF5+Zl5aR+IcBhLDQLkBJs78tuafk42BO4GAm5ge4L7lxTw==}
+  /@shopify/liquid-html-parser@1.1.1:
+    resolution: {integrity: sha512-nGTkGTu5UWwd9OcM6q5/8ZDWe5U8VTlKeCprwhBAQ/qWV57tBcOIT5+UeTc1tIPVnHMD/S9nkhXY04api3/HqQ==}
     dependencies:
       line-column: 1.0.2
       ohm-js: 16.6.0
@@ -4681,10 +4681,10 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-check-common@1.16.1:
-    resolution: {integrity: sha512-n7cZ6pmjHRrNWKYW8Rruu/hnPlX6H1qEQiYY94PKONf4VMjs83q/LJlzauOJ8mND9PxeTCwWTAApZgNqHngR7g==}
+  /@shopify/theme-check-common@1.20.1:
+    resolution: {integrity: sha512-M8176CVIDM9kZ8G991lN+HXefavMdk++UlaxgVBjVKLCtx0cn/z013KHFZTusUvcO+OyApZlcqMawN1zonT2LQ==}
     dependencies:
-      '@shopify/liquid-html-parser': 1.0.0
+      '@shopify/liquid-html-parser': 1.1.1
       cross-fetch: 4.0.0
       json-to-ast: 2.1.0
       line-column: 1.0.2
@@ -4695,11 +4695,11 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-check-docs-updater@1.16.1:
-    resolution: {integrity: sha512-sNft1xUx6iRiItsh3L9M0iaj5vzi2Sf2r8v4uoyS4jeZph0gRoIQVv18vXNs16WIwVP4ucYKf/8rt3uhI3sAUw==}
+  /@shopify/theme-check-docs-updater@1.20.1:
+    resolution: {integrity: sha512-AIqRwMQZZ2vWrdVZqQ9YXbqrPoY+ctG/yaIE/NK5+uESpy6AO/GJrCN2iT0lNaWvDYXb3ISyuMQpv4iL0z8kww==}
     hasBin: true
     dependencies:
-      '@shopify/theme-check-common': 1.16.1
+      '@shopify/theme-check-common': 1.20.1
       ajv: 8.12.0
       env-paths: 2.2.1
       node-fetch: 2.7.0
@@ -4707,22 +4707,22 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-check-node@1.16.1:
-    resolution: {integrity: sha512-fJU//djQ41ltSvSjhx5LKQsxRfwIdr4m9XooLCiFKoGlZ9DUNww3SHE6rRdqdGu4v8tlRju1ccRdBQhik+eaBA==}
+  /@shopify/theme-check-node@1.20.1:
+    resolution: {integrity: sha512-uU4SgAD43mX2NssytSl4CxL89WuPwWXVdx4/D/ZdYeanDmQgWAH0DD0yD6q6EwKjksXCt2GtrrJmtxEz7tmchA==}
     dependencies:
-      '@shopify/theme-check-common': 1.16.1
-      '@shopify/theme-check-docs-updater': 1.16.1
+      '@shopify/theme-check-common': 1.20.1
+      '@shopify/theme-check-docs-updater': 1.20.1
       glob: 8.1.0
       yaml: 2.3.2
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@shopify/theme-language-server-common@1.3.2:
-    resolution: {integrity: sha512-56Fg4tLrAUWHXHLYvejp94IwDPUmoT2zvjHHH1kwxnFzdXfq2WPMtIBnFdtDvzs/giNrxwkzu1S80ed0Ry2xdg==}
+  /@shopify/theme-language-server-common@1.5.1:
+    resolution: {integrity: sha512-/Oni9utNUM5iVRTcm7M2MZS7u+dS5mU7Kwq7CDl0j1F4mEY13p9MTbQQ0bo/DrbphYEWIbm6jejI3QhdzsE3WQ==}
     dependencies:
-      '@shopify/liquid-html-parser': 1.0.0
-      '@shopify/theme-check-common': 1.16.1
+      '@shopify/liquid-html-parser': 1.1.1
+      '@shopify/theme-check-common': 1.20.1
       '@vscode/web-custom-data': 0.4.8
       vscode-languageserver: 8.1.0
       vscode-languageserver-textdocument: 1.0.11
@@ -4731,12 +4731,12 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-language-server-node@1.3.2:
-    resolution: {integrity: sha512-NuE6aV0/nQ9haB3xk2ACWlPUETsKyGlOTjebLcMlyBdAwQhQRa9UgynCNb41NIUlyNIFKbkalWmOPqnXw+/QkA==}
+  /@shopify/theme-language-server-node@1.5.1:
+    resolution: {integrity: sha512-ufGHXwLHCXa9rlGszUIMP8+X4LhydD6QfxTlMUPCmSDKy6WWxpC0cvSBJzFTy4xpsAFgbQXRP2q89DyxvMpB+w==}
     dependencies:
-      '@shopify/theme-check-docs-updater': 1.16.1
-      '@shopify/theme-check-node': 1.16.1
-      '@shopify/theme-language-server-common': 1.3.2
+      '@shopify/theme-check-docs-updater': 1.20.1
+      '@shopify/theme-check-node': 1.20.1
+      '@shopify/theme-language-server-common': 1.5.1
       glob: 8.1.0
       node-fetch: 2.7.0
       vscode-languageserver: 8.1.0


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/theme-tools/issues/208 <!-- link to issue if one exists -->

The docs for our CLI was stating that for `theme check` the `--config :theme_app_extension` would auto load the [TAE config](https://github.com/Shopify/theme-tools/blob/main/packages/theme-check-node/configs/theme-app-extension.yml), but this was not working. After some digging, I realized we did not support this command, and hence added a backwards compatibility to ensure if `:theme_app_extension` was run, `theme-check:theme-app-extension,` was called.

### WHAT is this pull request doing?

This pull request is updating our docs for the config value, and is adding backwards compatibility.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Simply run `pnpm run shopify theme check --dev-preview --config :theme_app_extension` and make sure it run's succesfully.

### TopHat Screenshot

<img width="1130" alt="Screenshot 2023-10-31 at 3 13 34 PM" src="https://github.com/Shopify/cli/assets/90271670/610a3a3e-9591-4f33-b85b-fa8e0ad9c2c5">


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
