### PR TITLE
Create mobile QR code for POS UI Extensions using unified config

### DIFF
--- a/packages/app/src/cli/services/dev/extension/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.test.ts
@@ -37,6 +37,6 @@ describe('getExtensionPointTargetSurface()', () => {
   })
 
   test('returns "point_of_sale" for a POS UI extension', async () => {
-    expect(getExtensionPointTargetSurface('retail.home.tile.render')).toBe('point_of_sale')
+    expect(getExtensionPointTargetSurface('pos.home.tile.render')).toBe('point_of_sale')
   })
 })

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -51,7 +51,7 @@ export function getExtensionPointTargetSurface(extensionPointTarget: string) {
     }
 
     // Covers POS UI extensions (future)
-    case 'retail': {
+    case 'pos': {
       return 'point_of_sale'
     }
 

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.test.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.test.tsx
@@ -37,6 +37,11 @@ describe('<ExtensionRow/>', () => {
     extensionPoints: [{target: 'purchase.checkout.cart-line-list.render-after'}],
   })
 
+  const posUiExtension = mockExtension({
+    type: 'ui_extension',
+    extensionPoints: [{target: 'pos.home.tile.render', surface: 'point_of_sale'}],
+  })
+
   const defaultProps = {
     uuid: legacyAdminExtension.uuid,
   }
@@ -48,6 +53,7 @@ describe('<ExtensionRow/>', () => {
       legacyCheckoutExtension,
       adminUiExtension,
       checkoutUiExtension,
+      posUiExtension,
     ],
   }
 
@@ -55,6 +61,18 @@ describe('<ExtensionRow/>', () => {
     const container = render(<ExtensionRow {...defaultProps} />, withProviders(DefaultProviders), {state: defaultState})
 
     expect(container).toContainReactComponent(QRCodeModal, {code: undefined})
+  })
+
+  test('renders a <Button/> to open the QRCodeModal for a POS UI extension', () => {
+    const container = render(
+      <ExtensionRow {...defaultProps} uuid={posUiExtension.uuid} />,
+      withProviders(DefaultProviders),
+      {
+        state: defaultState,
+      },
+    )
+
+    expect(container).toContainReactComponent(Button, {id: 'showQRCodeModalButton'})
   })
 
   test('renders a <Button/> to open the QRCodeModal for a legacy Admin extension', () => {

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/ExtensionRow/ExtensionRow.tsx
@@ -6,17 +6,23 @@ import {QRCodeModal, Row, Status} from '..'
 import {useExtension} from '../../hooks/useExtension'
 import React, {useState} from 'react'
 import {useI18n} from '@shopify/react-i18n'
-import {ExtensionPayload, isUIExtension} from '@shopify/ui-extensions-server-kit'
+import {ExtensionPayload, ExtensionPoint, isUIExtension} from '@shopify/ui-extensions-server-kit'
 import {Button} from '@/components/Button'
 
 interface Props {
   uuid: ExtensionPayload['uuid']
 }
 
+function isUnifiedPOSUIExtension(extension: ExtensionPayload): boolean {
+  return (extension.extensionPoints as ExtensionPoint[])?.some((point) => {
+    return point.surface === 'point_of_sale'
+  })
+}
+
 function showMobileQrCode(extension: ExtensionPayload) {
   if (isUIExtension(extension)) {
-    // We currently don't have support for any of the new UI extensions on Mobile
-    return false
+    // We currently only support POS UI Extensions for mobile. We don't have support for Admin yet.
+    return isUnifiedPOSUIExtension(extension)
   }
 
   return extension.surface === 'point_of_sale' || extension.surface === 'admin'
@@ -54,7 +60,7 @@ export function ExtensionRow({uuid}: Props) {
             showModal
               ? {
                   url: extension.development.root.url,
-                  type: extension.surface,
+                  type: isUnifiedPOSUIExtension(extension) ? 'point_of_sale' : extension.surface,
                   title: extension.handle,
                 }
               : undefined


### PR DESCRIPTION
## Adding support for POS UI Extensions using unified package

### WHY are these changes introduced?

POS is moving to support the unified ui-extensions package. However, as it is currently, the QR code for mobile is not generated when we detect that the extension is using the new ui-extension. 

### WHAT is this pull request doing?

This PR adds some logic to check and see if the ui-extension has POS UI Extension targets. If it does, then we generate the QR code modal, and the proper kind of URL.

### How to test your changes?

1. You'll need to use pnpm to create an with a POS UI Extension.
2. Since generating will create the old style of template, you'll need to add `"@shopify/ui-extensions": "unstable"` to the package json. 
3. In your POS UI Extension, you can use the following toml code: 
```
# Learn more about configuring your checkout UI extension:
# https://shopify.dev/api/checkout-extensions/checkout/configuration

# The version of APIs your extension will receive. Learn more:
# https://shopify.dev/docs/api/usage/versioning
api_version = "2024-01"

[[extensions]]
type = "ui_extension"
name = "pos-ui"
handle = "pos-ui"

[[extensions.targeting]]
module = "./src/Tile.ts"
target = "pos.home.tile.render"

[[extensions.targeting]]
module = "./src/Modal.ts"
target = "pos.home.modal.render"

[extensions.settings]
[[extensions.settings.fields]]
key = "field"
type = "pos_ui_extension"
name = "Banner title"
description = "Enter a title for the banner"

```

4. Make a file called Tile.ts that has the following code:

```
import {extension} from '@shopify/ui-extensions/point-of-sale'

export default extension('pos.home.tile.render', (root, api) => {
  const tileProps = {
    title: 'My app',
    subtitle: 'SmartGrid Extension',
    enabled: true,
    onPress: () => {
      api.smartGrid.presentModal()
    },
  }

  const tile = root.createComponent('Tile', tileProps)

  root.append(tile)
  root.mount()
})

```

5. Remove the old index.ts file. The toml file will point to the new Tile.ts file.
6. from the cli run the `pnpm shopify app dev` command and point it to your test app.
7. When you open the dev console, your extension should show up there and you should be able to open the QR code modal.


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
