### PR TITLE
Improve styling and wording of disconnected banner

### DIFF
--- a/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
+++ b/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
@@ -1,7 +1,19 @@
 import {platformAndArch} from '@shopify/cli-kit/node/os'
 import React from 'react'
 import {renderToStaticMarkup} from 'react-dom/server'
-import {AppProvider, Badge, Banner, BlockStack, Box, Grid, InlineStack, Link, Select, Text} from '@shopify/polaris'
+import {
+  AppProvider,
+  Badge,
+  Banner,
+  BlockStack,
+  Box,
+  Card,
+  Grid,
+  InlineStack,
+  Link,
+  Select,
+  Text,
+} from '@shopify/polaris'
 import {CircleAlertMajor, LinkMinor} from '@shopify/polaris-icons'
 
 const controlKey = platformAndArch().platform === 'darwin' ? 'MAC_COMMAND_KEY' : 'Ctrl'
@@ -170,11 +182,14 @@ export function graphiqlTemplate({
             <Box background="bg-surface" padding="400">
               <BlockStack gap="300">
                 <div id="top-error-bar">
-                  <Banner
-                    tone="critical"
-                    title="The server has been stopped. Restart dev and launch the GraphiQL Explorer from the terminal again."
-                    onDismiss={() => {}}
-                  ></Banner>
+                  <Card padding={{xs: '0'}}>
+                    <Banner tone="critical" onDismiss={() => {}}>
+                      <p>
+                        The server has been stopped. Restart <code>dev</code> from the CLI and launch the GraphiQL
+                        explorer again.
+                      </p>
+                    </Banner>
+                  </Card>
                 </div>
                 <Grid columns={{xs: 3, sm: 3, md: 3}}>
                   <Grid.Cell columnSpan={{xs: 3, sm: 3, md: 3, lg: 7, xl: 7}}>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Responding to https://github.com/Shopify/cli/pull/3152#issuecomment-1834606516

There is a desire to make changes to the wording and style of the banner that appears after disconnecting.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Before:

<img width="1512" alt="Screenshot 2023-12-03 at 14 13 41" src="https://github.com/Shopify/cli/assets/6288426/67fd4ad8-c238-4cbb-bdc1-c1b19899ff07">

After:

<img width="1512" alt="Screenshot 2023-12-03 at 12 10 35" src="https://github.com/Shopify/cli/assets/6288426/2f3b7445-c0ba-407b-8dcb-1c219ed71e6c">

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Run `dev`, open GraphiQL, and WITHOUT CLOSING THE TAB quit `dev`. See the error banner.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
