### PR TITLE
Text input tab completion

### DIFF
--- a/.changeset/tidy-stingrays-sit.md
+++ b/.changeset/tidy-stingrays-sit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Add placeholder tab completion to text prompts

--- a/packages/cli-kit/src/private/node/ui/components/TextInput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextInput.test.tsx
@@ -12,6 +12,7 @@ import {describe, test, expect, vi} from 'vitest'
 const ARROW_LEFT = '\u001B[D'
 const ARROW_RIGHT = '\u001B[C'
 const DELETE = '\u007F'
+const TAB = '\u0009'
 
 describe('TextInput', () => {
   test('default state', () => {
@@ -202,5 +203,19 @@ describe('TextInput', () => {
     const renderInstance = render(<TextInput onChange={() => {}} value="ABC" password />)
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot('"[36m***[46m█[49m[39m"')
+  })
+
+  test('tab completes with placeholder content', async () => {
+    const StatefulTextInput = () => {
+      const [value, setValue] = useState('')
+      const placeholder = 'Hello'
+
+      return <TextInput value={value} onChange={setValue} placeholder={placeholder} />
+    }
+    const renderInstance = render(<StatefulTextInput />)
+
+    await waitForInputsToBeReady()
+    await sendInputAndWaitForChange(renderInstance, TAB)
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot('"[36mHello[46m█[49m[39m"')
   })
 })

--- a/packages/cli-kit/src/private/node/ui/components/TextInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextInput.tsx
@@ -52,12 +52,9 @@ const TextInput: FunctionComponent<TextInputProps> = ({
   const cursorChar = figures.square
   const defaultCursor = <Text backgroundColor={color}>{cursorChar}</Text>
 
-  const renderedPlaceholder =
-    defaultValue.length > 0
-      ? renderPlaceholder(defaultValue)
-      : placeholder.length > 0
-      ? renderPlaceholder(placeholder)
-      : defaultCursor
+  const placeholderText = defaultValue.length > 0 ? defaultValue : placeholder.length > 0 ? placeholder : ''
+
+  const renderedPlaceholder = placeholderText.length > 0 ? renderPlaceholder(placeholderText) : defaultCursor
 
   // render cursor
   renderedValue = value
@@ -82,15 +79,14 @@ const TextInput: FunctionComponent<TextInputProps> = ({
 
   useInput(
     (input, key) => {
-      if (
-        key.upArrow ||
-        key.downArrow ||
-        (key.ctrl && input === 'c') ||
-        key.tab ||
-        (key.shift && key.tab) ||
-        key.return
-      ) {
+      if (key.upArrow || key.downArrow || (key.ctrl && input === 'c') || (key.shift && key.tab) || key.return) {
         return
+      } else if (key.tab) {
+        if (originalValue.length === 0 && placeholderText) {
+          onChange(placeholderText)
+          setCursorOffset(placeholderText.length)
+          return
+        }
       }
 
       let nextCursorOffset = cursorOffset

--- a/packages/cli-kit/src/private/node/ui/components/TextInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextInput.tsx
@@ -26,7 +26,7 @@ const TextInput: FunctionComponent<TextInputProps> = ({
   color = noColor ? undefined : 'cyan',
   password = false,
   focus = true,
-}) => {
+}: TextInputProps) => {
   const [cursorOffset, setCursorOffset] = useState((originalValue || '').length)
 
   // if the updated value is shorter than the last one we need to reset the cursor


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Makes a small quality-of-life improvement to the CLI experience.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
When there is placeholder text, allows the user to tab-complete. It moves the cursor to the end of the text, so they can then continue to edit as usual.

I imagine this being especially useful for internal developers who generate many apps, extensions, etc. and might want to append some information to the auto-generated title.

![tab-completion](https://github.com/Shopify/cli/assets/6288426/6680a4af-4565-414f-89bd-fe2506290b1c)

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`pnpm create-app` should do the trick! See the generated name, press `tab` to complete and see that you can edit as usual.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
