### PR TITLE
Revert "Version Packages - main"

### DIFF
--- a/.changeset/empty-chicken-tap.md
+++ b/.changeset/empty-chicken-tap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/plugin-cloudflare': patch
+---
+
+Fix postinstall when the binary already exists but fails

--- a/.changeset/forty-terms-poke.md
+++ b/.changeset/forty-terms-poke.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/theme': minor
+---
+
+Refine `shopify theme pull` implementation to no longer require a Ruby setup

--- a/.changeset/fuzzy-mice-raise.md
+++ b/.changeset/fuzzy-mice-raise.md
@@ -1,0 +1,7 @@
+---
+'@shopify/ui-extensions-dev-console-app': patch
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+---
+
+Update @shopify/polaris and @shopify/polaris-icons to latest version

--- a/.changeset/gold-camels-dream.md
+++ b/.changeset/gold-camels-dream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Refresh token when updating extension draft

--- a/.changeset/late-beers-accept.md
+++ b/.changeset/late-beers-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Introduce `shopify theme rename` command

--- a/.changeset/light-ears-walk.md
+++ b/.changeset/light-ears-walk.md
@@ -1,0 +1,12 @@
+---
+'@shopify/plugin-did-you-mean': minor
+'@shopify/plugin-cloudflare': minor
+'@shopify/create-app': minor
+'@shopify/features': minor
+'@shopify/cli-kit': minor
+'@shopify/theme': minor
+'@shopify/app': minor
+'@shopify/cli': minor
+---
+
+Upgrade oclif to v3 (improved help menus and more)

--- a/.changeset/mean-zoos-worry.md
+++ b/.changeset/mean-zoos-worry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update app and store links from GraphiQL when dev is restarted

--- a/.changeset/pretty-peaches-pull.md
+++ b/.changeset/pretty-peaches-pull.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Add `performActionWithRetryAfterRecovery` to codify pattern of optimistic attempt + recovery/retry mechanism

--- a/.changeset/serious-squids-destroy.md
+++ b/.changeset/serious-squids-destroy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Fix password page error for safari

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,25 +1,5 @@
 # @shopify/app
 
-## 3.54.0
-
-### Minor Changes
-
-- d0c388f4f: Upgrade oclif to v3 (improved help menus and more)
-
-### Patch Changes
-
-- ea76f79e2: Update @shopify/polaris and @shopify/polaris-icons to latest version
-- 97f0c6b3e: Refresh token when updating extension draft
-- f9aabda1e: Update app and store links from GraphiQL when dev is restarted
-- Updated dependencies [947fab35a]
-- Updated dependencies [2d42d74ec]
-- Updated dependencies [ea76f79e2]
-- Updated dependencies [d0c388f4f]
-- Updated dependencies [97f0c6b3e]
-- Updated dependencies [437147ae0]
-  - @shopify/plugin-cloudflare@3.54.0
-  - @shopify/cli-kit@3.54.0
-
 ## 3.53.0
 
 ### Minor Changes

--- a/packages/app/oclif.manifest.json
+++ b/packages/app/oclif.manifest.json
@@ -2135,5 +2135,5 @@
       "strict": true
     }
   },
