### PR TITLE
Support graphiql query param

### DIFF
--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -149,6 +149,7 @@ export function setupGraphiQLServer({
         {
           url: localhostUrl,
           defaultQueries: [{query: defaultQuery}],
+          query: req.query.query,
         },
       ),
     )

--- a/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
+++ b/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
@@ -251,6 +251,9 @@ export function graphiqlTemplate({
               url: '{{url}}/graphiql/graphql.json?key=${key ?? ''}&api_version=' + apiVersion,
             }),
             defaultEditorToolsVisibility: true,
+            {% if query %}
+            query: '{{query}}',
+            {% endif %}
             defaultTabs: [
               {query: "${graphiqlIntroMessage
                 .replace(/"/g, '\\"')


### PR DESCRIPTION
Hello! 👋 

### WHY are these changes introduced?

It would be great if we could support more features of the GraphiQL explorer.
In particular, there is no way to pass a `query` query param to the url at the moment, but the GraphiQL explorer supports this and you can see it in action here [https://graphql.github.io/swapi-graphql?query=query](https://graphql.github.io/swapi-graphql?query=query)

### WHAT is this pull request doing?

This PRs simply forwards the `query` query param if present.

### How to test your changes?

- Run `dev`
- Press `g`
- Nothing should change
- Add `?query=test` to the url in the browser and refresh
- There should be a new tab with the query