### PR TITLE
Add custom onsite schema to payments extension

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
@@ -10,10 +10,20 @@ import {
   redeemablePaymentsAppExtensionDeployConfig,
   RedeemablePaymentsAppExtensionSchema,
 } from './payments_app_extension_schemas/redeemable_payments_app_extension_schema.js'
+import {
+  CUSTOM_ONSITE_TARGET,
+  CustomOnsitePaymentsAppExtensionConfigType,
+  customOnsitePaymentsAppExtensionDeployConfig,
+  CustomOnsitePaymentsAppExtensionSchema,
+} from './payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.js'
 import {createExtensionSpecification} from '../specification.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const PaymentsAppExtensionSchema = zod.union([OffsitePaymentsAppExtensionSchema, RedeemablePaymentsAppExtensionSchema])
+const PaymentsAppExtensionSchema = zod.union([
+  OffsitePaymentsAppExtensionSchema,
+  RedeemablePaymentsAppExtensionSchema,
+  CustomOnsitePaymentsAppExtensionSchema,
+])
 
 export type PaymentsAppExtensionConfigType = zod.infer<typeof PaymentsAppExtensionSchema>
 
@@ -22,13 +32,17 @@ const spec = createExtensionSpecification({
   schema: PaymentsAppExtensionSchema,
   appModuleFeatures: (_) => [],
   deployConfig: async (config, _) => {
-    if (config.targeting[0]!.target === OFFSITE_TARGET) {
-      return offsitePaymentsAppExtensionDeployConfig(config as OffsitePaymentsAppExtensionConfigType)
-    } else if (config.targeting[0]!.target === REDEEMABLE_TARGET) {
-      return redeemablePaymentsAppExtensionDeployConfig(config as RedeemablePaymentsAppExtensionConfigType)
+    const target = config.targeting[0]!.target
+    switch (target) {
+      case OFFSITE_TARGET:
+        return offsitePaymentsAppExtensionDeployConfig(config as OffsitePaymentsAppExtensionConfigType)
+      case REDEEMABLE_TARGET:
+        return redeemablePaymentsAppExtensionDeployConfig(config as RedeemablePaymentsAppExtensionConfigType)
+      case CUSTOM_ONSITE_TARGET:
+        return customOnsitePaymentsAppExtensionDeployConfig(config as CustomOnsitePaymentsAppExtensionConfigType)
+      default:
+        return {}
     }
-
-    return {}
   },
 })
 

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
@@ -1,0 +1,121 @@
+import {
+  CustomOnsitePaymentsAppExtensionConfigType,
+  CustomOnsitePaymentsAppExtensionSchema,
+  customOnsitePaymentsAppExtensionDeployConfig,
+} from './custom_onsite_payments_app_extension_schema.js'
+import {describe, expect, test} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const config: CustomOnsitePaymentsAppExtensionConfigType = {
+  name: 'CustomOnsite extension',
+  type: 'payments_extension',
+  targeting: [{target: 'payments.custom-onsite.render'}],
+  payment_session_url: 'http://foo.bar',
+  refund_session_url: 'http://foo.bar',
+  capture_session_url: 'http://foo.bar',
+  void_session_url: 'http://foo.bar',
+  confirmation_callback_url: 'http://foo.bar',
+  update_payment_session_url: 'http://foo.bar',
+  merchant_label: 'some-label',
+  supported_countries: ['CA'],
+  supported_payment_methods: ['visa'],
+  supports_oversell_protection: true,
+  supports_3ds: true,
+  supports_installments: true,
+  supports_deferred_payments: true,
+  test_mode_available: true,
+  multiple_capture: true,
+  api_version: '2022-07',
+  checkout_payment_method_fields: [],
+  modal_payment_method_fields: [],
+  description: 'Custom onsite extension',
+  metafields: [],
+  input: {
+    metafield_identifiers: {
+      namespace: 'namespace',
+      key: 'key',
+    },
+  },
+}
+
+describe('CustomOnsitePaymentsAppExtensionSchema', () => {
+  test('validates a configuration with valid fields', async () => {
+    // When
+    const {success} = CustomOnsitePaymentsAppExtensionSchema.safeParse(config)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('returns an error if no target is provided', async () => {
+    // When/Then
+    expect(() =>
+      CustomOnsitePaymentsAppExtensionSchema.parse({
+        ...config,
+        targeting: [{...config.targeting[0]!, target: null}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          received: null,
+          code: zod.ZodIssueCode.invalid_literal,
+          expected: 'payments.custom-onsite.render',
+          path: ['targeting', 0, 'target'],
+          message: 'Invalid literal value, expected "payments.custom-onsite.render"',
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if buyer_label_translations has invalid format', async () => {
+    // When/Then
+    expect(() =>
+      CustomOnsitePaymentsAppExtensionSchema.parse({
+        ...config,
+        buyer_label_translations: [{label: 'Translation without locale key'}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'string',
+          received: 'undefined',
+          path: ['buyer_label_translations', 0, 'locale'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+})
+
+describe('customOnsitePaymentsAppExtensionDeployConfig', () => {
+  test('maps deploy configuration from extension configuration', async () => {
+    // When
+    const result = await customOnsitePaymentsAppExtensionDeployConfig(config)
+
+    // Then
+    expect(result).toMatchObject({
+      target: config.targeting[0]!.target,
+      api_version: config.api_version,
+      start_payment_session_url: config.payment_session_url,
+      start_refund_session_url: config.refund_session_url,
+      start_capture_session_url: config.capture_session_url,
+      start_void_session_url: config.void_session_url,
+      confirmation_callback_url: config.confirmation_callback_url,
+      update_payment_session_url: config.update_payment_session_url,
+      merchant_label: config.merchant_label,
+      supports_oversell_protection: config.supports_oversell_protection,
+      supports_3ds: config.supports_3ds,
+      supports_installments: config.supports_installments,
+      supports_deferred_payments: config.supports_deferred_payments,
+      supported_countries: config.supported_countries,
+      supported_payment_methods: config.supported_payment_methods,
+      test_mode_available: config.test_mode_available,
+      multiple_capture: config.multiple_capture,
+      default_buyer_label: config.buyer_label,
+      buyer_label_to_locale: config.buyer_label_translations,
+      checkout_payment_method_fields: config.checkout_payment_method_fields,
+      modal_payment_method_fields: config.modal_payment_method_fields,
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
@@ -1,0 +1,68 @@
+import {BaseSchema} from '../../schemas.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+export type CustomOnsitePaymentsAppExtensionConfigType = zod.infer<typeof CustomOnsitePaymentsAppExtensionSchema>
+
+const MAX_LABEL_SIZE = 50
+
+export const CUSTOM_ONSITE_TARGET = 'payments.custom-onsite.render'
+export const CustomOnsitePaymentsAppExtensionSchema = BaseSchema.extend({
+  targeting: zod.array(zod.object({target: zod.literal(CUSTOM_ONSITE_TARGET)})).length(1),
+  api_version: zod.string(),
+  payment_session_url: zod.string().url(),
+  refund_session_url: zod.string().url().optional(),
+  capture_session_url: zod.string().url().optional(),
+  void_session_url: zod.string().url().optional(),
+  confirmation_callback_url: zod.string().url().optional(),
+  update_payment_session_url: zod.string().url().optional(),
+  merchant_label: zod.string().max(MAX_LABEL_SIZE),
+  buyer_label: zod.string().max(MAX_LABEL_SIZE).optional(),
+  buyer_label_translations: zod.array(zod.object({locale: zod.string(), label: zod.string()})).optional(),
+  supports_oversell_protection: zod.boolean(),
+  supports_3ds: zod.boolean(),
+  supports_installments: zod.boolean(),
+  supports_deferred_payments: zod.boolean(),
+  test_mode_available: zod.boolean(),
+  supported_countries: zod.array(zod.string()),
+  supported_payment_methods: zod.array(zod.string()),
+  multiple_capture: zod.boolean().optional(),
+  checkout_payment_method_fields: zod.array(zod.object({})).optional(),
+  modal_payment_method_fields: zod.array(zod.object({})).optional(),
+  input: zod
+    .object({
+      metafield_identifiers: zod
+        .object({
+          namespace: zod.string(),
+          key: zod.string(),
+        })
+        .optional(),
+    })
+    .optional(),
+})
+export async function customOnsitePaymentsAppExtensionDeployConfig(
+  config: CustomOnsitePaymentsAppExtensionConfigType,
+): Promise<{[key: string]: unknown} | undefined> {
+  return {
+    target: config.targeting[0]!.target,
+    api_version: config.api_version,
+    start_payment_session_url: config.payment_session_url,
+    start_refund_session_url: config.refund_session_url,
+    start_capture_session_url: config.capture_session_url,
+    start_void_session_url: config.void_session_url,
+    confirmation_callback_url: config.confirmation_callback_url,
+    update_payment_session_url: config.update_payment_session_url,
+    merchant_label: config.merchant_label,
+    supports_oversell_protection: config.supports_oversell_protection,
+    supports_3ds: config.supports_3ds,
+    supports_installments: config.supports_installments,
+    supports_deferred_payments: config.supports_deferred_payments,
+    supported_countries: config.supported_countries,
+    supported_payment_methods: config.supported_payment_methods,
+    test_mode_available: config.test_mode_available,
+    multiple_capture: config.multiple_capture,
+    default_buyer_label: config.buyer_label,
+    buyer_label_to_locale: config.buyer_label_translations,
+    checkout_payment_method_fields: config.checkout_payment_method_fields,
+    modal_payment_method_fields: config.modal_payment_method_fields,
+  }
+}


### PR DESCRIPTION
**Why are these changes introduced?**

This PR introduces a `custom onsite` payments app schema.

Subsequent PRs will include additional schema definitions, one for each payments extension type, that will populate the schema union.

These changes will be behind a feature flag and the current CLI version `3.53` will not have `Payment Extensions` available as an option to choose from

### How to test your changes?

- Create app with `npm init @shopify/app@latest`
- Pull this branch into your local `cli` copy
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app config link --path {YOUR-APP-PATH}`
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app deploy --path {YOUR-APP-PATH}`
- View `Payments Extensions`

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
