### PR TITLE
Eliminate flicker on reconnection to dev

### DIFF
--- a/.changeset/afraid-countries-melt.md
+++ b/.changeset/afraid-countries-melt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Eliminate status flicker when reconnecting to dev

--- a/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
+++ b/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
@@ -308,12 +308,16 @@ export function graphiqlTemplate({
       const statusInterval = setInterval(updateBadge, 1000)
 
       // Warn when the server has been stopped
+      const displayErrorServerStoppedTimeouts = []
       const pingInterval = setInterval(function() {
-        const displayErrorServerStoppedTimeout = setTimeout(function() { serverIsLive = false }, 3000)
+        displayErrorServerStoppedTimeouts.push(setTimeout(function() { serverIsLive = false }, 3000))
         fetch('{{url}}/graphiql/ping')
           .then(function(response) {
             if (response.status === 200) {
-              clearTimeout(displayErrorServerStoppedTimeout)
+              while (displayErrorServerStoppedTimeouts.length > 0) {
+                const timeout = displayErrorServerStoppedTimeouts.pop()
+                clearTimeout(timeout)
+              }
               serverIsLive = true
             } else {
               serverIsLive = false


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

There's an odd-looking status flicker (status goes quickly disconnected => running => disconnected => running) when reconnnecting to `dev`. This PR eliminate that. (video [here](https://videobin.shopify.io/v/k56dJm?t=160))

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

The problem was that even if the most recent request to the server succeeded, a prior request could fail (because it was sent before the server was up), and we incorrectly activated "disconnected" status due to a timeout that wasn't cleared.

The previous strategy was to associate each timeout with a request and a function to clear the timeout:

```
Timeout A => Function A => make request A, if it succeeds then clear Timeout A and consider GraphiQL "connected"
Timeout B => Function B => make request B, if it succeeds then clear Timeout B and consider GraphiQL "connected"
Timeout C => Function C => make request C, if it succeeds then clear Timeout C and consider GraphiQL "connected"
```

So if B succeeds but A was sent too early, we'll end up flashing back to disconnected because A isn't cleared. And then C will eventually confirm "connected" so the flicker stops.

Now, we keep an array of all timeouts, and clear them all on a successful request:

```
Function A => make request A, if it succeeds then clear all timeouts and consider GraphiQL "connected"
Function B => make request A, if it succeeds then clear all timeouts and consider GraphiQL "connected"
Function C => make request A, if it succeeds then clear all timeouts and consider GraphiQL "connected"
```

This eliminates the flicker.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Run `dev` and open GraphiQL
2. Quit `dev` and confirm the state is "Disconnected"
3. Restart `dev` and watch GraphiQL switch to "Running" - there should be no flicker of "Disconnected"

On `main`, following these steps, you would see the flicker basically every time.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
