### PR TITLE
[Functions] Add semicolons to generated WIT

### DIFF
--- a/.changeset/green-hornets-chew.md
+++ b/.changeset/green-hornets-chew.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Emit semicolons in generated WIT for Functions

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -356,10 +356,10 @@ describe('ExportJavyBuilder', () => {
     const got = builder.wit
 
     // Then
-    expect(got).toContain('package function:impl')
+    expect(got).toContain('package function:impl;')
     expect(got).toContain('world shopify-function')
-    expect(got).toContain('export %foo-bar: func()')
-    expect(got).toContain('export %foo-baz: func()')
+    expect(got).toContain('export %foo-bar: func();')
+    expect(got).toContain('export %foo-baz: func();')
   })
 
   test('entrypointContents', () => {

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -265,8 +265,8 @@ export class ExportJavyBuilder implements JavyBuilder {
 
   get wit() {
     // % escapes the name to avoid conflict with reserved words, if any
-    const witExports = this.exports.map((name) => `export %${hyphenate(name)}: func()`)
-    return `package function:impl
+    const witExports = this.exports.map((name) => `export %${hyphenate(name)}: func();`)
+    return `package function:impl;
 
 world ${JAVY_WORLD} {
   ${witExports.join('\n  ')}


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/7416

> the WIT file format will transition from not accepting semicolons, to accepting but not requiring semicolons, and finally to requiring semicolons

[WIT spec](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)

### WHAT is this pull request doing?

Adds semicolons to WIT statements (`package` and `export`)

### How to test your changes?

> 1. Set the `WIT_REQUIRE_SEMICOLONS` environment variable to `1`
> 2. Run the CLI command to deploy the function on the main branch, confirm Javy raises an error about not being able to parse the WIT file
> 3. Run the CLI command to deploy the function on the branch with the changes to emit semicolons, confirm Javy does not raise an error about not being able to parse the WIT file

https://github.com/Shopify/script-service/issues/7416#issuecomment-1854021387

#### :tophat:

Branch | Command | Result
-- | -- | --
`main` | `WIT_REQUIRE_SEMICOLONS=1 pnpm shopify app build` | Error
`functions/wit-semicolons` | `WIT_REQUIRE_SEMICOLONS=1 pnpm shopify app build` | Success
`functions/wit-semicolons` | `pnpm shopify app build` | Success

<details>
<summary>Error output</summary>

```
cart-checkout-validation │ Running javy...

Error: expected ';', found keyword `world`
     --> /private/var/folders/71/dg7xtsd97qv4m66wmggs2qz40000gn/T/ce5c16c1bffd4002f7966a1264c575bd/javy-world.wit:3:1
      |
    3 | world shopify-function {
      | ^
── external error ───────────────────────────────────────────────────────────

Error coming from `npm exec -- javy compile -d -o
/Users/d/apps/dec-13/extensions/cart-checkout-validation/dist/function.wasm
dist/function.js --wit /private/var/folders/71/dg7xtsd97qv4m66wmggs2qz40000gn
/T/ce5c16c1bffd4002f7966a1264c575bd/javy-world.wit -n shopify-function`

Command failed with exit code 1: npm exec -- javy compile -d -o
/Users/d/apps/dec-13/extensions/cart-checkout-validation/dist/function.wasm
dist/function.js --wit /private/var/folders/71/dg7xtsd97qv4m66wmggs2qz40000gn
/T/ce5c16c1bffd4002f7966a1264c575bd/javy-world.wit -n shopify-function

─────────────────────────────────────────────────────────────────────────────
```
</details>

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
