### PR TITLE
Clean up legacy function upload code

### DIFF
--- a/packages/app/src/cli/api/graphql/functions/upload_url_generate.ts
+++ b/packages/app/src/cli/api/graphql/functions/upload_url_generate.ts
@@ -1,28 +1,4 @@
-import {gql} from 'graphql-request'
-
-export const UploadUrlGenerateMutation = gql`
-  mutation uploadUrlGenerate {
-    uploadUrlGenerate {
-      url
-      moduleId
-      headers
-      maxSize
-    }
-  }
-`
-
 export interface UploadUrlGenerateMutationSchema {
-  data: {
-    uploadUrlGenerate: {
-      url: string
-      moduleId: string
-      headers: {[key: string]: string}
-      maxSize: string
-    }
-  }
-}
-
-export interface UploadUrlGenerateMutationSchemaNew {
   uploadUrlGenerate: {
     url: string
     moduleId: string

--- a/packages/app/src/cli/api/graphql/functions/upload_url_generate.ts
+++ b/packages/app/src/cli/api/graphql/functions/upload_url_generate.ts
@@ -21,3 +21,12 @@ export interface UploadUrlGenerateMutationSchema {
     }
   }
 }
+
+export interface UploadUrlGenerateMutationSchemaNew {
+  uploadUrlGenerate: {
+    url: string
+    moduleId: string
+    headers: {[key: string]: string}
+    maxSize: string
+  }
+}

--- a/packages/app/src/cli/api/graphql/functions/upload_url_generate.ts
+++ b/packages/app/src/cli/api/graphql/functions/upload_url_generate.ts
@@ -1,8 +1,0 @@
-export interface UploadUrlGenerateMutationSchema {
-  uploadUrlGenerate: {
-    url: string
-    moduleId: string
-    headers: {[key: string]: string}
-    maxSize: string
-  }
-}

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -1,6 +1,6 @@
 import {ensureDeployContext} from './context.js'
 import {deploy} from './deploy.js'
