### PR TITLE
Refactor app_config feature to the new experience field

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -638,8 +638,8 @@ export const testPartnersServiceSession: PartnersSession = {
 }
 
 export async function buildVersionedAppSchema() {
-  const configSpecifications = (await loadFSExtensionsSpecifications()).filter((spec) =>
-    spec.appModuleFeatures().includes('app_config'),
+  const configSpecifications = (await loadFSExtensionsSpecifications()).filter(
+    (spec) => spec.experience === 'configuration',
   )
   return {
     schema: getAppVersionedSchema(configSpecifications),

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -41,7 +41,7 @@ export const AppSchema = zod.object({
 export const AppConfigurationSchema = zod.union([LegacyAppSchema, AppSchema])
 
 export function getAppVersionedSchema(specs: ExtensionSpecification[]) {
-  const isConfigSpecification = (spec: ExtensionSpecification) => spec.appModuleFeatures().includes('app_config')
+  const isConfigSpecification = (spec: ExtensionSpecification) => spec.experience === 'configuration'
   const schema = specs
     .filter(isConfigSpecification)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -431,7 +431,7 @@ class AppLoader {
 
   async createConfigExtensionInstances(directory: string, appConfiguration: CurrentAppConfiguration) {
     return this.specifications
-      .filter((specification) => specification.appModuleFeatures().includes('app_config'))
+      .filter((specification) => specification.experience === 'configuration')
       .map(async (specification) => {
         const specConfiguration = await parseConfigurationObject(
           specification.schema,

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -87,7 +87,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   get isAppConfigExtension() {
-    return this.features.includes('app_config')
+    return this.specification.experience === 'configuration'
   }
 
   get isFlow() {
@@ -119,9 +119,10 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     this.directory = options.directory
     this.specification = options.specification
     this.devUUID = `dev-${randomUUID()}`
-    this.handle = this.specification.appModuleFeatures().includes('app_config')
-      ? slugify(this.specification.identifier)
-      : this.configuration.handle ?? slugify(this.configuration.name ?? '')
+    this.handle =
+      this.specification.experience === 'configuration'
+        ? slugify(this.specification.identifier)
+        : this.configuration.handle ?? slugify(this.configuration.name ?? '')
     this.localIdentifier = this.handle
     this.idEnvironmentVariableName = `SHOPIFY_${constantize(this.localIdentifier)}_ID`
     this.outputPath = this.directory

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -15,7 +15,6 @@ export type ExtensionFeature =
   | 'cart_url'
   | 'esbuild'
   | 'single_js_entry_path'
-  | 'app_config'
 
 export interface TransformationConfig {
   [key: string]: string
@@ -25,6 +24,8 @@ export interface CustomTransformationConfig {
   forward?: (obj: object) => object
   reverse?: (obj: object) => object
 }
+
+export type ExtensionExperience = 'extension' | 'configuration'
 
 /**
  * Extension specification with all the needed properties and methods to load an extension.
@@ -38,6 +39,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   partnersWebIdentifier: string
   surface: string
   registrationLimit: number
+  experience: ExtensionExperience
   dependency?: string
   graphQLType?: string
   schema: ZodSchemaType<TConfiguration>
@@ -113,6 +115,7 @@ export function createExtensionSpecification<TConfiguration extends BaseConfigTy
     registrationLimit: blocks.extensions.defaultRegistrationLimit,
     transform: spec.transform,
     reverseTransform: spec.reverseTransform,
+    experience: spec.experience ?? 'extension',
   }
   return {...defaults, ...spec}
 }
@@ -137,11 +140,10 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
     // This casting is required because `name` and `type` are mandatory for the existing extension spec configurations,
     // however, app config extensions config content is parsed from the `shopify.app.toml`
     schema: spec.schema as unknown as ZodSchemaType<TConfiguration>,
-    appModuleFeatures: appModuleFeatures().includes('app_config')
-      ? appModuleFeatures
-      : () => appModuleFeatures().concat('app_config'),
+    appModuleFeatures,
     transform: resolveAppConfigTransform(spec.transformConfig),
     reverseTransform: resolveReverseAppConfigTransform(spec.schema, spec.transformConfig),
+    experience: 'configuration',
   })
 }
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -311,7 +311,7 @@ export function remoteAppConfigurationExtensionContent(
   specifications: ExtensionSpecification[],
 ) {
   let remoteAppConfig: {[key: string]: unknown} = {}
-  const configSpecifications = specifications.filter((spec) => spec.appModuleFeatures().includes('app_config'))
+  const configSpecifications = specifications.filter((spec) => spec.experience === 'configuration')
   configRegistrations.forEach((extension) => {
     const configSpec = configSpecifications.find((spec) => spec.identifier === extension.type.toLowerCase())
     if (!configSpec) return

--- a/packages/app/src/cli/services/draft-extensions/push.ts
+++ b/packages/app/src/cli/services/draft-extensions/push.ts
@@ -16,7 +16,7 @@ export async function draftExtensionsPush(draftExtensionsPushOptions: DraftExten
 
   await renderConcurrent({
     processes: app.allExtensions
-      .filter((ext) => !ext.specification.appModuleFeatures().includes('app_config'))
+      .filter((ext) => ext.specification.experience !== 'configuration')
       .map((extension) => {
         return {
           prefix: extension.localIdentifier,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- We were using an appModule feature (`app_config`) to identify configuration modules
- We should use the same property Core uses for this: a new field called `experience`

Fixes https://github.com/Shopify/develop-app-management/issues/1602

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Remove `app_config` from the list of features
- Add a new `experience` field to the specs, either `extension` or `configuration`
- Migrate all uses of `app_config` to the new `experience`

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Configuration extensions work as expected, try with some deploys and enabling/disabling the deploy of configs
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
