### PR TITLE
Fix create script for none template

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -152,7 +152,8 @@ program
       }
     }
 
-    const flavorFlag = template === 'remix' ? `--flavor=${flavor}` : '';
+    let initArgs = [`--template=${template}`, `--name=${appName}`, `--path=${path.join(homeDir, "Desktop")}`];
+    if (template === 'remix') initArgs.push(`--flavor=${flavor}`);
 
     switch (options.install) {
       case "local":
@@ -160,18 +161,8 @@ program
         await nodeExec(["build"]);
 
         log(`Creating new app in '${appPath}'...`);
-        await nodeExec(
-          ["create-app"],
-          [
-            "--local",
-            `--template=${template}`,
-            flavorFlag,
-            `--name=${appName}`,
-            `--path=${path.join(homeDir, "Desktop")}`,
-            `--package-manager=${nodePackageManager}`,
-          ],
-          defaultOpts
-        );
+        initArgs.push("--local");
+        await nodeExec(["create-app"], initArgs, defaultOpts);
 
         // there are some bugs with lockfiles and local references
         ["package-lock.json", "pnpm-lock.yaml", "yarn.lock", "bun.lockb"].forEach((lockFile) => {
@@ -185,7 +176,6 @@ program
       case "nightly":
       case "experimental":
         log(`Creating new app in '${appPath}'...`);
-        let initArgs = [`--template=${template}`, flavorFlag, `--name=${appName}`, `--path=${path.join(homeDir, "Desktop")}`];
         switch (nodePackageManager) {
           case "yarn":
             // yarn doesn't support 'create @shopify/app@nightly' syntax


### PR DESCRIPTION
### WHY are these changes introduced?

The `create-test-app` script is failing when using the `none` template.

### WHAT is this pull request doing?

Fixes the command to avoid passing empty flags.

### How to test your changes?

`node bin/create-test-app.js -t none`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