-  "version": "3.54.0"
+  "version": "3.53.0"
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/app",
-  "version": "3.54.0",
+  "version": "3.53.0",
   "description": "Utilities for loading, building, and publishing apps.",
   "homepage": "https://github.com/shopify/cli#readme",
   "bugs": {
@@ -43,9 +43,9 @@
   "dependencies": {
     "@luckycatfactory/esbuild-graphql-loader": "3.8.1",
     "@oclif/core": "3.15.1",
-    "@shopify/cli-kit": "3.54.0",
+    "@shopify/cli-kit": "3.53.0",
     "@shopify/function-runner": "4.1.1",
-    "@shopify/plugin-cloudflare": "3.54.0",
+    "@shopify/plugin-cloudflare": "3.53.0",
     "@shopify/polaris": "12.10.0",
     "@shopify/polaris-icons": "8.0.0",
     "abort-controller": "3.0.0",

--- a/packages/cli-kit/CHANGELOG.md
+++ b/packages/cli-kit/CHANGELOG.md
@@ -1,18 +1,5 @@
 # @shopify/cli-kit
 
-## 3.54.0
-
-### Minor Changes
-
-- 2d42d74ec: Refine `shopify theme pull` implementation to no longer require a Ruby setup
-- d0c388f4f: Upgrade oclif to v3 (improved help menus and more)
-- 97f0c6b3e: Add `performActionWithRetryAfterRecovery` to codify pattern of optimistic attempt + recovery/retry mechanism
-- 437147ae0: Fix password page error for safari
-
-### Patch Changes
-
-- ea76f79e2: Update @shopify/polaris and @shopify/polaris-icons to latest version
-
 ## 3.53.0
 
 ### Minor Changes

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/cli-kit",
-  "version": "3.54.0",
+  "version": "3.53.0",
   "private": false,
   "description": "A set of utilities, interfaces, and models that are common across all the platform features",
   "keywords": [

--- a/packages/cli-kit/src/public/common/version.ts
+++ b/packages/cli-kit/src/public/common/version.ts
@@ -1,1 +1,1 @@
-export const CLI_KIT_VERSION = '3.54.0'
+export const CLI_KIT_VERSION = '3.53.0'

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,21 +1,5 @@
 # @shopify/cli
 
-## 3.54.0
-
-### Minor Changes
-
-- d0c388f4f: Upgrade oclif to v3 (improved help menus and more)
-
-### Patch Changes
-
-- Updated dependencies [2d42d74ec]
-- Updated dependencies [ea76f79e2]
-- Updated dependencies [d0c388f4f]
-- Updated dependencies [97f0c6b3e]
-- Updated dependencies [437147ae0]
-  - @shopify/cli-kit@3.54.0
-  - @shopify/plugin-did-you-mean@3.54.0
-
 ## 3.53.0
 
 ### Minor Changes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,7 +74,7 @@ DESCRIPTION
   Build the app.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/build.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/build.js)_
 
 ## `shopify app config link`
 
@@ -95,7 +95,7 @@ DESCRIPTION
   Fetch your app configuration from the Partner Dashboard.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/config/link.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/config/link.js)_
 
 ## `shopify app config push`
 
@@ -116,7 +116,7 @@ DESCRIPTION
   Push your app configuration to the Partner Dashboard.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/config/push.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/config/push.js)_
 
 ## `shopify app config use [CONFIG]`
 
@@ -139,7 +139,7 @@ DESCRIPTION
   Activate an app configuration.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/config/use.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/config/use.js)_
 
 ## `shopify app deploy`
 
@@ -169,7 +169,7 @@ DESCRIPTION
   Deploy your Shopify app.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/deploy.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/deploy.js)_
 
 ## `shopify app dev`
 
@@ -207,7 +207,7 @@ DESCRIPTION
   Run the app.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/dev.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/dev.js)_
 
 ## `shopify app env pull`
 
@@ -228,7 +228,7 @@ DESCRIPTION
   Pull app and extensions environment variables.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/env/pull.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/env/pull.js)_
 
 ## `shopify app env show`
 
@@ -248,7 +248,7 @@ DESCRIPTION
   Display app and extensions environment variables.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/env/show.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/env/show.js)_
 
 ## `shopify app function build`
 
@@ -268,7 +268,7 @@ DESCRIPTION
   Compile a function to wasm.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/function/build.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/function/build.js)_
 
 ## `shopify app function run`
 
@@ -291,7 +291,7 @@ DESCRIPTION
   Run a function locally for testing.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/function/run.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/function/run.js)_
 
 ## `shopify app function schema`
 
@@ -313,7 +313,7 @@ DESCRIPTION
   Fetch the latest GraphQL schema for a function.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/function/schema.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/function/schema.js)_
 
 ## `shopify app function typegen`
 
@@ -333,7 +333,7 @@ DESCRIPTION
   Generate GraphQL types for a JavaScript function.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/function/typegen.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/function/typegen.js)_
 
 ## `shopify app generate extension [FILE]`
 
