### PR TITLE
Remove path from extension instance configuration schema

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -142,7 +142,7 @@ export async function testUIExtension(
     },
     targeting: [{target: 'target1'}, {target: 'target2'}],
   }
-  const configurationPath = uiExtension?.configuration?.path ?? `${directory}/shopify.ui.extension.toml`
+  const configurationPath = uiExtension?.configurationPath ?? `${directory}/shopify.ui.extension.toml`
   const entryPath = uiExtension?.entrySourceFilePath ?? `${directory}/src/index.js`
 
   const allSpecs = await loadFSExtensionsSpecifications()

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -364,7 +364,7 @@ class AppLoader {
         this.abortOrReport(
           outputContent`Duplicated handle "${handle}" in extensions ${result}. Handle needs to be unique per extension.`,
           undefined,
-          extension.configuration.path,
+          extension.configurationPath,
         )
       } else if (extension.handle) {
         handles.add(extension.handle)

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -37,7 +37,8 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   localIdentifier: string
   idEnvironmentVariableName: string
   directory: string
-  configuration: TConfiguration & {path: string}
+  configuration: TConfiguration
+  configurationPath: string
   outputPath: string
   handle: string
   specification: ExtensionSpecification
@@ -102,11 +103,6 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     return `${this.handle}.js`
   }
 
