### PR TITLE
Fix extension watcher infinite loop

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -59,7 +59,7 @@ describe('watchPaths', async () => {
 
     const got = extensionInstance.watchPaths
 
-    expect(got).toEqual([joinPath('foo', '**', '*.{ts,tsx,js,jsx}')])
+    expect(got).toEqual([joinPath('foo', 'src', '**', '*.{ts,tsx,js,jsx}')])
   })
 
   test('return empty array for non-function non-esbuild extensions', async () => {

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -198,7 +198,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
       return watchPaths.map((path) => joinPath(this.directory, path))
     } else if (this.isESBuildExtension) {
-      return [joinPath(this.directory, '**', '*.{ts,tsx,js,jsx}')]
+      return [joinPath(this.directory, 'src', '**', '*.{ts,tsx,js,jsx}')]
     } else {
       return []
     }

--- a/packages/app/src/cli/services/dev/extension/bundler.test.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.test.ts
@@ -292,7 +292,9 @@ describe('setupExtensionWatcher', () => {
 
     await setupExtensionWatcher(watchOptions)
 
-    expect(chokidarWatchSpy).toHaveBeenCalledWith(expect.arrayContaining<string>([joinPath('foo', '*.rs')]))
+    expect(chokidarWatchSpy).toHaveBeenCalledWith(expect.arrayContaining<string>([joinPath('foo', '*.rs')]), {
+      ignored: '**/*.test.*',
+    })
     expect(chokidarOnSpy).toHaveBeenCalledWith('change', expect.any(Function))
   })
 
@@ -326,12 +328,17 @@ describe('setupExtensionWatcher', () => {
 
     // Then
     expect(chokidarOnSpy).toHaveBeenCalled()
-    expect(chokidarWatchSpy).toHaveBeenCalledWith([
-      `${watchOptions.extension.directory}/*.rs`,
-      `${watchOptions.extension.directory}/**/!(.)*.graphql`,
-      `${watchOptions.extension.directory}/locales/**.json`,
-      `${watchOptions.extension.directory}/**.toml`,
-    ])
+    expect(chokidarWatchSpy).toHaveBeenCalledWith(
+      [
+        `${watchOptions.extension.directory}/*.rs`,
+        `${watchOptions.extension.directory}/**/!(.)*.graphql`,
+        `${watchOptions.extension.directory}/locales/**.json`,
+        `${watchOptions.extension.directory}/**.toml`,
+      ],
+      {
+        ignored: '**/*.test.*',
+      },
+    )
     expect(updateExtensionConfig).toHaveBeenCalled()
   })
 

--- a/packages/app/src/cli/services/dev/extension/bundler.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.ts
@@ -184,7 +184,7 @@ Redeploy Paths:
 
   let buildController: AbortController | null
   const allPaths = [...rebuildAndRedeployWatchPaths, ...redeployWatchPaths]
-  const functionRebuildAndRedeployWatcher = chokidar.watch(allPaths).on('change', (path) => {
+  const functionRebuildAndRedeployWatcher = chokidar.watch(allPaths, {ignored: '**/*.test.*'}).on('change', (path) => {
     outputDebug(`Extension file at path ${path} changed`, stdout)
     if (buildController) {
       // terminate any existing builds


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
I recently introduced some changes in the extensions watcher to unify them into a single one.

However, I made a last minute change: from watching only inside `src` to watching in any folder. I didn't test that properly and it obviously breaks everything because we shouldn't watch in folders like `dist` or `node_modules`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Only watch for files inside the `src` folder
- Ignore test files  (we don't need to upload a new draft if you change the tests)

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- run `dev` in an app with different extension types and try to make changes in files inside src/dist/node_modules and also test file. Only actual source files should trigger a re-build
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
