### PR TITLE
Refactor and extract common fields from payment app schemas

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
@@ -1,0 +1,246 @@
+import {
+  BasePaymentsAppExtensionSchema,
+  BuyerLabelSchema,
+  ConfirmationSchema,
+  DeferredPaymentsSchema,
+} from './base_payments_app_extension_schema.js'
+import {describe, expect, test} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+describe('BasePaymentsAppExtensionSchema', () => {
+  const config = {
+    name: 'test extension',
+    type: 'payments_extension',
+    payment_session_url: 'http://foo.bar',
+    refund_session_url: 'http://foo.bar',
+    capture_session_url: 'http://foo.bar',
+    void_session_url: 'http://foo.bar',
+    merchant_label: 'some-label',
+    supported_countries: ['CA'],
+    supported_payment_methods: ['PAYMENT_METHOD'],
+    test_mode_available: true,
+    api_version: '2022-07',
+    description: 'my payments app extension',
+    metafields: [],
+    input: {
+      metafield_identifiers: {
+        namespace: 'namespace',
+        key: 'key',
+      },
+    },
+  }
+
+  test('validates a configuration with valid fields', async () => {
+    // When
+    const {success} = BasePaymentsAppExtensionSchema.safeParse(config)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('throws an error if no payment session url is provided', async () => {
+    // When/Then
+    expect(() =>
+      BasePaymentsAppExtensionSchema.parse({
+        ...config,
+        payment_session_url: undefined,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'string',
+          received: 'undefined',
+          path: ['payment_session_url'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+})
+
+describe('BuyerLabelSchema', () => {
+  const config = {
+    buyer_label: 'Sample label',
+    buyer_label_translations: [{locale: 'en', label: 'Translated label'}],
+  }
+
+  test('validates a configuration with valid fields', async () => {
+    // When
+    const {success} = BuyerLabelSchema.safeParse(config)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('throws an error if buyer_label is not a string', async () => {
+    // When/Then
+    expect(() =>
+      BuyerLabelSchema.parse({
+        ...config,
+        buyer_label: 1,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'string',
+          received: 'number',
+          path: ['buyer_label'],
+          message: 'Expected string, received number',
+        },
+      ]),
+    )
+  })
+
+  test('throws an error if buyer_label is too long', async () => {
+    // When/Then
+    expect(() =>
+      BuyerLabelSchema.parse({
+        ...config,
+        buyer_label: 'a'.repeat(60),
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.too_big,
+          maximum: 50,
+          type: 'string',
+          inclusive: true,
+          exact: false,
+          message: 'String must contain at most 50 character(s)',
+          path: ['buyer_label'],
+        },
+      ]),
+    )
+  })
+
+  test('throws an error if buyer_label_translations has an invalid format', async () => {
+    // When/Then
+    expect(() =>
+      BuyerLabelSchema.parse({
+        ...config,
+        buyer_label_translations: [{locale: 'en', text: 'invalid key'}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'string',
+          received: 'undefined',
+          path: ['buyer_label_translations', 0, 'label'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+})
+
+describe('DeferredPaymentsSchema', () => {
+  const config = {
+    supports_installments: true,
+    supports_deferred_payments: true,
+  }
+
+  test('validates a configuration with valid fields', async () => {
+    // When
+    const {success} = DeferredPaymentsSchema.safeParse(config)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('throws an error if no supports_installments is provided', async () => {
+    // When/Then
+    expect(() =>
+      DeferredPaymentsSchema.parse({
+        ...config,
+        supports_installments: undefined,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'boolean',
+          received: 'undefined',
+          path: ['supports_installments'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+
+  test('throws an error if no supports_deferred_payments is provided', async () => {
+    // When/Then
+    expect(() =>
+      DeferredPaymentsSchema.parse({
+        ...config,
+        supports_deferred_payments: undefined,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'boolean',
+          received: 'undefined',
+          path: ['supports_deferred_payments'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+})
+
+describe('ConfirmationSchema', () => {
+  const config = {
+    confirmation_callback_url: 'https://www.example.com',
+    supports_3ds: true,
+  }
+
+  test('validates a configuration with valid fields', async () => {
+    // When
+    const {success} = ConfirmationSchema.safeParse(config)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('throws an error if confirmation_callback_url is not a url', async () => {
+    // When/Then
+    expect(() =>
+      ConfirmationSchema.parse({
+        ...config,
+        confirmation_callback_url: 'not-a-url',
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          validation: 'url',
+          code: zod.ZodIssueCode.invalid_string,
+          message: 'Invalid url',
+          path: ['confirmation_callback_url'],
+        },
+      ]),
+    )
+  })
+
+  test('throws an error if supports_3ds is not provided', async () => {
+    // When/Then
+    expect(() =>
+      ConfirmationSchema.parse({
+        ...config,
+        supports_3ds: undefined,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'boolean',
+          received: 'undefined',
+          path: ['supports_3ds'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
@@ -1,0 +1,45 @@
+import {BaseSchema} from '../../schemas.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const MAX_LABEL_SIZE = 50
+
+export const BasePaymentsAppExtensionSchema = BaseSchema.extend({
+  api_version: zod.string(),
+  payment_session_url: zod.string().url(),
+  refund_session_url: zod.string().url().optional(),
+  capture_session_url: zod.string().url().optional(),
+  void_session_url: zod.string().url().optional(),
+
+  supported_countries: zod.array(zod.string()),
+  supported_payment_methods: zod.array(zod.string()),
+
+  test_mode_available: zod.boolean(),
+
+  merchant_label: zod.string().max(MAX_LABEL_SIZE),
+
+  input: zod
+    .object({
+      metafield_identifiers: zod
+        .object({
+          namespace: zod.string(),
+          key: zod.string(),
+        })
+        .optional(),
+    })
+    .optional(),
+})
+
+export const BuyerLabelSchema = zod.object({
+  buyer_label: zod.string().max(MAX_LABEL_SIZE).optional(),
+  buyer_label_translations: zod.array(zod.object({locale: zod.string(), label: zod.string()})).optional(),
+})
+
+export const DeferredPaymentsSchema = zod.object({
+  supports_installments: zod.boolean(),
+  supports_deferred_payments: zod.boolean(),
+})
+
+export const ConfirmationSchema = zod.object({
+  confirmation_callback_url: zod.string().url().optional(),
+  supports_3ds: zod.boolean(),
+})

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
@@ -21,7 +21,10 @@ const config: CustomCreditCardPaymentsAppExtensionConfigType = {
   supports_3ds: true,
   test_mode_available: true,
   multiple_capture: true,
-  encryption_certificate: {},
+  encryption_certificate: {
+    fingerprint: 'fingerprint',
+    certificate: '-----BEGIN CERTIFICATE-----\nSample certificate\n-----END CERTIFICATE-----',
+  },
   api_version: '2022-07',
   checkout_payment_method_fields: [],
   checkout_hosted_fields: ['fields'],

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
@@ -1,41 +1,40 @@
-import {BaseSchema} from '../../schemas.js'
+import {BasePaymentsAppExtensionSchema, ConfirmationSchema} from './base_payments_app_extension_schema.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 export type CustomCreditCardPaymentsAppExtensionConfigType = zod.infer<
   typeof CustomCreditCardPaymentsAppExtensionSchema
 >
 
-const MAX_LABEL_SIZE = 50
+const CERTIFICATE_REGEX = /^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$/
 
 export const CUSTOM_CREDIT_CARD_TARGET = 'payments.custom-credit-card.render'
-export const CustomCreditCardPaymentsAppExtensionSchema = BaseSchema.extend({
-  targeting: zod.array(zod.object({target: zod.literal(CUSTOM_CREDIT_CARD_TARGET)})).length(1),
-  api_version: zod.string(),
-  payment_session_url: zod.string().url(),
-  refund_session_url: zod.string().url(),
-  capture_session_url: zod.string().url(),
-  void_session_url: zod.string().url(),
-  confirmation_callback_url: zod.string().url().optional(),
-  merchant_label: zod.string().max(MAX_LABEL_SIZE),
-  supports_3ds: zod.boolean(),
-  supported_countries: zod.array(zod.string()),
-  supported_payment_methods: zod.array(zod.string()),
-  test_mode_available: zod.boolean(),
-  multiple_capture: zod.boolean(),
-  encryption_certificate: zod.object({}),
-  checkout_payment_method_fields: zod.array(zod.object({})).optional(),
-  checkout_hosted_fields: zod.array(zod.string()).optional(),
-  input: zod
-    .object({
-      metafield_identifiers: zod
-        .object({
-          namespace: zod.string(),
+
+export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(ConfirmationSchema)
+  .required({
+    refund_session_url: true,
+    capture_session_url: true,
+    void_session_url: true,
+  })
+  .extend({
+    targeting: zod.array(zod.object({target: zod.literal(CUSTOM_CREDIT_CARD_TARGET)})).length(1),
+    api_version: zod.string(),
+    multiple_capture: zod.boolean(),
+    checkout_hosted_fields: zod.array(zod.string()).optional(),
+    encryption_certificate: zod.object({
+      fingerprint: zod.string(),
+      certificate: zod.string().regex(CERTIFICATE_REGEX),
+    }),
+    checkout_payment_method_fields: zod
+      .array(
+        zod.object({
+          type: zod.union([zod.literal('string'), zod.literal('number'), zod.literal('boolean')]),
+          required: zod.boolean(),
           key: zod.string(),
-        })
-        .optional(),
-    })
-    .optional(),
-})
+        }),
+      )
+      .optional(),
+  })
+
 export async function customCreditCardPaymentsAppExtensionDeployConfig(
   config: CustomCreditCardPaymentsAppExtensionConfigType,
 ): Promise<{[key: string]: unknown} | undefined> {

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
@@ -1,44 +1,38 @@
-import {BaseSchema} from '../../schemas.js'
+import {
+  BasePaymentsAppExtensionSchema,
+  BuyerLabelSchema,
+  ConfirmationSchema,
+  DeferredPaymentsSchema,
+} from './base_payments_app_extension_schema.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 export type CustomOnsitePaymentsAppExtensionConfigType = zod.infer<typeof CustomOnsitePaymentsAppExtensionSchema>
 
-const MAX_LABEL_SIZE = 50
-
 export const CUSTOM_ONSITE_TARGET = 'payments.custom-onsite.render'
-export const CustomOnsitePaymentsAppExtensionSchema = BaseSchema.extend({
-  targeting: zod.array(zod.object({target: zod.literal(CUSTOM_ONSITE_TARGET)})).length(1),
-  api_version: zod.string(),
-  payment_session_url: zod.string().url(),
-  refund_session_url: zod.string().url().optional(),
-  capture_session_url: zod.string().url().optional(),
-  void_session_url: zod.string().url().optional(),
-  confirmation_callback_url: zod.string().url().optional(),
-  update_payment_session_url: zod.string().url().optional(),
-  merchant_label: zod.string().max(MAX_LABEL_SIZE),
-  buyer_label: zod.string().max(MAX_LABEL_SIZE).optional(),
-  buyer_label_translations: zod.array(zod.object({locale: zod.string(), label: zod.string()})).optional(),
-  supports_oversell_protection: zod.boolean(),
-  supports_3ds: zod.boolean(),
-  supports_installments: zod.boolean(),
-  supports_deferred_payments: zod.boolean(),
-  test_mode_available: zod.boolean(),
-  supported_countries: zod.array(zod.string()),
-  supported_payment_methods: zod.array(zod.string()),
-  multiple_capture: zod.boolean().optional(),
-  checkout_payment_method_fields: zod.array(zod.object({})).optional(),
-  modal_payment_method_fields: zod.array(zod.object({})).optional(),
-  input: zod
-    .object({
-      metafield_identifiers: zod
-        .object({
-          namespace: zod.string(),
+
+export const CustomOnsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(BuyerLabelSchema)
+  .merge(DeferredPaymentsSchema)
+  .merge(ConfirmationSchema)
+  .extend({
+    targeting: zod.array(zod.object({target: zod.literal(CUSTOM_ONSITE_TARGET)})).length(1),
+    update_payment_session_url: zod.string().url().optional(),
+    multiple_capture: zod.boolean().optional(),
+    supports_oversell_protection: zod.boolean().optional(),
+    modal_payment_method_fields: zod.array(zod.object({})).optional(),
+    checkout_payment_method_fields: zod
+      .array(
+        zod.object({
+          type: zod.union([zod.literal('string'), zod.literal('number'), zod.literal('boolean')]),
+          required: zod.boolean(),
           key: zod.string(),
-        })
-        .optional(),
-    })
-    .optional(),
-})
+        }),
+      )
+      .optional(),
+  })
+  .refine((schema) => schema.supports_installments === schema.supports_deferred_payments, {
+    message: 'supports_installments and supports_deferred_payments must be the same',
+  })
+
 export async function customOnsitePaymentsAppExtensionDeployConfig(
   config: CustomOnsitePaymentsAppExtensionConfigType,
 ): Promise<{[key: string]: unknown} | undefined> {

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.ts
@@ -1,39 +1,22 @@
-import {BaseSchema} from '../../schemas.js'
+import {
+  BasePaymentsAppExtensionSchema,
+  BuyerLabelSchema,
+  ConfirmationSchema,
+  DeferredPaymentsSchema,
+} from './base_payments_app_extension_schema.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 export type OffsitePaymentsAppExtensionConfigType = zod.infer<typeof OffsitePaymentsAppExtensionSchema>
 
-const MAX_LABEL_SIZE = 50
 export const OFFSITE_TARGET = 'payments.offsite.render'
-export const OffsitePaymentsAppExtensionSchema = BaseSchema.extend({
-  targeting: zod.array(zod.object({target: zod.literal(OFFSITE_TARGET)})).length(1),
-  api_version: zod.string(),
-  payment_session_url: zod.string().url(),
-  refund_session_url: zod.string().url().optional(),
-  capture_session_url: zod.string().url().optional(),
-  void_session_url: zod.string().url().optional(),
-  confirmation_callback_url: zod.string().url().optional(),
-  merchant_label: zod.string().max(MAX_LABEL_SIZE),
-  buyer_label: zod.string().max(MAX_LABEL_SIZE).optional(),
-  buyer_label_translations: zod.array(zod.object({locale: zod.string(), label: zod.string()})).optional(),
-  supports_oversell_protection: zod.boolean().optional(),
-  supports_3ds: zod.boolean(),
-  supports_installments: zod.boolean(),
-  supports_deferred_payments: zod.boolean(),
-  supported_countries: zod.array(zod.string()),
-  supported_payment_methods: zod.array(zod.string()),
-  test_mode_available: zod.boolean(),
-  input: zod
-    .object({
-      metafield_identifiers: zod
-        .object({
-          namespace: zod.string(),
-          key: zod.string(),
-        })
-        .optional(),
-    })
-    .optional(),
-})
+
+export const OffsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(BuyerLabelSchema)
+  .merge(DeferredPaymentsSchema)
+  .merge(ConfirmationSchema)
+  .extend({
+    targeting: zod.array(zod.object({target: zod.literal(OFFSITE_TARGET)})).length(1),
+    supports_oversell_protection: zod.boolean().optional(),
+  })
   .refine((schema) => !schema.supports_oversell_protection || schema.confirmation_callback_url, {
     message: 'Property required when supports_oversell_protection is true',
     path: ['confirmation_callback_url'],

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.ts
@@ -1,37 +1,18 @@
-import {BaseSchema} from '../../schemas.js'
+import {BasePaymentsAppExtensionSchema, BuyerLabelSchema} from './base_payments_app_extension_schema.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 export type RedeemablePaymentsAppExtensionConfigType = zod.infer<typeof RedeemablePaymentsAppExtensionSchema>
 
-const MAX_LABEL_SIZE = 50
 export const REDEEMABLE_TARGET = 'payments.redeemable.render'
-export const RedeemablePaymentsAppExtensionSchema = BaseSchema.extend({
+
+export const RedeemablePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(BuyerLabelSchema).extend({
   targeting: zod.array(zod.object({target: zod.literal(REDEEMABLE_TARGET)})).length(1),
   api_version: zod.string(),
-  payment_session_url: zod.string().url(),
-  refund_session_url: zod.string().url().optional(),
-  capture_session_url: zod.string().url().optional(),
-  void_session_url: zod.string().url().optional(),
   balance_url: zod.string().url(),
-  merchant_label: zod.string().max(MAX_LABEL_SIZE),
-  buyer_label: zod.string().max(MAX_LABEL_SIZE).optional(),
-  buyer_label_translations: zod.array(zod.object({locale: zod.string(), label: zod.string()})).optional(),
-  supported_countries: zod.array(zod.string()),
-  supported_payment_methods: zod.array(zod.string()),
-  test_mode_available: zod.boolean(),
   redeemable_type: zod.literal('gift_card'),
   checkout_payment_method_fields: zod.array(zod.string()).optional(),
-  input: zod
-    .object({
-      metafield_identifiers: zod
-        .object({
-          namespace: zod.string(),
-          key: zod.string(),
-        })
-        .optional(),
-    })
-    .optional(),
 })
+
 export async function redeemablePaymentsAppExtensionDeployConfig(
   config: RedeemablePaymentsAppExtensionConfigType,
 ): Promise<{[key: string]: unknown} | undefined> {


### PR DESCRIPTION
### WHY are these changes introduced?

To keep code maintanable, after creating the schemas for all payment app types, we decided to do a minor refactor to extract common fields into a base schema.

### WHAT is this pull request doing?

A new base schema, `BasePaymentsAppExtensionSchema`, is introduced with all the common fields. All existing schemas are going to extend this base schema, and add new fields when required.

Instead of extracting **strict** common fields (same types, same validations), I decided to leverage on the `omit` and `required` zod methods. This way, we can define *almost-common* fields, and make minor tweaks based on the payment app. For example, if a field is common and optional to all payment app types, but it is required within a specific type, then the `required` method would change the optional field from the base schema to be required in the sub schema. Something similar applies to `omit`; if a field is present in *almost* all payment app types, but not in all of them, the `omit` method can be used to skip that field for the specific type.

I tried to find a balance between extracting common fields and avoiding repetition. I think the current implementation doesn't create too much indirection between the base schema and the subschemas, but please let me know in comments if you find it hard to follow 🙏🏿 

I also made some minor changes to some schemas that were not properly formed, such as the custom credit card encryption certificate field

### How to test your changes?

- Create app with `npm init @shopify/app@latest`
- Pull this branch into your local `cli` copy
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app config link --path {YOUR-APP-PATH}`
- Run `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app deploy --path {YOUR-APP-PATH}`
- View `Payments Extensions`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
