### PR TITLE
Fix the error message that started occurring since Ruby 3.3.0

### DIFF
--- a/.changeset/fifty-waves-wait.md
+++ b/.changeset/fifty-waves-wait.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix the error message that started occurring since Ruby 3.3.0

--- a/packages/cli-kit/assets/cli-ruby/bin/shopify
+++ b/packages/cli-kit/assets/cli-ruby/bin/shopify
@@ -8,8 +8,9 @@ module Kernel
   def require(name)
     original_require(name)
   rescue LoadError => e
-    # Special case for readline.so, which fails harmlessly on Windows
-    raise if (name == "readline.so") && ShopifyCLI::Context.new.windows?
+    # Special case for readline, which may fail on Windows and always raises a
+    # LoadError from Ruby 3.3.0.
+    raise if name == "readline.#{RbConfig::CONFIG["DLEXT"]}"
     # Special case for psych (yaml), which rescues this itself
     raise if name == "#{RUBY_VERSION[/\d+\.\d+/]}/psych.so"
     # Special case for ffi, which rescues this itself


### PR DESCRIPTION
### WHY are these changes introduced?

Ruby 3.3.0 has deprecated readline [[1]](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) in favor of Reline, but the it does that by falling back to Reline [[2]](https://github.com/ruby/readline/blob/6e1e5d0eb8613d5522d0195779d1040b1bc5f078/lib/readline.rb#L4). Because Shopify CLI overrides the require method [[3]](https://github.com/Shopify/cli/blob/143521bb72cd7a172f6e2c30d43848addc13ee02/packages/cli-kit/assets/cli-ruby/bin/shopify#L8), an error message appears in our console (but the CLI internally fallbacks to Reline).

### WHAT is this pull request doing?

The CLI prevents the error message from being displayed when a `readline` load error happens (as that's expected).

### How to test your changes?

- Run `export SHOPIFY_RUBY_BINDIR=/opt/homebrew/Cellar/ruby/3.3.0/bin`
- Run `shopify theme console` on Ruby 3.3.0

**Before this PR**
<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/ca50bfd7-9bd8-4724-884b-0c73ca98647c"/>

**After this PR**
<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/5799c656-8d1c-4258-aa8c-911b3796bbb6"/>


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
