### PR TITLE
link command uses local scopes to create a new remote app

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -103,7 +103,6 @@ async function loadAppOrEmptyApp(
   remoteBetas?: BetaFlag[],
   remoteApp?: OrganizationApp,
 ): Promise<AppInterface> {
-  const emptyApp = new EmptyApp(await loadFSExtensionsSpecifications(), remoteBetas)
   try {
     const app = await loadApp({
       specifications,
@@ -112,12 +111,12 @@ async function loadAppOrEmptyApp(
       configName: options.baseConfigName,
       remoteBetas,
     })
-    if (app.configuration.client_id === undefined) return emptyApp
-    if (remoteApp?.apiKey === app.configuration.client_id?.toString()) return app
+    const configuration = app.configuration
+    if (!isCurrentAppSchema(configuration) || remoteApp?.apiKey === configuration.client_id) return app
     return new EmptyApp(await loadFSExtensionsSpecifications(), remoteBetas, remoteApp?.apiKey)
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
-    return emptyApp
+    return new EmptyApp(await loadFSExtensionsSpecifications(), remoteBetas)
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
If you create a new `remix` app from scratch, run `dev` and create a new remote app, the default scopes fetched from the `remix templates` are lost.

In this use case, the local scopes should be kept
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- When the local app configuration uses the legacy format, the scopes are used to create the new remote app
- This is a regression introduced by this two PRs:
  - [link uses an empty app if the current used app is different from the remote one](https://github.com/Shopify/cli/pull/3333)
  - [dev with the default toml without client_id reuses it](https://github.com/Shopify/cli/pull/3336)
  so this fix is working for those use cases too
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new app using Remix
- Run the dev command and create a new remote app
- Check that the `write_products` scope is included in the `toml`
- Open the app and click the create products button to check it's working

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
