### PR TITLE
Add support for new access module fields

### DIFF
--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -4,6 +4,7 @@ import {AppProxySpecIdentifier} from './specifications/app_config_app_proxy.js'
 import {PosSpecIdentifier} from './specifications/app_config_point_of_sale.js'
 import {WebhooksSpecIdentifier} from './specifications/app_config_webhook.js'
 import {BrandingSpecIdentifier} from './specifications/app_config_branding.js'
+import {AppAccessSpecIdentifier} from './specifications/app_config_app_access.js'
 import {loadUIExtensionSpecificationsFromPlugins} from '../../private/plugins/extension.js'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
 import {memoize} from '@shopify/cli-kit/common/function'
@@ -14,6 +15,7 @@ import {fileURLToPath} from 'url'
 
 const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   BrandingSpecIdentifier,
+  AppAccessSpecIdentifier,
   WebhooksSpecIdentifier,
   AppProxySpecIdentifier,
   PosSpecIdentifier,

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
@@ -9,6 +9,13 @@ describe('app_cofig_app_access', () => {
         access: {
           direct_api_offline_access: true,
         },
+        access_scopes: {
+          scopes: 'read_products,write_products',
+          use_legacy_install_flow: true,
+        },
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
       }
       const appAccessSpec = spec
 
@@ -20,6 +27,9 @@ describe('app_cofig_app_access', () => {
         access: {
           direct_api_offline_access: true,
         },
+        scopes: 'read_products,write_products',
+        use_legacy_install_flow: true,
+        redirect_url_allowlist: ['https://example.com/auth/callback'],
       })
     })
   })
@@ -31,6 +41,9 @@ describe('app_cofig_app_access', () => {
         access: {
           direct_api_offline_access: true,
         },
+        scopes: 'read_products,write_products',
+        use_legacy_install_flow: true,
+        redirect_url_allowlist: ['https://example.com/auth/callback'],
       }
       const appAccessSpec = spec
 
@@ -41,6 +54,13 @@ describe('app_cofig_app_access', () => {
       expect(result).toMatchObject({
         access: {
           direct_api_offline_access: true,
+        },
+        access_scopes: {
+          scopes: 'read_products,write_products',
+          use_legacy_install_flow: true,
+        },
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
         },
       })
     })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -1,3 +1,4 @@
+import {validateUrl} from '../../app/validation/common.js'
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -7,13 +8,30 @@ const AppAccessSchema = zod.object({
       direct_api_offline_access: zod.boolean().optional(),
     })
     .optional(),
+  access_scopes: zod
+    .object({
+      scopes: zod.string().optional(),
+      use_legacy_install_flow: zod.boolean().optional(),
+    })
+    .optional(),
+  auth: zod
+    .object({
+      redirect_urls: zod.array(validateUrl(zod.string())),
+    })
+    .optional(),
 })
+
+export const AppAccessSpecIdentifier = 'app_access'
+
 const AppAccessTransformConfig: TransformationConfig = {
   access: 'access',
+  scopes: 'access_scopes.scopes',
+  use_legacy_install_flow: 'access_scopes.use_legacy_install_flow',
+  redirect_url_allowlist: 'auth.redirect_urls',
 }
 
 const spec = createConfigExtensionSpecification({
-  identifier: 'app_access',
+  identifier: AppAccessSpecIdentifier,
   schema: AppAccessSchema,
   transformConfig: AppAccessTransformConfig,
 })

--- a/packages/app/src/cli/models/extensions/specifications/types/app_config.ts
+++ b/packages/app/src/cli/models/extensions/specifications/types/app_config.ts
@@ -16,4 +16,11 @@ export interface SpecsAppConfiguration {
     url: string
   }
   webhooks?: WebhooksConfig
