### PR TITLE
Add custom credit card extension schema

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
@@ -16,6 +16,12 @@ import {
   customOnsitePaymentsAppExtensionDeployConfig,
   CustomOnsitePaymentsAppExtensionSchema,
 } from './payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.js'
+import {
+  CUSTOM_CREDIT_CARD_TARGET,
+  CustomCreditCardPaymentsAppExtensionConfigType,
+  customCreditCardPaymentsAppExtensionDeployConfig,
+  CustomCreditCardPaymentsAppExtensionSchema,
+} from './payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.js'
 import {createExtensionSpecification} from '../specification.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -23,6 +29,7 @@ const PaymentsAppExtensionSchema = zod.union([
   OffsitePaymentsAppExtensionSchema,
   RedeemablePaymentsAppExtensionSchema,
   CustomOnsitePaymentsAppExtensionSchema,
+  CustomCreditCardPaymentsAppExtensionSchema,
 ])
 
 export type PaymentsAppExtensionConfigType = zod.infer<typeof PaymentsAppExtensionSchema>
@@ -40,6 +47,10 @@ const spec = createExtensionSpecification({
         return redeemablePaymentsAppExtensionDeployConfig(config as RedeemablePaymentsAppExtensionConfigType)
       case CUSTOM_ONSITE_TARGET:
         return customOnsitePaymentsAppExtensionDeployConfig(config as CustomOnsitePaymentsAppExtensionConfigType)
+      case CUSTOM_CREDIT_CARD_TARGET:
+        return customCreditCardPaymentsAppExtensionDeployConfig(
+          config as CustomCreditCardPaymentsAppExtensionConfigType,
+        )
       default:
         return {}
     }

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
@@ -1,0 +1,60 @@
+import {BaseSchema} from '../../schemas.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+export type CustomCreditCardPaymentsAppExtensionConfigType = zod.infer<
+  typeof CustomCreditCardPaymentsAppExtensionSchema
+>
+
+const MAX_LABEL_SIZE = 50
+
+export const CUSTOM_CREDIT_CARD_TARGET = 'payments.custom-credit-card.render'
+export const CustomCreditCardPaymentsAppExtensionSchema = BaseSchema.extend({
+  targeting: zod.array(zod.object({target: zod.literal(CUSTOM_CREDIT_CARD_TARGET)})).length(1),
+  api_version: zod.string(),
+  payment_session_url: zod.string().url(),
+  refund_session_url: zod.string().url(),
+  capture_session_url: zod.string().url(),
+  void_session_url: zod.string().url(),
+  confirmation_callback_url: zod.string().url().optional(),
+  merchant_label: zod.string().max(MAX_LABEL_SIZE),
+  supports_3ds: zod.boolean(),
+  supported_countries: zod.array(zod.string()),
+  supported_payment_methods: zod.array(zod.string()),
+  test_mode_available: zod.boolean(),
+  multiple_capture: zod.boolean(),
+  encryption_certificate: zod.object({}),
+  checkout_payment_method_fields: zod.array(zod.object({})).optional(),
+  checkout_hosted_fields: zod.array(zod.string()).optional(),
+  input: zod
+    .object({
+      metafield_identifiers: zod
+        .object({
+          namespace: zod.string(),
+          key: zod.string(),
+        })
+        .optional(),
+    })
+    .optional(),
+})
+export async function customCreditCardPaymentsAppExtensionDeployConfig(
+  config: CustomCreditCardPaymentsAppExtensionConfigType,
+): Promise<{[key: string]: unknown} | undefined> {
+  return {
+    target: config.targeting[0]!.target,
+    api_version: config.api_version,
+    start_payment_session_url: config.payment_session_url,
+    start_refund_session_url: config.refund_session_url,
+    start_capture_session_url: config.capture_session_url,
+    start_void_session_url: config.void_session_url,
+    confirmation_callback_url: config.confirmation_callback_url,
+    merchant_label: config.merchant_label,
+    supports_3ds: config.supports_3ds,
+    supported_countries: config.supported_countries,
+    supported_payment_methods: config.supported_payment_methods,
+    encryption_certificate: config.encryption_certificate,
+    test_mode_available: config.test_mode_available,
+    multiple_capture: config.multiple_capture,
+    checkout_payment_method_fields: config.checkout_payment_method_fields,
+    checkout_hosted_fields: config.checkout_hosted_fields,
+  }
+}

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_credit_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_credit_payments_app_extension_schema.test.ts
@@ -1,0 +1,93 @@
+import {
+  CustomCreditCardPaymentsAppExtensionConfigType,
+  customCreditCardPaymentsAppExtensionDeployConfig,
+  CustomCreditCardPaymentsAppExtensionSchema,
+} from './custom_credit_card_payments_app_extension_schema.js'
+import {describe, expect, test} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const config: CustomCreditCardPaymentsAppExtensionConfigType = {
+  name: 'Custom CreditCard extension',
+  type: 'payments_extension',
+  targeting: [{target: 'payments.custom-credit-card.render'}],
+  payment_session_url: 'http://foo.bar',
+  refund_session_url: 'http://foo.bar',
+  capture_session_url: 'http://foo.bar',
+  void_session_url: 'http://foo.bar',
+  confirmation_callback_url: 'http://foo.bar',
+  merchant_label: 'some-label',
+  supported_countries: ['CA'],
+  supported_payment_methods: ['visa'],
+  supports_3ds: true,
+  test_mode_available: true,
+  multiple_capture: true,
+  encryption_certificate: {},
+  api_version: '2022-07',
+  checkout_payment_method_fields: [],
+  checkout_hosted_fields: ['fields'],
+  description: 'Custom credit card extension',
+  metafields: [],
+  input: {
+    metafield_identifiers: {
+      namespace: 'namespace',
+      key: 'key',
+    },
+  },
+}
+
+describe('CustomCreditCardPaymentsAppExtensionSchema', () => {
+  test('validates a configuration with valid fields', async () => {
+    // When
+    const {success} = CustomCreditCardPaymentsAppExtensionSchema.safeParse(config)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('returns an error if no target is provided', async () => {
+    // When/Then
+    expect(() =>
+      CustomCreditCardPaymentsAppExtensionSchema.parse({
+        ...config,
+        targeting: [{...config.targeting[0]!, target: null}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          received: null,
+          code: zod.ZodIssueCode.invalid_literal,
+          expected: 'payments.custom-credit-card.render',
+          path: ['targeting', 0, 'target'],
+          message: 'Invalid literal value, expected "payments.custom-credit-card.render"',
+        },
+      ]),
+    )
+  })
+})
+
+describe('customCreditCardPaymentsAppExtensionDeployConfig', () => {
+  test('maps deploy configuration from extension configuration', async () => {
+    // When
+    const result = await customCreditCardPaymentsAppExtensionDeployConfig(config)
+
+    // Then
+    expect(result).toMatchObject({
+      target: config.targeting[0]!.target,
+      api_version: config.api_version,
+      start_payment_session_url: config.payment_session_url,
+      start_refund_session_url: config.refund_session_url,
+      start_capture_session_url: config.capture_session_url,
+      start_void_session_url: config.void_session_url,
+      confirmation_callback_url: config.confirmation_callback_url,
+      merchant_label: config.merchant_label,
+      supports_3ds: config.supports_3ds,
+      supported_countries: config.supported_countries,
+      supported_payment_methods: config.supported_payment_methods,
+      encryption_certificate: config.encryption_certificate,
+      test_mode_available: config.test_mode_available,
+      multiple_capture: config.multiple_capture,
+      checkout_payment_method_fields: config.checkout_payment_method_fields,
+      checkout_hosted_fields: config.checkout_hosted_fields,
+    })
+  })
+})


### PR DESCRIPTION
**Why are these changes introduced?**

This PR introduces a `custom credit card` payments app schema.

Subsequent PRs will include additional schema definitions, one for each payments extension type, that will populate the schema union.

These changes will be behind a feature flag and the current CLI version `3.53` will not have `Payment Extensions` available as an option to choose from

### How to test your changes?

- Create app with `npm init @shopify/app@latest`
- Pull this branch into your local `cli` copy
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app config link --path {YOUR-APP-PATH}`
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app deploy --path {YOUR-APP-PATH}`
- View `Payments Extensions`

<img width="243" alt="Screenshot 2024-01-19 at 12 08 07" src="https://github.com/Shopify/cli/assets/3664860/8abcda75-c707-4ff7-b17f-c83a282c1242">


<img width="930" alt="Screenshot 2024-01-19 at 12 08 35" src="https://github.com/Shopify/cli/assets/3664860/304d1d83-f2e8-4b84-b9d0-4f4afb41dcbc">


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
