### PR TITLE
Adds Company and Company Contact reference type to flow action/trigger fields serialization

### DIFF
--- a/.changeset/afraid-cameras-yell.md
+++ b/.changeset/afraid-cameras-yell.md
@@ -2,4 +2,4 @@
 '@shopify/cli-kit': minor
 ---
 
-Adds `startize` function which wraps the `capitalCase` function from change-case package
+Adds `pascalize` function which wraps the `pascalCase` function from change-case package

--- a/.changeset/afraid-cameras-yell.md
+++ b/.changeset/afraid-cameras-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Adds `startize` function which wraps the `capitalCase` function from change-case package

--- a/.changeset/curly-buckets-hug.md
+++ b/.changeset/curly-buckets-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Support Company and Company Contact commerce objects in Flow Action and Flow Trigger extensions

--- a/packages/app/src/cli/services/flow/constants.ts
+++ b/packages/app/src/cli/services/flow/constants.ts
@@ -5,14 +5,26 @@ export const SUPPORTED_COMMERCE_OBJECTS = {
   product_reference: 'product_reference',
   marketing_activity_reference: 'marketing_activity_reference',
   abandonment_reference: 'abandonment_reference',
+  company_reference: 'company_reference',
+  company_contact_reference: 'company_contact_reference',
 }
 
