### PR TITLE
`app config push` and `app update-url` commands deprecation

### DIFF
--- a/packages/app/src/cli/api/graphql/get_config.ts
+++ b/packages/app/src/cli/api/graphql/get_config.ts
@@ -28,6 +28,7 @@ export const GetConfig = gql`
       }
       betas {
         declarativeWebhooks
+        versionedAppConfig
       }
     }
   }
@@ -59,6 +60,7 @@ export interface App {
   }
   betas?: {
     declarativeWebhooks?: boolean
+    versionedAppConfig?: boolean
   }
 }
 

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -86,7 +86,11 @@ export async function confirmPushChanges(
 ) {
   if (force) return true
 
-  const remoteConfiguration = mergeAppConfiguration(configuration, app as OrganizationApp, false)
+  const remoteConfiguration = mergeAppConfiguration(
+    configuration,
+    app as OrganizationApp,
+    app.betas?.versionedAppConfig ?? false,
+  )
 
   const gitDiff = buildDiffConfigContent(configuration, remoteConfiguration, schema)
   if (!gitDiff) return false

--- a/packages/app/src/cli/services/app/config/push.test.ts
+++ b/packages/app/src/cli/services/app/config/push.test.ts
@@ -1,4 +1,4 @@
-import {PushOptions, pushConfig} from './push.js'
+import {DeprecatedPushMessage, PushOptions, pushConfig} from './push.js'
 import {confirmPushChanges} from '../../../prompts/config.js'
 import {
   DEFAULT_CONFIG,
@@ -317,6 +317,36 @@ describe('pushConfig', () => {
 
     // Then
     await expect(result).rejects.toThrow("Couldn't find app. Make sure you have a valid client ID.")
+  })
+
+  test('returns error when versioned app config beta flag is enabled', async () => {
+    // Given
+    const app = await mockApp({}, 'current')
+    const options: PushOptions = {
+      configuration: app.configuration,
+      force: true,
+      commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
+    }
+
+    vi.mocked(partnersRequest).mockResolvedValue({
+      app: {
+        apiKey: '43534543',
+        title: 'name of the app',
+        betas: {
+          versionedAppConfig: true,
+        },
+      },
+      appUpdate: {
+        userErrors: [],
+      },
+    })
+    vi.spyOn(loader, 'loadApp').mockResolvedValue(app)
+
+    // When
+    const result = pushConfig(options)
+
+    // Then
+    await expect(result).rejects.toThrow(DeprecatedPushMessage)
   })
 
   test('returns error when update mutation fails', async () => {

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -25,6 +25,7 @@ export async function fetchAppRemoteBetaFlags(apiKey: string, token: string) {
   const queryResult: GetConfigQuerySchema = await partnersRequest(GetConfig, token, {apiKey})
   if (queryResult.app) {
     const {app} = queryResult
+    if (app.betas?.versionedAppConfig) betas.push(BetaFlag.VersionedAppConfig)
   } else {
     outputDebug("Couldn't find app for beta flags. Make sure you have a valid client ID.")
   }

--- a/packages/app/src/cli/services/app/update-url.ts
+++ b/packages/app/src/cli/services/app/update-url.ts
@@ -1,4 +1,6 @@
 import {fetchAppFromConfigOrSelect} from './fetch-app-from-config-or-select.js'
+import {BetaFlag, fetchAppRemoteBetaFlags} from './select-app.js'
+import {abort, DeprecatedPushMessage} from './config/push.js'
 import {getURLs, PartnersURLs, updateURLs, validatePartnersURLs} from '../dev/urls.js'
 import {allowedRedirectionURLsPrompt, appUrlPrompt} from '../../prompts/update-url.js'
 import {AppConfigurationInterface} from '../../models/app/app.js'
@@ -15,6 +17,9 @@ export interface UpdateURLOptions {
 export default async function updateURL(options: UpdateURLOptions): Promise<void> {
   const token = await ensureAuthenticatedPartners()
   const apiKey = options.apiKey || (await fetchAppFromConfigOrSelect(options.app)).apiKey
+
+  const remoteBetas = await fetchAppRemoteBetaFlags(apiKey, token)
+  if (remoteBetas.includes(BetaFlag.VersionedAppConfig)) abort(DeprecatedPushMessage)
 
   const newURLs = await getNewURLs(token, apiKey, options)
   await updateURLs(newURLs, apiKey, token, options.app)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Follow-up: https://github.com/Shopify/cli/pull/3262

Partially-fixes: https://github.com/Shopify/develop-app-foundations/issues/855
Depends-on: https://github.com/Shopify/partners/pull/52716


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Check the `versioned_app_config` beta flag value once the remote app is selected for both commands
- If `enabled` the commands will display an error banner.
- Otherwise the current flow is executed
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new spin instance `spin up partners@app-update-return-error-versioned-app`
- Run `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name) npm run shopify app config link --path /PATH/TO/YOUR/APP` and create a new remote app

#### `versioned_app_config` beta flag `disabled` (default behaviour)
- Add a versioned app property to the `toml` (ie handle = 'My handle'). Modify the `name` value. Run `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name) npm run shopify app config push -- --path /PATH/TO/YOUR/APP`. You should see the `diff` and the `handle` field should not appear. Confirm and the command should finish successfully
- Run `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name) npm run shopify app update-url -- --path /PATH/TO/YOUR/APP` confirm the prompts with default values and the command should finish successfully

#### `versioned_app_config` beta flag `enabled`
- Access `Partners internal`, search the app and enable the beta flag `versioned_app_config`
- Modify some field inside the `toml` and run `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name) npm run shopify app config push -- --path /PATH/TO/YOUR/APP`. You should see this error
<img src="https://github.com/Shopify/partners/assets/105213827/4198e7ff-0255-4bfd-b7e2-7c278bf49c81" width=400/>


- Run `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name) npm run shopify app update-url  -- --path /PATH/TO/YOUR/APP` and you should see this error
<img src="https://github.com/Shopify/partners/assets/105213827/25166295-9880-4f1c-9b32-63e87678748c" width=400/>

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
