### PR TITLE
[Fix] node/git isClean to match returned type

### DIFF
--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -288,5 +288,5 @@ export async function ensureIsClean(directory?: string): Promise<void> {
 export async function isClean(directory?: string): Promise<boolean> {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  return (await git({baseDir: directory}).status()).isClean
+  return (await git({baseDir: directory}).status()).isClean()
 }


### PR DESCRIPTION
### WHY are these changes introduced?

While using git `isClean` I noticed the return type Promise<boolean> did not match the actual return. simple-git's `git.status().isClean` is a [function](https://github.com/steveukx/git-js/blob/8a31c45a1359248cb38d768d22a5e29903ceef8a/simple-git/typings/response.d.ts#L371C4-L371C11) and not a property.

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
