### PR TITLE
Update flow template spec for allowOneClickActivate

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_template.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_template.ts
@@ -13,10 +13,10 @@ const FlowTemplateExtensionSchema = BaseSchemaWithHandle.extend({
   template: zod.object({
     categories: zod.array(zod.string()),
     module: zod.string(),
-    require_app: zod.boolean(),
-    discoverable: zod.boolean(),
-    allow_one_click_activate: zod.boolean(),
-    enabled: zod.boolean(),
+    require_app: zod.boolean().optional(),
+    discoverable: zod.boolean().optional(),
+    allow_one_click_activate: zod.boolean().optional(),
+    enabled: zod.boolean().optional(),
   }),
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Related task: https://github.com/Shopify/flow-app/issues/3100

Marking some template extension fields as optional as we'll provide defaults if these values are not provided

### WHAT is this pull request doing?

Updates some properties on the Flow template extension schema to be optional

### How to test your changes?

[Video](https://screenshot.click/21-18-jbz9p-ftrjn.mp4)

### Post-release steps
None, unreleased feature to be tested with 1p later this year.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
