### PR TITLE
Fix run CLI manually in spin

### DIFF
--- a/.changeset/perfect-moons-search.md
+++ b/.changeset/perfect-moons-search.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix run CLI manually in spin

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -7,7 +7,7 @@ import {setCachedAppInfo} from '../local-storage.js'
 import {writeAppConfigurationFile} from '../app/write-app-configuration-file.js'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
 import {Config} from '@oclif/core'
-import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
+import {checkPortAvailability, getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {isValidURL} from '@shopify/cli-kit/common/url'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {appHost, appPort, isSpin, spinFqdn} from '@shopify/cli-kit/node/context/spin'
@@ -66,8 +66,9 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
 
   if (isSpin() && !options.tunnelUrl) {
     frontendUrl = `https://cli.${await spinFqdn()}`
-    if (appPort() !== undefined) {
-      frontendPort = appPort() ?? frontendPort
+    const cliMainServicePort = appPort()
+    if (cliMainServicePort !== undefined && (await checkPortAvailability(cliMainServicePort))) {
+      frontendPort = cliMainServicePort
       frontendUrl = `https://${appHost()}`
     }
     return {frontendUrl, frontendPort, usingLocalhost}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Fixes https://github.com/Shopify/develop-app-management/issues/1518

- When CLI should use the port reserved for the process `server` in the `Procfile`:
  - CLI `dev` command is configured as the `server` process in the `Procfile`. App is run through the CLI or it's an only extensions app
- When CLI should use the default `4040` port in spin (mainly to develop only extensions)
  - Run the `dev` command manually for an app which backend is configured to be run automatically for the process `server` in the `Procfile`. 
  - Run the `dev` command automatically for an app which backend is configured to be run automatically for the process `server` in the `Procfile`. The `dev` command is configured in a different entry in the `Procfile`
  - The backend is a legacy Rails app really complex to integrate or devs wants it to be run in standalone mode

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- In spin when the CLI is getting the port to listen to it selects the one reserved for the process `server` in the `Procfile`. In case the port is not available the default one (`4040` which has an nginx rule to be accesible) is used. 
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create an spin instance of any 1P app the has the backend configured as the `server` process.
```sh
spin up shopify_chat:theme-extension -c shopify_chat.branch=theme-extension-spin
```
- Create an app `npm init @shopify/app@release`
- Run the `dev` command and it should work as expected
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
