### PR TITLE
Localhost GraphiQL

### DIFF
--- a/.changeset/honest-dragons-yell.md
+++ b/.changeset/honest-dragons-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Serve GraphiQL on localhost

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -322,6 +322,13 @@
           "type": "option",
           "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
           "multiple": false
+        },
+        "graphiql-port": {
+          "name": "graphiql-port",
+          "type": "option",
+          "description": "Local port of the GraphiQL development server.",
+          "hidden": true,
+          "multiple": false
         }
       },
       "args": {}

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -333,7 +333,7 @@
         "graphiql-key": {
           "name": "graphiql-key",
           "type": "option",
-          "description": "Key used to authenticate GraphiQL requests.",
+          "description": "Key used to authenticate GraphiQL requests. Should be specified if exposing GraphiQL on a publicly accessible URL. By default, no key is required.",
           "hidden": true,
           "multiple": false
         }

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -329,6 +329,13 @@
           "description": "Local port of the GraphiQL development server.",
           "hidden": true,
           "multiple": false
+        },
+        "graphiql-key": {
+          "name": "graphiql-key",
+          "type": "option",
+          "description": "Key used to authenticate GraphiQL requests.",
+          "hidden": true,
+          "multiple": false
         }
       },
       "args": {}

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -96,6 +96,11 @@ export default class Dev extends Command {
       description: 'Local port of the GraphiQL development server.',
       env: 'SHOPIFY_FLAG_GRAPHIQL_PORT',
     }),
+    'graphiql-key': Flags.string({
+      hidden: true,
+      description: 'Key used to authenticate GraphiQL requests.',
+      env: 'SHOPIFY_FLAG_GRAPHIQL_KEY',
+    }),
   }
 
   public static analyticsStopCommand(): string | undefined {
@@ -140,6 +145,7 @@ export default class Dev extends Command {
       themeExtensionPort: flags['theme-app-extension-port'],
       notify: flags.notify,
       graphiqlPort: flags['graphiql-port'],
+      graphiqlKey: flags['graphiql-key'],
     }
 
     await dev(devOptions)

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -91,6 +91,11 @@ export default class Dev extends Command {
         'The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.',
       env: 'SHOPIFY_FLAG_NOTIFY',
     }),
+    'graphiql-port': Flags.integer({
+      hidden: true,
+      description: 'Local port of the GraphiQL development server.',
+      env: 'SHOPIFY_FLAG_GRAPHIQL_PORT',
+    }),
   }
 
   public static analyticsStopCommand(): string | undefined {
@@ -134,6 +139,7 @@ export default class Dev extends Command {
       theme: flags.theme,
       themeExtensionPort: flags['theme-app-extension-port'],
       notify: flags.notify,
+      graphiqlPort: flags['graphiql-port'],
     }
 
     await dev(devOptions)

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -98,7 +98,8 @@ export default class Dev extends Command {
     }),
     'graphiql-key': Flags.string({
       hidden: true,
-      description: 'Key used to authenticate GraphiQL requests.',
+      description:
+        'Key used to authenticate GraphiQL requests. Should be specified if exposing GraphiQL on a publicly accessible URL. By default, no key is required.',
       env: 'SHOPIFY_FLAG_GRAPHIQL_KEY',
     }),
   }

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -32,4 +32,8 @@ export const urlNamespaces = {
   devTools: '.shopify',
 } as const
 
