### PR TITLE
Adds support for ui extension handle

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
@@ -26,6 +26,7 @@ const config: CreditCardPaymentsAppExtensionConfigType = {
   api_version: '2022-07',
   description: 'my payments app extension',
   metafields: [],
+  ui_extension_handle: 'sample-ui-extension',
   encryption_certificate: {
     fingerprint: 'fingerprint',
     certificate: '-----BEGIN CERTIFICATE-----\nSample certificate\n-----END CERTIFICATE-----',
@@ -151,6 +152,7 @@ describe('creditCardPaymentsAppExtensionDeployConfig', () => {
       supports_deferred_payments: config.supports_deferred_payments,
       supports_installments: config.supports_installments,
       checkout_payment_method_fields: config.checkout_payment_method_fields,
+      ui_extension_handle: config.ui_extension_handle,
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
@@ -7,7 +7,7 @@ import {zod} from '@shopify/cli-kit/node/schema'
 
 export type CreditCardPaymentsAppExtensionConfigType = zod.infer<typeof CreditCardPaymentsAppExtensionSchema>
 
-const CERTIFICATE_REGEX = /^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$/
+const CERTIFICATE_REGEX = /^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$|^$/
 
 export const CREDIT_CARD_TARGET = 'payments.credit-card.render'
 
@@ -21,6 +21,7 @@ export const CreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSche
   .extend({
     targeting: zod.array(zod.object({target: zod.literal(CREDIT_CARD_TARGET)})).length(1),
     verification_session_url: zod.string().url().optional(),
+    ui_extension_handle: zod.string().optional(),
     encryption_certificate: zod.object({
       fingerprint: zod.string(),
       certificate: zod.string().regex(CERTIFICATE_REGEX),
@@ -63,5 +64,6 @@ export async function creditCardPaymentsAppExtensionDeployConfig(
     start_verification_session_url: config.verification_session_url,
     encryption_certificate: config.encryption_certificate,
     checkout_payment_method_fields: config.checkout_payment_method_fields,
+    ui_extension_handle: config.ui_extension_handle,
   }
 }

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
@@ -28,6 +28,7 @@ const config: CustomCreditCardPaymentsAppExtensionConfigType = {
   api_version: '2022-07',
   checkout_payment_method_fields: [],
   checkout_hosted_fields: ['fields'],
+  ui_extension_handle: 'sample-ui-extension',
   description: 'Custom credit card extension',
   metafields: [],
   input: {
@@ -90,6 +91,7 @@ describe('customCreditCardPaymentsAppExtensionDeployConfig', () => {
       multiple_capture: config.multiple_capture,
       checkout_payment_method_fields: config.checkout_payment_method_fields,
       checkout_hosted_fields: config.checkout_hosted_fields,
+      ui_extension_handle: config.ui_extension_handle,
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
@@ -5,7 +5,7 @@ export type CustomCreditCardPaymentsAppExtensionConfigType = zod.infer<
   typeof CustomCreditCardPaymentsAppExtensionSchema
 >
 
-const CERTIFICATE_REGEX = /^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$/
+const CERTIFICATE_REGEX = /^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$|^$/
 
 export const CUSTOM_CREDIT_CARD_TARGET = 'payments.custom-credit-card.render'
 
@@ -20,6 +20,7 @@ export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensi
     api_version: zod.string(),
     multiple_capture: zod.boolean(),
     checkout_hosted_fields: zod.array(zod.string()).optional(),
+    ui_extension_handle: zod.string().optional(),
     encryption_certificate: zod.object({
       fingerprint: zod.string(),
       certificate: zod.string().regex(CERTIFICATE_REGEX),
@@ -54,5 +55,6 @@ export async function customCreditCardPaymentsAppExtensionDeployConfig(
     multiple_capture: config.multiple_capture,
     checkout_payment_method_fields: config.checkout_payment_method_fields,
     checkout_hosted_fields: config.checkout_hosted_fields,
+    ui_extension_handle: config.ui_extension_handle,
   }
 }

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
@@ -29,6 +29,7 @@ const config: CustomOnsitePaymentsAppExtensionConfigType = {
   checkout_payment_method_fields: [],
   modal_payment_method_fields: [],
   description: 'Custom onsite extension',
+  ui_extension_handle: 'sample-ui-extension',
   metafields: [],
   input: {
     metafield_identifiers: {
@@ -115,6 +116,7 @@ describe('customOnsitePaymentsAppExtensionDeployConfig', () => {
       buyer_label_to_locale: config.buyer_label_translations,
       checkout_payment_method_fields: config.checkout_payment_method_fields,
       modal_payment_method_fields: config.modal_payment_method_fields,
+      ui_extension_handle: config.ui_extension_handle,
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
@@ -19,6 +19,7 @@ export const CustomOnsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSc
     multiple_capture: zod.boolean().optional(),
     supports_oversell_protection: zod.boolean().optional(),
     modal_payment_method_fields: zod.array(zod.object({})).optional(),
+    ui_extension_handle: zod.string().optional(),
     checkout_payment_method_fields: zod
       .array(
         zod.object({
@@ -57,5 +58,6 @@ export async function customOnsitePaymentsAppExtensionDeployConfig(
     buyer_label_to_locale: config.buyer_label_translations,
     checkout_payment_method_fields: config.checkout_payment_method_fields,
     modal_payment_method_fields: config.modal_payment_method_fields,
+    ui_extension_handle: config.ui_extension_handle,
   }
 }

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.test.ts
@@ -18,7 +18,8 @@ const config: RedeemablePaymentsAppExtensionConfigType = {
   supported_countries: ['CA'],
   supported_payment_methods: ['PAYMENT_METHOD'],
   test_mode_available: true,
-  redeemable_type: 'gift_card',
+  redeemable_type: 'gift-card',
+  ui_extension_handle: 'sample-ui-extension',
   targeting: [{target: 'payments.redeemable.render'}],
   api_version: '2022-07',
   description: 'my payments app extension',
@@ -72,9 +73,9 @@ describe('RedeemablePaymentsAppExtensionSchema', () => {
         {
           received: 'invalid type',
           code: zod.ZodIssueCode.invalid_literal,
-          expected: 'gift_card',
+          expected: 'gift-card',
           path: ['redeemable_type'],
-          message: 'Invalid literal value, expected "gift_card"',
+          message: 'Invalid literal value, expected "gift-card"',
         },
       ]),
     )
@@ -122,6 +123,7 @@ describe('redeemablePaymentsAppExtensionDeployConfig', () => {
       checkout_payment_method_fields: config.checkout_payment_method_fields,
       default_buyer_label: config.buyer_label,
       buyer_label_to_locale: config.buyer_label_translations,
+      ui_extension_handle: config.ui_extension_handle,
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.ts
@@ -9,7 +9,8 @@ export const RedeemablePaymentsAppExtensionSchema = BasePaymentsAppExtensionSche
   targeting: zod.array(zod.object({target: zod.literal(REDEEMABLE_TARGET)})).length(1),
   api_version: zod.string(),
   balance_url: zod.string().url(),
-  redeemable_type: zod.literal('gift_card'),
+  redeemable_type: zod.literal('gift-card'),
+  ui_extension_handle: zod.string().optional(),
   checkout_payment_method_fields: zod.array(zod.string()).optional(),
 })
 
@@ -31,5 +32,6 @@ export async function redeemablePaymentsAppExtensionDeployConfig(
     redeemable_type: config.redeemable_type,
     balance_url: config.balance_url,
     checkout_payment_method_fields: config.checkout_payment_method_fields,
+    ui_extension_handle: config.ui_extension_handle,
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Update payment apps capabilities

### WHAT is this pull request doing?

This PR:

- Introduces a new field to the schema validations, `ui_extension_handle`, so it can be sent to the backend.
- Makes the encryption certificate optional, so developers can test their apps without filling the values (by running `app dev`)

### How to test your changes?

Unit tests should pretty much cover everything.

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
