### PR TITLE
Add redeemable schema to payments extension

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
@@ -2,18 +2,18 @@ import {
   OffsitePaymentsAppExtensionConfigType,
   OffsitePaymentsAppExtensionSchema,
   offsitePaymentsAppExtensionDeployConfig,
+  OFFSITE_TARGET,
 } from './payments_app_extension_schemas/offsite_payments_app_extension_schema.js'
+import {
+  REDEEMABLE_TARGET,
+  RedeemablePaymentsAppExtensionConfigType,
+  redeemablePaymentsAppExtensionDeployConfig,
+  RedeemablePaymentsAppExtensionSchema,
+} from './payments_app_extension_schemas/redeemable_payments_app_extension_schema.js'
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-// NOTE: SamplePaymentsAppExtensionSchema is used since zod doesn't accept a single-element union. It will be removed
-// once we add a second schema for another payment app type.
-const SamplePaymentsAppExtensionSchema = BaseSchema.extend({
-  targeting: zod.array(zod.object({target: zod.literal('payments.sample.render')})).length(1),
-})
-
-const PaymentsAppExtensionSchema = zod.union([OffsitePaymentsAppExtensionSchema, SamplePaymentsAppExtensionSchema])
+const PaymentsAppExtensionSchema = zod.union([OffsitePaymentsAppExtensionSchema, RedeemablePaymentsAppExtensionSchema])
 
 export type PaymentsAppExtensionConfigType = zod.infer<typeof PaymentsAppExtensionSchema>
 
