### PR TITLE
[3.55] Fix the error message that started occurring since Ruby 3.3.0

### DIFF
--- a/.changeset/fifty-waves-wait.md
+++ b/.changeset/fifty-waves-wait.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix the error message that started occurring since Ruby 3.3.0

--- a/packages/cli-kit/assets/cli-ruby/bin/shopify
+++ b/packages/cli-kit/assets/cli-ruby/bin/shopify
@@ -8,8 +8,9 @@ module Kernel
   def require(name)
     original_require(name)
   rescue LoadError => e
-    # Special case for readline.so, which fails harmlessly on Windows
-    raise if (name == "readline.so") && ShopifyCLI::Context.new.windows?
+    # Special case for readline, which may fail on Windows and always raises a
+    # LoadError from Ruby 3.3.0.
+    raise if name == "readline.#{RbConfig::CONFIG["DLEXT"]}"
     # Special case for psych (yaml), which rescues this itself
     raise if name == "#{RUBY_VERSION[/\d+\.\d+/]}/psych.so"
     # Special case for ffi, which rescues this itself


### PR DESCRIPTION
Back-porting https://github.com/Shopify/cli/pull/3360