### PR TITLE
Remove target property from payment extension deploy configuration

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension.test.ts
@@ -66,11 +66,9 @@ describe('PaymentsAppExtension', () => {
       // When
       const result = await extension.deployConfig({apiKey, token})
       const extensionConfiguration = extension.configuration as OffsitePaymentsAppExtensionConfigType
-      const configTargeting = extensionConfiguration.targeting[0]!
 
       // Then
       expect(result).toEqual({
-        target: configTargeting.target,
         api_version: extensionConfiguration.api_version,
         start_payment_session_url: extensionConfiguration.payment_session_url,
         start_refund_session_url: extensionConfiguration.refund_session_url,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
@@ -147,7 +147,6 @@ describe('creditCardPaymentsAppExtensionDeployConfig', () => {
       supported_countries: config.supported_countries,
       supported_payment_methods: config.supported_payment_methods,
       test_mode_available: config.test_mode_available,
-      target: config.targeting[0]!.target,
       supports_3ds: config.supports_3ds,
       supports_deferred_payments: config.supports_deferred_payments,
       supports_installments: config.supports_installments,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
@@ -47,7 +47,6 @@ export async function creditCardPaymentsAppExtensionDeployConfig(
   config: CreditCardPaymentsAppExtensionConfigType,
 ): Promise<{[key: string]: unknown} | undefined> {
   return {
-    target: config.targeting[0]!.target,
     api_version: config.api_version,
     start_payment_session_url: config.payment_session_url,
     start_refund_session_url: config.refund_session_url,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
@@ -75,7 +75,6 @@ describe('customCreditCardPaymentsAppExtensionDeployConfig', () => {
 
     // Then
     expect(result).toMatchObject({
-      target: config.targeting[0]!.target,
       api_version: config.api_version,
       start_payment_session_url: config.payment_session_url,
       start_refund_session_url: config.refund_session_url,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
@@ -39,7 +39,6 @@ export async function customCreditCardPaymentsAppExtensionDeployConfig(
   config: CustomCreditCardPaymentsAppExtensionConfigType,
 ): Promise<{[key: string]: unknown} | undefined> {
   return {
-    target: config.targeting[0]!.target,
     api_version: config.api_version,
     start_payment_session_url: config.payment_session_url,
     start_refund_session_url: config.refund_session_url,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
@@ -95,7 +95,6 @@ describe('customOnsitePaymentsAppExtensionDeployConfig', () => {
 
     // Then
     expect(result).toMatchObject({
-      target: config.targeting[0]!.target,
       api_version: config.api_version,
       start_payment_session_url: config.payment_session_url,
       start_refund_session_url: config.refund_session_url,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
@@ -37,7 +37,6 @@ export async function customOnsitePaymentsAppExtensionDeployConfig(
   config: CustomOnsitePaymentsAppExtensionConfigType,
 ): Promise<{[key: string]: unknown} | undefined> {
   return {
-    target: config.targeting[0]!.target,
     api_version: config.api_version,
     start_payment_session_url: config.payment_session_url,
     start_refund_session_url: config.refund_session_url,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.test.ts
@@ -139,7 +139,6 @@ describe('offsitePaymentsAppExtensionDeployConfig', () => {
       supported_countries: config.supported_countries,
       supported_payment_methods: config.supported_payment_methods,
       test_mode_available: config.test_mode_available,
-      target: config.targeting[0]!.target,
       default_buyer_label: config.buyer_label,
       buyer_label_to_locale: config.buyer_label_translations,
       supports_oversell_protection: config.supports_oversell_protection,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.ts
@@ -29,7 +29,6 @@ export async function offsitePaymentsAppExtensionDeployConfig(
   config: OffsitePaymentsAppExtensionConfigType,
 ): Promise<{[key: string]: unknown} | undefined> {
   return {
-    target: config.targeting[0]!.target,
     api_version: config.api_version,
     start_payment_session_url: config.payment_session_url,
     start_refund_session_url: config.refund_session_url,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.test.ts
@@ -120,7 +120,6 @@ describe('redeemablePaymentsAppExtensionDeployConfig', () => {
       test_mode_available: config.test_mode_available,
       redeemable_type: config.redeemable_type,
       checkout_payment_method_fields: config.checkout_payment_method_fields,
-      target: config.targeting[0]!.target,
       default_buyer_label: config.buyer_label,
       buyer_label_to_locale: config.buyer_label_translations,
     })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.ts
@@ -17,7 +17,6 @@ export async function redeemablePaymentsAppExtensionDeployConfig(
   config: RedeemablePaymentsAppExtensionConfigType,
 ): Promise<{[key: string]: unknown} | undefined> {
   return {
-    target: config.targeting[0]!.target,
     api_version: config.api_version,
     start_payment_session_url: config.payment_session_url,
     start_refund_session_url: config.refund_session_url,


### PR DESCRIPTION
### WHY are these changes introduced?

These changes ensure that the `target` property is not embedded in the `deployConfig` payload. 
We aim to rather rely on the TOML file to parse the appropriate `target` and assign it to the `context`

See related PR: https://github.com/Shopify/cli/pull/3353

Note that these changes will not be visible in the latest CLI version `3.53` and this feature which allows payments extension support has currently not been released. 


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
