### PR TITLE
Add versioned app config metrics

### DIFF
--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -1,4 +1,4 @@
-import {deployOrReleaseConfirmationPrompt} from './deploy-release.js'
+import {buildConfigurationBreakdownMetadata, deployOrReleaseConfirmationPrompt} from './deploy-release.js'
 import metadata from '../metadata.js'
 import {
   ConfigExtensionIdentifiersBreakdown,
@@ -479,35 +479,13 @@ function verifyMetada({
   configExtensionIdentifiersBreakdown: ConfigExtensionIdentifiersBreakdown
   showConfig: boolean
 }) {
-  const currentConfiguration = [
-    ...configExtensionIdentifiersBreakdown.existingUpdatedFieldNames,
-    ...configExtensionIdentifiersBreakdown.newFieldNames,
-    ...configExtensionIdentifiersBreakdown.existingFieldNames,
-  ]
+  const configurationBreakdownMetadata = buildConfigurationBreakdownMetadata(
+    configExtensionIdentifiersBreakdown,
+    showConfig,
+  )
 
   expect(metadataSpyOn).toHaveBeenNthCalledWith(1, expect.any(Function))
-  expect(metadataSpyOn.mock.calls[0]![0]()).toEqual({
-    cmd_deploy_include_config_used: showConfig,
-    ...(showConfig
-      ? {
-          ...(currentConfiguration.length > 0
-            ? {cmd_deploy_config_modules_breakdown: currentConfiguration.join(',')}
-            : {}),
-          ...(configExtensionIdentifiersBreakdown.existingUpdatedFieldNames.length > 0
-            ? {
-                cmd_deploy_config_modules_updated:
-                  configExtensionIdentifiersBreakdown.existingUpdatedFieldNames.join(','),
-              }
-            : {}),
-          ...(configExtensionIdentifiersBreakdown.newFieldNames.length > 0
-            ? {cmd_deploy_config_modules_new: configExtensionIdentifiersBreakdown.newFieldNames.join(',')}
-            : {}),
-          ...(configExtensionIdentifiersBreakdown.deletedFieldNames.length > 0
-            ? {cmd_deploy_config_modules_deleted: configExtensionIdentifiersBreakdown.deletedFieldNames.join(',')}
-            : {}),
-        }
-      : {}),
-  })
+  expect(metadataSpyOn.mock.calls[0]![0]()).toEqual(configurationBreakdownMetadata)
 
   if (!extensionIdentifiersBreakdown) return
 

--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -34,7 +34,6 @@ describe('deployOrReleaseConfirmationPrompt', () => {
         metadataSpyOn,
         confirmed: result,
         configExtensionIdentifiersBreakdown: configExtensionIdentifiersBreakdown!,
-        showConfig: true,
       })
       expect(renderConfirmationPromptSpyOn).not.toHaveBeenCalled()
       expect(result).toBe(true)
@@ -64,7 +63,6 @@ describe('deployOrReleaseConfirmationPrompt', () => {
         extensionIdentifiersBreakdown,
         confirmed: result,
         configExtensionIdentifiersBreakdown,
-        showConfig: true,
       })
       expect(renderConfirmationPromptSpyOn).toHaveBeenCalledWith(
         renderConfirmationPromptContent({
@@ -99,7 +97,6 @@ describe('deployOrReleaseConfirmationPrompt', () => {
         extensionIdentifiersBreakdown: breakdownInfo.extensionIdentifiersBreakdown,
         confirmed: result,
         configExtensionIdentifiersBreakdown: breakdownInfo.configExtensionIdentifiersBreakdown!,
-        showConfig: true,
       })
       expect(renderConfirmationPromptSpyOn).toHaveBeenCalledWith(
         renderConfirmationPromptContent({
@@ -154,7 +151,6 @@ describe('deployOrReleaseConfirmationPrompt', () => {
         extensionIdentifiersBreakdown: breakdownInfo.extensionIdentifiersBreakdown,
         confirmed: result,
         configExtensionIdentifiersBreakdown: breakdownInfo.configExtensionIdentifiersBreakdown!,
-        showConfig: true,
       })
       expect(renderDangerousConfirmationPromptSpyOn).toHaveBeenCalledWith(
         renderConfirmationPromptContent({
@@ -213,7 +209,6 @@ describe('deployOrReleaseConfirmationPrompt', () => {
         extensionIdentifiersBreakdown: breakdownInfo.extensionIdentifiersBreakdown,
         confirmed: result,
         configExtensionIdentifiersBreakdown: breakdownInfo.configExtensionIdentifiersBreakdown!,
-        showConfig: true,
       })
       expect(renderConfirmationPromptSpyOn).toHaveBeenCalledWith(
         renderConfirmationPromptContent({
@@ -267,7 +262,6 @@ describe('deployOrReleaseConfirmationPrompt', () => {
         extensionIdentifiersBreakdown: breakdownInfo.extensionIdentifiersBreakdown,
         confirmed: result,
         configExtensionIdentifiersBreakdown: breakdownInfo.configExtensionIdentifiersBreakdown!,
-        showConfig: false,
       })
       expect(renderConfirmationPromptSpyOn).toHaveBeenCalledWith(
         renderConfirmationPromptContent({
@@ -314,7 +308,6 @@ describe('deployOrReleaseConfirmationPrompt', () => {
         extensionIdentifiersBreakdown: breakdownInfo.extensionIdentifiersBreakdown,
         confirmed: result,
         configExtensionIdentifiersBreakdown: breakdownInfo.configExtensionIdentifiersBreakdown,
-        showConfig: true,
       })
       expect(renderDangerousConfirmationPromptSpyOn).toHaveBeenCalledWith(
         renderConfirmationPromptContent({
@@ -367,7 +360,6 @@ describe('deployOrReleaseConfirmationPrompt', () => {
         extensionIdentifiersBreakdown: breakdownInfo.extensionIdentifiersBreakdown,
         confirmed: result,
         configExtensionIdentifiersBreakdown: breakdownInfo.configExtensionIdentifiersBreakdown!,
-        showConfig: true,
       })
       expect(renderConfirmationPromptSpyOn).toHaveBeenCalledWith(
         renderConfirmationPromptContent({
@@ -471,18 +463,13 @@ function verifyMetada({
   extensionIdentifiersBreakdown,
   confirmed,
   configExtensionIdentifiersBreakdown,
-  showConfig,
 }: {
   metadataSpyOn: SpyInstance
   extensionIdentifiersBreakdown?: ExtensionIdentifiersBreakdown
   confirmed: boolean
   configExtensionIdentifiersBreakdown: ConfigExtensionIdentifiersBreakdown
-  showConfig: boolean
 }) {
-  const configurationBreakdownMetadata = buildConfigurationBreakdownMetadata(
-    configExtensionIdentifiersBreakdown,
-    showConfig,
-  )
+  const configurationBreakdownMetadata = buildConfigurationBreakdownMetadata(configExtensionIdentifiersBreakdown)
 
   expect(metadataSpyOn).toHaveBeenNthCalledWith(1, expect.any(Function))
   expect(metadataSpyOn.mock.calls[0]![0]()).toEqual(configurationBreakdownMetadata)

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -35,11 +35,7 @@ export async function deployOrReleaseConfirmationPrompt({
   appTitle,
   release,
 }: DeployOrReleaseConfirmationPromptOptions) {
-  if (configExtensionIdentifiersBreakdown) {
-    await metadata.addPublicMetadata(() =>
-      buildConfigurationBreakdownMetadata(configExtensionIdentifiersBreakdown, showConfig),
-    )
-  }
+  await metadata.addPublicMetadata(() => buildConfigurationBreakdownMetadata(configExtensionIdentifiersBreakdown))
   if (force) return true
   const extensionsContentPrompt = await buildExtensionsContentPrompt(extensionIdentifiersBreakdown)
   const configContentPrompt = await buildConfigContentPrompt(release, configExtensionIdentifiersBreakdown)
@@ -164,16 +160,12 @@ async function buildConfigContentPrompt(
 }
 
 export function buildConfigurationBreakdownMetadata(
-  {
-    existingUpdatedFieldNames,
-    newFieldNames,
-    existingFieldNames,
-    deletedFieldNames,
-  }: ConfigExtensionIdentifiersBreakdown,
-  includeConfigOnDeploy: boolean,
+  configExtensionIdentifiersBreakdown?: ConfigExtensionIdentifiersBreakdown,
 ) {
-  if (!includeConfigOnDeploy) return {cmd_deploy_include_config_used: false}
+  if (!configExtensionIdentifiersBreakdown) return {cmd_deploy_include_config_used: false}
 
+  const {existingFieldNames, existingUpdatedFieldNames, newFieldNames, deletedFieldNames} =
+    configExtensionIdentifiersBreakdown
   const currentConfiguration = [...existingUpdatedFieldNames, ...newFieldNames, ...existingFieldNames]
   return {
     cmd_deploy_include_config_used: true,

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -97,7 +97,7 @@ async function deployConfirmationPrompt({
 
   await metadata.addPublicMetadata(() => ({
     cmd_deploy_confirm_cancelled: !confirmationResponse,
-    cmd_deploy_confirm_time_to_complete_ms: timeBeforeConfirmationMs,
+    cmd_deploy_confirm_time_to_complete_ms: timeToConfirmOrCancelMs,
   }))
 
   return confirmationResponse

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -1148,11 +1148,15 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
+    const metadataSpyOn = vi.spyOn(metadata, 'addPublicMetadata').mockImplementation(async () => {})
 
     // When
     await ensureDeployContext(options(app))
 
     // Then
+    expect(metadataSpyOn).toHaveBeenNthCalledWith(2, expect.any(Function))
+    expect(metadataSpyOn.mock.calls[1]![0]()).toEqual({cmd_deploy_confirm_include_config_used: true})
+
     expect(renderConfirmationPrompt).toHaveBeenCalled()
     expect(writeAppConfigurationFileSpy).toHaveBeenCalledWith(
       {...app.configuration, build: {include_config_on_deploy: true}},
@@ -1241,11 +1245,17 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
+    const metadataSpyOn = vi.spyOn(metadata, 'addPublicMetadata').mockImplementation(async () => {})
 
     // When
     await ensureDeployContext(options(app))
 
     // Then
+    expect(metadataSpyOn).toHaveBeenNthCalledWith(2, expect.any(Function))
+    expect(metadataSpyOn.mock.calls[1]![0]()).toEqual(
+      expect.not.objectContaining({cmd_deploy_confirm_include_config_used: expect.anything()}),
+    )
+
     expect(renderConfirmationPrompt).not.toHaveBeenCalled()
     expect(writeAppConfigurationFileSpy).not.toHaveBeenCalled()
     expect(renderInfo).toHaveBeenCalledWith({
@@ -1286,11 +1296,15 @@ describe('ensureDeployContext', () => {
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
       .mockResolvedValue()
+    const metadataSpyOn = vi.spyOn(metadata, 'addPublicMetadata').mockImplementation(async () => {})
 
     // When
     await ensureDeployContext(options(app, true))
 
     // Then
+    expect(metadataSpyOn).toHaveBeenNthCalledWith(2, expect.any(Function))
+    expect(metadataSpyOn.mock.calls[1]![0]()).toEqual({cmd_deploy_confirm_include_config_used: false})
+
     expect(renderConfirmationPrompt).toHaveBeenCalled()
     expect(writeAppConfigurationFileSpy).toHaveBeenCalledWith(
       {...app.configuration, build: {include_config_on_deploy: false}},

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -544,6 +544,8 @@ async function promptIncludeConfigOnDeploy(options: ShouldOrPromptIncludeConfigD
   }
 
   await writeAppConfigurationFile(localConfiguration, options.localApp.configSchema)
+
+  await metadata.addPublicMetadata(() => ({cmd_deploy_confirm_include_config_used: shouldIncludeConfigDeploy}))
 }
 
 function includeConfigOnDeployPrompt(): Promise<boolean> {

--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -39,6 +39,7 @@ export async function startAnalytics({
     cmd_all_alias_used: commandContent.alias,
     cmd_all_topic: commandContent.topic,
     cmd_all_plugin: commandClass?.plugin?.name,
+    cmd_all_force: flagIncluded('force', commandClass) ? args.includes('--force') : undefined,
   }))
 }
 
@@ -86,4 +87,11 @@ export async function getSensitiveEnvironmentData(config: Interfaces.Config) {
 function getPluginNames(config: Interfaces.Config) {
   const pluginNames = [...config.plugins.keys()]
   return pluginNames.sort().filter((plugin) => !plugin.startsWith('@oclif/'))
+}
+
+function flagIncluded(flag: string, commandClass?: Command.Class | typeof BaseCommand) {
+  if (!commandClass) return false
+
+  const commandFlags = commandClass.flags ?? {}
+  return Object.keys(commandFlags).includes(flag)
 }

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -110,7 +110,7 @@ export interface Schemas {
       cmd_deploy_include_config_used?: Optional<boolean>
       cmd_deploy_config_modules_breakdown?: Optional<string>
       cmd_deploy_config_modules_updated?: Optional<string>
-      cmd_deploy_config_modules_new?: Optional<string>
+      cmd_deploy_config_modules_added?: Optional<string>
       cmd_deploy_config_modules_deleted?: Optional<string>
 
       // Release related commands

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -10,7 +10,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 type Optional<T> = T | null
 
 // This is the topic name of the main event we log to Monorail, the command tracker
-export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.10' as const
+export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.11' as const
 
 export interface Schemas {
   [MONORAIL_COMMAND_TOPIC]: {

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -53,6 +53,7 @@ export interface Schemas {
       cmd_all_topic?: Optional<string>
       cmd_all_verbose?: Optional<boolean>
       cmd_all_exit?: Optional<string>
+      cmd_all_force?: Optional<boolean>
 
       cmd_all_timing_network_ms?: Optional<number>
       cmd_all_timing_prompts_ms?: Optional<number>
@@ -107,6 +108,7 @@ export interface Schemas {
       cmd_deploy_confirm_time_to_complete_ms?: Optional<number>
       cmd_deploy_prompt_upgrade_to_unified_displayed?: Optional<boolean>
       cmd_deploy_prompt_upgrade_to_unified_response?: Optional<string>
+      cmd_deploy_confirm_include_config_used?: Optional<boolean>
       cmd_deploy_include_config_used?: Optional<boolean>
       cmd_deploy_config_modules_breakdown?: Optional<string>
       cmd_deploy_config_modules_updated?: Optional<string>

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -107,6 +107,11 @@ export interface Schemas {
       cmd_deploy_confirm_time_to_complete_ms?: Optional<number>
       cmd_deploy_prompt_upgrade_to_unified_displayed?: Optional<boolean>
       cmd_deploy_prompt_upgrade_to_unified_response?: Optional<string>
+      cmd_deploy_include_config_used?: Optional<boolean>
+      cmd_deploy_config_modules_breakdown?: Optional<string>
+      cmd_deploy_config_modules_updated?: Optional<string>
+      cmd_deploy_config_modules_new?: Optional<string>
+      cmd_deploy_config_modules_deleted?: Optional<string>
 
       // Release related commands
       cmd_release_confirm_cancelled?: Optional<boolean>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Depends-on: https://github.com/Shopify/monorail/pull/17518

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Send metrics for the `configuration breakdown info` 
- The info included is the same displayed in the `deploy/release` prompt:
  - Affected top level fields
  - Affected sections (ie. modifying `api_version` returns `webhooks` as affected section`
- Tracks the response of the `include config` deploy prompt, only is case it's rendered
- Sends `force` flag used only for commands that supports it

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new `cli` app and run the `SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 p shopify app config link --path /PATH/TO/YOUR/APP` command to link it to a new remote app.
- Enable `versioned_app_config` beta flag for the created app in partners internal
- Modify/add/remove sections inside the `toml`
- Run `p shopify app deploy --path /PATH/TO/YOUR/APP --reset --verbose` and you should see something similar
```json
    "api_key": "b08239400aff3a2fefa7e246608bae73",
    "cmd_all_force": false,
    "cmd_deploy_confirm_include_config_used" : true,
    "cmd_deploy_include_config_used": true,
    "cmd_deploy_config_modules_breakdown": "access_scopes,app_preferences,name,auth,webhooks,app_proxy,application_url,embedded",
    "cmd_deploy_config_modules_updated": "access_scopes",
    "cmd_deploy_config_modules_new": "app_preferences",
    "cmd_deploy_config_modules_deleted": "pos",
    "cmd_deploy_confirm_new_registrations": 0,
```
- Switch the `include_config_on_deploy` flag value in the `toml`, run the `deploy` command and check the `verbose output` again
- Run the command again using the `--force` flag to check that its value is `true`
- Run  `SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 p shopify app config link --path /PATH/TO/YOUR/APP --verbose` to check that `cmd_all_force` doesn't appear as this command doesn't support it
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
