### PR TITLE
[Feature] Add flag to prevent remote file deletions on `theme dev`

### DIFF
--- a/.changeset/serious-kids-call.md
+++ b/.changeset/serious-kids-call.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/theme': minor
+'@shopify/cli': minor
+---
+
+Add new `nodelete` flag to `shopify theme dev` command

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/serve.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/serve.rb
@@ -26,6 +26,7 @@ module Theme
         parser.on("-e", "--theme-editor-sync") { flags[:editor_sync] = true }
         parser.on("--stable") { flags[:stable] = true }
         parser.on("-t", "--theme=NAME_OR_ID") { |theme| flags[:theme] = theme }
+        parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-o", "--only=PATTERN", Conversions::IncludeGlob) do |pattern|
           flags[:includes] ||= []
           flags[:includes] |= pattern
@@ -46,9 +47,10 @@ module Theme
         root = root_value(options, name)
         flags = options.flags.dup
         host = flags[:host] || DEFAULT_HTTP_HOST
+        delete = !flags[:nodelete]
 
         ShopifyCLI::Theme::DevServer.start(@ctx, root, host: host, **flags) do |syncer|
-          UI::SyncProgressBar.new(syncer).progress(:upload_theme!, delay_low_priority_files: true)
+          UI::SyncProgressBar.new(syncer).progress(:upload_theme!, delay_low_priority_files: true, delete: delete)
         end
       end
 

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server.rb
@@ -30,7 +30,7 @@ module ShopifyCLI
       include Singleton
 
       attr_reader :app, :stopped, :ctx, :root, :host, :theme_identifier, :port, :poll, :editor_sync, :stable, :mode,
-        :block, :includes, :ignores, :notify
+        :block, :includes, :ignores, :notify, :nodelete
 
       class << self
         def start(
@@ -48,6 +48,7 @@ module ShopifyCLI
           includes: nil,
           ignores: nil,
           notify: nil,
+          nodelete: false,
           &block
         )
           instance.setup(
@@ -65,6 +66,7 @@ module ShopifyCLI
             includes,
             ignores,
             notify,
+            nodelete,
             &block
           )
           instance.start
@@ -91,6 +93,7 @@ module ShopifyCLI
         includes,
         ignores,
         notify,
+        nodelete,
         &block
       )
         @ctx = ctx
@@ -108,6 +111,7 @@ module ShopifyCLI
         @ignores = ignores
         @notify = notify
         @block = block
+        @nodelete = nodelete
       end
 
       def start
@@ -184,7 +188,7 @@ module ShopifyCLI
         if block
           block.call(syncer)
         else
-          syncer.upload_theme!(delay_low_priority_files: true)
+          syncer.upload_theme!(delay_low_priority_files: true, delete: !nodelete)
         end
 
         ctx.open_browser_url!(address) if @open_browser
@@ -217,7 +221,8 @@ module ShopifyCLI
           theme: theme,
           ignore_filter: ignore_filter,
           syncer: syncer,
-          poll: poll
+          poll: poll,
+          delete: !nodelete
         )
       end
 

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/watcher.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/watcher.rb
@@ -11,11 +11,12 @@ module ShopifyCLI
 
         def_delegators :@listener, :add_observer, :changed, :notify_observers
 
-        def initialize(ctx, theme:, syncer:, ignore_filter: nil, poll: false)
+        def initialize(ctx, theme:, syncer:, ignore_filter: nil, poll: false, delete: true)
           @ctx = ctx
           @theme = theme
           @syncer = syncer
           @ignore_filter = ignore_filter
+          @delete = delete
           @listener = FileSystemListener.new(root: @theme.root, force_poll: poll,
             ignore_regex: @ignore_filter&.regexes)
 
@@ -35,6 +36,8 @@ module ShopifyCLI
           if modified_theme_files.any?
             @syncer.enqueue_updates(modified_theme_files)
           end
+
+          return unless @delete
 
           removed_theme_files = filter_remote_files(removed)
           if removed_theme_files.any?

--- a/packages/cli-kit/assets/cli-ruby/test/project_types/theme/commands/serve_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/project_types/theme/commands/serve_test.rb
@@ -74,6 +74,15 @@ module Theme
         end
       end
 
+      def test_can_specify_nodelete
+        ShopifyCLI::Theme::DevServer.expects(:start)
+          .with(@ctx, @root, host: Theme::Command::Serve::DEFAULT_HTTP_HOST, nodelete: true)
+
+        run_serve_command([@root]) do |command|
+          command.options.flags[:nodelete] = true
+        end
+      end
+
       def test_valid_authentication_method_when_storefront_renderer_from_cli3_in_env_is_present
         ShopifyCLI::Environment.stubs(:storefront_renderer_auth_token).returns("CLI3 SFR Token")
         ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("password")

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server_test.rb
@@ -118,10 +118,10 @@ module ShopifyCLI
       private
 
       def dev_server(identifier: nil, ignores: nil, includes: nil)
