### PR TITLE
Improve extension file watcher flow

### DIFF
--- a/packages/app/src/cli/services/dev/extension/bundler.test.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.test.ts
@@ -6,7 +6,7 @@ import {
 } from './bundler.js'
 import * as bundle from '../../extensions/bundle.js'
 import {testUIExtension, testFunctionExtension, testApp} from '../../../models/app/app.test-data.js'
-import {updateExtensionConfig} from '../update-extension.js'
+import {reloadExtensionConfig} from '../update-extension.js'
 import {FunctionConfigType} from '../../../models/extensions/specifications/function.js'
 import * as extensionBuild from '../../../services/build/extension.js'
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
@@ -255,9 +255,7 @@ describe('setupExtensionWatcher', () => {
       stdout: new Writable(),
       stderr: new Writable(),
       signal: signal ?? new AbortController().signal,
-      apiKey: 'mock-api-key',
-      registrationId: 'mock-registration-id',
-      token: 'mock-token',
+      onChange: vi.fn(),
     }
   }
 
@@ -339,7 +337,7 @@ describe('setupExtensionWatcher', () => {
         ignored: '**/*.test.*',
       },
     )
-    expect(updateExtensionConfig).toHaveBeenCalled()
+    expect(reloadExtensionConfig).toHaveBeenCalled()
   })
 
   test('builds and deploys the function on file change', async () => {
@@ -370,14 +368,11 @@ describe('setupExtensionWatcher', () => {
         useTasks: false,
       }),
     )
-    expect(updateExtensionConfig).toHaveBeenCalledWith({
+    expect(reloadExtensionConfig).toHaveBeenCalledWith({
       extension: watchOptions.extension,
-      token: watchOptions.token,
-      apiKey: watchOptions.apiKey,
-      registrationId: watchOptions.registrationId,
       stdout: watchOptions.stdout,
-      stderr: watchOptions.stderr,
     })
+    expect(watchOptions.onChange).toHaveBeenCalled()
   })
 
   test('does not deploy the function if the build fails', async () => {
@@ -398,7 +393,7 @@ describe('setupExtensionWatcher', () => {
     await flushPromises()
 
     expect(buildSpy).toHaveBeenCalled()
-    expect(updateExtensionConfig).not.toHaveBeenCalled()
+    expect(watchOptions.onChange).not.toHaveBeenCalled()
   })
 
   test('terminates existing builds on concurrent file change', async () => {

--- a/packages/app/src/cli/services/dev/processes/draftable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/draftable-extension.ts
@@ -44,9 +44,10 @@ export const pushUpdatesForDraftableExtensions: DevProcessFunction<DraftableExte
         stdout,
         stderr,
         signal,
-        token,
-        apiKey,
-        registrationId,
+        onChange: async () => {
+          // At this point the extension has alreday been built and is ready to be updated
+          await updateExtensionDraft({extension, token, apiKey, registrationId, stdout, stderr})
+        },
       })
     }),
   )

--- a/packages/app/src/cli/services/dev/update-extension.test.ts
+++ b/packages/app/src/cli/services/dev/update-extension.test.ts
@@ -1,4 +1,4 @@
-import {updateExtensionConfig, updateExtensionDraft} from './update-extension.js'
+import {reloadExtensionConfig, updateExtensionDraft} from './update-extension.js'
 import {ExtensionUpdateDraftMutation} from '../../api/graphql/update_draft.js'
 import {testUIExtension} from '../../models/app/app.test-data.js'
 import {parseConfigurationFile, parseConfigurationObject} from '../../models/app/loader.js'
@@ -206,14 +206,7 @@ another = "setting"
 
       await writeFile(mockExtension.outputPath, 'test content')
 
-      await updateExtensionConfig({
-        extension: mockExtension,
-        token,
-        apiKey,
-        registrationId,
-        stdout,
-        stderr,
-      })
+      await reloadExtensionConfig({extension: mockExtension, stdout})
 
       expect(partnersRequest).toHaveBeenCalledWith(ExtensionUpdateDraftMutation, token, {
         apiKey,

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -62,21 +62,10 @@ export async function updateExtensionDraft({
 
 interface UpdateExtensionConfigOptions {
   extension: ExtensionInstance
-  token: string
-  apiKey: string
-  registrationId: string
   stdout: Writable
-  stderr: Writable
 }
 
-export async function updateExtensionConfig({
-  extension,
-  token,
-  apiKey,
-  registrationId,
-  stdout,
-  stderr,
-}: UpdateExtensionConfigOptions) {
+export async function reloadExtensionConfig({extension, stdout}: UpdateExtensionConfigOptions) {
   const abort = (errorMessage: OutputMessage) => {
     stdout.write(errorMessage)
     throw new AbortError(errorMessage)
@@ -111,5 +100,4 @@ export async function updateExtensionConfig({
 
   // eslint-disable-next-line require-atomic-updates
   extension.configuration = newConfig
-  return updateExtensionDraft({extension, token, apiKey, registrationId, stdout, stderr})
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We watch for changes in extensions files to trigger updates during dev, but the current process is long and involves moving a lot of parameters around.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Current flow of information (we need to pass everything from the first step to the last):
```
Dev 
  -> Draftable process 
    -> Watchers 
      -> Update extension config 
        -> Update draft extension
```

Proposed change:
```
Dev 
  -> Draftable process 
    -> watchers (with callback to draftable process)
    -> Update draft extension
```

This allows the draftable process decide what to do after an extension change is detected.
And this will be useful for consistent-dev where we want to do a different thing on every change.

Relevant outcomes: less responsability for each function in the flow
- **The watcher** is now only responsible for watching and reporting changes for a extension (and build it if necessary). vs previously also triggering `updateExtensionConfig` and `updateExtensionDraft`
- The `updateExtensionConfig` function is now `reloadExtensionConfig`. Now only responsible to reload the config from the filesystem. vs previously also triggering a `updateExtensionDraft` mutation.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- `dev` with changes to files should still trigger draft updates as usual.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