-import {uploadWasmBlob, uploadExtensionsBundle, uploadFunctionExtensions} from './deploy/upload.js'
+import {uploadWasmBlob, uploadExtensionsBundle} from './deploy/upload.js'
 import {fetchAppExtensionRegistrations} from './dev/fetch.js'
 import {bundleAndBuildExtensions} from './deploy/bundle.js'
 import {
@@ -523,7 +523,6 @@ async function testDeployBundle({
   })
 
   vi.mocked(useThemebundling).mockReturnValue(true)
-  vi.mocked(uploadFunctionExtensions).mockResolvedValue(identifiers)
   vi.mocked(uploadExtensionsBundle).mockResolvedValue({
     validationErrors: [],
     versionTag,

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -1,15 +1,16 @@
-import {deploymentErrorsToCustomSections, uploadExtensionsBundle, uploadFunctionExtensions} from './upload.js'
+import {deploymentErrorsToCustomSections, uploadExtensionsBundle, uploadWasmBlob} from './upload.js'
 import {Identifiers} from '../../models/app/identifiers.js'
 import {
   UploadUrlGenerateMutation,
   UploadUrlGenerateMutationSchema,
+  UploadUrlGenerateMutationSchemaNew,
 } from '../../api/graphql/functions/upload_url_generate.js'
 import {AppFunctionSetMutation, AppFunctionSetMutationSchema} from '../../api/graphql/functions/app_function_set.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {testFunctionExtension} from '../../models/app/app.test-data.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
-import {functionProxyRequest, partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {getFunctionUploadUrl, partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
 import {fetch, formData} from '@shopify/cli-kit/node/http'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -21,9 +22,10 @@ vi.mock('@shopify/cli-kit/node/http')
 vi.mock('@shopify/cli-kit/node/session')
 vi.mock('@shopify/cli-kit/node/crypto')
 
-describe('uploadFunctionExtensions', () => {
+describe('uploadWasmBlob', () => {
   let extension: ExtensionInstance<FunctionConfigType>
   let identifiers: Identifiers
+  let apiKey: string
   let token: string
 
   beforeEach(async () => {
@@ -55,8 +57,7 @@ describe('uploadFunctionExtensions', () => {
         metafields: [],
       },
     })
-
-    token = 'token'
+    ;(apiKey = 'api-key'), (token = 'token')
     identifiers = {
       app: 'api=key',
       extensions: {},
@@ -71,13 +72,15 @@ describe('uploadFunctionExtensions', () => {
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
       const uploadURLError = new Error('upload error')
-      vi.mocked(functionProxyRequest).mockRejectedValueOnce(uploadURLError)
+      vi.mocked(getFunctionUploadUrl).mockRejectedValueOnce(uploadURLError)
 
       // When
-      await expect(uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrow(uploadURLError)
+      await expect(uploadWasmBlob(extension.localIdentifier, extension.outputPath, apiKey, token)).rejects.toThrow(
+        uploadURLError,
+      )
 
       // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
+      expect(getFunctionUploadUrl).toHaveBeenNthCalledWith(1, token)
     })
   })
 
@@ -87,68 +90,25 @@ describe('uploadFunctionExtensions', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
+      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+        uploadUrlGenerate: {
+          headers: {},
+          maxSize: '200 kb',
+          url: uploadUrl,
+          moduleId: 'module-id',
         },
       }
       const uploadError = new Error('error')
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
+      vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
       vi.mocked(fetch).mockRejectedValue(uploadError)
 
       // When
-      await expect(uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrow(uploadError)
-
-      // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
-    })
-  })
-
-  test('prints unsupported api version error if any user errors are returned with version_unsupported_error tag', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const uploadUrl = `test://test.com/moduleId.wasm`
-      extension.outputPath = joinPath(tmpDir, 'index.wasm')
-      await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
-        },
-      }
-      const functionSetMutationResponse: AppFunctionSetMutationSchema = {
-        data: {
-          functionSet: {
-            userErrors: [
-              {
-                field: '',
-                message: "Version '2022-07' for 'product_discounts' is unsupported.",
-                tag: 'version_unsupported_error',
-              },
-            ],
-          },
-        },
-      }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
-      vi.mocked(fetch).mockImplementation(vi.fn().mockResolvedValueOnce({status: 200}))
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(functionSetMutationResponse)
-
-      // When
-      await expect(() => uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrowError(
-        /Deployment failed due to an outdated API version/,
+      await expect(uploadWasmBlob(extension.localIdentifier, extension.outputPath, apiKey, token)).rejects.toThrow(
+        uploadError,
       )
 
       // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
+      expect(getFunctionUploadUrl).toHaveBeenNthCalledWith(1, token)
     })
   })
 
@@ -158,17 +118,15 @@ describe('uploadFunctionExtensions', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200 kb',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
+      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+        uploadUrlGenerate: {
+          headers: {},
+          maxSize: '200 kb',
+          url: uploadUrl,
+          moduleId: 'module-id',
         },
       }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
+      vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
 
       const mockedFetch = vi.fn().mockResolvedValueOnce({
         status: 400,
@@ -181,14 +139,16 @@ describe('uploadFunctionExtensions', () => {
       vi.mocked(fetch).mockImplementation(mockedFetch)
 
       // When
-      await expect(() => uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrowError(
+      await expect(() =>
+        uploadWasmBlob(extension.localIdentifier, extension.outputPath, apiKey, token),
+      ).rejects.toThrowError(
         new AbortError(
           'The size of the Wasm binary file for Function my-function is too large. It must be less than 200 kb.',
         ),
       )
 
       // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
+      expect(getFunctionUploadUrl).toHaveBeenNthCalledWith(1, token)
     })
   })
 
@@ -198,17 +158,15 @@ describe('uploadFunctionExtensions', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
+      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+        uploadUrlGenerate: {
+          headers: {},
+          maxSize: '200 kb',
+          url: uploadUrl,
+          moduleId: 'module-id',
         },
       }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
+      vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
 
       const mockedFetch = vi.fn().mockResolvedValueOnce({
         status: 401,
@@ -221,14 +179,16 @@ describe('uploadFunctionExtensions', () => {
       vi.mocked(fetch).mockImplementation(mockedFetch)
 
       // When
-      await expect(() => uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrowError(
+      await expect(() =>
+        uploadWasmBlob(extension.localIdentifier, extension.outputPath, apiKey, token),
+      ).rejects.toThrowError(
         new AbortError(
           'Something went wrong uploading the Function my-function. The server responded with status 401 and body: error body',
         ),
       )
 
       // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
+      expect(getFunctionUploadUrl).toHaveBeenNthCalledWith(1, token)
     })
   })
 
@@ -238,17 +198,15 @@ describe('uploadFunctionExtensions', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
+      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+        uploadUrlGenerate: {
+          headers: {},
+          maxSize: '200 kb',
+          url: uploadUrl,
+          moduleId: 'module-id',
         },
       }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
+      vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
 
       const mockedFetch = vi.fn().mockResolvedValueOnce({
         status: 500,
@@ -261,12 +219,12 @@ describe('uploadFunctionExtensions', () => {
       vi.mocked(fetch).mockImplementation(mockedFetch)
 
       // When
-      await expect(() => uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrowError(
-        new AbortError('Something went wrong uploading the Function my-function. Try again.'),
-      )
+      await expect(() =>
+        uploadWasmBlob(extension.localIdentifier, extension.outputPath, apiKey, token),
+      ).rejects.toThrowError(new AbortError('Something went wrong uploading the Function my-function. Try again.'))
 
       // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
+      expect(getFunctionUploadUrl).toHaveBeenNthCalledWith(1, token)
     })
   })
 
@@ -276,17 +234,15 @@ describe('uploadFunctionExtensions', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
+      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+        uploadUrlGenerate: {
+          headers: {},
+          maxSize: '200 kb',
+          url: uploadUrl,
+          moduleId: 'module-id',
         },
       }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
+      vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
 
       const mockedFetch = vi.fn().mockResolvedValueOnce({
         status: 399,
@@ -299,12 +255,12 @@ describe('uploadFunctionExtensions', () => {
       vi.mocked(fetch).mockImplementation(mockedFetch)
 
       // When
-      await expect(() => uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrowError(
-        new AbortError('Something went wrong uploading the Function my-function. Try again.'),
-      )
+      await expect(() =>
+        uploadWasmBlob(extension.localIdentifier, extension.outputPath, apiKey, token),
+      ).rejects.toThrowError(new AbortError('Something went wrong uploading the Function my-function. Try again.'))
 
       // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
+      expect(getFunctionUploadUrl).toHaveBeenNthCalledWith(1, token)
     })
   })
 
@@ -314,441 +270,25 @@ describe('uploadFunctionExtensions', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
+      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+        uploadUrlGenerate: {
+          headers: {},
+          maxSize: '200 kb',
+          url: uploadUrl,
+          moduleId: 'module-id',
         },
       }
       const uploadError = new Error('error')
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
+      vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
       vi.mocked(fetch).mockRejectedValue(uploadError)
 
       // When
-      await expect(uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrow(uploadError)
-
-      // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
-    })
-  })
-
-  test('errors if the update of the function errors', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const uploadUrl = `test://test.com/moduleId.wasm`
-      extension.outputPath = joinPath(tmpDir, 'index.wasm')
-      await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
-        },
-      }
-      const updateAppFunctionError = new Error('error')
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
-      vi.mocked(fetch).mockImplementation(vi.fn().mockResolvedValueOnce({status: 200}))
-      vi.mocked(functionProxyRequest).mockRejectedValueOnce(updateAppFunctionError)
-
-      // When
-      await expect(() => uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrowError(
-        updateAppFunctionError,
+      await expect(uploadWasmBlob(extension.localIdentifier, extension.outputPath, apiKey, token)).rejects.toThrow(
+        uploadError,
       )
 
       // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
-      expect(fetch).toHaveBeenCalledWith(uploadUrl, {
-        body: Buffer.from(''),
-        headers: {'Content-Type': 'application/wasm'},
-        method: 'PUT',
-      })
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(2, identifiers.app, AppFunctionSetMutation, token, {
-        id: undefined,
-        title: extension.configuration.name,
-        description: extension.configuration.description,
-        apiType: 'order_discounts',
-        apiVersion: extension.configuration.api_version,
-        appBridge: {
-          detailsPath: (extension.configuration.ui?.paths ?? {}).details,
-          createPath: (extension.configuration.ui?.paths ?? {}).create,
-        },
-        inputQueryVariables: {
-          singleJsonMetafield: {
-            namespace: 'namespace',
-            key: 'key',
-          },
-        },
-        enableCreationUi: true,
-        moduleUploadUrl: uploadUrl,
-      })
-    })
-  })
-
-  test('throws if the response from updating the app function contains errors', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const uploadUrl = `test://test.com/moduleId.wasm`
-      extension.outputPath = joinPath(tmpDir, 'index.wasm')
-      await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
-        },
-      }
-      const functionSetMutationResponse: AppFunctionSetMutationSchema = {
-        data: {
-          functionSet: {
-            userErrors: [
-              {
-                field: 'field',
-                message: 'missing field',
-                tag: 'tag',
-              },
-            ],
-          },
-        },
-      }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
-      vi.mocked(fetch).mockImplementation(vi.fn().mockResolvedValueOnce({status: 200}))
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(functionSetMutationResponse)
-
-      // When
-      await expect(() => uploadFunctionExtensions([extension], {token, identifiers})).rejects.toThrowError(
-        /The deployment of functions failed with the following errors:/,
-      )
-
-      // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
-      expect(fetch).toHaveBeenCalledWith(uploadUrl, {
-        body: Buffer.from(''),
-        headers: {'Content-Type': 'application/wasm'},
-        method: 'PUT',
-      })
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(2, identifiers.app, AppFunctionSetMutation, token, {
-        id: undefined,
-        title: extension.configuration.name,
-        description: extension.configuration.description,
-        apiType: 'order_discounts',
-        apiVersion: extension.configuration.api_version,
-        appBridge: {
-          detailsPath: (extension.configuration.ui?.paths ?? {}).details,
-          createPath: (extension.configuration.ui?.paths ?? {}).create,
-        },
-        inputQueryVariables: {
-          singleJsonMetafield: {
-            namespace: 'namespace',
-            key: 'key',
-          },
-        },
-        enableCreationUi: true,
-        moduleUploadUrl: uploadUrl,
-      })
-    })
-  })
-
-  test('creates and uploads the function', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const uploadUrl = `test://test.com/moduleId.wasm`
-      const createdID = 'ulid'
-      extension.outputPath = joinPath(tmpDir, 'index.wasm')
-      await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
-        },
-      }
-      const functionSetMutationResponse: AppFunctionSetMutationSchema = {
-        data: {
-          functionSet: {
-            userErrors: [],
-            function: {
-              id: createdID,
-            },
-          },
-        },
-      }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
-      vi.mocked(fetch).mockImplementation(vi.fn().mockResolvedValueOnce({status: 200}))
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(functionSetMutationResponse)
-
-      // When
-      const got = await uploadFunctionExtensions([extension], {token, identifiers})
-
-      // Then
-      expect(got.extensions[extension.localIdentifier]).toEqual(createdID)
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
-      expect(fetch).toHaveBeenCalledWith(uploadUrl, {
-        body: Buffer.from(''),
-        headers: {'Content-Type': 'application/wasm'},
-        method: 'PUT',
-      })
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(2, identifiers.app, AppFunctionSetMutation, token, {
-        id: undefined,
-        title: extension.configuration.name,
-        description: extension.configuration.description,
-        apiType: 'order_discounts',
-        apiVersion: extension.configuration.api_version,
-        appBridge: {
-          detailsPath: (extension.configuration.ui?.paths ?? {}).details,
-          createPath: (extension.configuration.ui?.paths ?? {}).create,
-        },
-        inputQueryVariables: {
-          singleJsonMetafield: {
-            namespace: 'namespace',
-            key: 'key',
-          },
-        },
-        enableCreationUi: true,
-        moduleUploadUrl: uploadUrl,
-      })
-    })
-  })
-
-  test('appBridge is set to undefined when there is no configuration.ui.paths', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      extension.configuration.ui!.paths = undefined
-
-      const uploadUrl = `test://test.com/moduleId.wasm`
-      extension.outputPath = joinPath(tmpDir, 'index.wasm')
-      await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
-        },
-      }
-      const functionSetMutationResponse: AppFunctionSetMutationSchema = {
-        data: {
-          functionSet: {
-            userErrors: [],
-            function: {
-              id: 'uuid',
-            },
-          },
-        },
-      }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
-      vi.mocked(fetch).mockImplementation(vi.fn().mockResolvedValueOnce({status: 200}))
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(functionSetMutationResponse)
-
-      // When
-      await uploadFunctionExtensions([extension], {token, identifiers})
-
-      // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(2, identifiers.app, AppFunctionSetMutation, token, {
-        id: undefined,
-        title: extension.configuration.name,
-        description: extension.configuration.description,
-        apiType: 'order_discounts',
-        apiVersion: extension.configuration.api_version,
-        appBridge: undefined,
-        enableCreationUi: true,
-        inputQueryVariables: {
-          singleJsonMetafield: {
-            namespace: 'namespace',
-            key: 'key',
-          },
-        },
-        moduleUploadUrl: uploadUrl,
-      })
-    })
-  })
-
-  test('inputQueryVariables is set to undefined when there is no configuration.inputs', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      extension.configuration.input = undefined
-
-      const uploadUrl = `test://test.com/moduleId.wasm`
-      extension.outputPath = joinPath(tmpDir, 'index.wasm')
-      await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
-        },
-      }
-      const functionSetMutationResponse: AppFunctionSetMutationSchema = {
-        data: {
-          functionSet: {
-            userErrors: [],
-            function: {
-              id: 'uuid',
-            },
-          },
-        },
-      }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
-      vi.mocked(fetch).mockImplementation(vi.fn().mockResolvedValueOnce({status: 200}))
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(functionSetMutationResponse)
-
-      // When
-      await uploadFunctionExtensions([extension], {token, identifiers})
-
-      // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(2, identifiers.app, AppFunctionSetMutation, token, {
-        id: undefined,
-        title: extension.configuration.name,
-        description: extension.configuration.description,
-        apiType: 'order_discounts',
-        apiVersion: extension.configuration.api_version,
-        appBridge: {
-          detailsPath: (extension.configuration.ui?.paths ?? {}).details,
-          createPath: (extension.configuration.ui?.paths ?? {}).create,
-        },
-        enableCreationUi: true,
-        inputQueryVariables: undefined,
-        moduleUploadUrl: uploadUrl,
-      })
-    })
-  })
-
-  test('enableCreationUi is set to false when configuration.ui.enable_create is false', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      extension.configuration.ui!.enable_create = false
-
-      const uploadUrl = `test://test.com/moduleId.wasm`
-      extension.outputPath = joinPath(tmpDir, 'index.wasm')
-      await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
-        },
-      }
-      const functionSetMutationResponse: AppFunctionSetMutationSchema = {
-        data: {
-          functionSet: {
-            userErrors: [],
-            function: {
-              id: 'uuid',
-            },
-          },
-        },
-      }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
-      vi.mocked(fetch).mockImplementation(vi.fn().mockResolvedValueOnce({status: 200}))
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(functionSetMutationResponse)
-
-      // When
-      await uploadFunctionExtensions([extension], {token, identifiers})
-
-      // Then
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(2, identifiers.app, AppFunctionSetMutation, token, {
-        id: undefined,
-        title: extension.configuration.name,
-        description: extension.configuration.description,
-        apiType: 'order_discounts',
-        apiVersion: extension.configuration.api_version,
-        appBridge: {
-          detailsPath: (extension.configuration.ui?.paths ?? {}).details,
-          createPath: (extension.configuration.ui?.paths ?? {}).create,
-        },
-        inputQueryVariables: {
-          singleJsonMetafield: {
-            namespace: 'namespace',
-            key: 'key',
-          },
-        },
-        enableCreationUi: false,
-        moduleUploadUrl: uploadUrl,
-      })
-    })
-  })
-
-  test('UUID identifier detected and ULID Function ID returned', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const existingID = 'uuid-with-hyphens'
-      identifiers.extensions[extension.localIdentifier] = existingID
-      const uploadUrl = `test://test.com/moduleId.wasm`
-      const updatedID = 'ulid'
-      extension.outputPath = joinPath(tmpDir, 'index.wasm')
-      await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        data: {
-          uploadUrlGenerate: {
-            headers: {},
-            maxSize: '200',
-            url: uploadUrl,
-            moduleId: 'module-id',
-          },
-        },
-      }
-      const functionSetMutationResponse: AppFunctionSetMutationSchema = {
-        data: {
-          functionSet: {
-            userErrors: [],
-            function: {
-              id: updatedID,
-            },
-          },
-        },
-      }
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(uploadURLResponse)
-      vi.mocked(fetch).mockImplementation(vi.fn().mockResolvedValueOnce({status: 200}))
-      vi.mocked(functionProxyRequest).mockResolvedValueOnce(functionSetMutationResponse)
-
-      // When
-      const got = await uploadFunctionExtensions([extension], {token, identifiers})
-
-      // Then
-      expect(got.extensions[extension.localIdentifier]).toEqual(updatedID)
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(1, identifiers.app, UploadUrlGenerateMutation, token)
-      expect(fetch).toHaveBeenCalledWith(uploadUrl, {
-        body: Buffer.from(''),
-        headers: {'Content-Type': 'application/wasm'},
-        method: 'PUT',
-      })
-      expect(functionProxyRequest).toHaveBeenNthCalledWith(2, identifiers.app, AppFunctionSetMutation, token, {
-        id: undefined,
-        legacyUuid: existingID,
-        title: extension.configuration.name,
-        description: extension.configuration.description,
-        apiType: 'order_discounts',
-        apiVersion: extension.configuration.api_version,
-        appBridge: {
-          detailsPath: (extension.configuration.ui?.paths ?? {}).details,
-          createPath: (extension.configuration.ui?.paths ?? {}).create,
-        },
-        inputQueryVariables: {
-          singleJsonMetafield: {
-            namespace: 'namespace',
-            key: 'key',
-          },
-        },
-        enableCreationUi: true,
-        moduleUploadUrl: uploadUrl,
-      })
+      expect(getFunctionUploadUrl).toHaveBeenNthCalledWith(1, token)
     })
   })
 })

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -1,11 +1,14 @@
 import {deploymentErrorsToCustomSections, uploadExtensionsBundle, uploadWasmBlob} from './upload.js'
 import {Identifiers} from '../../models/app/identifiers.js'
