### PR TITLE
Add credit card schema to payments extension

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
@@ -1,8 +1,8 @@
 import {
+  OFFSITE_TARGET,
   OffsitePaymentsAppExtensionConfigType,
   OffsitePaymentsAppExtensionSchema,
   offsitePaymentsAppExtensionDeployConfig,
-  OFFSITE_TARGET,
 } from './payments_app_extension_schemas/offsite_payments_app_extension_schema.js'
 import {
   REDEEMABLE_TARGET,
@@ -22,6 +22,12 @@ import {
   customCreditCardPaymentsAppExtensionDeployConfig,
   CustomCreditCardPaymentsAppExtensionSchema,
 } from './payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.js'
+import {
+  CREDIT_CARD_TARGET,
+  CreditCardPaymentsAppExtensionConfigType,
+  CreditCardPaymentsAppExtensionSchema,
+  creditCardPaymentsAppExtensionDeployConfig,
+} from './payments_app_extension_schemas/credit_card_payments_app_extension_schema.js'
 import {createExtensionSpecification} from '../specification.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -30,6 +36,7 @@ const PaymentsAppExtensionSchema = zod.union([
   RedeemablePaymentsAppExtensionSchema,
   CustomOnsitePaymentsAppExtensionSchema,
   CustomCreditCardPaymentsAppExtensionSchema,
+  CreditCardPaymentsAppExtensionSchema,
 ])
 
 export type PaymentsAppExtensionConfigType = zod.infer<typeof PaymentsAppExtensionSchema>
