### PR TITLE
remove format config option as we default to json

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -55,7 +55,6 @@ const EndpointValidation = zod
 export const WebhookSubscriptionSchema = zod.object({
   topic: zod.string(),
   sub_topic: zod.string().optional(),
-  format: zod.enum(['json', 'xml']).optional(),
   include_fields: zod.array(zod.string()).optional(),
   metafield_namespaces: zod.array(zod.string()).optional(),
   endpoint: zod.preprocess(removeTrailingSlash, EndpointValidation),

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2305,7 +2305,6 @@ describe('WebhooksSchema', () => {
       subscriptions: [
         {
           topic: 'products/create',
-          format: 'xml',
         },
       ],
     }
@@ -2374,27 +2373,6 @@ describe('WebhooksSchema', () => {
         message: 'To use top-level topics, you must also provide a top-level `endpoint`',
         fatal: true,
         path: ['webhooks', 'topics'],
-      }
-
-      const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-      expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
-    })
-
-    test('throws an error if format is not json or xml', async () => {
-      const webhookConfig: WebhookConfig = {
-        subscriptions: [
-          {
-            topic: 'products/create',
-            format: 'csv' as any,
-          },
-        ],
-      }
-      const errorObj = {
-        received: 'csv',
-        code: zod.ZodIssueCode.invalid_enum_value,
-        options: ['json', 'xml'],
-        path: ['webhooks', 'subscriptions', 0, 'format'],
-        message: "Invalid enum value. Expected 'json' | 'xml', received 'csv'",
       }
 
       const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -526,7 +526,6 @@ describe('deploy', () => {
             },
             {
               topic: 'products/delete',
-              format: 'xml',
             },
           ],
         }),
@@ -550,7 +549,6 @@ describe('deploy', () => {
         {
           endpoint: 'https://example.com',
           topic: 'products/delete',
-          format: 'xml',
         },
       ])
       expect(renderSuccess).toHaveBeenCalledWith(
@@ -576,7 +574,6 @@ describe('deploy', () => {
             },
             {
               topic: 'products/delete',
-              format: 'xml',
             },
           ],
         }),
@@ -600,7 +597,6 @@ describe('deploy', () => {
         {
           endpoint: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/123/my_webhook_path',
           topic: 'products/delete',
-          format: 'xml',
         },
       ])
       expect(renderSuccess).toHaveBeenCalledWith(
@@ -626,7 +622,6 @@ describe('deploy', () => {
             },
             {
               topic: 'products/delete',
-              format: 'xml',
             },
           ],
         }),
@@ -650,7 +645,6 @@ describe('deploy', () => {
         {
           endpoint: 'pubsub://my-project-123:my-topic',
           topic: 'products/delete',
-          format: 'xml',
         },
       ])
       expect(renderSuccess).toHaveBeenCalledWith(


### PR DESCRIPTION

### WHY are these changes introduced?

- we're moving away from `xml` webhook payloads, so we want to not support the option to set this proprty, and just default to `json`
- documented more in the [decision log](https://vault.shopify.io/gsd/projects/36745/decisions/4088)
- the related core changes to the module are in https://github.com/Shopify/shopify/pull/466324

### WHAT is this pull request doing?

- remove the format property from the schema as we don't need it and wont process it anymore

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
