### PR TITLE
Specify package manager default by ENV var not flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "graph": "nx graph",
     "shopify": "nx build cli && node packages/cli/bin/dev.js",
     "shopify:run": "node packages/cli/bin/dev.js",
-    "create-app": "nx build create-app && node packages/create-app/bin/dev.js --package-manager npm",
+    "create-app": "nx build create-app && cross-env SHOPIFY_FLAG_PACKAGE_MANAGER=npm node packages/create-app/bin/dev.js",
     "clean": "nx run-many --target=clean --all --skip-nx-cache && nx reset",
     "docs:generate": "nx run-many --target=docs:generate --all --skip-nx-cache",
     "lint": "nx run-many --target=lint --all --skip-nx-cache",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Previously, oclif treated `--flag=a --flag=b` as the second overriding the first. In v3, though, oclif [treats that as an invalid condition](https://github.com/oclif/core/blob/54447d4f1c849714c7b6f2b9f4f011ae3e27cb0e/src/parser/parse.ts#L147-L150).

We use this double-specification in `bin/create-test-app.js`, where the default is `--package-manager=npm` but we override with `--package-manager=yarn`. Hence:

<img width="1007" alt="Screenshot 2024-01-25 at 13 59 40" src="https://github.com/Shopify/cli/assets/6288426/6dd73367-115f-4db8-bff9-ecb9b3792a92">

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Use an ENV var to specify the npm default instead.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`node bin/create-test-app.js -p yarn` should work without seeing a failure.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
