### PR TITLE
support relative paths to `application_url` for declarative webhooks

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2350,9 +2350,8 @@ describe('WebhooksSchema', () => {
       ],
     }
     const errorObj = {
-      validation: 'regex' as zod.ZodInvalidStringIssue['validation'],
-      code: zod.ZodIssueCode.invalid_string,
-      message: 'Invalid',
+      code: zod.ZodIssueCode.custom,
+      message: 'Must be a valid https, pubsub, or ARN URI',
       path: ['webhooks', 'subscriptions', 0, 'uri'],
     }
 
@@ -2378,9 +2377,8 @@ describe('WebhooksSchema', () => {
       subscriptions: [{uri: 'my::URI-thing::Shopify::123', topics: ['products/create']}],
     }
     const errorObj = {
-      validation: 'regex' as zod.ZodInvalidStringIssue['validation'],
-      code: zod.ZodIssueCode.invalid_string,
-      message: 'Invalid',
+      code: zod.ZodIssueCode.custom,
+      message: 'Must be a valid https, pubsub, or ARN URI',
       path: ['webhooks', 'subscriptions', 0, 'uri'],
     }
 
@@ -2426,6 +2424,22 @@ describe('WebhooksSchema', () => {
     expect(parsedConfiguration.webhooks).toMatchObject(webhookConfig)
   })
 
+  test('accepts a relative path uri', async () => {
+    const webhookConfig: WebhooksConfig = {
+      api_version: '2021-07',
+      subscriptions: [
+        {
+          uri: '/webhooks',
+          topics: ['products/create'],
+        },
+      ],
+    }
+
+    const {abortOrReport, parsedConfiguration} = await setupParsing({}, webhookConfig)
+    expect(abortOrReport).not.toHaveBeenCalled()
+    expect(parsedConfiguration.webhooks).toMatchObject(webhookConfig)
+  })
+
   test('accepts combination of uris', async () => {
     const webhookConfig: WebhooksConfig = {
       api_version: '2021-07',
@@ -2440,6 +2454,10 @@ describe('WebhooksSchema', () => {
         },
         {
           uri: 'pubsub://my-project-123:my-topic',
+          topics: ['products/create', 'products/update'],
+        },
+        {
+          uri: '/webhooks',
           topics: ['products/create', 'products/update'],
         },
       ],
@@ -2531,9 +2549,8 @@ describe('WebhooksSchema', () => {
       ],
     }
     const errorObj = {
-      validation: 'regex' as zod.ZodInvalidStringIssue['validation'],
-      code: zod.ZodIssueCode.invalid_string,
-      message: 'Invalid',
+      code: zod.ZodIssueCode.custom,
+      message: 'Must be a valid https, pubsub, or ARN URI',
       path: ['webhooks', 'subscriptions', 0, 'uri'],
     }
 

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -191,6 +191,7 @@ class AppLoader {
   private errors: AppErrors = new AppErrors()
   private specifications: ExtensionSpecification[]
   private remoteBetas: BetaFlag[]
+  private fullAppConfiguration?: AppConfiguration
 
   constructor({directory, configName, mode, specifications, remoteBetas}: AppLoaderConstructorArgs) {
     this.mode = mode ?? 'strict'
@@ -220,6 +221,7 @@ class AppLoader {
       specifications: this.specifications,
     })
     const {directory, configuration, configurationLoadResultMetadata, configSchema} = await configurationLoader.loaded()
+    this.fullAppConfiguration = configuration
     await logMetadataFromAppLoadingProcess(configurationLoadResultMetadata)
 
     const dotenv = await loadDotEnv(directory, configuration.path)
@@ -334,6 +336,7 @@ class AppLoader {
       entryPath,
       directory,
       specification,
+      fullAppConfig: this.fullAppConfiguration,
     })
 
     const validateResult = await extensionInstance.validate()

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -21,7 +21,7 @@ export interface TransformationConfig {
 }
 
 export interface CustomTransformationConfig {
-  forward?: (obj: object) => object
+  forward?: (obj: object, fullAppConfiguration?: object) => object
   reverse?: (obj: object) => object
 }
 
@@ -55,8 +55,8 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   buildValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   hasExtensionPointTarget?(config: TConfiguration, target: string): boolean
   appModuleFeatures: (config?: TConfiguration) => ExtensionFeature[]
-  transform?: (content: object) => object
-  reverseTransform?: (content: object) => object
+  transform?: (content: object, fullAppConfiguration?: object) => object
+  reverseTransform?: (content: object, fullAppConfiguration?: object) => object
 }
 
 /**

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
@@ -25,7 +25,7 @@ const WebhooksSchema = zod.object({
   subscriptions: zod.array(WebhookSubscriptionSchema).optional(),
 })
 
-export const WebhooksSchemaWithDeclarative = WebhooksSchema.superRefine(webhookValidator)
+const WebhooksSchemaWithDeclarative = WebhooksSchema.superRefine(webhookValidator)
 
 export const WebhookSchema = zod.object({
   webhooks: WebhooksSchemaWithDeclarative,
@@ -34,8 +34,8 @@ export const WebhookSchema = zod.object({
 export const WebhooksSpecIdentifier = 'webhooks'
 
 const WebhookTransformConfig: CustomTransformationConfig = {
-  forward: (content: object) => transformWebhookConfig(content),
-  reverse: (content: object) => transformToWebhookConfig(content),
+  forward: transformWebhookConfig,
+  reverse: transformToWebhookConfig,
 }
 
 const spec = createConfigExtensionSpecification({

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.ts
@@ -1,9 +1,13 @@
+import {SpecsAppConfiguration} from '../types/app_config.js'
 import {WebhooksConfig, NormalizedWebhookSubscription} from '../types/app_config_webhook.js'
 import {deepMergeObjects, getPathValue} from '@shopify/cli-kit/common/object'
 
-export function transformWebhookConfig(content: object) {
+export function transformWebhookConfig(content: object, fullAppConfig?: object) {
   const webhooks = getPathValue(content, 'webhooks') as WebhooksConfig
   if (!webhooks) return content
+
+  const appConfig = fullAppConfig as SpecsAppConfiguration
+  const applicationUrl = appConfig?.application_url
 
   const webhookSubscriptions = []
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -12,13 +16,14 @@ export function transformWebhookConfig(content: object) {
   // eslint-disable-next-line no-warning-comments
   // TODO: pass along compliance_topics once we're ready to store them in its own module
   for (const {uri, topics, compliance_topics: _, ...optionalFields} of subscriptions) {
-    webhookSubscriptions.push(topics.map((topic) => ({uri, topic, ...optionalFields})))
+    const uriWithRelativePath = uri.startsWith('/') && applicationUrl ? `${applicationUrl}${uri}` : uri
+    webhookSubscriptions.push(topics.map((topic) => ({uri: uriWithRelativePath, topic, ...optionalFields})))
   }
 
   return webhookSubscriptions.length > 0 ? {subscriptions: webhookSubscriptions.flat(), api_version} : {api_version}
 }
 
-export function transformToWebhookConfig(content: object) {
+export function transformToWebhookConfig(content: object, fullAppConfig?: object) {
   let webhooks = {}
   const apiVersion = getPathValue(content, 'api_version') as string
   webhooks = {...(apiVersion ? {webhooks: {api_version: apiVersion}} : {})}
@@ -27,15 +32,22 @@ export function transformToWebhookConfig(content: object) {
 
   const webhooksSubscriptions: WebhooksConfig['subscriptions'] = []
 
+  const appConfig = fullAppConfig as SpecsAppConfiguration
+  const applicationUrl = appConfig?.application_url
+
   // eslint-disable-next-line @typescript-eslint/naming-convention
   for (const {uri, topic, sub_topic, ...optionalFields} of serverWebhooks) {
-    const currSubscription = webhooksSubscriptions.find((sub) => sub.uri === uri && sub.sub_topic === sub_topic)
+    const uriWithRelativePath = uri.includes(applicationUrl) ? uri.replace(applicationUrl, '') : uri
+
+    const currSubscription = webhooksSubscriptions.find(
+      (sub) => sub.uri === uriWithRelativePath && sub.sub_topic === sub_topic,
+    )
     if (currSubscription) {
       currSubscription.topics.push(topic)
     } else {
       webhooksSubscriptions.push({
         topics: [topic],
-        uri,
+        uri: uriWithRelativePath,
         ...(sub_topic ? {sub_topic} : {}),
         ...optionalFields,
       })

--- a/packages/app/src/cli/models/extensions/specifications/validation/common.ts
+++ b/packages/app/src/cli/models/extensions/specifications/validation/common.ts
@@ -15,8 +15,13 @@ export const ensureHttpsOnlyUrl = validateUrl(zod.string(), {
   message: 'Only https urls are allowed',
 }).refine((url) => !url.endsWith('/'), {message: 'URL can’t end with a forward slash'})
 
-export const UriValidation = zod.union([
-  zod.string().regex(httpsRegex),
-  zod.string().regex(pubSubRegex),
-  zod.string().regex(arnRegex),
-])
+export const UriValidation = zod.string().refine(
+  (uri) => {
+    if (uri.startsWith('/')) return true
+
+    return httpsRegex.test(uri) || pubSubRegex.test(uri) || arnRegex.test(uri)
+  },
+  {
+    message: 'Must be a valid https, pubsub, or ARN URI',
+  },
+)

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -47,7 +47,10 @@ export function remoteAppConfigurationExtensionContent(
     if (!configString) return
     const config = configString ? JSON.parse(configString) : {}
 
-    remoteAppConfig = deepMergeObjects(remoteAppConfig, configSpec.reverseTransform?.(config) ?? config)
+    remoteAppConfig = deepMergeObjects(
+      remoteAppConfig,
+      configSpec.reverseTransform?.(config, remoteAppConfig) ?? config,
+    )
   })
   return {...remoteAppConfig}
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/develop-app-management/issues/1599

### WHAT is this pull request doing?

- adds support for declarative webhook `uri`s that are relative to the `application_url`
ex:

```toml
application_url = "https://my-app-url.com"

[[webhooks.subscriptions]]
topics = ["products/create", "products/update"]
uri = "/products" # https://my-app-url.com/products
```

- this is especially useful when using `app dev` as the app url changes every time


- this also transforms the config on `app config link`, and we simplify like we do with the `topics` array
ex. if you have 

```toml
application_url = "https://my-app-url.com"

[[webhooks.subscriptions]]
topics = ["products/create"]
uri = "https://my-app-url.com/products"

[[webhooks.subscriptions]]
topics = ["orders/create"]
uri = "https://my-app-url.com/orders"
```

and link, we will simplify the config to

```toml
application_url = "https://my-app-url.com"

[[webhooks.subscriptions]]
topics = ["products/create"]
uri = "/products"

[[webhooks.subscriptions]]
topics = ["orders/create"]
uri = "/orders"
```

<hr />

- There is also nothing stopping anyone from creating a bad relative path like
```toml
application_url = "https://my-app-url.com"

[[webhooks.subscriptions]]
topics = ["products/create"]
uri = "//////products" # https://my-app-url.com//////products
```

- As technically to https spec, this is still a valid URL. We could parse out extra forward slashes, but I think a developer would realize this once they see it in their TOML or on the dashboard
- The `application_url` cannot end in a forward slash so this protects against this on the app url side


### How to test your changes?

- create an app and opt into the versioned config and declarative webhooks betas (both app and dev shop)
- create some webhook subscriptions with a relative path
- deploy the version
- go to the dashboard, you should see the full URL
- you can also link and make sure the toml does not change (unless it is this simplification case like mentioned)


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
