### PR TITLE
Link use version app configuration

### DIFF
--- a/.changeset/loud-grapes-change.md
+++ b/.changeset/loud-grapes-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Link command uses current version app configuration modules instead extensions registrations

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -639,11 +639,13 @@ export const testPartnersServiceSession: PartnersSession = {
 }
 
 export async function buildVersionedAppSchema() {
-  const configSpecifications = (await loadLocalExtensionsSpecifications()).filter(
-    (spec) => spec.experience === 'configuration',
-  )
+  const configSpecifications = await configurationSpecifications()
   return {
     schema: getAppVersionedSchema(configSpecifications),
     configSpecifications,
   }
+}
+
+export async function configurationSpecifications() {
+  return (await loadLocalExtensionsSpecifications()).filter((spec) => spec.experience === 'configuration')
 }

--- a/packages/app/src/cli/services/app/select-app.test.ts
+++ b/packages/app/src/cli/services/app/select-app.test.ts
@@ -1,0 +1,135 @@
+import {fetchAppRemoteConfiguration} from './select-app.js'
+import {AppModuleVersion} from '../../api/graphql/app_active_version.js'
+import {fetchActiveAppVersion} from '../dev/fetch.js'
+import {configurationSpecifications} from '../../models/app/app.test-data.js'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../dev/fetch.js')
+
+describe('fetchAppRemoteConfiguration', () => {
+  test('when configuration modules are present the remote configuration is returned ', async () => {
+    const configActiveAppModule: AppModuleVersion = {
+      registrationId: 'C_A',
+      registrationUuid: 'UUID_C_A',
+      registrationTitle: 'Registration title',
+      type: 'app_home',
+      config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
+      specification: {
+        identifier: 'app_home',
+        name: 'App Ui',
+        experience: 'configuration',
+        options: {
+          managementExperience: 'cli',
+        },
+      },
+    }
+    const activeVersion = {
+      app: {
+        activeAppVersion: {
+          appModuleVersions: [configActiveAppModule],
+        },
+      },
+    }
+    vi.mocked(fetchActiveAppVersion).mockResolvedValue(activeVersion)
+
+    // When
+    const result = await fetchAppRemoteConfiguration('token', 'apiKey', await configurationSpecifications())
+
+    // Then
+    expect(result).toEqual({
+      application_url: 'https://myapp.com',
+      embedded: true,
+    })
+  })
+
+  test('when no configuration modules are present the remote configuration is returned empty', async () => {
+    const checkoutModule: AppModuleVersion = {
+      registrationId: 'A',
+      registrationUuid: 'UUID_A',
+      registrationTitle: 'Checkout post purchase',
+      type: 'post_purchase_ui_extension',
+      specification: {
+        identifier: 'post_purchase_ui_extension',
+        name: 'Post purchase UI extension',
+        experience: 'extension',
+        options: {
+          managementExperience: 'cli',
+        },
+      },
+    }
+    const activeVersion = {
+      app: {
+        activeAppVersion: {
+          appModuleVersions: [checkoutModule],
+        },
+      },
+    }
+    vi.mocked(fetchActiveAppVersion).mockResolvedValue(activeVersion)
+
+    // When
+    const result = await fetchAppRemoteConfiguration('token', 'apiKey', await configurationSpecifications())
+
+    // Then
+    expect(result).toEqual({})
+  })
+
+  test('when two configuration modules are under the same section the remote configuration is returned deep merged', async () => {
+    const webhooksActiveAppModule: AppModuleVersion = {
+      registrationId: 'C_A',
+      registrationUuid: 'UUID_C_A',
+      registrationTitle: 'Registration title',
+      type: 'webhooks',
+      config: JSON.stringify({api_version: '2023-04'}),
+      specification: {
+        identifier: 'webhooks',
+        name: 'webhooks',
+        experience: 'configuration',
+        options: {
+          managementExperience: 'cli',
+        },
+      },
+    }
+    const complianceActiveAppModule: AppModuleVersion = {
+      registrationId: 'C_B',
+      registrationUuid: 'UUID_C_B',
+      registrationTitle: 'Registration title',
+      type: 'privacy_compliance_webhooks',
+      config: JSON.stringify({
+        customers_redact_url: 'https://myapp.com/redact',
+        customers_data_request_url: 'https://myapp.com/data_request',
+        shop_redact_url: 'https://myapp.com/shop_redact',
+      }),
+      specification: {
+        identifier: 'privacy_compliance_webhooks',
+        name: 'privacy compliance webhooks',
+        experience: 'configuration',
+        options: {
+          managementExperience: 'cli',
+        },
+      },
+    }
+    const activeVersion = {
+      app: {
+        activeAppVersion: {
+          appModuleVersions: [webhooksActiveAppModule, complianceActiveAppModule],
+        },
+      },
+    }
+    vi.mocked(fetchActiveAppVersion).mockResolvedValue(activeVersion)
+
+    // When
+    const result = await fetchAppRemoteConfiguration('token', 'apiKey', await configurationSpecifications())
+
+    // Then
+    expect(result).toEqual({
+      webhooks: {
+        api_version: '2023-04',
+        privacy_compliance: {
+          customer_deletion_url: 'https://myapp.com/redact',
+          customer_data_request_url: 'https://myapp.com/data_request',
+          shop_deletion_url: 'https://myapp.com/shop_redact',
+        },
+      },
+    })
+  })
+})

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -1,10 +1,13 @@
 import {OrganizationApp} from '../../models/organization.js'
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {fetchPartnersSession} from '../context/partner-account-info.js'
-import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
+import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps, fetchActiveAppVersion} from '../dev/fetch.js'
 import {FindAppQuery, FindAppQuerySchema} from '../../api/graphql/find_app.js'