@@ -365,7 +365,7 @@ EXAMPLES
   $ shopify app generate extension
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/generate/extension.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/generate/extension.js)_
 
 ## `shopify app generate schema`
 
@@ -387,7 +387,7 @@ DESCRIPTION
   Fetch the latest GraphQL schema for a function.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/generate/schema.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/generate/schema.js)_
 
 ## `shopify app import-flow-legacy-extensions`
 
@@ -409,7 +409,7 @@ DESCRIPTION
   Import dashboard-managed flow extensions into your app.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/import-flow-legacy-extensions.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/import-flow-legacy-extensions.js)_
 
 ## `shopify app info`
 
@@ -431,7 +431,7 @@ DESCRIPTION
   Print basic information about your app and extensions.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/info.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/info.js)_
 
 ## `shopify app release`
 
@@ -456,7 +456,7 @@ DESCRIPTION
   Release an app version.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/release.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/release.js)_
 
 ## `shopify app update-url`
 
@@ -481,7 +481,7 @@ DESCRIPTION
   Update your app and redirect URLs in the Partners Dashboard.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/update-url.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/update-url.js)_
 
 ## `shopify app versions list [FILE]`
 
@@ -507,7 +507,7 @@ EXAMPLES
   $ shopify app versions list
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/app/versions/list.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/app/versions/list.js)_
 
 ## `shopify auth logout`
 
@@ -521,7 +521,7 @@ DESCRIPTION
   Logout from Shopify.
 ```
 
-_See code: [dist/cli/commands/auth/logout.js](https://github.com/Shopify/cli/edit/main/packages/cli/blob/v3.54.0/dist/cli/commands/auth/logout.js)_
+_See code: [dist/cli/commands/auth/logout.js](https://github.com/Shopify/cli/edit/main/packages/cli/blob/v3.53.0/dist/cli/commands/auth/logout.js)_
 
 ## `shopify commands`
 
@@ -846,7 +846,7 @@ DESCRIPTION
   Starts a search on shopify.dev.
 ```
 
-_See code: [dist/cli/commands/search.js](https://github.com/Shopify/cli/edit/main/packages/cli/blob/v3.54.0/dist/cli/commands/search.js)_
+_See code: [dist/cli/commands/search.js](https://github.com/Shopify/cli/edit/main/packages/cli/blob/v3.53.0/dist/cli/commands/search.js)_
 
 ## `shopify theme check`
 
@@ -888,7 +888,7 @@ DESCRIPTION
   Validate the theme.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/check.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/check.js)_
 
 ## `shopify theme console`
 
@@ -913,7 +913,7 @@ DESCRIPTION
   Shopify Liquid REPL (read-eval-print loop) tool
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/console.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/console.js)_
 
 ## `shopify theme delete`
 
@@ -940,7 +940,7 @@ DESCRIPTION
   Delete remote themes from the connected store. This command can't be undone.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/delete.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/delete.js)_
 
 ## `shopify theme dev`
 
@@ -1015,7 +1015,7 @@ DESCRIPTION
   your terminal. While running, changes will push to the store in real time.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/dev.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/dev.js)_
 
 ## `shopify theme info`
 
@@ -1033,7 +1033,7 @@ DESCRIPTION
   Print basic information about your theme environment.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/info.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/info.js)_
 
 ## `shopify theme init [NAME]`
 
@@ -1058,7 +1058,7 @@ DESCRIPTION
   Clones a Git repository to use as a starting point for building a new theme.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/init.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/init.js)_
 
 ## `shopify theme language-server`
 
@@ -1078,7 +1078,7 @@ DESCRIPTION
   Start a Language Server Protocol server.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/language-server.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/language-server.js)_
 
 ## `shopify theme list`
 
@@ -1106,7 +1106,7 @@ DESCRIPTION
   Lists your remote themes.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/list.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/list.js)_
 
 ## `shopify theme open`
 
@@ -1133,7 +1133,7 @@ DESCRIPTION
   Opens the preview of your remote theme.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/open.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/open.js)_
 
 ## `shopify theme package`
 
@@ -1152,7 +1152,7 @@ DESCRIPTION
   Package your theme into a .zip file, ready to upload to the Online Store.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/package.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/package.js)_
 
 ## `shopify theme publish`
 
