### PR TITLE
dev with the default toml without client_id reuses it

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -112,6 +112,7 @@ async function loadAppOrEmptyApp(
       configName: options.baseConfigName,
       remoteBetas,
     })
+    if (app.configuration.client_id === undefined) return emptyApp
     if (remoteApp?.apiKey === app.configuration.client_id?.toString()) return app
     return new EmptyApp(await loadFSExtensionsSpecifications(), remoteBetas, remoteApp?.apiKey)
     // eslint-disable-next-line no-catch-all/no-catch-all


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When you run the `dev` command with an empty default `shopify.app.toml` this config file should be reused instead creating a new one

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Checks if the current `toml` includes `client_id` to detect if it's an empty app
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new local app or modify the `shopify.app.toml` to only have `scopes = ""`
- Run the `dev` command and create or link an existing app
- You should not see the prompt to select the `toml` file to use
- The `shopify.app.toml` should be populated with the remote app config
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
