### PR TITLE
Refresh token when necessary during dev

### DIFF
--- a/.changeset/old-goats-leave.md
+++ b/.changeset/old-goats-leave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Refresh Partners token in the background as necessary during dev

--- a/.changeset/unlucky-cars-perform.md
+++ b/.changeset/unlucky-cars-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Allow refreshing a Partners token without a fallback to prompting

--- a/packages/app/src/cli/services/dev.test.ts
+++ b/packages/app/src/cli/services/dev.test.ts
@@ -1,0 +1,37 @@
+import {developerPreviewController} from './dev.js'
+import {fetchAppPreviewMode} from './dev/fetch.js'
+import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/session')
+vi.mock('./dev/fetch.js')
+
+describe('developerPreviewController', () => {
+  test('does not refresh the tokens when they are still valid', async () => {
+    // Given
+    const controller = developerPreviewController('apiKey', 'originalToken')
+    vi.mocked(fetchAppPreviewMode).mockResolvedValueOnce(true)
+
+    // When
+    const got = await controller.fetchMode()
+
+    // Then
+    expect(got).toBe(true)
+  })
+  test('refreshes the tokens when they expire', async () => {
+    // Given
+    const controller = developerPreviewController('apiKey', 'originalToken')
+    vi.mocked(fetchAppPreviewMode).mockRejectedValueOnce(new Error('expired token'))
+    vi.mocked(ensureAuthenticatedPartners).mockResolvedValueOnce('newToken')
+    vi.mocked(fetchAppPreviewMode).mockResolvedValueOnce(true)
+
+    // When
+    const got = await controller.fetchMode()
+
+    // Then
+    expect(got).toBe(true)
+    expect(ensureAuthenticatedPartners).toHaveBeenCalledOnce()
+    expect(fetchAppPreviewMode).toHaveBeenNthCalledWith(1, 'apiKey', 'originalToken')
+    expect(fetchAppPreviewMode).toHaveBeenNthCalledWith(2, 'apiKey', 'newToken')
+  })
+})

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -314,7 +314,7 @@ async function launchDevProcesses({
   })
 }
 