+export const ports = {
+  graphiql: 3457,
+} as const
+
 export const EsbuildEnvVarRegex = /^([a-zA-Z0-9_])*$/

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -57,6 +57,7 @@ export interface DevOptions {
   theme?: string
   themeExtensionPort?: number
   notify?: string
+  graphiqlPort?: number
 }
 
 export async function dev(commandOptions: DevOptions) {
@@ -125,7 +126,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
   const allExtensionsWithDevUUIDs = getDevUUIDsForAllExtensions(localApp, apiKey)
   localApp.allExtensions = allExtensionsWithDevUUIDs
 
-  const graphiqlPort = ports.graphiql
+  const graphiqlPort = commandOptions.graphiqlPort || ports.graphiql
 
   return {
     storeFqdn,

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -58,6 +58,7 @@ export interface DevOptions {
   themeExtensionPort?: number
   notify?: string
   graphiqlPort?: number
+  graphiqlKey?: string
 }
 
 export async function dev(commandOptions: DevOptions) {
@@ -99,6 +100,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
   }
 
   const graphiqlPort = commandOptions.graphiqlPort || ports.graphiql
+  const {graphiqlKey} = commandOptions
 
   const {webs, ...network} = await setupNetworkingOptions(
     localApp.webs,
@@ -140,6 +142,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
     network,
     partnerUrlsUpdated,
     graphiqlPort,
+    graphiqlKey,
   }
 }
 

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -25,6 +25,7 @@ import {Web, isCurrentAppSchema, getAppScopesArray, AppInterface} from '../model
 import {getAppIdentifiers} from '../models/app/identifiers.js'
 import {OrganizationApp} from '../models/organization.js'
 import {getAnalyticsTunnelType} from '../utilities/analytics.js'
+import {ports} from '../constants.js'
 import metadata from '../metadata.js'
 import {Config} from '@oclif/core'
 import {AbortController} from '@shopify/cli-kit/node/abort'
@@ -124,6 +125,8 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
   const allExtensionsWithDevUUIDs = getDevUUIDsForAllExtensions(localApp, apiKey)
   localApp.allExtensions = allExtensionsWithDevUUIDs
 
+  const graphiqlPort = ports.graphiql
+
   return {
     storeFqdn,
     storeId,
@@ -134,6 +137,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
     commandOptions,
     network,
     partnerUrlsUpdated,
+    graphiqlPort,
   }
 }
 
