### PR TITLE
Skip coverage report for dependabot PRs

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -206,7 +206,7 @@ jobs:
   pr-test-coverage:
     name: '[PR] Run Test Coverage with Node ${{ matrix.node }} in ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && !startsWith(github.ref_name, 'dependabot-') }}
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
### WHY are these changes introduced?

CI is failing for Dependabot PRs because of the coverage report ([example](https://github.com/Shopify/cli/actions/runs/6770338012/job/18559637692?pr=3000)): `Error: Resource not accessible by integration`.

But that report is not every useful in this case.

### WHAT is this pull request doing?

Avoid running the coverage report when the branch name starts with `dependabot-`

### How to test your changes?

Merge and rerun a failing PR

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
