### PR TITLE
Fix postinstall step for Cloudflare when the binary fails

### DIFF
--- a/.changeset/empty-chicken-tap.md
+++ b/.changeset/empty-chicken-tap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/plugin-cloudflare': patch
+---
+
+Fix postinstall when the binary already exists but fails

--- a/packages/plugin-cloudflare/scripts/postinstall.js
+++ b/packages/plugin-cloudflare/scripts/postinstall.js
@@ -58,17 +58,21 @@ export default async function install() {
     throw new Error(`Unsupported system platform: ${process.platform} or arch: ${process.arch}`)
   }
 
-  const fileUrlPath = CLOUDFLARE_REPO + fileName;
+  const fileUrlPath = CLOUDFLARE_REPO + fileName
   const binTarget = getBinPathTarget()
 
   if (existsSync(binTarget)) {
     // --version returns an string like "cloudflared version 2023.3.1 (built 2023-03-13-1444 UTC)"
-    const versionArray = execFileSync(binTarget, ['--version'], {encoding: 'utf8'}).split(' ')
-    const versionNumber = versionArray.length > 2 ? versionArray[2] : '0.0.0'
-    const needsUpdate = semver.gt(CLOUDFLARE_VERSION, versionNumber)
-    if (!needsUpdate) {
-      console.log('cloudflared already installed, skipping')
-      return
+    try {
+      const versionArray = execFileSync(binTarget, ['--version'], {encoding: 'utf8'}).split(' ')
+      const versionNumber = versionArray.length > 2 ? versionArray[2] : '0.0.0'
+      const needsUpdate = semver.gt(CLOUDFLARE_VERSION, versionNumber)
+      if (!needsUpdate) {
+        console.log('cloudflared already installed, skipping')
+        return
+      }
+    } catch {
+      console.log('version check failed, reinstalling')
     }
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/3267

When running the postinstall script for the Cloudflare plugin, after checking that a binary already exists, we try to check the version by running `cloudflare --version` to see if it needs an upgrade.

But if the binary is damaged, or you don't have Rosetta installed and it needs it, it crashes and it doesn't reinstall.

### WHAT is this pull request doing?

Adds a try/catch to avoid crashing when checking the version. If it fails, it just continues with the reinstallation.

That would fix the broken binary, and if Rosetta is missing, the CLI will show a [proper message](https://github.com/Shopify/cli/blob/8ad91863e038a4207c81802bfd126be46233db29/packages/plugin-cloudflare/src/tunnel.ts#L130) on the next run.

### How to test your changes?

- `rm packages/plugin-cloudflare/bin/cloudflared`
- `echo 'fail' > packages/plugin-cloudflare/bin/cloudflared`
- `p i` => It should work and show `version check failed, reinstalling`
- `p shopify app dev` => it should work

I couldn't test the Rosetta scenario because it's hard to uninstall, but it should be the same.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
