### PR TITLE
Refresh theme auth

### DIFF
--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -7,8 +7,8 @@ import {useEmbeddedThemeCLI} from '@shopify/cli-kit/node/context/local'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AdminSession, ensureAuthenticatedAdmin, ensureAuthenticatedPartners, ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
 
-// Tokens are valid for 120 min, better to be safe and refresh every 110 min
-const THEME_REFRESH_TIMEOUT_IN_MS = 110 * 60 * 1000
+// Tokens may be invalidated after as little as 4 minutes, better to be safe and refresh every 3 minutes
+const PARTNERS_TOKEN_REFRESH_TIMEOUT_IN_MS = 3 * 60 * 1000
 
 export interface PreviewThemeAppExtensionsOptions {
   adminSession: AdminSession
@@ -32,9 +32,10 @@ export const runThemeAppExtensionsServer: DevProcessFunction<PreviewThemeAppExte
         outputDebug('Refreshed theme session token successfully', stdout)
       })
       .catch((error) => {
+        outputDebug(`Failed to refresh theme session token: ${error}`, stderr)
         throw error
       })
-  }, THEME_REFRESH_TIMEOUT_IN_MS)
+  }, PARTNERS_TOKEN_REFRESH_TIMEOUT_IN_MS)
 
   await refreshToken()
   await execCLI2(['extension', 'serve', ...args], {

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -5,7 +5,7 @@ import {themeExtensionArgs} from '../theme-extension-args.js'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {useEmbeddedThemeCLI} from '@shopify/cli-kit/node/context/local'
 import {outputDebug} from '@shopify/cli-kit/node/output'
-import {AdminSession, ensureAuthenticatedAdmin, ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
+import {AdminSession, ensureAuthenticatedAdmin, ensureAuthenticatedPartners, ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
 
 // Tokens are valid for 120 min, better to be safe and refresh every 110 min
 const THEME_REFRESH_TIMEOUT_IN_MS = 110 * 60 * 1000
@@ -23,11 +23,11 @@ export interface PreviewThemeAppExtensionsProcess extends BaseProcess<PreviewThe
 
 export const runThemeAppExtensionsServer: DevProcessFunction<PreviewThemeAppExtensionsOptions> = async (
   {stdout, stderr, abortSignal},
-  {adminSession, themeExtensionServerArgs: args, storefrontToken, token},
+  {adminSession, themeExtensionServerArgs: args, storefrontToken},
 ) => {
   setInterval(() => {
     outputDebug('Refreshing theme session token...', stdout)
-    refreshToken(adminSession.storeFqdn)
+    refreshToken()
       .then(() => {
         outputDebug('Refreshed theme session token successfully', stdout)
       })
@@ -36,12 +36,11 @@ export const runThemeAppExtensionsServer: DevProcessFunction<PreviewThemeAppExte
       })
   }, THEME_REFRESH_TIMEOUT_IN_MS)
 
-  await refreshToken(adminSession.storeFqdn)
-
+  await refreshToken()
   await execCLI2(['extension', 'serve', ...args], {
     store: adminSession.storeFqdn,
+    adminToken: adminSession.token,
     storefrontToken,
-    token,
     stdout,
     stderr,
     signal: abortSignal,
@@ -102,10 +101,9 @@ export async function setupPreviewThemeAppExtensionsProcess({
   }
 }
 
-async function refreshToken(storeFqdn: string) {
-  const adminSession = await ensureAuthenticatedAdmin(storeFqdn, [], false, {noPrompt: true})
+async function refreshToken() {
+  const newToken = await ensureAuthenticatedPartners([], process.env, {noPrompt: true})
   if (useEmbeddedThemeCLI()) {
-    await execCLI2(['theme', 'token', '--admin', adminSession.token])
+    await execCLI2(['theme', 'token', '--partners', newToken])
   }
-  return {adminSession}
 }

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -5,7 +5,12 @@ import {themeExtensionArgs} from '../theme-extension-args.js'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {useEmbeddedThemeCLI} from '@shopify/cli-kit/node/context/local'
 import {outputDebug} from '@shopify/cli-kit/node/output'
-import {AdminSession, ensureAuthenticatedAdmin, ensureAuthenticatedPartners, ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
+import {
+  AdminSession,
+  ensureAuthenticatedAdmin,
+  ensureAuthenticatedPartners,
+  ensureAuthenticatedStorefront,
+} from '@shopify/cli-kit/node/session'
 
 // Tokens may be invalidated after as little as 4 minutes, better to be safe and refresh every 3 minutes
 const PARTNERS_TOKEN_REFRESH_TIMEOUT_IN_MS = 3 * 60 * 1000

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -36,9 +36,10 @@ export const runThemeAppExtensionsServer: DevProcessFunction<PreviewThemeAppExte
       })
   }, THEME_REFRESH_TIMEOUT_IN_MS)
 
+  await refreshToken(adminSession.storeFqdn)
+
   await execCLI2(['extension', 'serve', ...args], {
     store: adminSession.storeFqdn,
-    adminToken: adminSession.token,
     storefrontToken,
     token,
     stdout,
@@ -101,8 +102,8 @@ export async function setupPreviewThemeAppExtensionsProcess({
   }
 }
 
-async function refreshToken(store: string) {
-  const adminSession = await ensureAuthenticatedAdmin(store, [], false, {noPrompt: true})
+async function refreshToken(storeFqdn: string) {
+  const adminSession = await ensureAuthenticatedAdmin(storeFqdn, [], false, {noPrompt: true})
   if (useEmbeddedThemeCLI()) {
     await execCLI2(['theme', 'token', '--admin', adminSession.token])
   }

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/token.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/theme/commands/token.rb
@@ -6,13 +6,16 @@ module Theme
       options do |parser, flags|
         parser.on("--admin ADMIN_TOKEN") { |token| flags[:admin_token] = token }
         parser.on("--sfr STOREFRONT_RENDERER_TOKEN") { |token| flags[:sfr_token] = token }
+        parser.on("--partners PARTNERS_TOKEN") { |token| flags[:partners_token] = token }
       end
 
       def call(_args, _name)
         admin_token = options.flags[:admin_token]
         sfr_token = options.flags[:sfr_token]
+        partners_token = options.flags[:partners_token]
         ShopifyCLI::DB.set(shopify_exchange_token: admin_token) if admin_token
         ShopifyCLI::DB.set(storefront_renderer_production_exchange_token: sfr_token) if sfr_token
+        ShopifyCLI::DB.set(partners_exchange_token: partners_token) if partners_token
       end
     end
   end

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -14,7 +14,7 @@ export interface AdminSession {
   storeFqdn: string
 }
 
-interface EnsureAuthenticatedPartnersOptions {
+interface EnsureAuthenticatedAdditionalOptions {
   noPrompt?: boolean
 }
 
@@ -31,7 +31,7 @@ interface EnsureAuthenticatedPartnersOptions {
 export async function ensureAuthenticatedPartners(
   scopes: string[] = [],
   env = process.env,
-  options: EnsureAuthenticatedPartnersOptions = {},
+  options: EnsureAuthenticatedAdditionalOptions = {},
 ): Promise<string> {
   outputDebug(outputContent`Ensuring that the user is authenticated with the Partners API with the following scopes:
 ${outputToken.json(scopes)}
@@ -78,19 +78,21 @@ ${outputToken.json(scopes)}
  * @param store - Store fqdn to request auth for.
  * @param scopes - Optional array of extra scopes to authenticate with.
  * @param forceRefresh - Optional flag to force a refresh of the token.
+ * @param options - Optional extra options to use.
  * @returns The access token for the Admin API.
  */
 export async function ensureAuthenticatedAdmin(
   store: string,
   scopes: string[] = [],
   forceRefresh = false,
+  options: EnsureAuthenticatedAdditionalOptions = {},
 ): Promise<AdminSession> {
   outputDebug(outputContent`Ensuring that the user is authenticated with the Admin API with the following scopes for the store ${outputToken.raw(
     store,
   )}:
 ${outputToken.json(scopes)}
 `)
-  const tokens = await ensureAuthenticated({adminApi: {scopes, storeFqdn: store}}, process.env, {forceRefresh})
+  const tokens = await ensureAuthenticated({adminApi: {scopes, storeFqdn: store}}, process.env, {forceRefresh, ...options})
   if (!tokens.admin) {
     throw new BugError('No admin token found after ensuring authenticated')
   }

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -92,7 +92,10 @@ export async function ensureAuthenticatedAdmin(
   )}:
 ${outputToken.json(scopes)}
 `)
-  const tokens = await ensureAuthenticated({adminApi: {scopes, storeFqdn: store}}, process.env, {forceRefresh, ...options})
+  const tokens = await ensureAuthenticated({adminApi: {scopes, storeFqdn: store}}, process.env, {
+    forceRefresh,
+    ...options,
+  })
   if (!tokens.admin) {
     throw new BugError('No admin token found after ensuring authenticated')
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #3173 <!-- link to issue if one exists -->

Pushing Theme App Extension drafts requires unexpired Partners auth. Unfortunately, given the Ruby subprocess system we live with (for now), nothing is refreshing authentication, so sometime within ~2 hours the authentication expires, and the theme app extension silently stops reloading on save.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

1. Instead of sending a Partners auth token Node => Ruby by CLI flag, we use the hidden `theme token` command to pass a Partners token and save in the local `Shopify::DB`. That token is utilized by the `extension serve` process because we no longer pass a `token` flag.
2. The token is refreshed once before `theme extension serve` is called, and refreshed again every 3 minutes.
3. If the token fails to refresh, we make 2 more attempts after a 30-second window. Failing that, we kill the `dev` process, because we don't want to pretend things are still working when they aren't.

Note this means that if the internet connection is down for a few minutes, `dev` will crash rather than recovering smoothly when the connection is restored. I'm not sure whether that's a concern or not.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Start `dev` on an app with a Theme App Extension
2. Wait several hours
3. Make a change to a file in the theme and confirm the crash in #3173 no longer happens, instead the TAE updates successfully.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
