### PR TITLE
Use rainbow bar for dev launch

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -77,15 +77,11 @@ export async function dev(commandOptions: DevOptions) {
     {
       title: 'Configuring dev processes',
       task: async (ctx: DevTasksContext) => {
-        await actionsBeforeSettingUpDevProcesses(ctx.config!)
-        const {processes, graphiqlUrl, previewUrl} = await setupDevProcesses(ctx.config!)
+        const devConfig = ctx.config!
+        await actionsBeforeSettingUpDevProcesses(devConfig)
+        const {processes, graphiqlUrl, previewUrl} = await setupDevProcesses(devConfig)
         Object.assign(ctx, {processes, graphiqlUrl, previewUrl})
-      },
-    },
-    {
-      title: 'Preparing to launch',
-      task: async (ctx: DevTasksContext) => {
-        await actionsBeforeLaunchingDevProcesses(ctx.config!)
+        await actionsBeforeLaunchingDevProcesses(devConfig)
       },
     },
   ])


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Makes dev loading more tolerable

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Cashing in on the recent changes to the Dev implementation. Uses `renderTasks` to show a loader while dev is starting up.

![rainbow-bar-for-dev-launch](https://github.com/Shopify/cli/assets/6288426/11300450-c8cc-4bb2-993d-985073c118d5)

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run `dev`. Try with `--reset` and also try after logging out.

In the case of logging out first, the login shouldn't interfere with the taskbar.

In the case of `--reset`, we should basically just lose the rainbow taskbar, and things should proceed as they did before. It's sadly inconsistent, but it's no worse than what we have now.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
