### PR TITLE
Use correct source for app name for GraphiQL

### DIFF
--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -90,7 +90,7 @@ export async function setupDevProcesses({
     })),
     shouldRenderGraphiQL
       ? await setupGraphiQLServerProcess({
-          appName: localApp.name,
+          appName: remoteApp.title,
           appUrl: appPreviewUrl,
           port: graphiqlPort,
           apiKey,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Previously we used the default local app name instead of the actual name of the remote app.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Uses `remoteApp` (i.e., what we've actually connected to) as the source of truth for the app name in the GraphiQL web UI.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
On an app with multiple configs, switch between the configs and relaunch GraphiQL. It should show the correct app title each time in the top bar.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
