### PR TITLE
Toml webhook subscription parsing

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1,4 +1,4 @@
-import {App, AppConfiguration, AppInterface, WebType} from './app.js'
+import {App, AppConfiguration, AppInterface, WebType, WebhookConfig} from './app.js'
 import {ExtensionTemplate} from './template.js'
 import {RemoteSpecification} from '../../api/graphql/extension_specifications.js'
 import themeExtension from '../templates/theme-specifications/theme.js'
@@ -87,6 +87,16 @@ export function testAppWithConfig(options?: TestAppWithConfigOptions): AppInterf
   }
 
   return app
+}
+
+export function getWebhookConfig(webhookConfigOverrides?: WebhookConfig) {
+  return {
+    ...DEFAULT_CONFIG,
+    webhooks: {
+      ...DEFAULT_CONFIG.webhooks,
+      ...webhookConfigOverrides,
+    },
+  }
 }
 
 export function testOrganizationApp(app: Partial<OrganizationApp> = {}): OrganizationApp {

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -24,9 +24,9 @@ const CORRECT_CURRENT_APP_SCHEMA: CurrentAppConfiguration = {
   webhooks: {
     api_version: '2023-04',
     privacy_compliance: {
-      customer_deletion_url: 'https://google.com/',
-      customer_data_request_url: 'https://google.com/',
-      shop_deletion_url: 'https://google.com/',
+      customer_deletion_url: 'https://google.com',
+      customer_data_request_url: 'https://google.com',
+      shop_deletion_url: 'https://google.com',
     },
   },
   application_url: 'http://example.com',
@@ -35,19 +35,19 @@ const CORRECT_CURRENT_APP_SCHEMA: CurrentAppConfiguration = {
     redirect_urls: ['https://google.com'],
   },
   app_proxy: {
-    url: 'https://google.com/',
-    subpath: 'https://google.com/',
-    prefix: 'https://google.com/',
+    url: 'https://google.com',
+    subpath: 'https://google.com',
+    prefix: 'https://google.com',
   },
   pos: {
     embedded: false,
   },
   app_preferences: {
-    url: 'https://google.com/',
+    url: 'https://google.com',
   },
   build: {
     automatically_update_urls_on_dev: true,
-    dev_store_url: 'https://google.com/',
+    dev_store_url: 'https://google.com',
   },
 }
 

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -84,14 +84,15 @@ const WebhooksSchema = zod
     // eslint-disable-next-line @typescript-eslint/naming-convention
     ({subscription_endpoint_url, pubsub_project, pubsub_topic, arn, topics = [], subscriptions = []}, ctx) => {
       const topLevelDestinations = [subscription_endpoint_url, pubsub_project && pubsub_topic, arn].filter(Boolean)
-      const pubSubValidationErrMsg = 'You must declare both pubsub_project and pubsub_topic if you wish to use'
-      const tooManyDestinationsErrMsg =
-        'You are only allowed to declare one (1) of subscription_endpoint_url, pubsub_project & pubsub_topic, or arn'
+      const getFullPubSubValidationError = (suffix: string) =>
+        `You must declare both pubsub_project and pubsub_topic if you wish to use ${suffix}`
+      const getTooManyDesignationsError = (suffix: string) =>
+        `You are only allowed to declare one (1) of subscription_endpoint_url, pubsub_project & pubsub_topic, or arn ${suffix}`
 
       if ([pubsub_project, pubsub_topic].filter(Boolean).length === 1) {
         ctx.addIssue({
           code: zod.ZodIssueCode.custom,
-          message: `${pubSubValidationErrMsg} a top-level pub sub destination`,
+          message: getFullPubSubValidationError('a top-level pub sub destination'),
           fatal: true,
         })
         return zod.NEVER
@@ -100,7 +101,7 @@ const WebhooksSchema = zod
       if (topLevelDestinations.length > 1) {
         ctx.addIssue({
           code: zod.ZodIssueCode.custom,
-          message: `${tooManyDestinationsErrMsg} at the top level`,
+          message: getTooManyDesignationsError('at the top level'),
           fatal: true,
         })
         return zod.NEVER
@@ -166,7 +167,7 @@ const WebhooksSchema = zod
           if ([subscription.pubsub_project, subscription.pubsub_topic].filter(Boolean).length === 1) {
             ctx.addIssue({
               code: zod.ZodIssueCode.custom,
-              message: `${pubSubValidationErrMsg} a pub sub destination`,
+              message: getFullPubSubValidationError('a pub sub destination'),
               fatal: true,
               path,
             })
@@ -176,7 +177,7 @@ const WebhooksSchema = zod
           if (subscriptionDestinations.length > 1) {
             ctx.addIssue({
               code: zod.ZodIssueCode.custom,
-              message: `${tooManyDestinationsErrMsg} per subscription`,
+              message: getTooManyDesignationsError('per subscription'),
               fatal: true,
               path,
             })

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -32,6 +32,11 @@ import {resolve} from 'path'
 vi.mock('../../services/local-storage.js')
 vi.mock('../../services/app/config/use.js')
 
+vi.mock('../../utilities/app/config/webhooks.js', async () => ({
+  ...((await vi.importActual('../../utilities/app/config/webhooks.js')) as any),
+  TEMP_OMIT_DECLARATIVE_WEBHOOKS_SCHEMA: false,
+}))
+
 describe('load', () => {
   let specifications: ExtensionSpecification[] = []
 

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -19,7 +19,6 @@ export type OrganizationApp = MinimalOrganizationApp & {
   newApp?: boolean
   grantedScopes: string[]
   betas?: {
-    unifiedAppDeployment?: boolean
     declarativeWebhooks?: boolean
   }
   applicationUrl: string

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -18,6 +18,10 @@ export type OrganizationApp = MinimalOrganizationApp & {
   appType?: string
   newApp?: boolean
   grantedScopes: string[]
+  betas?: {
+    unifiedAppDeployment?: boolean
+    declarativeWebhooks?: boolean
+  }
   applicationUrl: string
   redirectUrlWhitelist: string[]
   requestedAccessScopes?: string[]

--- a/packages/app/src/cli/services/app/write-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.ts
@@ -33,6 +33,9 @@ export const rewriteConfiguration = <T extends zod.ZodTypeAny>(schema: T, config
   if (schema instanceof zod.ZodArray) {
     return (config as unknown[]).map((item) => rewriteConfiguration(schema.element, item))
   }
+  if (schema instanceof zod.ZodEffects) {
+    return rewriteConfiguration(schema._def.schema, config)
+  }
   if (schema instanceof zod.ZodObject) {
     const entries = Object.entries(schema.shape)
     const confObj = config as {[key: string]: unknown}

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -422,7 +422,7 @@ describe('deploy', () => {
     test('does not run the webhook subscription task if the declarativeWebhooks beta is disabled', async () => {
       const app = testApp({
         configuration: getWebhookConfig({
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topics: ['products/create'],
         }),
       })
@@ -463,7 +463,7 @@ describe('deploy', () => {
     test('runs the webhook subscription task if the declarativeWebhooks beta is enabled', async () => {
       const app = testApp({
         configuration: getWebhookConfig({
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topics: ['products/create'],
         }),
       })
@@ -472,7 +472,7 @@ describe('deploy', () => {
 
       expect(fakedWebhookSubscriptionsMutation).toHaveBeenCalledWith([
         {
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topic: 'products/create',
         },
       ])
@@ -483,10 +483,10 @@ describe('deploy', () => {
       )
     })
 
-    test('normalizes top level http subscriptions', async () => {
+    test('normalizes top level subscriptions', async () => {
       const app = testApp({
         configuration: getWebhookConfig({
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topics: ['products/create', 'products/update'],
         }),
       })
@@ -495,68 +495,11 @@ describe('deploy', () => {
 
       expect(fakedWebhookSubscriptionsMutation).toHaveBeenCalledWith([
         {
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topic: 'products/create',
         },
         {
-          subscription_endpoint_url: 'https://example.com',
-          topic: 'products/update',
-        },
-      ])
-      expect(renderSuccess).toHaveBeenCalledWith(
-        expect.objectContaining({
-          headline: 'New version released to users.',
-        }),
-      )
-    })
-
-    test('normalizes top level arn subscriptions', async () => {
-      const app = testApp({
-        configuration: getWebhookConfig({
-          arn: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
-          topics: ['products/create', 'products/update'],
-        }),
-      })
-
-      await testWebhooks(app)
-
-      expect(fakedWebhookSubscriptionsMutation).toHaveBeenCalledWith([
-        {
-          arn: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
-          topic: 'products/create',
-        },
-        {
-          arn: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
-          topic: 'products/update',
-        },
-      ])
-      expect(renderSuccess).toHaveBeenCalledWith(
-        expect.objectContaining({
-          headline: 'New version released to users.',
-        }),
-      )
-    })
-
-    test('normalizes top level pub sub subscriptions', async () => {
-      const app = testApp({
-        configuration: getWebhookConfig({
-          pubsub_project: 'my-project-123',
-          pubsub_topic: 'my-topic',
-          topics: ['products/create', 'products/update'],
-        }),
-      })
-
-      await testWebhooks(app)
-
-      expect(fakedWebhookSubscriptionsMutation).toHaveBeenCalledWith([
-        {
-          pubsub_project: 'my-project-123',
-          pubsub_topic: 'my-topic',
-          topic: 'products/create',
-        },
-        {
-          pubsub_project: 'my-project-123',
-          pubsub_topic: 'my-topic',
+          endpoint: 'https://example.com',
           topic: 'products/update',
         },
       ])
@@ -570,16 +513,15 @@ describe('deploy', () => {
     test('top level http config is overwritten by subscription specific config', async () => {
       const app = testApp({
         configuration: getWebhookConfig({
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topics: ['products/create'],
           subscriptions: [
             {
-              subscription_endpoint_url: 'https://example2.com',
+              endpoint: 'https://example2.com',
               topic: 'products/create',
             },
             {
-              pubsub_project: 'my-project-123',
-              pubsub_topic: 'my-topic',
+              endpoint: 'pubsub://my-project-123:my-topic',
               topic: 'products/create',
             },
             {
@@ -594,20 +536,19 @@ describe('deploy', () => {
 
       expect(fakedWebhookSubscriptionsMutation).toHaveBeenCalledWith([
         {
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topic: 'products/create',
         },
         {
-          subscription_endpoint_url: 'https://example2.com',
+          endpoint: 'https://example2.com',
           topic: 'products/create',
         },
         {
-          pubsub_project: 'my-project-123',
-          pubsub_topic: 'my-topic',
+          endpoint: 'pubsub://my-project-123:my-topic',
           topic: 'products/create',
         },
         {
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topic: 'products/delete',
           format: 'xml',
         },
@@ -622,16 +563,15 @@ describe('deploy', () => {
     test('top level arn config is overwritten by subscription specific config', async () => {
       const app = testApp({
         configuration: getWebhookConfig({
-          arn: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
+          endpoint: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
           topics: ['products/create'],
           subscriptions: [
             {
-              arn: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_new_webhook_path',
+              endpoint: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_new_webhook_path',
               topic: 'products/create',
             },
             {
-              pubsub_project: 'my-project-123',
-              pubsub_topic: 'my-topic',
+              endpoint: 'pubsub://my-project-123:my-topic',
               topic: 'products/create',
             },
             {
@@ -646,20 +586,19 @@ describe('deploy', () => {
 
       expect(fakedWebhookSubscriptionsMutation).toHaveBeenCalledWith([
         {
-          arn: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
+          endpoint: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
           topic: 'products/create',
         },
         {
-          arn: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_new_webhook_path',
+          endpoint: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_new_webhook_path',
           topic: 'products/create',
         },
         {
-          pubsub_project: 'my-project-123',
-          pubsub_topic: 'my-topic',
+          endpoint: 'pubsub://my-project-123:my-topic',
           topic: 'products/create',
         },
         {
-          arn: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
+          endpoint: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
           topic: 'products/delete',
           format: 'xml',
         },
@@ -674,17 +613,15 @@ describe('deploy', () => {
     test('top level pub sub config is overwritten by subscription specific config', async () => {
       const app = testApp({
         configuration: getWebhookConfig({
-          pubsub_project: 'my-project-123',
-          pubsub_topic: 'my-topic',
+          endpoint: 'pubsub://my-project-123:my-topic',
           topics: ['products/create'],
           subscriptions: [
             {
-              pubsub_project: 'my-project-456',
-              pubsub_topic: 'my-new-topic',
+              endpoint: 'pubsub://my-project-456:my-new-topic',
               topic: 'products/create',
             },
             {
-              subscription_endpoint_url: 'https://example.com',
+              endpoint: 'https://example.com',
               topic: 'products/create',
             },
             {
@@ -699,22 +636,19 @@ describe('deploy', () => {
 
       expect(fakedWebhookSubscriptionsMutation).toHaveBeenCalledWith([
         {
-          pubsub_project: 'my-project-123',
-          pubsub_topic: 'my-topic',
+          endpoint: 'pubsub://my-project-123:my-topic',
           topic: 'products/create',
         },
         {
-          pubsub_project: 'my-project-456',
-          pubsub_topic: 'my-new-topic',
+          endpoint: 'pubsub://my-project-456:my-new-topic',
           topic: 'products/create',
         },
         {
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topic: 'products/create',
         },
         {
-          pubsub_project: 'my-project-123',
-          pubsub_topic: 'my-topic',
+          endpoint: 'pubsub://my-project-123:my-topic',
           topic: 'products/delete',
           format: 'xml',
         },
@@ -726,10 +660,10 @@ describe('deploy', () => {
       )
     })
 
-    test('subscription level path is appended to top level subscription_endpoint_url', async () => {
+    test('subscription level path is appended to top level endpoint', async () => {
       const app = testApp({
         configuration: getWebhookConfig({
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topics: ['products/create'],
           subscriptions: [
             {
@@ -745,11 +679,11 @@ describe('deploy', () => {
 
       expect(fakedWebhookSubscriptionsMutation).toHaveBeenCalledWith([
         {
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topic: 'products/create',
         },
         {
-          subscription_endpoint_url: 'https://example.com/delete',
+          endpoint: 'https://example.com/delete',
           topic: 'products/delete',
           include_fields: ['id'],
         },
@@ -761,15 +695,15 @@ describe('deploy', () => {
       )
     })
 
-    test('subscription level path is appended to inner level subscription_endpoint_url', async () => {
+    test('subscription level path is appended to inner level endpoint', async () => {
       const app = testApp({
         configuration: getWebhookConfig({
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topics: ['products/create'],
           subscriptions: [
             {
               topic: 'products/delete',
-              subscription_endpoint_url: 'https://example2.com',
+              endpoint: 'https://example2.com',
               path: '/delete',
               include_fields: ['id'],
             },
@@ -781,11 +715,11 @@ describe('deploy', () => {
 
       expect(fakedWebhookSubscriptionsMutation).toHaveBeenCalledWith([
         {
-          subscription_endpoint_url: 'https://example.com',
+          endpoint: 'https://example.com',
           topic: 'products/create',
         },
         {
-          subscription_endpoint_url: 'https://example2.com/delete',
+          endpoint: 'https://example2.com/delete',
           topic: 'products/delete',
           include_fields: ['id'],
         },

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -436,7 +436,6 @@ describe('deploy', () => {
           redirectUrlWhitelist: ['https://my-app.com/auth'],
           title: 'app-title',
           grantedScopes: [],
-          betas: {unifiedAppDeployment: true},
         },
       })
 
@@ -870,7 +869,7 @@ async function testWebhooks(app: AppInterface) {
       redirectUrlWhitelist: ['https://my-app.com/auth'],
       title: 'app-title',
       grantedScopes: [],
-      betas: {unifiedAppDeployment: true, declarativeWebhooks: true},
+      betas: {declarativeWebhooks: true},
     },
   })
 }

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -3,20 +3,9 @@ import {uploadThemeExtensions, uploadExtensionsBundle, UploadExtensionsBundleOut
 
 import {ensureDeployContext} from './context.js'
 import {bundleAndBuildExtensions} from './deploy/bundle.js'
-import {AppInterface} from '../models/app/app.js'
+import {AppInterface, type NormalizedWebhookSubscriptions} from '../models/app/app.js'
 import {updateAppIdentifiers} from '../models/app/identifiers.js'
-import {fetchAppExtensionRegistrations} from './dev/fetch.js'
-import {DeploymentMode} from './deploy/mode.js'
-import {AppInterface} from '../models/app/app.js'
-import {Identifiers, updateAppIdentifiers} from '../models/app/identifiers.js'
-import {OrganizationApp} from '../models/organization.js'
-import {AllAppExtensionRegistrationsQuerySchema} from '../api/graphql/all_app_extension_registrations.js'
-import {ExtensionInstance} from '../models/extensions/extension-instance.js'
-import {FunctionConfigType} from '../models/extensions/specifications/function.js'
-import {
-  fakedWebhookSubscriptionsMutation,
-  type NormalizedWebhookSubscriptions,
-} from '../utilities/app/config/webhooks.js'
+import {fakedWebhookSubscriptionsMutation, filterFalsey} from '../utilities/app/config/webhooks.js'
 import {renderInfo, renderSuccess, renderTasks} from '@shopify/cli-kit/node/ui'
 import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
@@ -24,9 +13,8 @@ import {outputNewline, outputInfo, formatPackageManagerCommand} from '@shopify/c
 import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
 import {Config} from '@oclif/core'
-import type {Task} from '@shopify/cli-kit/node/ui'
 import {pickBy} from '@shopify/cli-kit/common/object'
-import type {AlertCustomSection, Task} from '@shopify/cli-kit/node/ui'
+import type {Task} from '@shopify/cli-kit/node/ui'
 
 interface DeployOptions {
   /** The app to be built and uploaded */
@@ -133,10 +121,8 @@ export async function deploy(options: DeployOptions) {
         },
       ]
 
-      // should this be included in the above app deploy task? split out into its own task? still technically part of an app version
       if (partnersApp.betas?.declarativeWebhooks) {
         tasks.push({
-          // again, todo title based on if it will be part of above task
           title: 'Releasing webhooks',
           task: async () => {
             if (!('webhooks' in app.configuration)) return
@@ -150,30 +136,26 @@ export async function deploy(options: DeployOptions) {
                 ['subscription_endpoint_url', 'arn', 'pubsub_project', 'pubsub_topic'].includes(key) && value,
             )
 
-            // top level subscriptions
             if (Object.keys(topLevelDestination).length && topics?.length) {
               for (const topic of topics) {
                 webhookSubscriptions.push({
                   topic,
                   ...topLevelDestination,
                 })
-                // we could add the defaults here as well (include_fields: [], metafield_namespaces: [], format: 'json)
-                // but I think thats better suited for server side / info over the wire
               }
             }
 
-            // inner subscriptions
             if (subscriptions?.length) {
               for (const {path, ...subscription} of subscriptions) {
                 const hasLocalDestination = Boolean(
-                  [
+                  filterFalsey([
                     subscription.subscription_endpoint_url,
                     subscription.arn,
                     subscription.pubsub_project && subscription.pubsub_topic,
-                  ].filter(Boolean).length,
+                  ]).length,
                 )
 
-                // we can assume this is valid from validation earlier, and local config will overwrite top level if there is any
+                // we can assume this is valid from earlier validation, and local config will overwrite top level if there is any
                 const subscriptionConfig = {
                   ...(hasLocalDestination ? {} : topLevelDestination),
                   ...subscription,
@@ -190,7 +172,6 @@ export async function deploy(options: DeployOptions) {
             // eslint-disable-next-line no-warning-comments
             // TODO - make request with webhookSubscriptions
             fakedWebhookSubscriptionsMutation(webhookSubscriptions)
-            // console.log('~~Normalized Subscriptions~~', webhookSubscriptions)
           },
         })
       }

--- a/packages/app/src/cli/utilities/app/config/webhooks.ts
+++ b/packages/app/src/cli/utilities/app/config/webhooks.ts
@@ -1,10 +1,191 @@
-import {WebhookSubscriptionSchema} from '../../../models/app/app.js'
 import {zod} from '@shopify/cli-kit/node/schema'
+import type {NormalizedWebhookSubscriptions, WebhookConfig} from '../../../models/app/app.js'
 
-export type NormalizedWebhookSubscriptions = Partial<zod.infer<typeof WebhookSubscriptionSchema>>[]
+// used in tandem with declarativeWebhooks beta when we are not in the context of an app
+export const TEMP_OMIT_DECLARATIVE_WEBHOOKS_SCHEMA = true
 
 // eslint-disable-next-line no-warning-comments
 // TODO - remove this when mutation is ready
 export function fakedWebhookSubscriptionsMutation(subscriptions: NormalizedWebhookSubscriptions) {
   return subscriptions
+}
+
+export const getFullPubSubValidationError = (suffix: string) =>
+  `You must declare both pubsub_project and pubsub_topic if you wish to use ${suffix}`
+
+export const getTooManyDestinationsError = (suffix: string) =>
+  `You are only allowed to declare one (1) of subscription_endpoint_url, pubsub_project & pubsub_topic, or arn ${suffix}`
+
+const duplicateSubscriptionsError = 'You can’t have duplicate subscriptions with the exact same topic and destination'
+
+export function filterFalsey(values: (string | boolean | undefined)[]) {
+  return values.filter(Boolean)
+}
+
+const SUBSCRIPTION_KEY_DELIMITER = '::'
+
+const generateSubscriptionKey = (topic: string, destination: string) =>
+  `${topic}${SUBSCRIPTION_KEY_DELIMITER}${destination}`
+
+export function validateTopLevelSubscriptions({subscriptions = [], ...schema}: WebhookConfig) {
+  const topLevelDestinationsLength = filterFalsey([
+    schema.subscription_endpoint_url,
+    schema.pubsub_project && schema.pubsub_topic,
+    schema.arn,
+  ]).length
+  const hasTopics = Boolean(schema?.topics?.length)
+
+  if (filterFalsey([schema.pubsub_project, schema.pubsub_topic]).length === 1) {
+    return {
+      code: zod.ZodIssueCode.custom,
+      message: getFullPubSubValidationError('a top-level pub sub destination'),
+      fatal: true,
+    }
+  }
+
+  if (topLevelDestinationsLength > 1) {
+    return {
+      code: zod.ZodIssueCode.custom,
+      message: getTooManyDestinationsError('at the top level'),
+      fatal: true,
+    }
+  }
+
+  if (topLevelDestinationsLength && !hasTopics && !subscriptions.length) {
+    return {
+      code: zod.ZodIssueCode.custom,
+      message:
+        'To use a top-level destination, you must also provide a `topics` array or `subscriptions` configuration',
+      fatal: true,
+    }
+  }
+
+  if (!topLevelDestinationsLength && hasTopics) {
+    return {
+      code: zod.ZodIssueCode.custom,
+      message:
+        'To use top-level topics, you must also provide a top-level destination of either subscription_endpoint_url, pubsub_project & pubsub_topic, or arn',
+      fatal: true,
+      path: ['topics'],
+    }
+  }
+}
+
+export function validateInnerSubscriptions({subscriptions = [], ...schema}: WebhookConfig) {
+  const hasTopLevelDestinations = Boolean(
+    filterFalsey([schema.subscription_endpoint_url, schema.pubsub_project && schema.pubsub_topic, schema.arn]).length,
+  )
+  // build top level destination key portion
+  const topLevelDestination = filterFalsey([
+    schema.subscription_endpoint_url,
+    schema.pubsub_project,
+    schema.pubsub_topic,
+    schema.arn,
+  ]).join(SUBSCRIPTION_KEY_DELIMITER)
+  const subscriptionDestinationsSet = new Set()
+
+  // top level subscriptions are normalized and added for duplication validation
+  if (topLevelDestination && schema?.topics?.length) {
+    for (const topic of schema.topics) {
+      const key = generateSubscriptionKey(topic, topLevelDestination)
+
+      if (subscriptionDestinationsSet.has(key)) {
+        return {
+          code: zod.ZodIssueCode.custom,
+          message: duplicateSubscriptionsError,
+          fatal: true,
+          path: ['topics', topic],
+        }
+      }
+
+      subscriptionDestinationsSet.add(key)
+    }
+  }
+
+  if (!subscriptions.length) return
+
+  for (const [i, subscription] of subscriptions.entries()) {
+    const subscriptionDestinations = filterFalsey([
+      subscription.subscription_endpoint_url,
+      subscription.pubsub_project && subscription.pubsub_topic,
+      subscription.arn,
+    ])
+    const path = ['subscriptions', i]
+
+    if (filterFalsey([subscription.pubsub_project, subscription.pubsub_topic]).length === 1) {
+      return {
+        code: zod.ZodIssueCode.custom,
+        message: getFullPubSubValidationError('a pub sub destination'),
+        fatal: true,
+        path,
+      }
+    }
+
+    if (subscriptionDestinations.length > 1) {
+      return {
+        code: zod.ZodIssueCode.custom,
+        message: getTooManyDestinationsError('per subscription'),
+        fatal: true,
+        path,
+      }
+    }
+
+    // If no top-level destinations are provided, ensure each subscription has at least one destination
+    if (!hasTopLevelDestinations && subscriptionDestinations.length === 0) {
+      return {
+        code: zod.ZodIssueCode.custom,
+        message: 'You must declare either a top-level destination or a destination per subscription',
+        fatal: true,
+        path,
+      }
+    }
+
+    if (!schema.subscription_endpoint_url && !subscription.subscription_endpoint_url && subscription.path) {
+      return {
+        code: zod.ZodIssueCode.custom,
+        message: 'You must declare a subscription_endpoint_url if you wish to use a relative path',
+        fatal: true,
+        path,
+      }
+    }
+
+    if ((subscription.arn || subscription.pubsub_project) && subscription.path) {
+      return {
+        code: zod.ZodIssueCode.custom,
+        message: 'You can’t define a path when using arn or pubsub',
+        fatal: true,
+        path,
+      }
+    }
+
+    let destination = filterFalsey([
+      subscription.subscription_endpoint_url,
+      subscription.pubsub_project,
+      subscription.pubsub_topic,
+      subscription.arn,
+    ]).join(SUBSCRIPTION_KEY_DELIMITER)
+
+    // if there is no destination override, use top level destination. we are sure there will be one from earlier validation
+    if (!destination) {
+      destination = topLevelDestination
+    }
+
+    // concat the path to the destination if it exists to ensure uniqueness
+    if (subscription.path) {
+      destination = `${destination}${subscription.path}`
+    }
+
+    const key = generateSubscriptionKey(subscription.topic, destination)
+
+    if (subscriptionDestinationsSet.has(key)) {
+      return {
+        code: zod.ZodIssueCode.custom,
+        message: duplicateSubscriptionsError,
+        fatal: true,
+        path: [...path, subscription.topic],
+      }
+    }
+
+    subscriptionDestinationsSet.add(key)
+  }
 }

--- a/packages/app/src/cli/utilities/app/config/webhooks.ts
+++ b/packages/app/src/cli/utilities/app/config/webhooks.ts
@@ -1,0 +1,10 @@
+import {WebhookSubscriptionSchema} from '../../../models/app/app.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+export type NormalizedWebhookSubscriptions = Partial<zod.infer<typeof WebhookSubscriptionSchema>>[]
+
+// eslint-disable-next-line no-warning-comments
+// TODO - remove this when mutation is ready
+export function fakedWebhookSubscriptionsMutation(subscriptions: NormalizedWebhookSubscriptions) {
+  return subscriptions
+}

--- a/packages/app/src/cli/utilities/app/config/webhooks.ts
+++ b/packages/app/src/cli/utilities/app/config/webhooks.ts
@@ -9,175 +9,97 @@ export const TEMP_OMIT_DECLARATIVE_WEBHOOKS_SCHEMA = true
 export function fakedWebhookSubscriptionsMutation(subscriptions: NormalizedWebhookSubscriptions) {
   return subscriptions
 }
+export const httpsRegex = /^(https:\/\/)/
 
-export const getFullPubSubValidationError = (suffix: string) =>
-  `You must declare both pubsub_project and pubsub_topic if you wish to use ${suffix}`
-
-export const getTooManyDestinationsError = (suffix: string) =>
-  `You are only allowed to declare one (1) of subscription_endpoint_url, pubsub_project & pubsub_topic, or arn ${suffix}`
-
-const duplicateSubscriptionsError = 'You can’t have duplicate subscriptions with the exact same topic and destination'
+const duplicateSubscriptionsError = 'You can’t have duplicate subscriptions with the exact same `topic` and `endpoint`'
 
 export function filterFalsey(values: (string | boolean | undefined)[]) {
   return values.filter(Boolean)
 }
 
-const SUBSCRIPTION_KEY_DELIMITER = '::'
+const generateSubscriptionKey = (topic: string, endpoint: string) => `${topic}::${endpoint}`
 
-const generateSubscriptionKey = (topic: string, destination: string) =>
-  `${topic}${SUBSCRIPTION_KEY_DELIMITER}${destination}`
+export function validateTopLevelSubscriptions(schema: WebhookConfig) {
+  const hasEndpoint = Boolean(schema.endpoint)
+  const hasTopics = Boolean(schema.topics?.length)
 
-export function validateTopLevelSubscriptions({subscriptions = [], ...schema}: WebhookConfig) {
-  const topLevelDestinationsLength = filterFalsey([
-    schema.subscription_endpoint_url,
-    schema.pubsub_project && schema.pubsub_topic,
-    schema.arn,
-  ]).length
-  const hasTopics = Boolean(schema?.topics?.length)
-
-  if (filterFalsey([schema.pubsub_project, schema.pubsub_topic]).length === 1) {
+  if (hasEndpoint && !hasTopics && !schema.subscriptions?.length) {
     return {
       code: zod.ZodIssueCode.custom,
-      message: getFullPubSubValidationError('a top-level pub sub destination'),
+      message: 'To use a top-level `endpoint`, you must also provide a `topics` array or `[[webhooks.subscriptions]]`',
       fatal: true,
     }
   }
 
-  if (topLevelDestinationsLength > 1) {
+  if (!hasEndpoint && hasTopics) {
     return {
       code: zod.ZodIssueCode.custom,
-      message: getTooManyDestinationsError('at the top level'),
+      message: 'To use top-level topics, you must also provide a top-level `endpoint`',
       fatal: true,
+      path: ['topics'],
     }
   }
 
-  if (topLevelDestinationsLength && !hasTopics && !subscriptions.length) {
+  // given the endpoint will be static, the only way to have duplicate top-level subscriptions is if there are multiple identical topics
+  if (hasTopics && schema.topics?.length !== new Set(schema.topics).size) {
     return {
       code: zod.ZodIssueCode.custom,
-      message:
-        'To use a top-level destination, you must also provide a `topics` array or `subscriptions` configuration',
-      fatal: true,
-    }
-  }
-
-  if (!topLevelDestinationsLength && hasTopics) {
-    return {
-      code: zod.ZodIssueCode.custom,
-      message:
-        'To use top-level topics, you must also provide a top-level destination of either subscription_endpoint_url, pubsub_project & pubsub_topic, or arn',
+      message: duplicateSubscriptionsError,
       fatal: true,
       path: ['topics'],
     }
   }
 }
 
-export function validateInnerSubscriptions({subscriptions = [], ...schema}: WebhookConfig) {
-  const hasTopLevelDestinations = Boolean(
-    filterFalsey([schema.subscription_endpoint_url, schema.pubsub_project && schema.pubsub_topic, schema.arn]).length,
-  )
-  // build top level destination key portion
-  const topLevelDestination = filterFalsey([
-    schema.subscription_endpoint_url,
-    schema.pubsub_project,
-    schema.pubsub_topic,
-    schema.arn,
-  ]).join(SUBSCRIPTION_KEY_DELIMITER)
-  const subscriptionDestinationsSet = new Set()
+export function validateInnerSubscriptions({endpoint, subscriptions = [], ...schema}: WebhookConfig) {
+  const uniqueSubscriptionEndpointSet = new Set()
 
-  // top level subscriptions are normalized and added for duplication validation
-  if (topLevelDestination && schema?.topics?.length) {
+  // add validated unique top level subscriptions to set
+  if (endpoint && schema.topics?.length) {
     for (const topic of schema.topics) {
-      const key = generateSubscriptionKey(topic, topLevelDestination)
-
-      if (subscriptionDestinationsSet.has(key)) {
-        return {
-          code: zod.ZodIssueCode.custom,
-          message: duplicateSubscriptionsError,
-          fatal: true,
-          path: ['topics', topic],
-        }
-      }
-
-      subscriptionDestinationsSet.add(key)
+      uniqueSubscriptionEndpointSet.add(generateSubscriptionKey(topic, endpoint))
     }
   }
 
   if (!subscriptions.length) return
 
   for (const [i, subscription] of subscriptions.entries()) {
-    const subscriptionDestinations = filterFalsey([
-      subscription.subscription_endpoint_url,
-      subscription.pubsub_project && subscription.pubsub_topic,
-      subscription.arn,
-    ])
     const path = ['subscriptions', i]
 
-    if (filterFalsey([subscription.pubsub_project, subscription.pubsub_topic]).length === 1) {
+    // If no top-level endpoints are provided, ensure each subscription has at least one endpoint
+    if (!endpoint && !subscription.endpoint) {
       return {
         code: zod.ZodIssueCode.custom,
-        message: getFullPubSubValidationError('a pub sub destination'),
+        message: 'You must include either a top-level endpoint or an endpoint per `[[webhooks.subscriptions]]`',
         fatal: true,
         path,
       }
     }
 
-    if (subscriptionDestinations.length > 1) {
+    let finalEndpoint = subscription.endpoint
+
+    // if there is no endpoint override, use top level endpoint. we are sure there will be one from earlier validation
+    if (!finalEndpoint) {
+      finalEndpoint = endpoint
+    }
+
+    if (subscription.path && !httpsRegex.test(finalEndpoint!)) {
       return {
         code: zod.ZodIssueCode.custom,
-        message: getTooManyDestinationsError('per subscription'),
+        message: 'You must use an https `endpoint` to use a relative path',
         fatal: true,
         path,
       }
     }
 
-    // If no top-level destinations are provided, ensure each subscription has at least one destination
-    if (!hasTopLevelDestinations && subscriptionDestinations.length === 0) {
-      return {
-        code: zod.ZodIssueCode.custom,
-        message: 'You must declare either a top-level destination or a destination per subscription',
-        fatal: true,
-        path,
-      }
-    }
-
-    if (!schema.subscription_endpoint_url && !subscription.subscription_endpoint_url && subscription.path) {
-      return {
-        code: zod.ZodIssueCode.custom,
-        message: 'You must declare a subscription_endpoint_url if you wish to use a relative path',
-        fatal: true,
-        path,
-      }
-    }
-
-    if ((subscription.arn || subscription.pubsub_project) && subscription.path) {
-      return {
-        code: zod.ZodIssueCode.custom,
-        message: 'You can’t define a path when using arn or pubsub',
-        fatal: true,
-        path,
-      }
-    }
-
-    let destination = filterFalsey([
-      subscription.subscription_endpoint_url,
-      subscription.pubsub_project,
-      subscription.pubsub_topic,
-      subscription.arn,
-    ]).join(SUBSCRIPTION_KEY_DELIMITER)
-
-    // if there is no destination override, use top level destination. we are sure there will be one from earlier validation
-    if (!destination) {
-      destination = topLevelDestination
-    }
-
-    // concat the path to the destination if it exists to ensure uniqueness
+    // concat the path to the endpoint if it exists to ensure uniqueness
     if (subscription.path) {
-      destination = `${destination}${subscription.path}`
+      finalEndpoint = `${finalEndpoint}${subscription.path}`
     }
 
-    const key = generateSubscriptionKey(subscription.topic, destination)
+    const key = generateSubscriptionKey(subscription.topic, finalEndpoint!)
 
-    if (subscriptionDestinationsSet.has(key)) {
+    if (uniqueSubscriptionEndpointSet.has(key)) {
       return {
         code: zod.ZodIssueCode.custom,
         message: duplicateSubscriptionsError,
@@ -186,6 +108,6 @@ export function validateInnerSubscriptions({subscriptions = [], ...schema}: Webh
       }
     }
 
-    subscriptionDestinationsSet.add(key)
+    uniqueSubscriptionEndpointSet.add(key)
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

closes: https://github.com/Shopify/develop-app-management/issues/1500

- Introduces schema changes to the app TOML that will provide the parsing and validation for declarative webhooks
- Also somewhat consumes the beta, but not fully wired up to the mutation yet
- The rest of the tidy up/wire up can come once we have mutations created to push declarative webhook data


### WHAT is this pull request doing?

- Adds new TOML fields, all are currently optional and validation is not checked until we turn it on. See the full property break down and content in which they refer to below
- Validates the declarative webhook subscription heavily. Trying to give the best DX by surfacing errors early and often
- Normalizes the TOML input into an easily consumable and consistent format we will ingest

### How to test your changes?

- spin up local branch, otherwise review the code
- this is in a good spot but I expect this to change a bunch, so we can get this in and iterate

<details>
  <summary><h3>👀 New TOML Fields<h2></summary>

  > [!NOTE]  
  > These fields will exist on the schema but are not consumed until we enable the beta and remove static blocking flags

  **New Top Level Fields**
  ```toml
  [webhooks]
  api_version = "2023-10" # existing 
  
  # *NEW*
  # subscription_endpoint_url - HTTPS endpoint
  # pubsub_project & pubsub_topic - Google PubSub config
  # arn - AWS Eventbridge ARN
  # topics - String[] of top level topics
  
  #  🛑 Only one of these destinations can be used at the top level

  # Examples
  subscription_endpoint_url = "https://my-app.com/webhooks"

  pubsub_project = "absolute-feat-123"
  pubsub_topic = "pub-sub-topic1"
  
  arn = "arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/SOMETHING"
  
  topics = ['products/create', 'products/update', 'products/delete']

  # existing
  [webhooks.privacy_compliance]
  customer_deletion_url = "https://example.com/privacy/customer_deletion"
  customer_data_request_url = "https://example.com/privacy/customer_request"
  shop_deletion_url = "https://example.com/privacy/deletion"
  ```

 **New `subscriptions` Level Fields**
  ```toml
  [webhooks]
  api_version = "2023-10" # existing 
  
  # Example top level config 
  subscription_endpoint_url = "https://my-app.com/webhooks"
  topics = ['products/create', 'products/update', 'products/delete']

  # *NEW*
  # topic - mandatory topic
  # subscription_endpoint_url OR pubsub_project & pubsub_topic OR arn - The destination, that will override the top level destination if provided (optional if top level is defined)
  # sub_topic - sub topic (optional)
  # path - path to append to top level https URL or defined subscription_endpoint_url if defined (optional)
  # include_fields - string[] (optional)
  # metafield_namespaces - string[] (optional)
  # format - 'json' | 'xml' (optional, defaults to json)
  
  #  Examples

  [[webhooks.subscriptions]]
  topic = 'products/create'
  path = '/my-neat-path'
  subscription_endpoint_url = 'https://valid-url'

  [[webhooks.subscriptions]]
  topic = 'products/create'
  sub_topic = 'something'
  path = '/only-path'

  [[webhooks.subscriptions]]
  topic = 'products/create'
  path = '/my-neat-path-new'
  include_fields = ['variants', 'title']
  metafield_namespaces = ['size']
  subscription_endpoint_url = 'https://valid-url'

  [[webhooks.subscriptions]]
  topic = 'products/delete'
  format = 'xml'
  subscription_endpoint_url = 'https://valid-url'

  [[webhooks.subscriptions]]
  topic = 'products/delete'
  format = 'json'
  pubsub_project = "absolute-feat-123"
  pubsub_topic = "pub-sub-topic1"

  [[webhooks.subscriptions]]
  subscription_endpoint_url = 'https://valid-url'
  topic = 'products/delete'
  format = 'xml'
  path = "/absolute-feat-123"

  [[webhooks.subscriptions]]
  arn = "arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/SOMETHING"
  topic = 'products/delete'

  [[webhooks.subscriptions]]
  topic = "orders/delete"
  path = "/absolute-feat-123"
  ```

</details>

<details>

  <summary><h3>👀 New CLI Content<h2></summary>
  
   | content                                                                                                                                             | TOML scenario                                                                                                                                                                                                                              |
  |-----------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
  | "Only https urls are allowed"                                                                                                                       | `subscription_endpoint_url` is not https                                                                                                                                                                                                   |
  | "URL can’t end with a forward slash"                                                                                                                | `subscription_endpoint_url` ends with a forward slash (could conflict with path) ex. `https://example.ca/`                                                                                                                                 |
  | "Path must start with a forward slash and be longer than 1 character"                                                                               | `path` does not start with a forward slash or is only 1 character (only the `/`)                                                                                                                                                           |
  | "You must declare both pubsub_project and pubsub_topic if you wish to use a top-level pub sub destination"                                          | Only one of pubsub_project or pubsub_topic is defined at the top level                                                                                                                                                                     |
  | "You must declare both pubsub_project and pubsub_topic if you wish to use a pub sub destination"                                                    | Only one of pubsub_project or pubsub_topic is defined at an inner subscription                                                                                                                                                             |
  | "You are only allowed to declare one (1) of subscription_endpoint_url, pubsub_project & pubsub_topic, or arn at the top level"                      | Multiple top level destinations are defined at the top level                                                                                                                                                                               |
  | "You are only allowed to declare one (1) of subscription_endpoint_url, pubsub_project & pubsub_topic, or arn per subscription"                      | Multiple top level destinations are defined at an inner subscription                                                                                                                                                                       |
  | "To use a top-level destination, you must also provide a `topics` array or `subscriptions` configuration"                                           | Top level destination is provided but no top level topics array or inner subscriptions                                                                                                                                                     |
  | "To use top-level topics, you must also provide a top-level destination of either subscription_endpoint_url, pubsub_project & pubsub_topic, or arn" | Top level topics array is provided but no top level destination                                                                                                                                                                            |
  | "You can’t have duplicate subscriptions with the exact same topic and destination"                                                                  | There are duplicate subscription definitions. This could be an identical topic/destination at the top level, an identical topic/destination at an inner subscription, or identical topic/destination defined through a combination of both |
  | "You must declare either a top-level destination or a destination per subscription"                                                                 | Inner subscriptions are defined, but there is no top level or sub level destination defined                                                                                                                                                |
  | "You must declare a subscription_endpoint_url if you wish to use a relative path"                                                                   | No top level or sub level https URL is defined but path was included                                                                                                                                                                       |
  | "You can’t define a path when using arn or pubsub"                                                                                                  | Path is defined at an inner level but so is an arn or pub sub configuration                                                                                                                                                                |



</details>

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
