### PR TITLE
Highlight updated config field in the diff prompt

### DIFF
--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -106,7 +106,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Configuration:',
               items: [
                 {bullet: '+', item: ['new field name1', {subdued: '(new)'}], color: 'green'},
-                'updating field name1',
+                {item: ['updating field name1', {subdued: '(updated)'}], color: '#FF8800'},
                 'existing field name1',
                 {bullet: '-', item: ['deleted field name1', {subdued: '(removed)'}], color: 'red'},
               ],
@@ -160,7 +160,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Configuration:',
               items: [
                 {bullet: '+', item: ['new field name1', {subdued: '(new)'}], color: 'green'},
-                'updating field name1',
+                {item: ['updating field name1', {subdued: '(updated)'}], color: '#FF8800'},
                 'existing field name1',
                 {bullet: '-', item: ['deleted field name1', {subdued: '(removed)'}], color: 'red'},
               ],
@@ -218,7 +218,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Configuration:',
               items: [
                 {bullet: '+', item: ['new field name1', {subdued: '(new)'}], color: 'green'},
-                'updating field name1',
+                {item: ['updating field name1', {subdued: '(updated)'}], color: '#FF8800'},
                 'existing field name1',
                 {bullet: '-', item: ['deleted field name1', {subdued: '(removed)'}], color: 'red'},
               ],
@@ -369,7 +369,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Configuration:',
               items: [
                 {bullet: '+', item: ['new field name1', {subdued: '(new)'}], color: 'green'},
-                'updating field name1',
+                {item: ['updating field name1', {subdued: '(updated)'}], color: '#FF8800'},
                 'existing field name1',
                 {bullet: '-', item: ['deleted field name1', {subdued: '(removed)'}], color: 'red'},
               ],

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -113,7 +113,7 @@ async function buildExtensionsContentPrompt(extensionsContentBreakdown: Extensio
   let extensionsInfoTable
   const section = {
     new: toCreateBreakdown.map((extension) => mapExtensionToInfoTableItem(extension, 'new, ')),
-    updated: toUpdate.map((extension) => mapExtensionToInfoTableItem(extension, '')),
+    unchanged: toUpdate.map((extension) => mapExtensionToInfoTableItem(extension, '')),
     removed: onlyRemote.map((extension) => mapExtensionToInfoTableItem(extension, 'removed, ')),
   }
   const extensionsInfo = buildDeployReleaseInfoTableSection(section)
@@ -145,7 +145,8 @@ async function buildConfigContentPrompt(
 
   const section = {
     new: newFieldNames,
-    updated: [...existingUpdatedFieldNames, ...existingFieldNames],
+    updated: existingUpdatedFieldNames,
+    unchanged: existingFieldNames,
     removed: deletedFieldNames,
   }
   const configurationInfo = buildDeployReleaseInfoTableSection(section)

--- a/packages/app/src/cli/prompts/ui/deploy-release-info-table-section.test.ts
+++ b/packages/app/src/cli/prompts/ui/deploy-release-info-table-section.test.ts
@@ -1,12 +1,13 @@
 import {buildDeployReleaseInfoTableSection} from './deploy-release-info-table-section.js'
 import {describe, expect, test} from 'vitest'
 
-describe('buildNURInfoTableSection', () => {
+describe('buildDeployReleaseInfoTableSection', () => {
   test('when section includes content in all lists the complete result is returned', async () => {
     // Given
     const section = {
       new: ['new'],
       updated: ['updated'],
+      unchanged: ['unchanged'],
       removed: ['removed'],
     }
 
@@ -16,7 +17,8 @@ describe('buildNURInfoTableSection', () => {
     // Then
     expect(result).toEqual([
       {bullet: '+', item: ['new', {subdued: '(new)'}], color: 'green'},
-      'updated',
+      {item: ['updated', {subdued: '(updated)'}], color: '#FF8800'},
+      'unchanged',
       {bullet: '-', item: ['removed', {subdued: '(removed)'}], color: 'red'},
     ])
   })
@@ -24,7 +26,7 @@ describe('buildNURInfoTableSection', () => {
     // Given
     const section = {
       new: [],
-      updated: [],
+      unchanged: [],
       removed: [],
     }
 
@@ -38,7 +40,7 @@ describe('buildNURInfoTableSection', () => {
     // Given
     const section = {
       new: [['new', {subdued: '(my new suffix)'}]],
-      updated: [],
+      unchanged: [],
       removed: [],
     }
 
@@ -52,7 +54,7 @@ describe('buildNURInfoTableSection', () => {
     // Given
     const section = {
       new: [],
-      updated: [],
+      unchanged: [],
       removed: [['deleted', {subdued: '(my deleted suffix)'}]],
     }
 

--- a/packages/app/src/cli/prompts/ui/deploy-release-info-table-section.ts
+++ b/packages/app/src/cli/prompts/ui/deploy-release-info-table-section.ts
@@ -1,11 +1,12 @@
 export interface DeployReleaseInfoTableSection<T> {
   new: T[]
-  updated: T[]
+  updated?: T[]
+  unchanged: T[]
   removed: T[]
 }
 
 interface ItemTemplate {
-  bullet: string
+  bullet?: string
   color: string
   suffix?: string
 }
@@ -14,6 +15,11 @@ const NewItem = {
   bullet: '+',
   color: 'green',
   suffix: '(new)',
+}
+
+const UpdatedItem = {
+  color: '#FF8800',
+  suffix: '(updated)',
 }
 
 const RemovedItem = {
@@ -25,12 +31,13 @@ const RemovedItem = {
 export function buildDeployReleaseInfoTableSection<T>(section: DeployReleaseInfoTableSection<T>) {
   return [
     ...section.new.map((item) => buildItem(item, NewItem)),
-    ...section.updated,
+    ...(section.updated ? section.updated.map((item) => buildItem(item, UpdatedItem)) : []),
+    ...section.unchanged,
     ...section.removed.map((item) => buildItem(item, RemovedItem)),
   ]
 }
 
 function buildItem<T>(item: T, itemTemplate: ItemTemplate) {
   const itemContent = typeof item === 'string' ? [item, {subdued: itemTemplate.suffix ?? ''}] : item
-  return {bullet: itemTemplate.bullet, item: itemContent, color: itemTemplate.color}
+  return {...(itemTemplate.bullet ? {bullet: itemTemplate.bullet} : {}), item: itemContent, color: itemTemplate.color}
 }


### PR DESCRIPTION
### WHY are these changes introduced?
The configuration diff content display in the deploy/release prompts don't differentiate when a config field is updated or not. 

The user should be able to check if a config property has changed or not

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Adds a new list of items to the configuration diif prompt
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new app
- Enable versioned app config beta flag
- Run deploy
- Modify some value in the `toml``
- Run deploy again

<img src="https://github.com/Shopify/cli/assets/105213827/0aaa16d4-57b8-4d63-b185-368c0be1daee" width=400/>


<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
