### PR TITLE
`link` uses an empty app if the current used app is different from the remote one

### DIFF
--- a/.changeset/chatty-steaks-draw.md
+++ b/.changeset/chatty-steaks-draw.md
@@ -1,0 +1,10 @@
+---
+'@shopify/app': minor
+---
+
+- Deploy command will push the configuration to the server
+- Added a new flag in the toml to opt-in/opt-out deploying the configuration with the deploy command
+- Deploy and release prompts will display the differences between the local and the remote app configuration
+- Deploy and release prompts will display if the dashboard managed extensions are new or deleted for the new version
+- Added support to configure the `Direct API offline access` in the `toml`
+- Configuration will be pushed automatically to the draft version when you run the `dev` command

--- a/.changeset/chatty-steaks-draw.md
+++ b/.changeset/chatty-steaks-draw.md
@@ -3,7 +3,7 @@
 ---
 
 - Deploy command will push the configuration to the server
-- Added a new flag in the toml to opt-in/opt-out deploying the configuration with the deploy command
+- Added the new flag `update_config_on_deploy` to the toml to opt-in/opt-out deploying the configuration with the deploy command
 - Deploy and release prompts will display the differences between the local and the remote app configuration
 - Deploy and release prompts will display if the dashboard managed extensions are new or deleted for the new version
 - Added support to configure the `Direct API offline access` in the `toml`

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -372,8 +372,10 @@ function findExtensionByHandle(allExtensions: ExtensionInstance[], handle: strin
 }
 
 export class EmptyApp extends App {
-  constructor(specifications?: ExtensionSpecification[], betas?: BetaFlag[]) {
-    const configuration = {scopes: '', extension_directories: [], path: ''}
+  constructor(specifications?: ExtensionSpecification[], betas?: BetaFlag[], clientId?: string) {
+    const configuration = clientId
+      ? {client_id: clientId, access_scopes: {scopes: ''}, path: ''}
+      : {scopes: '', path: ''}
     const configSchema = getAppVersionedSchema(specifications ?? [])
     super(
       '',

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -24,8 +24,6 @@ import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {outputContent} from '@shopify/cli-kit/node/output'
 import {setPathValue} from '@shopify/cli-kit/common/object'
 
-const REMOTE_APP = testOrganizationApp()
-
 vi.mock('./use.js')
 vi.mock('../../../prompts/config.js')
 vi.mock('../../../models/app/loader.js', async () => {
@@ -68,7 +66,7 @@ describe('link', () => {
           configName: 'Default value',
         }
         vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
 
         // When
         await link(options)
@@ -87,7 +85,7 @@ describe('link', () => {
           commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         }
         vi.mocked(loadApp).mockRejectedValue('App not found')
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...REMOTE_APP, newApp: true})
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
 
         // When
         await link(options)
@@ -96,7 +94,7 @@ describe('link', () => {
         const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
         const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = "api-key"
+client_id = "12345"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
@@ -161,7 +159,7 @@ embedded = false
             },
           } as CurrentAppConfiguration,
         }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp, [BetaFlag.VersionedAppConfig], 'current'))
         vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
           testOrganizationApp({
             apiKey: '12345',
@@ -223,7 +221,7 @@ embedded = false
       })
     })
 
-    test('build section is removed if the client_id in the local configuration is different from the remote one', async () => {
+    test('user selects a new file if the client_id in the local configuration is different from the remote one', async () => {
       await inTemporaryDirectory(async (tmp) => {
         // Given
         const options: LinkOptions = {
@@ -232,7 +230,7 @@ embedded = false
         }
         const localApp = {
           configuration: {
-            path: 'shopify.app.staging.toml',
+            path: 'shopify.app.toml',
             name: 'my app',
             client_id: '12345',
             scopes: 'write_products',
@@ -245,7 +243,7 @@ embedded = false
             },
           } as CurrentAppConfiguration,
         }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
+        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp, [BetaFlag.VersionedAppConfig], 'current'))
         vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
           testOrganizationApp({
             apiKey: 'different-api-key',
@@ -297,7 +295,7 @@ embedded = false
           commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         }
         vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
 
         // When
         await link(options)
@@ -306,7 +304,7 @@ embedded = false
         const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
         const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = "api-key"
+client_id = "12345"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
@@ -356,7 +354,7 @@ embedded = false
           commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         }
         vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
 
         // When
         await link(options, false)
@@ -365,7 +363,7 @@ embedded = false
         const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
         const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = "api-key"
+client_id = "12345"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
@@ -398,7 +396,7 @@ embedded = false
         }
         vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
         vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-        vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(REMOTE_APP)
+        vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(mockRemoteApp())
         vi.mocked(selectConfigName).mockResolvedValue('staging')
 
         // When
@@ -480,7 +478,7 @@ embedded = false
           commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         }
         vi.mocked(loadApp).mockRejectedValue(new Error('Shopify.app.toml not found'))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
 
         // When
         await link(options)
@@ -489,7 +487,7 @@ embedded = false
         const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
         const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = "api-key"
+client_id = "12345"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
@@ -520,7 +518,7 @@ embedded = false
         }
         vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
         vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({
-          ...REMOTE_APP,
+          ...mockRemoteApp(),
           requestedAccessScopes: ['read_products', 'write_orders'],
         })
 
@@ -531,7 +529,7 @@ embedded = false
         const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
         const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = "api-key"
+client_id = "12345"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
@@ -562,7 +560,7 @@ embedded = false
         }
         vi.mocked(loadApp).mockRejectedValue('App not found')
         vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({
-          ...REMOTE_APP,
+          ...mockRemoteApp(),
           gdprWebhooks: {customerDataRequestUrl: 'https://example.com/customer-data'},
         })
 
