### PR TITLE
`handle` not shown in the removed list in the deploy prompt

### DIFF
--- a/packages/app/src/cli/services/context/breakdown-extensions.test.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.test.ts
@@ -950,7 +950,7 @@ describe('configExtensionsIdentifiersBreakdown', () => {
         registrationUuid: 'UUID_C_B',
         registrationTitle: 'Registration title',
         type: 'branding',
-        config: JSON.stringify({name: 'my app'}),
+        config: JSON.stringify({name: 'my app', app_handle: 'handle'}),
         specification: {
           identifier: 'branding',
           name: 'Branding',

--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -170,8 +170,9 @@ function resolveRemoteConfigExtensionIdentifiersBreakdown(
     (field) => !remoteDiffModifications.includes(field) && versionedLocalFieldNames.includes(field),
   )
   // List of versioned field that exists remotely but not locally
+  // `handle` property won't be temporary shown in the list of removed properties
   const deletedVersionedLocalFieldNames = remoteDiffModifications.filter(
-    (field) => !localDiffModifications.includes(field),
+    (field) => !localDiffModifications.includes(field) && field !== 'handle',
   )
 
   return {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When you create a new remote app, the `branding` configuration app module is automatically created including a default `handle` value. For current existing remote apps, a backfill process has also been triggered to run the same logic

This means, that the first time the user runs the `deploy` command with a `toml` that doesn't include the `handle` property, the `handle` property appears in the list of removed attributes. This is a confusing UX because the current users don't know anything about this new field.

`handle` property should not be shown in the removed list. Only in case the user adds it manually it should be displayed in the prompt diff content

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Adds a fixed check in the configuration breakdown info builder to remove the `handle` attribute explicitly
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new remote app using the `link` command
- Check in the partners dashboard that the version created automatically includes the `handle` property
- Run the `deploy` command. `No changes` message should be shown. Under the hood the CLI is going to remove the `handle` property in the newly created app version
- Check in the partners dashboard that the new version doesn't include the `handle` property
- Add the `handle` property to the `toml` so it's displayed as `new` in the prompt and included in the app version
- Check the new value in the partners dashboard

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