@@ -1176,7 +1176,7 @@ DESCRIPTION
   Set a remote theme as the live theme.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/publish.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/publish.js)_
 
 ## `shopify theme pull`
 
@@ -1206,7 +1206,7 @@ DESCRIPTION
   Download your remote theme files locally.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/pull.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/pull.js)_
 
 ## `shopify theme push`
 
@@ -1240,7 +1240,7 @@ DESCRIPTION
   Uploads your local theme files to the connected store, overwriting the remote version if specified.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/push.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/push.js)_
 
 ## `shopify theme rename`
 
@@ -1267,7 +1267,7 @@ DESCRIPTION
   Renames an existing theme.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/rename.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/rename.js)_
 
 ## `shopify theme share`
 
@@ -1291,7 +1291,7 @@ DESCRIPTION
   `shopify theme push -u -t=RANDOMIZED_NAME`.
 ```
 
-_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.54.0/dist/cli/commands/theme/share.js)_
+_See code: [@shopify/theme](https://github.com/Shopify/cli/edit/main/packages/theme/blob/v3.53.0/dist/cli/commands/theme/share.js)_
 
 ## `shopify upgrade`
 
@@ -1308,7 +1308,7 @@ DESCRIPTION
   Upgrade the Shopify CLI.
 ```
 
-_See code: [dist/cli/commands/upgrade.js](https://github.com/Shopify/cli/edit/main/packages/cli/blob/v3.54.0/dist/cli/commands/upgrade.js)_
+_See code: [dist/cli/commands/upgrade.js](https://github.com/Shopify/cli/edit/main/packages/cli/blob/v3.53.0/dist/cli/commands/upgrade.js)_
 
 ## `shopify version`
 
@@ -1322,7 +1322,7 @@ DESCRIPTION
   Shopify CLI version.
 ```
 
-_See code: [dist/cli/commands/version.js](https://github.com/Shopify/cli/edit/main/packages/cli/blob/v3.54.0/dist/cli/commands/version.js)_
+_See code: [dist/cli/commands/version.js](https://github.com/Shopify/cli/edit/main/packages/cli/blob/v3.53.0/dist/cli/commands/version.js)_
 
 ## `shopify webhook trigger`
 
@@ -1367,5 +1367,5 @@ DESCRIPTION
   Trigger delivery of a sample webhook topic payload to a designated address.
 ```
 
-_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.54.0/dist/cli/commands/webhook/trigger.js)_
+_See code: [@shopify/app](https://github.com/Shopify/cli/edit/main/packages/app/blob/v3.53.0/dist/cli/commands/webhook/trigger.js)_
 <!-- commandsstop -->

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -409,5 +409,5 @@
       "strict": true
     }
   },
-  "version": "3.54.0"
+  "version": "3.53.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/cli",
-  "version": "3.54.0",
+  "version": "3.53.0",
   "private": false,
   "description": "A CLI tool to build for the Shopify platform",
   "keywords": [
@@ -98,13 +98,13 @@
     "@oclif/plugin-commands": "2.2.24",
     "@oclif/plugin-help": "5.2.18",
     "@oclif/plugin-plugins": "3.1.8",
-    "@shopify/cli-kit": "3.54.0",
-    "@shopify/plugin-did-you-mean": "3.54.0",
+    "@shopify/cli-kit": "3.53.0",
+    "@shopify/plugin-did-you-mean": "3.53.0",
     "zod-to-json-schema": "3.21.4"
   },
   "devDependencies": {
-    "@shopify/app": "3.54.0",
-    "@shopify/theme": "3.54.0",
+    "@shopify/app": "3.53.0",
+    "@shopify/theme": "3.53.0",
     "@types/node": "18.19.3",
     "@vitest/coverage-istanbul": "^0.34.3",
     "vite": "^4.4.9",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,20 +1,5 @@
 # @shopify/create-app
 
-## 3.54.0
-
-### Minor Changes
-
-- d0c388f4f: Upgrade oclif to v3 (improved help menus and more)
-
-### Patch Changes
-
-- Updated dependencies [2d42d74ec]
-- Updated dependencies [ea76f79e2]
-- Updated dependencies [d0c388f4f]
-- Updated dependencies [97f0c6b3e]
-- Updated dependencies [437147ae0]
-  - @shopify/cli-kit@3.54.0
-
 ## 3.53.0
 
 ### Minor Changes

--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -98,5 +98,5 @@
       "strict": true
     }
   },
