### PR TITLE
Update link pills when dev restarts

### DIFF
--- a/.changeset/mean-zoos-worry.md
+++ b/.changeset/mean-zoos-worry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update app and store links from GraphiQL when dev is restarted

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -115,7 +115,7 @@ export function setupGraphiQLServer({
 
   app.get('/graphiql/status', (_req, res) => {
     fetchApiVersionsWithTokenRefresh()
-      .then(() => res.send({status: 'OK'}))
+      .then(() => res.send({status: 'OK', storeFqdn, appName, appUrl}))
       .catch(() => res.send({status: 'UNAUTHENTICATED'}))
   })
 

--- a/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
+++ b/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
@@ -213,20 +213,7 @@ export function graphiqlTemplate({
                           onChange={() => {}}
                         />
                       </div>
-                      <div id="outbound-links" className="top-bar-section with-shrunk-icon">
-                        <span className="top-bar-section-title">Store: </span>
-                        <Link url={`https://${storeFqdn}/admin`} target="_blank">
-                          <Badge tone="info" icon={LinkMinor}>
-                            {storeFqdn}
-                          </Badge>
-                        </Link>
-                        <span className="top-bar-section-title">App: </span>
-                        <Link url={appUrl} target="_blank">
-                          <Badge tone="info" icon={LinkMinor}>
-                            {appName}
-                          </Badge>
-                        </Link>
-                      </div>
+                      {linkPills({storeFqdn, appName, appUrl})}
                     </InlineStack>
                   </Grid.Cell>
                   <Grid.Cell columnSpan={{xs: 3, sm: 3, md: 3, lg: 5, xl: 5}}>
@@ -325,15 +312,48 @@ export function graphiqlTemplate({
           })
       }, 2000)
 
-      // Warn when the app has been uninstalled
+      // Verify the current store/app connection
       setInterval(function() {
         fetch('{{ url }}/graphiql/status')
           .then(async function(response) {
-            appIsInstalled = (await response.json()).status === 'OK'
+            const {status, storeFqdn, appName, appUrl} = await response.json()
+            appIsInstalled = status === 'OK'
+            if (storeFqdn) {
+              document.getElementById('outbound-links').innerHTML = \`${renderToStaticMarkup(
+                // Create HTML string with substitutions included
+                <AppProvider i18n={{}}>
+                  {
+                    // eslint-disable-next-line no-template-curly-in-string
+                    linkPills({storeFqdn: '${storeFqdn}', appName: '${appName}', appUrl: '${appUrl}'})
+                  }
+                </AppProvider>,
+              )}\`
+            }
           })
       }, 5000)
     </script>
   </body>
 </html>
 `
+}
+
+interface LinkPillOptions {
+  storeFqdn: string
+  appName: string
+  appUrl: string
+}
+
+function linkPills({storeFqdn, appName, appUrl}: LinkPillOptions) {
+  return (
+    <div id="outbound-links" className="top-bar-section with-shrunk-icon">
+      <span className="top-bar-section-title">Store: </span>
+      <Link url={`https://${storeFqdn}/admin`} target="_blank">
+        <Badge tone="info" icon={LinkMinor} children={storeFqdn} />
+      </Link>
+      <span className="top-bar-section-title">App: </span>
+      <Link url={appUrl} target="_blank">
+        <Badge tone="info" icon={LinkMinor} children={appName} />
+      </Link>
+    </div>
+  )
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Link pills on top of GraphiQL reflect the state of `dev` when GraphiQL was first opened. But it doesn't get updated when the connection changes.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Updates the link contents and targets when `dev` is restarted on a new app or store.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Start `app dev` with one app and store.
2. Open GraphiQL
3. Stop `app dev` and restart with another app and store
4. Confirm that the links are updated (text itself + clicking the link gets to the right place)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