-function developerPreviewController(apiKey: string, originalToken: string): DeveloperPreviewController {
+export function developerPreviewController(apiKey: string, originalToken: string): DeveloperPreviewController {
   let currentToken = originalToken
 
   const refreshToken = async () => {
@@ -324,7 +324,8 @@ function developerPreviewController(apiKey: string, originalToken: string): Deve
 
   const withRefreshToken = async <T>(fn: (token: string) => Promise<T>): Promise<T> => {
     try {
-      return fn(currentToken)
+      const result = await fn(currentToken)
+      return result
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch (_err) {
       try {

--- a/packages/app/src/cli/services/dev/ui.test.tsx
+++ b/packages/app/src/cli/services/dev/ui.test.tsx
@@ -8,7 +8,6 @@ import {
   testUIExtension,
 } from '../../models/app/app.test-data.js'
 import {AppInterface} from '../../models/app/app.js'
-import {disableDeveloperPreview, enableDeveloperPreview} from '../context.js'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -18,6 +17,13 @@ import {terminalSupportsRawMode} from '@shopify/cli-kit/node/system'
 vi.mock('@shopify/cli-kit/node/system')
 vi.mock('./ui/components/Dev.js')
 vi.mock('../context.js')
+
+const developerPreview = {
+  fetchMode: vi.fn(async () => true),
+  enable: vi.fn(async () => {}),
+  disable: vi.fn(async () => {}),
+  update: vi.fn(async (_state: boolean) => true),
+}
 
 afterEach(() => {
   mockAndCaptureOutput().clear()
@@ -145,7 +151,7 @@ describe('ui', () => {
 
       const abortController = new AbortController()
 
-      await renderDev({processes, previewUrl, graphiqlUrl, app, abortController})
+      await renderDev({processes, previewUrl, graphiqlUrl, app, abortController, developerPreview})
 
       expect(vi.mocked(Dev)).not.toHaveBeenCalled()
       expect(concurrentProcess.action).toHaveBeenNthCalledWith(
@@ -175,11 +181,11 @@ describe('ui', () => {
 
       const abortController = new AbortController()
 
-      await renderDev({processes, previewUrl, graphiqlUrl, app, abortController})
+      await renderDev({processes, previewUrl, graphiqlUrl, app, abortController, developerPreview})
       abortController.abort()
 
-      expect(enableDeveloperPreview).toHaveBeenCalled()
-      expect(disableDeveloperPreview).toHaveBeenCalled()
+      expect(developerPreview.enable).toHaveBeenCalled()
+      expect(developerPreview.disable).toHaveBeenCalled()
     })
 
     test("don't enable dev preview when terminal doesn't support TTY and the app doesn't supports it", async () => {
@@ -201,11 +207,11 @@ describe('ui', () => {
 
       const abortController = new AbortController()
 
-      await renderDev({processes, previewUrl, graphiqlUrl, app, abortController})
+      await renderDev({processes, previewUrl, graphiqlUrl, app, abortController, developerPreview})
       abortController.abort()
 
-      expect(enableDeveloperPreview).not.toHaveBeenCalled()
-      expect(disableDeveloperPreview).not.toHaveBeenCalled()
+      expect(developerPreview.enable).not.toHaveBeenCalled()
+      expect(developerPreview.disable).not.toHaveBeenCalled()
     })
 
     test('uses ink when terminal supports TTY', async () => {
@@ -228,7 +234,7 @@ describe('ui', () => {
       const abortController = new AbortController()
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      renderDev({processes, previewUrl, graphiqlUrl, app, abortController})
+      renderDev({processes, previewUrl, graphiqlUrl, app, abortController, developerPreview})
 
       await new Promise((resolve) => setTimeout(resolve, 100))
 

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -61,7 +61,7 @@ export async function outputUpdateURLsResult(
   }
 }
 
-export async function renderDev({processes, previewUrl, app, abortController, graphiqlUrl}: DevProps) {
+export async function renderDev({processes, previewUrl, app, abortController, graphiqlUrl, developerPreview}: DevProps) {
   if (terminalSupportsRawMode(process.stdin)) {
     return render(
       <Dev
@@ -70,13 +70,14 @@ export async function renderDev({processes, previewUrl, app, abortController, gr
         previewUrl={previewUrl}
         app={app}
         graphiqlUrl={graphiqlUrl}
+        developerPreview={developerPreview}
       />,
       {
         exitOnCtrlC: false,
       },
     )
   } else {
-    await renderDevNonInteractive({processes, app, abortController})
+    await renderDevNonInteractive({processes, app, abortController, developerPreview})
   }
 }
 
@@ -91,13 +92,14 @@ async function partnersURL(organizationId: string, appId: string) {
 
 async function renderDevNonInteractive({
   processes,
-  app: {apiKey, token, canEnablePreviewMode},
+  app: {canEnablePreviewMode},
   abortController,
+  developerPreview,
 }: Omit<DevProps, 'previewUrl'>) {
   if (canEnablePreviewMode) {
-    await enableDeveloperPreview({apiKey, token})
+    await developerPreview.enable()
     abortController?.signal.addEventListener('abort', async () => {
-      await disableDeveloperPreview({apiKey, token})
+      await developerPreview.disable()
     })
   }
   return Promise.all(

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -1,5 +1,4 @@
 import {Dev} from './Dev.js'
-import {developerPreviewUpdate, disableDeveloperPreview, enableDeveloperPreview} from '../../../context.js'
 import {fetchAppPreviewMode} from '../../fetch.js'
 import {
   getLastFrameAfterUnmount,
@@ -26,6 +25,13 @@ const testApp = {
   developmentStorePreviewEnabled: false,
   apiKey: '123',
   token: '123',
+}
+
+const developerPreview = {
+  fetchMode: vi.fn(async () => true),
+  enable: vi.fn(async () => {}),
+  disable: vi.fn(async () => {}),
+  update: vi.fn(async (_state: boolean) => true),
 }
 
 describe('Dev', () => {
@@ -74,6 +80,7 @@ describe('Dev', () => {
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -151,6 +158,7 @@ describe('Dev', () => {
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
+        developerPreview={developerPreview}
       />,
       {stdin: new Stdin({isTTY: false})},
     )
@@ -179,7 +187,7 @@ describe('Dev', () => {
   test('opens the previewUrl when p is pressed', async () => {
     // When
     const renderInstance = render(
-      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} />,
+      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} developerPreview={developerPreview} />,
     )
 
     await waitForInputsToBeReady()
@@ -197,7 +205,7 @@ describe('Dev', () => {
 
     // When
     const renderInstance = render(
-      <Dev processes={[]} abortController={abortController} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} />,
+      <Dev processes={[]} abortController={abortController} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} developerPreview={developerPreview} />,
     )
 
     const promise = renderInstance.waitUntilExit()
@@ -217,7 +225,7 @@ describe('Dev', () => {
 
     // When
     const renderInstance = render(
-      <Dev processes={[]} abortController={abortController} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} />,
+      <Dev processes={[]} abortController={abortController} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} developerPreview={developerPreview} />,
     )
 
     const promise = renderInstance.waitUntilExit()
@@ -258,6 +266,7 @@ describe('Dev', () => {
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -289,10 +298,7 @@ describe('Dev', () => {
       00:00:00 │ backend │ third backend message
       "
     `)
-    expect(vi.mocked(disableDeveloperPreview)).toHaveBeenNthCalledWith(1, {
-      apiKey: '123',
-      token: '123',
-    })
+    expect(developerPreview.disable).toHaveBeenCalledOnce()
 
     // unmount so that polling is cleared after every test
     renderInstance.unmount()
@@ -323,6 +329,7 @@ describe('Dev', () => {
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -354,10 +361,7 @@ describe('Dev', () => {
       00:00:00 │ backend │ third backend message
       "
     `)
-    expect(vi.mocked(disableDeveloperPreview)).toHaveBeenNthCalledWith(1, {
-      apiKey: '123',
-      token: '123',
-    })
+    expect(developerPreview.disable).toHaveBeenCalledOnce()
 
     // unmount so that polling is cleared after every test
     renderInstance.unmount()
@@ -382,6 +386,7 @@ describe('Dev', () => {
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -431,6 +436,7 @@ describe('Dev', () => {
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -473,6 +479,7 @@ describe('Dev', () => {
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
         pollingTime={200}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -539,6 +546,7 @@ describe('Dev', () => {
           canEnablePreviewMode: false,
         }}
         pollingTime={200}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -559,11 +567,11 @@ describe('Dev', () => {
       "
     `)
 
-    expect(vi.mocked(fetchAppPreviewMode)).not.toHaveBeenCalled()
-    expect(vi.mocked(enableDeveloperPreview)).not.toHaveBeenCalled()
+    expect(developerPreview.fetchMode).not.toHaveBeenCalled()
+    expect(developerPreview.enable).not.toHaveBeenCalled()
 
     await sendInputAndWait(renderInstance, 100, 'd')
-    expect(vi.mocked(developerPreviewUpdate)).not.toHaveBeenCalled()
+    expect(developerPreview.update).not.toHaveBeenCalled()
 
     // unmount so that polling is cleared after every test
     renderInstance.unmount()
@@ -571,7 +579,7 @@ describe('Dev', () => {
 
   test('shows an error message when polling for preview mode fails', async () => {
     // Given
-    vi.mocked(fetchAppPreviewMode).mockRejectedValueOnce(new Error('something went wrong'))
+    vi.mocked(developerPreview.fetchMode).mockRejectedValueOnce(new Error('something went wrong'))
 
     const backendProcess = {
       prefix: 'backend',
@@ -590,6 +598,7 @@ describe('Dev', () => {
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
         pollingTime={200}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -618,10 +627,10 @@ describe('Dev', () => {
 
   test('enables preview mode when pressing d', async () => {
     // Given
-    vi.mocked(developerPreviewUpdate).mockResolvedValueOnce(true)
+    vi.mocked(developerPreview.update).mockResolvedValueOnce(true)
 
     const renderInstance = render(
-      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} />,
+      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} developerPreview={developerPreview} />,
     )
 
     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
@@ -639,11 +648,7 @@ describe('Dev', () => {
 
     await waitForInputsToBeReady()
     await sendInputAndWait(renderInstance, 100, 'd')
-    expect(vi.mocked(developerPreviewUpdate)).toHaveBeenNthCalledWith(1, {
-      apiKey: '123',
-      token: '123',
-      enabled: false,
-    })
+    expect(developerPreview.update).toHaveBeenCalledOnce()
 
     await waitForContent(renderInstance, 'off')
 
@@ -666,7 +671,7 @@ describe('Dev', () => {
 
   test("shows an error message if enabling preview mode by pressing d doesn't succeed", async () => {
     // Given
-    vi.mocked(developerPreviewUpdate).mockResolvedValueOnce(false)
+    vi.mocked(developerPreview.update).mockResolvedValueOnce(false)
 
     const backendProcess = {
       prefix: 'backend',
@@ -684,6 +689,7 @@ describe('Dev', () => {
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -713,7 +719,7 @@ describe('Dev', () => {
 
   test('shows an error message if enabling preview mode by pressing d throws an exception', async () => {
     // Given
-    vi.mocked(developerPreviewUpdate).mockRejectedValueOnce(new Error('something went wrong'))
+    vi.mocked(developerPreview.update).mockRejectedValueOnce(new Error('something went wrong'))
 
     const backendProcess = {
       prefix: 'backend',
@@ -731,6 +737,7 @@ describe('Dev', () => {
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
         app={testApp}
+        developerPreview={developerPreview}
       />,
     )
 
@@ -761,7 +768,7 @@ describe('Dev', () => {
   test('enables preview mode at startup', async () => {
     // Given
     const renderInstance = render(
-      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} />,
+      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} developerPreview={developerPreview} />,
     )
 
     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
@@ -780,10 +787,7 @@ describe('Dev', () => {
     // wait for useEffect callbacks to be run
     await new Promise((resolve) => setTimeout(resolve, 500))
 
-    expect(vi.mocked(enableDeveloperPreview)).toHaveBeenNthCalledWith(1, {
-      apiKey: '123',
-      token: '123',
-    })
+    expect(developerPreview.enable).toHaveBeenCalledOnce()
 
     // unmount so that polling is cleared after every test
     renderInstance.unmount()
@@ -791,10 +795,10 @@ describe('Dev', () => {
 
   test('shows an error message if enabling preview mode at startup fails', async () => {
     // Given
-    vi.mocked(enableDeveloperPreview).mockRejectedValueOnce(new Error('something went wrong'))
+    vi.mocked(developerPreview.enable).mockRejectedValueOnce(new Error('something went wrong'))
 
     const renderInstance = render(
-      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} />,
+      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} developerPreview={developerPreview} />,
     )
 
     await waitForContent(renderInstance, 'Failed to turn on development store preview automatically.')
@@ -822,7 +826,7 @@ describe('Dev', () => {
     vi.mocked(openURL).mockRejectedValueOnce(new Error('something went wrong'))
 
     const renderInstance = render(
-      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} />,
+      <Dev processes={[]} abortController={new AbortController()} previewUrl="https://shopify.com" graphiqlUrl="https://graphiql.shopify.com" app={testApp} developerPreview={developerPreview} />,
     )
 
     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -1,6 +1,4 @@
 import metadata from '../../../../metadata.js'
-import {developerPreviewUpdate, disableDeveloperPreview, enableDeveloperPreview} from '../../../context.js'
-import {fetchAppPreviewMode} from '../../fetch.js'
 import {OutputProcess} from '@shopify/cli-kit/node/output'
 import {ConcurrentOutput} from '@shopify/cli-kit/node/ui/components'
 import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
@@ -26,6 +24,12 @@ export interface DevProps {
     token: string
   }
   pollingTime?: number
+  developerPreview: {
+    fetchMode: () => Promise<boolean>
+    enable: () => Promise<void>
+    disable: () => Promise<void>
+    update: (state: boolean) => Promise<boolean>
+  }
 }
 
 const Dev: FunctionComponent<DevProps> = ({
@@ -35,8 +39,9 @@ const Dev: FunctionComponent<DevProps> = ({
   graphiqlUrl,
   app,
   pollingTime = 5000,
+  developerPreview,
 }) => {
-  const {apiKey, token, canEnablePreviewMode, developmentStorePreviewEnabled} = app
+  const {canEnablePreviewMode, developmentStorePreviewEnabled} = app
   const {isRawModeSupported: canUseShortcuts} = useStdin()
   const pollingInterval = useRef<NodeJS.Timeout>()
   const [statusMessage, setStatusMessage] = useState(`Preview URL: ${previewUrl}`)
@@ -54,7 +59,7 @@ const Dev: FunctionComponent<DevProps> = ({
       }, 2000)
     }
     clearInterval(pollingInterval.current)
-    await disableDeveloperPreview({apiKey, token})
+    await developerPreview.disable()
   })
 
   const [devPreviewEnabled, setDevPreviewEnabled] = useState<boolean>(true)
@@ -79,7 +84,7 @@ const Dev: FunctionComponent<DevProps> = ({
   useEffect(() => {
     const pollDevPreviewMode = async () => {
       try {
-        const enabled = await fetchAppPreviewMode(apiKey, token)
+        const enabled = await developerPreview.fetchMode()
         setDevPreviewEnabled(enabled ?? false)
         setError('')
         // eslint-disable-next-line no-catch-all/no-catch-all
@@ -91,7 +96,7 @@ const Dev: FunctionComponent<DevProps> = ({
     const enablePreviewMode = async () => {
       // Enable dev preview on app dev start
       try {
-        await enableDeveloperPreview({apiKey, token})
+        await developerPreview.enable()
         setError('')
         // eslint-disable-next-line no-catch-all/no-catch-all
       } catch (_) {
@@ -149,11 +154,7 @@ const Dev: FunctionComponent<DevProps> = ({
             const newDevPreviewEnabled = !devPreviewEnabled
             setDevPreviewEnabled(newDevPreviewEnabled)
             try {
-              const developerPreviewUpdateSucceded = await developerPreviewUpdate({
-                apiKey,
-                token,
-                enabled: newDevPreviewEnabled,
-              })
+              const developerPreviewUpdateSucceded = await developerPreview.update(newDevPreviewEnabled)
               if (!developerPreviewUpdateSucceded) {
                 throw new Error(`Failed to turn ${newDevPreviewEnabled ? 'on' : 'off'} development store preview.`)
               }

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -12,6 +12,13 @@ import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {treeKill} from '@shopify/cli-kit/node/tree-kill'
 import {Writable} from 'stream'
 
+export interface DeveloperPreviewController {
+  fetchMode: () => Promise<boolean>
+  enable: () => Promise<void>
+  disable: () => Promise<void>
+  update: (state: boolean) => Promise<boolean>
+}
+
 export interface DevProps {
   processes: OutputProcess[]
   abortController: AbortController
@@ -24,12 +31,7 @@ export interface DevProps {
     token: string
   }
   pollingTime?: number
-  developerPreview: {
-    fetchMode: () => Promise<boolean>
-    enable: () => Promise<void>
-    disable: () => Promise<void>
-    update: (state: boolean) => Promise<boolean>
-  }
+  developerPreview: DeveloperPreviewController
 }
 
 const Dev: FunctionComponent<DevProps> = ({

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -125,6 +125,21 @@ describe('ensureAuthenticated when previous session is invalid', () => {
     expect(got).toEqual(validTokens)
   })
 
+  test('throws an error if there is no session and prompting is disabled', async () => {
+    // Given
+    vi.mocked(validateSession).mockResolvedValueOnce('needs_full_auth')
+    vi.mocked(secureFetch).mockResolvedValue(undefined)
+
+    // When
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    expect(ensureAuthenticated(defaultApplications, process.env, {noPrompt: true})).rejects.toThrow(
+      'Authentication required but prompting is disallowed',
+    )
+
+    // Then
+    expect(authorize).not.toHaveBeenCalled()
+  })
+
   test('executes complete auth flow if session is for a different fqdn', async () => {
     // Given
     vi.mocked(validateSession).mockResolvedValueOnce('needs_full_auth')
@@ -202,7 +217,7 @@ describe('when existing session is valid', () => {
     vi.mocked(secureFetch).mockResolvedValue(validSession)
 
     // When
-    const got = await ensureAuthenticated(defaultApplications, process.env, true)
+    const got = await ensureAuthenticated(defaultApplications, process.env, {forceRefresh: true})
 
     // Then
     expect(authorize).not.toHaveBeenCalledOnce()

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -133,7 +133,9 @@ describe('ensureAuthenticated when previous session is invalid', () => {
     // When
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     expect(ensureAuthenticated(defaultApplications, process.env, {noPrompt: true})).rejects.toThrow(
-      'Authentication required but prompting is disallowed',
+      `The currently available CLI credentials are invalid.
+
+The CLI is currently unable to prompt for reauthentication.`,
     )
 
     // Then

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -97,7 +97,7 @@ export interface OAuthSession {
 export async function ensureAuthenticated(
   applications: OAuthApplications,
   _env?: NodeJS.ProcessEnv,
-  forceRefresh = false,
+  {forceRefresh = false, noPrompt = false}: {forceRefresh?: boolean; noPrompt?: boolean} = {},
 ): Promise<OAuthSession> {
   const fqdn = await identityFqdn()
 
@@ -123,6 +123,9 @@ ${outputToken.json(applications)}
   let newSession = {}
 
   if (validationResult === 'needs_full_auth') {
+    if (noPrompt) {
+      throw new AbortError('Authentication required but prompting is disallowed')
+    }
     outputDebug(outputContent`Initiating the full authentication flow...`)
     newSession = await executeCompleteFlow(applications, fqdn)
   } else if (validationResult === 'needs_refresh' || forceRefresh) {

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -124,7 +124,12 @@ ${outputToken.json(applications)}
 
   if (validationResult === 'needs_full_auth') {
     if (noPrompt) {
-      throw new AbortError('Authentication required but prompting is disallowed')
+      throw new AbortError(
+        `The currently available CLI credentials are invalid.
+
+The CLI is currently unable to prompt for reauthentication.`,
+        'Restart the CLI process you were running. If in an interactive terminal, you will be prompted to reauthenticate. If in a non-interactive terminal, ensure the correct credentials are available in the program environment.',
+      )
     }
     outputDebug(outputContent`Initiating the full authentication flow...`)
     newSession = await executeCompleteFlow(applications, fqdn)

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -14,16 +14,25 @@ export interface AdminSession {
   storeFqdn: string
 }
 
+interface EnsureAuthenticatedPartnersOptions {
+  noPrompt?: boolean
+}
+
 /**
  * Ensure that we have a valid session to access the Partners API.
  * If SHOPIFY_CLI_PARTNERS_TOKEN exists, that token will be used to obtain a valid Partners Token
  * If SHOPIFY_CLI_PARTNERS_TOKEN exists, scopes will be ignored.
  *
  * @param scopes - Optional array of extra scopes to authenticate with.
- * @param _env - Optional environment variables to use.
+ * @param env - Optional environment variables to use.
+ * @param options - Optional extra options to use.
  * @returns The access token for the Partners API.
  */
-export async function ensureAuthenticatedPartners(scopes: string[] = [], _env = process.env): Promise<string> {
+export async function ensureAuthenticatedPartners(
+  scopes: string[] = [],
+  env = process.env,
+  options: EnsureAuthenticatedPartnersOptions = {},
+): Promise<string> {
   outputDebug(outputContent`Ensuring that the user is authenticated with the Partners API with the following scopes:
 ${outputToken.json(scopes)}
 `)
@@ -31,7 +40,7 @@ ${outputToken.json(scopes)}
   if (envToken) {
     return (await exchangeCustomPartnerToken(envToken)).accessToken
   }
-  const tokens = await ensureAuthenticated({partnersApi: {scopes}})
+  const tokens = await ensureAuthenticated({partnersApi: {scopes}}, env, options)
   if (!tokens.partners) {
     throw new BugError('No partners token found after ensuring authenticated')
   }
@@ -56,7 +65,7 @@ export async function ensureAuthenticatedStorefront(
   outputDebug(outputContent`Ensuring that the user is authenticated with the Storefront API with the following scopes:
 ${outputToken.json(scopes)}
 `)
-  const tokens = await ensureAuthenticated({storefrontRendererApi: {scopes}}, process.env, forceRefresh)
+  const tokens = await ensureAuthenticated({storefrontRendererApi: {scopes}}, process.env, {forceRefresh})
   if (!tokens.storefront) {
     throw new BugError('No storefront token found after ensuring authenticated')
   }
@@ -81,7 +90,7 @@ export async function ensureAuthenticatedAdmin(
   )}:
 ${outputToken.json(scopes)}
 `)
-  const tokens = await ensureAuthenticated({adminApi: {scopes, storeFqdn: store}}, process.env, forceRefresh)
+  const tokens = await ensureAuthenticated({adminApi: {scopes, storeFqdn: store}}, process.env, {forceRefresh})
   if (!tokens.admin) {
     throw new BugError('No admin token found after ensuring authenticated')
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-management/issues/215

<!--
  Context about the problem that’s being addressed.
-->

`dev` is crashing after an hour because we aren't refreshing the access token. This adds that functionality. It also extracts much of the logic from the `Dev` component into the caller.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

1. `ensureAuthenticatedPartners` gets a new option, `noPrompt` which will fail instead of prompting.
2. We extract the logic to fetch/update development store preview mode to `dev`. (Theoretically it could live in its own file, I'm debating whether it's worth extracting already, but wanted to get feedback on the approach first.)
3. Adds a step when hitting Partners where we rescue => refresh the token => try again. The logic is pretty generic (no analysis of the error) since the cost of retrying is low and there is little potential to cause harm by doing so.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Run `dev` and try these 3 things:

1. Wait a few hours and see if an error condition is reached (shouldn't be)
2. Cut off your internet for a minute and make sure everything recovers properly
3. Log out in your browser and see what happens (CLI crashing or showing an error is fine in that case, as there's really no way to recover)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
