### PR TITLE
Switch to versioned app configuration beta flag

### DIFF
--- a/packages/app/src/cli/api/graphql/get_config.ts
+++ b/packages/app/src/cli/api/graphql/get_config.ts
@@ -28,6 +28,7 @@ export const GetConfig = gql`
       }
       betas {
         declarativeWebhooks
+        versionedAppConfig
       }
     }
   }
@@ -59,6 +60,7 @@ export interface App {
   }
   betas?: {
     declarativeWebhooks?: boolean
+    versionedAppConfig?: boolean
   }
 }
 

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -174,7 +174,6 @@ export interface AppInterface extends AppConfigurationInterface {
   extensionsForType: (spec: {identifier: string; externalIdentifier: string}) => ExtensionInstance[]
   updateExtensionUUIDS: (uuids: {[key: string]: string}) => void
   preDeployValidation: () => Promise<void>
-  addExtensions: (extension: ExtensionInstance[]) => void
 }
 
 export class App implements AppInterface {
@@ -230,10 +229,6 @@ export class App implements AppInterface {
     return this.realExtensions.filter(
       (ext) => !ext.isAppConfigExtension || (this.useVersionedAppConfig && this.includeConfigOnDeploy),
     )
-  }
-
-  addExtensions(extensions: ExtensionInstance[]) {
-    this.realExtensions = [...this.realExtensions, ...extensions]
   }
 
   async updateDependencies() {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -13,7 +13,6 @@ import {fileRealPath, findPathUp} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {getPathValue} from '@shopify/cli-kit/common/object'
-import {useVersionedAppConfig} from '@shopify/cli-kit/node/context/local'
 
 export const LegacyAppSchema = zod
   .object({
@@ -105,7 +104,7 @@ export function appIsLaunchable(app: AppInterface) {
 
 export function includeConfigOnDeploy(configuration: AppConfiguration) {
   if (isLegacyAppSchema(configuration)) return false
-  return configuration.build?.include_config_on_deploy && useVersionedAppConfig()
+  return configuration.build?.include_config_on_deploy
 }
 
 export function filterNonVersionedAppFields(configuration: {[key: string]: unknown}) {

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -15,6 +15,7 @@ import {getCachedAppInfo} from '../../services/local-storage.js'
 import use from '../../services/app/config/use.js'
 import {WebhookSchema} from '../extensions/specifications/app_config_webhook.js'
 import {WebhooksConfig} from '../extensions/specifications/types/app_config_webhook.js'
+import {BetaFlag} from '../../services/app/select-app.js'
 import {describe, expect, beforeEach, afterEach, beforeAll, test, vi} from 'vitest'
 import {
   installNodeModules,
@@ -1677,6 +1678,9 @@ wrong = "property"
     application_url = "https://example.com/lala"
     embedded = true
 
+    [build]
+    include_config_on_deploy = true
+
     [webhooks]
     api_version = "2023-07"
 
@@ -1686,7 +1690,7 @@ wrong = "property"
     await writeConfig(linkedAppConfigurationWithPosConfiguration)
 
     // When
-    const app = await loadApp({directory: tmpDir, specifications})
+    const app = await loadApp({directory: tmpDir, specifications, remoteBetas: [BetaFlag.VersionedAppConfig]})
 
     // Then
     expect(app.allExtensions).toHaveLength(4)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -20,6 +20,7 @@ import {ExtensionSpecification} from '../extensions/specification.js'
 import {getCachedAppInfo} from '../../services/local-storage.js'
 import use from '../../services/app/config/use.js'
 import {loadFSExtensionsSpecifications} from '../extensions/load-specifications.js'
+import {BetaFlag} from '../../services/app/select-app.js'
 import {deepStrict, zod} from '@shopify/cli-kit/node/schema'
 import {fileExists, readFile, glob, findPathUp, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
@@ -150,6 +151,7 @@ interface AppLoaderConstructorArgs {
   mode?: AppLoaderMode
   configName?: string
   specifications?: ExtensionSpecification[]
+  remoteBetas?: BetaFlag[]
 }
 
 /**
@@ -181,12 +183,14 @@ class AppLoader {
   private configName?: string
   private errors: AppErrors = new AppErrors()
   private specifications: ExtensionSpecification[]
+  private remoteBetas: BetaFlag[]
 
-  constructor({directory, configName, mode, specifications}: AppLoaderConstructorArgs) {
+  constructor({directory, configName, mode, specifications, remoteBetas}: AppLoaderConstructorArgs) {
     this.mode = mode ?? 'strict'
     this.directory = directory
     this.specifications = specifications ?? []
     this.configName = configName
+    this.remoteBetas = remoteBetas ?? []
   }
 
   findSpecificationForType(type: string) {
@@ -244,6 +248,7 @@ class AppLoader {
       undefined,
       this.specifications,
       configSchema,
+      this.remoteBetas,
     )
 
     if (!this.errors.isEmpty()) appClass.errors = this.errors
@@ -510,6 +515,7 @@ interface AppConfigurationLoaderConstructorArgs {
   directory: string
   configName?: string
   specifications?: ExtensionSpecification[]
+  remoteBetas?: BetaFlag[]
 }
 
 type LinkedConfigurationSource =
@@ -537,11 +543,13 @@ class AppConfigurationLoader {
   private directory: string
   private configName?: string
   private specifications?: ExtensionSpecification[]
+  private remoteBetas: BetaFlag[]
 
-  constructor({directory, configName, specifications}: AppConfigurationLoaderConstructorArgs) {
+  constructor({directory, configName, specifications, remoteBetas}: AppConfigurationLoaderConstructorArgs) {
     this.directory = directory
     this.configName = configName
     this.specifications = specifications
+    this.remoteBetas = remoteBetas ?? []
   }
 
   async loaded() {

--- a/packages/app/src/cli/prompts/config.test.ts
+++ b/packages/app/src/cli/prompts/config.test.ts
@@ -203,7 +203,11 @@ describe('confirmPushChanges', () => {
 
       vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
-      const configuration = mergeAppConfiguration({...DEFAULT_CONFIG, path: configurationPath}, app as OrganizationApp)
+      const configuration = mergeAppConfiguration(
+        {...DEFAULT_CONFIG, path: configurationPath},
+        app as OrganizationApp,
+        true,
+      )
 
       configuration.name = 'app2'
       configuration.access_scopes = {scopes: 'read_themes, read_customers'}
@@ -255,7 +259,11 @@ api_version = "unstable"
       // Given
       const configurationPath = joinPath(tmpDir, 'shopify.app.toml')
       const app = testOrganizationApp() as App
-      const configuration = mergeAppConfiguration({...DEFAULT_CONFIG, path: configurationPath}, app as OrganizationApp)
+      const configuration = mergeAppConfiguration(
+        {...DEFAULT_CONFIG, path: configurationPath},
+        app as OrganizationApp,
+        true,
+      )
       const options: PushOptions = {
         configuration,
         force: false,
@@ -358,7 +366,11 @@ api_version = "unstable"
       // Given
       const configurationPath = joinPath(tmpDir, 'shopify.app.toml')
       const app = testOrganizationApp() as App
-      const configuration = mergeAppConfiguration({...DEFAULT_CONFIG, path: configurationPath}, app as OrganizationApp)
+      const configuration = mergeAppConfiguration(
+        {...DEFAULT_CONFIG, path: configurationPath},
+        app as OrganizationApp,
+        true,
+      )
       const options: PushOptions = {
         configuration: {
           ...configuration,

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -86,7 +86,11 @@ export async function confirmPushChanges(
 ) {
   if (force) return true
 
-  const remoteConfiguration = mergeAppConfiguration(configuration, app as OrganizationApp)
+  const remoteConfiguration = mergeAppConfiguration(
+    configuration,
+    app as OrganizationApp,
+    app.betas?.versionedAppConfig ?? false,
+  )
 
   const gitDiff = buildDiffConfigContent(configuration, remoteConfiguration, schema)
   if (!gitDiff) return false

--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -231,9 +231,10 @@ describe('deployOrReleaseConfirmationPrompt', () => {
       expect(result).toBe(true)
     })
 
-    test('and no force with modified and deleted configuration but versioned app not enabled then the config information should not be displayed', async () => {
+    test('and the configuration extension breakdown is undefined then the config information should not be displayed', async () => {
       // Given
       const breakdownInfo = buildCompleteBreakdownInfo()
+      breakdownInfo.configExtensionIdentifiersBreakdown = undefined
 
       const renderConfirmationPromptSpyOn = vi.spyOn(ui, 'renderConfirmationPrompt').mockResolvedValue(true)
       const metadataSpyOn = vi.spyOn(metadata, 'addPublicMetadata').mockImplementation(async () => {})

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -22,11 +22,10 @@ export interface DeployConfirmationPromptOptions {
     extensionsInfoTable?: InfoTableSection
     hasDeletedExtensions: boolean
   }
-  configContentPrompt: {
+  configContentPrompt?: {
     configInfoTable: InfoTableSection
   }
   release: boolean
-  showConfig: boolean
 }
 
 export async function deployOrReleaseConfirmationPrompt({
@@ -35,7 +34,6 @@ export async function deployOrReleaseConfirmationPrompt({
   configExtensionIdentifiersBreakdown,
   appTitle,
   release,
-  showConfig = true,
 }: DeployOrReleaseConfirmationPromptOptions) {
   if (force) return true
   const extensionsContentPrompt = await buildExtensionsContentPrompt(extensionIdentifiersBreakdown)
@@ -46,26 +44,24 @@ export async function deployOrReleaseConfirmationPrompt({
     extensionsContentPrompt,
     configContentPrompt,
     release,
-    showConfig,
   })
 }
 
 async function deployConfirmationPrompt({
   appTitle,
   extensionsContentPrompt: {extensionsInfoTable, hasDeletedExtensions},
-  configContentPrompt: {configInfoTable},
+  configContentPrompt,
   release,
-  showConfig,
 }: DeployConfirmationPromptOptions): Promise<boolean> {
   const timeBeforeConfirmationMs = new Date().valueOf()
   let confirmationResponse = true
 
   const infoTable = []
-  if ((extensionsInfoTable || configInfoTable.items.length > 0) && showConfig) {
+  if (configContentPrompt && (extensionsInfoTable || configContentPrompt.configInfoTable.items.length > 0)) {
     infoTable.push(
-      configInfoTable.items.length === 0
-        ? {...configInfoTable, emptyItemsText: 'No changes', items: []}
-        : configInfoTable,
+      configContentPrompt.configInfoTable.items.length === 0
+        ? {...configContentPrompt.configInfoTable, emptyItemsText: 'No changes', items: []}
+        : configContentPrompt.configInfoTable,
     )
   }
   const isDangerous = appTitle !== undefined && hasDeletedExtensions
@@ -142,11 +138,7 @@ async function buildConfigContentPrompt(
   release: boolean,
   configContentBreakdown?: ConfigExtensionIdentifiersBreakdown,
 ) {
-  if (!configContentBreakdown)
-    return {
-      configInfoTable: {header: 'Configuration: ', items: []},
-      deletedInfoTable: undefined,
-    }
+  if (!configContentBreakdown) return
 
   const {existingFieldNames, existingUpdatedFieldNames, newFieldNames, deletedFieldNames} = configContentBreakdown
 

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -22,6 +22,7 @@ import {fileExistsSync, inTemporaryDirectory, readFile, writeFileSync} from '@sh
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {outputContent} from '@shopify/cli-kit/node/output'
+import {setPathValue} from '@shopify/cli-kit/common/object'
 
 const REMOTE_APP = testOrganizationApp()
 
@@ -57,42 +58,43 @@ beforeEach(async () => {
 })
 
 describe('link', () => {
-  test('does not ask for a name when it is provided as a flag', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-        configName: 'Default value',
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+  describe('when version app configuration beta is enabled', () => {
+    test('does not ask for a name when it is provided as a flag', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+          configName: 'Default value',
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
 
-      // When
-      await link(options)
+        // When
+        await link(options)
 
-      // Then
-      expect(selectConfigName).not.toHaveBeenCalled()
-      expect(fileExistsSync(joinPath(tmp, 'shopify.app.default-value.toml'))).toBeTruthy()
+        // Then
+        expect(selectConfigName).not.toHaveBeenCalled()
+        expect(fileExistsSync(joinPath(tmp, 'shopify.app.default-value.toml'))).toBeTruthy()
+      })
     })
-  })
 
-  test('creates a new shopify.app.toml file when it does not exist', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      vi.mocked(loadApp).mockRejectedValue('App not found')
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+    test('creates a new shopify.app.toml file when it does not exist', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockRejectedValue('App not found')
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...REMOTE_APP, newApp: true})
 
-      // When
-      await link(options)
+        // When
+        await link(options)
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "api-key"
 name = "app1"
@@ -115,67 +117,67 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-      expect(content).toEqual(expectedContent)
-      expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.toml', directory: tmp})
-      expect(renderSuccess).toHaveBeenCalledWith({
-        headline: 'shopify.app.toml is now linked to "app1" on Shopify',
-        body: 'Using shopify.app.toml as your default config.',
-        nextSteps: [
-          [`Make updates to shopify.app.toml in your local project`],
-          ['To upload your config, run', {command: 'npm run shopify app config push'}],
-        ],
-        reference: [
-          {
-            link: {
-              label: 'App configuration',
-              url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+        expect(content).toEqual(expectedContent)
+        expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.toml', directory: tmp})
+        expect(renderSuccess).toHaveBeenCalledWith({
+          headline: 'shopify.app.toml is now linked to "app1" on Shopify',
+          body: 'Using shopify.app.toml as your default config.',
+          nextSteps: [
+            [`Make updates to shopify.app.toml in your local project`],
+            ['To upload your config, run', {command: 'npm run shopify app deploy'}],
+          ],
+          reference: [
+            {
+              link: {
+                label: 'App configuration',
+                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+              },
             },
-          },
-        ],
+          ],
+        })
       })
     })
-  })
 
-  test('creates a new shopify.app.staging.toml file when shopify.app.toml already linked', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      const localApp = {
-        configuration: {
-          path: 'shopify.app.development.toml',
-          name: 'my app',
-          client_id: '12345',
-          scopes: 'write_products',
-          webhooks: {api_version: '2023-04'},
-          application_url: 'https://myapp.com',
-          embedded: true,
-          build: {
-            automatically_update_urls_on_dev: true,
-            dev_store_url: 'my-store.myshopify.com',
-            include_config_on_deploy: true,
-          },
-        } as CurrentAppConfiguration,
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
-        testOrganizationApp({
-          apiKey: '12345',
-          applicationUrl: 'https://myapp.com',
-          title: 'my app',
-          requestedAccessScopes: ['write_products'],
-        }),
-      )
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
+    test('creates a new shopify.app.staging.toml file when shopify.app.toml already linked', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        const localApp = {
+          configuration: {
+            path: 'shopify.app.development.toml',
+            name: 'my app',
+            client_id: '12345',
+            scopes: 'write_products',
+            webhooks: {api_version: '2023-04'},
+            application_url: 'https://myapp.com',
+            embedded: true,
+            build: {
+              automatically_update_urls_on_dev: true,
+              dev_store_url: 'my-store.myshopify.com',
+              include_config_on_deploy: true,
+            },
+          } as CurrentAppConfiguration,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
+          testOrganizationApp({
+            apiKey: '12345',
+            applicationUrl: 'https://myapp.com',
+            title: 'my app',
+            requestedAccessScopes: ['write_products'],
+          }),
+        )
+        vi.mocked(selectConfigName).mockResolvedValue('staging')
 
-      // When
-      await link(options)
+        // When
+        await link(options)
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
-      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "my app"
@@ -200,73 +202,71 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-      expect(content).toEqual(expectedContent)
-      expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.staging.toml', directory: tmp})
-      expect(renderSuccess).toHaveBeenCalledWith({
-        headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
-        body: 'Using shopify.app.staging.toml as your default config.',
-        nextSteps: [
-          [`Make updates to shopify.app.staging.toml in your local project`],
-          ['To upload your config, run', {command: 'yarn shopify app config push'}],
-        ],
-        reference: [
-          {
-            link: {
-              label: 'App configuration',
-              url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+        expect(content).toEqual(expectedContent)
+        expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.staging.toml', directory: tmp})
+        expect(renderSuccess).toHaveBeenCalledWith({
+          headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
+          body: 'Using shopify.app.staging.toml as your default config.',
+          nextSteps: [
+            [`Make updates to shopify.app.staging.toml in your local project`],
+            ['To upload your config, run', {command: 'yarn shopify app deploy'}],
+          ],
+          reference: [
+            {
+              link: {
+                label: 'App configuration',
+                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+              },
             },
-          },
-        ],
+          ],
+        })
       })
     })
-  })
-  test('build section is removed if the client_id in the local configuration is different from the remote one', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      const localApp = {
-        configuration: {
-          path: 'shopify.app.staging.toml',
-          name: 'my app',
-          client_id: '12345',
-          scopes: 'write_products',
-          webhooks: {api_version: '2023-04'},
-          application_url: 'https://myapp.com',
-          embedded: true,
-          build: {
-            automatically_update_urls_on_dev: true,
-            dev_store_url: 'my-store.myshopify.com',
-          },
-        } as CurrentAppConfiguration,
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
-        testOrganizationApp({
-          apiKey: 'different-api-key',
-          applicationUrl: 'https://myapp.com',
-          title: 'my app',
-          requestedAccessScopes: ['write_products'],
-        }),
-      )
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
 
-      // When
-      await link(options)
+    test('build section is removed if the client_id in the local configuration is different from the remote one', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        const localApp = {
+          configuration: {
+            path: 'shopify.app.staging.toml',
+            name: 'my app',
+            client_id: '12345',
+            scopes: 'write_products',
+            webhooks: {api_version: '2023-04'},
+            application_url: 'https://myapp.com',
+            embedded: true,
+            build: {
+              automatically_update_urls_on_dev: true,
+              dev_store_url: 'my-store.myshopify.com',
+            },
+          } as CurrentAppConfiguration,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
+          testOrganizationApp({
+            apiKey: 'different-api-key',
+            applicationUrl: 'https://myapp.com',
+            title: 'my app',
+            requestedAccessScopes: ['write_products'],
+          }),
+        )
+        vi.mocked(selectConfigName).mockResolvedValue('staging')
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
-      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+        // When
+        await link(options)
+
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "different-api-key"
 name = "my app"
 application_url = "https://myapp.com"
 embedded = true
-
-[build]
-include_config_on_deploy = true
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
@@ -281,38 +281,35 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-      expect(content).toEqual(expectedContent)
+        expect(content).toEqual(expectedContent)
+      })
     })
-  })
 
-  test('updates the shopify.app.toml when it already exists and is unlinked', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const filePath = joinPath(tmp, 'shopify.app.toml')
-      const initialContent = `scopes = ""
+    test('updates the shopify.app.toml when it already exists and is unlinked', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const filePath = joinPath(tmp, 'shopify.app.toml')
+        const initialContent = `scopes = ""
       `
-      writeFileSync(filePath, initialContent)
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        writeFileSync(filePath, initialContent)
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
 
-      // When
-      await link(options)
+        // When
+        await link(options)
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "api-key"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
-
-[build]
-include_config_on_deploy = true
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
@@ -327,54 +324,51 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-      expect(content).toEqual(expectedContent)
-      expect(renderSuccess).toHaveBeenCalledWith({
-        headline: 'shopify.app.toml is now linked to "app1" on Shopify',
-        body: 'Using shopify.app.toml as your default config.',
-        nextSteps: [
-          [`Make updates to shopify.app.toml in your local project`],
-          ['To upload your config, run', {command: 'yarn shopify app config push'}],
-        ],
-        reference: [
-          {
-            link: {
-              label: 'App configuration',
-              url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+        expect(content).toEqual(expectedContent)
+        expect(renderSuccess).toHaveBeenCalledWith({
+          headline: 'shopify.app.toml is now linked to "app1" on Shopify',
+          body: 'Using shopify.app.toml as your default config.',
+          nextSteps: [
+            [`Make updates to shopify.app.toml in your local project`],
+            ['To upload your config, run', {command: 'yarn shopify app deploy'}],
+          ],
+          reference: [
+            {
+              link: {
+                label: 'App configuration',
+                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+              },
             },
-          },
-        ],
+          ],
+        })
       })
     })
