### PR TITLE
fix for isospin2

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,6 +3,7 @@ name: shopify-cli-next
 up:
   - node:
       version: v18.16.1
+      package_mananager: pnpm
       packages: []
   - ruby:
       version: 3.1.2
@@ -10,7 +11,6 @@ up:
       gemfile: packages/cli-kit/assets/cli-ruby/Gemfile
   - packages:
     - jq
-    - pnpm
   - custom:
       name: 'Install PNPM dependencies'
       # we flip these two conditions to always run `pnpm install`


### PR DESCRIPTION
Apply fix to resolve error regarding missing pnpm package when spinning up the `extensions` constellation, which has been migrated to use isospin2.
```
┏━━ 👩‍💻  3/7 Install package dependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
--
  | ┃ ⭑ Install ruby-install
  | ┃ 𝒾 update package cache
  | spin : PWD=/home/spin/src/github.com/Shopify/cli ; USER=root ; COMMAND=/usr/bin/apt-get update
  | ┃ Hit:1 http://packages.cloud.google.com/apt cloud-sdk InRelease
  | ┃ Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
  | ┃ Get:3 https://pkgs.shopify.io/STATIC_CLOUDSMITH_TOKEN/public/deb/ubuntu jammy InRelease [7,227 B]
  | ┃ Hit:4 https://cli.github.com/packages stable InRelease
  | ┃ Hit:5 http://repo.percona.com/tools/apt jammy InRelease
  | ┃ Hit:6 http://archive.ubuntu.com/ubuntu jammy InRelease
  | ┃ Hit:7 http://openresty.org/package/ubuntu jammy InRelease
  | ┃ Hit:8 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
  | ┃ Hit:9 http://repo.percona.com/ps-80/apt jammy InRelease
  | ┃ Hit:10 https://packages.microsoft.com/repos/code stable InRelease
  | ┃ Hit:11 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
  | ┃ Hit:12 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu jammy InRelease
  | ┃ Fetched 7,227 B in 1s (8,208 B/s)
  | ┃ Reading package lists...
  | Job for spin-environment-2@shopify--cli.service failed because the control process exited with error code.
  | See "systemctl status spin-environment-2@shopify--cli.service" and "journalctl -xeu spin-environment-2@shopify--cli.service" for details.
  | ┃┏━━ ⚠️  Unknown packages ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  | ┃┃ Some of the packages listed in your dev.yml do not exist:
  | ┃┃   - pnpm
  | ┃┃
  | ┃┃ For a list of packages, refer to
  | ┃┃ https://github.com/Shopify/dev//blob/master/misc/packages.yml.
  | ┃┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.0s)
  | ┗━━ 💥  Failed! Aborting! ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (283.29s)
  | spin-environment-2@shopify--cli.service: Main process exited, code=exited, status=1/FAILURE
```
### WHY are these changes introduced?

Not a defect with CLI, but with the `extensions` constellation (and virtually all other repos) using isospin2, the CLI repo in the spinstance is erroring during `dev up`, and while this doesn't affect the services, this error does prevent spin snapshots from being created, and so each `spin up` takes extremely long to complete.
### WHAT is this pull request doing?

Instead of listing `pnpm` as a package, I'm specifying it as the package manager the `node` section, as suggested https://shopify.slack.com/archives/C016FHHJP0B/p1706132938783439?thread_ts=1706132318.014279&cid=C016FHHJP0B.
### How to test your changes?

`spin up extensions --config cli.branch=isospin2test`

### Post-release steps

Don't think this warrants a release, does it?

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
