### PR TITLE
[Feature]: Add developer preview of `app dev` in typescript

### DIFF
--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -1,11 +1,11 @@
+import {Flags} from '@oclif/core'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 import {appFlags} from '../../flags.js'
+import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {dev} from '../../services/dev.js'
 import Command from '../../utilities/app-command.js'
-import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
-import {Flags} from '@oclif/core'
-import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
 export default class Dev extends Command {
   static description = 'Run the app.'
@@ -91,6 +91,12 @@ export default class Dev extends Command {
         'The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.',
       env: 'SHOPIFY_FLAG_NOTIFY',
     }),
+    'dev-preview': Flags.boolean({
+      description:
+        'Uses the new implementation of app dev implemented in typescript. This is a developer preview feature and may change in the future.',
+      env: 'SHOPIFY_FLAG_DEV_PREVIEW',
+      required: false,
+    }),
   }
 
   public static analyticsStopCommand(): string | undefined {
@@ -119,21 +125,22 @@ export default class Dev extends Command {
     const commandConfig = this.config
 
     const devOptions = {
-      directory: flags.path,
-      configName: flags.config,
       apiKey,
-      storeFqdn: flags.store,
-      reset: flags.reset,
-      update: !flags['no-update'],
-      skipDependenciesInstallation: flags['skip-dependencies-installation'],
-      commandConfig,
-      subscriptionProductUrl: flags['subscription-product-url'],
       checkoutCartUrl: flags['checkout-cart-url'],
-      tunnelUrl: flags['tunnel-url'],
+      commandConfig,
+      configName: flags.config,
+      devPreview: flags['dev-preview'],
+      directory: flags.path,
+      notify: flags.notify,
       noTunnel: flags['no-tunnel'],
+      reset: flags.reset,
+      skipDependenciesInstallation: flags['skip-dependencies-installation'],
+      storeFqdn: flags.store,
+      subscriptionProductUrl: flags['subscription-product-url'],
       theme: flags.theme,
       themeExtensionPort: flags['theme-app-extension-port'],
-      notify: flags.notify,
+      tunnelUrl: flags['tunnel-url'],
+      update: !flags['no-update'],
     }
 
     await dev(devOptions)

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -62,10 +62,10 @@ export interface DevOptions {
 export async function dev(commandOptions: DevOptions) {
   const config = await prepareForDev(commandOptions)
 
-  if (commandOptions.devPreview) {
-    console.log('new functionality!', config)
-    return
-  }
+  // if (commandOptions.devPreview) {
+  //   console.log('new functionality!', config)
+  //   return
+  // }
 
   await actionsBeforeSettingUpDevProcesses(config)
   const {processes, graphiqlUrl, previewUrl} = await setupDevProcesses(config)

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -40,26 +40,33 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 
 export interface DevOptions {
+  apiKey?: string
+  checkoutCartUrl?: string
+  commandConfig: Config
+  configName?: string
+  devPreview: boolean
   directory: string
   id?: number
-  configName?: string
-  apiKey?: string
-  storeFqdn?: string
-  reset: boolean
-  update: boolean
-  commandConfig: Config
-  skipDependenciesInstallation: boolean
-  subscriptionProductUrl?: string
-  checkoutCartUrl?: string
-  tunnelUrl?: string
+  notify?: string
   noTunnel: boolean
+  reset: boolean
+  skipDependenciesInstallation: boolean
+  storeFqdn?: string
+  subscriptionProductUrl?: string
   theme?: string
   themeExtensionPort?: number
-  notify?: string
+  tunnelUrl?: string
+  update: boolean
 }
 
 export async function dev(commandOptions: DevOptions) {
   const config = await prepareForDev(commandOptions)
+
+  if (commandOptions.devPreview) {
+    console.log('new functionality!', config)
+    return
+  }
+
   await actionsBeforeSettingUpDevProcesses(config)
   const {processes, graphiqlUrl, previewUrl} = await setupDevProcesses(config)
   await actionsBeforeLaunchingDevProcesses(config)

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -4,7 +4,7 @@ import {WebProcess, launchWebProcess} from './web.js'
 import {PreviewableExtensionProcess, launchPreviewableExtensionProcess} from './previewable-extension.js'
 import {GraphiQLServerProcess, launchGraphiQLServer} from './graphiql.js'
 import {pushUpdatesForDraftableExtensions} from './draftable-extension.js'
-import {runThemeAppExtensionsServer} from './theme-app-extension.js'
+import {runLegacyThemeAppExtensionsServer} from './theme-app-extension.js'
 import {
   testAppWithConfig,
   testTaxCalculationExtension,
@@ -197,7 +197,7 @@ describe('setup-dev-processes', () => {
     expect(res.processes[4]).toMatchObject({
       type: 'theme-app-extensions',
       prefix: 'extensions',
-      function: runThemeAppExtensionsServer,
+      function: runLegacyThemeAppExtensionsServer,
       options: {
         adminSession: {
           storeFqdn: 'store.myshopify.io',

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -1,5 +1,5 @@
-import {BaseProcess, DevProcessFunction} from './types.js'
-import {PreviewThemeAppExtensionsProcess, setupPreviewThemeAppExtensionsProcess} from './theme-app-extension.js'
+import type {BaseProcess, DevProcessFunction, PreviewThemeAppExtensionsProcess} from './types.js'
+import {setupPreviewThemeAppExtensionsProcess} from './theme-app-extension.js'
 import {PreviewableExtensionProcess, setupPreviewableExtensionsProcess} from './previewable-extension.js'
 import {DraftableExtensionProcess, setupDraftableExtensionsProcess} from './draftable-extension.js'
 import {SendWebhookProcess, setupSendUninstallWebhookProcess} from './uninstall-webhook.js'
@@ -123,6 +123,7 @@ export async function setupDevProcesses({
       theme: commandOptions.theme,
       themeExtensionPort: commandOptions.themeExtensionPort,
       notify: commandOptions.notify,
+      devPreview: commandOptions.devPreview,
     }),
     setupSendUninstallWebhookProcess({
       webs: localApp.webs,

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension-dev-preview.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension-dev-preview.ts
@@ -1,0 +1,8 @@
+import type {PreviewThemeAppExtensionsOptions, DevProcessFunction} from './types.js'
+
+export const runThemeAppExtensionServer: DevProcessFunction<PreviewThemeAppExtensionsOptions> = async (
+  {stdout, stderr, abortSignal},
+  {adminSession, themeExtensionServerArgs: args, storefrontToken, token},
+) => {
+  console.log('this is where the new http server will be')
+}

--- a/packages/app/src/cli/services/dev/processes/types.ts
+++ b/packages/app/src/cli/services/dev/processes/types.ts
@@ -1,4 +1,5 @@
-import {AbortSignal} from '@shopify/cli-kit/node/abort'
+import type {AbortSignal} from '@shopify/cli-kit/node/abort'
+import type {AdminSession} from '@shopify/cli-kit/node/session'
 
 import {Writable} from 'node:stream'
 
@@ -11,4 +12,15 @@ export interface BaseProcess<T> {
   prefix: string
   function: DevProcessFunction<T>
   options: T
+}
+
+export interface PreviewThemeAppExtensionsOptions {
+  adminSession: AdminSession
+  themeExtensionServerArgs: string[]
+  storefrontToken: string
+  token: string
+}
+
+export interface PreviewThemeAppExtensionsProcess extends BaseProcess<PreviewThemeAppExtensionsOptions> {
+  type: 'theme-app-extensions'
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes Shopify/develop-advanced-edits#41

We wanna keep sunsetting ruby implemented CLI functionality. This addresses it for `shopify app dev`

### WHAT is this pull request doing?


### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