@@ -309,6 +313,7 @@ async function launchDevProcesses({
     processes: processesForTaskRunner,
     previewUrl,
     graphiqlUrl,
+    graphiqlPort: config.graphiqlPort,
     app,
     abortController,
     developerPreview: developerPreviewController(apiKey, token),

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -59,6 +59,11 @@ export function setupGraphiQLServer({
       next()
     })
 
+  // Assumes that the proxy adds to the beginning of the URL string
+  function isProxied(req: express.Request, canonicalUrl: string): boolean {
+    return req.originalUrl.split('?', 2)[0] !== canonicalUrl
+  }
+
   function failIfUnmatchedKey(str: string, res: express.Response): boolean {
     if (str === randomKey) return false
     res.status(404).send(`Invalid path ${res.req.originalUrl}`)
@@ -133,7 +138,7 @@ export function setupGraphiQLServer({
   app.get('/graphiql', async (req, res) => {
     outputDebug('Handling /graphiql request', stdout)
     if (
-      req.originalUrl !== '/graphiql' &&
+      isProxied(req, '/graphiql') &&
       failIfUnmatchedKey(req.query.key as string, res)
     ) return
 
@@ -179,7 +184,7 @@ export function setupGraphiQLServer({
   app.post('/graphiql/graphql.json', async (req, res) => {
     outputDebug('Handling /graphiql/graphql.json request', stdout)
     if (
-      req.originalUrl.split('?', 2)[0] !== '/graphiql/graphql.json' &&
+      isProxied(req, '/graphiql/graphql.json') &&
       failIfUnmatchedKey(req.query.key as string, res)
     ) return
 

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -137,10 +137,7 @@ export function setupGraphiQLServer({
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   app.get('/graphiql', async (req, res) => {
     outputDebug('Handling /graphiql request', stdout)
-    if (
-      isProxied(req, '/graphiql') &&
-      failIfUnmatchedKey(req.query.key as string, res)
-    ) return
+    if (isProxied(req, '/graphiql') && failIfUnmatchedKey(req.query.key as string, res)) return
 
     const url = req.hostname === 'localhost' ? localhostUrl : namespacedShopifyUrl
     let apiVersions: string[]
@@ -183,10 +180,7 @@ export function setupGraphiQLServer({
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   app.post('/graphiql/graphql.json', async (req, res) => {
     outputDebug('Handling /graphiql/graphql.json request', stdout)
-    if (
-      isProxied(req, '/graphiql/graphql.json') &&
-      failIfUnmatchedKey(req.query.key as string, res)
-    ) return
+    if (isProxied(req, '/graphiql/graphql.json') && failIfUnmatchedKey(req.query.key as string, res)) return
 
     const graphqlUrl = adminUrl(storeFqdn, req.query.api_version as string)
     try {

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -228,5 +228,5 @@ export function setupGraphiQLServer({
     }
     res.end()
   })
-  return app.listen(port, () => stdout.write('GraphiQL server started'))
+  return app.listen(port, () => stdout.write(`GraphiQL server started on port ${port}`))
 }

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -46,8 +46,9 @@ export function setupGraphiQLServer({
   url,
   storeFqdn,
 }: SetupGraphiQLServerOptions): Server {
-  outputDebug(`Setting up GraphiQL HTTP server...`, stdout)
+  outputDebug(`Setting up GraphiQL HTTP server on port ${port}...`, stdout)
   const namespacedShopifyUrl = `https://${url}/${urlNamespaces.devTools}`
+  const localhostUrl = `http://localhost:${port}/${urlNamespaces.devTools}`
 
   const app = express()
     // Make the app accept all routes starting with /.shopify/xxx as /xxx
@@ -130,6 +131,8 @@ export function setupGraphiQLServer({
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   app.get('/graphiql', async (req, res) => {
+    const url = req.hostname === 'localhost' ? localhostUrl : namespacedShopifyUrl
+
     outputDebug('Handling /graphiql request', stdout)
     if (failIfUnmatchedKey(req.query.key as string, res)) return
     let apiVersions: string[]
@@ -140,7 +143,7 @@ export function setupGraphiQLServer({
         return res.send(
           await renderLiquidTemplate(unauthorizedTemplate, {
             previewUrl: appUrl,
-            url: namespacedShopifyUrl,
+            url,
           }),
         )
       }
@@ -160,7 +163,7 @@ export function setupGraphiQLServer({
           storeFqdn,
         }),
         {
-          url: namespacedShopifyUrl,
+          url,
           defaultQueries: [{query: defaultQuery}],
         },
       ),

--- a/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
+++ b/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
@@ -63,7 +63,7 @@ interface GraphiQLTemplateOptions {
   apiVersions: string[]
   appName: string
   appUrl: string
-  randomKey: string
+  key?: string
   storeFqdn: string
 }
 
@@ -72,7 +72,7 @@ export function graphiqlTemplate({
   apiVersions,
   appName,
   appUrl,
-  randomKey,
+  key,
   storeFqdn,
 }: GraphiQLTemplateOptions): string {
   return `<!DOCTYPE html>
@@ -266,7 +266,7 @@ export function graphiqlTemplate({
         ReactDOM.render(
           React.createElement(GraphiQL, {
             fetcher: GraphiQL.createFetcher({
-              url: '{{url}}/graphiql/graphql.json?key=${randomKey}&api_version=' + apiVersion,
+              url: '{{url}}/graphiql/graphql.json?key=${key ?? ''}&api_version=' + apiVersion,
             }),
             defaultEditorToolsVisibility: true,
             defaultTabs: [

--- a/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
+++ b/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
@@ -187,8 +187,7 @@ export function graphiqlTemplate({
                   <Card padding={{xs: '0'}}>
                     <Banner tone="critical" onDismiss={() => {}}>
                       <p>
-                        The server has been stopped. Restart <code>dev</code> from the CLI and launch the GraphiQL
-                        explorer again.
+                        The server has been stopped. Restart <code>dev</code> from the CLI.
                       </p>
                     </Banner>
                   </Card>

--- a/packages/app/src/cli/services/dev/processes/graphiql.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql.ts
@@ -1,5 +1,4 @@
 import {BaseProcess, DevProcessFunction} from './types.js'
-import {urlNamespaces} from '../../../constants.js'
 import {setupGraphiQLServer} from '../graphiql/server.js'
 
 interface GraphiQLServerProcessOptions {
@@ -9,13 +8,11 @@ interface GraphiQLServerProcessOptions {
   apiSecret: string
   storeFqdn: string
   key?: string
-  url: string
   port: number
 }
 
 export interface GraphiQLServerProcess extends BaseProcess<GraphiQLServerProcessOptions> {
   type: 'graphiql'
-  urlPrefix: string
 }
 
 export async function setupGraphiQLServerProcess(
@@ -24,7 +21,6 @@ export async function setupGraphiQLServerProcess(
   return {
     type: 'graphiql',
     prefix: `graphiql`,
-    urlPrefix: `/${urlNamespaces.devTools}/graphiql`,
     options,
     function: launchGraphiQLServer,
   }

--- a/packages/app/src/cli/services/dev/processes/graphiql.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql.ts
@@ -19,13 +19,13 @@ export interface GraphiQLServerProcess extends BaseProcess<GraphiQLServerProcess
 }
 
 export async function setupGraphiQLServerProcess(
-  options: Omit<GraphiQLServerProcessOptions, 'port'>,
+  options: GraphiQLServerProcessOptions,
 ): Promise<GraphiQLServerProcess> {
   return {
     type: 'graphiql',
     prefix: `graphiql`,
     urlPrefix: `/${urlNamespaces.devTools}/graphiql`,
-    options: {...options, port: -1},
+    options,
     function: launchGraphiQLServer,
   }
 }

--- a/packages/app/src/cli/services/dev/processes/graphiql.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql.ts
@@ -8,7 +8,7 @@ interface GraphiQLServerProcessOptions {
   apiKey: string
   apiSecret: string
   storeFqdn: string
-  randomKey: string
+  key?: string
   url: string
   port: number
 }

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -13,7 +13,6 @@ import {
 } from '../../../models/app/app.test-data.js'
 import {WebType} from '../../../models/app/app.js'
 import {ensureDeploymentIdsPresence} from '../../context/identifiers.js'
-import {urlNamespaces} from '../../../constants.js'
 import {fetchAppExtensionRegistrations} from '../fetch.js'
 import {describe, test, expect, beforeEach, vi} from 'vitest'
 import {ensureAuthenticatedAdmin, ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
@@ -115,6 +114,8 @@ describe('setup-dev-processes', () => {
       redirectUrlWhitelist: [],
     }
 
+    const graphiqlKey = 'somekey'
+
     const res = await setupDevProcesses({
       localApp,
       commandOptions,
@@ -126,6 +127,7 @@ describe('setup-dev-processes', () => {
       token,
       partnerUrlsUpdated: true,
       graphiqlPort,
+      graphiqlKey,
     })
 
     expect(res.previewUrl).toBe('https://example.com/proxy/extensions/dev-console')
@@ -153,15 +155,14 @@ describe('setup-dev-processes', () => {
       type: 'graphiql',
       function: launchGraphiQLServer,
       prefix: 'graphiql',
-      urlPrefix: `/${urlNamespaces.devTools}/graphiql`,
       options: {
         appName: 'App',
         apiKey: 'api-key',
         apiSecret: 'api-secret',
         port: expect.any(Number),
         appUrl: 'https://store.myshopify.io/admin/oauth/redirect_from_cli?client_id=api-key',
+        key: 'somekey',
         storeFqdn: 'store.myshopify.io',
-        url: 'example.com/proxy',
       },
     })
     expect(res.processes[2]).toMatchObject({
@@ -239,7 +240,6 @@ describe('setup-dev-processes', () => {
         port: 444,
         rules: {
           '/extensions': `http://localhost:${previewExtensionPort}`,
-          [`/${urlNamespaces.devTools}/graphiql`]: `http://localhost:${graphiqlPort}`,
           '/ping': `http://localhost:${hmrPort}`,
           default: `http://localhost:${webPort}`,
           websocket: `http://localhost:${hmrPort}`,

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -2,7 +2,7 @@ import {DevConfig, setupDevProcesses, startProxyServer} from './setup-dev-proces
 import {sendWebhook} from './uninstall-webhook.js'
 import {WebProcess, launchWebProcess} from './web.js'
 import {PreviewableExtensionProcess, launchPreviewableExtensionProcess} from './previewable-extension.js'
-import {GraphiQLServerProcess, launchGraphiQLServer} from './graphiql.js'
+import {launchGraphiQLServer} from './graphiql.js'
 import {pushUpdatesForDraftableExtensions} from './draftable-extension.js'
 import {runThemeAppExtensionsServer} from './theme-app-extension.js'
 import {
@@ -54,6 +54,7 @@ describe('setup-dev-processes', () => {
     const storeFqdn = 'store.myshopify.io'
     const storeId = '123456789'
     const remoteAppUpdated = true
+    const graphiqlPort = 1234
     const commandOptions: DevConfig['commandOptions'] = {
       subscriptionProductUrl: '/products/999999',
       checkoutCartUrl: '/cart/999999:1',
@@ -124,6 +125,7 @@ describe('setup-dev-processes', () => {
       storeId,
       token,
       partnerUrlsUpdated: true,
+      graphiqlPort,
     })
 
     expect(res.previewUrl).toBe('https://example.com/proxy/extensions/dev-console')
@@ -227,7 +229,6 @@ describe('setup-dev-processes', () => {
     // Check the ports & rule mapping
     const webPort = (res.processes[0] as WebProcess).options.port
     const hmrPort = (res.processes[0] as WebProcess).options.hmrServerOptions?.port
-    const graphiqlPort = (res.processes[1] as GraphiQLServerProcess).options.port
     const previewExtensionPort = (res.processes[2] as PreviewableExtensionProcess).options.port
 
     expect(res.processes[6]).toMatchObject({

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -16,7 +16,6 @@ import {PartnersURLs} from '../urls.js'
 import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {isShopify, isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
-import {randomHex} from '@shopify/cli-kit/node/crypto'
 
 export interface ProxyServerProcess extends BaseProcess<{port: number; rules: {[key: string]: string}}> {
   type: 'proxy-server'
@@ -54,6 +53,7 @@ export interface DevConfig {
   network: DevNetworkOptions
   partnerUrlsUpdated: boolean
   graphiqlPort: number
+  graphiqlKey?: string
 }
 
 export async function setupDevProcesses({
@@ -66,6 +66,7 @@ export async function setupDevProcesses({
   commandOptions,
   network,
   graphiqlPort,
+  graphiqlKey,
 }: DevConfig): Promise<{
   processes: DevProcesses
   previewUrl: string
@@ -76,7 +77,6 @@ export async function setupDevProcesses({
   const appPreviewUrl = buildAppURLForWeb(storeFqdn, apiKey)
   const shouldRenderGraphiQL =
     isUnitTest() || (await isShopify()) || isTruthy(process.env[environmentVariableNames.enableGraphiQLExplorer])
-  const randomKey = randomHex(16)
 
   const processes = [
     ...(await setupWebProcesses({
@@ -95,7 +95,7 @@ export async function setupDevProcesses({
           port: graphiqlPort,
           apiKey,
           apiSecret,
-          randomKey,
+          key: graphiqlKey,
           storeFqdn,
           url: network.proxyUrl.replace(/^https?:\/\//, ''),
         })
@@ -152,7 +152,7 @@ export async function setupDevProcesses({
     processes: processesWithProxy,
     previewUrl,
     graphiqlUrl: shouldRenderGraphiQL
-      ? `${network.proxyUrl}/${urlNamespaces.devTools}/graphiql?key=${randomKey}`
+      ? `${network.proxyUrl}/${urlNamespaces.devTools}/graphiql${graphiqlKey ? `?key=${graphiqlKey}` : ''}`
       : undefined,
   }
 }

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -53,6 +53,7 @@ export interface DevConfig {
   commandOptions: DevOptions
   network: DevNetworkOptions
   partnerUrlsUpdated: boolean
+  graphiqlPort: number
 }
 
 export async function setupDevProcesses({
@@ -64,6 +65,7 @@ export async function setupDevProcesses({
   storeId,
   commandOptions,
   network,
+  graphiqlPort
 }: DevConfig): Promise<{
   processes: DevProcesses
   previewUrl: string
@@ -90,7 +92,7 @@ export async function setupDevProcesses({
       ? await setupGraphiQLServerProcess({
           appName: localApp.name,
           appUrl: appPreviewUrl,
-          port: 3457,
+          port: graphiqlPort,
           apiKey,
           apiSecret,
           randomKey,

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -65,7 +65,7 @@ export async function setupDevProcesses({
   storeId,
   commandOptions,
   network,
-  graphiqlPort
+  graphiqlPort,
 }: DevConfig): Promise<{
   processes: DevProcesses
   previewUrl: string

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -5,7 +5,7 @@ import {DraftableExtensionProcess, setupDraftableExtensionsProcess} from './draf
 import {SendWebhookProcess, setupSendUninstallWebhookProcess} from './uninstall-webhook.js'
 import {GraphiQLServerProcess, setupGraphiQLServerProcess} from './graphiql.js'
 import {WebProcess, setupWebProcesses} from './web.js'
-import {environmentVariableNames, urlNamespaces} from '../../../constants.js'
+import {environmentVariableNames} from '../../../constants.js'
 import {AppInterface, getAppScopes} from '../../../models/app/app.js'
 
 import {OrganizationApp} from '../../../models/organization.js'
@@ -97,7 +97,6 @@ export async function setupDevProcesses({
           apiSecret,
           key: graphiqlKey,
           storeFqdn,
-          url: network.proxyUrl.replace(/^https?:\/\//, ''),
         })
       : undefined,
     await setupPreviewableExtensionsProcess({
@@ -152,7 +151,7 @@ export async function setupDevProcesses({
     processes: processesWithProxy,
     previewUrl,
     graphiqlUrl: shouldRenderGraphiQL
-      ? `${network.proxyUrl}/${urlNamespaces.devTools}/graphiql${graphiqlKey ? `?key=${graphiqlKey}` : ''}`
+      ? `http://localhost:${graphiqlPort}/graphiql${graphiqlKey ? `?key=${graphiqlKey}` : ''}`
       : undefined,
   }
 }
@@ -180,8 +179,6 @@ async function setPortsAndAddProxyProcess(processes: DevProcesses, proxyPort: nu
         const targetPort = await getAvailableTCPPort()
         rules[process.options.pathPrefix] = `http://localhost:${targetPort}`
         process.options.port = targetPort
-      } else if (process.type === 'graphiql') {
-        rules[process.urlPrefix] = `http://localhost:${process.options.port}`
       }
 
       return {process, rules}

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -90,6 +90,7 @@ export async function setupDevProcesses({
       ? await setupGraphiQLServerProcess({
           appName: localApp.name,
           appUrl: appPreviewUrl,
+          port: 3457,
           apiKey,
           apiSecret,
           randomKey,
@@ -178,9 +179,7 @@ async function setPortsAndAddProxyProcess(processes: DevProcesses, proxyPort: nu
         rules[process.options.pathPrefix] = `http://localhost:${targetPort}`
         process.options.port = targetPort
       } else if (process.type === 'graphiql') {
-        const targetPort = await getAvailableTCPPort()
-        rules[process.urlPrefix] = `http://localhost:${targetPort}`
-        process.options.port = targetPort
+        rules[process.urlPrefix] = `http://localhost:${process.options.port}`
       }
 
       return {process, rules}

--- a/packages/app/src/cli/services/dev/ui.test.tsx
+++ b/packages/app/src/cli/services/dev/ui.test.tsx
@@ -142,6 +142,7 @@ describe('ui', () => {
       const processes = [concurrentProcess]
       const previewUrl = 'https://lala.cloudflare.io/'
       const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
+      const graphiqlPort = 1234
       const app = {
         canEnablePreviewMode: true,
         developmentStorePreviewEnabled: false,
@@ -151,7 +152,7 @@ describe('ui', () => {
 
       const abortController = new AbortController()
 
-      await renderDev({processes, previewUrl, graphiqlUrl, app, abortController, developerPreview})
+      await renderDev({processes, previewUrl, graphiqlUrl, graphiqlPort, app, abortController, developerPreview})
 
       expect(vi.mocked(Dev)).not.toHaveBeenCalled()
       expect(concurrentProcess.action).toHaveBeenNthCalledWith(
@@ -172,6 +173,7 @@ describe('ui', () => {
       const processes = [concurrentProcess]
       const previewUrl = 'https://lala.cloudflare.io/'
       const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
+      const graphiqlPort = 1234
       const app = {
         canEnablePreviewMode: true,
         developmentStorePreviewEnabled: false,
@@ -181,7 +183,7 @@ describe('ui', () => {
 
       const abortController = new AbortController()
 
-      await renderDev({processes, previewUrl, graphiqlUrl, app, abortController, developerPreview})
+      await renderDev({processes, previewUrl, graphiqlUrl, graphiqlPort, app, abortController, developerPreview})
       abortController.abort()
 
       expect(developerPreview.enable).toHaveBeenCalled()
@@ -198,6 +200,7 @@ describe('ui', () => {
       const processes = [concurrentProcess]
       const previewUrl = 'https://lala.cloudflare.io/'
       const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
+      const graphiqlPort = 1234
       const app = {
         canEnablePreviewMode: false,
         developmentStorePreviewEnabled: false,
@@ -207,7 +210,7 @@ describe('ui', () => {
 
       const abortController = new AbortController()
 
-      await renderDev({processes, previewUrl, graphiqlUrl, app, abortController, developerPreview})
+      await renderDev({processes, previewUrl, graphiqlUrl, graphiqlPort, app, abortController, developerPreview})
       abortController.abort()
 
       expect(developerPreview.enable).not.toHaveBeenCalled()
@@ -224,6 +227,7 @@ describe('ui', () => {
       const processes = [concurrentProcess]
       const previewUrl = 'https://lala.cloudflare.io/'
       const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
+      const graphiqlPort = 1234
       const app = {
         canEnablePreviewMode: true,
         developmentStorePreviewEnabled: false,
@@ -234,7 +238,7 @@ describe('ui', () => {
       const abortController = new AbortController()
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      renderDev({processes, previewUrl, graphiqlUrl, app, abortController, developerPreview})
+      renderDev({processes, previewUrl, graphiqlUrl, graphiqlPort, app, abortController, developerPreview})
 
       await new Promise((resolve) => setTimeout(resolve, 100))
 

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -66,6 +66,7 @@ export async function renderDev({
   app,
   abortController,
   graphiqlUrl,
+  graphiqlPort,
   developerPreview,
 }: DevProps) {
   if (terminalSupportsRawMode(process.stdin)) {
@@ -76,6 +77,7 @@ export async function renderDev({
         previewUrl={previewUrl}
         app={app}
         graphiqlUrl={graphiqlUrl}
+        graphiqlPort={graphiqlPort}
         developerPreview={developerPreview}
       />,
       {
@@ -101,7 +103,7 @@ async function renderDevNonInteractive({
   app: {canEnablePreviewMode},
   abortController,
   developerPreview,
-}: Omit<DevProps, 'previewUrl'>) {
+}: Omit<DevProps, 'previewUrl' | 'graphiqlPort'>) {
   if (canEnablePreviewMode) {
     await developerPreview.enable()
     abortController?.signal.addEventListener('abort', async () => {

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -79,6 +79,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -158,6 +159,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -194,6 +196,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -219,6 +222,7 @@ describe('Dev', () => {
         abortController={abortController}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -246,6 +250,7 @@ describe('Dev', () => {
         abortController={abortController}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -288,6 +293,7 @@ describe('Dev', () => {
         abortController={abortController}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -351,6 +357,7 @@ describe('Dev', () => {
         abortController={abortController}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -408,6 +415,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -459,6 +467,7 @@ describe('Dev', () => {
         abortController={abortController}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -501,6 +510,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         pollingTime={200}
         developerPreview={developerPreview}
@@ -567,6 +577,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={{
           ...testApp,
           canEnablePreviewMode: false,
@@ -623,6 +634,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         pollingTime={200}
         developerPreview={developerPreview}
@@ -663,6 +675,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -725,6 +738,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -774,6 +788,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -812,6 +827,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -850,6 +866,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,
@@ -886,6 +903,7 @@ describe('Dev', () => {
         abortController={new AbortController()}
         previewUrl="https://shopify.com"
         graphiqlUrl="https://graphiql.shopify.com"
+        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
       />,

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -104,7 +104,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -180,7 +181,8 @@ describe('Dev', () => {
       ────────────────────────────────────────────────────────────────────────────────────────────────────
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -436,7 +438,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -532,7 +535,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -551,7 +555,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -601,7 +606,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -656,7 +662,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:1234/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to fetch the latest status of the development store preview, trying again in 5 seconds.
       "
     `)
@@ -691,7 +698,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -711,7 +719,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -760,7 +769,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to turn off development store preview.
       "
     `)
@@ -810,7 +820,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to turn off development store preview.
       "
     `)
@@ -843,7 +854,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -884,7 +896,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to turn on development store preview automatically.
       Try turning it on manually by pressing \`d\`.
       "
@@ -919,7 +932,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -936,7 +950,8 @@ describe('Dev', () => {
       › Press q │ quit
 
       Preview URL: https://shopify.com
-      GraphiQL URL: https://graphiql.shopify.com
+      GraphiQL URL: http://localhost:0000/graphiql
+      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to handle your input.
       "
     `)

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -105,7 +105,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -182,7 +181,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -439,7 +437,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -536,7 +533,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -556,7 +552,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -607,7 +602,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -663,7 +657,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:1234/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to fetch the latest status of the development store preview, trying again in 5 seconds.
       "
     `)
@@ -699,7 +692,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -720,7 +712,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -770,7 +761,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to turn off development store preview.
       "
     `)
@@ -821,7 +811,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to turn off development store preview.
       "
     `)
@@ -855,7 +844,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -897,7 +885,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to turn on development store preview automatically.
       Try turning it on manually by pressing \`d\`.
       "
@@ -933,7 +920,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       "
     `)
 
@@ -951,7 +937,6 @@ describe('Dev', () => {
 
       Preview URL: https://shopify.com
       GraphiQL URL: http://localhost:0000/graphiql
-      GraphiQL URL if localhost is inaccessible: https://graphiql.shopify.com
       Failed to handle your input.
       "
     `)

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -38,7 +38,7 @@ const Dev: FunctionComponent<DevProps> = ({
   abortController,
   processes,
   previewUrl,
-  graphiqlUrl,
+  graphiqlUrl = '',
   app,
   pollingTime = 5000,
   developerPreview,
@@ -46,7 +46,8 @@ const Dev: FunctionComponent<DevProps> = ({
   const {canEnablePreviewMode, developmentStorePreviewEnabled} = app
   const {isRawModeSupported: canUseShortcuts} = useStdin()
   const pollingInterval = useRef<NodeJS.Timeout>()
-  const defaultStatusMessage = `Preview URL: ${previewUrl}${graphiqlUrl ? `\nGraphiQL URL: ${graphiqlUrl}` : ''}`
+  const localhostGraphiqlUrl = 'http://localhost:3457/graphiql'
+  const defaultStatusMessage = `Preview URL: ${previewUrl}${graphiqlUrl ? `\nGraphiQL URL: ${localhostGraphiqlUrl}\nGraphiQL URL if localhost is inaccessible: ${graphiqlUrl}` : ''}`
   const [statusMessage, setStatusMessage] = useState(defaultStatusMessage)
 
   const {isAborted} = useAbortSignal(abortController.signal, async (err) => {
@@ -147,7 +148,7 @@ const Dev: FunctionComponent<DevProps> = ({
             await metadata.addPublicMetadata(() => ({
               cmd_dev_graphiql_opened: true,
             }))
-            await openURL(graphiqlUrl)
+            await openURL(localhostGraphiqlUrl)
           } else if (input === 'q') {
             abortController.abort()
           } else if (input === 'd' && canEnablePreviewMode) {

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -24,6 +24,7 @@ export interface DevProps {
   abortController: AbortController
   previewUrl: string
   graphiqlUrl?: string
+  graphiqlPort: number
   app: {
     canEnablePreviewMode: boolean
     developmentStorePreviewEnabled?: boolean
@@ -39,6 +40,7 @@ const Dev: FunctionComponent<DevProps> = ({
   processes,
   previewUrl,
   graphiqlUrl = '',
+  graphiqlPort,
   app,
   pollingTime = 5000,
   developerPreview,
@@ -46,7 +48,7 @@ const Dev: FunctionComponent<DevProps> = ({
   const {canEnablePreviewMode, developmentStorePreviewEnabled} = app
   const {isRawModeSupported: canUseShortcuts} = useStdin()
   const pollingInterval = useRef<NodeJS.Timeout>()
-  const localhostGraphiqlUrl = 'http://localhost:3457/graphiql'
+  const localhostGraphiqlUrl = `http://localhost:${graphiqlPort}/graphiql`
   const defaultStatusMessage = `Preview URL: ${previewUrl}${graphiqlUrl ? `\nGraphiQL URL: ${localhostGraphiqlUrl}\nGraphiQL URL if localhost is inaccessible: ${graphiqlUrl}` : ''}`
   const [statusMessage, setStatusMessage] = useState(defaultStatusMessage)
 

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -50,9 +50,7 @@ const Dev: FunctionComponent<DevProps> = ({
   const pollingInterval = useRef<NodeJS.Timeout>()
   const localhostGraphiqlUrl = `http://localhost:${graphiqlPort}/graphiql`
   const defaultStatusMessage = `Preview URL: ${previewUrl}${
-    graphiqlUrl
-      ? `\nGraphiQL URL: ${localhostGraphiqlUrl}\nGraphiQL URL if localhost is inaccessible: ${graphiqlUrl}`
-      : ''
+    graphiqlUrl ? `\nGraphiQL URL: ${localhostGraphiqlUrl}` : ''
   }`
   const [statusMessage, setStatusMessage] = useState(defaultStatusMessage)
 

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -49,7 +49,11 @@ const Dev: FunctionComponent<DevProps> = ({
   const {isRawModeSupported: canUseShortcuts} = useStdin()
   const pollingInterval = useRef<NodeJS.Timeout>()
   const localhostGraphiqlUrl = `http://localhost:${graphiqlPort}/graphiql`
-  const defaultStatusMessage = `Preview URL: ${previewUrl}${graphiqlUrl ? `\nGraphiQL URL: ${localhostGraphiqlUrl}\nGraphiQL URL if localhost is inaccessible: ${graphiqlUrl}` : ''}`
+  const defaultStatusMessage = `Preview URL: ${previewUrl}${
+    graphiqlUrl
+      ? `\nGraphiQL URL: ${localhostGraphiqlUrl}\nGraphiQL URL if localhost is inaccessible: ${graphiqlUrl}`
+      : ''
+  }`
   const [statusMessage, setStatusMessage] = useState(defaultStatusMessage)
 
   const {isAborted} = useAbortSignal(abortController.signal, async (err) => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Allows us to maintain query history and not lose work. Also, if `dev` dies or is killed, you can restart `dev` and your tab starts working again. Woot!
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Uses a primary method of localhost access to GraphiQL, while leaving the proxy-based option open for now (though we should consider removing it entirely).

Defaults to port 3457 for serving; we should give the option of specifying another port by ENV variable and/or config file to enable running `dev` on multiple apps simultaneously.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Spin up `dev` and verify that GraphiQL still works.
2. Quit `dev` and restart. Your tab should restore itself.
3. Open a new tab after the restart, and it should still keep your history.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
