### PR TITLE
Update reject_duplicated_checksums to only apply to asset files

### DIFF
--- a/.changeset/eight-eagles-explain.md
+++ b/.changeset/eight-eagles-explain.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+No longer drops *.json templates when there is a *.json.liquid template with the same name.

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer/checksums.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer/checksums.rb
@@ -45,7 +45,7 @@ module ShopifyCLI
         # on disk.
         def reject_duplicated_checksums!
           checksums_mutex.synchronize do
-            checksum_by_key.reject! { |key, _| checksum_by_key.key?("#{key}.liquid") }
+            checksum_by_key.reject! { |key, _| key.starts_with?(“assets/“) && checksum_by_key.key?("#{key}.liquid") }
           end
         end
 

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer/checksums.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/syncer/checksums.rb
@@ -45,7 +45,7 @@ module ShopifyCLI
         # on disk.
         def reject_duplicated_checksums!
           checksums_mutex.synchronize do
-            checksum_by_key.reject! { |key, _| key.starts_with?(“assets/“) && checksum_by_key.key?("#{key}.liquid") }
+            checksum_by_key.reject! { |key, _| key.start_with?("assets/") && checksum_by_key.key?("#{key}.liquid") }
           end
         end
 

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/syncer/checksums_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/syncer/checksums_test.rb
@@ -55,15 +55,23 @@ module ShopifyCLI
 
         def test_reject_duplicated_checksums
           @checksums.stubs(:checksum_by_key).returns({
-            "file1.liquid" => "",
-            "file2.liquid" => "",
-            "file1" => "",
-            "file2" => "",
+            "assets/file1.liquid" => "",
+            "assets/file2.liquid" => "",
+            "assets/file1" => "",
+            "assets/file2" => "",
+            "templates/product.json" => "",
+            "templates/product.json.liquid" => "",
           })
 
           @checksums.reject_duplicated_checksums!
 
-          assert_equal(["file1.liquid", "file2.liquid"], @checksums.keys.sort)
+          expected_keys = [
+            "assets/file1.liquid",
+            "assets/file2.liquid",
+            "templates/product.json",
+            "templates/product.json.liquid",
+          ]
+          assert_equal(expected_keys, @checksums.keys.sort)
         end
 
         private


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3138

### WHAT is this pull request doing?

We only want to reject duplicate `*.json` and `*.json.liquid` for files under `assets/*` and not files under other directories.

### How to test your changes?

1. Add `product.json` and `product.json.liquid` to your theme
2. `shopify theme pull`
3. See that both files are pulled locally

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