@@ -573,7 +571,7 @@ embedded = false
         const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
         const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = "api-key"
+client_id = "12345"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
@@ -753,7 +751,7 @@ embedded = true
           commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         }
         vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...REMOTE_APP, newApp: true})
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
 
         // When
         await link(options)
@@ -762,7 +760,7 @@ embedded = true
         const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
         const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = "api-key"
+client_id = "12345"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
@@ -800,7 +798,7 @@ embedded = false
           commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         }
         vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, undefined, []))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
 
         // When
         await link(options)
@@ -837,7 +835,7 @@ embedded = false
           commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         }
         vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, undefined, []))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
 
         // When
         await link(options)
@@ -846,7 +844,7 @@ embedded = false
         const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
         const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = "api-key"
+client_id = "12345"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
@@ -880,7 +878,7 @@ embedded = false
           commandConfig: {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config,
         }
         vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, undefined, []))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(REMOTE_APP)
+        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
         vi.mocked(fetchAppExtensionRegistrations).mockResolvedValue({
           app: {
             extensionRegistrations: [],
@@ -906,7 +904,7 @@ embedded = false
         const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
         const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = "api-key"
+client_id = "12345"
 name = "app1"
 application_url = "https://example.com"
 embedded = true
@@ -930,12 +928,24 @@ embedded = false
   })
 })
 
-async function mockApp(directory: string, app?: Partial<AppInterface>, betas = [BetaFlag.VersionedAppConfig]) {
+async function mockApp(
+  directory: string,
+  app?: Partial<AppInterface>,
+  betas = [BetaFlag.VersionedAppConfig],
+  schemaType: 'current' | 'legacy' = 'legacy',
+) {
   const versionSchema = await buildVersionedAppSchema()
   const localApp = testApp(app)
+  localApp.configuration.client_id = schemaType === 'legacy' ? 12345 : '12345'
   localApp.configSchema = versionSchema.schema
   localApp.specifications = versionSchema.configSpecifications
   localApp.directory = directory
   setPathValue(localApp, 'remoteBetaFlags', betas)
   return localApp
+}
+
+function mockRemoteApp() {
+  const remoteApp = testOrganizationApp()
+  remoteApp.apiKey = '12345'
+  return remoteApp
 }

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -221,7 +221,7 @@ embedded = false
       })
     })
 
-    test('user selects a new file if the client_id in the local configuration is different from the remote one', async () => {
+    test('the local configuration is discarded if the client_id is different from the remote one', async () => {
       await inTemporaryDirectory(async (tmp) => {
         // Given
         const options: LinkOptions = {


### PR DESCRIPTION


<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When you run the `link` command the CLI creates the final configuration content following these steps:
- Content from the current used local `toml` 
- Overwrites the previous content with the remote `Api Client Configuration`
- Overwrites the previous content with the existing remote `configuration` App Modules

`link` command lets you select an existing app or a new one.

There's an issue because  in case you don't select the same remote app than the current used locally the CLI should skip the first step from the ones above and use an empty configuration instead.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Checks if the local app to link matches the remote one
- Writes the configuration in the default `shopify.app.toml` file only when the file is missing or the remote app matches its `client_id`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Run the `link` command an create a new app
- Enable the `versioned app config` beta flag
- Run the `link` command again and select the same app. Check that the `handle` value should be set
- Run the `link` command again and create a new app
  - The prompt to select the name of the new toml should be displayed
  - The new toml file should not include the `previous` handle value
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