+import {ExtensionSpecification} from '../../models/extensions/specification.js'
+import {AppModuleVersion} from '../../api/graphql/app_active_version.js'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 
 export async function selectApp(): Promise<OrganizationApp> {
   const partnersSession = await fetchPartnersSession()
@@ -31,4 +34,35 @@ export async function fetchAppRemoteBetaFlags(apiKey: string, token: string) {
     outputDebug("Couldn't find app for beta flags. Make sure you have a valid client ID.")
     return []
   }
+}
+
+export async function fetchAppRemoteConfiguration(
+  apiKey: string,
+  token: string,
+  specifications: ExtensionSpecification[],
+) {
+  const activeAppVersion = await fetchActiveAppVersion({token, apiKey})
+  const appModuleVersionsConfig =
+    activeAppVersion.app.activeAppVersion?.appModuleVersions.filter(
+      (module) => module.specification?.experience === 'configuration',
+    ) || []
+  return remoteAppConfigurationExtensionContent(appModuleVersionsConfig, specifications)
+}
+
+export function remoteAppConfigurationExtensionContent(
+  configRegistrations: AppModuleVersion[],
+  specifications: ExtensionSpecification[],
+) {
+  let remoteAppConfig: {[key: string]: unknown} = {}
+  const configSpecifications = specifications.filter((spec) => spec.experience === 'configuration')
+  configRegistrations.forEach((module) => {
+    const configSpec = configSpecifications.find((spec) => spec.identifier === module.type.toLowerCase())
+    if (!configSpec) return
+    const configString = module.config
+    if (!configString) return
+    const config = configString ? JSON.parse(configString) : {}
+
+    remoteAppConfig = deepMergeObjects(remoteAppConfig, configSpec.reverseTransform?.(config) ?? config)
+  })
+  return {...remoteAppConfig}
 }

--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -4,11 +4,10 @@ import {fetchActiveAppVersion, fetchAppExtensionRegistrations} from '../dev/fetc
 import {versionDiffByVersion} from '../release/version-diff.js'
 import {AppVersionsDiffExtensionSchema} from '../../api/graphql/app_versions_diff.js'
 import {AppInterface, CurrentAppConfiguration, filterNonVersionedAppFields} from '../../models/app/app.js'
