### PR TITLE
[Direct API] Update Direct API Access Config

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -329,6 +329,7 @@ export class App implements AppInterface {
     const scopes = getPathValue<string>(configuration, 'access_scopes.scopes')
     const useLegacyInstallFlow = getPathValue<boolean>(configuration, 'access_scopes.use_legacy_install_flow')
     const redirectUrls = getPathValue<string[]>(configuration, 'auth.redirect_urls')
+
     return {
       ...(scopes || useLegacyInstallFlow
         ? {access_scopes: {scopes, use_legacy_install_flow: useLegacyInstallFlow}}

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -329,7 +329,6 @@ export class App implements AppInterface {
     const scopes = getPathValue<string>(configuration, 'access_scopes.scopes')
     const useLegacyInstallFlow = getPathValue<boolean>(configuration, 'access_scopes.use_legacy_install_flow')
     const redirectUrls = getPathValue<string[]>(configuration, 'auth.redirect_urls')
-
     return {
       ...(scopes || useLegacyInstallFlow
         ? {access_scopes: {scopes, use_legacy_install_flow: useLegacyInstallFlow}}

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1880,6 +1880,9 @@ wrong = "property"
     [webhooks]
     api_version = "2023-07"
 
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
     [access.admin]
     direct_api_mode = "online"
     `
@@ -1902,6 +1905,9 @@ wrong = "property"
 
     [webhooks]
     api_version = "2023-07"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
 
     [access.admin]
     direct_api_mode = "offline"
@@ -1926,6 +1932,9 @@ wrong = "property"
     [webhooks]
     api_version = "2023-07"
 
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
     [access.admin]
     direct_api_mode = "foo"
     `
@@ -1945,6 +1954,9 @@ wrong = "property"
 
     [webhooks]
     api_version = "2023-07"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
 
     [access.admin]
     embedded_app_direct_api_access = true
@@ -1969,6 +1981,9 @@ wrong = "property"
     [webhooks]
     api_version = "2023-07"
 
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
     [access.admin]
     embedded_app_direct_api_access = false
     `
@@ -1991,6 +2006,9 @@ wrong = "property"
 
     [webhooks]
     api_version = "2023-07"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
 
     [access.admin]
     embedded_app_direct_api_access = "foo"

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -72,7 +72,10 @@ automatically_update_urls_on_dev = true
     }
   })
 
-  const writeConfig = async (appConfiguration: string, packageJson?: PackageJson) => {
+  const writeConfig = async (
+    appConfiguration: string,
+    packageJson?: PackageJson,
+  ): Promise<{webDirectory: string; appConfigurationPath: string}> => {
     const appConfigurationPath = joinPath(tmpDir, configurationFileNames.app)
     const packageJsonPath = joinPath(tmpDir, 'package.json')
     const webDirectory = joinPath(tmpDir, blocks.web.directoryName)
@@ -1864,6 +1867,138 @@ wrong = "property"
     // Then
     await expect(result).rejects.toThrow(`Couldn't find shopify.app.non-existent.toml in ${tmpDir}.`)
     expect(use).not.toHaveBeenCalled()
+  })
+
+  test('loads the app when access.admin.direct_api_mode = "online"', async () => {
+    // Given
+    const config = `
+    name = "my_app"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [webhooks]
+    api_version = "2023-07"
+
+    [access.admin]
+    direct_api_mode = "online"
+    `
+    await writeConfig(config)
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.name).toBe('my_app')
+  })
+
+  test('loads the app when access.admin.direct_api_mode = "offline"', async () => {
+    // Given
+    const config = `
+    name = "my_app"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [webhooks]
+    api_version = "2023-07"
+
+    [access.admin]
+    direct_api_mode = "offline"
+    `
+    await writeConfig(config)
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.name).toBe('my_app')
+  })
+
+  test('throws an error when access.admin.direct_api_mode is invalid', async () => {
+    // Given
+    const config = `
+    name = "my_app"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [webhooks]
+    api_version = "2023-07"
+
+    [access.admin]
+    direct_api_mode = "foo"
+    `
+    await writeConfig(config)
+
+    // When
+    await expect(loadApp({directory: tmpDir, specifications})).rejects.toThrow()
+  })
+
+  test('loads the app when access.admin.embedded_app_direct_api_access = true', async () => {
+    // Given
+    const config = `
+    name = "my_app"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [webhooks]
+    api_version = "2023-07"
+
+    [access.admin]
+    embedded_app_direct_api_access = true
+    `
+    await writeConfig(config)
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.name).toBe('my_app')
+  })
+
+  test('loads the app when access.admin.embedded_app_direct_api_access = false', async () => {
+    // Given
+    const config = `
+    name = "my_app"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [webhooks]
+    api_version = "2023-07"
+
+    [access.admin]
+    embedded_app_direct_api_access = false
+    `
+    await writeConfig(config)
+
+    // When
+    const app = await loadApp({directory: tmpDir, specifications})
+
+    // Then
+    expect(app.name).toBe('my_app')
+  })
+
+  test('throws an error when access.admin.embedded_app_direct_api_access is invalid', async () => {
+    // Given
+    const config = `
+    name = "my_app"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [webhooks]
+    api_version = "2023-07"
+
+    [access.admin]
+    embedded_app_direct_api_access = "foo"
+    `
+    await writeConfig(config)
+
+    // When
+    await expect(loadApp({directory: tmpDir, specifications})).rejects.toThrow()
   })
 
   const runningOnWindows = platformAndArch().platform === 'windows'

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -434,8 +434,8 @@ class AppLoader {
           this.abortOrReport.bind(this),
         )
 
-        const {path, ...specConfigurationWithouPath} = specConfiguration
-        if (Object.keys(specConfigurationWithouPath).length === 0) return
+        const {path, ...specConfigurationWithoutPath} = specConfiguration
+        if (Object.keys(specConfigurationWithoutPath).length === 0) return
 
         return this.createExtensionInstance(
           specification.identifier,

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -175,7 +175,7 @@ function resolveReverseAppConfigTransform<T>(
  * ```json
  * { source: { fieldSourceA: 'valueA' } }
  * ```
- *  and a tranform config content like this:
+ *  and a transform config content like this:
  * ```json
  * { 'target.fieldTargetA': 'source.fieldSourceA'}
  * ```

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
@@ -1,13 +1,13 @@
 import spec from './app_config_app_access.js'
 import {describe, expect, test} from 'vitest'
 
-describe('app_cofig_app_access', () => {
+describe('app_config_app_access', () => {
   describe('transform', () => {
     test('should return the transformed object', () => {
       // Given
       const object = {
         access: {
-          direct_api_offline_access: true,
+          admin: {direct_api_mode: 'online'},
         },
         access_scopes: {
           scopes: 'read_products,write_products',
@@ -25,7 +25,7 @@ describe('app_cofig_app_access', () => {
       // Then
       expect(result).toMatchObject({
         access: {
-          direct_api_offline_access: true,
+          admin: {direct_api_mode: 'online'},
         },
         scopes: 'read_products,write_products',
         use_legacy_install_flow: true,
@@ -39,7 +39,7 @@ describe('app_cofig_app_access', () => {
       // Given
       const object = {
         access: {
-          direct_api_offline_access: true,
+          admin: {direct_api_mode: 'offline'},
         },
         scopes: 'read_products,write_products',
         use_legacy_install_flow: true,
@@ -53,7 +53,7 @@ describe('app_cofig_app_access', () => {
       // Then
       expect(result).toMatchObject({
         access: {
-          direct_api_offline_access: true,
+          admin: {direct_api_mode: 'offline'},
         },
         access_scopes: {
           scopes: 'read_products,write_products',

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -5,7 +5,12 @@ import {zod} from '@shopify/cli-kit/node/schema'
 const AppAccessSchema = zod.object({
   access: zod
     .object({
-      direct_api_offline_access: zod.boolean().optional(),
+      admin: zod
+        .object({
+          direct_api_mode: zod.union([zod.literal('online'), zod.literal('offline')]).optional(),
+          embedded_app_direct_api_access: zod.boolean().optional(),
+        })
+        .optional(),
     })
     .optional(),
   access_scopes: zod

--- a/packages/cli-kit/src/public/node/toml.test.ts
+++ b/packages/cli-kit/src/public/node/toml.test.ts
@@ -1,0 +1,30 @@
+import {decodeToml} from './toml.js'
+import {describe, expect, test} from 'vitest'
+
+describe('decodeToml', () => {
+  test("returns {name} when input is name = 'app'", () => {
+    const input = `
+    name = 'app'
+    `
+    const result = decodeToml(input)
+    expect(result).toStrictEqual({name: 'app'})
+  })
+
+  test('returns {webhooks: {api_version}} when input is [webhooks.api_version] = "2023-07"', () => {
+    const input = `
+    [webhooks]
+    api_version = "2023-07"
+    `
+    const result = decodeToml(input)
+    expect(result).toStrictEqual({webhooks: {api_version: '2023-07'}})
+  })
+
+  test('returns {access: {admin: {direct_api_mode}}} when input is [access.admin.direct_api_mode] = "online"', () => {
+    const input = `
+    [access]
+    admin = {direct_api_mode = "online"}
+    `
+    const result = decodeToml(input)
+    expect(result).toStrictEqual({access: {admin: {direct_api_mode: 'online'}}})
+  })
+})


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

## WHY are these changes introduced?

These changes are being introduced to make the Direct API toml config more explicit.  

TLDR: 

```toml
[access.admin]
# Valid values include "online", and "offline"
# "online" is the default. 
direct_api_mode = "online"
# false is the default. 
embedded_app_direct_api_access = false
```

## WHAT is this pull request doing?

- Adds `access` to `accessConfiguration`
   - Adds `admin` inside `access`
   - Adds `directApiMode` inside `admin`
   - Adds `embedded_app_direct_api_access` inside `admin`
- Replaces the old config (`[access.direct_api_offline_access]`) with the new config (`[access.admin.direct_api_mode]`). 
- Adds `admin`, `directApiMode`, embeddedAppDirectApiAccess` to `AppAccessSchema`
- Passes `directApiMode` to the `dev` service
- Fixes some typos
- Adds/updates tests

## References

- Docs
   - [Direct API access](https://shopify.dev/docs/api/admin-extensions#direct-api-access)
   - [Access Modes](https://shopify.dev/docs/apps/auth/oauth/access-modes)
   - Action and Block Extension [Wiki](https://github.com/Shopify/app-ui/wiki/Action-and-Block-Extension)
   - https://vault.shopify.io/page/App-module-development-in-Spin~ToYp.md
   - [Google Doc: App config toml](https://docs.google.com/document/d/1EwN1mceHGdvepj8AxrgvchIlenzkiJs3tznfr_O1VSQ/edit?usp=sharing)
- RFCs
   - [Option 6](https://github.com/Shopify/ui-api-design/discussions/191#discussioncomment-8112987) from the CLI Config for API Access/Access Mode RFC
- PRs
   - https://github.com/Shopify/cli/pull/2802
   - https://github.com/Shopify/cli/pull/3258
   - https://github.com/Shopify/shopify/pull/476372
   - https://github.com/Shopify/web/pull/115252
   - https://github.com/Shopify/web/pull/115621

## How to test your changes?

### Confirm that you can `app deploy` config values from your local app to your Spin DB

### Confirm that you can `app config link` config values from your Spin DB to your local app

## Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

## Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

## Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
