### PR TITLE
Avoid `RemoteAssetJson` + naming suggestions

### DIFF
--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -1,6 +1,6 @@
 import {BulkUploadResult, Checksum, Theme, ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 
-interface RemoteThemeJson {
+interface RemoteThemeResponse {
   id: number
   name: string
   role: string
@@ -8,20 +8,20 @@ interface RemoteThemeJson {
   processing?: boolean
 }
 
-export interface RemoteAssetJson {
+interface RemoteAssetResponse {
   key: string
   checksum: string
   attachment: string
   value: string
 }
 
-export interface BulkUploadResponse {
-  body: {asset: RemoteAssetJson}
+interface RemoteBulkUploadResponse {
+  body: {asset: RemoteAssetResponse}
   code: number
   errors?: string[]
 }
 
-export function buildTheme(themeJson?: RemoteThemeJson): Theme | undefined {
+export function buildTheme(themeJson?: RemoteThemeResponse): Theme | undefined {
   if (!themeJson) return
 
   themeJson.processing ??= false
@@ -38,27 +38,27 @@ export function buildTheme(themeJson?: RemoteThemeJson): Theme | undefined {
   }
 }
 
-export function buildChecksum(assetJson?: RemoteAssetJson): Checksum | undefined {
-  if (!assetJson) return
+export function buildChecksum(asset?: RemoteAssetResponse): Checksum | undefined {
+  if (!asset) return
 
-  const {key, checksum} = assetJson
+  const {key, checksum} = asset
   return {key, checksum}
 }
 
-export function buildThemeAsset(assetJson?: RemoteAssetJson): ThemeAsset | undefined {
-  if (!assetJson) return
+export function buildThemeAsset(asset?: RemoteAssetResponse): ThemeAsset | undefined {
+  if (!asset) return
 
-  const {key, checksum, attachment, value} = assetJson
+  const {key, checksum, attachment, value} = asset
   return {key, checksum, attachment, value}
 }
 
-export function buildBulkUploadResults(response?: BulkUploadResponse): BulkUploadResult | undefined {
-  if (!response) return
+export function buildBulkUploadResults(bulkUpload?: RemoteBulkUploadResponse): BulkUploadResult | undefined {
+  if (!bulkUpload) return
 
   return {
-    key: response.body.asset.key,
-    success: response.code === 200,
-    errors: response.errors || [],
-    asset: response.body.asset || {},
+    key: bulkUpload.body.asset.key,
+    success: bulkUpload.code === 200,
+    errors: bulkUpload.errors || [],
+    asset: bulkUpload.body.asset || {},
   }
 }

--- a/packages/cli-kit/src/public/node/themes/types.ts
+++ b/packages/cli-kit/src/public/node/themes/types.ts
@@ -1,5 +1,3 @@
-import {RemoteAssetJson} from './factories.js'
-
 /**
  * {@link Key} represents the unique identifier of a file in a theme.
  */
@@ -104,5 +102,5 @@ export interface BulkUploadResult {
   /**
    * The asset that was uploaded as part of the upload operation for this file.
    */
-  asset: RemoteAssetJson
+  asset: ThemeAsset
 }


### PR DESCRIPTION
Hey @jamesmengo,

I've opened this PR because I believe the original naming convention I used in [`factories.ts`](https://github.com/Shopify/cli/pull/3331/files#diff-6c0bc949bbf87917ae230deef790e87623d0da2635c24333f4967270cdc2958a) was a bit misleading. So:
- I've updated `RemoteThemeJson`, `RemoteAssetJson`, and `BulkUploadResponse` to clarify that they are private types, aligning them with the same naming convention
- I've replaced `RemoteAssetJson` with `ThemeAsset, as `types.ts` holds our public types