### PR TITLE
Enable GraphiQL by default

### DIFF
--- a/.changeset/tough-shrimps-agree.md
+++ b/.changeset/tough-shrimps-agree.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Enable GraphiQL for everyone by default

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -1,6 +1,6 @@
 export const environmentVariableNames = {
   skipEsbuildReactDedeuplication: 'SHOPIFY_CLI_SKIP_ESBUILD_REACT_DEDUPLICATION',
-  enableGraphiQLExplorer: 'SHOPIFY_CLI_ENABLE_GRAPHIQL_EXPLORER',
+  disableGraphiQLExplorer: 'SHOPIFY_CLI_DISABLE_GRAPHIQL',
 }
 
 export const configurationFileNames = {

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -14,7 +14,6 @@ import {getProxyingWebServer} from '../../../utilities/app/http-reverse-proxy.js
 import {buildAppURLForWeb} from '../../../utilities/app/app-url.js'
 import {PartnersURLs} from '../urls.js'
 import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
-import {isShopify, isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 
 export interface ProxyServerProcess extends BaseProcess<{port: number; rules: {[key: string]: string}}> {
@@ -75,8 +74,7 @@ export async function setupDevProcesses({
   const apiKey = remoteApp.apiKey
   const apiSecret = (remoteApp.apiSecret as string) ?? ''
   const appPreviewUrl = buildAppURLForWeb(storeFqdn, apiKey)
-  const shouldRenderGraphiQL =
-    isUnitTest() || (await isShopify()) || isTruthy(process.env[environmentVariableNames.enableGraphiQLExplorer])
+  const shouldRenderGraphiQL = !isTruthy(process.env[environmentVariableNames.disableGraphiQLExplorer])
 
   const processes = [
     ...(await setupWebProcesses({


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

GraphiQL is ready to go. Let's ship it! (But to be extra cautious, we'll have a secret ENV variable to disable in case it unexpectedly doesn't work in some environments.)
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Switches the default to GraphiQL being run.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Run `dev` as non-Shopifolk (`RUN_AS_USER=1`)
2. GraphiQL should be available
3. Run `dev` as non-Shopifolk (`RUN_AS_USER=1`) with env var `SHOPIFY_CLI_DISABLE_GRAPHIQL=1`
4. GraphiQL should be unavailable

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->
Merge https://github.com/Shopify/shopify-dev/pull/39355

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
