### PR TITLE
Redirect to spin shopify domain if it in a spin env

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -3,6 +3,7 @@ import {getUIExtensionResourceURL} from '../../../../utilities/extensions/config
 import {ExtensionDevOptions} from '../../extension.js'
 import {getExtensionPointTargetSurface} from '../utilities.js'
 import {createError, H3Error, ServerResponse, sendError as h3SendError} from 'h3'
+import {isSpinEnvironment} from '@shopify/cli-kit/node/context/spin'
 
 export function getRedirectUrl(extension: ExtensionInstance, options: ExtensionDevOptions): string {
   const {url: resourceUrl} = getUIExtensionResourceURL(extension.configuration.type, options)
@@ -62,8 +63,10 @@ function getCustomerAccountsRedirectUrl(
 ): URL {
   const origin = `${options.url}/extensions`
   const storeId = options.storeId
+  const [_, ...storeDomainParts] = options.storeFqdn.split('.')
+  const customerAccountHost = isSpinEnvironment() ? storeDomainParts.join('.') : 'shopify.com'
+  const rawUrl = new URL(`https://${customerAccountHost}/${storeId}/account/extensions-development`)
 
-  const rawUrl = new URL(`https://shopify.com/${storeId}/account/extensions-development`)
   rawUrl.searchParams.append('origin', origin)
   rawUrl.searchParams.append('extensionId', extension.devUUID)
   rawUrl.searchParams.append('source', 'CUSTOMER_ACCOUNT_EXTENSION')


### PR DESCRIPTION
 
### WHY are these changes introduced?

Redirect to spin shopify domain if it in a spin env
 
### Questions

Is this the correct way to check the spin env?

 
### How to test your changes?
1. use my dev console:  https://mailed-emacs-victorian-canon.trycloudflare.com/extensions/dev-console
2. Cope the link behind any target name. You will be redirect to 
`https://shopify.create-an-order.hao-li.us.spin.dev/8/account/extensions-development`
<img width="1408" alt="image" src="https://github.com/Shopify/cli/assets/37116651/51e9ac8e-4e44-4f18-89ec-3c1dc89a0850">

 
### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
