### PR TITLE
Remove "useExtensionFramework" from functions config

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -223,7 +223,6 @@ interface TestFunctionExtensionOptions {
   dir?: string
   config?: FunctionConfigType
   entryPath?: string
-  usingExtensionFramework?: boolean
 }
 
 export async function testFunctionExtension(
@@ -242,7 +241,6 @@ export async function testFunctionExtension(
     directory,
     specification,
   })
-  extension.usingExtensionsFramework = opts.usingExtensionFramework ?? false
   return extension
 }
 

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -41,15 +41,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   handle: string
   specification: ExtensionSpecification
 
-  private useExtensionsFramework: boolean
-
   get graphQLType() {
-    if (this.features.includes('function')) {
-      if (this.useExtensionsFramework) return 'FUNCTION'
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const functionConfig: any = this.configuration
-      return functionConfig.type.toUpperCase()
-    }
     return (this.specification.graphQLType ?? this.specification.identifier).toUpperCase()
   }
 
@@ -101,10 +93,6 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     return `${this.handle}.js`
   }
 
-  set usingExtensionsFramework(value: boolean) {
-    this.useExtensionsFramework = value
-  }
-
   constructor(options: {
     configuration: TConfiguration
     configurationPath: string
@@ -120,7 +108,6 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     this.handle = this.configuration.handle ?? slugify(this.configuration.name ?? '')
     this.localIdentifier = this.handle
     this.idEnvironmentVariableName = `SHOPIFY_${constantize(this.localIdentifier)}_ID`
-    this.useExtensionsFramework = false
     this.outputPath = this.directory
 
     if (this.features.includes('esbuild') || this.type === 'tax_calculation') {

--- a/packages/app/src/cli/models/extensions/specification.integration.test.ts
+++ b/packages/app/src/cli/models/extensions/specification.integration.test.ts
@@ -1,5 +1,4 @@
 import {loadFSExtensionsSpecifications} from './load-specifications.js'
-import {testFunctionExtension} from '../app/app.test-data.js'
 import {describe, test, expect} from 'vitest'
 
 describe('allUISpecifications', () => {
@@ -19,31 +18,5 @@ describe('allLocalSpecs', () => {
 
     // Then
     expect(got.length).not.toEqual(0)
-  })
-})
-
-describe('graphQLType', () => {
-  test('returns type when not using extensions framework', async () => {
-    // Given
-    const functionA = await testFunctionExtension()
-
-    // When
-    functionA.usingExtensionsFramework = false
-    const got = functionA.graphQLType
-
-    // Then
-    expect(got).toEqual('PRODUCT_DISCOUNTS')
-  })
-
-  test('returns FUNCTION when using extensions framework', async () => {
-    // Given
-    const functionA = await testFunctionExtension()
-
-    // When
-    functionA.usingExtensionsFramework = true
-    const got = functionA.graphQLType
-
-    // Then
-    expect(got).toEqual('FUNCTION')
   })
 })

--- a/packages/app/src/cli/services/context/id-matching.test.ts
+++ b/packages/app/src/cli/services/context/id-matching.test.ts
@@ -63,13 +63,6 @@ const REGISTRATION_D = {
   type: 'WEB_PIXEL_EXTENSION',
 }
 
-const REGISTRATION_LEGACY_FUNCTION_A = {
-  uuid: 'FUNCTION_UUID_A',
-  id: 'FUNCTION_A',
-  title: 'FUNCTION A',
-  type: 'PRODUCT_DISCOUNTS',
-}
-
 const REGISTRATION_FUNCTION_A = {
   uuid: 'FUNCTION_UUID_A',
   id: 'FUNCTION_A',
@@ -89,7 +82,6 @@ let EXTENSION_B: ExtensionInstance
 let EXTENSION_B_2: ExtensionInstance
 let EXTENSION_C: ExtensionInstance
 let EXTENSION_D: ExtensionInstance
-let LEGACY_FUNCTION_A: ExtensionInstance
 let FUNCTION_A: ExtensionInstance
 
 beforeAll(async () => {
@@ -208,23 +200,6 @@ beforeAll(async () => {
     devUUID: 'devUUID',
   })
 
-  LEGACY_FUNCTION_A = await testFunctionExtension({
-    dir: '/FUNCTION_A',
-    config: {
-      name: 'FUNCTION A',
-      type: 'product_discounts',
-      description: 'Function',
-      build: {
-        command: 'make build',
-        path: 'dist/index.wasm',
-      },
-      configuration_ui: false,
-      api_version: '2022-07',
-      metafields: [],
-    },
-    usingExtensionFramework: false,
-  })
-
   FUNCTION_A = await testFunctionExtension({
     dir: '/FUNCTION_A',
     config: {
@@ -239,7 +214,6 @@ beforeAll(async () => {
       api_version: '2022-07',
       metafields: [],
     },
-    usingExtensionFramework: false,
   })
 })
 
@@ -641,20 +615,6 @@ describe('automaticMatchmaking: functions', () => {
       identifiers: {},
       toConfirm: [],
       toCreate: [FUNCTION_A],
-      toManualMatch: {local: [], remote: []},
-    }
-    expect(got).toEqual(expected)
-  })
-
-  test('updates existing function', async () => {
-    // When
-    const got = await automaticMatchmaking([LEGACY_FUNCTION_A], [REGISTRATION_LEGACY_FUNCTION_A], {}, 'id')
-
-    // Then
-    const expected = {
-      identifiers: {'function-a': 'FUNCTION_A'},
-      toConfirm: [],
-      toCreate: [],
       toManualMatch: {local: [], remote: []},
     }
     expect(got).toEqual(expected)

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -27,7 +27,6 @@ export async function ensureExtensionsIds(
   let localExtensions = options.app.allExtensions.filter((ext) => !ext.isFunctionExtension)
 
   const functionExtensions = options.app.allExtensions.filter((ext) => ext.isFunctionExtension)
-  functionExtensions.forEach((ext) => (ext.usingExtensionsFramework = true))
   localExtensions = localExtensions.concat(functionExtensions)
 
   const uiExtensionsToMigrate = getUIExtensionsToMigrate(localExtensions, remoteExtensions, validIdentifiers)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
All extensions use the extension framework now, this PR just cleans up some old code.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
remove the `useExtensionFramework` property for functions.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