-import {UploadUrlGenerateMutationSchema} from '../../api/graphql/functions/upload_url_generate.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {testFunctionExtension} from '../../models/app/app.test-data.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
-import {getFunctionUploadUrl, partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {
+  FunctionUploadUrlGenerateResponse,
+  getFunctionUploadUrl,
+  partnersRequest,
+} from '@shopify/cli-kit/node/api/partners'
 import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
 import {fetch, formData} from '@shopify/cli-kit/node/http'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -86,12 +89,15 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        uploadUrlGenerate: {
-          headers: {},
-          maxSize: '200 kb',
-          url: uploadUrl,
-          moduleId: 'module-id',
+      const uploadURLResponse: FunctionUploadUrlGenerateResponse = {
+        functionUploadUrlGenerate: {
+          generatedUrlDetails: {
+            headers: {},
+            maxSize: '200 kb',
+            url: uploadUrl,
+            moduleId: 'module-id',
+            maxBytes: 200,
+          },
         },
       }
       const uploadError = new Error('error')
@@ -114,12 +120,15 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        uploadUrlGenerate: {
-          headers: {},
-          maxSize: '200 kb',
-          url: uploadUrl,
-          moduleId: 'module-id',
+      const uploadURLResponse: FunctionUploadUrlGenerateResponse = {
+        functionUploadUrlGenerate: {
+          generatedUrlDetails: {
+            headers: {},
+            maxSize: '200 kb',
+            url: uploadUrl,
+            moduleId: 'module-id',
+            maxBytes: 200,
+          },
         },
       }
       vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
@@ -154,12 +163,15 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        uploadUrlGenerate: {
-          headers: {},
-          maxSize: '200 kb',
-          url: uploadUrl,
-          moduleId: 'module-id',
+      const uploadURLResponse: FunctionUploadUrlGenerateResponse = {
+        functionUploadUrlGenerate: {
+          generatedUrlDetails: {
+            headers: {},
+            maxSize: '200 kb',
+            url: uploadUrl,
+            moduleId: 'module-id',
+            maxBytes: 200,
+          },
         },
       }
       vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
@@ -194,12 +206,15 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        uploadUrlGenerate: {
-          headers: {},
-          maxSize: '200 kb',
-          url: uploadUrl,
-          moduleId: 'module-id',
+      const uploadURLResponse: FunctionUploadUrlGenerateResponse = {
+        functionUploadUrlGenerate: {
+          generatedUrlDetails: {
+            headers: {},
+            maxSize: '200 kb',
+            url: uploadUrl,
+            moduleId: 'module-id',
+            maxBytes: 200,
+          },
         },
       }
       vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
@@ -230,12 +245,15 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        uploadUrlGenerate: {
-          headers: {},
-          maxSize: '200 kb',
-          url: uploadUrl,
-          moduleId: 'module-id',
+      const uploadURLResponse: FunctionUploadUrlGenerateResponse = {
+        functionUploadUrlGenerate: {
+          generatedUrlDetails: {
+            headers: {},
+            maxSize: '200 kb',
+            url: uploadUrl,
+            moduleId: 'module-id',
+            maxBytes: 200,
+          },
         },
       }
       vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
@@ -266,12 +284,15 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
-        uploadUrlGenerate: {
-          headers: {},
-          maxSize: '200 kb',
-          url: uploadUrl,
-          moduleId: 'module-id',
+      const uploadURLResponse: FunctionUploadUrlGenerateResponse = {
+        functionUploadUrlGenerate: {
+          generatedUrlDetails: {
+            headers: {},
+            maxSize: '200 kb',
+            url: uploadUrl,
+            moduleId: 'module-id',
+            maxBytes: 200,
+          },
         },
       }
       const uploadError = new Error('error')

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -277,37 +277,6 @@ describe('uploadWasmBlob', () => {
       expect(getFunctionUploadUrl).toHaveBeenNthCalledWith(1, token)
     })
   })
-
-  test('errors if the compilation request errors', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const uploadUrl = 'test://test.com/moduleId.wasm'
-      extension.outputPath = joinPath(tmpDir, 'index.wasm')
-      await writeFile(extension.outputPath, '')
-      const uploadURLResponse: FunctionUploadUrlGenerateResponse = {
-        functionUploadUrlGenerate: {
-          generatedUrlDetails: {
-            headers: {},
-            maxSize: '200 kb',
-            url: uploadUrl,
-            moduleId: 'module-id',
-            maxBytes: 200,
-          },
-        },
-      }
-      const uploadError = new Error('error')
-      vi.mocked(getFunctionUploadUrl).mockResolvedValueOnce(uploadURLResponse)
-      vi.mocked(fetch).mockRejectedValue(uploadError)
-
-      // When
-      await expect(uploadWasmBlob(extension.localIdentifier, extension.outputPath, apiKey, token)).rejects.toThrow(
-        uploadError,
-      )
-
-      // Then
-      expect(getFunctionUploadUrl).toHaveBeenNthCalledWith(1, token)
-    })
-  })
 })
 
 describe('uploadExtensionsBundle', () => {

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -1,11 +1,6 @@
 import {deploymentErrorsToCustomSections, uploadExtensionsBundle, uploadWasmBlob} from './upload.js'
 import {Identifiers} from '../../models/app/identifiers.js'
-import {
-  UploadUrlGenerateMutation,
-  UploadUrlGenerateMutationSchema,
-  UploadUrlGenerateMutationSchemaNew,
-} from '../../api/graphql/functions/upload_url_generate.js'
-import {AppFunctionSetMutation, AppFunctionSetMutationSchema} from '../../api/graphql/functions/app_function_set.js'
+import {UploadUrlGenerateMutationSchema} from '../../api/graphql/functions/upload_url_generate.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {testFunctionExtension} from '../../models/app/app.test-data.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
@@ -57,7 +52,8 @@ describe('uploadWasmBlob', () => {
         metafields: [],
       },
     })
-    ;(apiKey = 'api-key'), (token = 'token')
+    apiKey = 'api-key'
+    token = 'token'
     identifiers = {
       app: 'api=key',
       extensions: {},
@@ -90,7 +86,7 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
         uploadUrlGenerate: {
           headers: {},
           maxSize: '200 kb',
@@ -118,7 +114,7 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
         uploadUrlGenerate: {
           headers: {},
           maxSize: '200 kb',
@@ -158,7 +154,7 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
         uploadUrlGenerate: {
           headers: {},
           maxSize: '200 kb',
@@ -198,7 +194,7 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
         uploadUrlGenerate: {
           headers: {},
           maxSize: '200 kb',
@@ -234,7 +230,7 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
         uploadUrlGenerate: {
           headers: {},
           maxSize: '200 kb',
@@ -270,7 +266,7 @@ describe('uploadWasmBlob', () => {
       const uploadUrl = 'test://test.com/moduleId.wasm'
       extension.outputPath = joinPath(tmpDir, 'index.wasm')
       await writeFile(extension.outputPath, '')
-      const uploadURLResponse: UploadUrlGenerateMutationSchemaNew = {
+      const uploadURLResponse: UploadUrlGenerateMutationSchema = {
         uploadUrlGenerate: {
           headers: {},
           maxSize: '200 kb',

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -1,6 +1,5 @@
 import {themeExtensionConfig as generateThemeExtensionConfig} from './theme-extension-config.js'
 import {Identifiers, IdentifiersExtensions} from '../../models/app/identifiers.js'
-import {UploadUrlGenerateMutationSchema} from '../../api/graphql/functions/upload_url_generate.js'
 import {
   ExtensionUpdateDraftInput,
   ExtensionUpdateDraftMutation,
@@ -417,11 +416,24 @@ interface GetFunctionExtensionUploadURLOutput {
   headers: {[key: string]: string}
 }
 
+export interface FunctionUploadUrlGenerateMutationSchema {
+  functionUploadUrlGenerate: {
+    generatedUrlDetails: {
+      url: string
+      moduleId: string
+      headers: {[key: string]: string}
+      maxSize: string
+    }
+  }
+}
+
 async function getFunctionExtensionUploadUrlFromPartners(
   options: GetFunctionExtensionUploadURLOptions,
 ): Promise<GetFunctionExtensionUploadURLOutput> {
-  const res: UploadUrlGenerateMutationSchema = await handlePartnersErrors(() => getFunctionUploadUrl(options.token))
-  return res.uploadUrlGenerate
+  const res: FunctionUploadUrlGenerateMutationSchema = await handlePartnersErrors(() =>
+    getFunctionUploadUrl(options.token),
+  )
+  return res.functionUploadUrlGenerate.generatedUrlDetails
 }
 
 async function handlePartnersErrors<T>(request: () => Promise<T>): Promise<T> {

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -12,7 +12,11 @@ import {
   GenerateSignedUploadUrlVariables,
 } from '../../api/graphql/generate_signed_upload_url.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
-import {getFunctionUploadUrl, partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {
+  getFunctionUploadUrl,
+  FunctionUploadUrlGenerateResponse,
+  partnersRequest,
+} from '@shopify/cli-kit/node/api/partners'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {readFile, readFileSync} from '@shopify/cli-kit/node/fs'
 import {fetch, formData} from '@shopify/cli-kit/node/http'
@@ -416,23 +420,10 @@ interface GetFunctionExtensionUploadURLOutput {
   headers: {[key: string]: string}
 }
 
-export interface FunctionUploadUrlGenerateMutationSchema {
-  functionUploadUrlGenerate: {
-    generatedUrlDetails: {
-      url: string
-      moduleId: string
-      headers: {[key: string]: string}
-      maxSize: string
-    }
-  }
-}
-
 async function getFunctionExtensionUploadUrlFromPartners(
   options: GetFunctionExtensionUploadURLOptions,
 ): Promise<GetFunctionExtensionUploadURLOutput> {
-  const res: FunctionUploadUrlGenerateMutationSchema = await handlePartnersErrors(() =>
-    getFunctionUploadUrl(options.token),
-  )
+  const res: FunctionUploadUrlGenerateResponse = await handlePartnersErrors(() => getFunctionUploadUrl(options.token))
   return res.functionUploadUrlGenerate.generatedUrlDetails
 }
 

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -1,10 +1,6 @@
 import {themeExtensionConfig as generateThemeExtensionConfig} from './theme-extension-config.js'
 import {Identifiers, IdentifiersExtensions} from '../../models/app/identifiers.js'
-import {
-  UploadUrlGenerateMutation,
-  UploadUrlGenerateMutationSchema,
-  UploadUrlGenerateMutationSchemaNew,
-} from '../../api/graphql/functions/upload_url_generate.js'
+import {UploadUrlGenerateMutationSchema} from '../../api/graphql/functions/upload_url_generate.js'
 import {
   ExtensionUpdateDraftInput,
   ExtensionUpdateDraftMutation,
@@ -16,19 +12,13 @@ import {
   GenerateSignedUploadUrlSchema,
   GenerateSignedUploadUrlVariables,
 } from '../../api/graphql/generate_signed_upload_url.js'
-import {
-  AppFunctionSetMutation,
-  AppFunctionSetMutationSchema,
-  AppFunctionSetVariables,
-} from '../../api/graphql/functions/app_function_set.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
-import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {getFunctionUploadUrl, partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
-import {fileExists, readFile, readFileSync} from '@shopify/cli-kit/node/fs'
+import {readFile, readFileSync} from '@shopify/cli-kit/node/fs'
 import {fetch, formData} from '@shopify/cli-kit/node/http'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
-import {formatPackageManagerCommand, outputContent, outputToken} from '@shopify/cli-kit/node/output'
+import {formatPackageManagerCommand, outputContent} from '@shopify/cli-kit/node/output'
 import {AlertCustomSection, ListToken, TokenItem} from '@shopify/cli-kit/node/ui'
 import {partition} from '@shopify/cli-kit/common/collection'
 import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager'
@@ -430,7 +420,7 @@ interface GetFunctionExtensionUploadURLOutput {
 async function getFunctionExtensionUploadUrlFromPartners(
   options: GetFunctionExtensionUploadURLOptions,
 ): Promise<GetFunctionExtensionUploadURLOutput> {
-  const res: UploadUrlGenerateMutationSchemaNew = await handlePartnersErrors(() => getFunctionUploadUrl(options.token))
+  const res: UploadUrlGenerateMutationSchema = await handlePartnersErrors(() => getFunctionUploadUrl(options.token))
   return res.uploadUrlGenerate
 }
 

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -23,7 +23,6 @@ import {
 } from '../../api/graphql/functions/app_function_set.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
-import {functionProxyRequest} from '@shopify/cli-kit/node/api/partners'
 import {getFunctionUploadUrl, partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {fileExists, readFile, readFileSync} from '@shopify/cli-kit/node/fs'
@@ -389,132 +388,6 @@ export async function getExtensionUploadURL(apiKey: string) {
   return result.appVersionGenerateSignedUploadUrl.signedUploadUrl
 }
 
-interface UploadFunctionExtensionsOptions {
-  /** The token to send authenticated requests to the partners' API  */
-  token: string
-
-  // Set of local identifiers
-  identifiers: Identifiers
-}
-
-/**
- * This function takes a list of function extensions and uploads them.
- * As part of the upload it creates a function server-side if it does not exist
- * and includes its remote identifier in the returned identifiers instance.
- * If the function already has a local id, that one is used and the upload
- * does an override of the function existing server-side.
- *
- * @param extensions - The list of extensions to upload.
- * @param options - Options to adjust the upload.
- * @returns A promise that resolves with the identifiers.
- */
-export async function uploadFunctionExtensions(
-  extensions: ExtensionInstance<FunctionConfigType>[],
-  options: UploadFunctionExtensionsOptions,
-): Promise<Identifiers> {
-  let identifiers = options.identifiers
-
-  const functionIds: IdentifiersExtensions = {}
-
-  // Functions are uploaded sequentially to avoid reaching the API limit
-  for (const extension of extensions) {
-    // eslint-disable-next-line no-await-in-loop
-    const remoteIdentifier = await uploadFunctionExtension(extension, {
-      apiKey: options.identifiers.app,
-      token: options.token,
-      identifier: identifiers.extensions[extension.localIdentifier],
-    })
-    functionIds[extension.localIdentifier] = remoteIdentifier
-  }
-
-  identifiers = {
-    ...identifiers,
-    extensions: {
-      ...identifiers.extensions,
-      ...functionIds,
-    },
-  }
-
-  return identifiers
-}
-
-interface UploadFunctionExtensionOptions {
-  apiKey: string
-  identifier?: string
-  token: string
-}
-
-async function uploadFunctionExtension(
-  extension: ExtensionInstance<FunctionConfigType>,
-  options: UploadFunctionExtensionOptions,
-): Promise<string> {
-  const {url} = await uploadWasmBlob(extension.localIdentifier, extension.outputPath, options.apiKey, options.token)
-
-  let inputQuery: string | undefined
-  if (await fileExists(extension.inputQueryPath)) {
-    inputQuery = await readFile(extension.inputQueryPath)
-  }
-
-  const query = AppFunctionSetMutation
-  const variables: AppFunctionSetVariables = {
-    // NOTE: This is a shim to support CLI projects that currently use the UUID instead of the ULID
-    ...(options.identifier?.includes('-') ? {legacyUuid: options.identifier} : {id: options.identifier}),
-    title: extension.configuration.name,
-    description: extension.configuration.description ?? '',
-    apiType: extension.configuration.type,
-    apiVersion: extension.configuration.api_version,
-    inputQuery,
-    inputQueryVariables: extension.configuration.input?.variables
-      ? {
-          singleJsonMetafield: extension.configuration.input.variables,
-        }
-      : undefined,
-    appBridge: extension.configuration.ui?.paths
-      ? {
-          detailsPath: extension.configuration.ui.paths.details,
-          createPath: extension.configuration.ui.paths.create,
-        }
-      : undefined,
-    enableCreationUi: extension.configuration.ui?.enable_create ?? true,
-    moduleUploadUrl: url,
-  }
-
-  const res: AppFunctionSetMutationSchema = await functionProxyRequest(options.apiKey, query, options.token, variables)
-  const userErrors = res.data.functionSet.userErrors ?? []
-  if (userErrors.length !== 0) {
-    if (userErrors.find((error) => error.tag === 'version_unsupported_error')) {
-      const errorMessage = outputContent`Deployment failed due to an outdated API version`
-      const tryMessage: TokenItem = {
-        subdued: `Deployment failed because one or more Functions (${variables.apiType}) is targeting an unsupported API version (${variables.apiVersion}).`,
-      }
-      const customSections: AlertCustomSection[] = [
-        {
-          body: {
-            list: {
-              title: 'Reference',
-              items: [
-                {
-                  link: {
-                    label: 'API versioning',
-                    url: 'https://shopify.dev/docs/api/usage/versioning',
-                  },
-                },
-              ],
-            },
-          },
-        },
-      ]
-      throw new AbortError(errorMessage, tryMessage, [], customSections)
-    } else {
-      const errorMessage = outputContent`The deployment of functions failed with the following errors:${outputToken.json(
-        userErrors,
-      )}`
-      throw new AbortError(errorMessage)
-    }
-  }
-  return res.data.functionSet.function?.id as string
-}
-
 export async function uploadWasmBlob(
   extensionIdentifier: string,
   wasmPath: string,
@@ -552,15 +425,6 @@ interface GetFunctionExtensionUploadURLOutput {
   moduleId: string
   maxSize: string
   headers: {[key: string]: string}
-}
-
-async function getFunctionExtensionUploadURL(
-  options: GetFunctionExtensionUploadURLOptions,
-): Promise<GetFunctionExtensionUploadURLOutput> {
-  const res: UploadUrlGenerateMutationSchema = await handlePartnersErrors(() =>
-    functionProxyRequest(options.apiKey, UploadUrlGenerateMutation, options.token),
-  )
-  return res.data.uploadUrlGenerate
 }
 
 async function getFunctionExtensionUploadUrlFromPartners(

--- a/packages/cli-kit/src/public/node/api/partners.test.ts
+++ b/packages/cli-kit/src/public/node/api/partners.test.ts
@@ -48,7 +48,7 @@ describe('getFunctionUploadUrl', () => {
 
     // Then
     expect(graphqlRequest).toHaveBeenLastCalledWith({
-      query: expect.stringContaining('uploadUrlGenerate'),
+      query: expect.stringContaining('functionUploadUrlGenerate'),
       api: 'Partners',
       url,
       token: mockedToken,

--- a/packages/cli-kit/src/public/node/api/partners.test.ts
+++ b/packages/cli-kit/src/public/node/api/partners.test.ts
@@ -1,4 +1,4 @@
-import {partnersRequest, functionProxyRequest, handleDeprecations} from './partners.js'
+import {partnersRequest, functionProxyRequest, getFunctionUploadUrl, handleDeprecations} from './partners.js'
 import {graphqlRequest, GraphQLResponse} from './graphql.js'
 import {partnersFqdn} from '../context/fqdn.js'
 import {setNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
@@ -63,6 +63,25 @@ describe('functionProxyRequest', () => {
         query,
         variables: JSON.stringify(variables) || '{}',
       },
+      responseOptions: {onResponse: handleDeprecations},
+    })
+  })
+})
+
+describe('getFunctionUploadUrl', () => {
+  test('graphqlRequest is called with correct parameters', async () => {
+    // Given
+    vi.mocked(graphqlRequest).mockResolvedValue({})
+
+    // When
+    await getFunctionUploadUrl(mockedToken)
+
+    // Then
+    expect(graphqlRequest).toHaveBeenLastCalledWith({
+      query: expect.stringContaining('uploadUrlGenerate'),
+      api: 'Partners',
+      url,
+      token: mockedToken,
       responseOptions: {onResponse: handleDeprecations},
     })
   })

--- a/packages/cli-kit/src/public/node/api/partners.test.ts
+++ b/packages/cli-kit/src/public/node/api/partners.test.ts
@@ -1,4 +1,4 @@
-import {partnersRequest, functionProxyRequest, getFunctionUploadUrl, handleDeprecations} from './partners.js'
+import {partnersRequest, getFunctionUploadUrl, handleDeprecations} from './partners.js'
 import {graphqlRequest, GraphQLResponse} from './graphql.js'
 import {partnersFqdn} from '../context/fqdn.js'
 import {setNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
@@ -33,36 +33,6 @@ describe('partnersRequest', () => {
       url,
       token: mockedToken,
       variables: {variables: 'variables'},
-      responseOptions: {onResponse: handleDeprecations},
-    })
-  })
-})
-
-describe('functionProxyRequest', () => {
-  test('graphqlRequest is called with correct parameters', async () => {
-    // Given
-    const extensions = {deprecations: [{supportedUntilDate: new Date().toISOString()}]}
-    const scriptServiceResponse = {data: {}, extensions}
-    const proxyResponse = {scriptServiceProxy: JSON.stringify(scriptServiceResponse)}
-    vi.mocked(graphqlRequest).mockResolvedValue(proxyResponse)
-
-    // When
-    const apiKey = 'api-key'
-    const query = 'query'
-    const variables = {variables: 'variables'}
-    await functionProxyRequest(apiKey, query, mockedToken, variables)
-
-    // Then
-    expect(graphqlRequest).toHaveBeenLastCalledWith({
-      query: expect.stringContaining('scriptServiceProxy'),
-      api: 'Partners',
-      url,
-      token: mockedToken,
-      variables: {
-        api_key: apiKey,
-        query,
-        variables: JSON.stringify(variables) || '{}',
-      },
       responseOptions: {onResponse: handleDeprecations},
     })
   })

--- a/packages/cli-kit/src/public/node/api/partners.ts
+++ b/packages/cli-kit/src/public/node/api/partners.ts
@@ -38,45 +38,6 @@ export async function partnersRequest<T>(query: string, token: string, variables
   return result
 }
 
-interface ProxyResponse {
-  scriptServiceProxy: string
-}
-
-/**
- * Function queries are proxied through the script service proxy.
- * To execute a query, we encapsulate it inside another query (including the variables)
- * This is done automatically, you just need to provide the query and the variables.
- *
- * @param apiKey - APIKey of the app where the query will be executed.
- * @param query - GraphQL query to execute.
- * @param token - Partners token.
- * @param variables - GraphQL variables to pass to the query.
- * @returns The response of the query.
- */
-export async function functionProxyRequest<T>(
-  apiKey: string,
-  query: unknown,
-  token: string,
-  variables?: unknown,
-): Promise<T> {
-  const proxyVariables = {
-    api_key: apiKey,
-    query,
-    variables: JSON.stringify(variables) || '{}',
-  }
-  const proxyQuery = ScriptServiceProxyQuery
-  const res: ProxyResponse = await partnersRequest(proxyQuery, token, proxyVariables)
-  const json = JSON.parse(res.scriptServiceProxy)
-  handleDeprecations(json)
-  return json as T
-}
-
-const ScriptServiceProxyQuery = gql`
-  query ProxyRequest($api_key: String, $query: String!, $variables: String) {
-    scriptServiceProxy(apiKey: $api_key, query: $query, variables: $variables)
-  }
-`
-
 interface FunctionUploadUrlGenerateResponse {
   uploadUrlGenerate: {
     url: string

--- a/packages/cli-kit/src/public/node/api/partners.ts
+++ b/packages/cli-kit/src/public/node/api/partners.ts
@@ -77,6 +77,40 @@ const ScriptServiceProxyQuery = gql`
   }
 `
 
+interface FunctionUploadUrlGenerateResponse {
+  uploadUrlGenerate: {
+    url: string
+    moduleId: string
+    headers: string
+    maxBytes: number
+    maxSize: string
+  }
+}
+
+/**
+ * Request a URL from partners to which we will upload our function.
+ *
+ * @param token - Partners token.
+ * @returns The response of the query.
+ */
+export async function getFunctionUploadUrl<T>(token: string): Promise<T> {
+  const functionUploadUrlGenerateMutation = FunctionUploadUrlGenerateMutation
+  const res: FunctionUploadUrlGenerateResponse = await partnersRequest(FunctionUploadUrlGenerateMutation, token)
+  return res as T
+}
+
+const FunctionUploadUrlGenerateMutation = gql`
+  mutation functionUploadUrlGenerateMutation {
+    uploadUrlGenerate(input: {}) {
+      url
+      moduleId
+      headers
+      maxBytes
+      maxSize
+    }
+  }
+`
+
 interface Deprecation {
   supportedUntilDate?: string
 }

--- a/packages/cli-kit/src/public/node/api/partners.ts
+++ b/packages/cli-kit/src/public/node/api/partners.ts
@@ -38,13 +38,15 @@ export async function partnersRequest<T>(query: string, token: string, variables
   return result
 }
 
-interface FunctionUploadUrlGenerateResponse {
-  uploadUrlGenerate: {
-    url: string
-    moduleId: string
-    headers: string
-    maxBytes: number
-    maxSize: string
+export interface FunctionUploadUrlGenerateResponse {
+  functionUploadUrlGenerate: {
+    generatedUrlDetails: {
+      url: string
+      moduleId: string
+      headers: {[key: string]: string}
+      maxBytes: number
+      maxSize: string
+    }
   }
 }
 
@@ -54,20 +56,22 @@ interface FunctionUploadUrlGenerateResponse {
  * @param token - Partners token.
  * @returns The response of the query.
  */
-export async function getFunctionUploadUrl<T>(token: string): Promise<T> {
+export async function getFunctionUploadUrl(token: string): Promise<FunctionUploadUrlGenerateResponse> {
   const functionUploadUrlGenerateMutation = FunctionUploadUrlGenerateMutation
   const res: FunctionUploadUrlGenerateResponse = await partnersRequest(FunctionUploadUrlGenerateMutation, token)
-  return res as T
+  return res
 }
 
 const FunctionUploadUrlGenerateMutation = gql`
   mutation functionUploadUrlGenerateMutation {
-    uploadUrlGenerate(input: {}) {
-      url
-      moduleId
-      headers
-      maxBytes
-      maxSize
+    functionUploadUrlGenerate {
+      generatedUrlDetails {
+        url
+        moduleId
+        headers
+        maxBytes
+        maxSize
+      }
     }
   }
 `


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Part of https://github.com/Shopify/script-service/issues/7746

<!--
  Context about the problem that’s being addressed.
-->


### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Replaces `functionProxyRequest`, a concept that used to make sense with script service, with something more aligned with how things are done today, `getFunctionUploadUrl`

Cleans up a bunch of unused code, such as everything related to `uploadFunctionExtensions`, since functions are no longer uploaded this way.

Retains many of the relevant `uploadFunctionExtensions` relating to uploading the wasm blob by moving them under a new `describe uploadWasmBlob` section in the test file.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