-        host, port, poll, editor_sync, overwrite_json, open_browser, stable, mode, notify = nil
+        host, port, poll, editor_sync, overwrite_json, open_browser, stable, mode, notify, nodelete = nil
         server = DevServer.instance
         server.setup(ctx, root, host, identifier, port, poll, editor_sync, overwrite_json, open_browser,
-          stable, mode, includes, ignores, notify)
+          stable, mode, includes, ignores, notify, nodelete)
         server
       end
 

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/extension/dev_server_test.rb
@@ -148,10 +148,10 @@ module ShopifyCLI
         private
 
         def dev_server(identifier: nil)
-          poll, editor_sync, overwrite_json, open_browser, stable, mode, ignores, includes, notify = nil
+          poll, editor_sync, overwrite_json, open_browser, stable, mode, ignores, includes, notify, nodelete = nil
           server = Extension::DevServer.instance
           server.setup(ctx, root, @server_host, identifier, @server_port, poll, editor_sync, overwrite_json,
-            open_browser, stable, mode, ignores, includes, notify)
+            open_browser, stable, mode, ignores, includes, notify, nodelete)
           server.project = project
           server.specification_handler = specification_handler
           server

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -990,12 +990,15 @@ Uploads the current theme as a development theme to the connected store, then pr
 ```
 USAGE
   $ shopify theme dev [--no-color] [--verbose] [--path <value>] [--host <value>] [--live-reload
-    hot-reload|full-page|off] [--poll] [--theme-editor-sync] [--port <value>] [-s <value>] [-t <value>] [-o <value>] [-x
-    <value>] [--password <value>] [-e <value>] [--notify <value>] [--open]
+    hot-reload|full-page|off] [--poll] [--theme-editor-sync] [--port <value>] [-s <value>] [-t <value>] [-n] [-o
+    <value>] [-x <value>] [--password <value>] [-e <value>] [--notify <value>] [--open]
 
 FLAGS
   -e, --environment=<value>
       The environment to apply to the current command.
+
+  -n, --nodelete
+      Runs the dev command without deleting local files.
 
   -o, --only=<value>...
       Hot reload only files that match the specified pattern.

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -372,6 +372,13 @@
           "description": "Theme ID or name of the remote theme.",
           "multiple": false
         },
+        "nodelete": {
+          "name": "nodelete",
+          "type": "boolean",
+          "char": "n",
+          "description": "Runs the dev command without deleting local files.",
+          "allowNo": false
+        },
         "only": {
           "name": "only",
           "type": "option",
@@ -436,6 +443,7 @@
         "overwrite-json",
         "port",
         "theme",
+        "nodelete",
         "only",
         "ignore",
         "stable",
@@ -1177,6 +1185,13 @@
           "char": "t",
           "description": "Theme ID or name of the remote theme.",
           "multiple": false
+        },
+        "nodelete": {
+          "name": "nodelete",
+          "type": "boolean",
+          "char": "n",
+          "description": "Runs the dev command without deleting local files.",
+          "allowNo": false
         },
         "only": {
           "name": "only",

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -46,6 +46,11 @@ export default class Dev extends ThemeCommand {
       description: 'Theme ID or name of the remote theme.',
       env: 'SHOPIFY_FLAG_THEME_ID',
     }),
+    nodelete: Flags.boolean({
+      char: 'n',
+      description: 'Runs the dev command without deleting local files.',
+      env: 'SHOPIFY_FLAG_NODELETE',
+    }),
     only: Flags.string({
       char: 'o',
       multiple: true,
@@ -92,6 +97,7 @@ export default class Dev extends ThemeCommand {
     'overwrite-json',
     'port',
     'theme',
+    'nodelete',
     'only',
     'ignore',
     'stable',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2816 

tl;dr when bundlers are used for compilation, files are deleted/restored, which causes unecessary remote deletions and uploads

### WHAT is this pull request doing?

- Adds a new `--nodelete` flag to `theme dev`
  - prevents locally removed files from being remotely deleted on startup
  - prevents locally removed files from being remotely deleted while watching for changes

### How to test your changes?

1. Run `shopify theme dev --nodelete`
2. Delete a theme file
3. Ensure the file is not removed remotely
4. Stop the process
5. Delete another theme file
6. Run `shopify theme dev --nodelete`
7. Ensure the file is not removed remotely

### Post-release steps

[Documentation](https://shopify.dev/docs/themes/tools/cli/commands#dev) will be updated

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