+  access_scopes?: {
+    scopes?: string
+    use_legacy_install_flow?: boolean
+  }
+  auth?: {
+    redirect_urls: string[]
+  }
 }

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import {AppSchema, CurrentAppConfiguration, getAppScopesArray} from '../models/app/app.js'
+import {AppSchema, CurrentAppConfiguration, getAppScopes, getAppScopesArray} from '../models/app/app.js'
 import {mergeAppConfiguration} from '../services/app/config/link.js'
 import {OrganizationApp} from '../models/organization.js'
 import {App} from '../api/graphql/get_config.js'
@@ -16,7 +16,7 @@ import {basename, joinPath} from '@shopify/cli-kit/node/path'
 import {slugify} from '@shopify/cli-kit/common/string'
 import {err, ok, Result} from '@shopify/cli-kit/node/result'
 import {encodeToml} from '@shopify/cli-kit/node/toml'
-import {deepCompare, deepDifference} from '@shopify/cli-kit/common/object'
+import {deepCompare, deepDifference, setPathValue} from '@shopify/cli-kit/common/object'
 import colors from '@shopify/cli-kit/node/colors'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -109,7 +109,9 @@ export function buildDiffConfigContent(
   schema: zod.ZodTypeAny = AppSchema,
   renderNoChanges = true,
 ) {
-  if (localConfig.access_scopes?.scopes) localConfig.access_scopes.scopes = getAppScopesArray(localConfig).join(',')
+  if (getAppScopes(localConfig) !== '') {
+    setPathValue(localConfig, 'access_scopes.scopes', getAppScopesArray(localConfig).join(','))
+  }
 
   const [updated, baseline] = deepDifference(
     {...(rewriteConfiguration(schema, localConfig) as object), build: undefined},

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -175,6 +175,10 @@ name = "my app"
 application_url = "https://myapp.com"
 embedded = true
 
+[build]
+automatically_update_urls_on_dev = true
+dev_store_url = "my-store.myshopify.com"
+
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "write_products"
@@ -187,10 +191,6 @@ api_version = "2023-07"
 
 [pos]
 embedded = false
-
-[build]
-automatically_update_urls_on_dev = true
-dev_store_url = "my-store.myshopify.com"
 `
       expect(content).toEqual(expectedContent)
       expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.staging.toml', directory: tmp})

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -63,7 +63,7 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
 }
 
 async function selectRemoteApp(options: LinkOptions) {
-  const localApp = await loadAppConfigFromDefaultToml(options)
+  const localApp = await loadAppConfigFromCurrentToml(options)
   const directory = localApp?.directory || options.directory
   const partnersSession = await fetchPartnersSession()
   const remoteApp = await loadRemoteApp(localApp, options.apiKey, partnersSession, directory)
@@ -81,7 +81,7 @@ async function loadLocalApp(options: LinkOptions, token: string, remoteApp: Orga
     config: options.commandConfig,
   })
 
-  const localApp = await loadAppConfigFromDefaultToml(options, specifications)
+  const localApp = await loadAppConfigFromCurrentToml(options, specifications)
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
   const configFilePath = joinPath(directory, configFileName)
   return {
@@ -91,7 +91,7 @@ async function loadLocalApp(options: LinkOptions, token: string, remoteApp: Orga
   }
 }
 
-async function loadAppConfigFromDefaultToml(
+async function loadAppConfigFromCurrentToml(
   options: LinkOptions,
   specifications?: ExtensionSpecification[],
 ): Promise<AppInterface> {
@@ -100,7 +100,7 @@ async function loadAppConfigFromDefaultToml(
       specifications,
       directory: options.directory,
       mode: 'report',
-      configName: configurationFileNames.app,
+      configName: undefined,
     })
     return app
     // eslint-disable-next-line no-catch-all/no-catch-all

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -100,7 +100,7 @@ async function loadAppConfigFromCurrentToml(
       specifications,
       directory: options.directory,
       mode: 'report',
-      configName: undefined,
+      configName: configurationFileNames.app,
     })
     return app
     // eslint-disable-next-line no-catch-all/no-catch-all
@@ -236,20 +236,15 @@ function addRemoteAppAccessScopesConfig(appConfiguration: AppConfiguration, remo
     accessScopesContent = {
       scopes: remoteApp.requestedAccessScopes.join(','),
     }
-    // if we have scopes locally and not upstream, preserve them but don't push them upstream (legacy is true)
-  } else if (isLegacyAppSchema(appConfiguration) && appConfiguration.scopes) {
-    accessScopesContent = {
-      scopes: appConfiguration.scopes,
-      use_legacy_install_flow: true,
-    }
-  } else if (isCurrentAppSchema(appConfiguration) && getAppScopes(appConfiguration) !== '') {
-    accessScopesContent = {
-      scopes: getAppScopes(appConfiguration),
-      use_legacy_install_flow: true,
-    }
     // if we can't find scopes or have to fall back, omit setting a scope and set legacy to true
+  } else if (getAppScopes(appConfiguration) === '') {
+    accessScopesContent = {
+      use_legacy_install_flow: true,
+    }
+    // if we have scopes locally and not upstream, preserve them but don't push them upstream (legacy is true)
   } else {
     accessScopesContent = {
+      scopes: getAppScopes(appConfiguration),
       use_legacy_install_flow: true,
     }
   }

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -4,6 +4,7 @@ import {
   AppInterface,
   CurrentAppConfiguration,
   EmptyApp,
+  getAppScopes,
   isCurrentAppSchema,
   isLegacyAppSchema,
 } from '../../../models/app/app.js'
@@ -241,9 +242,9 @@ function addRemoteAppAccessScopesConfig(appConfiguration: AppConfiguration, remo
       scopes: appConfiguration.scopes,
       use_legacy_install_flow: true,
     }
-  } else if (isCurrentAppSchema(appConfiguration) && appConfiguration.access_scopes?.scopes) {
+  } else if (isCurrentAppSchema(appConfiguration) && getAppScopes(appConfiguration) !== '') {
     accessScopesContent = {
-      scopes: appConfiguration.access_scopes.scopes,
+      scopes: getAppScopes(appConfiguration),
       use_legacy_install_flow: true,
     }
     // if we can't find scopes or have to fall back, omit setting a scope and set legacy to true

--- a/packages/app/src/cli/services/app/config/push.test.ts
+++ b/packages/app/src/cli/services/app/config/push.test.ts
@@ -95,9 +95,14 @@ describe('pushConfig', () => {
   })
 
   test('successfully calls the update mutation without scopes when legacy behavior. does not call scopes clear when upstream doesnt have scopes.', async () => {
-    const app = await mockApp({}, 'current')
+    const localApp = {
+      configuration: {
+        ...DEFAULT_CONFIG,
+        access_scopes: {scopes: 'write_products', use_legacy_install_flow: true},
+      } as CurrentAppConfiguration,
+    }
+    const app = await mockApp(localApp, 'current')
 
-    app.configuration = {...app.configuration, access_scopes: {scopes: 'write_products', use_legacy_install_flow: true}}
     const options: PushOptions = {
       configuration: app.configuration,
       force: true,
@@ -141,9 +146,14 @@ describe('pushConfig', () => {
   })
 
   test('successfully calls the update mutation without scopes when legacy behavior. does call scopes clear when upstream has scopes.', async () => {
-    const app = await mockApp({}, 'current')
+    const localApp = {
+      configuration: {
+        ...DEFAULT_CONFIG,
+        access_scopes: {scopes: 'write_products', use_legacy_install_flow: true},
+      } as CurrentAppConfiguration,
+    }
+    const app = await mockApp(localApp, 'current')
 
-    app.configuration = {...app.configuration, access_scopes: {scopes: 'write_products', use_legacy_install_flow: true}}
     const options: PushOptions = {
       configuration: app.configuration,
       force: true,
@@ -189,8 +199,13 @@ describe('pushConfig', () => {
   })
 
   test('successfully calls the update mutation with empty scopes', async () => {
-    const app = await mockApp({}, 'current')
-    app.configuration = {...app.configuration, access_scopes: {scopes: ''}}
+    const localApp = {
+      configuration: {
+        ...DEFAULT_CONFIG,
+        access_scopes: {scopes: ''},
+      } as CurrentAppConfiguration,
+    }
+    const app = await mockApp(localApp, 'current')
 
     const options: PushOptions = {
       configuration: app.configuration,
@@ -234,8 +249,13 @@ describe('pushConfig', () => {
   })
 
   test('deletes requested access scopes when scopes are omitted', async () => {
-    const app = await mockApp({}, 'current')
-    app.configuration = {...app.configuration, access_scopes: undefined}
+    const localApp = {
+      configuration: {
+        ...DEFAULT_CONFIG,
+        access_scopes: undefined,
+      } as CurrentAppConfiguration,
+    }
+    const app = await mockApp(localApp, 'current')
 
     const options: PushOptions = {
       configuration: app.configuration,

--- a/packages/app/src/cli/services/app/config/push.ts
+++ b/packages/app/src/cli/services/app/config/push.ts
@@ -95,7 +95,7 @@ export async function pushConfig(options: PushOptions) {
 
   const shouldDeleteScopes =
     app.requestedAccessScopes &&
-    (configuration.access_scopes?.scopes === undefined || usesLegacyScopesBehavior(configuration))
+    (variables.requestedAccessScopes === undefined || usesLegacyScopesBehavior(configuration))
 
   if (shouldDeleteScopes) {
     const clearResult: ClearScopesSchema = await partnersRequest(clearRequestedScopes, token, {apiKey: app.apiKey})

--- a/packages/app/src/cli/services/app/write-app-configuration-file.test.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.test.ts
@@ -52,6 +52,10 @@ name = "my app"
 application_url = "https://myapp.com"
 embedded = true
 
+[build]
+automatically_update_urls_on_dev = true
+dev_store_url = "example.myshopify.com"
+
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "read_products"
@@ -80,10 +84,6 @@ embedded = false
 
 [app_preferences]
 url = "https://example.com/prefs"
-
-[build]
-automatically_update_urls_on_dev = true
-dev_store_url = "example.myshopify.com"
 `
       expect(content).toEqual(expectedContent)
     })

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -596,15 +596,15 @@ name = "my app"
 application_url = "https://myapp.com"
 embedded = true
 