@@ -45,6 +52,8 @@ const spec = createExtensionSpecification({
         return offsitePaymentsAppExtensionDeployConfig(config as OffsitePaymentsAppExtensionConfigType)
       case REDEEMABLE_TARGET:
         return redeemablePaymentsAppExtensionDeployConfig(config as RedeemablePaymentsAppExtensionConfigType)
+      case CREDIT_CARD_TARGET:
+        return creditCardPaymentsAppExtensionDeployConfig(config as CreditCardPaymentsAppExtensionConfigType)
       case CUSTOM_ONSITE_TARGET:
         return customOnsitePaymentsAppExtensionDeployConfig(config as CustomOnsitePaymentsAppExtensionConfigType)
       case CUSTOM_CREDIT_CARD_TARGET:

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
@@ -1,0 +1,157 @@
+import {
+  CreditCardPaymentsAppExtensionConfigType,
+  CreditCardPaymentsAppExtensionSchema,
+  creditCardPaymentsAppExtensionDeployConfig,
+} from './credit_card_payments_app_extension_schema.js'
+import {describe, expect, test} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const config: CreditCardPaymentsAppExtensionConfigType = {
+  name: 'test extension',
+  type: 'payments_extension',
+  payment_session_url: 'http://foo.bar',
+  refund_session_url: 'http://foo.bar',
+  capture_session_url: 'http://foo.bar',
+  void_session_url: 'http://foo.bar',
+  verification_session_url: 'http://foo.bar',
+  confirmation_callback_url: 'http://foo.bar',
+  merchant_label: 'some-label',
+  supported_countries: ['CA'],
+  supported_payment_methods: ['PAYMENT_METHOD'],
+  supports_3ds: false,
+  test_mode_available: true,
+  supports_deferred_payments: false,
+  supports_installments: false,
+  targeting: [{target: 'payments.credit-card.render'}],
+  api_version: '2022-07',
+  description: 'my payments app extension',
+  metafields: [],
+  encryption_certificate: {
+    fingerprint: 'fingerprint',
+    certificate: '-----BEGIN CERTIFICATE-----\nSample certificate\n-----END CERTIFICATE-----',
+  },
+  checkout_payment_method_fields: [{type: 'string', required: false, key: 'sample_key'}],
+  input: {
+    metafield_identifiers: {
+      namespace: 'namespace',
+      key: 'key',
+    },
+  },
+}
+
+describe('CreditCardPaymentsAppExtensionSchema', () => {
+  test('validates a configuration with valid fields', async () => {
+    // When
+    const {success} = CreditCardPaymentsAppExtensionSchema.safeParse(config)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('returns an error if no target is provided', async () => {
+    // When/Then
+    expect(() =>
+      CreditCardPaymentsAppExtensionSchema.parse({
+        ...config,
+        targeting: [{...config.targeting[0]!, target: null}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          received: null,
+          code: zod.ZodIssueCode.invalid_literal,
+          expected: 'payments.credit-card.render',
+          path: ['targeting', 0, 'target'],
+          message: 'Invalid literal value, expected "payments.credit-card.render"',
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if no confirmation_callback_url is provided with supports 3ds', async () => {
+    // When/Then
+    expect(() =>
+      CreditCardPaymentsAppExtensionSchema.parse({
+        ...config,
+        supports_3ds: true,
+        confirmation_callback_url: undefined,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          message: 'Property required when supports_3ds is true',
+          path: ['confirmation_callback_url'],
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if encryption_certificate has invalid format', async () => {
+    // When/Then
+    expect(() =>
+      CreditCardPaymentsAppExtensionSchema.parse({
+        ...config,
+        encryption_certificate: {
+          fingerprint: 'fingerprint',
+          certificate: 'invalid certificate',
+        },
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          validation: 'regex',
+          code: zod.ZodIssueCode.invalid_string,
+          message: 'Invalid',
+          path: ['encryption_certificate', 'certificate'],
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if supports_installments does not match supports_deferred_payments', async () => {
+    // When/Then
+    expect(() =>
+      CreditCardPaymentsAppExtensionSchema.parse({
+        ...config,
+        supports_installments: true,
+        supports_deferred_payments: false,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          message: 'supports_installments and supports_deferred_payments must be the same',
+          path: [],
+        },
+      ]),
+    )
+  })
+})
+
+describe('creditCardPaymentsAppExtensionDeployConfig', () => {
+  test('maps deploy configuration from extension configuration', async () => {
+    // When
+    const result = await creditCardPaymentsAppExtensionDeployConfig(config)
+
+    // Then
+    expect(result).toMatchObject({
+      api_version: config.api_version,
+      start_payment_session_url: config.payment_session_url,
+      start_refund_session_url: config.refund_session_url,
+      start_capture_session_url: config.capture_session_url,
+      start_void_session_url: config.void_session_url,
+      start_verification_session_url: config.verification_session_url,
+      confirmation_callback_url: config.confirmation_callback_url,
+      merchant_label: config.merchant_label,
+      supported_countries: config.supported_countries,
+      supported_payment_methods: config.supported_payment_methods,
+      test_mode_available: config.test_mode_available,
+      target: config.targeting[0]!.target,
+      supports_3ds: config.supports_3ds,
+      supports_deferred_payments: config.supports_deferred_payments,
+      supports_installments: config.supports_installments,
+      checkout_payment_method_fields: config.checkout_payment_method_fields,
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
@@ -1,0 +1,80 @@
+import {BaseSchema} from '../../schemas.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+export type CreditCardPaymentsAppExtensionConfigType = zod.infer<typeof CreditCardPaymentsAppExtensionSchema>
+
+const MAX_LABEL_SIZE = 50
+const CERTIFICATE_REGEX = /^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$/
+
+export const CREDIT_CARD_TARGET = 'payments.credit-card.render'
+export const CreditCardPaymentsAppExtensionSchema = BaseSchema.extend({
+  targeting: zod.array(zod.object({target: zod.literal(CREDIT_CARD_TARGET)})).length(1),
+  api_version: zod.string(),
+  payment_session_url: zod.string().url(),
+  refund_session_url: zod.string().url(),
+  capture_session_url: zod.string().url(),
+  void_session_url: zod.string().url(),
+  verification_session_url: zod.string().url().optional(),
+  confirmation_callback_url: zod.string().url().optional(),
+  supports_3ds: zod.boolean(),
+  supported_countries: zod.array(zod.string()),
+  supported_payment_methods: zod.array(zod.string()),
+  supports_installments: zod.boolean(),
+  supports_deferred_payments: zod.boolean(),
+  test_mode_available: zod.boolean(),
+  merchant_label: zod.string().max(MAX_LABEL_SIZE),
+  encryption_certificate: zod.object({
+    fingerprint: zod.string(),
+    certificate: zod.string().regex(CERTIFICATE_REGEX),
+  }),
+  checkout_payment_method_fields: zod
+    .array(
+      zod.object({
+        type: zod.union([zod.literal('string'), zod.literal('number'), zod.literal('boolean')]),
+        required: zod.boolean(),
+        key: zod.string(),
+      }),
+    )
+    .optional(),
+  input: zod
+    .object({
+      metafield_identifiers: zod
+        .object({
+          namespace: zod.string(),
+          key: zod.string(),
+        })
+        .optional(),
+    })
+    .optional(),
+})
+  .refine((schema) => !schema.supports_3ds || schema.confirmation_callback_url, {
+    message: 'Property required when supports_3ds is true',
+    path: ['confirmation_callback_url'],
+  })
+  .refine((schema) => schema.supports_installments === schema.supports_deferred_payments, {
+    message: 'supports_installments and supports_deferred_payments must be the same',
+  })
+
+export async function creditCardPaymentsAppExtensionDeployConfig(
+  config: CreditCardPaymentsAppExtensionConfigType,
+): Promise<{[key: string]: unknown} | undefined> {
+  return {
+    target: config.targeting[0]!.target,
+    api_version: config.api_version,
+    start_payment_session_url: config.payment_session_url,
+    start_refund_session_url: config.refund_session_url,
+    start_capture_session_url: config.capture_session_url,
+    start_void_session_url: config.void_session_url,
+    confirmation_callback_url: config.confirmation_callback_url,
+    merchant_label: config.merchant_label,
+    supported_countries: config.supported_countries,
+    supported_payment_methods: config.supported_payment_methods,
+    test_mode_available: config.test_mode_available,
+    supports_3ds: config.supports_3ds,
+    supports_deferred_payments: config.supports_deferred_payments,
+    supports_installments: config.supports_installments,
+    start_verification_session_url: config.verification_session_url,
+    encryption_certificate: config.encryption_certificate,
+    checkout_payment_method_fields: config.checkout_payment_method_fields,
+  }
+}


### PR DESCRIPTION
**Why are these changes introduced?**

This PR introduces a `credit-card` payments app schema.

Subsequent PRs will include additional schema definitions, one for each payments extension type, that will populate the schema union.

These changes will be behind a feature flag and the current CLI version `3.53` will not have `Payment Extensions` available as an option to choose from

### How to test your changes?

- Create app with `npm init @shopify/app@latest`
- Pull this branch into your local `cli` copy
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app config link --path {YOUR-APP-PATH}`
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app deploy --path {YOUR-APP-PATH}`
- View `Payments Extensions`

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
