### PR TITLE
add new optional privacy settings config to web pixels

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -234,6 +234,12 @@ export async function testWebPixelExtension(directory = './my-extension'): Promi
     type: 'web_pixel' as const,
     metafields: [],
     runtime_context: 'strict',
+    customer_privacy: {
+      analytics: false,
+      marketing: true,
+      preferences: false,
+      sale_of_data: 'enabled',
+    },
     settings: [],
   }
 
@@ -256,6 +262,12 @@ export async function testTaxCalculationExtension(directory = './my-extension'):
     type: 'tax_calculation' as const,
     metafields: [],
     runtime_context: 'strict',
+    customer_privacy: {
+      analytics: false,
+      marketing: true,
+      preferences: false,
+      sale_of_data: 'enabled',
+    },
   }
 
   const allSpecs = await loadFSExtensionsSpecifications()

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1551,6 +1551,83 @@ wrong = "property"
     }
   })
 
+  test('loads the app with a Web Pixel extension that has a full valid configuration with privacy settings', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      type = "web_pixel_extension"
+      name = "pixel"
+      runtime_context = "strict"
+
+      [customer_privacy]
+      analytics = false
+      preferences = false
+      marketing = true
+      sale_of_data = "enabled"
+
+      [settings]
+      type = "object"
+
+      [settings.fields.first]
+      name = "first"
+      description = "description"
+      type = "single_line_text_field"
+      validations = [{ choices = ["a", "b", "c"] }]
+
+      [settings.fields.second]
+      name = "second"
+      description = "description"
+      type = "single_line_text_field"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'pixel',
+    })
+    await writeFile(joinPath(blockPath('pixel'), 'index.js'), '')
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    const extension = app.allExtensions[0]
+    expect(extension).not.toBeUndefined()
+    if (extension) {
+      expect(extension.configuration).toMatchObject({
+        type: 'web_pixel_extension',
+        name: 'pixel',
+        runtime_context: 'strict',
+        customer_privacy: {
+          analytics: false,
+          marketing: true,
+          preferences: false,
+          sale_of_data: 'enabled',
+        },
+        settings: {
+          type: 'object',
+          fields: {
+            first: {
+              description: 'description',
+              name: 'first',
+              type: 'single_line_text_field',
+              validations: [
+                {
+                  choices: ['a', 'b', 'c'],
+                },
+              ],
+            },
+            second: {
+              description: 'description',
+              name: 'second',
+              type: 'single_line_text_field',
+            },
+          },
+        },
+      })
+    }
+  })
+
   test('loads the app with a Legacy Checkout UI extension that has a full valid configuration', async () => {
     // Given
     await writeConfig(appConfiguration)

--- a/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
@@ -14,6 +14,14 @@ const WebPixelSchema = BaseSchema.extend({
   runtime_context: zod.string(),
   version: zod.string().optional(),
   configuration: zod.any(),
+  customer_privacy: zod
+    .object({
+      analytics: zod.boolean(),
+      preferences: zod.boolean(),
+      marketing: zod.boolean(),
+      sale_of_data: zod.enum(['enabled', 'disabled', 'ldu']),
+    })
+    .optional(),
   settings: zod.any(),
 })
 
@@ -26,6 +34,7 @@ const spec = createExtensionSpecification({
   deployConfig: async (config, _) => {
     return {
       runtime_context: config.runtime_context,
+      customer_privacy: config.customer_privacy,
       runtime_configuration_definition: config.settings,
     }
   },

--- a/packages/app/templates/ui-extensions/projects/web_pixel_extension/shopify.extension.toml.liquid
+++ b/packages/app/templates/ui-extensions/projects/web_pixel_extension/shopify.extension.toml.liquid
@@ -3,6 +3,12 @@ name = "{{ name }}"
 
 runtime_context = "strict"
 
+[customer_privacy]
+analytics = false
+preferences = true
+marketing = false
+sale_of_data = "enabled"
+
 [settings]
 type = "object"
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

As part of https://github.com/Shopify/ce-customer-behaviour/issues/3598

Tech Design: https://docs.google.com/document/d/1Qmvp6Xw1KUPC-Lj-c6fo8lHh0KtaLNtc-4vgMKIOuYI/edit#heading=h.62oius9y1lvr

We are now enabling partners to provide their custom granular privacy settings to their pixel. (I.e. does their pixel require customers to allow analytics consent, marketing consent, preferences or sale of data)

Presently every pixel is given a default analytics and marketing setting. We load every pixel if the customer has given consent to those 2 purposes. However, every pixel is different! So we are now offering the ability for app pixels to specify their own granular consent. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This pull request creates a new input config field for app pixels to specify their app pixel privacy settings. It is optional, so they don't have to include it! Their new `.toml` file can look like:

```
type = "web_pixel_extension"
name = "web pixel"

runtime_context = "strict"

[privacy_settings]
analytics = true
preferences = true
marketing = false
sale_of_data = "sells_data"

[settings]
type = "object"

[settings.fields.pixelID]
name = "Pixel ID"
description = "Pixel ID"
type = "single_line_text_field"
validations =  [
  { name = "min", value = "1" }
]

```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
