### PR TITLE
Push config draft in dev

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -192,7 +192,7 @@ export async function testAppConfigExtensions(emptyConfig = false): Promise<Exte
 
   const extension = new ExtensionInstance({
     configuration,
-    configurationPath: '',
+    configurationPath: 'shopify.app.toml',
     directory: './',
     specification,
   })

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -165,6 +165,7 @@ export interface AppInterface extends AppConfigurationInterface {
   usesWorkspaces: boolean
   dotenv?: DotEnvFile
   allExtensions: ExtensionInstance[]
+  draftExtensions: ExtensionInstance[]
   specifications?: ExtensionSpecification[]
   errors?: AppErrors
   useVersionedAppConfig: boolean
@@ -228,6 +229,12 @@ export class App implements AppInterface {
   get allExtensions() {
     return this.realExtensions.filter(
       (ext) => !ext.isAppConfigExtension || (this.useVersionedAppConfig && this.includeConfigOnDeploy),
+    )
+  }
+
+  get draftExtensions() {
+    return this.realExtensions.filter(
+      (ext) => ext.isDraftable() && (!ext.isAppConfigExtension || this.useVersionedAppConfig),
     )
   }
 

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -165,7 +165,7 @@ export interface AppInterface extends AppConfigurationInterface {
   usesWorkspaces: boolean
   dotenv?: DotEnvFile
   allExtensions: ExtensionInstance[]
-  draftExtensions: ExtensionInstance[]
+  draftableExtensions: ExtensionInstance[]
   specifications?: ExtensionSpecification[]
   errors?: AppErrors
   useVersionedAppConfig: boolean
@@ -232,7 +232,7 @@ export class App implements AppInterface {
     )
   }
 
-  get draftExtensions() {
+  get draftableExtensions() {
     return this.realExtensions.filter(
       (ext) => ext.isDraftable() && (!ext.isAppConfigExtension || this.useVersionedAppConfig),
     )

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2037,7 +2037,7 @@ describe('parseConfigurationObject', () => {
     const {path, ...toParse} = configurationObject
     await parseConfigurationObject(schema, 'tmp', toParse, abortOrReport)
 
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', errorObject)
   })
 
   test('throws an error if fields are missing in a legacy schema TOML file', async () => {
@@ -2058,7 +2058,7 @@ describe('parseConfigurationObject', () => {
     const abortOrReport = vi.fn()
     await parseConfigurationObject(LegacyAppSchema, 'tmp', configurationObject, abortOrReport)
 
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', errorObject)
   })
 
   test('throws an error if fields are missing in a frontend config web TOML file', async () => {
@@ -2105,7 +2105,7 @@ describe('parseConfigurationObject', () => {
     const abortOrReport = vi.fn()
     await parseConfigurationObject(WebConfigurationSchema, 'tmp', configurationObject, abortOrReport)
 
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', expect.anything())
   })
 })
 
@@ -2128,7 +2128,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('removes trailing slashes on uri', async () => {
@@ -2156,7 +2156,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('accepts an https uri', async () => {
@@ -2237,7 +2237,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('throws an error if we have duplicate subscriptions in different topics array', async () => {
@@ -2256,7 +2256,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('allows unique topics in both same topic array and different subscriptions', async () => {
@@ -2309,7 +2309,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('accepts a pub sub config with both project and topic', async () => {
@@ -2350,7 +2350,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('throws an error if we have duplicate pub sub subscriptions', async () => {
@@ -2375,7 +2375,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('throws an error if we have duplicate arn subscriptions', async () => {
@@ -2400,7 +2400,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('does not allow identical topic and uri and sub_topic in different subscriptions', async () => {
@@ -2427,7 +2427,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('allows identical topic and uri if sub_topic is different', async () => {
@@ -2478,7 +2478,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('does not allow identical compliance_topics in same subscription (will get by zod enum validation)', async () => {
@@ -2501,7 +2501,7 @@ describe('WebhooksSchema', () => {
     }
 
     const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
   test('allows same compliance_topics if uri is different', async () => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -44,7 +44,12 @@ const defaultExtensionDirectory = 'extensions/*'
 
 export type AppLoaderMode = 'strict' | 'report'
 
-type AbortOrReport = <T>(errorMessage: OutputMessage, fallback: T, configurationPath: string) => T
+type AbortOrReport = <T>(
+  errorMessage: OutputMessage,
+  fallback: T,
+  configurationPath: string,
+  rawErrors?: zod.ZodIssueBase[],
+) => T
 const noopAbortOrReport: AbortOrReport = (errorMessage, fallback, configurationPath) => fallback
 
 export async function loadConfigurationFile(
@@ -112,6 +117,7 @@ export async function parseConfigurationObject<TSchema extends zod.ZodType>(
       outputContent`Fix a schema error in ${outputToken.path(filepath)}:\n${formattedError}`,
       fallbackOutput,
       filepath,
+      parseResult.error.issues,
     )
   }
   return {...parseResult.data, path: filepath}

--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -37,7 +37,7 @@ describe('watchPaths', async () => {
       dir: 'foo',
     })
 
-    const got = extensionInstance.watchPaths
+    const got = extensionInstance.watchBuildPaths
 
     expect(got).toEqual([joinPath('foo', 'src', 'single-path.foo'), joinPath('foo', '**', '!(.)*.graphql')])
   })
@@ -51,7 +51,7 @@ describe('watchPaths', async () => {
       dir: 'foo',
     })
 
-    const got = extensionInstance.watchPaths
+    const got = extensionInstance.watchBuildPaths
 
     expect(got).toEqual([joinPath('foo', 'src', '**', '*.{js,ts}'), joinPath('foo', '**', '!(.)*.graphql')])
   })
@@ -59,7 +59,7 @@ describe('watchPaths', async () => {
   test('returns js and ts paths for esbuild extensions', async () => {
     const extensionInstance = await testUIExtension({directory: 'foo'})
 
-    const got = extensionInstance.watchPaths
+    const got = extensionInstance.watchBuildPaths
 
     expect(got).toEqual([joinPath('foo', 'src', '**', '*.{ts,tsx,js,jsx}')])
   })
@@ -67,7 +67,7 @@ describe('watchPaths', async () => {
   test('return empty array for non-function non-esbuild extensions', async () => {
     const extensionInstance = await testTaxCalculationExtension('foo')
 
-    const got = extensionInstance.watchPaths
+    const got = extensionInstance.watchBuildPaths
 
     expect(got).toEqual([])
   })
@@ -82,7 +82,7 @@ describe('watchPaths', async () => {
       dir: 'foo',
     })
 
-    const got = extensionInstance.watchPaths
+    const got = extensionInstance.watchBuildPaths
 
     expect(got).toEqual([
       joinPath('foo', 'src/**/*.rs'),
@@ -98,7 +98,7 @@ describe('watchPaths', async () => {
       config,
     })
 
-    const got = extensionInstance.watchPaths
+    const got = extensionInstance.watchBuildPaths
 
     expect(got).toBeNull()
   })
@@ -118,7 +118,7 @@ describe('isDraftable', () => {
 
     const got1 = extensionInstance.isDraftable()
 
-    expect(got1).toBe(false)
+    expect(got1).toBe(true)
   })
 
   test('returns true for web pixel extensions', async () => {
@@ -258,5 +258,51 @@ describe('bundleConfig', async () => {
         config: '{"subscriptions":[{"uri":"https://my-app.com/webhooks","topic":"orders/delete"}]}',
       }),
     )
+  })
+})
+
+describe('draftMessages', async () => {
+  test('returns correct success message when the extension is draftable and not configuration', async () => {
+    // Given
+    const extensionInstance = await testUIExtension()
+
+    // When
+    const result = extensionInstance.draftMessages.successMessage
+
+    // Then
+    expect(result).toEqual('Draft updated successfully for extension: test-ui-extension')
+  })
+
+  test('returns no success message when the extension is draftable but configuration', async () => {
+    // Given
+    const extensionInstance = await testAppConfigExtensions()
+
+    // When
+    const result = extensionInstance.draftMessages.successMessage
+
+    // Then
+    expect(result).toBeUndefined()
+  })
+
+  test('returns correct error message when the extension is draftable and not configuration', async () => {
+    // Given
+    const extensionInstance = await testUIExtension()
+
+    // When
+    const result = extensionInstance.draftMessages.errorMessage
+
+    // Then
+    expect(result).toEqual('Error while deploying updated extension draft')
+  })
+
+  test('returns no error message when the extension is draftable but configuration', async () => {
+    // Given
+    const extensionInstance = await testAppConfigExtensions()
+
+    // When
+    const result = extensionInstance.draftMessages.successMessage
+
+    // Then
+    expect(result).toBeUndefined()
   })
 })

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -132,7 +132,11 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   isDraftable() {
-    return !this.isThemeExtension && !this.isAppConfigExtension
+    return !this.isThemeExtension
+  }
+
+  displayDraftUpdateSuccesMessage() {
+    return this.isDraftable() && !this.isAppConfigExtension
   }
 
   isUuidManaged() {
@@ -231,6 +235,8 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
       return watchPaths.map((path) => joinPath(this.directory, path))
     } else if (this.isESBuildExtension) {
       return [joinPath(this.directory, 'src', '**', '*.{ts,tsx,js,jsx}')]
+    } else if (this.isAppConfigExtension) {
+      return [this.configuration.path]
     } else {
       return []
     }

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -17,7 +17,7 @@ import link from './app/config/link.js'
 import {writeAppConfigurationFile} from './app/write-app-configuration-file.js'
 import {PartnersSession, fetchPartnersSession} from './context/partner-account-info.js'
 import {fetchSpecifications} from './generate/fetch-extension-specifications.js'
-import {BetaFlag, fetchAppRemoteBetaFlags} from './app/select-app.js'
+import {fetchAppRemoteBetaFlags} from './app/select-app.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
 import {
   AppConfiguration,
@@ -203,10 +203,13 @@ export async function ensureDevContext(
     apiKey: selectedApp.apiKey,
     config: options.commandConfig,
   })
+  const betas = await fetchAppRemoteBetaFlags(selectedApp.apiKey, token)
+
   const localApp = await loadApp({
     directory: options.directory,
     specifications,
     configName: getAppConfigurationShorthand(configuration.path),
+    remoteBetas: betas,
   })
 
   // We only update the cache or config if the current app is the right one
@@ -304,7 +307,6 @@ interface DeployContextOutput {
   partnersApp: Omit<OrganizationApp, 'apiSecretKeys' | 'apiKey'>
   identifiers: Identifiers
   release: boolean
-  betas: BetaFlag[]
 }
 
 /**
@@ -433,7 +435,6 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
     identifiers,
     token,
     release: !options.noRelease,
-    betas,
   }
 
   await logMetadataForLoadedContext({

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -94,6 +94,7 @@ export async function deployConfirmed(
     configurationRegistrations,
     options.app,
     options.appId,
+    options.includeDraftExtensions,
   )
 
   const validMatchesById: {[key: string]: string} = {}
@@ -122,8 +123,12 @@ async function ensureNonUuidManagedExtensionsIds(
   remoteConfigurationRegistrations: RemoteSource[],
   app: AppInterface,
   appId: string,
+  includeDraftExtensions = false,
 ) {
-  const localExtensionRegistrations = app.allExtensions.filter((ext) => !ext.isUuidManaged())
+  let localExtensionRegistrations = app.allExtensions
+  if (includeDraftExtensions) localExtensionRegistrations = app.draftExtensions
+
+  localExtensionRegistrations = localExtensionRegistrations.filter((ext) => !ext.isUuidManaged())
   const extensionsToCreate: LocalSource[] = []
   const validMatches: {[key: string]: string} = {}
   const validMatchesById: {[key: string]: string} = {}

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -125,8 +125,7 @@ async function ensureNonUuidManagedExtensionsIds(
   appId: string,
   includeDraftExtensions = false,
 ) {
-  let localExtensionRegistrations = app.allExtensions
-  if (includeDraftExtensions) localExtensionRegistrations = app.draftableExtensions
+  let localExtensionRegistrations = includeDraftExtensions ? app.draftableExtensions : app.allExtensions
 
   localExtensionRegistrations = localExtensionRegistrations.filter((ext) => !ext.isUuidManaged())
   const extensionsToCreate: LocalSource[] = []

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -126,7 +126,7 @@ async function ensureNonUuidManagedExtensionsIds(
   includeDraftExtensions = false,
 ) {
   let localExtensionRegistrations = app.allExtensions
-  if (includeDraftExtensions) localExtensionRegistrations = app.draftExtensions
+  if (includeDraftExtensions) localExtensionRegistrations = app.draftableExtensions
 
   localExtensionRegistrations = localExtensionRegistrations.filter((ext) => !ext.isUuidManaged())
   const extensionsToCreate: LocalSource[] = []

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -17,6 +17,7 @@ export interface EnsureDeploymentIdsPresenceOptions {
   force: boolean
   release: boolean
   partnersApp?: PartnersAppForIdentifierMatching
+  includeDraftExtensions?: boolean
 }
 
 export interface RemoteSource {

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -554,7 +554,6 @@ async function testDeployBundle({
       }),
     token: 'api-token',
     release: !options?.noRelease,
-    betas,
   })
 
   vi.mocked(useThemebundling).mockReturnValue(true)

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -50,7 +50,7 @@ interface TasksContext {
 
 export async function deploy(options: DeployOptions) {
   // eslint-disable-next-line prefer-const
-  let {app, identifiers, partnersApp, token, release, betas: remoteAppBetaFlags} = await ensureDeployContext(options)
+  let {app, identifiers, partnersApp, token, release} = await ensureDeployContext(options)
   const apiKey = identifiers.app
 
   outputNewline()

--- a/packages/app/src/cli/services/dev/extension/bundler.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.ts
@@ -205,10 +205,10 @@ Redeploy Paths:
         if (!extension.isAppConfigExtension) return onChange()
 
         const isChanged = !deepCompare(
-          reloadedConfig!.newExtension.configuration,
-          reloadedConfig!.previousExtension.configuration,
+          reloadedConfig.newExtension.configuration,
+          reloadedConfig.previousExtension.configuration,
         )
-        if (isChanged) extension.configuration = reloadedConfig!.newExtension.configuration
+        if (isChanged) extension.configuration = reloadedConfig.newExtension.configuration
         return isChanged ? onChange() : undefined
       })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -225,6 +225,6 @@ export async function reloadAndbuildIfNecessary(
   options: ExtensionBuildOptions,
 ) {
   const reloadedConfig = reloadExtensionConfig({extension, stdout: options.stdout})
-  if (!build) return
+  if (!build) return reloadedConfig
   return extension.build(options).then(() => reloadedConfig)
 }

--- a/packages/app/src/cli/services/dev/extension/bundler.ts
+++ b/packages/app/src/cli/services/dev/extension/bundler.ts
@@ -200,19 +200,16 @@ Redeploy Paths:
       environment: 'development',
       appURL: url,
     })
-      .then((reloadedConfig) => {
+      .then(({newConfig, previousConfig}) => {
         if (buildSignal.aborted) return
         if (!extension.isAppConfigExtension) return onChange()
 
-        const isChanged = !deepCompare(
-          reloadedConfig.newExtension.configuration,
-          reloadedConfig.previousExtension.configuration,
-        )
-        if (isChanged) extension.configuration = reloadedConfig.newExtension.configuration
-        return isChanged ? onChange() : undefined
+        if (deepCompare(newConfig, previousConfig)) return
+
+        extension.configuration = newConfig
+        return onChange()
       })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .catch((updateError: any) => {
+      .catch((updateError: Error) => {
         outputWarn(`Error while deploying updated extension draft: ${updateError.message}`, stdout)
       })
   })

--- a/packages/app/src/cli/services/dev/processes/draftable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/draftable-extension.ts
@@ -74,7 +74,7 @@ export async function setupDraftableExtensionsProcess({
   remoteApp: PartnersAppForIdentifierMatching
 }): Promise<DraftableExtensionProcess | undefined> {
   // it would be good if this process didn't require the full local & remote app instances
-  const draftableExtensions = localApp.draftExtensions
+  const draftableExtensions = localApp.draftableExtensions
   if (draftableExtensions.length === 0) {
     return
   }

--- a/packages/app/src/cli/services/dev/processes/draftable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/draftable-extension.ts
@@ -74,7 +74,7 @@ export async function setupDraftableExtensionsProcess({
   remoteApp: PartnersAppForIdentifierMatching
 }): Promise<DraftableExtensionProcess | undefined> {
   // it would be good if this process didn't require the full local & remote app instances
-  const draftableExtensions = localApp.allExtensions.filter((ext) => ext.isDraftable())
+  const draftableExtensions = localApp.draftExtensions
   if (draftableExtensions.length === 0) {
     return
   }
@@ -89,6 +89,7 @@ export async function setupDraftableExtensionsProcess({
     release: true,
     token,
     envIdentifiers: prodEnvIdentifiers,
+    includeDraftExtensions: true,
   })
 
   // Update the local app with the remote extension UUIDs.

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -57,7 +57,7 @@ export async function updateExtensionDraft({
   if (mutationResult.extensionUpdateDraft?.userErrors?.length > 0) {
     const errors = mutationResult.extensionUpdateDraft.userErrors.map((error) => error.message).join(', ')
     stderr.write(`Error while updating drafts: ${errors}`)
-  } else {
+  } else if (extension.displayDraftUpdateSuccesMessage()) {
     outputInfo(`Draft updated successfully for extension: ${extension.localIdentifier}`, stdout)
   }
 }

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -6,7 +6,6 @@ import {
 import {loadConfigurationFile, parseConfigurationFile, parseConfigurationObject} from '../../models/app/loader.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {ExtensionsArraySchema, UnifiedSchema} from '../../models/extensions/schemas.js'
-import {deepClone} from '@shopify/cli-kit/common/object'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {readFile} from '@shopify/cli-kit/node/fs'
@@ -105,10 +104,9 @@ export async function reloadExtensionConfig({extension}: UpdateExtensionConfigOp
     configObject,
     abort,
   )
-  const newExtension = deepClone(extension) as ExtensionInstance
-  newExtension.configuration = newConfig
+
   return {
-    previousExtension: extension,
-    newExtension,
+    previousConfig: extension.configuration,
+    newConfig,
   }
 }

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -56,8 +56,9 @@ export async function updateExtensionDraft({
   if (mutationResult.extensionUpdateDraft?.userErrors?.length > 0) {
     const errors = mutationResult.extensionUpdateDraft.userErrors.map((error) => error.message).join(', ')
     stderr.write(`Error while updating drafts: ${errors}`)
-  } else if (extension.displayDraftUpdateSuccesMessage()) {
-    outputInfo(`Draft updated successfully for extension: ${extension.localIdentifier}`, stdout)
+  } else {
+    const draftUpdateSuccesMessage = extension.draftMessages.successMessage
+    if (draftUpdateSuccesMessage) outputInfo(draftUpdateSuccesMessage, stdout)
   }
 }
 
@@ -105,8 +106,11 @@ export async function reloadExtensionConfig({extension}: UpdateExtensionConfigOp
     abort,
   )
 
+  const previousConfig = extension.configuration
+  extension.configuration = {...newConfig}
+
   return {
-    previousConfig: extension.configuration,
+    previousConfig,
     newConfig,
   }
 }

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -107,7 +107,7 @@ export async function reloadExtensionConfig({extension}: UpdateExtensionConfigOp
   )
 
   const previousConfig = extension.configuration
-  extension.configuration = {...newConfig}
+  extension.configuration = newConfig
 
   return {
     previousConfig,

--- a/packages/cli-kit/src/public/common/object.ts
+++ b/packages/cli-kit/src/public/common/object.ts
@@ -122,15 +122,3 @@ export function isEmpty(object: object): boolean {
 
   return isEmpty(object)
 }
-
-/**
- * Creates a shallow recursively clone of value.
- *
- * @param object - The value to recursively clone.
- * @returns - Returns the deep cloned value.
- */
-export function deepClone(object: object): object {
-  const cloneDeep = require('lodash/cloneDeep.js')
-
-  return cloneDeep(object)
-}

--- a/packages/cli-kit/src/public/common/object.ts
+++ b/packages/cli-kit/src/public/common/object.ts
@@ -122,3 +122,15 @@ export function isEmpty(object: object): boolean {
 
   return isEmpty(object)
 }
+
+/**
+ * Creates a shallow recursively clone of value.
+ *
+ * @param object - The value to recursively clone.
+ * @returns - Returns the deep cloned value.
+ */
+export function deepClone(object: object): object {
+  const cloneDeep = require('lodash/cloneDeep.js')
+
+  return cloneDeep(object)
+}

--- a/packages/cli-kit/src/public/node/schema.test.ts
+++ b/packages/cli-kit/src/public/node/schema.test.ts
@@ -1,4 +1,4 @@
-import {deepStrict} from './schema.js'
+import {deepStrict, errorsToString} from './schema.js'
 import {describe, expect, test} from 'vitest'
 import {z} from 'zod'
 
@@ -36,5 +36,32 @@ describe('deepStrict', () => {
 
     // Then
     expect(result.success).toBeTruthy()
+  })
+})
+
+describe('errorsToString', () => {
+  test('returns the message formatted correctly', async () => {
+    // Given
+    const zodErrors = [
+      {
+        path: ['root_property'],
+        message: 'root property error',
+      },
+      {
+        path: ['section', 'property'],
+        message: 'section property error',
+      },
+      {
+        path: ['section', 'property_unkonwn'],
+      },
+    ]
+
+    // When
+    const result = errorsToString(zodErrors)
+
+    // Then
+    expect(result).toEqual(
+      'root_property: root property error\nsection.property: section property error\nsection.property_unkonwn: Unknow error',
+    )
   })
 })

--- a/packages/cli-kit/src/public/node/schema.ts
+++ b/packages/cli-kit/src/public/node/schema.ts
@@ -21,3 +21,20 @@ export function deepStrict(schema: ZodTypeAny): ZodTypeAny {
     return schema
   }
 }
+
+/**
+ * Returns a human-readable string of the list of zod errors.
+ *
+ * @param errors - The list of zod errors.
+ * @returns The human-readable string.
+ */
+export function errorsToString(errors: z.ZodIssueBase[]): string {
+  return errors
+    .map((error) =>
+      error.path
+        .join('.')
+        .concat(': ')
+        .concat(error.message ?? 'Unknow error'),
+    )
+    .join('\n')
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

WIP: Missing unit tests

Right now, when you run the `dev` command, `configuration` extensions draft content are not pushed. This means that for instance ui extensions that rely on some configuration value when the `developer preview` is enabled, their preview mode is not working properly

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- `deploy` rely on the local flag `include_config_on_deploy` to include the config module (and create them if they don't exist) 
- `dev` always includes the config modules as draft extensions (creates the extensions if they don't exist)
- both command should not include the config extensions in case the `versioned_app_beta` is not enabled
- pushed deploy success message is not displayed for `config modules`
- config errors messages are displayed in the `dev console` using a human readable format

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create an spin instance if you want to verify the database content `spin up partners`. In this case, prepend the CLI commands with `NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=$(spin show -o name)`
- Create a new remote app `p shopify app config link --path /PATH/TO/YOUR/APP`
- Enable the `versioned_app_config` remote beta
- Run  `p shopify app config link --path /PATH/TO/YOUR/APP`
- Run  `p shopify app deploy --path /PATH/TO/YOUR/APP` and select `no` when you are prompted to include the `configuration`. 
- Optional: Check the database in the table `app_extension_registrations` and you should not see any records for the `client_id` inside the toml
-  Run  `p shopify app dev --path /PATH/TO/YOUR/APP` and wait until the `dev console` is loaded
- Optional: Check the database in the table `app_extension_registrations` and you should see some records for the `client_id` inside the toml. Only with draft_id
- Modify some versioned config value in the `toml`. You should not see any message in the `dev console`
- Optional: Check the database in the table `app_static_extension_config` the records linked to the registrations id inside the table `app_extension_registrations`. Check the value of the config column to verify it contains the correct value
-  Modify some versioned config value in the `toml` using a wrong value. You should an error message like this
![image](https://github.com/Shopify/cli/assets/105213827/5f30fcc0-a4e4-4301-b6de-bb9b4ce064e6)

- Optional: Check the database in the table `app_static_extension_config` the records linked to the registrations id inside the table `app_extension_registrations`. Check the value hasn't been modified
- Restore the correct  last value in the `toml`
- Run `p shopify app config link --path /PATH/TO/YOUR/APP`. The modified value will be restored with the default value as the modification has only been made in the draft content
- Stop the `dev` process and run `p shopify app deploy --path /PATH/TO/YOUR/APP --reset`. Select the same remote app and this time confirm the prompt to include the configuration. 
- Modify something in the `toml`
- Run `p shopify app config link --path /PATH/TO/YOUR/APP`. The modified value will be restored with the last deployed configuration

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