-export const PARTNERS_COMMERCE_OBJECTS = ['customer', 'order', 'product', 'marketing_activity', 'abandonment']
+export const PARTNERS_COMMERCE_OBJECTS = [
+  'customer',
+  'order',
+  'product',
+  'marketing_activity',
+  'abandonment',
+  'company',
+  'company_contact',
+]
 
 export const TRIGGER_SUPPORTED_COMMERCE_OBJECTS = [
   SUPPORTED_COMMERCE_OBJECTS.customer_reference,
   SUPPORTED_COMMERCE_OBJECTS.order_reference,
   SUPPORTED_COMMERCE_OBJECTS.product_reference,
+  SUPPORTED_COMMERCE_OBJECTS.company_reference,
+  SUPPORTED_COMMERCE_OBJECTS.company_contact_reference,
 ]
 
 export const ACTION_SUPPORTED_COMMERCE_OBJECTS = [
@@ -21,6 +33,8 @@ export const ACTION_SUPPORTED_COMMERCE_OBJECTS = [
   SUPPORTED_COMMERCE_OBJECTS.product_reference,
   SUPPORTED_COMMERCE_OBJECTS.marketing_activity_reference,
   SUPPORTED_COMMERCE_OBJECTS.abandonment_reference,
+  SUPPORTED_COMMERCE_OBJECTS.company_reference,
+  SUPPORTED_COMMERCE_OBJECTS.company_contact_reference,
 ]
 
 const UI_TYPES = {

--- a/packages/app/src/cli/services/flow/serialize-fields.test.ts
+++ b/packages/app/src/cli/services/flow/serialize-fields.test.ts
@@ -125,7 +125,7 @@ describe('serializeCommerceObjectField', () => {
     expect(serializedField).toEqual({
       name: 'company_contact_id',
       uiType: 'commerce-object-id',
-      label: 'Company Contact ID',
+      label: 'CompanyContact ID',
       description: 'This is my field',
       required: true,
     })

--- a/packages/app/src/cli/services/flow/serialize-fields.test.ts
+++ b/packages/app/src/cli/services/flow/serialize-fields.test.ts
@@ -108,6 +108,29 @@ describe('serializeCommerceObjectField', () => {
     })
   })
 
+  test('should serialize a company contact commerce object field for a flow action', () => {
+    // given
+    const commerceObjectField: ConfigField = {
+      type: 'company_contact_reference',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // when
+    const serializedField = serializeCommerceObjectField(commerceObjectField, 'flow_action')
+
+    // then
+    expect(serializedField).toEqual({
+      name: 'company_contact_id',
+      uiType: 'commerce-object-id',
+      label: 'Company Contact ID',
+      description: 'This is my field',
+      required: true,
+    })
+  })
+
   test('should serialize a commerce object field for a flow trigger', () => {
     // given
     const commerceObjectField: ConfigField = {
@@ -125,6 +148,27 @@ describe('serializeCommerceObjectField', () => {
     expect(serializedField).toEqual({
       name: 'product_id',
       uiType: 'product',
+      description: 'This is my field',
+    })
+  })
+
+  test('should serialize a company contact commerce object field for a flow trigger', () => {
+    // given
+    const commerceObjectField: ConfigField = {
+      type: 'company_contact_reference',
+      key: 'my-field',
+      name: 'My Field',
+      description: 'This is my field',
+      required: true,
+    }
+
+    // when
+    const serializedField = serializeCommerceObjectField(commerceObjectField, 'flow_trigger')
+
+    // then
+    expect(serializedField).toEqual({
+      name: 'company_contact_id',
+      uiType: 'company_contact',
       description: 'This is my field',
     })
   })

--- a/packages/app/src/cli/services/flow/serialize-fields.ts
+++ b/packages/app/src/cli/services/flow/serialize-fields.ts
@@ -8,7 +8,7 @@ import {
 } from './constants.js'
 import {isSchemaTypeReference} from './validation.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {startize} from '@shopify/cli-kit/common/string'
+import {pascalize} from '@shopify/cli-kit/common/string'
 
 const actionTypesToUiTypes = new Map<string, string>(actionUiTypesMap)
 const triggerTypesToUiTypes = new Map<string, string>(triggerUiTypesMap)
@@ -66,7 +66,7 @@ export const serializeCommerceObjectField = (field: ConfigField, type: FlowExten
   }
 
   if (type === 'flow_action') {
-    serializedField.label = `${startize(commerceObject)} ID`
+    serializedField.label = `${pascalize(commerceObject)} ID`
     serializedField.required = field.required
   }
 

--- a/packages/app/src/cli/services/flow/serialize-fields.ts
+++ b/packages/app/src/cli/services/flow/serialize-fields.ts
@@ -8,7 +8,7 @@ import {
 } from './constants.js'
 import {isSchemaTypeReference} from './validation.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {capitalize} from '@shopify/cli-kit/common/string'
+import {startize} from '@shopify/cli-kit/common/string'
 
 const actionTypesToUiTypes = new Map<string, string>(actionUiTypesMap)
 const triggerTypesToUiTypes = new Map<string, string>(triggerUiTypesMap)
@@ -66,7 +66,7 @@ export const serializeCommerceObjectField = (field: ConfigField, type: FlowExten
   }
 
   if (type === 'flow_action') {
-    serializedField.label = `${capitalize(commerceObject)} ID`
+    serializedField.label = `${startize(commerceObject)} ID`
     serializedField.required = field.required
   }
 

--- a/packages/cli-kit/src/public/common/string.ts
+++ b/packages/cli-kit/src/public/common/string.ts
@@ -368,7 +368,7 @@ export function joinWithAnd(items: string[]): string {
 
 /**
  * Given a string, it returns it with the all the first letter of words capitalized.
- * Eg: start_case -> Start Case.
+ * Eg: "start_case" returns "Start Case".
  *
  * @param str - String to startCase.
  * @returns String with all the first letter capitalized.

--- a/packages/cli-kit/src/public/common/string.ts
+++ b/packages/cli-kit/src/public/common/string.ts
@@ -1,7 +1,7 @@
 import {takeRandomFromArray} from './array.js'
 import {unstyled} from '../../public/node/output.js'
 import {Token, TokenItem} from '../../private/node/ui/components/TokenizedText.js'
-import {camelCase, capitalCase, constantCase, paramCase, snakeCase} from 'change-case'
+import {camelCase, constantCase, paramCase, snakeCase, pascalCase} from 'change-case'
 
 const SAFE_RANDOM_BUSINESS_ADJECTIVES = [
   'commercial',
@@ -367,12 +367,12 @@ export function joinWithAnd(items: string[]): string {
 }
 
 /**
- * Given a string, it returns it with the all the first letter of words capitalized.
- * Eg: "start_case" returns "Start Case".
+ * Given a string, it returns the PascalCase form of it.
+ * Eg: "pascal_case" returns "PascalCase".
  *
- * @param str - String to startCase.
- * @returns String with all the first letter capitalized.
+ * @param str - String to PascalCase.
+ * @returns String with all the first letter capitalized with no spaces.
  */
-export function startize(str: string): string {
-  return capitalCase(str)
+export function pascalize(str: string): string {
+  return pascalCase(str)
 }

--- a/packages/cli-kit/src/public/common/string.ts
+++ b/packages/cli-kit/src/public/common/string.ts
@@ -1,7 +1,7 @@
 import {takeRandomFromArray} from './array.js'
 import {unstyled} from '../../public/node/output.js'
 import {Token, TokenItem} from '../../private/node/ui/components/TokenizedText.js'
-import {camelCase, constantCase, paramCase, snakeCase} from 'change-case'
+import {camelCase, capitalCase, constantCase, paramCase, snakeCase} from 'change-case'
 
 const SAFE_RANDOM_BUSINESS_ADJECTIVES = [
   'commercial',
@@ -364,4 +364,15 @@ export function joinWithAnd(items: string[]): string {
     .slice(0, -1)
     .map((item) => `"${item}"`)
     .join(', ')} and "${items[items.length - 1]}"`
+}
+
+/**
+ * Given a string, it returns it with the all the first letter of words capitalized.
+ * Eg: start_case -> Start Case.
+ *
+ * @param str - String to startCase.
+ * @returns String with all the first letter capitalized.
+ */
+export function startize(str: string): string {
+  return capitalCase(str)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

- Resolves https://github.com/Shopify/flow/issues/21146
- Depends on 
  - https://github.com/Shopify/shopify/pull/462061 
  - https://github.com/Shopify/flow/pull/21328
  - https://github.com/Shopify/flow/pull/21366
- Adds support for Company and Company Contact references

### WHAT is this pull request doing?

- Adds support for Company and Company Contact references

### How to test your changes?

- Manual test and automated tests

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
