### PR TITLE
Redirect to shopify com for customer account extension

### DIFF
--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -381,6 +381,7 @@ describe('ensureDevContext', async () => {
       expect(got).toEqual({
         remoteApp: {...APP2, apiSecret: 'secret2'},
         storeFqdn: STORE1.shopDomain,
+        storeId: STORE1.shopId,
         remoteAppUpdated: true,
         updateURLs: true,
       })
@@ -448,6 +449,7 @@ dev_store_url = "domain1"
       expect(got).toEqual({
         remoteApp: {...APP2, apiSecret: 'secret2'},
         storeFqdn: STORE1.shopDomain,
+        storeId: STORE1.shopId,
         remoteAppUpdated: true,
         updateURLs: true,
       })
@@ -607,6 +609,7 @@ dev_store_url = "domain1"
     expect(got).toEqual({
       remoteApp: {...APP1, apiSecret: 'secret1'},
       storeFqdn: STORE1.shopDomain,
+      storeId: STORE1.shopId,
       remoteAppUpdated: true,
       updateURLs: undefined,
     })
@@ -638,6 +641,7 @@ dev_store_url = "domain1"
     expect(got).toEqual({
       remoteApp: {...APP1, apiSecret: 'secret1'},
       storeFqdn: STORE1.shopDomain,
+      storeId: STORE1.shopId,
       remoteAppUpdated: true,
       updateURLs: undefined,
     })
@@ -656,6 +660,7 @@ dev_store_url = "domain1"
     expect(got).toEqual({
       remoteApp: {...APP1, apiSecret: 'secret1'},
       storeFqdn: STORE1.shopDomain,
+      storeId: STORE1.shopId,
       remoteAppUpdated: false,
       updateURLs: undefined,
     })
@@ -706,6 +711,7 @@ dev_store_url = "domain1"
     expect(got).toEqual({
       remoteApp: {...APP2, apiSecret: 'secret2'},
       storeFqdn: STORE1.shopDomain,
+      storeId: STORE1.shopId,
       remoteAppUpdated: true,
       updateURLs: undefined,
     })

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -66,6 +66,7 @@ interface DevContextOutput {
   remoteApp: Omit<OrganizationApp, 'apiSecretKeys'> & {apiSecret?: string}
   remoteAppUpdated: boolean
   storeFqdn: string
+  storeId: string
   updateURLs: boolean | undefined
 }
 
@@ -244,6 +245,7 @@ function buildOutput(app: OrganizationApp, store: OrganizationStore, cachedInfo?
     },
     remoteAppUpdated: app.apiKey !== cachedInfo?.previousAppId,
     storeFqdn: store.shopDomain,
+    storeId: store.shopId,
     updateURLs: cachedInfo?.updateURLs,
   }
 }

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -78,6 +78,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
   const token = partnersSession.token
   const {
     storeFqdn,
+    storeId,
     remoteApp,
     remoteAppUpdated,
     updateURLs: cachedUpdateURLs,
@@ -125,6 +126,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
 
   return {
     storeFqdn,
+    storeId,
     remoteApp,
     remoteAppUpdated,
     localApp,

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -75,6 +75,11 @@ export interface ExtensionDevOptions {
   storeFqdn: string
 
   /**
+   * Id of the store where the extension wants to be previewed
+   */
+  storeId: string
+
+  /**
    * List of granted approval scopes belonging to the parent app
    */
   grantedScopes: string[]

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -55,6 +55,7 @@ describe('getUIExtensionPayload', () => {
         port: 123,
         url: 'http://tunnel-url.com',
         storeFqdn: 'my-domain.com',
+        storeId: '123456789',
         buildDirectory: tmpDir,
         checkoutCartUrl: 'https://my-domain.com/cart',
         subscriptionProductUrl: 'https://my-domain.com/subscription',

--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -55,13 +55,14 @@ describe('getRedirectURL()', () => {
 
     const options = {
       storeFqdn: 'example.myshopify.com',
+      storeId: '123456789',
       url: 'https://localhost:8081',
     } as unknown as ExtensionDevOptions
 
     const result = getRedirectUrl(extension, options)
 
     expect(result).toBe(
-      'https://example.account.myshopify.com/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=test-ui-extension-uuid&source=CUSTOMER_ACCOUNT_EXTENSION',
+      'https://shopify.com/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=test-ui-extension-uuid&source=CUSTOMER_ACCOUNT_EXTENSION',
     )
   })
 })
@@ -112,13 +113,14 @@ describe('getExtensionPointRedirectUrl()', () => {
 
     const options = {
       storeFqdn: 'example.myshopify.com',
+      storeId: '123456789',
       url: 'https://localhost:8081',
     } as unknown as ExtensionDevOptions
 
     const result = getExtensionPointRedirectUrl('customer-account.page.render', extension, options)
 
     expect(result).toBe(
-      'https://example.account.myshopify.com/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&target=customer-account.page.render',
+      'https://shopify.com/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&target=customer-account.page.render',
     )
   })
 
@@ -129,13 +131,14 @@ describe('getExtensionPointRedirectUrl()', () => {
 
     const options = {
       storeFqdn: 'example.myshopify.com',
+      storeId: '123456789',
       url: 'https://localhost:8081',
     } as unknown as ExtensionDevOptions
 
     const result = getExtensionPointRedirectUrl('CustomerAccount::FullPage::RenderWithin', extension, options)
 
     expect(result).toBe(
-      'https://example.account.myshopify.com/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&target=CustomerAccount%3A%3AFullPage%3A%3ARenderWithin',
+      'https://shopify.com/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&target=CustomerAccount%3A%3AFullPage%3A%3ARenderWithin',
     )
   })
 

--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -60,11 +60,10 @@ function getCustomerAccountsRedirectUrl(
   options: ExtensionDevOptions,
   requestedTarget = '',
 ): URL {
-  const [storeName, ...storeDomainParts] = options.storeFqdn.split('.')
-  const accountsUrl = `${storeName}.account.${storeDomainParts.join('.')}`
   const origin = `${options.url}/extensions`
+  const storeId = options.storeId
 
-  const rawUrl = new URL(`https://${accountsUrl}/extensions-development`)
+  const rawUrl = new URL(`https://shopify.com/${storeId}/account/extensions-development`)
   rawUrl.searchParams.append('origin', origin)
   rawUrl.searchParams.append('extensionId', extension.devUUID)
   rawUrl.searchParams.append('source', 'CUSTOMER_ACCOUNT_EXTENSION')

--- a/packages/app/src/cli/services/dev/processes/previewable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/previewable-extension.ts
@@ -9,6 +9,7 @@ export const MANIFEST_VERSION = '3'
 export interface PreviewableExtensionOptions {
   apiKey: string
   storeFqdn: string
+  storeId: string
   port: number
   pathPrefix: string
   cartUrl?: string
@@ -31,6 +32,7 @@ export const launchPreviewableExtensionProcess: DevProcessFunction<PreviewableEx
   {
     apiKey,
     storeFqdn,
+    storeId,
     subscriptionProductUrl,
     port,
     cartUrl,
@@ -55,6 +57,7 @@ export const launchPreviewableExtensionProcess: DevProcessFunction<PreviewableEx
     url: proxyUrl,
     port,
     storeFqdn,
+    storeId,
     apiKey,
     grantedScopes,
     checkoutCartUrl: cartUrl,

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -52,6 +52,7 @@ describe('setup-dev-processes', () => {
   test('can create a process list', async () => {
     const token = 'token'
     const storeFqdn = 'store.myshopify.io'
+    const storeId = '123456789'
     const remoteAppUpdated = true
     const commandOptions: DevConfig['commandOptions'] = {
       subscriptionProductUrl: '/products/999999',
@@ -120,6 +121,7 @@ describe('setup-dev-processes', () => {
       remoteApp,
       remoteAppUpdated,
       storeFqdn,
+      storeId,
       token,
       partnerUrlsUpdated: true,
     })

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -48,6 +48,7 @@ export interface DevConfig {
   }
   token: string
   storeFqdn: string
+  storeId: string
   commandOptions: DevOptions
   network: DevNetworkOptions
   partnerUrlsUpdated: boolean
@@ -59,6 +60,7 @@ export async function setupDevProcesses({
   token,
   remoteApp,
   storeFqdn,
+  storeId,
   commandOptions,
   network,
   partnerUrlsUpdated,
@@ -100,6 +102,7 @@ export async function setupDevProcesses({
     await setupPreviewableExtensionsProcess({
       allExtensions: localApp.allExtensions,
       storeFqdn,
+      storeId,
       apiKey,
       subscriptionProductUrl: commandOptions.subscriptionProductUrl,
       checkoutCartUrl: commandOptions.checkoutCartUrl,


### PR DESCRIPTION
### WHY are these changes introduced?
Redirect to customer account on `shopify.com/shop_id/account`

Details could be seen here: https://github.com/Shopify/core-issues/issues/51644#issuecomment-1804714760
 

### How to test your changes?
1. Use my cli console: https://literally-children-drag-lighting.trycloudflare.com/extensions/dev-console  (let me know if the server is down)
2. Open browser dev console. Cope-paste the link on any target name . Check if will redirect to `shopify.com/shop_id/account`
 
<img width="1224" alt="image" src="https://github.com/Shopify/cli/assets/37116651/48c37d4a-69f6-432f-a002-dfbfb52c37be">

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