-  "version": "3.54.0"
+  "version": "3.53.0"
 }

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/create-app",
-  "version": "3.54.0",
+  "version": "3.53.0",
   "private": false,
   "description": "A CLI tool to create a new Shopify app.",
   "keywords": [
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@oclif/core": "3.15.1",
-    "@shopify/cli-kit": "3.54.0"
+    "@shopify/cli-kit": "3.53.0"
   },
   "devDependencies": {
     "@types/node": "18.19.3",

--- a/packages/features/CHANGELOG.md
+++ b/packages/features/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @shopify/features
 
-## 0.11.0
-
-### Minor Changes
-
-- d0c388f4f: Upgrade oclif to v3 (improved help menus and more)
-
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/features",
-  "version": "0.11.0",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-cloudflare/CHANGELOG.md
+++ b/packages/plugin-cloudflare/CHANGELOG.md
@@ -1,21 +1,5 @@
 # @shopify/plugin-cloudflare
 
-## 3.54.0
-
-### Minor Changes
-
-- d0c388f4f: Upgrade oclif to v3 (improved help menus and more)
-
-### Patch Changes
-
-- 947fab35a: Fix postinstall when the binary already exists but fails
-- Updated dependencies [2d42d74ec]
-- Updated dependencies [ea76f79e2]
-- Updated dependencies [d0c388f4f]
-- Updated dependencies [97f0c6b3e]
-- Updated dependencies [437147ae0]
-  - @shopify/cli-kit@3.54.0
-
 ## 3.53.0
 
 ### Minor Changes

--- a/packages/plugin-cloudflare/oclif.manifest.json
+++ b/packages/plugin-cloudflare/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
   "commands": {
   },
-  "version": "3.54.0"
+  "version": "3.53.0"
 }

--- a/packages/plugin-cloudflare/package.json
+++ b/packages/plugin-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/plugin-cloudflare",
-  "version": "3.54.0",
+  "version": "3.53.0",
   "description": "Enables the creation of Cloudflare tunnels from `shopify app dev`, allowing previews from any device",
   "keywords": [
     "shopify",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@oclif/core": "3.15.1",
-    "@shopify/cli-kit": "3.54.0",
+    "@shopify/cli-kit": "3.53.0",
     "node-fetch": "3.3.2",
     "semver": "7.5.4"
   },

--- a/packages/plugin-did-you-mean/CHANGELOG.md
+++ b/packages/plugin-did-you-mean/CHANGELOG.md
@@ -1,20 +1,5 @@
 # @shopify/plugin-did-you-mean
 
-## 3.54.0
-
-### Minor Changes
-
-- d0c388f4f: Upgrade oclif to v3 (improved help menus and more)
-
-### Patch Changes
-
-- Updated dependencies [2d42d74ec]
-- Updated dependencies [ea76f79e2]
-- Updated dependencies [d0c388f4f]
-- Updated dependencies [97f0c6b3e]
-- Updated dependencies [437147ae0]
-  - @shopify/cli-kit@3.54.0
-
 ## 3.53.0
 
 ### Minor Changes

--- a/packages/plugin-did-you-mean/oclif.manifest.json
+++ b/packages/plugin-did-you-mean/oclif.manifest.json
@@ -76,5 +76,5 @@
       "strict": true
     }
   },
-  "version": "3.54.0"
+  "version": "3.53.0"
 }