+[build]
+dev_store_url = "domain1"
+
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "read_products"
 
 [webhooks]
 api_version = "2023-04"
-
-[build]
-dev_store_url = "domain1"
 `
       expect(content).toEqual(expectedContent)
     })

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -199,7 +199,7 @@ export async function updateURLs(
       ...localApp.configuration,
       application_url: urls.applicationUrl,
       auth: {
-        ...localApp.configuration.auth,
+        ...(localApp.configuration.auth ?? {}),
         redirect_urls: urls.redirectUrlWhitelist,
       },
     }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?


Follow-up: https://github.com/Shopify/cli/pull/3237

Add support for the new fields added to the [app_access](https://github.com/Shopify/shopify/pull/471575) module


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Move the new `app_access` fields from the `AppSchema` to the `app_access` spec definition
- Removed the `NonVersionedSchema`. This means that the config `[build]` section will be written inside the `toml` in a different position than the one used to be. Plus the new `branding` app module that versions the `name` property, the modifications applied to the `toml` structure will be:
  - `name` after the `client_id`, rather than before
  - `[build]` sections is the first one after the top level properties
- Fixed an issue with the `link` command. The file used as reference to create/update the final `toml` file was the `default` one instead of the `current` one.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new `cli` app and run the `p shopify app config link --path /PATH/TO/YOUR/APP` command to link it to a new remote app.
- Modify `acccess_scopes`, `access` and `auth` values
- Run `SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 npm run shopify app deploy --path /PATH/TO/YOUR/APP`  and confirm
- Modify the values and run `p shopify app config link --path /PATH/TO/YOUR/APP` to restore the pushed values
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
