### PR TITLE
[Cleanup] Remove unused developmentTheme parameter in findOrSelectTheme function

### DIFF
--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -81,7 +81,6 @@ export default class Pull extends ThemeCommand {
 
       const theme = await findOrSelectTheme(adminSession, {
         header: 'Select a theme to open',
-        developmentTheme: developmentTheme?.id,
         filter: {
           live,
           theme: development ? `${developmentTheme?.id}` : flags.theme,

--- a/packages/theme/src/cli/services/open.test.ts
+++ b/packages/theme/src/cli/services/open.test.ts
@@ -114,7 +114,6 @@ describe('open', () => {
 
       expect(findOrSelectTheme).toHaveBeenCalledWith(session, {
         header,
-        developmentTheme: undefined,
         filter: {
           live,
           theme: undefined,
@@ -129,7 +128,6 @@ describe('open', () => {
 
       expect(findOrSelectTheme).toHaveBeenCalledWith(session, {
         header,
-        developmentTheme: developmentTheme.id,
         filter: {
           live,
           theme: options.theme,
@@ -144,7 +142,6 @@ describe('open', () => {
 
       expect(findOrSelectTheme).toHaveBeenCalledWith(session, {
         header,
-        developmentTheme: developmentTheme.id,
         filter: {
           live,
           theme: developmentTheme.id.toString(),

--- a/packages/theme/src/cli/services/open.ts
+++ b/packages/theme/src/cli/services/open.ts
@@ -16,7 +16,6 @@ export async function open(
   )?.id
   const theme = await findOrSelectTheme(adminSession, {
     header: 'Select a theme to open',
-    developmentTheme,
     filter: {
       live: options.live,
       theme: options.development ? `${developmentTheme}` : options.theme,

--- a/packages/theme/src/cli/utilities/theme-selector.test.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.test.ts
@@ -53,7 +53,6 @@ describe('findOrSelectTheme', () => {
     // When
     await findOrSelectTheme(session, {
       header,
-      developmentTheme: themes[0]!.id,
       filter: {},
     })
 

--- a/packages/theme/src/cli/utilities/theme-selector.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.ts
@@ -13,14 +13,10 @@ import {capitalize} from '@shopify/cli-kit/common/string'
  *  - header:           the header presented when users select a theme
  *  - filter:           the filter ({@link FilterProps}) applied in the list
  *                      of themes in the store
- *  - developmentTheme: ID of current development theme, so that it can be tagged as [yours]
  *
  * @returns the selected {@link Theme}
  */
-export async function findOrSelectTheme(
-  session: AdminSession,
-  options: {header?: string; filter: FilterProps; developmentTheme?: number},
-) {
+export async function findOrSelectTheme(session: AdminSession, options: {header?: string; filter: FilterProps}) {
   const themes = await fetchStoreThemes(session)
   const filter = new Filter(options.filter)
   const store = session.storeFqdn


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- Remove unused arg from function call

### WHAT is this pull request doing?
- Removes the `developmentTheme` property from the `options` for the function `findOrSelectTheme` in the `theme-selector` module.
- This property was previously used to specify the ID of the current development theme but is no longer needed, as we are now calling `getDevelopmentTheme` as of [Improve theme selector component by grouping themes by role (#1662) · Shopify/cli@dcc95e1](https://github.com/Shopify/cli/commit/dcc95e191bcaf1cd580aaf6ed3ba605e5b5fb303#diff-7633fa15fdce1b666ec9e64add1637d9a51d681f0ea67bfbda93a396198b4b8dR35-R36)
### How to test your changes?
- Run automated unit tests
- Execute a command such as 

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
