### PR TITLE
Deploy fetch remote specs

### DIFF
--- a/packages/app/src/cli/api/graphql/extension_specifications.ts
+++ b/packages/app/src/cli/api/graphql/extension_specifications.ts
@@ -32,7 +32,7 @@ export interface RemoteSpecification {
   gated: boolean
   externalIdentifier: string
   options: {
-    managementExperience: 'cli' | 'custom' | 'dashboard'
+    managementExperience: 'cli' | 'custom' | 'dashboard' | 'app_config'
     registrationLimit: number
   }
   features?: {

--- a/packages/app/src/cli/api/graphql/extension_specifications.ts
+++ b/packages/app/src/cli/api/graphql/extension_specifications.ts
@@ -8,6 +8,7 @@ export const ExtensionSpecificationsQuery = gql`
       externalIdentifier
       identifier
       gated
+      experience
       options {
         managementExperience
         registrationLimit
@@ -31,8 +32,9 @@ export interface RemoteSpecification {
   identifier: string
   gated: boolean
   externalIdentifier: string
+  experience: 'extension' | 'configuration' | 'deprecated'
   options: {
-    managementExperience: 'cli' | 'custom' | 'dashboard' | 'app_config'
+    managementExperience: 'cli' | 'custom' | 'dashboard'
     registrationLimit: number
   }
   features?: {

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -4,7 +4,6 @@ import {AppInterface} from '../../models/app/app.js'
 import {loadApp} from '../../models/app/loader.js'
 import {validateVersion} from '../../validations/version-name.js'
 import Command from '../../utilities/app-command.js'
-import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {validateMessage} from '../../validations/message.js'
 import metadata from '../../metadata.js'
@@ -94,8 +93,7 @@ export default class Deploy extends Command {
       cmd_app_reset_used: flags.reset,
     }))
 
-    const specifications = await loadLocalExtensionsSpecifications(this.config)
-    const app: AppInterface = await loadApp({specifications, directory: flags.path, configName: flags.config})
+    const app: AppInterface = await loadApp({directory: flags.path, configName: flags.config})
 
     const requiredNonTTYFlags = ['force']
     if (!apiKey && !app.configuration.client_id) requiredNonTTYFlags.push('client-id')

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -371,23 +371,6 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     },
   },
   {
-    name: 'Customer Accounts',
-    externalName: 'Customer Accounts',
-    identifier: 'customer_accounts_ui_extension',
-    externalIdentifier: 'customer_accounts_ui_extension_external',
-    gated: false,
-    experience: 'extension',
-    options: {
-      managementExperience: 'cli',
-      registrationLimit: 10,
-    },
-    features: {
-      argo: {
-        surface: 'customer_accounts',
-      },
-    },
-  },
-  {
     name: 'Checkout Extension',
     externalName: 'Checkout UI',
     identifier: 'checkout_ui_extension',

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -313,6 +313,7 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     identifier: 'checkout_post_purchase',
     externalIdentifier: 'checkout_post_purchase_external',
     gated: false,
+    experience: 'extension',
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
@@ -329,6 +330,7 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     identifier: 'theme',
     externalIdentifier: 'theme_external',
     gated: false,
+    experience: 'extension',
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
@@ -340,6 +342,7 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     identifier: 'product_subscription',
     externalIdentifier: 'product_subscription_external',
     gated: false,
+    experience: 'extension',
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
@@ -356,6 +359,7 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     identifier: 'ui_extension',
     externalIdentifier: 'ui_extension_external',
     gated: false,
+    experience: 'extension',
     options: {
       managementExperience: 'cli',
       registrationLimit: 50,
@@ -367,11 +371,29 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     },
   },
   {
+    name: 'Customer Accounts',
+    externalName: 'Customer Accounts',
+    identifier: 'customer_accounts_ui_extension',
+    externalIdentifier: 'customer_accounts_ui_extension_external',
+    gated: false,
+    experience: 'extension',
+    options: {
+      managementExperience: 'cli',
+      registrationLimit: 10,
+    },
+    features: {
+      argo: {
+        surface: 'customer_accounts',
+      },
+    },
+  },
+  {
     name: 'Checkout Extension',
     externalName: 'Checkout UI',
     identifier: 'checkout_ui_extension',
     externalIdentifier: 'checkout_ui_extension_external',
     gated: false,
+    experience: 'extension',
     options: {
       managementExperience: 'cli',
       registrationLimit: 5,
@@ -390,6 +412,7 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     identifier: 'subscription_management',
     externalIdentifier: 'product_subscription_external',
     gated: false,
+    experience: 'extension',
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
@@ -406,6 +429,7 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     identifier: 'marketing_activity_extension',
     externalIdentifier: 'marketing_activity_extension_external',
     gated: false,
+    experience: 'extension',
     options: {
       managementExperience: 'dashboard',
       registrationLimit: 100,
@@ -417,6 +441,7 @@ export const testRemoteSpecifications: RemoteSpecification[] = [
     identifier: 'function',
     externalIdentifier: 'function',
     gated: false,
+    experience: 'extension',
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -117,15 +117,7 @@ export const AppSchema = zod
       .optional(),
     access: zod
       .object({
-        admin: zod
-          .union([
-            zod.literal(true),
-            zod.object({
-              mode: zod.enum(['online', 'offline']).optional(),
-            }),
-          ])
-          .optional(),
-        customer_account: zod.boolean().optional(),
+        direct_api_offline_access: zod.boolean().optional(),
       })
       .optional(),
     webhooks: WebhooksSchemaWithDeclarative,

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -115,6 +115,19 @@ export const AppSchema = zod
         redirect_urls: zod.array(validateUrl(zod.string())),
       })
       .optional(),
+    access: zod
+      .object({
+        admin: zod
+          .union([
+            zod.literal(true),
+            zod.object({
+              mode: zod.enum(['online', 'offline']).optional(),
+            }),
+          ])
+          .optional(),
+        customer_account: zod.boolean().optional(),
+      })
+      .optional(),
     webhooks: WebhooksSchemaWithDeclarative,
     app_proxy: zod
       .object({

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -162,7 +162,7 @@ interface AppLoaderConstructorArgs {
   directory: string
   mode?: AppLoaderMode
   configName?: string
-  specifications: ExtensionSpecification[]
+  specifications?: ExtensionSpecification[]
 }
 
 /**
@@ -198,7 +198,7 @@ class AppLoader {
   constructor({directory, configName, mode, specifications}: AppLoaderConstructorArgs) {
     this.mode = mode ?? 'strict'
     this.directory = directory
-    this.specifications = specifications
+    this.specifications = specifications ?? []
     this.configName = configName
   }
 
@@ -342,6 +342,8 @@ class AppLoader {
   }
 
   async loadExtensions(appDirectory: string, appConfiguration: AppConfiguration): Promise<ExtensionInstance[]> {
+    if (this.specifications.length === 0) return []
+
     const extensionPromises = await this.createExtensionInstances(appDirectory, appConfiguration.extension_directories)
     const configExtensionPromises = isCurrentSchema(appConfiguration)
       ? await this.createConfigExtensionInstances(appDirectory, appConfiguration as CurrentAppConfiguration)

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -271,7 +271,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
   async bundleConfig({identifiers, token, apiKey}: ExtensionBundleConfigOptions) {
     const configValue = await this.deployConfig({apiKey, token})
-    if (!configValue || Object.keys(configValue).length === 0) return undefined
+    if (!configValue) return undefined
 
     const {handle, ...remainingConfigs} = configValue
     const contextValue = (handle as string) || ''

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -271,7 +271,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
   async bundleConfig({identifiers, token, apiKey}: ExtensionBundleConfigOptions) {
     const configValue = await this.deployConfig({apiKey, token})
-    if (!configValue) return undefined
+    if (!configValue || Object.keys(configValue).length === 0) return undefined
 
     const {handle, ...remainingConfigs} = configValue
     const contextValue = (handle as string) || ''

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
@@ -6,18 +6,8 @@ describe('app_cofig_app_access', () => {
     test('should return the transformed object', () => {
       // Given
       const object = {
-        access_scopes: {
-          scopes: 'scope',
-          use_legacy_install_flow: true,
-        },
-        auth: {
-          redirect_urls: ['https://redirect-1.com', 'https://redirect-2.com'],
-        },
         access: {
-          admin: {
-            mode: 'online',
-          },
-          customer_account: true,
+          direct_api_offline_access: true,
         },
       }
       const appAccessSpec = spec
@@ -27,13 +17,9 @@ describe('app_cofig_app_access', () => {
 
       // Then
       expect(result).toMatchObject({
-        scopes: 'scope',
-        use_legacy_install_flow: true,
-        admin: {
-          mode: 'online',
+        access: {
+          direct_api_offline_access: true,
         },
-        customer_account: true,
-        redirect_urls: ['https://redirect-1.com', 'https://redirect-2.com'],
       })
     })
   })
@@ -42,13 +28,9 @@ describe('app_cofig_app_access', () => {
     test('should return the reversed transformed object', () => {
       // Given
       const object = {
-        scopes: 'scope',
-        use_legacy_install_flow: true,
-        admin: {
-          mode: 'online',
+        access: {
+          direct_api_offline_access: true,
         },
-        customer_account: true,
-        redirect_urls: ['https://redirect-1.com', 'https://redirect-2.com'],
       }
       const appAccessSpec = spec
 
@@ -57,18 +39,8 @@ describe('app_cofig_app_access', () => {
 
       // Then
       expect(result).toMatchObject({
-        access_scopes: {
-          scopes: 'scope',
-          use_legacy_install_flow: true,
-        },
-        auth: {
-          redirect_urls: ['https://redirect-1.com', 'https://redirect-2.com'],
-        },
         access: {
-          admin: {
-            mode: 'online',
-          },
-          customer_account: true,
+          direct_api_offline_access: true,
         },
       })
     })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
@@ -1,0 +1,76 @@
+import spec from './app_config_app_access.js'
+import {describe, expect, test} from 'vitest'
+
+describe('app_cofig_app_access', () => {
+  describe('transform', () => {
+    test('should return the transformed object', () => {
+      // Given
+      const object = {
+        access_scopes: {
+          scopes: 'scope',
+          use_legacy_install_flow: true,
+        },
+        auth: {
+          redirect_urls: ['https://redirect-1.com', 'https://redirect-2.com'],
+        },
+        access: {
+          admin: {
+            mode: 'online',
+          },
+          customer_account: true,
+        },
+      }
+      const appAccessSpec = spec
+
+      // When
+      const result = appAccessSpec.transform!(object)
+
+      // Then
+      expect(result).toMatchObject({
+        scopes: 'scope',
+        use_legacy_install_flow: true,
+        admin: {
+          mode: 'online',
+        },
+        customer_account: true,
+        redirect_urls: ['https://redirect-1.com', 'https://redirect-2.com'],
+      })
+    })
+  })
+
+  describe('reverseTransform', () => {
+    test('should return the reversed transformed object', () => {
+      // Given
+      const object = {
+        scopes: 'scope',
+        use_legacy_install_flow: true,
+        admin: {
+          mode: 'online',
+        },
+        customer_account: true,
+        redirect_urls: ['https://redirect-1.com', 'https://redirect-2.com'],
+      }
+      const appAccessSpec = spec
+
+      // When
+      const result = appAccessSpec.reverseTransform!(object)
+
+      // Then
+      expect(result).toMatchObject({
+        access_scopes: {
+          scopes: 'scope',
+          use_legacy_install_flow: true,
+        },
+        auth: {
+          redirect_urls: ['https://redirect-1.com', 'https://redirect-2.com'],
+        },
+        access: {
+          admin: {
+            mode: 'online',
+          },
+          customer_account: true,
+        },
+      })
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -1,0 +1,20 @@
+import {AppSchema} from '../../app/app.js'
+import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+
+const AppAccessSchema = AppSchema.pick({access_scopes: true, auth: true, access: true}).strip()
+
+const AppAccessTransformConfig: TransformationConfig = {
+  scopes: 'access_scopes.scopes',
+  use_legacy_install_flow: 'access_scopes.use_legacy_install_flow',
+  admin: 'access.admin',
+  customer_account: 'access.customer_account',
+  redirect_urls: 'auth.redirect_urls',
+}
+
+const spec = createConfigExtensionSpecification({
+  identifier: 'app_access',
+  schema: AppAccessSchema,
+  transformConfig: AppAccessTransformConfig,
+})
+
+export default spec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -1,14 +1,10 @@
 import {AppSchema} from '../../app/app.js'
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 
-const AppAccessSchema = AppSchema.pick({access_scopes: true, auth: true, access: true}).strip()
+const AppAccessSchema = AppSchema.pick({access: true}).strip()
 
 const AppAccessTransformConfig: TransformationConfig = {
-  scopes: 'access_scopes.scopes',
-  use_legacy_install_flow: 'access_scopes.use_legacy_install_flow',
-  admin: 'access.admin',
-  customer_account: 'access.customer_account',
-  redirect_urls: 'auth.redirect_urls',
+  access: 'access',
 }
 
 const spec = createConfigExtensionSpecification({

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -1027,6 +1027,7 @@ describe('ensureDeployContext', () => {
       app: APP2.apiKey,
       extensions: {},
       extensionIds: {},
+      extensionsNonUuidManaged: {},
     }
 
     const appWithExtensions = testApp({

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -25,6 +25,8 @@ import {createExtension} from './dev/create-extension.js'
 import {CachedAppInfo, clearCachedAppInfo, getCachedAppInfo, setCachedAppInfo} from './local-storage.js'
 import link from './app/config/link.js'
 import {fetchPartnersSession} from './context/partner-account-info.js'
+import {fetchSpecifications} from './generate/fetch-extension-specifications.js'
+import {loadFSExtensionsSpecifications} from '../models/extensions/load-specifications.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
 import {updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
@@ -34,6 +36,7 @@ import {
   testAppWithConfig,
   testOrganizationApp,
   testThemeExtensions,
+  testAppConfigExtensions,
 } from '../models/app/app.test-data.js'
 import metadata from '../metadata.js'
 import {
@@ -45,47 +48,13 @@ import {
 } from '../models/app/loader.js'
 import {AppInterface} from '../models/app/app.js'
 import * as loadSpecifications from '../models/extensions/load-specifications.js'
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderInfo, renderTasks, Task} from '@shopify/cli-kit/node/ui'
 import {Config} from '@oclif/core'
-
-vi.mock('./local-storage.js')
-vi.mock('./dev/fetch')
-vi.mock('./dev/create-extension')
-vi.mock('./dev/select-app')
-vi.mock('./dev/select-store')
-vi.mock('../prompts/dev')
-vi.mock('../models/app/identifiers')
-vi.mock('./context/identifiers')
-vi.mock('../models/app/loader.js')
-vi.mock('@shopify/cli-kit/node/node-package-manager.js')
-vi.mock('@shopify/cli-kit/node/ui')
-vi.mock('./deploy/mode.js')
-vi.mock('./app/config/link.js')
-vi.mock('./context/partner-account-info.js')
-
-beforeEach(() => {
-  vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-  vi.mocked(isWebType).mockReturnValue(true)
-
-  // this is needed because using importActual to mock the ui module
-  // creates a circular dependency between ui and context/local
-  // so we need to mock the whole module and just replace the functions we use
-  vi.mocked(renderTasks).mockImplementation(async (tasks: Task[]) => {
-    for (const task of tasks) {
-      // eslint-disable-next-line no-await-in-loop
-      await task.task({}, task)
-    }
-  })
-})
-
-afterEach(() => {
-  mockAndCaptureOutput().clear()
-})
 
 const COMMAND_CONFIG = {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config
 
@@ -185,6 +154,26 @@ const draftExtensionsPushOptions = (app: AppInterface): DraftExtensionsPushOptio
   }
 }
 
+vi.mock('./local-storage.js')
+vi.mock('./dev/fetch')
+vi.mock('./dev/create-extension')
+vi.mock('./dev/select-app')
+vi.mock('./dev/select-store')
+vi.mock('../prompts/dev')
+vi.mock('../models/app/identifiers')
+vi.mock('./context/identifiers')
+vi.mock('../models/app/loader.js')
+vi.mock('@shopify/cli-kit/node/node-package-manager.js')
+vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('./deploy/mode.js')
+vi.mock('./app/config/link.js')
+vi.mock('./context/partner-account-info.js')
+vi.mock('./generate/fetch-extension-specifications.js')
+
+beforeAll(async () => {
+  vi.mocked(fetchSpecifications).mockResolvedValue(await loadFSExtensionsSpecifications())
+})
+
 beforeEach(async () => {
   vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
   vi.mocked(selectOrganizationPrompt).mockResolvedValue(ORG1)
@@ -194,6 +183,22 @@ beforeEach(async () => {
   vi.mocked(fetchOrgFromId).mockResolvedValue(ORG1)
   vi.mocked(fetchOrgAndApps).mockResolvedValue(FETCH_RESPONSE)
   vi.mocked(getPackageManager).mockResolvedValue('npm')
+  vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
+  vi.mocked(isWebType).mockReturnValue(true)
+
+  // this is needed because using importActual to mock the ui module
+  // creates a circular dependency between ui and context/local
+  // so we need to mock the whole module and just replace the functions we use
+  vi.mocked(renderTasks).mockImplementation(async (tasks: Task[]) => {
+    for (const task of tasks) {
+      // eslint-disable-next-line no-await-in-loop
+      await task.task({}, task)
+    }
+  })
+})
+
+afterEach(() => {
+  mockAndCaptureOutput().clear()
 })
 
 describe('ensureGenerateContext', () => {
@@ -851,6 +856,7 @@ describe('ensureDeployContext', () => {
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(loadApp).mockResolvedValue(app)
 
     // When
     const got = await ensureDeployContext(options(app))
@@ -880,6 +886,7 @@ describe('ensureDeployContext', () => {
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
     vi.mocked(reuseDevConfigPrompt).mockResolvedValueOnce(true)
+    vi.mocked(loadApp).mockResolvedValue(app)
 
     // When
     const got = await ensureDeployContext(options(app))
@@ -906,6 +913,7 @@ describe('ensureDeployContext', () => {
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(loadApp).mockResolvedValue(app)
 
     // When
     const got = await ensureDeployContext(options(app))
@@ -933,6 +941,8 @@ describe('ensureDeployContext', () => {
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(loadApp).mockResolvedValue(app)
+
     // When
     const got = await ensureDeployContext(options(app))
 
@@ -962,6 +972,7 @@ describe('ensureDeployContext', () => {
     const app = testApp()
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP1.apiKey})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(undefined)
+    vi.mocked(loadApp).mockResolvedValue(app)
 
     // When
     await expect(ensureDeployContext(options(app))).rejects.toThrow(/Couldn't find the app with Client ID key1/)
@@ -981,6 +992,7 @@ describe('ensureDeployContext', () => {
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(loadApp).mockResolvedValue(app)
 
     const opts = options(app)
     opts.reset = true
@@ -1007,6 +1019,38 @@ describe('ensureDeployContext', () => {
     expect(got.partnersApp.appType).toEqual(APP1.appType)
     expect(got.identifiers).toEqual({app: APP1.apiKey, extensions: {}, extensionIds: {}, extensionsNonUuidManaged: {}})
     expect(got.release).toEqual(true)
+  })
+  test('load the app extension using the remote extensions specifications', async () => {
+    // Given
+    const app = testApp()
+    const identifiers = {
+      app: APP2.apiKey,
+      extensions: {},
+      extensionIds: {},
+    }
+
+    const appWithExtensions = testApp({
+      allExtensions: [await testAppConfigExtensions()],
+    })
+    vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
+    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(loadApp).mockResolvedValue(appWithExtensions)
+    vi.mocked(updateAppIdentifiers).mockResolvedValue(appWithExtensions)
+
+    // When
+    const got = await ensureDeployContext(options(app))
+
+    // Then
+    expect(selectOrCreateApp).not.toHaveBeenCalled()
+    expect(got.partnersApp.id).toEqual(APP2.id)
+    expect(got.partnersApp.title).toEqual(APP2.title)
+    expect(got.partnersApp.appType).toEqual(APP2.appType)
+    expect(got.identifiers).toEqual(identifiers)
+    expect(got.release).toEqual(true)
+    expect(got.app.allExtensions).toEqual(appWithExtensions.allExtensions)
+
+    expect(metadata.getAllPublicMetadata()).toMatchObject({api_key: APP2.apiKey, partner_id: 1})
   })
 })
 

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -186,34 +186,6 @@ describe('deploy', () => {
     expect(updateAppIdentifiers).toHaveBeenCalledOnce()
   })
 
-  test('uploads the extension bundle with 1 App access extension', async () => {
-    // Given
-    const app = testApp()
-    const appConfigExtension = await testAppConfigExtensions()
-    const appWithExtensions = testApp({allExtensions: [appConfigExtension]})
-
-    // When
-    await testDeployBundle({app, appToDeploy: appWithExtensions})
-
-    // Then
-    expect(uploadExtensionsBundle).toHaveBeenCalledWith({
-      apiKey: 'app-id',
-      appModules: [
-        {
-          specificationIdentifier: appConfigExtension.specification.identifier,
-          config: '{"embedded":true}',
-          context: '',
-          handle: appConfigExtension.handle,
-        },
-      ],
-      token: 'api-token',
-      extensionIds: {},
-      release: true,
-    })
-    expect(bundleAndBuildExtensions).toHaveBeenCalledOnce()
-    expect(updateAppIdentifiers).toHaveBeenCalledOnce()
-  })
-
   test('uploads the extension bundle with 1 theme extension', async () => {
     // Given
     const themeExtension = await testThemeExtensions()

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -98,7 +98,7 @@ export async function deploy(options: DeployOptions) {
               useVersionedAppConfig() || !extension.isAppConfigExtension
 
             const appModules = await Promise.all(
-              options.app.allExtensions
+              app.allExtensions
                 .filter(filterConfigurationAppModules)
                 .flatMap((ext) => ext.bundleConfig({identifiers, token, apiKey})),
             )

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -116,7 +116,7 @@ export async function deploy(options: DeployOptions) {
             })
 
             if (!useThemebundling()) {
-              const themeExtensions = options.app.allExtensions.filter((ext) => ext.isThemeExtension)
+              const themeExtensions = app.allExtensions.filter((ext) => ext.isThemeExtension)
               await uploadThemeExtensions(themeExtensions, {apiKey, identifiers, token})
             }
 

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -37,11 +37,7 @@ export async function fetchSpecifications({
   })
 
   const extensionSpecifications: FlattenedRemoteSpecification[] = result.extensionSpecifications
-    .filter(
-      (specification) =>
-        ['extension', 'configuration'].includes(specification.experience) ||
-        (specification.experience === 'deprecated' && ['cli'].includes(specification.options.managementExperience)),
-    )
+    .filter((specification) => ['extension', 'configuration'].includes(specification.experience))
     .map((spec) => {
       const newSpec = spec as FlattenedRemoteSpecification
       // WORKAROUND: The identifiers in the API are different for these extensions to the ones the CLI

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -37,7 +37,11 @@ export async function fetchSpecifications({
   })
 
   const extensionSpecifications: FlattenedRemoteSpecification[] = result.extensionSpecifications
-    .filter((specification) => specification.options.managementExperience === 'cli')
+    .filter(
+      (specification) =>
+        ['extension', 'configuration'].includes(specification.experience) ||
+        (specification.experience === 'deprecated' && ['cli'].includes(specification.options.managementExperience)),
+    )
     .map((spec) => {
       const newSpec = spec as FlattenedRemoteSpecification
       // WORKAROUND: The identifiers in the API are different for these extensions to the ones the CLI


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Follow-up: https://github.com/Shopify/cli/pull/3170
Follow-up:  https://github.com/Shopify/cli/pull/3214

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Make `specifications` optional for the `App loader`. Set default value to an empty array so no extensions are loaded in this case.
- `deploy` command loads the app again with the extensions once the `remote app` is selected, thus, the `gated` specs are applied and in case they are not allowed the extensions are not loaded
- Temporal `app access` config module added. Supports the new section `access`
  - `direct_api_offline_access` true | false to enable Online access for Direct API
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new `cli` app and run the `app config link` command to link it to a new remote app. 

- With the org beta flag `App Access Module` disabled
  - Add the section `access` with whatever value 
  - Run the `deploy` command
  - Run the `link` command. The added `access` section content will be removed as the app module wasn't uploaded in the previous `deploy`
- With the org beta flag `App Access Module` enabled
  - Add the section `access` with whatever value 
  - Run the `deploy` command
  - Modify the value inside the `access` section
  - Run the `link` command. The `access` section content will be restored to the content it had before running the `deploy` command as it was uploaded with it
  <!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
