### PR TITLE
Fixed misleading message in `shopify theme console` in specific scenarios

### DIFF
--- a/.changeset/healthy-toes-share.md
+++ b/.changeset/healthy-toes-share.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fixed misleading message in `shopify theme console` in specific scenarios

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/remote_evaluator.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/remote_evaluator.rb
@@ -72,9 +72,14 @@ module ShopifyCLI
 
           error = body.gsub(/ \(snippets\/eval line \d+\)/, "")
 
-          ctx.puts("{{red:#{error}}}")
+          print_syntax_error(error)
+        end
 
-          nil
+        def print_syntax_error(error)
+          error_message = "Unknown object, property, tag, or filter: '#{input}'"
+          error_message = error unless error.include?("Unknown tag")
+
+          ctx.puts("{{red:#{error_message}}}")
         end
 
         def json_from_response(response)

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/repl/remote_evaluator_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/repl/remote_evaluator_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rack/mock"
+
+require "shopify_cli/theme/repl/remote_evaluator"
+
+module ShopifyCLI
+  module Theme
+    class Repl
+      class RemoteEvaluatorTest < Minitest::Test
+        def test_print_syntax_error
+          remote_error = "Liquid syntax error: Unexpected character + in \"{{ a + b }}\""
+          expected_error = "{{red:#{remote_error}}}"
+
+          ctx.expects(:puts).with(expected_error)
+
+          evaluator("a + b").send(:print_syntax_error, remote_error)
+        end
+
+        def test_print_syntax_error_with_unknown_tag_error
+          remote_error = "Unknown tag 'unknown_object'"
+          expected_error = "{{red:Unknown object, property, tag, or filter: 'unknown_object'}}"
+
+          ctx.expects(:puts).with(expected_error)
+
+          evaluator("unknown_object").send(:print_syntax_error, remote_error)
+        end
+
+        private
+
+        def evaluator(input)
+          @evaluator ||= RemoteEvaluator.new(
+            stub(input: input, ctx: ctx)
+          )
+        end
+
+        def ctx
+          @ctx ||= mock
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2881.

### WHAT is this pull request doing?

The `shopify theme console` evaluates Liquid snippets remotely. In certain instances, the error messages can mislead users into thinking that their Liquid snippet is handling a tag instead of a property.

Given the context of remote evaluation, this pull request proposes a shift towards a more comprehensive error message when users encounter this issue.

### How to test your changes?

To test these changes, follow these steps:

1. Run `shopify theme console`.
2. Type `shop.something`.

Here are the before and after screenshots for reference:

**Before**
<img src="https://github.com/Shopify/cli/assets/1079279/b22691c4-4580-4de3-81dc-48f7864529c2" width="60%">

**After**
<img src="https://github.com/Shopify/cli/assets/1079279/97387745-0f77-4ea6-a407-10e0ccef07d8" width="60%">

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).