-  })
 
-  test('does not render success banner if shouldRenderSuccess is false', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const filePath = joinPath(tmp, 'shopify.app.toml')
-      const initialContent = `scopes = ""
+    test('does not render success banner if shouldRenderSuccess is false', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const filePath = joinPath(tmp, 'shopify.app.toml')
+        const initialContent = `scopes = ""
       `
-      writeFileSync(filePath, initialContent)
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        writeFileSync(filePath, initialContent)
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
 
-      // When
-      await link(options, false)
+        // When
+        await link(options, false)
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "api-key"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
-
-[build]
-include_config_on_deploy = true
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
@@ -389,164 +383,158 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-      expect(content).toEqual(expectedContent)
-      expect(renderSuccess).not.toHaveBeenCalled()
-    })
-  })
-
-  test('fetches the app directly when an api key is provided', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-        apiKey: 'api-key',
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-      vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(REMOTE_APP)
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
-
-      // When
-      await link(options)
-
-      // Then
-      expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith('api-key', 'token')
-    })
-  })
-
-  test('throws an error when an invalid api key is is provided', async () => {
-    vi.mocked(InvalidApiKeyErrorMessage).mockReturnValue({
-      message: outputContent`Invalid Client ID`,
-      tryMessage: outputContent`You can find the Client ID in the app settings in the Partners Dashboard.`,
+        expect(content).toEqual(expectedContent)
+        expect(renderSuccess).not.toHaveBeenCalled()
+      })
     })
 
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-        apiKey: '1234-5678',
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-      vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(undefined)
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
+    test('fetches the app directly when an api key is provided', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+          apiKey: 'api-key',
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+        vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
+        vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(REMOTE_APP)
+        vi.mocked(selectConfigName).mockResolvedValue('staging')
 
-      // When
-      const result = link(options)
+        // When
+        await link(options)
 
-      // Then
-      await expect(result).rejects.toThrow(/Invalid Client ID/)
+        // Then
+        expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith('api-key', 'token')
+      })
     })
-  })
 
-  test('skips config name question if re-linking to existing current app schema', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      const localApp = {
-        configuration: {
-          path: 'shopify.app.foo.toml',
-          name: 'my app',
-          client_id: '12345',
-          scopes: 'write_products',
-          webhooks: {api_version: '2023-04'},
-          application_url: 'https://myapp.com',
-          embedded: true,
-        } as CurrentAppConfiguration,
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
-        testOrganizationApp({
-          apiKey: '12345',
-          applicationUrl: 'https://myapp.com',
-          title: 'my app',
-          requestedAccessScopes: ['write_products'],
-        }),
-      )
-      vi.mocked(getCachedCommandInfo).mockReturnValue({askConfigName: false, selectedToml: 'shopify.app.foo.toml'})
-
-      // When
-      await link(options)
-
-      expect(selectConfigName).not.toHaveBeenCalled()
-      expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.foo.toml', directory: tmp})
-    })
-  })
-
-  test('generates the file when there is no shopify.app.toml', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      vi.mocked(loadApp).mockRejectedValue(new Error('Shopify.app.toml not found'))
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
-
-      // When
-      await link(options)
-
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
-
-client_id = "api-key"
-name = "app1"
-application_url = "https://example.com"
-embedded = true
-
-[build]
-include_config_on_deploy = true
-
-[access_scopes]
-# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-use_legacy_install_flow = true
-
-[auth]
-redirect_urls = [ "https://example.com/callback1" ]
-
-[webhooks]
-api_version = "2023-07"
-
-[pos]
-embedded = false
-`
-      expect(content).toEqual(expectedContent)
-    })
-  })
-
-  test('uses scopes on platform if defined', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({
-        ...REMOTE_APP,
-        requestedAccessScopes: ['read_products', 'write_orders'],
+    test('throws an error when an invalid api key is is provided', async () => {
+      vi.mocked(InvalidApiKeyErrorMessage).mockReturnValue({
+        message: outputContent`Invalid Client ID`,
+        tryMessage: outputContent`You can find the Client ID in the app settings in the Partners Dashboard.`,
       })
 
-      // When
-      await link(options)
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+          apiKey: '1234-5678',
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+        vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
+        vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(undefined)
+        vi.mocked(selectConfigName).mockResolvedValue('staging')
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+        // When
+        const result = link(options)
+
+        // Then
+        await expect(result).rejects.toThrow(/Invalid Client ID/)
+      })
+    })
+
+    test('skips config name question if re-linking to existing current app schema', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        const localApp = {
+          configuration: {
+            path: 'shopify.app.foo.toml',
+            name: 'my app',
+            client_id: '12345',
+            scopes: 'write_products',
+            webhooks: {api_version: '2023-04'},
+            application_url: 'https://myapp.com',
+            embedded: true,
+          } as CurrentAppConfiguration,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
+          testOrganizationApp({
+            apiKey: '12345',
+            applicationUrl: 'https://myapp.com',
+            title: 'my app',
+            requestedAccessScopes: ['write_products'],
+          }),
+        )
+        vi.mocked(getCachedCommandInfo).mockReturnValue({askConfigName: false, selectedToml: 'shopify.app.foo.toml'})
+
+        // When
+        await link(options)
+
+        expect(selectConfigName).not.toHaveBeenCalled()
+        expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.foo.toml', directory: tmp})
+      })
+    })
+
+    test('generates the file when there is no shopify.app.toml', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockRejectedValue(new Error('Shopify.app.toml not found'))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+
+        // When
+        await link(options)
+
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "api-key"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
 
-[build]
-include_config_on_deploy = true
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+use_legacy_install_flow = true
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[webhooks]
+api_version = "2023-07"
+
+[pos]
+embedded = false
+`
+        expect(content).toEqual(expectedContent)
+      })
+    })
+
+    test('uses scopes on platform if defined', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({
+          ...REMOTE_APP,
+          requestedAccessScopes: ['read_products', 'write_orders'],
+        })
+
+        // When
+        await link(options)
+
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "api-key"
+name = "app1"
+application_url = "https://example.com"
+embedded = true
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
@@ -561,37 +549,34 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-      expect(content).toEqual(expectedContent)
-    })
-  })
-
-  test('unset privacy compliance urls are undefined', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      vi.mocked(loadApp).mockRejectedValue('App not found')
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({
-        ...REMOTE_APP,
-        gdprWebhooks: {customerDataRequestUrl: 'https://example.com/customer-data'},
+        expect(content).toEqual(expectedContent)
       })
+    })
 
-      // When
-      await link(options)
+    test('unset privacy compliance urls are undefined', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockRejectedValue('App not found')
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({
+          ...REMOTE_APP,
+          gdprWebhooks: {customerDataRequestUrl: 'https://example.com/customer-data'},
+        })
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+        // When
+        await link(options)
+
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "api-key"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
-
-[build]
-include_config_on_deploy = true
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
@@ -609,118 +594,115 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-      expect(content).toEqual(expectedContent)
-      expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.toml', directory: tmp})
-      expect(renderSuccess).toHaveBeenCalledWith({
-        headline: 'shopify.app.toml is now linked to "app1" on Shopify',
-        body: 'Using shopify.app.toml as your default config.',
-        nextSteps: [
-          [`Make updates to shopify.app.toml in your local project`],
-          ['To upload your config, run', {command: 'npm run shopify app config push'}],
-        ],
-        reference: [
-          {
-            link: {
-              label: 'App configuration',
-              url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+        expect(content).toEqual(expectedContent)
+        expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.toml', directory: tmp})
+        expect(renderSuccess).toHaveBeenCalledWith({
+          headline: 'shopify.app.toml is now linked to "app1" on Shopify',
+          body: 'Using shopify.app.toml as your default config.',
+          nextSteps: [
+            [`Make updates to shopify.app.toml in your local project`],
+            ['To upload your config, run', {command: 'npm run shopify app deploy'}],
+          ],
+          reference: [
+            {
+              link: {
+                label: 'App configuration',
+                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+              },
             },
-          },
-        ],
+          ],
+        })
       })
     })
-  })
 
-  test('the api client configuration is deep merged with the remote app_config extension registrations', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const options: LinkOptions = {
-        directory: tmp,
-        commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
-      }
-      const localApp = {
-        configuration: {
-          path: 'shopify.app.development.toml',
-          name: 'my app',
-          client_id: '12345',
-          scopes: 'write_products',
-          webhooks: {
-            api_version: '2023-04',
+    test('the api client configuration is deep merged with the remote app_config extension registrations', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        const localApp = {
+          configuration: {
+            path: 'shopify.app.development.toml',
+            name: 'my app',
+            client_id: '12345',
+            scopes: 'write_products',
+            webhooks: {
+              api_version: '2023-04',
+            },
+            application_url: 'https://myapp.com',
+            embedded: true,
+            pos: {
+              embedded: false,
+            },
+          } as CurrentAppConfiguration,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
+          testOrganizationApp({
+            apiKey: '12345',
+            applicationUrl: 'https://myapp.com',
+            title: 'my app',
+            requestedAccessScopes: ['write_products'],
+          }),
+        )
+        vi.mocked(selectConfigName).mockResolvedValue('staging')
+        vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({
+          app: {
+            extensionRegistrations: [
+              {
+                type: 'THEME_APP_EXTENSION',
+                id: '123',
+                uuid: '123',
+                title: 'mock-theme',
+                activeVersion: {
+                  config: JSON.stringify({name: 'my-theme-app', type: 'theme_app_extension'}),
+                },
+              },
+            ],
+            configurationRegistrations: [
+              {
+                type: 'point_of_sale',
+                id: '321',
+                uuid: '321',
+                title: 'point_of_sale',
+                activeVersion: {
+                  config: JSON.stringify({embedded: true}),
+                },
+              },
+              {
+                type: 'webhooks',
+                id: '543',
+                uuid: '543',
+                title: 'webhooks',
+                activeVersion: {
+                  config: JSON.stringify({
+                    subscriptions: [
+                      {
+                        topic: 'products/create',
+                        uri: 'https://my-app.com/webhooks',
+                      },
+                    ],
+                  }),
+                },
+              },
+            ],
+            dashboardManagedExtensionRegistrations: [],
           },
-          application_url: 'https://myapp.com',
-          embedded: true,
-          pos: {
-            embedded: false,
-          },
-        } as CurrentAppConfiguration,
-      }
-      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
-      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
-        testOrganizationApp({
-          apiKey: '12345',
-          applicationUrl: 'https://myapp.com',
-          title: 'my app',
-          requestedAccessScopes: ['write_products'],
-        }),
-      )
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
-      vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({
-        app: {
-          extensionRegistrations: [
-            {
-              type: 'THEME_APP_EXTENSION',
-              id: '123',
-              uuid: '123',
-              title: 'mock-theme',
-              activeVersion: {
-                config: JSON.stringify({name: 'my-theme-app', type: 'theme_app_extension'}),
-              },
-            },
-          ],
-          configurationRegistrations: [
-            {
-              type: 'point_of_sale',
-              id: '321',
-              uuid: '321',
-              title: 'point_of_sale',
-              activeVersion: {
-                config: JSON.stringify({embedded: true}),
-              },
-            },
-            {
-              type: 'webhooks',
-              id: '543',
-              uuid: '543',
-              title: 'webhooks',
-              activeVersion: {
-                config: JSON.stringify({
-                  subscriptions: [
-                    {
-                      topic: 'products/create',
-                      uri: 'https://my-app.com/webhooks',
-                    },
-                  ],
-                }),
-              },
-            },
-          ],
-          dashboardManagedExtensionRegistrations: [],
-        },
-      })
+        })
 
-      // When
-      await link(options)
+        // When
+        await link(options)
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
-      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "my app"
 application_url = "https://myapp.com"
 embedded = true
-
-[build]
-include_config_on_deploy = true
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
@@ -739,32 +721,221 @@ api_version = "2023-07"
 [pos]
 embedded = true
 `
-      expect(content).toEqual(expectedContent)
-      expect(renderSuccess).toHaveBeenCalledWith({
-        headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
-        body: 'Using shopify.app.staging.toml as your default config.',
-        nextSteps: [
-          [`Make updates to shopify.app.staging.toml in your local project`],
-          ['To upload your config, run', {command: 'yarn shopify app deploy'}],
-        ],
-        reference: [
-          {
-            link: {
-              label: 'App configuration',
-              url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+        expect(content).toEqual(expectedContent)
+        expect(renderSuccess).toHaveBeenCalledWith({
+          headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
+          body: 'Using shopify.app.staging.toml as your default config.',
+          nextSteps: [
+            [`Make updates to shopify.app.staging.toml in your local project`],
+            ['To upload your config, run', {command: 'yarn shopify app deploy'}],
+          ],
+          reference: [
+            {
+              link: {
+                label: 'App configuration',
+                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+              },
             },
+          ],
+        })
+      })
+    })
+
+    test('when local app doesnt include build section and the remote app is new then include include_config_on_deploy is added', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const filePath = joinPath(tmp, 'shopify.app.toml')
+        const initialContent = `scopes = ""
+    `
+        writeFileSync(filePath, initialContent)
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...REMOTE_APP, newApp: true})
+
+        // When
+        await link(options)
+
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "api-key"
+name = "app1"
+application_url = "https://example.com"
+embedded = true
+
+[build]
+include_config_on_deploy = true
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+use_legacy_install_flow = true
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[webhooks]
+api_version = "2023-07"
+
+[pos]
+embedded = false
+`
+        expect(content).toEqual(expectedContent)
+      })
+    })
+  })
+  describe('when version app configuration beta is disabled', () => {
+    test('success banner message will include config push command', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const filePath = joinPath(tmp, 'shopify.app.toml')
+        const initialContent = `scopes = ""
+    `
+        writeFileSync(filePath, initialContent)
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, undefined, []))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+
+        // When
+        await link(options)
+
+        // Then
+        expect(renderSuccess).toHaveBeenCalledWith({
+          headline: 'shopify.app.toml is now linked to "app1" on Shopify',
+          body: 'Using shopify.app.toml as your default config.',
+          nextSteps: [
+            [`Make updates to shopify.app.toml in your local project`],
+            ['To upload your config, run', {command: 'yarn shopify app config push'}],
+          ],
+          reference: [
+            {
+              link: {
+                label: 'App configuration',
+                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
+              },
+            },
+          ],
+        })
+      })
+    })
+
+    test('when local app doesnt include build section then no build section is added', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const filePath = joinPath(tmp, 'shopify.app.toml')
+        const initialContent = `scopes = ""
+    `
+        writeFileSync(filePath, initialContent)
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, undefined, []))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+
+        // When
+        await link(options)
+
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "api-key"
+name = "app1"
+application_url = "https://example.com"
+embedded = true
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+use_legacy_install_flow = true
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[webhooks]
+api_version = "2023-07"
+
+[pos]
+embedded = false
+`
+        expect(content).toEqual(expectedContent)
+      })
+    })
+
+    test('app modules configuration are not merged', async () => {
+      await inTemporaryDirectory(async (tmp) => {
+        // Given
+        const filePath = joinPath(tmp, 'shopify.app.toml')
+        const initialContent = `scopes = ""
+    `
+        writeFileSync(filePath, initialContent)
+        const options: LinkOptions = {
+          directory: tmp,
+          commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+        }
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, undefined, []))
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({
+          app: {
+            extensionRegistrations: [],
+            configurationRegistrations: [
+              {
+                type: 'point_of_sale',
+                id: '321',
+                uuid: '321',
+                title: 'point_of_sale',
+                activeVersion: {
+                  config: JSON.stringify({embedded: true}),
+                },
+              },
+            ],
+            dashboardManagedExtensionRegistrations: [],
           },
-        ],
+        })
+
+        // When
+        await link(options)
+
+        // Then
+        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "api-key"
+name = "app1"
+application_url = "https://example.com"
+embedded = true
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+use_legacy_install_flow = true
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[webhooks]
+api_version = "2023-07"
+
+[pos]
+embedded = false
+`
+        expect(content).toEqual(expectedContent)
       })
     })
   })
 })
 
-async function mockApp(directory: string, app?: Partial<AppInterface>) {
+async function mockApp(directory: string, app?: Partial<AppInterface>, betas = [BetaFlag.VersionedAppConfig]) {
   const versionSchema = await buildVersionedAppSchema()
   const localApp = testApp(app)
   localApp.configSchema = versionSchema.schema
   localApp.specifications = versionSchema.configSpecifications
   localApp.directory = directory
+  setPathValue(localApp, 'remoteBetaFlags', betas)
   return localApp
 }

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -15,13 +15,13 @@ import {fetchPartnersSession} from '../../context/partner-account-info.js'
 import {AppInterface, CurrentAppConfiguration} from '../../../models/app/app.js'
 import {loadFSExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {fetchSpecifications} from '../../generate/fetch-extension-specifications.js'
+import {BetaFlag, fetchAppRemoteBetaFlags} from '../select-app.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {Config} from '@oclif/core'
 import {fileExistsSync, inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {outputContent} from '@shopify/cli-kit/node/output'
-import {useVersionedAppConfig} from '@shopify/cli-kit/node/context/local'
 
 const REMOTE_APP = testOrganizationApp()
 
@@ -41,7 +41,7 @@ vi.mock('../../dev/fetch.js')
 vi.mock('../../context.js')
 vi.mock('../../context/partner-account-info.js')
 vi.mock('../../generate/fetch-extension-specifications.js')
-vi.mock('@shopify/cli-kit/node/context/local')
+vi.mock('../select-app.js')
 
 beforeEach(async () => {
   vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
@@ -53,7 +53,7 @@ beforeEach(async () => {
     },
   })
   vi.mocked(fetchSpecifications).mockResolvedValue(await loadFSExtensionsSpecifications())
-  vi.mocked(useVersionedAppConfig).mockResolvedValue(true)
+  vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 })
 
 describe('link', () => {

--- a/packages/app/src/cli/services/app/config/push.test.ts
+++ b/packages/app/src/cli/services/app/config/push.test.ts
@@ -536,15 +536,14 @@ async function mockApp(
   schemaType: 'current' | 'legacy' = 'legacy',
 ): Promise<AppInterface> {
   const versionSchema = await buildVersionedAppSchema()
-  const localApp = testApp(app, schemaType)
+  let localApp = testApp(app, schemaType)
+  const extensions = await createConfigExtensionInstances(
+    localApp.configuration as CurrentAppConfiguration,
+    versionSchema.configSpecifications,
+  )
+  localApp = testApp({...app, allExtensions: extensions}, schemaType)
   localApp.configSchema = versionSchema.schema
   localApp.specifications = versionSchema.configSpecifications
-  localApp.addExtensions(
-    await createConfigExtensionInstances(
-      localApp.configuration as CurrentAppConfiguration,
-      versionSchema.configSpecifications,
-    ),
-  )
   return localApp
 }
 

--- a/packages/app/src/cli/services/app/config/push.test.ts
+++ b/packages/app/src/cli/services/app/config/push.test.ts
@@ -539,9 +539,11 @@ async function mockApp(
   const localApp = testApp(app, schemaType)
   localApp.configSchema = versionSchema.schema
   localApp.specifications = versionSchema.configSpecifications
-  localApp.allExtensions = await createConfigExtensionInstances(
-    localApp.configuration as CurrentAppConfiguration,
-    versionSchema.configSpecifications,
+  localApp.addExtensions(
+    await createConfigExtensionInstances(
+      localApp.configuration as CurrentAppConfiguration,
+      versionSchema.configSpecifications,
+    ),
   )
   return localApp
 }

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -1,7 +1,10 @@
+import {GetConfig, GetConfigQuerySchema} from '../../api/graphql/get_config.js'
 import {OrganizationApp} from '../../models/organization.js'
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {fetchPartnersSession} from '../context/partner-account-info.js'
 import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
+import {outputDebug} from '@shopify/cli-kit/node/output'
+import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 
 export async function selectApp(): Promise<OrganizationApp> {
   const partnersSession = await fetchPartnersSession()
@@ -11,4 +14,20 @@ export async function selectApp(): Promise<OrganizationApp> {
   const selectedAppApiKey = await selectAppPrompt(apps, org.id, partnersSession)
   const fullSelectedApp = await fetchAppDetailsFromApiKey(selectedAppApiKey, partnersSession.token)
   return fullSelectedApp!
+}
+
+export enum BetaFlag {
+  VersionedAppConfig,
+}
+
+export async function fetchAppRemoteBetaFlags(apiKey: string, token: string) {
+  const betas: BetaFlag[] = []
+  const queryResult: GetConfigQuerySchema = await partnersRequest(GetConfig, token, {apiKey})
+  if (queryResult.app) {
+    const {app} = queryResult
+    if (app.betas?.versionedAppConfig) betas.push(BetaFlag.VersionedAppConfig)
+  } else {
+    outputDebug("Couldn't find app for beta flags. Make sure you have a valid client ID.")
+  }
+  return betas
 }

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -27,7 +27,7 @@ import link from './app/config/link.js'
 import {fetchPartnersSession} from './context/partner-account-info.js'
 import {fetchSpecifications} from './generate/fetch-extension-specifications.js'
 import * as writeAppConfigurationFile from './app/write-app-configuration-file.js'
-import {BetaFlag, fetchAppRemoteBetaFlags} from './app/select-app.js'
+import {BetaFlag} from './app/select-app.js'
 import {loadFSExtensionsSpecifications} from '../models/extensions/load-specifications.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
 import {updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
@@ -59,6 +59,7 @@ import {inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/no
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderConfirmationPrompt, renderInfo, renderTasks, Task} from '@shopify/cli-kit/node/ui'
 import {Config} from '@oclif/core'
+import {setPathValue} from '@shopify/cli-kit/common/object'
 
 const COMMAND_CONFIG = {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config
 
@@ -200,7 +201,6 @@ beforeEach(async () => {
       await task.task({}, task)
     }
   })
-  vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([])
 })
 
 afterEach(() => {
@@ -1132,6 +1132,7 @@ describe('ensureDeployContext', () => {
   test('prompts the user to include the configuration and persist the flag if the flag is not present and the beta is enabled', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey}})
+    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1147,7 +1148,6 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app))
@@ -1179,6 +1179,7 @@ describe('ensureDeployContext', () => {
   test('prompts the user to include the configuration and set it to false when not confirmed if the flag is not present and the beta is enabled', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey}})
+    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1194,7 +1195,6 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app))
@@ -1226,6 +1226,7 @@ describe('ensureDeployContext', () => {
   test('doesnt prompt the user to include the configuration and display the current value if the flag and beta are enabled', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey, build: {include_config_on_deploy: true}}})
+    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1240,7 +1241,6 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app))
@@ -1269,6 +1269,7 @@ describe('ensureDeployContext', () => {
   test('prompts the user to include the configuration when reset is used if the flag and beta are enabled', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey, build: {include_config_on_deploy: true}}})
+    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1285,7 +1286,6 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app, true))
@@ -1317,6 +1317,7 @@ describe('ensureDeployContext', () => {
   test('doesnt prompt the user to include the configuration when force is used if the flag is not present and beta are enabled', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey}})
+    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1332,7 +1333,6 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app, false, true))
@@ -1361,6 +1361,7 @@ describe('ensureDeployContext', () => {
   test('prompt the user to include the configuration when force is used  if the flag and beta are enabled', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey, build: {include_config_on_deploy: true}}})
+    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1376,7 +1377,6 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app, false, true))

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -27,6 +27,7 @@ import link from './app/config/link.js'
 import {fetchPartnersSession} from './context/partner-account-info.js'
 import {fetchSpecifications} from './generate/fetch-extension-specifications.js'
 import * as writeAppConfigurationFile from './app/write-app-configuration-file.js'
+import {BetaFlag, fetchAppRemoteBetaFlags} from './app/select-app.js'
 import {loadFSExtensionsSpecifications} from '../models/extensions/load-specifications.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
 import {updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
@@ -58,7 +59,6 @@ import {inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/no
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderConfirmationPrompt, renderInfo, renderTasks, Task} from '@shopify/cli-kit/node/ui'
 import {Config} from '@oclif/core'
-import {useVersionedAppConfig} from '@shopify/cli-kit/node/context/local'
 
 const COMMAND_CONFIG = {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config
 
@@ -173,7 +173,7 @@ vi.mock('./deploy/mode.js')
 vi.mock('./app/config/link.js')
 vi.mock('./context/partner-account-info.js')
 vi.mock('./generate/fetch-extension-specifications.js')
-vi.mock('@shopify/cli-kit/node/context/local')
+vi.mock('./app/select-app.js')
 
 beforeAll(async () => {
   vi.mocked(fetchSpecifications).mockResolvedValue(await loadFSExtensionsSpecifications())
@@ -200,6 +200,7 @@ beforeEach(async () => {
       await task.task({}, task)
     }
   })
+  vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([])
 })
 
 afterEach(() => {
@@ -1146,7 +1147,7 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(useVersionedAppConfig).mockReturnValue(true)
+    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app))
@@ -1193,7 +1194,7 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(useVersionedAppConfig).mockReturnValue(true)
+    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app))
@@ -1239,7 +1240,7 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(useVersionedAppConfig).mockReturnValue(true)
+    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app))
@@ -1284,7 +1285,7 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(useVersionedAppConfig).mockReturnValue(true)
+    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app, true))
@@ -1331,7 +1332,7 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(useVersionedAppConfig).mockReturnValue(true)
+    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app, false, true))
@@ -1375,7 +1376,7 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(useVersionedAppConfig).mockReturnValue(true)
+    vi.mocked(fetchAppRemoteBetaFlags).mockResolvedValue([BetaFlag.VersionedAppConfig])
 
     // When
     await ensureDeployContext(options(app, false, true))
@@ -1419,7 +1420,6 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
-    vi.mocked(useVersionedAppConfig).mockReturnValue(false)
 
     // When
     await ensureDeployContext(options(app, false, true))

--- a/packages/app/src/cli/services/context/breakdown-extensions.test.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.test.ts
@@ -10,13 +10,20 @@ import {
 import {RemoteSource} from './identifiers.js'
 import {fetchActiveAppVersion, fetchAppExtensionRegistrations} from '../dev/fetch.js'
 import {AppConfiguration, AppInterface, CurrentAppConfiguration} from '../../models/app/app.js'
-import {buildVersionedAppSchema, testApp, testUIExtension} from '../../models/app/app.test-data.js'
+import {
+  buildVersionedAppSchema,
+  testApp,
+  testAppConfigExtensions,
+  testUIExtension,
+} from '../../models/app/app.test-data.js'
 import {OrganizationApp} from '../../models/organization.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {AppModuleVersion} from '../../api/graphql/app_active_version.js'
 import {AppVersionsDiffExtensionSchema} from '../../api/graphql/app_versions_diff.js'
 import {versionDiffByVersion} from '../release/version-diff.js'
+import {BetaFlag} from '../app/select-app.js'
 import {describe, vi, test, beforeAll, expect} from 'vitest'
+import {setPathValue} from '@shopify/cli-kit/common/object'
 
 const REGISTRATION_A: RemoteSource = {
   uuid: 'UUID_A',
@@ -199,22 +206,29 @@ const APP_CONFIGURATION: CurrentAppConfiguration = {
   },
   application_url: 'https://myapp.com',
   embedded: true,
+  build: {
+    include_config_on_deploy: true,
+  },
 }
 
 const LOCAL_APP = async (
   uiExtensions: ExtensionInstance[],
   configuration: AppConfiguration = APP_CONFIGURATION,
+  betas = [BetaFlag.VersionedAppConfig],
 ): Promise<AppInterface> => {
   const versionSchema = await buildVersionedAppSchema()
 
-  return testApp({
+  const localApp = testApp({
     name: 'my-app',
     directory: '/app',
     configuration,
-    allExtensions: [...uiExtensions],
+    allExtensions: [...uiExtensions, await testAppConfigExtensions()],
     specifications: versionSchema.configSpecifications,
     configSchema: versionSchema.schema,
   })
+
+  setPathValue(localApp, 'remoteBetaFlags', betas)
+  return localApp
 }
 
 const options = async (
@@ -637,6 +651,7 @@ describe('configExtensionsIdentifiersBreakdown', () => {
         build: {
           automatically_update_urls_on_dev: false,
           dev_store_url: 'https://my-dev-store.com',
+          include_config_on_deploy: true,
         },
         webhooks: {
           api_version: '2023-04',
@@ -671,6 +686,9 @@ describe('configExtensionsIdentifiersBreakdown', () => {
         embedded: true,
         webhooks: {
           api_version: '2023-04',
+        },
+        build: {
+          include_config_on_deploy: true,
         },
       }
       const configActiveAppModule: AppModuleVersion = {
@@ -759,6 +777,9 @@ describe('configExtensionsIdentifiersBreakdown', () => {
         embedded: true,
         webhooks: {
           api_version: '2023-04',
+        },
+        build: {
+          include_config_on_deploy: true,
         },
       }
       const configActiveAppModule: AppModuleVersion = {
@@ -850,6 +871,9 @@ describe('configExtensionsIdentifiersBreakdown', () => {
         webhooks: {
           api_version: '2023-04',
         },
+        build: {
+          include_config_on_deploy: true,
+        },
       }
       const configActiveAppModule: AppModuleVersion = {
         registrationId: 'C_A',
@@ -901,6 +925,9 @@ describe('configExtensionsIdentifiersBreakdown', () => {
         embedded: true,
         webhooks: {
           api_version: '2023-04',
+        },
+        build: {
+          include_config_on_deploy: true,
         },
       }
       const configActiveAppModule: AppModuleVersion = {
@@ -1259,6 +1286,118 @@ describe('configExtensionsIdentifiersBreakdown', () => {
         newFieldNames: [],
         deletedFieldNames: ['pos'],
       })
+    })
+  })
+  describe('deploy not including the configuration app modules', () => {
+    test('when the beta is not enabled the configuration breakdown info is not returned', async () => {
+      // Given
+      const configToReleaseAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'app_home',
+        config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
+        specification: {
+          identifier: 'app_home',
+          name: 'App Ui',
+          experience: 'configuration',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const configActiveAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'app_home',
+        config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
+        specification: {
+          identifier: 'app_home',
+          name: 'App Ui',
+          experience: 'configuration',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const activeVersion = {app: {activeAppVersion: {appModuleVersions: [configActiveAppModule, MODULE_DASHBOARD_A]}}}
+      vi.mocked(fetchActiveAppVersion).mockResolvedValue(activeVersion)
+
+      // When
+      const result = await configExtensionsIdentifiersBreakdown({
+        token: 'token',
+        apiKey: 'apiKey',
+        localApp: await LOCAL_APP([], APP_CONFIGURATION, []),
+        versionAppModules: [configToReleaseAppModule],
+        release: true,
+      })
+
+      // Then
+      expect(result).toBeUndefined()
+    })
+    test('when the include_config_on_deploy is not true the configuration breakdown info is not returned', async () => {
+      // Given
+      const configuration = {
+        path: 'shopify.app.development.toml',
+        name: 'my app',
+        client_id: '12345',
+        application_url: 'https://myapp.com',
+        embedded: true,
+        pos: {
+          embedded: false,
+        },
+        build: {
+          include_config_on_deploy: false,
+        },
+        webhooks: {
+          api_version: '2023-04',
+        },
+      }
+      const configToReleaseAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'app_home',
+        config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
+        specification: {
+          identifier: 'app_home',
+          name: 'App Ui',
+          experience: 'configuration',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const configActiveAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'app_home',
+        config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
+        specification: {
+          identifier: 'app_home',
+          name: 'App Ui',
+          experience: 'configuration',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const activeVersion = {app: {activeAppVersion: {appModuleVersions: [configActiveAppModule, MODULE_DASHBOARD_A]}}}
+      vi.mocked(fetchActiveAppVersion).mockResolvedValue(activeVersion)
+
+      // When
+      const result = await configExtensionsIdentifiersBreakdown({
+        token: 'token',
+        apiKey: 'apiKey',
+        localApp: await LOCAL_APP([], configuration),
+        versionAppModules: [configToReleaseAppModule],
+        release: true,
+      })
+
+      // Then
+      expect(result).toBeUndefined()
     })
   })
 })

--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -94,6 +94,7 @@ export async function configExtensionsIdentifiersBreakdown({
   versionAppModules?: AppModuleVersion[]
   release?: boolean
 }) {
+  if (localApp.allExtensions.filter((extension) => extension.isAppConfigExtension).length === 0) return
   if (!release) return loadLocalConfigExtensionIdentifiersBreakdown(localApp)
 
   const activeAppVersion = await fetchActiveAppVersion({token, apiKey})

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -671,9 +671,10 @@ describe('excludes non uuid managed extensions', () => {
     })
 
     // When
-    const ensureExtensionsIdsOptions = options([EXTENSION_A])
     const CONFIG_A = await testAppConfigExtensions()
-    ensureExtensionsIdsOptions.app.addExtensions([CONFIG_A])
+    const ensureExtensionsIdsOptions = options([EXTENSION_A], [], {}, testOrganizationApp(), true, false, false, [
+      CONFIG_A,
+    ])
     await ensureExtensionsIds(ensureExtensionsIdsOptions, {
       extensionRegistrations: [REGISTRATION_A],
       dashboardManagedExtensionRegistrations: [],

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -16,9 +16,11 @@ import {getUIExtensionsToMigrate, migrateExtensionsToUIExtension} from '../dev/m
 import {OrganizationApp} from '../../models/organization.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {createExtension} from '../dev/create-extension.js'
+import {BetaFlag} from '../app/select-app.js'
 import {beforeEach, describe, expect, vi, test, beforeAll} from 'vitest'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
+import {setPathValue} from '@shopify/cli-kit/common/object'
 
 const REGISTRATION_A = {
   uuid: 'UUID_A',
@@ -71,6 +73,7 @@ const LOCAL_APP = (
   uiExtensions: ExtensionInstance[],
   functionExtensions: ExtensionInstance[] = [],
   includeDeployConfig = false,
+  configExtensions: ExtensionInstance[] = [],
 ): AppInterface => {
   return testApp({
     name: 'my-app',
@@ -81,7 +84,7 @@ const LOCAL_APP = (
       extension_directories: ['extensions/*'],
       ...(includeDeployConfig ? {build: {include_config_on_deploy: true}} : {}),
     },
-    allExtensions: [...uiExtensions, ...functionExtensions],
+    allExtensions: [...uiExtensions, ...functionExtensions, ...configExtensions],
   })
 }
 
@@ -93,9 +96,11 @@ const options = (
   release = true,
   includeDeployConfig = false,
   useVersionedAppConfig = false,
+  configExtensions: ExtensionInstance[] = [],
+  betas = [BetaFlag.VersionedAppConfig],
 ) => {
-  return {
-    app: LOCAL_APP(uiExtensions, functionExtensions, includeDeployConfig),
+  const localApp = {
+    app: LOCAL_APP(uiExtensions, functionExtensions, includeDeployConfig, configExtensions),
     token: 'token',
     appId: 'appId',
     appName: 'appName',
@@ -105,6 +110,8 @@ const options = (
     release,
     useVersionedAppConfig,
   }
+  setPathValue(localApp.app, 'remoteBetaFlags', betas)
+  return localApp
 }
 
 vi.mock('@shopify/cli-kit/node/session')
@@ -666,7 +673,7 @@ describe('excludes non uuid managed extensions', () => {
     // When
     const ensureExtensionsIdsOptions = options([EXTENSION_A])
     const CONFIG_A = await testAppConfigExtensions()
-    ensureExtensionsIdsOptions.app.allExtensions.push(CONFIG_A)
+    ensureExtensionsIdsOptions.app.addExtensions([CONFIG_A])
     await ensureExtensionsIds(ensureExtensionsIdsOptions, {
       extensionRegistrations: [REGISTRATION_A],
       dashboardManagedExtensionRegistrations: [],
@@ -750,9 +757,8 @@ describe('ensuredeployConfirmed: handle non existent uuid managed extensions', (
     }
 
     // When
-    const ensureExtensionsIdsOptions = options([], [], {}, testOrganizationApp(), true, true, true)
     const CONFIG_A = await testAppConfigExtensions()
-    ensureExtensionsIdsOptions.app.allExtensions.push(CONFIG_A)
+    const ensureExtensionsIdsOptions = options([], [], {}, testOrganizationApp(), true, true, true, [CONFIG_A])
     const got = await deployConfirmed(ensureExtensionsIdsOptions, [], [REGISTRATION_CONFIG_A], {
       extensionsToCreate,
       validMatches,
@@ -779,9 +785,9 @@ describe('ensuredeployConfirmed: handle non existent uuid managed extensions', (
     vi.mocked(createExtension).mockResolvedValueOnce(REGISTRATION_CONFIG_A)
 
     // When
-    const ensureExtensionsIdsOptions = options([])
+
     const CONFIG_A = await testAppConfigExtensions()
-    ensureExtensionsIdsOptions.app.allExtensions.push(CONFIG_A)
+    const ensureExtensionsIdsOptions = options([], [], {}, testOrganizationApp(), true, true, false, [CONFIG_A])
     const got = await deployConfirmed(ensureExtensionsIdsOptions, [], [REGISTRATION_CONFIG_A], {
       extensionsToCreate,
       validMatches,
@@ -791,8 +797,8 @@ describe('ensuredeployConfirmed: handle non existent uuid managed extensions', (
     expect(createExtension).not.toHaveBeenCalled()
     expect(got).toEqual({
       extensions: {},
-      extensionIds: {},
-      extensionsNonUuidManaged: {},
+      extensionIds: {'point-of-sale': 'C_A'},
+      extensionsNonUuidManaged: {'point-of-sale': 'UUID_C_A'},
     })
   })
 })
@@ -809,9 +815,9 @@ describe('ensuredeployConfirmed: handle existent uuid managed extensions', () =>
     }
 
     // When
-    const ensureExtensionsIdsOptions = options([], [], {}, testOrganizationApp(), true, true, true)
     const CONFIG_A = await testAppConfigExtensions()
-    ensureExtensionsIdsOptions.app.allExtensions.push(CONFIG_A)
+
+    const ensureExtensionsIdsOptions = options([], [], {}, testOrganizationApp(), true, true, true, [CONFIG_A])
     const got = await deployConfirmed(ensureExtensionsIdsOptions, [], [REGISTRATION_CONFIG_A], {
       extensionsToCreate,
       validMatches,

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -19,7 +19,6 @@ import {createExtension} from '../dev/create-extension.js'
 import {beforeEach, describe, expect, vi, test, beforeAll} from 'vitest'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
-import {useVersionedAppConfig} from '@shopify/cli-kit/node/context/local'
 
 const REGISTRATION_A = {
   uuid: 'UUID_A',
@@ -93,6 +92,7 @@ const options = (
   partnersApp: OrganizationApp = testOrganizationApp(),
   release = true,
   includeDeployConfig = false,
+  useVersionedAppConfig = false,
 ) => {
   return {
     app: LOCAL_APP(uiExtensions, functionExtensions, includeDeployConfig),
@@ -103,6 +103,7 @@ const options = (
     force: false,
     partnersApp,
     release,
+    useVersionedAppConfig,
   }
 }
 
@@ -120,7 +121,6 @@ vi.mock('../dev/create-extension')
 vi.mock('./id-matching')
 vi.mock('./id-manual-matching')
 vi.mock('../dev/migrate-to-ui-extension')
-vi.mock('@shopify/cli-kit/node/context/local')
 
 beforeAll(async () => {
   EXTENSION_A = await testUIExtension({
@@ -748,10 +748,9 @@ describe('ensuredeployConfirmed: handle non existent uuid managed extensions', (
       title: 'C_A',
       type: 'POINT_OF_SALE',
     }
-    vi.mocked(useVersionedAppConfig).mockResolvedValue(true)
 
     // When
-    const ensureExtensionsIdsOptions = options([], [], {}, testOrganizationApp(), true, true)
+    const ensureExtensionsIdsOptions = options([], [], {}, testOrganizationApp(), true, true, true)
     const CONFIG_A = await testAppConfigExtensions()
     ensureExtensionsIdsOptions.app.allExtensions.push(CONFIG_A)
     const got = await deployConfirmed(ensureExtensionsIdsOptions, [], [REGISTRATION_CONFIG_A], {
@@ -808,10 +807,9 @@ describe('ensuredeployConfirmed: handle existent uuid managed extensions', () =>
       title: 'C_A',
       type: 'POINT_OF_SALE',
     }
-    vi.mocked(useVersionedAppConfig).mockResolvedValue(true)
 
     // When
-    const ensureExtensionsIdsOptions = options([], [], {}, testOrganizationApp(), true, true)
+    const ensureExtensionsIdsOptions = options([], [], {}, testOrganizationApp(), true, true, true)
     const CONFIG_A = await testAppConfigExtensions()
     ensureExtensionsIdsOptions.app.allExtensions.push(CONFIG_A)
     const got = await deployConfirmed(ensureExtensionsIdsOptions, [], [REGISTRATION_CONFIG_A], {

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -6,7 +6,7 @@ import {createExtension} from '../dev/create-extension.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {getUIExtensionsToMigrate, migrateExtensionsToUIExtension} from '../dev/migrate-to-ui-extension.js'
 import {getFlowExtensionsToMigrate, migrateFlowExtensions} from '../dev/migrate-flow-extension.js'
-import {AppInterface, includeConfigOnDeploy} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {outputCompleted} from '@shopify/cli-kit/node/output'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
@@ -94,7 +94,6 @@ export async function deployConfirmed(
     configurationRegistrations,
     options.app,
     options.appId,
-    options.useVersionedAppConfig ?? false,
   )
 
   const validMatchesById: {[key: string]: string} = {}
@@ -123,11 +122,7 @@ async function ensureNonUuidManagedExtensionsIds(
   remoteConfigurationRegistrations: RemoteSource[],
   app: AppInterface,
   appId: string,
-  useVersionedAppConfig: boolean,
 ) {
-  if (!includeConfigOnDeploy(app.configuration) || !useVersionedAppConfig)
-    return {extensionsNonUuidManaged: {}, extensionsIdsNonUuidManaged: {}}
-
   const localExtensionRegistrations = app.allExtensions.filter((ext) => !ext.isUuidManaged())
   const extensionsToCreate: LocalSource[] = []
   const validMatches: {[key: string]: string} = {}

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -94,6 +94,7 @@ export async function deployConfirmed(
     configurationRegistrations,
     options.app,
     options.appId,
+    options.useVersionedAppConfig ?? false,
   )
 
   const validMatchesById: {[key: string]: string} = {}
@@ -122,8 +123,10 @@ async function ensureNonUuidManagedExtensionsIds(
   remoteConfigurationRegistrations: RemoteSource[],
   app: AppInterface,
   appId: string,
+  useVersionedAppConfig: boolean,
 ) {
-  if (!includeConfigOnDeploy(app.configuration)) return {extensionsNonUuidManaged: {}, extensionsIdsNonUuidManaged: {}}
+  if (!includeConfigOnDeploy(app.configuration) || !useVersionedAppConfig)
+    return {extensionsNonUuidManaged: {}, extensionsIdsNonUuidManaged: {}}
 
   const localExtensionRegistrations = app.allExtensions.filter((ext) => !ext.isUuidManaged())
   const extensionsToCreate: LocalSource[] = []

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -1,6 +1,6 @@
 import {deployConfirmed} from './identifiers-extensions.js'
 import {configExtensionsIdentifiersBreakdown, extensionsIdentifiersDeployBreakdown} from './breakdown-extensions.js'
-import {AppInterface, includeConfigOnDeploy} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {Identifiers} from '../../models/app/identifiers.js'
 import {MinimalOrganizationApp} from '../../models/organization.js'
 import {deployOrReleaseConfirmationPrompt} from '../../prompts/deploy-release.js'
@@ -17,7 +17,6 @@ export interface EnsureDeploymentIdsPresenceOptions {
   force: boolean
   release: boolean
   partnersApp?: PartnersAppForIdentifierMatching
-  useVersionedAppConfig?: boolean
 }
 
 export interface RemoteSource {
@@ -52,7 +51,6 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     appTitle: options.partnersApp?.title,
     release: options.release,
     force: options.force,
-    showConfig: includeConfigOnDeploy(options.app.configuration) && options.useVersionedAppConfig,
   })
   if (!confirmed) throw new AbortSilentError()
 

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -17,6 +17,7 @@ export interface EnsureDeploymentIdsPresenceOptions {
   force: boolean
   release: boolean
   partnersApp?: PartnersAppForIdentifierMatching
+  useVersionedAppConfig?: boolean
 }
 
 export interface RemoteSource {
@@ -51,7 +52,7 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     appTitle: options.partnersApp?.title,
     release: options.release,
     force: options.force,
-    showConfig: includeConfigOnDeploy(options.app.configuration),
+    showConfig: includeConfigOnDeploy(options.app.configuration) && options.useVersionedAppConfig,
   })
   if (!confirmed) throw new AbortSilentError()
 

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -21,6 +21,7 @@ import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import {renderInfo, renderSuccess, renderTasks, renderTextPrompt, Task} from '@shopify/cli-kit/node/ui'
 import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 import {Config} from '@oclif/core'
+import {setPathValue} from '@shopify/cli-kit/common/object'
 
 const versionTag = 'unique-version-tag'
 
@@ -304,6 +305,7 @@ describe('deploy', () => {
       configuration: {...DEFAULT_CONFIG, build: {include_config_on_deploy: true}},
     }
     const app = testApp(localApp)
+    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const commitReference = 'https://github.com/deploytest/repo/commit/d4e5ce7999242b200acde378654d62c14b211bcc'
 
     // When

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -3,10 +3,8 @@ import {uploadThemeExtensions, uploadExtensionsBundle, UploadExtensionsBundleOut
 
 import {ensureDeployContext} from './context.js'
 import {bundleAndBuildExtensions} from './deploy/bundle.js'
-import {BetaFlag} from './app/select-app.js'
-import {AppInterface, includeConfigOnDeploy} from '../models/app/app.js'
+import {AppInterface} from '../models/app/app.js'
 import {updateAppIdentifiers} from '../models/app/identifiers.js'
-import {ExtensionInstance} from '../models/extensions/extension-instance.js'
 import {renderInfo, renderSuccess, renderTasks} from '@shopify/cli-kit/node/ui'
 import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
@@ -95,14 +93,8 @@ export async function deploy(options: DeployOptions) {
         {
           title: uploadTaskTitle,
           task: async () => {
-            const filterConfigurationAppModules = (extension: ExtensionInstance) =>
-              (includeConfigOnDeploy(app.configuration) && remoteAppBetaFlags.includes(BetaFlag.VersionedAppConfig)) ||
-              !extension.isAppConfigExtension
-
             const appModules = await Promise.all(
-              app.allExtensions
-                .filter(filterConfigurationAppModules)
-                .flatMap((ext) => ext.bundleConfig({identifiers, token, apiKey})),
+              app.allExtensions.flatMap((ext) => ext.bundleConfig({identifiers, token, apiKey})),
             )
 
             uploadExtensionsBundleResult = await uploadExtensionsBundle({

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -3,6 +3,7 @@ import {uploadThemeExtensions, uploadExtensionsBundle, UploadExtensionsBundleOut
 
 import {ensureDeployContext} from './context.js'
 import {bundleAndBuildExtensions} from './deploy/bundle.js'
+import {BetaFlag} from './app/select-app.js'
 import {AppInterface, includeConfigOnDeploy} from '../models/app/app.js'
 import {updateAppIdentifiers} from '../models/app/identifiers.js'
 import {ExtensionInstance} from '../models/extensions/extension-instance.js'
@@ -51,7 +52,7 @@ interface TasksContext {
 
 export async function deploy(options: DeployOptions) {
   // eslint-disable-next-line prefer-const
-  let {app, identifiers, partnersApp, token, release} = await ensureDeployContext(options)
+  let {app, identifiers, partnersApp, token, release, betas: remoteAppBetaFlags} = await ensureDeployContext(options)
   const apiKey = identifiers.app
 
   outputNewline()
@@ -95,7 +96,8 @@ export async function deploy(options: DeployOptions) {
           title: uploadTaskTitle,
           task: async () => {
             const filterConfigurationAppModules = (extension: ExtensionInstance) =>
-              includeConfigOnDeploy(app.configuration) || !extension.isAppConfigExtension
+              (includeConfigOnDeploy(app.configuration) && remoteAppBetaFlags.includes(BetaFlag.VersionedAppConfig)) ||
+              !extension.isAppConfigExtension
 
             const appModules = await Promise.all(
               app.allExtensions

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -81,6 +81,9 @@ describe('setup-dev-processes', () => {
         redirectUrlWhitelist: ['https://example.com/redirect'],
       },
     }
+    const previewable = await testUIExtension({type: 'checkout_ui_extension'})
+    const draftable = await testTaxCalculationExtension()
+    const theme = await testThemeExtensions()
     const localApp = testAppWithConfig({
       config: {},
       app: {
@@ -97,13 +100,9 @@ describe('setup-dev-processes', () => {
             },
           },
         ],
+        allExtensions: [previewable, draftable, theme],
       },
     })
-
-    const previewable = await testUIExtension({type: 'checkout_ui_extension'})
-    const draftable = await testTaxCalculationExtension()
-    const theme = await testThemeExtensions()
-    localApp.addExtensions([previewable, draftable, theme])
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -101,13 +101,9 @@ describe('setup-dev-processes', () => {
     })
 
     const previewable = await testUIExtension({type: 'checkout_ui_extension'})
-    localApp.allExtensions.push(previewable)
-
     const draftable = await testTaxCalculationExtension()
-    localApp.allExtensions.push(draftable)
-
     const theme = await testThemeExtensions()
-    localApp.allExtensions.push(theme)
+    localApp.addExtensions([previewable, draftable, theme])
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',

--- a/packages/cli-kit/src/public/common/version.ts
+++ b/packages/cli-kit/src/public/common/version.ts
@@ -1,1 +1,1 @@
-export const CLI_KIT_VERSION = '3.55.0'
+export const CLI_KIT_VERSION = '3.53.0'

--- a/packages/cli-kit/src/public/common/version.ts
+++ b/packages/cli-kit/src/public/common/version.ts
@@ -1,1 +1,1 @@
-export const CLI_KIT_VERSION = '3.53.0'
+export const CLI_KIT_VERSION = '3.55.0'

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -8,7 +8,6 @@ import {
   useDeviceAuth,
   cloudEnvironment,
   macAddress,
-  useVersionedAppConfig,
 } from './local.js'
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
@@ -330,17 +329,5 @@ describe('ciPlatform', () => {
         url: 'https://github.com/user/repo/actions/runs/456',
       },
     })
-  })
-})
-describe('useVersionedAppConfig', () => {
-  test('returns true when SHOPIFY_CLI_VERSIONED_APP_CONFIG is debug', () => {
-    // Given
-    const env = {SHOPIFY_CLI_VERSIONED_APP_CONFIG: '1'}
-
-    // When
-    const got = useVersionedAppConfig(env)
-
-    // Then
-    expect(got).toBe(true)
   })
 })

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -284,13 +284,3 @@ export function opentelemetryDomain(env = process.env): string | undefined {
 }
 
 export type CIMetadata = Metadata
-
-/**
- * Returns true if configuration extensions are enabled.
- *
- * @param env - Environment variables used when the cli is launched.
- * @returns True if SHOPIFY_CLI_VERSIONED_APP_CONFIG is truthy.
- */
-export function useVersionedAppConfig(env = process.env): boolean {
-  return isTruthy(env[environmentVariables.versionedAppConfig])
-}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Follow-up: https://github.com/Shopify/cli/pull/3250
Depends-on:
  - Partners: https://github.com/Shopify/partners/pull/52536

From the first PR regarding the n[ew versioned app configuration feature](https://github.com/Shopify/develop-app-foundations/issues/841) users could opt-in it using the env variable `SHOPIFY_CLI_VERSIONED_APP_CONFIG=1` in the `deploy` and `link` commands.
As it's required to opt-in for everyone at once, the CLI will switch from the use of the env variable to the use of the remote app `versioned app configuration` beta flag. This flag is used as well by the server side to enable the registration of the new `configuration` app modules
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Remove the support for the env variable `SHOPIFY_CLI_VERSIONED_APP_CONFIG` 
- Add support for the new app beta flag `versioned_app_config` returned by `partners`
- Swap the use of the env variable with the use of the beta flag. This means run a new API request to get the app betas where required.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Run the [same tests](https://github.com/Shopify/cli/pull/3161) suggested when the env variable `SHOPIFY_CLI_VERSIONED_APP_CONFIG` was added.
- Create first a new spin instance `spin up partners -n versioned-app-config-beta`
- Create a new remote app `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=versioned-app-config-beta p shopify app config link --path /PATH/TO/YOUR/APP`
- This time after creating the remote app, the beta `versioned_app_config` should be enabled for the app from `internal partners dashboard`
- Run the commands against spin `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=versioned-app-config-beta p shopify app deploy --path /PATH/TO/YOUR/APP`

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