-  get configurationContent() {
-    const {path, ...configuration} = this.configuration
-    return configuration
-  }
-
   constructor(options: {
     configuration: TConfiguration
     configurationPath: string
@@ -114,7 +110,8 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     directory: string
     specification: ExtensionSpecification
   }) {
-    this.configuration = {...options.configuration, path: options.configurationPath}
+    this.configuration = options.configuration
+    this.configurationPath = options.configurationPath
     this.entrySourceFilePath = options.entryPath ?? ''
     this.directory = options.directory
     this.specification = options.specification
@@ -177,16 +174,14 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
   async commonDeployConfig(apiKey: string): Promise<{[key: string]: unknown} | undefined> {
     const deployConfig = await this.specification.deployConfig?.(this.configuration, this.directory, apiKey, undefined)
-    const transformedConfig = this.specification.transform?.(this.configurationContent) as
-      | {[key: string]: unknown}
-      | undefined
+    const transformedConfig = this.specification.transform?.(this.configuration) as {[key: string]: unknown} | undefined
     const resultDeployConfig = deployConfig ?? transformedConfig ?? undefined
     return resultDeployConfig && Object.keys(resultDeployConfig).length > 0 ? resultDeployConfig : undefined
   }
 
   validate() {
     if (!this.specification.validate) return Promise.resolve(ok(undefined))
-    return this.specification.validate(this.configuration, this.directory)
+    return this.specification.validate(this.configuration, this.configurationPath, this.directory)
   }
 
   preDeployValidation(): Promise<void> {
@@ -253,7 +248,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
   async watchConfigurationPaths() {
     if (this.isAppConfigExtension) {
-      return [this.configuration.path]
+      return [this.configurationPath]
     } else {
       const additionalPaths = []
       if (await fileExists(joinPath(this.directory, 'locales'))) {

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -48,7 +48,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
     apiKey: string,
     moduleId?: string,
   ) => Promise<{[key: string]: unknown} | undefined>
-  validate?: (config: TConfiguration & {path: string}, directory: string) => Promise<Result<unknown, string>>
+  validate?: (config: TConfiguration, configPath: string, directory: string) => Promise<Result<unknown, string>>
   preDeployValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   buildValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   hasExtensionPointTarget?(config: TConfiguration, target: string): boolean

--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -52,7 +52,7 @@ describe('functionConfiguration', () => {
 
     extension = await testFunctionExtension({
       dir: '/function',
-      config,
+      config: {...config},
     })
   })
 

--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -97,8 +97,12 @@ describe('functionConfiguration', () => {
   test('returns a snake_case object with only required fields', async () => {
     await inTemporaryDirectory(async (_tmpDir) => {
       // Given
-      extension.configuration.input = undefined
-      extension.configuration.ui = undefined
+      const newConfig = {
+        ...extension.configuration,
+        input: undefined,
+        ui: undefined,
+      }
+      extension.configuration = newConfig
 
       // When
       const got = await extension.deployConfig({apiKey, token})
@@ -127,10 +131,14 @@ describe('functionConfiguration', () => {
       extension.directory = tmpDir
       const inputQuery = 'query { f }'
       const inputQueryFileName = 'target1.graphql'
-      extension.configuration.targeting = [
-        {target: 'some.api.target1', input_query: inputQueryFileName},
-        {target: 'some.api.target2', export: 'run_target2'},
-      ]
+      const newConfig = {
+        ...config,
+        targeting: [
+          {target: 'some.api.target1', input_query: inputQueryFileName},
+          {target: 'some.api.target2', export: 'run_target2'},
+        ],
+      }
+      extension.configuration = newConfig
       await writeFile(joinPath(extension.directory, inputQueryFileName), inputQuery)
 
       // When
@@ -146,7 +154,11 @@ describe('functionConfiguration', () => {
 
   test('aborts when an target input query file is missing', async () => {
     // Given
-    extension.configuration.targeting = [{target: 'some.api.target1', input_query: 'this-is-not-a-file.graphql'}]
+    const newConfig = {
+      ...extension.configuration,
+      targeting: [{target: 'some.api.target1', input_query: 'this-is-not-a-file.graphql'}],
+    }
+    extension.configuration = newConfig
 
     // When & Then
     await expect(() => extension.deployConfig({apiKey, token})).rejects.toThrowError(AbortError)
@@ -206,8 +218,12 @@ describe('functionConfiguration', () => {
     test('returns a snake_case object with only required fields', async () => {
       await inTemporaryDirectory(async (_tmpDir) => {
         // Given
-        extension.configuration.input = undefined
-        extension.configuration.ui = undefined
+        const newConfig = {
+          ...extension.configuration,
+          input: undefined,
+          ui: undefined,
+        }
+        extension.configuration = newConfig
 
         // When
         const got = await extension.deployConfig({apiKey, token})
@@ -264,8 +280,12 @@ describe('functionConfiguration', () => {
   test("parses ui.handle when it's an empty string", async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
+      const newConfigUi = {
+        ...extension.configuration.ui,
+        handle: '',
+      }
       extension.directory = tmpDir
-      extension.configuration.ui!.handle = ''
+      extension.configuration.ui = newConfigUi
 
       // When
       const got = (await extension.deployConfig({
@@ -282,7 +302,11 @@ describe('functionConfiguration', () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       extension.directory = tmpDir
-      extension.configuration.ui = undefined
+      const newConfig = {
+        ...extension.configuration,
+        ui: undefined,
+      }
+      extension.configuration = newConfig
 
       // When
       const got = (await extension.deployConfig({

--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -97,12 +97,8 @@ describe('functionConfiguration', () => {
   test('returns a snake_case object with only required fields', async () => {
     await inTemporaryDirectory(async (_tmpDir) => {
       // Given
-      const newConfig = {
-        ...extension.configuration,
-        input: undefined,
-        ui: undefined,
-      }
-      extension.configuration = newConfig
+      extension.configuration.input = undefined
+      extension.configuration.ui = undefined
 
       // When
       const got = await extension.deployConfig({apiKey, token})
@@ -131,14 +127,10 @@ describe('functionConfiguration', () => {
       extension.directory = tmpDir
       const inputQuery = 'query { f }'
       const inputQueryFileName = 'target1.graphql'
-      const newConfig = {
-        ...config,
-        targeting: [
-          {target: 'some.api.target1', input_query: inputQueryFileName},
-          {target: 'some.api.target2', export: 'run_target2'},
-        ],
-      }
-      extension.configuration = newConfig
+      extension.configuration.targeting = [
+        {target: 'some.api.target1', input_query: inputQueryFileName},
+        {target: 'some.api.target2', export: 'run_target2'},
+      ]
       await writeFile(joinPath(extension.directory, inputQueryFileName), inputQuery)
 
       // When
@@ -154,11 +146,7 @@ describe('functionConfiguration', () => {
 
   test('aborts when an target input query file is missing', async () => {
     // Given
-    const newConfig = {
-      ...extension.configuration,
-      targeting: [{target: 'some.api.target1', input_query: 'this-is-not-a-file.graphql'}],
-    }
-    extension.configuration = newConfig
+    extension.configuration.targeting = [{target: 'some.api.target1', input_query: 'this-is-not-a-file.graphql'}]
 
     // When & Then
     await expect(() => extension.deployConfig({apiKey, token})).rejects.toThrowError(AbortError)
@@ -218,12 +206,8 @@ describe('functionConfiguration', () => {
     test('returns a snake_case object with only required fields', async () => {
       await inTemporaryDirectory(async (_tmpDir) => {
         // Given
-        const newConfig = {
-          ...extension.configuration,
-          input: undefined,
-          ui: undefined,
-        }
-        extension.configuration = newConfig
+        extension.configuration.input = undefined
+        extension.configuration.ui = undefined
 
         // When
         const got = await extension.deployConfig({apiKey, token})
@@ -280,12 +264,8 @@ describe('functionConfiguration', () => {
   test("parses ui.handle when it's an empty string", async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
-      const newConfigUi = {
-        ...extension.configuration.ui,
-        handle: '',
-      }
       extension.directory = tmpDir
-      extension.configuration.ui = newConfigUi
+      extension.configuration.ui!.handle = ''
 
       // When
       const got = (await extension.deployConfig({
@@ -302,11 +282,7 @@ describe('functionConfiguration', () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       extension.directory = tmpDir
-      const newConfig = {
-        ...extension.configuration,
-        ui: undefined,
-      }
-      extension.configuration = newConfig
+      extension.configuration.ui = undefined
 
       // When
       const got = (await extension.deployConfig({

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -167,7 +167,7 @@ describe('ui_extension', async () => {
           err(`Couldn't find ${notFoundPath}
 Please check the module path for EXTENSION::POINT::A
 
-Please check the configuration in ${uiExtension.configuration.path}`),
+Please check the configuration in ${uiExtension.configurationPath}`),
         )
       })
     })
@@ -200,7 +200,7 @@ Please check the configuration in ${uiExtension.configuration.path}`),
           err(`Duplicate targets found: EXTENSION::POINT::A
 Extension point targets must be unique
 
-Please check the configuration in ${uiExtension.configuration.path}`),
+Please check the configuration in ${uiExtension.configurationPath}`),
         )
       })
     })

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -43,8 +43,8 @@ const spec = createExtensionSpecification({
       }) !== undefined
     return needsCart ? [...basic, 'cart_url'] : basic
   },
-  validate: async (config, directory) => {
-    return validateUIExtensionPointConfig(directory, config.extension_points, config.path)
+  validate: async (config, path, directory) => {
+    return validateUIExtensionPointConfig(directory, config.extension_points, path)
   },
   deployConfig: async (config, directory) => {
     return {

--- a/packages/app/src/cli/services/dev/update-extension.test.ts
+++ b/packages/app/src/cli/services/dev/update-extension.test.ts
@@ -253,7 +253,7 @@ another = "setting"
       // Then
       expect(mockExtension.configuration).toEqual(parsedConfig)
       expect(result.newConfig).toEqual(parsedConfig)
-      expect(result.previousConfig).toEqual({...configuration, path: configPath})
+      expect(result.previousConfig).toEqual(configuration)
     })
   })
 })

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -79,19 +79,19 @@ export async function reloadExtensionConfig({extension}: UpdateExtensionConfigOp
     throw new AbortError(message)
   }
 
-  let configObject = await loadConfigurationFile(extension.configuration.path)
+  let configObject = await loadConfigurationFile(extension.configurationPath)
   const {extensions} = ExtensionsArraySchema.parse(configObject)
 
   if (extensions) {
     // If the config has an array, find our extension using the handle.
-    const configuration = await parseConfigurationFile(UnifiedSchema, extension.configuration.path, abort)
+    const configuration = await parseConfigurationFile(UnifiedSchema, extension.configurationPath, abort)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const extensionConfig = configuration.extensions.find((config: any) => config.handle === extension.handle)
     if (!extensionConfig) {
       abort(
         `ERROR: Invalid handle
   - Expected handle: "${extension.handle}"
-  - Configuration file path: ${relativizePath(extension.configuration.path)}.
+  - Configuration file path: ${relativizePath(extension.configurationPath)}.
   - Handles are immutable, you can't change them once they are set.`,
       )
     }
@@ -101,7 +101,7 @@ export async function reloadExtensionConfig({extension}: UpdateExtensionConfigOp
 
   const newConfig = await parseConfigurationObject(
     extension.specification.schema,
-    extension.configuration.path,
+    extension.configurationPath,
     configObject,
     abort,
   )

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -250,25 +250,25 @@ describe('info', () => {
       // Given
       const uiExtension1 = await testUIExtension({
         configuration: {
-          path: 'extension/path/1',
           name: 'Extension 1',
           handle: 'handle-for-extension-1',
           type: 'ui_extension',
           metafields: [],
         },
+        configurationPath: 'extension/path/1',
       })
       const uiExtension2 = await testUIExtension({
         configuration: {
-          path: 'extension/path/2',
           name: 'Extension 2',
           type: 'checkout_ui_extension',
           metafields: [],
         },
+        configurationPath: 'extension/path/2',
       })
 
       const errors = new AppErrors()
-      errors.addError(uiExtension1.configuration.path, 'Mock error with ui_extension')
-      errors.addError(uiExtension2.configuration.path, 'Mock error with checkout_ui_extension')
+      errors.addError(uiExtension1.configurationPath, 'Mock error with ui_extension')
+      errors.addError(uiExtension2.configurationPath, 'Mock error with checkout_ui_extension')
 
       const app = mockApp({
         directory: tmp,

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -191,7 +191,7 @@ class AppInfo {
     const config = extension.configuration
     const details = [
       [`📂 ${extension.handle}`, relativePath(this.app.directory, extension.directory)],
-      ['     config file', relativePath(extension.directory, extension.configuration.path)],
+      ['     config file', relativePath(extension.directory, extension.configurationPath)],
     ]
     if (config && config.metafields?.length) {
       details.push(['     metafields', `${config.metafields.length}`])
@@ -201,11 +201,11 @@ class AppInfo {
   }
 
   invalidExtensionSubSection(extension: ExtensionInstance): string {
-    const error = this.app.errors?.getError(extension.configuration.path)
+    const error = this.app.errors?.getError(extension.configurationPath)
     if (!error) return ''
     const details = [
       [`📂 ${extension.handle}`, relativePath(this.app.directory, extension.directory)],
-      ['     config file', relativePath(extension.directory, extension.configuration.path)],
+      ['     config file', relativePath(extension.directory, extension.configurationPath)],
     ]
     const formattedError = this.formattedError(error)
     return `\n${linesToColumns(details)}\n${formattedError}`


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- At some point we added `path: string` as an extra field of the extensions configuration (to make it possible to do `ext.configuration.path` instead of passing a different parameter: `ext.configurationPath`
- This has added complexity when dealing with the configuration objects because they no longer follow the expected schema defined in each specification and the toml

Contributes to https://github.com/Shopify/develop-app-management/issues/1603

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Remove`& {path: string}` from the extensions configuration, make it a separate field.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Nothing in particular, creating and deploying extensions continues to work
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
