### PR TITLE
Webhooks specs doesn't parse empty privacy compliance urls or subscriptions

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.test.ts
@@ -1,4 +1,5 @@
 import spec from './app_config_privacy_compliance_webhooks.js'
+import {isEmpty} from '@shopify/cli-kit/common/object'
 import {describe, expect, test} from 'vitest'
 
 describe('privacy_compliance_webhooks', () => {
@@ -51,6 +52,21 @@ describe('privacy_compliance_webhooks', () => {
           },
         },
       })
+    })
+    test('should return undefined if all properties are empty', () => {
+      // Given
+      const object = {
+        customers_redact_url: '',
+        customers_data_request_url: '',
+        shop_redact_url: undefined,
+      }
+      const privacyComplianceSpec = spec
+
+      // When
+      const result = privacyComplianceSpec.reverseTransform!(object)
+
+      // Then
+      expect(isEmpty(result)).toBeTruthy()
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.test.ts
@@ -27,6 +27,26 @@ describe('privacy_compliance_webhooks', () => {
         shop_redact_url: 'https://shop-deletion-url.dev',
       })
     })
+    test('should return undefined if all porperties are empty', () => {
+      // Given
+      const object = {
+        webhooks: {
+          api_version: '2021-01',
+        },
+        privacy_compliance: {
+          customer_deletion_url: '',
+          customer_data_request_url: undefined,
+          shop_deletion_url: '',
+        },
+      }
+      const privacyComplianceSpec = spec
+
+      // When
+      const result = privacyComplianceSpec.transform!(object)
+
+      // Then
+      expect(isEmpty(result)).toBeTruthy()
+    })
   })
 
   describe('reverseTransform', () => {
@@ -67,6 +87,27 @@ describe('privacy_compliance_webhooks', () => {
 
       // Then
       expect(isEmpty(result)).toBeTruthy()
+    })
+    test('should return only the properties that are not empty', () => {
+      // Given
+      const object = {
+        customers_redact_url: 'http://customer-deletion-url.dev',
+        customers_data_request_url: '',
+        shop_redact_url: undefined,
+      }
+      const privacyComplianceSpec = spec
+
+      // When
+      const result = privacyComplianceSpec.reverseTransform!(object)
+
+      // Then
+      expect(result).toEqual({
+        webhooks: {
+          privacy_compliance: {
+            customer_deletion_url: 'http://customer-deletion-url.dev',
+          },
+        },
+      })
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.ts
@@ -3,12 +3,6 @@ import {WebhooksConfig} from './types/app_config_webhook.js'
 import {CustomTransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {getPathValue} from '@shopify/cli-kit/common/object'
 
-// const PrivacyComplianceWebbhooksTransformConfig: TransformationConfig = {
-//   customers_redact_url: 'webhooks.privacy_compliance.customer_deletion_url',
-//   customers_data_request_url: 'webhooks.privacy_compliance.customer_data_request_url',
-//   shop_redact_url: 'webhooks.privacy_compliance.shop_deletion_url',
-// }
-
 const PrivacyComplianceWebbhooksTransformConfig: CustomTransformationConfig = {
   forward: (content: object) => transformToPrivacyComplianceWebhooksModule(content),
   reverse: (content: object) => transformFromPrivacyComplianceWebhooksModule(content),
@@ -27,11 +21,18 @@ export default spec
 
 function transformToPrivacyComplianceWebhooksModule(content: object) {
   const webhooks = getPathValue(content, 'webhooks') as WebhooksConfig
-  return {
-    customers_redact_url: webhooks?.privacy_compliance?.customer_deletion_url,
-    customers_data_request_url: webhooks?.privacy_compliance?.customer_data_request_url,
-    shop_redact_url: webhooks?.privacy_compliance?.shop_deletion_url,
+  if (
+    webhooks?.privacy_compliance?.customer_deletion_url ||
+    webhooks?.privacy_compliance?.customer_data_request_url ||
+    webhooks?.privacy_compliance?.shop_deletion_url
+  ) {
+    return {
+      customers_redact_url: webhooks?.privacy_compliance?.customer_deletion_url,
+      customers_data_request_url: webhooks?.privacy_compliance?.customer_data_request_url,
+      shop_redact_url: webhooks?.privacy_compliance?.shop_deletion_url,
+    }
   }
+  return {}
 }
 
 function transformFromPrivacyComplianceWebhooksModule(content: object) {
@@ -39,13 +40,13 @@ function transformFromPrivacyComplianceWebhooksModule(content: object) {
   const customersDataRequestUrl = getPathValue(content, 'customers_data_request_url') as string
   const shopRedactUrl = getPathValue(content, 'shop_redact_url') as string
 
-  if (customersDataRequestUrl?.length > 0 && customersDataRequestUrl?.length > 0 && shopRedactUrl?.length > 0) {
+  if (customersRedactUrl?.length > 0 || customersDataRequestUrl?.length > 0 || shopRedactUrl?.length > 0) {
     return {
       webhooks: {
         privacy_compliance: {
-          customer_deletion_url: customersRedactUrl,
-          customer_data_request_url: customersDataRequestUrl,
-          shop_deletion_url: shopRedactUrl,
+          ...(customersRedactUrl?.length > 0 ? {customer_deletion_url: customersRedactUrl} : {}),
+          ...(customersDataRequestUrl?.length > 0 ? {customer_data_request_url: customersDataRequestUrl} : {}),
+          ...(shopRedactUrl?.length > 0 ? {shop_deletion_url: shopRedactUrl} : {}),
         },
       },
     }

--- a/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.ts
@@ -1,10 +1,17 @@
 import {WebhookSchema} from './app_config_webhook.js'
-import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {WebhooksConfig} from './types/app_config_webhook.js'
+import {CustomTransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {getPathValue} from '@shopify/cli-kit/common/object'
 
-const PrivacyComplianceWebbhooksTransformConfig: TransformationConfig = {
-  customers_redact_url: 'webhooks.privacy_compliance.customer_deletion_url',
-  customers_data_request_url: 'webhooks.privacy_compliance.customer_data_request_url',
-  shop_redact_url: 'webhooks.privacy_compliance.shop_deletion_url',
+// const PrivacyComplianceWebbhooksTransformConfig: TransformationConfig = {
+//   customers_redact_url: 'webhooks.privacy_compliance.customer_deletion_url',
+//   customers_data_request_url: 'webhooks.privacy_compliance.customer_data_request_url',
+//   shop_redact_url: 'webhooks.privacy_compliance.shop_deletion_url',
+// }
+
+const PrivacyComplianceWebbhooksTransformConfig: CustomTransformationConfig = {
+  forward: (content: object) => transformToPrivacyComplianceWebhooksModule(content),
+  reverse: (content: object) => transformFromPrivacyComplianceWebhooksModule(content),
 }
 
 export const PrivacyComplianceWebbhooksSpecIdentifier = 'privacy_compliance_webhooks'
@@ -17,3 +24,31 @@ const spec = createConfigExtensionSpecification({
 })
 
 export default spec
+
+function transformToPrivacyComplianceWebhooksModule(content: object) {
+  const webhooks = getPathValue(content, 'webhooks') as WebhooksConfig
+  return {
+    customers_redact_url: webhooks?.privacy_compliance?.customer_deletion_url,
+    customers_data_request_url: webhooks?.privacy_compliance?.customer_data_request_url,
+    shop_redact_url: webhooks?.privacy_compliance?.shop_deletion_url,
+  }
+}
+
+function transformFromPrivacyComplianceWebhooksModule(content: object) {
+  const customersRedactUrl = getPathValue(content, 'customers_redact_url') as string
+  const customersDataRequestUrl = getPathValue(content, 'customers_data_request_url') as string
+  const shopRedactUrl = getPathValue(content, 'shop_redact_url') as string
+
+  if (customersDataRequestUrl?.length > 0 && customersDataRequestUrl?.length > 0 && shopRedactUrl?.length > 0) {
+    return {
+      webhooks: {
+        privacy_compliance: {
+          customer_deletion_url: customersRedactUrl,
+          customer_data_request_url: customersDataRequestUrl,
+          shop_deletion_url: shopRedactUrl,
+        },
+      },
+    }
+  }
+  return {}
+}

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.ts
@@ -25,15 +25,15 @@ export function transformToWebhookConfig(content: object) {
   const serverWebhooks = getPathValue(content, 'subscriptions') as NormalizedWebhookSubscription[]
   if (!serverWebhooks) return webhooks
 
-  const webhooksSubscriptionsConfig: WebhooksConfig['subscriptions'] = []
+  const webhooksSubscriptions: WebhooksConfig['subscriptions'] = []
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   for (const {uri, topic, sub_topic, ...optionalFields} of serverWebhooks) {
-    const currSubscription = webhooksSubscriptionsConfig.find((sub) => sub.uri === uri && sub.sub_topic === sub_topic)
+    const currSubscription = webhooksSubscriptions.find((sub) => sub.uri === uri && sub.sub_topic === sub_topic)
     if (currSubscription) {
       currSubscription.topics.push(topic)
     } else {
-      webhooksSubscriptionsConfig.push({
+      webhooksSubscriptions.push({
         topics: [topic],
         uri,
         ...(sub_topic ? {sub_topic} : {}),
@@ -42,5 +42,6 @@ export function transformToWebhookConfig(content: object) {
     }
   }
 
-  return deepMergeObjects(webhooks, {webhooks: {subscriptions: webhooksSubscriptionsConfig}})
+  const webhooksSubscriptionsObject = webhooksSubscriptions.length > 0 ? {subscriptions: webhooksSubscriptions} : {}
+  return deepMergeObjects(webhooks, {webhooks: webhooksSubscriptionsObject})
 }

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -316,7 +316,10 @@ export function remoteAppConfigurationExtensionContent(
     if (!configExtensionString) return
     const configExtension = configExtensionString ? JSON.parse(configExtensionString) : {}
 
-    remoteAppConfig = {...remoteAppConfig, ...(configSpec.reverseTransform?.(configExtension) ?? configExtension)}
+    remoteAppConfig = deepMergeObjects(
+      remoteAppConfig,
+      configSpec.reverseTransform?.(configExtension) ?? configExtension,
+    )
   })
   return {...remoteAppConfig}
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
There's a backfill process that is creating/updating configuration app modules for every app with at least once app version. 
The `privacy_compliance_webhooks` app module is being populated with the current url values in case they exist. Otherwise they are set to `null` but the app module is created.
Something similar is happening with the `webhooks` app modules, the `subscriptions` property is set to an empty array
To avoid some issues with the information displayed in the `diff` content, these specs will consider these use cases as empty app modules so the diff content will not display any differences for them if they don't exist in the local `toml`
Besides this, a fix has been added to the method that builds the remote configuration content from using the `configuration` app modules tha

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Transform methods for `webhooks` and `privacy_compliance_webhooks` will consider the properties `subscriptions` and `privacy_compliance_webhooks` when their content is empty
- The method to build the remote configuration that merges the content of each configuration app module, will use `deepMerge` to avoid that two app modules sharing the same sections  (`webhooks`) make the latest to overwrite the content of the former.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new app using the `link` command
- Run `deploy` command to create a new app version
- Modify the `toml` and run `cofig push`
- Enable the remote beta flag `versioned_app_config`
- Run the `link` command. No modifications should be applied inside the `toml`
- Add some valid `privacy compliance` and run `deploy`. You should see the `update webhooks`
```
  [webhooks.privacy_compliance]
  customer_deletion_url = "https://my-compliance.com/webhooks/customers/data_request"
  customer_data_request_url = "https://my-compliance.com/webhooks/customers/redact"
  shop_deletion_url = "https://my-compliance.com/webhooks/shop/redact"
```
- Run the `link` command. No modifications should be applied inside the `toml`
- Remove one of the privacy urls and run `deploy` again.  You should see the `update webhooks`
- Run the `link` command. No modifications should be applied inside the `toml`
- Remove all the privacy urls and run `deploy` again.  You should see the `update webhooks`
- Run the `link` command. No modifications should be applied inside the `toml`


<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