-import {remoteAppConfigurationExtensionContent} from '../app/config/link.js'
 import {buildDiffConfigContent} from '../../prompts/config.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
-import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
 import {ActiveAppVersionQuerySchema, AppModuleVersion} from '../../api/graphql/app_active_version.js'
+import {fetchAppRemoteConfiguration, remoteAppConfigurationExtensionContent} from '../app/select-app.js'
 
 export interface ConfigExtensionIdentifiersBreakdown {
   existingFieldNames: string[]
@@ -97,28 +96,7 @@ export async function configExtensionsIdentifiersBreakdown({
   if (localApp.allExtensions.filter((extension) => extension.isAppConfigExtension).length === 0) return
   if (!release) return loadLocalConfigExtensionIdentifiersBreakdown(localApp)
 
-  const activeAppVersion = await fetchActiveAppVersion({token, apiKey})
-  const appModuleVersionsConfig =
-    activeAppVersion.app.activeAppVersion?.appModuleVersions.filter(
-      (module) => module.specification?.experience === 'configuration',
-    ) || []
-
-  return resolveRemoteConfigExtensionIdentifiersBreakdown(
-    appModuleVersionsConfig.map(mapAppModuleToExtensionRegistration),
-    localApp,
-    versionAppModules ? versionAppModules.map(mapAppModuleToExtensionRegistration) : undefined,
-  )
-}
-
-function mapAppModuleToExtensionRegistration(appModule: AppModuleVersion): ExtensionRegistration {
-  return {
-    id: appModule.registrationId,
-    uuid: appModule.registrationUuid,
-    title: appModule.registrationTitle,
-    type: appModule.specification?.identifier ?? '',
-    draftVersion: appModule.config ? {config: appModule.config} : undefined,
-    activeVersion: appModule.config ? {config: appModule.config} : undefined,
-  }
+  return resolveRemoteConfigExtensionIdentifiersBreakdown(token, apiKey, localApp, versionAppModules)
 }
 
 function loadLocalConfigExtensionIdentifiersBreakdown(app: AppInterface): ConfigExtensionIdentifiersBreakdown {
@@ -130,14 +108,15 @@ function loadLocalConfigExtensionIdentifiersBreakdown(app: AppInterface): Config
   }
 }
 
-function resolveRemoteConfigExtensionIdentifiersBreakdown(
-  extensionRegistrations: ExtensionRegistration[],
+async function resolveRemoteConfigExtensionIdentifiersBreakdown(
+  token: string,
+  apiKey: string,
   app: AppInterface,
-  versionExtensionRegistrations?: ExtensionRegistration[],
-): ConfigExtensionIdentifiersBreakdown {
-  const remoteConfig = remoteAppConfigurationExtensionContent(extensionRegistrations, app.specifications ?? [])
-  const baselineConfig = versionExtensionRegistrations
-    ? remoteAppConfigurationExtensionContent(versionExtensionRegistrations, app.specifications ?? [])
+  versionAppModules?: AppModuleVersion[],
+) {
+  const remoteConfig = await fetchAppRemoteConfiguration(apiKey, token, app.specifications ?? [])
+  const baselineConfig = versionAppModules
+    ? remoteAppConfigurationExtensionContent(versionAppModules, app.specifications ?? [])
     : app.configuration
   const diffConfigContent = buildDiffConfigContent(
     baselineConfig as CurrentAppConfiguration,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
`link` command was using the content from the `configuration` extension registration to build the remote configuration. Although the content of the registrations should be equivalent to the current app version configuration modules, it's better to use always the current app version content because the api to get the extension registrations will be eventually deprecated

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Create a new method to fetch the content of the remote configuration
- Use this method in whatever place where the remote config is required in the code base
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- `deploy` and `link` command should work as expected

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