--- a/packages/plugin-did-you-mean/package.json
+++ b/packages/plugin-did-you-mean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/plugin-did-you-mean",
-  "version": "3.54.0",
+  "version": "3.53.0",
   "bugs": {
     "url": "https://github.com/Shopify/cli/issues"
   },
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@oclif/core": "3.15.1",
-    "@shopify/cli-kit": "3.54.0",
+    "@shopify/cli-kit": "3.53.0",
     "n-gram": "2.0.2"
   },
   "devDependencies": {

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,22 +1,5 @@
 # @shopify/theme
 
-## 3.54.0
-
-### Minor Changes
-
-- 2d42d74ec: Refine `shopify theme pull` implementation to no longer require a Ruby setup
-- 615c1d5af: Introduce `shopify theme rename` command
-- d0c388f4f: Upgrade oclif to v3 (improved help menus and more)
-
-### Patch Changes
-
-- Updated dependencies [2d42d74ec]
-- Updated dependencies [ea76f79e2]
-- Updated dependencies [d0c388f4f]
-- Updated dependencies [97f0c6b3e]
-- Updated dependencies [437147ae0]
-  - @shopify/cli-kit@3.54.0
-
 ## 3.53.0
 
 ### Minor Changes

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -1868,5 +1868,5 @@
       "strict": true
     }
   },
-  "version": "3.54.0"
+  "version": "3.53.0"
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme",
-  "version": "3.54.0",
+  "version": "3.53.0",
   "private": false,
   "description": "Utilities for building and publishing themes",
   "homepage": "https://github.com/shopify/cli#readme",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@oclif/core": "3.15.1",
-    "@shopify/cli-kit": "3.54.0",
+    "@shopify/cli-kit": "3.53.0",
     "@shopify/theme-check-node": "1.22.0",
     "@shopify/theme-language-server-node": "1.7.1",
     "yaml": "2.3.2"

--- a/packages/ui-extensions-dev-console/CHANGELOG.md
+++ b/packages/ui-extensions-dev-console/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @shopify/ui-extensions-dev-console-app
 
-## 3.54.0
-
-### Patch Changes
-
-- ea76f79e2: Update @shopify/polaris and @shopify/polaris-icons to latest version
-
 ## 3.53.0
 
 ### Minor Changes

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/ui-extensions-dev-console-app",
-  "version": "3.54.0",
+  "version": "3.53.0",
   "private": true,
   "scripts": {
     "build": "nx build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,13 +161,13 @@ importers:
         specifier: 3.15.1
         version: 3.15.1(typescript@5.2.2)
       '@shopify/cli-kit':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../cli-kit
       '@shopify/function-runner':
         specifier: 4.1.1
         version: 4.1.1
       '@shopify/plugin-cloudflare':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../plugin-cloudflare
       '@shopify/polaris':
         specifier: 12.10.0
@@ -288,20 +288,20 @@ importers:
         specifier: 3.1.8
         version: 3.1.8(typescript@5.2.2)
       '@shopify/cli-kit':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../cli-kit
       '@shopify/plugin-did-you-mean':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../plugin-did-you-mean
       zod-to-json-schema:
         specifier: 3.21.4
         version: 3.21.4(zod@3.22.3)
     devDependencies:
       '@shopify/app':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../app
       '@shopify/theme':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../theme
       '@types/node':
         specifier: 18.19.3
@@ -569,7 +569,7 @@ importers:
         specifier: 3.15.1
         version: 3.15.1(typescript@5.2.2)
       '@shopify/cli-kit':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../cli-kit
     devDependencies:
       '@types/node':
@@ -691,7 +691,7 @@ importers:
         specifier: 3.15.1
         version: 3.15.1(typescript@5.2.2)
       '@shopify/cli-kit':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../cli-kit
       node-fetch:
         specifier: 3.3.2
@@ -713,7 +713,7 @@ importers:
         specifier: 3.15.1
         version: 3.15.1(typescript@5.2.2)
       '@shopify/cli-kit':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../cli-kit
       n-gram:
         specifier: 2.0.2
@@ -732,7 +732,7 @@ importers:
         specifier: 3.15.1
         version: 3.15.1(typescript@5.2.2)
       '@shopify/cli-kit':
-        specifier: 3.54.0
+        specifier: 3.53.0
         version: link:../cli-kit
       '@shopify/theme-check-node':
         specifier: 1.22.0


### PR DESCRIPTION
Reverts Shopify/cli#3231

I pulled the trigger on this too early. I believe we can revert and then re-up the version once the last changes are in.