### PR TITLE
[Checkout extensibility] Adds support for collect_buyer_consent.write_privacy_consent capability

### DIFF
--- a/.changeset/red-houses-rule.md
+++ b/.changeset/red-houses-rule.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Adds new, nested `write_privacy_consent` capability under `collect_buyer_consent`

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -131,6 +131,7 @@ export async function testUIExtension(
       api_access: false,
       collect_buyer_consent: {
         sms_marketing: false,
+        write_privacy_consent: false,
       },
     },
   }

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1178,6 +1178,7 @@ automatically_update_urls_on_dev = true
         api_access = true
 
         [extensions.capabilities.collect_buyer_consent]
+        write_privacy_consent = false
         sms_marketing = true
 
         [extensions.settings]
@@ -1245,6 +1246,7 @@ automatically_update_urls_on_dev = true
           block_progress: true,
           api_access: true,
           collect_buyer_consent: {
+            write_privacy_consent: false,
             sms_marketing: true,
           },
         },
@@ -1534,6 +1536,7 @@ automatically_update_urls_on_dev = true
       api_access = true
 
       [capabilities.collect_buyer_consent]
+      write_privacy_consent = true
       sms_marketing = true
 
       [settings]
@@ -1570,6 +1573,7 @@ automatically_update_urls_on_dev = true
           block_progress: true,
           network_access: true,
           collect_buyer_consent: {
+            write_privacy_consent: true,
             sms_marketing: true,
           },
         },

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -10,6 +10,7 @@ export const MetafieldSchema = zod.object({
 
 export const CollectBuyerConsentCapabilitySchema = zod.object({
   sms_marketing: zod.boolean().optional(),
+  write_privacy_consent: zod.boolean().optional(),
 })
 
 export const CapabilitiesSchema = zod.object({

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -29,6 +29,7 @@ describe('ui_extension', async () => {
         network_access: false,
         api_access: false,
         collect_buyer_consent: {
+          write_privacy_consent: true,
           sms_marketing: false,
         },
       },
@@ -89,6 +90,7 @@ describe('ui_extension', async () => {
           network_access: false,
           api_access: false,
           collect_buyer_consent: {
+            write_privacy_consent: true,
             sms_marketing: false,
           },
         },
@@ -123,6 +125,7 @@ describe('ui_extension', async () => {
           network_access: false,
           api_access: false,
           collect_buyer_consent: {
+            write_privacy_consent: true,
             sms_marketing: false,
           },
         },

--- a/packages/app/src/cli/services/context/id-manual-matching.test.ts
+++ b/packages/app/src/cli/services/context/id-manual-matching.test.ts
@@ -39,6 +39,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -58,6 +59,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -77,6 +79,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },

--- a/packages/app/src/cli/services/context/id-matching.test.ts
+++ b/packages/app/src/cli/services/context/id-matching.test.ts
@@ -97,6 +97,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -116,6 +117,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -135,6 +137,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -154,6 +157,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -173,6 +177,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -192,6 +197,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -117,6 +117,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -136,6 +137,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -156,6 +158,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },

--- a/packages/app/src/cli/services/context/identifiers.test.ts
+++ b/packages/app/src/cli/services/context/identifiers.test.ts
@@ -72,6 +72,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },
@@ -91,6 +92,7 @@ beforeAll(async () => {
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },

--- a/packages/app/src/cli/services/dev/extension/localization.test.ts
+++ b/packages/app/src/cli/services/dev/extension/localization.test.ts
@@ -22,6 +22,7 @@ async function testGetLocalization(tmpDir: string, currentLocalization?: Localiz
         api_access: false,
         collect_buyer_consent: {
           sms_marketing: false,
+          write_privacy_consent: false,
         },
       },
     },

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -36,6 +36,7 @@ describe('getUIExtensionPayload', () => {
             block_progress: false,
             collect_buyer_consent: {
               sms_marketing: false,
+              write_privacy_consent: false,
             },
           },
           extension_points: ['CUSTOM_EXTENSION_POINT'],
@@ -160,6 +161,7 @@ describe('getUIExtensionPayload', () => {
             api_access: false,
             collect_buyer_consent: {
               sms_marketing: false,
+              write_privacy_consent: false,
             },
           },
           extension_points: [
@@ -245,6 +247,7 @@ describe('getUIExtensionPayload', () => {
             api_access: false,
             collect_buyer_consent: {
               sms_marketing: false,
+              write_privacy_consent: false,
             },
           },
           extension_points: [

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -34,6 +34,8 @@ export async function getUIExtensionPayload(
       apiAccess: extension.configuration.capabilities?.api_access || false,
       collectBuyerConsent: {
         smsMarketing: extension.configuration.capabilities?.collect_buyer_consent?.sms_marketing || false,
+        writePrivacyConsent:
+          extension.configuration.capabilities?.collect_buyer_consent?.write_privacy_consent || false,
       },
     },
     development: {

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -99,6 +99,7 @@ export type ExtensionPoints = string[] | ExtensionPoint[] | null
 
 interface CollectBuyerConsentCapabilities {
   smsMarketing: boolean
+  writePrivacyConsent: boolean
 }
 
 interface Capabilities {


### PR DESCRIPTION
### WHY are these changes introduced?

Partially resolves [#1529](https://github.com/Shopify/develop-app-management/issues/1529) (3rd party cookies/consent settings management is TBD).

This PR introduces support for a new extension capability under the `collect_buyer_consent` category: `write_privacy_consent` as part of the [Privacy Consent API](https://vault.shopify.io/gsd/projects/37679) project.

Note:  The `privacy_cookies` capability will be handled separately after requirements are confirmed.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR allows users to set and update the `collect_buyer_consent.write_privacy_cookies` capability. It also updates the extensions query to return the capability value.

### How to test your changes?

This CLI branch has been added to a spin constellation and was used to set the writePrivacyConsent capability to true for the `checkout-ui` extension.

- [ ] Navigate to the [core graphiql instance for the development shop](https://app.shopify.constellation-cli-dev-3hsp.rick-caplan.us.spin.dev/services/internal/shops/8/graphql?appID=1830279)
- [ ] Run the following query and confirm that `writePrivacyConsent` returns as true for the `checkout-ui` extension and false for the `display-privacy-consent` extension.

query
```graphql
query Extensions($first: Int!, $after: String) {
  checkoutUiExtensions(first: $first, after: $after) {
    edges {
      node {
        name
        capabilities {
          apiAccess
          networkAccess
          blockProgress
          collectBuyerConsent {
            smsMarketing
            writePrivacyConsent
          }
        }
      }
    }
  }
}
```

query variables

```graphql
{
  "first": 10
}
```

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
