### PR TITLE
Timing metrics shouldn't be reported with sub-ms precision

### DIFF
--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -67,9 +67,9 @@ describe('event tracking', () => {
       const commandContent = {command: 'dev', topic: 'app', alias: 'alias'}
       await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
 
-      // Log some timings from the command
+      // Log some timings from the command, confirm that submitted timings are always rounded down
       await addPublicMetadata(() => ({
-        cmd_all_timing_network_ms: 30,
+        cmd_all_timing_network_ms: 30.00001,
         cmd_all_timing_prompts_ms: 20,
       }))
 
@@ -106,7 +106,7 @@ describe('event tracking', () => {
         env_device_id: 'hashed-macaddress',
         env_cloud: 'spin',
         cmd_all_exit: 'ok',
-        cmd_all_timing_active_ms: 50,
+        cmd_all_timing_active_ms: 49,
         cmd_all_timing_network_ms: 30,
         cmd_all_timing_prompts_ms: 20,
       }

--- a/packages/cli-kit/src/public/node/analytics.ts
+++ b/packages/cli-kit/src/public/node/analytics.ts
@@ -54,9 +54,9 @@ export async function reportAnalyticsEvent(options: ReportAnalyticsEventOptions)
       }
     }
     const doOpenTelemetry = async () => {
-      const active = Math.floor(payload.public.cmd_all_timing_active_ms || 0)
-      const network = Math.floor(payload.public.cmd_all_timing_network_ms || 0)
-      const prompt = Math.floor(payload.public.cmd_all_timing_prompts_ms || 0)
+      const active = payload.public.cmd_all_timing_active_ms || 0
+      const network = payload.public.cmd_all_timing_network_ms || 0
+      const prompt = payload.public.cmd_all_timing_prompts_ms || 0
 
       return recordMetrics(
         {
@@ -149,6 +149,15 @@ async function buildPayload({config, errorMessage, exitMode}: ReportAnalyticsEve
       }),
     },
   }
+
+  // round down timing metrics
+  const timingMetrics = ['cmd_all_timing_active_ms', 'cmd_all_timing_network_ms', 'cmd_all_timing_prompts_ms'] as const
+  timingMetrics.forEach((metric) => {
+    const current = payload.public[metric]
+    if (current !== undefined) {
+      payload.public[metric] = Math.floor(current)
+    }
+  })
 
   // strip undefined fields -- they make up the majority of payloads due to wide metadata structure.
   payload = JSON.parse(JSON.stringify(payload))


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Related to https://github.com/Shopify/develop-app-management/issues/1531

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Monorail is expecting `long` values for command timing data, but we were in some instances submitting `double`s, leading to some odd behaviour. Round the measures down instead.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

`SHOPIFY_CLI_ALWAYS_LOG_ANALYTICS=1 p shopify app info --path="<path to your app>" --verbose`

With this change, the monorail logging works, without it, it doesn't.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
