### PR TITLE
Improvements to cloudflared download

### DIFF
--- a/.changeset/khaki-colts-remember.md
+++ b/.changeset/khaki-colts-remember.md
@@ -1,0 +1,5 @@
+---
+'@shopify/plugin-cloudflare': minor
+---
+
+Added cloudflared download support for Windows ARM, and improved error messaging for download failures.

--- a/packages/plugin-cloudflare/scripts/postinstall.js
+++ b/packages/plugin-cloudflare/scripts/postinstall.js
@@ -27,12 +27,13 @@ const MACOS_URL = {
 const WINDOWS_URL = {
   x64: 'cloudflared-windows-amd64.exe',
   ia32: 'cloudflared-windows-386.exe',
+  arm64: 'cloudflared-windows-amd64.exe',
 }
 
 const URL = {
-  linux: CLOUDFLARE_REPO + LINUX_URL[process.arch],
-  darwin: CLOUDFLARE_REPO + MACOS_URL[process.arch],
-  win32: CLOUDFLARE_REPO + WINDOWS_URL[process.arch],
+  linux: LINUX_URL[process.arch],
+  darwin: MACOS_URL[process.arch],
+  win32: WINDOWS_URL[process.arch],
 }
 
 /**
@@ -52,11 +53,12 @@ function getBinPathTarget() {
 }
 
 export default async function install() {
-  const fileUrlPath = URL[process.platform]
-  if (fileUrlPath === undefined) {
+  const fileName = URL[process.platform]
+  if (fileName === undefined) {
     throw new Error(`Unsupported system platform: ${process.platform} or arch: ${process.arch}`)
   }
 
+  const fileUrlPath = CLOUDFLARE_REPO + fileName;
   const binTarget = getBinPathTarget()
 
   if (existsSync(binTarget)) {
@@ -104,7 +106,7 @@ async function downloadFile(url, to) {
   }
   const streamPipeline = util.promisify(pipeline)
   const response = await fetch(url, {redirect: 'follow'})
-  if (!response.ok) throw new Error("Couldn't download file")
+  if (!response.ok) throw new Error(`Couldn't download file ${url} (${response.status} ${response.statusText})`)
   const fileObject = createWriteStream(to)
   await streamPipeline(response.body, fileObject)
   return to


### PR DESCRIPTION
### WHY are these changes introduced?

Attempting to create an app on Windows ARM, with Node ARM installed resulted in the following error:

```
npm ERR!   if (!response.ok) throw new Error("Couldn't download file")
npm ERR!                           ^
npm ERR!
npm ERR! Error: Couldn't download file
npm ERR!     at downloadFile (file:///C:/Users/NICKWE~1/AppData/Local/Temp/9a90443df0b5afec2bfd15aa70426016/app/node_mod
ules/@shopify/plugin-cloudflare/scripts/postinstall.js:107:27)
```

This pointed to a few issues in the cloudflared download:
* No handling for Win ARM (it can just use the x64 version)
* The error handling for platform/arch in this script doesn't work (URL was never undefined, it just ended with the string `undefined`)
* The download error message is not helpful (which I encountered again while testing this when GitHub went down 😆)

### WHAT is this pull request doing?

* Handle node ARM on windows
* Fix error check for platform/arch
* Improve message for download errors

### How to test your changes?

Manually, since there are no unit tests for this script.
* Test on UTM with Node ARM
* Remove your current arch to test arch error messaging
* Update a file name to test download message

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
