### PR TITLE
Bundle install should count as network rather than active usage

### DIFF
--- a/packages/cli-kit/src/public/node/ruby.ts
+++ b/packages/cli-kit/src/public/node/ruby.ts
@@ -9,6 +9,7 @@ import {isSpinEnvironment, spinFqdn} from './context/spin.js'
 import {firstPartyDev, useEmbeddedThemeCLI} from './context/local.js'
 import {outputContent, outputToken} from './output.js'
 import {isTruthy} from './context/utilities.js'
+import {runWithTimer} from './metadata.js'
 import {pathConstants} from '../../private/node/constants.js'
 import {coerceSemverVersion} from '../../private/node/semver.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
@@ -450,7 +451,9 @@ async function getSpinEnvironmentVariables() {
  * @param directory - Directory where the Gemfile is located.
  */
 async function shopifyBundleInstall(directory: string): Promise<void> {
-  await runBundler(['install'], {cwd: directory})
+  return runWithTimer('cmd_all_timing_network_ms')(async () => {
+    await runBundler(['install'], {cwd: directory})
+  })
 }
 
 /**


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Related to https://github.com/Shopify/develop-app-management/issues/1531

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Wrap up the call to `bundle install...` such that its treated as time spent on the network, rather than actively processing the command.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
