### PR TITLE
Removed versioned app config beta flag

### DIFF
--- a/.changeset/hip-jobs-jog.md
+++ b/.changeset/hip-jobs-jog.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Remover versiond app config beta

--- a/packages/app/src/cli/api/graphql/get_config.ts
+++ b/packages/app/src/cli/api/graphql/get_config.ts
@@ -26,9 +26,6 @@ export const GetConfig = gql`
         subPathPrefix
         url
       }
-      betas {
-        declarativeWebhooks
-      }
       disabledBetas
     }
   }
@@ -57,9 +54,6 @@ export interface App {
     proxySubPath: string
     proxySubPathPrefix: string
     proxyUrl: string
-  }
-  betas?: {
-    declarativeWebhooks?: boolean
   }
   disabledBetas: string[]
 }

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -168,7 +168,6 @@ export interface AppInterface extends AppConfigurationInterface {
   draftableExtensions: ExtensionInstance[]
   specifications?: ExtensionSpecification[]
   errors?: AppErrors
-  useVersionedAppConfig: boolean
   includeConfigOnDeploy: boolean | undefined
   hasExtensions: () => boolean
   updateDependencies: () => Promise<void>
@@ -243,15 +242,11 @@ export class App implements AppInterface {
   }
 
   get allExtensions() {
-    return this.realExtensions.filter(
-      (ext) => !ext.isAppConfigExtension || (this.useVersionedAppConfig && this.includeConfigOnDeploy),
-    )
+    return this.realExtensions.filter((ext) => !ext.isAppConfigExtension || this.includeConfigOnDeploy)
   }
 
   get draftableExtensions() {
-    return this.realExtensions.filter(
-      (ext) => ext.isDraftable() && (!ext.isAppConfigExtension || this.useVersionedAppConfig),
-    )
+    return this.realExtensions.filter((ext) => ext.isDraftable())
   }
 
   async updateDependencies() {
@@ -288,10 +283,6 @@ export class App implements AppInterface {
     this.allExtensions.forEach((extension) => {
       extension.devUUID = uuids[extension.localIdentifier] ?? extension.devUUID
     })
-  }
-
-  get useVersionedAppConfig() {
-    return this.remoteBetaFlags.includes(BetaFlag.VersionedAppConfig)
   }
 
   get includeConfigOnDeploy() {

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -15,7 +15,6 @@ import {getCachedAppInfo} from '../../services/local-storage.js'
 import use from '../../services/app/config/use.js'
 import {WebhookSchema} from '../extensions/specifications/app_config_webhook.js'
 import {WebhooksConfig} from '../extensions/specifications/types/app_config_webhook.js'
-import {BetaFlag} from '../../services/app/select-app.js'
 import {describe, expect, beforeEach, afterEach, beforeAll, test, vi} from 'vitest'
 import {
   installNodeModules,
@@ -1699,7 +1698,7 @@ wrong = "property"
     await writeConfig(linkedAppConfigurationWithPosConfiguration)
 
     // When
-    const app = await loadApp({directory: tmpDir, specifications, remoteBetas: [BetaFlag.VersionedAppConfig]})
+    const app = await loadApp({directory: tmpDir, specifications})
 
     // Then
     expect(app.allExtensions).toHaveLength(5)

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -18,9 +18,6 @@ export type OrganizationApp = MinimalOrganizationApp & {
   appType?: string
   newApp?: boolean
   grantedScopes: string[]
-  betas?: {
-    declarativeWebhooks?: boolean
-  }
   applicationUrl: string
   redirectUrlWhitelist: string[]
   requestedAccessScopes?: string[]

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -16,16 +16,12 @@ export async function selectApp(): Promise<OrganizationApp> {
   return fullSelectedApp!
 }
 
-export enum BetaFlag {
-  VersionedAppConfig,
-}
+export enum BetaFlag {}
 
-const FlagMap: {[key: string]: BetaFlag} = {
-  versioned_app_config: BetaFlag.VersionedAppConfig,
-}
+const FlagMap: {[key: string]: BetaFlag} = {}
 
 export async function fetchAppRemoteBetaFlags(apiKey: string, token: string) {
-  const defaultActiveBetas: BetaFlag[] = [BetaFlag.VersionedAppConfig]
+  const defaultActiveBetas: BetaFlag[] = []
   const queryResult: GetConfigQuerySchema = await partnersRequest(GetConfig, token, {apiKey})
   if (queryResult.app) {
     const {app} = queryResult

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -27,7 +27,6 @@ import link from './app/config/link.js'
 import {fetchPartnersSession} from './context/partner-account-info.js'
 import {fetchSpecifications} from './generate/fetch-extension-specifications.js'
 import * as writeAppConfigurationFile from './app/write-app-configuration-file.js'
-import {BetaFlag} from './app/select-app.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
 import {updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
 import {reuseDevConfigPrompt, selectOrganizationPrompt} from '../prompts/dev.js'
@@ -58,7 +57,6 @@ import {inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/no
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderConfirmationPrompt, renderInfo, renderTasks, Task} from '@shopify/cli-kit/node/ui'
 import {Config} from '@oclif/core'
-import {setPathValue} from '@shopify/cli-kit/common/object'
 
 const COMMAND_CONFIG = {runHook: vi.fn(() => Promise.resolve({successes: []}))} as unknown as Config
 
@@ -1128,10 +1126,9 @@ describe('ensureDeployContext', () => {
 
     expect(metadata.getAllPublicMetadata()).toMatchObject({api_key: APP2.apiKey, partner_id: 1})
   })
-  test('prompts the user to include the configuration and persist the flag if the flag is not present and the beta is enabled', async () => {
+  test('prompts the user to include the configuration and persist the flag if the flag is not present', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey}})
-    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1179,10 +1176,9 @@ describe('ensureDeployContext', () => {
     })
     writeAppConfigurationFileSpy.mockRestore()
   })
-  test('prompts the user to include the configuration and set it to false when not confirmed if the flag is not present and the beta is enabled', async () => {
+  test('prompts the user to include the configuration and set it to false when not confirmed if the flag is not present', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey}})
-    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1226,10 +1222,9 @@ describe('ensureDeployContext', () => {
     })
     writeAppConfigurationFileSpy.mockRestore()
   })
-  test('doesnt prompt the user to include the configuration and display the current value if the flag and beta are enabled', async () => {
+  test('doesnt prompt the user to include the configuration and display the current value if the flag', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey, build: {include_config_on_deploy: true}}})
-    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1275,10 +1270,9 @@ describe('ensureDeployContext', () => {
     })
     writeAppConfigurationFileSpy.mockRestore()
   })
-  test('prompts the user to include the configuration when reset is used if the flag and beta are enabled', async () => {
+  test('prompts the user to include the configuration when reset is used if the flag', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey, build: {include_config_on_deploy: true}}})
-    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1327,10 +1321,9 @@ describe('ensureDeployContext', () => {
     })
     writeAppConfigurationFileSpy.mockRestore()
   })
-  test('doesnt prompt the user to include the configuration when force is used if the flag is not present and beta are enabled', async () => {
+  test('doesnt prompt the user to include the configuration when force is used if the flag is not present', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey}})
-    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1371,10 +1364,9 @@ describe('ensureDeployContext', () => {
     })
     writeAppConfigurationFileSpy.mockRestore()
   })
-  test('prompt the user to include the configuration when force is used  if the flag and beta are enabled', async () => {
+  test('prompt the user to include the configuration when force is used  if the flag', async () => {
     // Given
     const app = testAppWithConfig({config: {client_id: APP2.apiKey, build: {include_config_on_deploy: true}}})
-    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const identifiers = {
       app: APP2.apiKey,
       extensions: {},
@@ -1402,50 +1394,6 @@ describe('ensureDeployContext', () => {
         {
           list: {
             items: ['Org:             org1', 'App:             app2', 'Include config:  Yes'],
-          },
-        },
-        '\n',
-        'You can pass',
-        {
-          command: '--reset',
-        },
-        'to your command to reset your app configuration.',
-      ],
-      headline: 'Using shopify.app.toml:',
-    })
-    writeAppConfigurationFileSpy.mockRestore()
-  })
-  test('doesnt prompt the user to include the configuration regardless the value of the flag is the beta is not enabled', async () => {
-    // Given
-    const app = testAppWithConfig({config: {client_id: APP2.apiKey}})
-    const identifiers = {
-      app: APP2.apiKey,
-      extensions: {},
-      extensionIds: {},
-      extensionsNonUuidManaged: {},
-    }
-    vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
-    vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
-    vi.mocked(loadApp).mockResolvedValue(app)
-    vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
-    vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.toml')
-    const writeAppConfigurationFileSpy = vi
-      .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
-      .mockResolvedValue()
-
-    // When
-    await ensureDeployContext(options(app, false, true))
-
-    // Then
-    // Then
-    expect(renderConfirmationPrompt).not.toHaveBeenCalled()
-    expect(writeAppConfigurationFileSpy).not.toHaveBeenCalled()
-    expect(renderInfo).toHaveBeenCalledWith({
-      body: [
-        {
-          list: {
-            items: ['Org:             org1', 'App:             app2'],
           },
         },
         '\n',

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -376,7 +376,7 @@ export interface DeployContextOptions {
 export async function ensureDeployContext(options: DeployContextOptions): Promise<DeployContextOutput> {
   const partnersSession = await fetchPartnersSession()
   const token = partnersSession.token
-  const [partnersApp, envIdentifiers] = await fetchAppAndIdentifiers(options, partnersSession)
+  const [partnersApp] = await fetchAppAndIdentifiers(options, partnersSession)
   const betas = await fetchAppRemoteBetaFlags(partnersApp.apiKey, token)
 
   const specifications = await fetchSpecifications({
@@ -522,10 +522,10 @@ async function ensureIncludeConfigOnDeploy({
     appDotEnv: app.dotenv?.path,
     configFile: isCurrentAppSchema(app.configuration) ? basename(app.configuration.path) : undefined,
     resetMessage: resetHelpMessage,
-    includeConfigOnDeploy: app.useVersionedAppConfig ? previousIncludeConfigOnDeploy : undefined,
+    includeConfigOnDeploy: previousIncludeConfigOnDeploy,
   })
 
-  if (!app.useVersionedAppConfig || force || previousIncludeConfigOnDeploy !== undefined) return
+  if (force || previousIncludeConfigOnDeploy !== undefined) return
   await promptIncludeConfigOnDeploy({
     appDirectory: app.directory,
     localApp: app,

--- a/packages/app/src/cli/services/context/breakdown-extensions.test.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.test.ts
@@ -21,7 +21,6 @@ import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {AppModuleVersion} from '../../api/graphql/app_active_version.js'
 import {AppVersionsDiffExtensionSchema} from '../../api/graphql/app_versions_diff.js'
 import {versionDiffByVersion} from '../release/version-diff.js'
-import {BetaFlag} from '../app/select-app.js'
 import {describe, vi, test, beforeAll, expect} from 'vitest'
 import {setPathValue} from '@shopify/cli-kit/common/object'
 
@@ -214,7 +213,7 @@ const APP_CONFIGURATION: CurrentAppConfiguration = {
 const LOCAL_APP = async (
   uiExtensions: ExtensionInstance[],
   configuration: AppConfiguration = APP_CONFIGURATION,
-  betas = [BetaFlag.VersionedAppConfig],
+  betas = [],
 ): Promise<AppInterface> => {
   const versionSchema = await buildVersionedAppSchema()
 
@@ -1289,53 +1288,6 @@ describe('configExtensionsIdentifiersBreakdown', () => {
     })
   })
   describe('deploy not including the configuration app modules', () => {
-    test('when the beta is not enabled the configuration breakdown info is not returned', async () => {
-      // Given
-      const configToReleaseAppModule: AppModuleVersion = {
-        registrationId: 'C_A',
-        registrationUuid: 'UUID_C_A',
-        registrationTitle: 'Registration title',
-        type: 'app_home',
-        config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
-        specification: {
-          identifier: 'app_home',
-          name: 'App Ui',
-          experience: 'configuration',
-          options: {
-            managementExperience: 'cli',
-          },
-        },
-      }
-      const configActiveAppModule: AppModuleVersion = {
-        registrationId: 'C_A',
-        registrationUuid: 'UUID_C_A',
-        registrationTitle: 'Registration title',
-        type: 'app_home',
-        config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
-        specification: {
-          identifier: 'app_home',
-          name: 'App Ui',
-          experience: 'configuration',
-          options: {
-            managementExperience: 'cli',
-          },
-        },
-      }
-      const activeVersion = {app: {activeAppVersion: {appModuleVersions: [configActiveAppModule, MODULE_DASHBOARD_A]}}}
-      vi.mocked(fetchActiveAppVersion).mockResolvedValue(activeVersion)
-
-      // When
-      const result = await configExtensionsIdentifiersBreakdown({
-        token: 'token',
-        apiKey: 'apiKey',
-        localApp: await LOCAL_APP([], APP_CONFIGURATION, []),
-        versionAppModules: [configToReleaseAppModule],
-        release: true,
-      })
-
-      // Then
-      expect(result).toBeUndefined()
-    })
     test('when the include_config_on_deploy is not true the configuration breakdown info is not returned', async () => {
       // Given
       const configuration = {

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -16,7 +16,6 @@ import {getUIExtensionsToMigrate, migrateExtensionsToUIExtension} from '../dev/m
 import {OrganizationApp} from '../../models/organization.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {createExtension} from '../dev/create-extension.js'
-import {BetaFlag} from '../app/select-app.js'
 import {beforeEach, describe, expect, vi, test, beforeAll} from 'vitest'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
@@ -96,7 +95,7 @@ const options = (
   release = true,
   includeDeployConfig = false,
   configExtensions: ExtensionInstance[] = [],
-  betas = [BetaFlag.VersionedAppConfig],
+  betas = [],
 ): EnsureDeploymentIdsPresenceOptions => {
   const localApp = {
     app: LOCAL_APP(uiExtensions, functionExtensions, includeDeployConfig, configExtensions),

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -3,7 +3,6 @@ import {deploy} from './deploy.js'
 import {uploadWasmBlob, uploadExtensionsBundle} from './deploy/upload.js'
 import {fetchAppExtensionRegistrations} from './dev/fetch.js'
 import {bundleAndBuildExtensions} from './deploy/bundle.js'
-import {BetaFlag} from './app/select-app.js'
 import {
   testApp,
   testFunctionExtension,
@@ -21,7 +20,6 @@ import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import {renderInfo, renderSuccess, renderTasks, renderTextPrompt, Task} from '@shopify/cli-kit/node/ui'
 import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 import {Config} from '@oclif/core'
-import {setPathValue} from '@shopify/cli-kit/common/object'
 
 const versionTag = 'unique-version-tag'
 
@@ -297,7 +295,7 @@ describe('deploy', () => {
     expect(updateAppIdentifiers).toHaveBeenCalledOnce()
   })
 
-  test('pushes the configuration extension if include config on deploy and the beta flag are enabled', async () => {
+  test('pushes the configuration extension if include config on deploy ', async () => {
     // Given
     const extensionNonUuidManaged = await testAppConfigExtensions()
     const localApp = {
@@ -305,11 +303,10 @@ describe('deploy', () => {
       configuration: {...DEFAULT_CONFIG, build: {include_config_on_deploy: true}},
     }
     const app = testApp(localApp)
-    setPathValue(app, 'remoteBetaFlags', [BetaFlag.VersionedAppConfig])
     const commitReference = 'https://github.com/deploytest/repo/commit/d4e5ce7999242b200acde378654d62c14b211bcc'
 
     // When
-    await testDeployBundle({app, released: false, commitReference, betas: [BetaFlag.VersionedAppConfig]})
+    await testDeployBundle({app, released: false, commitReference})
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
@@ -331,36 +328,10 @@ describe('deploy', () => {
     expect(updateAppIdentifiers).toHaveBeenCalledOnce()
   })
 
-  test('doesnt push the configuration extension if include config on deploy is disabled and the beta flag is enabled', async () => {
+  test('doesnt push the configuration extension if include config on deploy is disabled', async () => {
     // Given
     const extensionNonUuidManaged = await testAppConfigExtensions()
     const app = testApp({allExtensions: [extensionNonUuidManaged]})
-    const commitReference = 'https://github.com/deploytest/repo/commit/d4e5ce7999242b200acde378654d62c14b211bcc'
-
-    // When
-    await testDeployBundle({app, released: false, commitReference, betas: [BetaFlag.VersionedAppConfig]})
-
-    // Then
-    expect(uploadExtensionsBundle).toHaveBeenCalledWith({
-      apiKey: 'app-id',
-      appModules: [],
-      token: 'api-token',
-      extensionIds: {},
-      release: true,
-      commitReference,
-    })
-    expect(bundleAndBuildExtensions).toHaveBeenCalledOnce()
-    expect(updateAppIdentifiers).toHaveBeenCalledOnce()
-  })
-
-  test('doesnt push the configuration extension if include config on deploy is enabled and the beta flag is disabled', async () => {
-    // Given
-    const extensionNonUuidManaged = await testAppConfigExtensions()
-    const localApp = {
-      allExtensions: [extensionNonUuidManaged],
-      configuration: {...DEFAULT_CONFIG, build: {include_config_on_deploy: true}},
-    }
-    const app = testApp(localApp)
     const commitReference = 'https://github.com/deploytest/repo/commit/d4e5ce7999242b200acde378654d62c14b211bcc'
 
     // When
@@ -515,7 +486,6 @@ interface TestDeployBundleInput {
   released?: boolean
   commitReference?: string
   appToDeploy?: AppInterface
-  betas?: BetaFlag[]
 }
 
 async function testDeployBundle({
@@ -525,7 +495,6 @@ async function testDeployBundle({
   released = true,
   commitReference,
   appToDeploy,
-  betas = [],
 }: TestDeployBundleInput) {
   // Given
   const extensionsPayload: {[key: string]: string} = {}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Versioned app configuration has been 100% rolled out altogether with the 3.55.0 release. This means that all conditional logic depending on the value of the beta should be always executed
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Doesn't fetch deprecated and non used `betas` property from the partners `app` API
- Removes `VersionedApp` from the local `BetaFlags` 
- Removes references to `VersionedApp`  BetaFlag. In those case the logic that was executed when the beta was enabled should be executed
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Run `app deploy`, `app link` and `app dev` commands doing different modifications in the `toml` including the flag `include_config_on_deploy`. All versioned app features should be available
  - Prompt to include config on deploy
  - Any update configuration message displayed in banners should indicate `app deploy`
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
