### PR TITLE
Display empty sections inside the deploy release prompt

### DIFF
--- a/.changeset/wet-socks-hope.md
+++ b/.changeset/wet-socks-hope.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Display empty sections inside the deploy release prompt

--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -39,7 +39,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
       expect(result).toBe(true)
     })
 
-    test('and no force without any modifications either extension or config should not display sections', async () => {
+    test('and no force without any modifications either extension or config should display empty sections', async () => {
       // Given
       const extensionIdentifiersBreakdown = buildEmptyExtensionsBreakdownInfo()
       const configExtensionIdentifiersBreakdown = buildEmptyConfigExtensionsBreakdownInfo()
@@ -67,7 +67,18 @@ describe('deployOrReleaseConfirmationPrompt', () => {
       expect(renderConfirmationPromptSpyOn).toHaveBeenCalledWith(
         renderConfirmationPromptContent({
           appTitle,
-          infoTable: [],
+          infoTable: [
+            {
+              header: 'Configuration:',
+              items: [],
+              emptyItemsText: 'No changes',
+            },
+            {
+              header: 'Extensions:',
+              items: [],
+              emptyItemsText: 'None',
+            },
+          ],
           dangerPrompt: false,
         }),
       )

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -58,7 +58,7 @@ async function deployConfirmationPrompt({
   let confirmationResponse = true
 
   const infoTable = []
-  if (configContentPrompt && (extensionsInfoTable || configContentPrompt.configInfoTable.items.length > 0)) {
+  if (configContentPrompt) {
     infoTable.push(
       configContentPrompt.configInfoTable.items.length === 0
         ? {...configContentPrompt.configInfoTable, emptyItemsText: 'No changes', items: []}
@@ -66,12 +66,15 @@ async function deployConfirmationPrompt({
     )
   }
   const isDangerous = appTitle !== undefined && hasDeletedExtensions
-  if (extensionsInfoTable)
+  if (extensionsInfoTable) {
     infoTable.push(
       isDangerous
         ? {...extensionsInfoTable, helperText: 'Removing extensions can permanentely delete app user data'}
         : extensionsInfoTable,
     )
+  } else {
+    infoTable.push({header: 'Extensions:', emptyItemsText: 'None', items: []})
+  }
 
   const question = `${release ? 'Release' : 'Create'} a new version${appTitle ? ` of ${appTitle}` : ''}?`
   if (isDangerous) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
 When there are no extensions and no configuration changes, CLI shows an empty deploy confirmation. 

<img src="https://github.com/Shopify/cli/assets/105213827/d7008149-fa09-43ef-b719-53631ba2352e" width=400/>

When there are no extensions, we should explicitly show "Extensions: none" in the prompt. And if there are no config changes, we should say "Configuration: no changes"


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- `Configuration` sections is always shown regardless the content of the `Extensions` sections. This sections is optional, so in case no value is received the sections is not displayed
- `Extensions` section is always rendered either with the breakdown info content or the message `None` is case no value is received

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Run the `deploy` command with `--reset` and create a new remote app
- Confirm the prompt to `include the configuration`
- Diff content shown

<img src="https://github.com/Shopify/cli/assets/105213827/09c0c6b4-a446-4f83-af57-705e62fc4496" width=400/>

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
