### PR TITLE
[Feature] Add feature for user now able to use their own cloudflare tunnel and custom domain

### DIFF
--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -71,6 +71,9 @@ class TunnelClientInstance implements TunnelClient {
     }
 
     const args: string[] = ['tunnel', '--url', `http://localhost:${this.port}`, '--no-autoupdate']
+    if (process.env.SHOPIFY_CLI_CUSTOM_CLOUDFLARED_TUNNEL_NAME) {
+      args.push('run', process.env.SHOPIFY_CLI_CUSTOM_CLOUDFLARED_TUNNEL_NAME)
+    }
     const errors: string[] = []
 
     let connected = false
@@ -166,6 +169,9 @@ function whatToTry() {
 }
 
 function findUrl(data: Buffer): string | undefined {
+  if (process.env.SHOPIFY_CLI_CUSTOM_CLOUDFLARED_DOMAIN) {
+    return process.env.SHOPIFY_CLI_CUSTOM_CLOUDFLARED_DOMAIN
+  }
   const regex = new RegExp(`(https:\\/\\/[^\\s]+\\.${getTunnelDomain()})`)
   const match = data.toString().match(regex) ?? undefined
   return match && match[1]


### PR DESCRIPTION
### WHY are these changes introduced?
These changes are introduced to enhance the flexibility and user control within the Shopify CLI regarding Cloudflare tunnel configurations. Prior to this update, users were restricted to the default Cloudflare URLs, which could be limiting in environments with pre-existing or specific tunnel/URL requirements. By allowing users to specify their own tunnel name and tunnel URL, we are extending the customization capabilities of the Shopify CLI, thereby catering to a broader range of use cases and user preferences.

Fixes #3020  <!-- link to issue if one exists -->
https://github.com/Shopify/cli/issues/3020
Also some what relates to this issue -> https://github.com/Shopify/cli/issues/3010


### WHAT is this pull request doing?

The user now just need to add cloudflare tunnel name(SHOPIFY_CLI_CUSTOM_CLOUDFLARED_TUNNEL_NAME) and cloudflare tunnel url(SHOPIFY_CLI_CUSTOM_CLOUDFLARED_DOMAIN) in process.env, and the app will use this tunnel.

### How to test your changes?
To test these changes you have to add the following env variables.
SHOPIFY_CLI_CUSTOM_CLOUDFLARED_DOMAIN
SHOPIFY_CLI_CUSTOM_CLOUDFLARED_TUNNEL_NAME

One way to do this is to change the package.json dev command as follows

"dev": "shopify app dev", to ->

"dev": "SHOPIFY_CLI_CUSTOM_CLOUDFLARED_DOMAIN=https://<subdomain>.<domain>.<tld> SHOPIFY_CLI_CUSTOM_CLOUDFLARED_TUNNEL_NAME=<tunnelname> shopify app dev",



How do we know this change was effective? Please choose one:

n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
