### PR TITLE
Skip reviewers reminder for dependabot PRs

### DIFF
--- a/.github/workflows/reviewers-reminder.yml
+++ b/.github/workflows/reviewers-reminder.yml
@@ -9,7 +9,7 @@ jobs:
   remind:
     name: "[PR] Remind reviewers"
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: comment PR
         uses: unsplash/comment-on-pr@ffe8f97ccc63ce12c3c23c6885b169db67958d3b # pin@v1.3.0


### PR DESCRIPTION
### WHY are these changes introduced?

Reviewers reminder action is failing for dependabot PRs: https://github.com/Shopify/cli/actions/runs/6956746365/job/18928220186?pr=3130

### WHAT is this pull request doing?

Skip that step for dependabot PRs, as we did in https://github.com/Shopify/cli/pull/3128

### How to test your changes?

Merge and check

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