@@ -22,8 +22,10 @@ const spec = createExtensionSpecification({
   schema: PaymentsAppExtensionSchema,
   appModuleFeatures: (_) => [],
   deployConfig: async (config, _) => {
-    if (config.targeting[0]!.target === 'payments.offsite.render') {
+    if (config.targeting[0]!.target === OFFSITE_TARGET) {
       return offsitePaymentsAppExtensionDeployConfig(config as OffsitePaymentsAppExtensionConfigType)
+    } else if (config.targeting[0]!.target === REDEEMABLE_TARGET) {
+      return redeemablePaymentsAppExtensionDeployConfig(config as RedeemablePaymentsAppExtensionConfigType)
     }
 
     return {}

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.test.ts
@@ -1,0 +1,128 @@
+import {
+  RedeemablePaymentsAppExtensionConfigType,
+  RedeemablePaymentsAppExtensionSchema,
+  redeemablePaymentsAppExtensionDeployConfig,
+} from './redeemable_payments_app_extension_schema.js'
+import {describe, expect, test} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const config: RedeemablePaymentsAppExtensionConfigType = {
+  name: 'Redeemable extension',
+  type: 'payments_extension',
+  payment_session_url: 'http://foo.bar',
+  refund_session_url: 'http://foo.bar',
+  capture_session_url: 'http://foo.bar',
+  void_session_url: 'http://foo.bar',
+  balance_url: 'http://foo.bar',
+  merchant_label: 'some-label',
+  supported_countries: ['CA'],
+  supported_payment_methods: ['PAYMENT_METHOD'],
+  test_mode_available: true,
+  redeemable_type: 'gift_card',
+  targeting: [{target: 'payments.redeemable.render'}],
+  api_version: '2022-07',
+  description: 'my payments app extension',
+  metafields: [],
+  input: {
+    metafield_identifiers: {
+      namespace: 'namespace',
+      key: 'key',
+    },
+  },
+}
+
+describe('RedeemablePaymentsAppExtensionSchema', () => {
+  test('validates a configuration with valid fields', async () => {
+    // When
+    const {success} = RedeemablePaymentsAppExtensionSchema.safeParse(config)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('returns an error if no target is provided', async () => {
+    // When/Then
+    expect(() =>
+      RedeemablePaymentsAppExtensionSchema.parse({
+        ...config,
+        targeting: [{...config.targeting[0]!, target: null}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          received: null,
+          code: zod.ZodIssueCode.invalid_literal,
+          expected: 'payments.redeemable.render',
+          path: ['targeting', 0, 'target'],
+          message: 'Invalid literal value, expected "payments.redeemable.render"',
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if invalid redeemable type is provided', async () => {
+    // When/Then
+    expect(() =>
+      RedeemablePaymentsAppExtensionSchema.parse({
+        ...config,
+        redeemable_type: 'invalid type',
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          received: 'invalid type',
+          code: zod.ZodIssueCode.invalid_literal,
+          expected: 'gift_card',
+          path: ['redeemable_type'],
+          message: 'Invalid literal value, expected "gift_card"',
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if buyer_label_translations has invalid format', async () => {
+    // When/Then
+    expect(() =>
+      RedeemablePaymentsAppExtensionSchema.parse({
+        ...config,
+        buyer_label_translations: [{label: 'Translation without locale key'}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'string',
+          received: 'undefined',
+          path: ['buyer_label_translations', 0, 'locale'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+})
+
+describe('redeemablePaymentsAppExtensionDeployConfig', () => {
+  test('maps deploy configuration from extension configuration', async () => {
+    // When
+    const result = await redeemablePaymentsAppExtensionDeployConfig(config)
+
+    // Then
+    expect(result).toMatchObject({
+      api_version: config.api_version,
+      start_payment_session_url: config.payment_session_url,
+      start_refund_session_url: config.refund_session_url,
+      start_capture_session_url: config.capture_session_url,
+      start_void_session_url: config.void_session_url,
+      balance_url: config.balance_url,
+      merchant_label: config.merchant_label,
+      supported_countries: config.supported_countries,
+      supported_payment_methods: config.supported_payment_methods,
+      test_mode_available: config.test_mode_available,
+      redeemable_type: config.redeemable_type,
+      checkout_payment_method_fields: config.checkout_payment_method_fields,
+      target: config.targeting[0]!.target,
+      default_buyer_label: config.buyer_label,
+      buyer_label_to_locale: config.buyer_label_translations,
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.ts
@@ -1,28 +1,26 @@
 import {BaseSchema} from '../../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-export type OffsitePaymentsAppExtensionConfigType = zod.infer<typeof OffsitePaymentsAppExtensionSchema>
+export type RedeemablePaymentsAppExtensionConfigType = zod.infer<typeof RedeemablePaymentsAppExtensionSchema>
 
 const MAX_LABEL_SIZE = 50
-export const OFFSITE_TARGET = 'payments.offsite.render'
-export const OffsitePaymentsAppExtensionSchema = BaseSchema.extend({
-  targeting: zod.array(zod.object({target: zod.literal(OFFSITE_TARGET)})).length(1),
+export const REDEEMABLE_TARGET = 'payments.redeemable.render'
+export const RedeemablePaymentsAppExtensionSchema = BaseSchema.extend({
+  targeting: zod.array(zod.object({target: zod.literal(REDEEMABLE_TARGET)})).length(1),
   api_version: zod.string(),
   payment_session_url: zod.string().url(),
   refund_session_url: zod.string().url().optional(),
   capture_session_url: zod.string().url().optional(),
   void_session_url: zod.string().url().optional(),
-  confirmation_callback_url: zod.string().url().optional(),
+  balance_url: zod.string().url(),
   merchant_label: zod.string().max(MAX_LABEL_SIZE),
   buyer_label: zod.string().max(MAX_LABEL_SIZE).optional(),
   buyer_label_translations: zod.array(zod.object({locale: zod.string(), label: zod.string()})).optional(),
-  supports_oversell_protection: zod.boolean().optional(),
-  supports_3ds: zod.boolean(),
-  supports_installments: zod.boolean(),
-  supports_deferred_payments: zod.boolean(),
   supported_countries: zod.array(zod.string()),
   supported_payment_methods: zod.array(zod.string()),
   test_mode_available: zod.boolean(),
+  redeemable_type: zod.literal('gift_card'),
+  checkout_payment_method_fields: zod.array(zod.string()).optional(),
   input: zod
     .object({
       metafield_identifiers: zod
@@ -34,16 +32,8 @@ export const OffsitePaymentsAppExtensionSchema = BaseSchema.extend({
     })
     .optional(),
 })
-  .refine((schema) => !schema.supports_oversell_protection || schema.confirmation_callback_url, {
-    message: 'Property required when supports_oversell_protection is true',
-    path: ['confirmation_callback_url'],
-  })
-  .refine((schema) => schema.supports_installments === schema.supports_deferred_payments, {
-    message: 'supports_installments and supports_deferred_payments must be the same',
-  })
-
-export async function offsitePaymentsAppExtensionDeployConfig(
-  config: OffsitePaymentsAppExtensionConfigType,
+export async function redeemablePaymentsAppExtensionDeployConfig(
+  config: RedeemablePaymentsAppExtensionConfigType,
 ): Promise<{[key: string]: unknown} | undefined> {
   return {
     target: config.targeting[0]!.target,
@@ -52,16 +42,14 @@ export async function offsitePaymentsAppExtensionDeployConfig(
     start_refund_session_url: config.refund_session_url,
     start_capture_session_url: config.capture_session_url,
     start_void_session_url: config.void_session_url,
-    confirmation_callback_url: config.confirmation_callback_url,
     merchant_label: config.merchant_label,
     supported_countries: config.supported_countries,
     supported_payment_methods: config.supported_payment_methods,
     test_mode_available: config.test_mode_available,
     default_buyer_label: config.buyer_label,
     buyer_label_to_locale: config.buyer_label_translations,
-    supports_oversell_protection: config.supports_oversell_protection,
-    supports_3ds: config.supports_3ds,
-    supports_deferred_payments: config.supports_deferred_payments,
-    supports_installments: config.supports_installments,
+    redeemable_type: config.redeemable_type,
+    balance_url: config.balance_url,
+    checkout_payment_method_fields: config.checkout_payment_method_fields,
   }
 }


### PR DESCRIPTION
**Why are these changes introduced?**

This PR introduces a `redeemable` payments extension schema.

Subsequent PRs will include additional schema definitions, one for each payments extension, that will populate the schema union.

These changes will be behind a feature flag and the current CLI version `3.53` will not have `Payment Extensions` available as an option to choose from

### How to test your changes?

- Create app with `npm init @shopify/app@latest`
- Pull this branch into your local `cli` copy
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app config link --path {YOUR-APP-PATH}`
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app deploy --path {YOUR-APP-PATH}`
- View `Payments Extensions`

These changes cannot be tested with the CLI version `3.53` and is can only be tested internally at this moment.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
