### PR TITLE
Bring the new `shopify theme pull` implementation behind the `--beta` flag and use the legacy version by default

### DIFF
--- a/.changeset/slimy-dots-invent.md
+++ b/.changeset/slimy-dots-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Bring the new `shopify theme pull` implementation behind the `--beta` flag and use the legacy version by default

--- a/packages/theme/oclif.manifest.json
+++ b/packages/theme/oclif.manifest.json
@@ -1090,6 +1090,14 @@
       ],
       "description": "Download your remote theme files locally.",
       "flags": {
+        "beta": {
+          "allowNo": false,
+          "description": "Performs the pull command by relying on the new download implementation.",
+          "env": "SHOPIFY_FLAG_BETA",
+          "hidden": true,
+          "name": "beta",
+          "type": "boolean"
+        },
         "development": {
           "allowNo": false,
           "char": "d",

--- a/packages/theme/src/cli/commands/theme/pull.test.ts
+++ b/packages/theme/src/cli/commands/theme/pull.test.ts
@@ -28,7 +28,7 @@ describe('Pull', () => {
   describe('run with CLI 3 implementation', () => {
     test('should pass call the CLI 3 command', async () => {
       const theme = buildTheme({id: 1, name: 'Theme', role: 'development'})!
-      const flags = ['--ignore=config', '--only=assets', '--nodelete']
+      const flags = ['--ignore=config', '--only=assets', '--nodelete', '--beta']
 
       vi.mocked(useEmbeddedThemeCLI).mockReturnValue(true)
       vi.mocked(findOrSelectTheme).mockResolvedValue(theme)

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -60,6 +60,11 @@ export default class Pull extends ThemeCommand {
       description: 'Performs the pull command by relying on the legacy download implementation.',
       env: 'SHOPIFY_FLAG_STABLE',
     }),
+    beta: Flags.boolean({
+      hidden: true,
+      description: 'Performs the pull command by relying on the new download implementation.',
+      env: 'SHOPIFY_FLAG_BETA',
+    }),
   }
 
   static cli2Flags = ['theme', 'development', 'live', 'nodelete', 'only', 'ignore', 'force', 'development-theme-id']
@@ -76,7 +81,7 @@ export default class Pull extends ThemeCommand {
       ? developmentThemeManager.find()
       : developmentThemeManager.fetch())
 
-    if (!flags.stable) {
+    if (flags.beta) {
       const {path, nodelete, live, development, only, ignore, force} = flags
 
       const theme = await findOrSelectTheme(adminSession, {


### PR DESCRIPTION
### WHY are these changes introduced?

We've noticed that the new implementation of `shopify theme pull` has introduced some friction for theme developers. These issues will be fixed, but until then, we're moving the new implementation behind the `--beta` flag.

### WHAT is this pull request doing?

This PR introduces a hidden `--beta` flag for the `shopify theme pull` command. However, we're retaining the `--stable` flag for backward compatibility reasons.

### How to test your changes?

- Run `shopify theme pull` and notice it uses the legacy implementation

<img width="50%" src="https://github.com/Shopify/cli/assets/1079279/595fb254-d1a7-4deb-ac7b-0ad2de9ffe40">

- Run `shopify theme pull --stable` and notice it uses the legacy implementation

<img width="50%" src="https://github.com/Shopify/cli/assets/1079279/1299fa99-45b6-48f4-99fc-85f5f3c17ab7">

- Run `shopify theme pull --beta` and notice it uses the new implementation

<img width="50%" src="https://github.com/Shopify/cli/assets/1079279/9ebb90a6-c66f-440e-865b-3e624645d523">

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
