### PR TITLE
Fix password page redirect in Safari [2]

### DIFF
--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -49,7 +49,7 @@ module ShopifyCLI
           return [204, {}, []] if IGNORED_ENDPOINTS.any? { |endpoint| env["PATH_INFO"].include?(endpoint) }
 
           headers = extract_http_request_headers(env)
-          is_chrome = headers['User-Agent'] =~ /[Cc]hrome/
+          is_chrome = headers["User-Agent"] =~ /[Cc]hrome/
           headers["Host"] = shop
           headers["Cookie"] = add_session_cookie(headers["Cookie"])
           headers["Accept-Encoding"] = "none"

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -49,6 +49,7 @@ module ShopifyCLI
           return [204, {}, []] if IGNORED_ENDPOINTS.any? { |endpoint| env["PATH_INFO"].include?(endpoint) }
 
           headers = extract_http_request_headers(env)
+          is_chrome = headers['User-Agent'] =~ /[Cc]hrome/
           headers["Host"] = shop
           headers["Cookie"] = add_session_cookie(headers["Cookie"])
           headers["Accept-Encoding"] = "none"
@@ -76,7 +77,7 @@ module ShopifyCLI
           end
 
           headers = get_response_headers(response, env)
-          headers = modify_headers(headers)
+          headers = modify_headers(headers) unless is_chrome
 
           unless headers["x-storefront-renderer-rendered"]
             @core_endpoints << env["PATH_INFO"]

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -563,6 +563,31 @@ module ShopifyCLI
             response.headers["set-cookie"])
         end
 
+        def test_does_not_modify_set_cookie_headers_on_chrome
+          stub_request(:post, "https://dev-theme-server-store.myshopify.com/password?_fd=0&pb=0")
+            .with(
+              body: {
+                "form_type" => "storefront_password",
+                "password" => "notapassword",
+              },
+            )
+            .to_return(status: 302, headers: {
+              "set-cookie" => "storefront_digest=123abc; path=/; secure; HttpOnly; SameSite=None",
+            })
+          stub_session_id_request
+
+          response = request.post("/password", {
+            params: {
+              "form_type" => "storefront_password",
+              "password" => "notapassword",
+            },
+            "HTTP_USER_AGENT" => "Mozilla/1 (Macintosh) AppleWebKit/1 (KHTML, like Gecko) Chrome/1 Safari/1",
+          })
+
+          assert_equal("storefront_digest=123abc; path=/; secure; HttpOnly; SameSite=None",
+            response.headers["set-cookie"])
+        end
+
         private
 
         def request


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/pull/3249

### WHAT is this pull request doing?

This PR changes the approach adopted on  https://github.com/Shopify/cli/pull/3249 to not modify headers when users are on Chrome.

### How to test your changes?

- Run `shopify theme dev`
- Open the browser in a incognito window
- Type the password
- Notice the password page works on all browsers

**Before (Chrome)**

https://github.com/Shopify/cli/assets/1079279/d5f62f6d-e41b-4064-bedb-441df0fccdd2

**After (Safari, Firefox, and Chrome)**

https://github.com/Shopify/cli/assets/1079279/d8e09883-4ac4-40b5-897a-e4d8b6ed8f39

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).