### PR TITLE
Manage new_updated_removed dashboard extensions in confirmation prompt

### DIFF
--- a/packages/app/src/cli/api/graphql/app_versions_diff.ts
+++ b/packages/app/src/cli/api/graphql/app_versions_diff.ts
@@ -9,6 +9,10 @@ export const AppVersionsDiffQuery = gql`
           registrationTitle
           specification {
             identifier
+            experience
+            options {
+              managementExperience
+            }
           }
         }
         updated {
@@ -16,6 +20,10 @@ export const AppVersionsDiffQuery = gql`
           registrationTitle
           specification {
             identifier
+            experience
+            options {
+              managementExperience
+            }
           }
         }
         removed {
@@ -23,6 +31,10 @@ export const AppVersionsDiffQuery = gql`
           registrationTitle
           specification {
             identifier
+            experience
+            options {
+              managementExperience
+            }
           }
         }
       }
@@ -35,6 +47,10 @@ export interface AppVersionsDiffExtensionSchema {
   registrationTitle: string
   specification: {
     identifier: string
+    experience: string
+    options: {
+      managementExperience: string
+    }
   }
 }
 

--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -3,6 +3,8 @@ import metadata from '../metadata.js'
 import {
   ConfigExtensionIdentifiersBreakdown,
   ExtensionIdentifiersBreakdown,
+  buildDashboardBreakdownInfo,
+  buildExtensionBreakdownInfo,
 } from '../services/context/breakdown-extensions.js'
 import {SpyInstance, beforeEach, describe, expect, test, vi} from 'vitest'
 import * as ui from '@shopify/cli-kit/node/ui'
@@ -126,7 +128,8 @@ describe('deployOrReleaseConfirmationPrompt', () => {
     test('and no force with deleted extensions should display the complete danger confirmation prompt', async () => {
       // Given
       const breakdownInfo = buildCompleteBreakdownInfo()
-
+      breakdownInfo.extensionIdentifiersBreakdown.onlyRemote.push(buildDashboardBreakdownInfo('remote dashboard'))
+      breakdownInfo.extensionIdentifiersBreakdown.toCreate.push(buildDashboardBreakdownInfo('to create dashboard'))
       const renderDangerousConfirmationPromptSpyOn = vi
         .spyOn(ui, 'renderDangerousConfirmationPrompt')
         .mockResolvedValue(true)
@@ -165,9 +168,15 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               helperText: 'Removing extensions can permanentely delete app user data',
               items: [
                 {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
+                {
+                  bullet: '+',
+                  item: ['to create dashboard', {subdued: '(new, from Partner Dashboard)'}],
+                  color: 'green',
+                },
                 'to update extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
                 {bullet: '-', item: ['remote extension', {subdued: '(removed)'}], color: 'red'},
+                {bullet: '-', item: ['remote dashboard', {subdued: '(removed, from Partner Dashboard)'}], color: 'red'},
               ],
             },
           ],
@@ -400,10 +409,12 @@ function renderConfirmationPromptContent(options: RenderConfirmationPromptConten
 function buildCompleteBreakdownInfo() {
   const emptyBreakdownInfo = buildEmptyBreakdownInfo()
 
-  emptyBreakdownInfo.extensionIdentifiersBreakdown.onlyRemote.push('remote extension')
-  emptyBreakdownInfo.extensionIdentifiersBreakdown.toCreate.push('to create extension')
-  emptyBreakdownInfo.extensionIdentifiersBreakdown.toUpdate.push('to update extension')
-  emptyBreakdownInfo.extensionIdentifiersBreakdown.fromDashboard.push('from dashboard extension')
+  emptyBreakdownInfo.extensionIdentifiersBreakdown.onlyRemote.push(buildExtensionBreakdownInfo('remote extension'))
+  emptyBreakdownInfo.extensionIdentifiersBreakdown.toCreate.push(buildExtensionBreakdownInfo('to create extension'))
+  emptyBreakdownInfo.extensionIdentifiersBreakdown.toUpdate.push(
+    buildExtensionBreakdownInfo('to update extension'),
+    buildDashboardBreakdownInfo('from dashboard extension'),
+  )
 
   emptyBreakdownInfo.configExtensionIdentifiersBreakdown!.existingFieldNames.push('existing field name1')
   emptyBreakdownInfo.configExtensionIdentifiersBreakdown!.existingUpdatedFieldNames.push('updating field name1')
@@ -428,7 +439,6 @@ function buildEmptyExtensionsBreakdownInfo(): ExtensionIdentifiersBreakdown {
     onlyRemote: [],
     toCreate: [],
     toUpdate: [],
-    fromDashboard: [],
   }
 }
 

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -2,6 +2,7 @@ import {buildDeployReleaseInfoTableSection} from './ui/deploy-release-info-table
 import metadata from '../metadata.js'
 import {
   ConfigExtensionIdentifiersBreakdown,
+  ExtensionIdentifierBreakdownInfo,
   ExtensionIdentifiersBreakdown,
 } from '../services/context/breakdown-extensions.js'
 import {useVersionedAppConfig} from '@shopify/cli-kit/node/context/local'
@@ -98,13 +99,21 @@ async function deployConfirmationPrompt({
 }
 
 async function buildExtensionsContentPrompt(extensionsContentBreakdown: ExtensionIdentifiersBreakdown) {
-  const {fromDashboard, onlyRemote, toCreate: toCreateBreakdown, toUpdate} = extensionsContentBreakdown
+  const {onlyRemote, toCreate: toCreateBreakdown, toUpdate} = extensionsContentBreakdown
 
+  const mapExtensionToInfoTableItem = (extension: ExtensionIdentifierBreakdownInfo, preffix: string) => {
+    switch (extension.experience) {
+      case 'dashboard':
+        return [extension.title, {subdued: `(${preffix}from Partner Dashboard)`}]
+      case 'extension':
+        return extension.title
+    }
+  }
   let extensionsInfoTable
   const section = {
-    new: toCreateBreakdown,
-    updated: [...toUpdate, ...fromDashboard.map((identifier) => [identifier, {subdued: '(from Partner Dashboard)'}])],
-    removed: onlyRemote,
+    new: toCreateBreakdown.map((extension) => mapExtensionToInfoTableItem(extension, 'new, ')),
+    updated: toUpdate.map((extension) => mapExtensionToInfoTableItem(extension, '')),
+    removed: onlyRemote.map((extension) => mapExtensionToInfoTableItem(extension, 'removed, ')),
   }
   const extensionsInfo = buildDeployReleaseInfoTableSection(section)
 

--- a/packages/app/src/cli/services/context/breakdown-extensions.test.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @shopify/prefer-module-scope-constants */
 import {ensureExtensionsIds} from './identifiers-extensions.js'
 import {
+  buildDashboardBreakdownInfo,
+  buildExtensionBreakdownInfo,
   configExtensionsIdentifiersBreakdown,
   extensionsIdentifiersDeployBreakdown,
   extensionsIdentifiersReleaseBreakdown,
@@ -13,7 +15,6 @@ import {OrganizationApp} from '../../models/organization.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {AppModuleVersion} from '../../api/graphql/app_active_version.js'
 import {AppVersionsDiffExtensionSchema} from '../../api/graphql/app_versions_diff.js'
-import {loadFSExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {versionDiffByVersion} from '../release/version-diff.js'
 import {describe, vi, test, beforeAll, expect} from 'vitest'
 
@@ -35,6 +36,16 @@ const REGISTRATION_DASHBOARD_A = {
   id: 'D_A',
   title: 'Dashboard A',
   uuid: 'UUID_D_A',
+  type: 'flow_action_definition',
+  activeVersion: {
+    config: '{}',
+  },
+}
+
+const REGISTRATION_DASHBOARD_NEW = {
+  id: 'D_NEW',
+  title: 'Dashboard New',
+  uuid: 'UUID_D_NEW',
   type: 'flow_action_definition',
   activeVersion: {
     config: '{}',
@@ -136,6 +147,10 @@ const VERSION_DIFF_CONFIG_A: AppVersionsDiffExtensionSchema = {
   registrationTitle: 'Registration title',
   specification: {
     identifier: 'app_access',
+    experience: 'configuration',
+    options: {
+      managementExperience: 'cli',
+    },
   },
 }
 
@@ -144,6 +159,10 @@ const VERSION_DIFF_DASH_A: AppVersionsDiffExtensionSchema = {
   registrationTitle: 'Dashboard A',
   specification: {
     identifier: 'flow_action_definition',
+    experience: 'legacy',
+    options: {
+      managementExperience: 'dashboard',
+    },
   },
 }
 
@@ -152,6 +171,10 @@ const VERSION_DIFF_CLI_A: AppVersionsDiffExtensionSchema = {
   registrationTitle: 'Checkout post purchase',
   specification: {
     identifier: 'post_purchase_ui_extension',
+    experience: 'extension',
+    options: {
+      managementExperience: 'cli',
+    },
   },
 }
 
@@ -160,6 +183,10 @@ const VERSION_DIFF_DELETED_CLI_B: AppVersionsDiffExtensionSchema = {
   registrationTitle: 'Checkout post purchase Deleted B',
   specification: {
     identifier: 'post_purchase_ui_extension',
+    experience: 'extension',
+    options: {
+      managementExperience: 'cli',
+    },
   },
 }
 
@@ -309,8 +336,7 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
           toCreate: [],
-          toUpdate: ['EXTENSION_A', 'extension-a-2'],
-          fromDashboard: [],
+          toUpdate: [buildExtensionBreakdownInfo('EXTENSION_A'), buildExtensionBreakdownInfo('extension-a-2')],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,
@@ -344,9 +370,12 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
       expect(result).toEqual({
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
-          toCreate: ['EXTENSION_A', 'extension-a-2'],
+          toCreate: [
+            buildExtensionBreakdownInfo('EXTENSION_A'),
+            buildExtensionBreakdownInfo('extension-a-2'),
+            buildDashboardBreakdownInfo('Dashboard A'),
+          ],
           toUpdate: [],
-          fromDashboard: ['Dashboard A'],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,
@@ -378,9 +407,8 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
       expect(result).toEqual({
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
-          toCreate: ['EXTENSION_A', 'extension-a-2'],
-          toUpdate: [],
-          fromDashboard: ['Dashboard A'],
+          toCreate: [buildExtensionBreakdownInfo('EXTENSION_A'), buildExtensionBreakdownInfo('extension-a-2')],
+          toUpdate: [buildDashboardBreakdownInfo('Dashboard A')],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,
@@ -414,9 +442,8 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
       expect(result).toEqual({
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
-          toCreate: ['extension-a-2'],
-          toUpdate: ['EXTENSION_A'],
-          fromDashboard: ['Dashboard A'],
+          toCreate: [buildExtensionBreakdownInfo('extension-a-2')],
+          toUpdate: [buildExtensionBreakdownInfo('EXTENSION_A'), buildDashboardBreakdownInfo('Dashboard A')],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,
@@ -454,9 +481,11 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
       expect(result).toEqual({
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
-          toCreate: ['DASH_MIGRATED_EXTENSION_A', 'extension-a-2'],
-          toUpdate: ['EXTENSION_A'],
-          fromDashboard: ['Dashboard A'],
+          toCreate: [
+            buildExtensionBreakdownInfo('DASH_MIGRATED_EXTENSION_A'),
+            buildExtensionBreakdownInfo('extension-a-2'),
+          ],
+          toUpdate: [buildExtensionBreakdownInfo('EXTENSION_A'), buildDashboardBreakdownInfo('Dashboard A')],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,
@@ -468,13 +497,17 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
         app: {
           extensionRegistrations: [REGISTRATION_A, REGISTRATION_DASH_MIGRATED_A],
           configurationRegistrations: [],
-          dashboardManagedExtensionRegistrations: [REGISTRATION_DASHBOARD_A, REGISTRATION_DASH_MIGRATED_A],
+          dashboardManagedExtensionRegistrations: [
+            REGISTRATION_DASHBOARD_A,
+            REGISTRATION_DASH_MIGRATED_A,
+            REGISTRATION_DASHBOARD_NEW,
+          ],
         },
       }
       vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue(remoteExtensionRegistrations)
       const extensionsToConfirm = {
         validMatches: {EXTENSION_A: 'UUID_A', DASH_MIGRATED_EXTENSION_A: 'UUID_DM_A'},
-        dashboardOnlyExtensions: [REGISTRATION_DASHBOARD_A, REGISTRATION_DASH_MIGRATED_A],
+        dashboardOnlyExtensions: [REGISTRATION_DASHBOARD_A, REGISTRATION_DASH_MIGRATED_A, REGISTRATION_DASHBOARD_NEW],
         extensionsToCreate: [EXTENSION_A_2],
       }
       vi.mocked(ensureExtensionsIds).mockResolvedValue(extensionsToConfirm)
@@ -500,10 +533,16 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
       // Then
       expect(result).toEqual({
         extensionIdentifiersBreakdown: {
-          onlyRemote: ['Dashboard Deleted B', 'Checkout post purchase Deleted B'],
-          toCreate: ['DASH_MIGRATED_EXTENSION_A', 'extension-a-2'],
-          toUpdate: ['EXTENSION_A'],
-          fromDashboard: ['Dashboard A'],
+          onlyRemote: [
+            buildExtensionBreakdownInfo('Checkout post purchase Deleted B'),
+            buildDashboardBreakdownInfo('Dashboard Deleted B'),
+          ],
+          toCreate: [
+            buildExtensionBreakdownInfo('DASH_MIGRATED_EXTENSION_A'),
+            buildExtensionBreakdownInfo('extension-a-2'),
+            buildDashboardBreakdownInfo('Dashboard New'),
+          ],
+          toUpdate: [buildExtensionBreakdownInfo('EXTENSION_A'), buildDashboardBreakdownInfo('Dashboard A')],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,
@@ -515,7 +554,6 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
 describe('extensionsIdentifiersReleaseBreakdown', () => {
   test('when active version only includes app config modules then the response will be empty', async () => {
     // Given
-    const specifications = await loadFSExtensionsSpecifications()
     const versionDiff = {
       versionsDiff: {
         added: [],
@@ -534,7 +572,7 @@ describe('extensionsIdentifiersReleaseBreakdown', () => {
     vi.mocked(versionDiffByVersion).mockResolvedValue(versionDiff)
 
     // When
-    const result = await extensionsIdentifiersReleaseBreakdown('token', 'apiKey', ' 1.0.0', specifications)
+    const result = await extensionsIdentifiersReleaseBreakdown('token', 'apiKey', ' 1.0.0')
 
     // Then
     expect(result).toEqual({
@@ -542,7 +580,6 @@ describe('extensionsIdentifiersReleaseBreakdown', () => {
         onlyRemote: [],
         toCreate: [],
         toUpdate: [],
-        fromDashboard: [],
       },
       versionDetails: versionDiff.versionDetails,
     })
@@ -550,7 +587,6 @@ describe('extensionsIdentifiersReleaseBreakdown', () => {
 
   test('when active version only includes not only app config modules then the response will return them', async () => {
     // Given
-    const specifications = await loadFSExtensionsSpecifications()
     const versionDiff = {
       versionsDiff: {
         added: [VERSION_DIFF_CLI_A],
@@ -569,15 +605,14 @@ describe('extensionsIdentifiersReleaseBreakdown', () => {
     vi.mocked(versionDiffByVersion).mockResolvedValue(versionDiff)
 
     // When
-    const result = await extensionsIdentifiersReleaseBreakdown('token', 'apiKey', ' 1.0.0', specifications)
+    const result = await extensionsIdentifiersReleaseBreakdown('token', 'apiKey', ' 1.0.0')
 
     // Then
     expect(result).toEqual({
       extensionIdentifiersBreakdown: {
-        onlyRemote: ['Checkout post purchase Deleted B'],
-        toCreate: ['Checkout post purchase'],
-        toUpdate: ['Dashboard A'],
-        fromDashboard: [],
+        onlyRemote: [buildExtensionBreakdownInfo('Checkout post purchase Deleted B')],
+        toCreate: [buildExtensionBreakdownInfo('Checkout post purchase')],
+        toUpdate: [buildDashboardBreakdownInfo('Dashboard A')],
       },
       versionDetails: versionDiff.versionDetails,
     })

--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -1,7 +1,6 @@
 import {ensureExtensionsIds} from './identifiers-extensions.js'
 import {EnsureDeploymentIdsPresenceOptions, LocalSource, RemoteSource} from './identifiers.js'
 import {fetchActiveAppVersion, fetchAppExtensionRegistrations} from '../dev/fetch.js'
-import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {versionDiffByVersion} from '../release/version-diff.js'
 import {AppVersionsDiffExtensionSchema} from '../../api/graphql/app_versions_diff.js'
 import {AppInterface, CurrentAppConfiguration, filterNonVersionedAppFields} from '../../models/app/app.js'
@@ -9,7 +8,7 @@ import {remoteAppConfigurationExtensionContent} from '../app/config/link.js'
 import {buildDiffConfigContent} from '../../prompts/config.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
-import {AppModuleVersion} from '../../api/graphql/app_active_version.js'
+import {ActiveAppVersionQuerySchema, AppModuleVersion} from '../../api/graphql/app_active_version.js'
 
 export interface ConfigExtensionIdentifiersBreakdown {
   existingFieldNames: string[]
@@ -18,11 +17,23 @@ export interface ConfigExtensionIdentifiersBreakdown {
   deletedFieldNames: string[]
 }
 
+export interface ExtensionIdentifierBreakdownInfo {
+  title: string
+  experience: 'extension' | 'dashboard'
+}
+
+export function buildExtensionBreakdownInfo(title: string): ExtensionIdentifierBreakdownInfo {
+  return {title, experience: 'extension'}
+}
+
+export function buildDashboardBreakdownInfo(title: string): ExtensionIdentifierBreakdownInfo {
+  return {title, experience: 'dashboard'}
+}
+
 export interface ExtensionIdentifiersBreakdown {
-  onlyRemote: string[]
-  toCreate: string[]
-  toUpdate: string[]
-  fromDashboard: string[]
+  onlyRemote: ExtensionIdentifierBreakdownInfo[]
+  toCreate: ExtensionIdentifierBreakdownInfo[]
+  toUpdate: ExtensionIdentifierBreakdownInfo[]
 }
 
 export async function extensionsIdentifiersDeployBreakdown(options: EnsureDeploymentIdsPresenceOptions) {
@@ -32,10 +43,7 @@ export async function extensionsIdentifiersDeployBreakdown(options: EnsureDeploy
   })
 
   const extensionsToConfirm = await ensureExtensionsIds(options, remoteExtensionsRegistrations.app)
-  let extensionIdentifiersBreakdown = loadLocalExtensionsIdentifiersBreakdown(
-    extensionsToConfirm.validMatches,
-    extensionsToConfirm.extensionsToCreate,
-  )
+  let extensionIdentifiersBreakdown = loadLocalExtensionsIdentifiersBreakdown(extensionsToConfirm)
   if (options.release) {
     extensionIdentifiersBreakdown = await resolveRemoteExtensionIdentifiersBreakdown(
       options.token,
@@ -52,28 +60,22 @@ export async function extensionsIdentifiersDeployBreakdown(options: EnsureDeploy
   }
 }
 
-export async function extensionsIdentifiersReleaseBreakdown(
-  token: string,
-  apiKey: string,
-  version: string,
-  specifications: ExtensionSpecification[],
-) {
+export async function extensionsIdentifiersReleaseBreakdown(token: string, apiKey: string, version: string) {
   const {versionsDiff, versionDetails} = await versionDiffByVersion(apiKey, version, token)
 
-  // The content of the app_config extensions are not included in the versions diff so it's not possible to get the
-  // comparison between the version to release and the current active version
-  const filterAppConfigExtension = (remoteExtension: AppVersionsDiffExtensionSchema) =>
-    !specifications
-      .filter((specification) => specification.appModuleFeatures().includes('app_config'))
-      .map((specification) => specification.identifier)
-      .includes(remoteExtension.specification.identifier)
+  const mapIsExtension = (extensions: AppVersionsDiffExtensionSchema[]) =>
+    extensions
+      .filter((extension) => extension.specification.experience === 'extension')
+      .map((extension) => buildExtensionBreakdownInfo(extension.registrationTitle))
+  const mapIsDashboard = (extensions: AppVersionsDiffExtensionSchema[]) =>
+    extensions
+      .filter((extension) => extension.specification.options.managementExperience === 'dashboard')
+      .map((extension) => buildDashboardBreakdownInfo(extension.registrationTitle))
 
   const extensionIdentifiersBreakdown = {
-    onlyRemote: versionsDiff.removed.filter(filterAppConfigExtension).map((extension) => extension.registrationTitle),
-    toCreate: versionsDiff.added.filter(filterAppConfigExtension).map((extension) => extension.registrationTitle),
-    toUpdate: versionsDiff.updated.filter(filterAppConfigExtension).map((extension) => extension.registrationTitle),
-    // dashboard specs will appear in the oher sections
-    fromDashboard: [] as string[],
+    onlyRemote: [...mapIsExtension(versionsDiff.removed), ...mapIsDashboard(versionsDiff.removed)],
+    toCreate: [...mapIsExtension(versionsDiff.added), ...mapIsDashboard(versionsDiff.added)],
+    toUpdate: [...mapIsExtension(versionsDiff.updated), ...mapIsDashboard(versionsDiff.updated)],
   }
 
   return {extensionIdentifiersBreakdown, versionDetails}
@@ -233,17 +235,24 @@ function getFieldsFromDiffConfigContent(diffConfigContent: string): string[] {
   return Array.from(new Set(fields))
 }
 
-function loadLocalExtensionsIdentifiersBreakdown(
-  localRegistration: IdentifiersExtensions,
-  localSourceToCreate: LocalSource[],
-): ExtensionIdentifiersBreakdown {
-  const identifiersToUpdate = Object.keys(localRegistration)
-  const identifiersToCreate = localSourceToCreate.map((source) => source.localIdentifier)
+function loadLocalExtensionsIdentifiersBreakdown({
+  validMatches: localRegistration,
+  extensionsToCreate: localSourceToCreate,
+  dashboardOnlyExtensions,
+}: {
+  validMatches: IdentifiersExtensions
+  extensionsToCreate: LocalSource[]
+  dashboardOnlyExtensions: RemoteSource[]
+}): ExtensionIdentifiersBreakdown {
+  const identifiersToUpdate = Object.keys(localRegistration).map(buildExtensionBreakdownInfo)
+  const identifiersToCreate = localSourceToCreate.map((source) => buildExtensionBreakdownInfo(source.localIdentifier))
+  const dashboardToUpdate = dashboardOnlyExtensions
+    .filter((dashboard) => !Object.values(localRegistration).includes(dashboard.uuid))
+    .map((dashboard) => buildDashboardBreakdownInfo(dashboard.title))
   return {
-    onlyRemote: [] as string[],
-    toCreate: [] as string[],
-    toUpdate: [...identifiersToUpdate, ...identifiersToCreate],
-    fromDashboard: [] as string[],
+    onlyRemote: [] as ExtensionIdentifierBreakdownInfo[],
+    toCreate: [] as ExtensionIdentifierBreakdownInfo[],
+    toUpdate: [...identifiersToUpdate, ...identifiersToCreate, ...dashboardToUpdate],
   }
 }
 
@@ -256,45 +265,88 @@ async function resolveRemoteExtensionIdentifiersBreakdown(
 ): Promise<ExtensionIdentifiersBreakdown> {
   const activeAppVersion = await fetchActiveAppVersion({token, apiKey})
 
-  const appModuleVersionsNonConfig =
+  const extensionIdentifiersBreakdown = loadExtensionsIdentifiersBreakdown(
+    activeAppVersion,
+    localRegistration,
+    toCreate,
+  )
+
+  const dashboardOnlyFinal = dashboardOnly.filter(
+    (dashboardOnly) =>
+      !Object.values(localRegistration).includes(dashboardOnly.uuid) &&
+      !toCreate.map((source) => source.localIdentifier).includes(dashboardOnly.uuid),
+  )
+  const dashboardIdentifiersBreakdown = loadDashboardIdentifiersBreakdown(dashboardOnlyFinal, activeAppVersion)
+
+  return {
+    onlyRemote: [...extensionIdentifiersBreakdown.onlyRemote, ...dashboardIdentifiersBreakdown.onlyRemote],
+    toCreate: [...extensionIdentifiersBreakdown.toCreate, ...dashboardIdentifiersBreakdown.toCreate],
+    toUpdate: [...extensionIdentifiersBreakdown.toUpdate, ...dashboardIdentifiersBreakdown.toUpdate],
+  }
+}
+
+function loadExtensionsIdentifiersBreakdown(
+  activeAppVersion: ActiveAppVersionQuerySchema,
+  localRegistration: IdentifiersExtensions,
+  toCreate: LocalSource[],
+) {
+  const extensionModules =
     activeAppVersion.app.activeAppVersion?.appModuleVersions.filter(
-      (module) => !module.specification || module.specification.experience !== 'configuration',
+      (module) => !module.specification || module.specification.experience === 'extension',
     ) || []
 
-  const nonDashboardRemoteRegistrationUuids =
-    appModuleVersionsNonConfig
-      .filter((module) => module.specification!.options.managementExperience !== 'dashboard')
-      .map((remoteRegistration) => remoteRegistration.registrationUuid) ?? []
+  const extensionsToUpdate = Object.entries(localRegistration)
+    .filter(([_identifier, uuid]) => extensionModules.map((module) => module.registrationUuid).includes(uuid))
+    .map(([identifier, _uuid]) => identifier)
 
-  let toCreateFinal: string[] = []
-  const toUpdate: string[] = []
-  let dashboardOnlyFinal = dashboardOnly
+  let extensionsToCreate = Object.entries(localRegistration)
+    .filter(([_identifier, uuid]) => !extensionModules.map((module) => module.registrationUuid).includes(uuid))
+    .map(([identifier, _uuid]) => identifier)
+  extensionsToCreate = Array.from(new Set(extensionsToCreate.concat(toCreate.map((source) => source.localIdentifier))))
 
-  for (const [identifier, uuid] of Object.entries(localRegistration)) {
-    if (nonDashboardRemoteRegistrationUuids.includes(uuid)) {
-      toUpdate.push(identifier)
-    } else {
-      toCreateFinal.push(identifier)
-    }
+  const extensionsOnlyRemote = extensionModules
+    .filter(
+      (module) =>
+        !Object.values(localRegistration).includes(module.registrationUuid) &&
+        !toCreate.map((source) => source.localIdentifier).includes(module.registrationUuid),
+    )
+    .map((module) => module.registrationTitle)
 
-    dashboardOnlyFinal = dashboardOnlyFinal.filter((dashboardOnly) => dashboardOnly.uuid !== uuid)
+  return {
+    onlyRemote: extensionsOnlyRemote.map(buildExtensionBreakdownInfo),
+    toCreate: extensionsToCreate.map(buildExtensionBreakdownInfo),
+    toUpdate: extensionsToUpdate.map(buildExtensionBreakdownInfo),
   }
+}
 
-  toCreateFinal = Array.from(new Set(toCreateFinal.concat(toCreate.map((source) => source.localIdentifier))))
+function loadDashboardIdentifiersBreakdown(
+  currentRegistrations: RemoteSource[],
+  activeAppVersion: ActiveAppVersionQuerySchema,
+) {
+  const currentVersions =
+    activeAppVersion.app.activeAppVersion?.appModuleVersions.filter(
+      (module) => module.specification!.options.managementExperience === 'dashboard',
+    ) || []
 
-  const localRegistrationAndDashboard = [
-    ...Object.values(localRegistration),
-    ...dashboardOnly.map((source) => source.uuid),
-  ]
-  const onlyRemote =
-    appModuleVersionsNonConfig
-      .filter((module) => !localRegistrationAndDashboard.includes(module.registrationUuid))
-      .map((module) => module.registrationTitle) ?? []
+  const versionsNotIncluded = (version: AppModuleVersion) =>
+    !currentRegistrations.map((registration) => registration.uuid).includes(version.registrationUuid)
+  const onlyRemote = currentVersions
+    .filter(versionsNotIncluded)
+    .map((module) => buildDashboardBreakdownInfo(module.registrationTitle))
+
+  const registrationIncluded = (registration: RemoteSource) =>
+    currentVersions.map((version) => version.registrationUuid).includes(registration.uuid)
+  const registrationNotIncluded = (registration: RemoteSource) => !registrationIncluded(registration)
+  const toCreate = currentRegistrations
+    .filter(registrationNotIncluded)
+    .map((registration) => buildDashboardBreakdownInfo(registration.title))
+  const toUpdate = currentRegistrations
+    .filter(registrationIncluded)
+    .map((registration) => buildDashboardBreakdownInfo(registration.title))
 
   return {
     onlyRemote,
-    toCreate: toCreateFinal.map((identifier) => identifier),
+    toCreate,
     toUpdate,
-    fromDashboard: dashboardOnlyFinal.map((source) => source.title),
   }
 }

--- a/packages/app/src/cli/services/release.ts
+++ b/packages/app/src/cli/services/release.ts
@@ -38,7 +38,6 @@ export async function release(options: ReleaseOptions) {
     token,
     partnersApp.apiKey,
     options.version,
-    app.specifications ?? [],
   )
   const configExtensionIdentifiersBreakdown = await configExtensionsIdentifiersBreakdown({
     token,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Follow-up: https://github.com/Shopify/cli/pull/3205

UX: [figma](https://www.figma.com/file/cTu9Ag52V4IdqZe1cij6kK/Versioned-app-config?type=design&node-id=10462%3A3898&mode=design&t=oBcgyeoQdDYSZWPc-1) 

Right now the source extension breakdown info data is different for the `deploy` and the `release` command. The former uses the `local` information and the second the API operation `appVersionDiff`
The `appVersionDiff` API return properly classified the `dashboard` extensions as `new`, `update` or `removed` (but it doesn't distinguish between `dashboard` or `extension`), however the local logic in the `deploy` command manages a list of `affected` dashboard extension regardless the modification made to them.
This drives us to a situation like this.
- `release` command prompt
<img src="https://github.com/Shopify/cli/assets/105213827/6213a173-c977-44cf-9661-d3c3b9162994" width=300/>

- `deploy` command prompt

<img src="https://github.com/Shopify/cli/assets/105213827/cbb03c2c-c45d-4b0b-bf43-37261955c671" width=300/>

the extension `my cool admin link` is the same dashboard extension in both cases





<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Extensions breakdown info now includes the `experience` of the extension
- Extensions breakdown info doesn't return the `dashboard` extensions in a specific list but included in the list `toUpdate`, `toCreate`, `toRemove`
- The method that builds the prompt `TableInfo` content from the extensions breakdown info, now manage the `dashboard` extensions:
  - In each of the three list the `extensions` goes always first and then the `dashboard`
  - `dashboard` extensions includes a custom suffix which value depends on the list type (`new, from Partners dashboard`, `from Partners Dashboard`, `removed, from Partners Dashboard)
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- NOTE: Prompts will always display `┃  + webhooks (new)` and  it's not possible to display the message `No changes`.  The problem is that `api_version` inside `webhooks` is not versioned yet in the server side thus it's not deployed. Each time you run `deploy` command you will see the change. This behaviour will be fixed once  this [Add support for the versioned field webhooks->api_version](https://github.com/Shopify/cli/pull/3227) PR is merged
- Create a new `cli` app and run the `p shopify app config link --path /PATH/TO/YOUR/APP` command to link it to a new remote app. 

#### Scenario 1
- Generate a new extension `p shopify app generate extension --path /PATH/TO/YOUR/APP`
- Create a new dashboard extension from partners in the app created in the first step (ie `Admin link`)
- Run the `SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 npm run shopify app deploy --path /PATH/TO/YOUR/APP` and confirm the deployment
<img src="https://github.com/Shopify/cli/assets/105213827/d9872558-af8c-4e01-9a59-dd6a36e7c69d" width=300/>

#### Scenario 2
- Generate a new extension `p shopify app generate extension --path /PATH/TO/YOUR/APP`
- Create a new dashboard extension from partners in the app created in the first step (ie `Admin link`)
- Run the `SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 npm run shopify app deploy --path /PATH/TO/YOUR/APP`
<img src="https://github.com/Shopify/cli/assets/105213827/b46f5a96-b1fd-4519-adf7-3ebe0109aab8" width=300/>

#### Scenario 3
- Delete one of your local previous extension
- Delete one of the dashboard extension
- Generate a new extension `p shopify app generate extension --path /PATH/TO/YOUR/APP`
- Create a new dashboard extension from partners in the app created in the first step (ie `Admin link`)
- Run the `SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 npm run shopify app deploy --path /PATH/TO/YOUR/APP`
<img src="https://github.com/Shopify/cli/assets/105213827/cfc08eb4-da32-4d70-b2a6-0eea8d214ba8" width=300/>


Repeat the same three scenarios but in this case using the `release` command so instead of using `deploy` with release you should run:
- `SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 npm run shopify app deploy --path /PATH/TO/YOUR/APP --no-release`
- `SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 npm run shopify app release --path /PATH/TO/YOUR/APP --version PREVIOUS_VERSION`
The prompt output should be the same
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
