### PR TITLE
Remove API Client config from `link` command

### DIFF
--- a/.changeset/hip-pets-wave.md
+++ b/.changeset/hip-pets-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Remove api client configuration from the link command

--- a/packages/app/src/cli/api/graphql/create_app.ts
+++ b/packages/app/src/cli/api/graphql/create_app.ts
@@ -32,20 +32,6 @@ export const CreateAppQuery = gql`
         applicationUrl
         redirectUrlWhitelist
         requestedAccessScopes
-        webhookApiVersion
-        embedded
-        posEmbedded
-        preferencesUrl
-        gdprWebhooks {
-          customerDeletionUrl
-          customerDataRequestUrl
-          shopDeletionUrl
-        }
-        appProxy {
-          subPath
-          subPathPrefix
-          url
-        }
       }
       userErrors {
         field
@@ -79,20 +65,6 @@ export interface CreateAppQuerySchema {
       applicationUrl: string
       redirectUrlWhitelist: string[]
       requestedAccessScopes?: string[]
-      webhookApiVersion: string
-      embedded: boolean
-      posEmbedded?: boolean
-      preferencesUrl?: string
-      gdprWebhooks?: {
-        customerDeletionUrl?: string
-        customerDataRequestUrl?: string
-        shopDeletionUrl?: string
-      }
-      appProxy?: {
-        subPath: string
-        subPathPrefix: string
-        url: string
-      }
     }
     userErrors: {
       field: string[]

--- a/packages/app/src/cli/api/graphql/find_app.ts
+++ b/packages/app/src/cli/api/graphql/find_app.ts
@@ -15,20 +15,6 @@ export const FindAppQuery = gql`
       applicationUrl
       redirectUrlWhitelist
       requestedAccessScopes
-      webhookApiVersion
-      embedded
-      posEmbedded
-      preferencesUrl
-      gdprWebhooks {
-        customerDeletionUrl
-        customerDataRequestUrl
-        shopDeletionUrl
-      }
-      appProxy {
-        subPath
-        subPathPrefix
-        url
-      }
       developmentStorePreviewEnabled
       disabledBetas
     }
@@ -49,20 +35,6 @@ export interface FindAppQuerySchema {
     applicationUrl: string
     redirectUrlWhitelist: string[]
     requestedAccessScopes?: string[]
-    webhookApiVersion: string
-    embedded: boolean
-    posEmbedded?: boolean
-    preferencesUrl?: string
-    gdprWebhooks?: {
-      customerDeletionUrl?: string
-      customerDataRequestUrl?: string
-      shopDeletionUrl?: string
-    }
-    appProxy?: {
-      subPath: string
-      subPathPrefix: string
-      url: string
-    }
     developmentStorePreviewEnabled: boolean
     disabledBetas: string[]
   }

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -294,61 +294,66 @@ export class App implements AppInterface {
     if (isLegacyAppSchema(configuration)) return configuration
     return {
       ...configuration,
-      ...this.homeConfiguration(configuration),
-      ...this.appProxyConfiguration(configuration),
-      ...this.posConfiguration(configuration),
-      ...this.webhooksConfiguration(configuration),
-      ...this.accessConfiguration(configuration),
+      ...buildSpecsAppConfiguration(configuration),
     } as CurrentAppConfiguration & SpecsAppConfiguration
   }
+}
 
-  private appProxyConfiguration(configuration: AppConfiguration) {
-    if (!getPathValue(configuration, 'app_proxy')) return
-    return {
-      app_proxy: {
-        url: getPathValue<string>(configuration, 'app_proxy.url')!,
-        prefix: getPathValue<string>(configuration, 'app_proxy.prefix')!,
-        subpath: getPathValue<string>(configuration, 'app_proxy.subpath')!,
-      },
-    }
+export function buildSpecsAppConfiguration(content: object) {
+  return {
+    ...homeConfiguration(content),
+    ...appProxyConfiguration(content),
+    ...posConfiguration(content),
+    ...webhooksConfiguration(content),
+    ...accessConfiguration(content),
   }
+}
 
-  private homeConfiguration(configuration: AppConfiguration) {
-    const appPreferencesUrl = getPathValue<string>(configuration, 'app_preferences.url')
-    return {
-      application_url: getPathValue<string>(configuration, 'application_url')!,
-      embedded: getPathValue<boolean>(configuration, 'embedded')!,
-      ...(appPreferencesUrl ? {app_preferences: {url: appPreferencesUrl}} : {}),
-    }
+function appProxyConfiguration(configuration: object) {
+  if (!getPathValue(configuration, 'app_proxy')) return
+  return {
+    app_proxy: {
+      url: getPathValue<string>(configuration, 'app_proxy.url')!,
+      prefix: getPathValue<string>(configuration, 'app_proxy.prefix')!,
+      subpath: getPathValue<string>(configuration, 'app_proxy.subpath')!,
+    },
   }
+}
 
-  private posConfiguration(configuration: AppConfiguration) {
-    const embedded = getPathValue<boolean>(configuration, 'pos.embedded')
-    return embedded === undefined
-      ? undefined
-      : {
-          pos: {
-            embedded,
-          },
-        }
+function homeConfiguration(configuration: object) {
+  const appPreferencesUrl = getPathValue<string>(configuration, 'app_preferences.url')
+  return {
+    name: getPathValue<string>(configuration, 'name')!,
+    application_url: getPathValue<string>(configuration, 'application_url')!,
+    embedded: getPathValue<boolean>(configuration, 'embedded')!,
+    ...(appPreferencesUrl ? {app_preferences: {url: appPreferencesUrl}} : {}),
   }
+}
 
-  private webhooksConfiguration(configuration: AppConfiguration) {
-    return {
-      webhooks: {...getPathValue<WebhooksConfig>(configuration, 'webhooks')},
-    }
+function posConfiguration(configuration: object) {
+  const embedded = getPathValue<boolean>(configuration, 'pos.embedded')
+  return embedded === undefined
+    ? undefined
+    : {
+        pos: {
+          embedded,
+        },
+      }
+}
+
+function webhooksConfiguration(configuration: object) {
+  return {
+    webhooks: {...getPathValue<WebhooksConfig>(configuration, 'webhooks')},
   }
+}
 
-  private accessConfiguration(configuration: AppConfiguration) {
-    const scopes = getPathValue<string>(configuration, 'access_scopes.scopes')
-    const useLegacyInstallFlow = getPathValue<boolean>(configuration, 'access_scopes.use_legacy_install_flow')
-    const redirectUrls = getPathValue<string[]>(configuration, 'auth.redirect_urls')
-    return {
-      ...(scopes || useLegacyInstallFlow
-        ? {access_scopes: {scopes, use_legacy_install_flow: useLegacyInstallFlow}}
-        : {}),
-      ...(redirectUrls ? {auth: {redirect_urls: redirectUrls}} : {}),
-    }
+function accessConfiguration(configuration: object) {
+  const scopes = getPathValue<string>(configuration, 'access_scopes.scopes')
+  const useLegacyInstallFlow = getPathValue<boolean>(configuration, 'access_scopes.use_legacy_install_flow')
+  const redirectUrls = getPathValue<string[]>(configuration, 'auth.redirect_urls')
+  return {
+    ...(scopes || useLegacyInstallFlow ? {access_scopes: {scopes, use_legacy_install_flow: useLegacyInstallFlow}} : {}),
+    ...(redirectUrls ? {auth: {redirect_urls: redirectUrls}} : {}),
   }
 }
 

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -23,20 +23,6 @@ export type OrganizationApp = MinimalOrganizationApp & {
   applicationUrl: string
   redirectUrlWhitelist: string[]
   requestedAccessScopes?: string[]
-  webhookApiVersion?: string
-  embedded?: boolean
-  posEmbedded?: boolean
-  preferencesUrl?: string
-  gdprWebhooks?: {
-    customerDeletionUrl?: string
-    customerDataRequestUrl?: string
-    shopDeletionUrl?: string
-  }
-  appProxy?: {
-    subPath: string
-    subPathPrefix: string
-    url: string
-  }
   developmentStorePreviewEnabled?: boolean
   betas?: BetaFlag[]
 }

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -41,49 +41,57 @@ vi.mock('../../context/partner-account-info.js')
 vi.mock('../../generate/fetch-extension-specifications.js')
 vi.mock('../select-app.js')
 
+const DEFAULT_REMOTE_CONFIGURATION = {
+  name: 'app1',
+  application_url: 'https://example.com',
+  embedded: true,
+  auth: {redirect_urls: ['https://example.com/callback1']},
+  webhooks: {api_version: '2023-07'},
+  pos: {embedded: false},
+  access_scopes: {use_legacy_install_flow: true},
+}
+
 beforeEach(async () => {
   vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-  vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue({})
   vi.mocked(fetchSpecifications).mockResolvedValue(await loadLocalExtensionsSpecifications())
+  vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(DEFAULT_REMOTE_CONFIGURATION)
 })
 
 describe('link', () => {
-  describe('when version app configuration beta is enabled', () => {
-    test('does not ask for a name when it is provided as a flag', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
+  test('does not ask for a name when it is provided as a flag', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+        configName: 'Default value',
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
 
-          configName: 'Default value',
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
+      // When
+      await link(options)
 
-        // When
-        await link(options)
-
-        // Then
-        expect(selectConfigName).not.toHaveBeenCalled()
-        expect(fileExistsSync(joinPath(tmp, 'shopify.app.default-value.toml'))).toBeTruthy()
-      })
+      // Then
+      expect(selectConfigName).not.toHaveBeenCalled()
+      expect(fileExistsSync(joinPath(tmp, 'shopify.app.default-value.toml'))).toBeTruthy()
     })
+  })
 
-    test('creates a new shopify.app.toml file when it does not exist', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        vi.mocked(loadApp).mockRejectedValue('App not found')
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
+  test('creates a new shopify.app.toml file when it does not exist', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      vi.mocked(loadApp).mockRejectedValue('App not found')
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
 
-        // When
-        await link(options)
+      // When
+      await link(options)
 
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "app1"
@@ -106,66 +114,70 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-        expect(content).toEqual(expectedContent)
-        expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.toml', directory: tmp})
-        expect(renderSuccess).toHaveBeenCalledWith({
-          headline: 'shopify.app.toml is now linked to "app1" on Shopify',
-          body: 'Using shopify.app.toml as your default config.',
-          nextSteps: [
-            [`Make updates to shopify.app.toml in your local project`],
-            ['To upload your config, run', {command: 'npm run shopify app deploy'}],
-          ],
-          reference: [
-            {
-              link: {
-                label: 'App configuration',
-                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
-              },
+      expect(content).toEqual(expectedContent)
+      expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.toml', directory: tmp})
+      expect(renderSuccess).toHaveBeenCalledWith({
+        headline: 'shopify.app.toml is now linked to "app1" on Shopify',
+        body: 'Using shopify.app.toml as your default config.',
+        nextSteps: [
+          [`Make updates to shopify.app.toml in your local project`],
+          ['To upload your config, run', {command: 'npm run shopify app deploy'}],
+        ],
+        reference: [
+          {
+            link: {
+              label: 'App configuration',
+              url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
             },
-          ],
-        })
+          },
+        ],
       })
     })
+  })
 
-    test('creates a new shopify.app.staging.toml file when shopify.app.toml already linked', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        const localApp = {
-          configuration: {
-            path: 'shopify.app.development.toml',
-            name: 'my app',
-            client_id: '12345',
-            scopes: 'write_products',
-            webhooks: {api_version: '2023-04'},
-            application_url: 'https://myapp.com',
-            embedded: true,
-            build: {
-              automatically_update_urls_on_dev: true,
-              dev_store_url: 'my-store.myshopify.com',
-              include_config_on_deploy: true,
-            },
-          } as CurrentAppConfiguration,
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp, [], 'current'))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
-          testOrganizationApp({
-            apiKey: '12345',
-            applicationUrl: 'https://myapp.com',
-            title: 'my app',
-            requestedAccessScopes: ['write_products'],
-          }),
-        )
-        vi.mocked(selectConfigName).mockResolvedValue('staging')
+  test('creates a new shopify.app.staging.toml file when shopify.app.toml already linked', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      const localApp = {
+        configuration: {
+          path: 'shopify.app.development.toml',
+          name: 'my app',
+          client_id: '12345',
+          scopes: 'write_products',
+          webhooks: {api_version: '2023-04'},
+          application_url: 'https://myapp.com',
+          embedded: true,
+          build: {
+            automatically_update_urls_on_dev: true,
+            dev_store_url: 'my-store.myshopify.com',
+            include_config_on_deploy: true,
+          },
+        } as CurrentAppConfiguration,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp, [], 'current'))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
+        testOrganizationApp({
+          apiKey: '12345',
+        }),
+      )
+      vi.mocked(selectConfigName).mockResolvedValue('staging')
+      const remoteConfiguration = {
+        ...DEFAULT_REMOTE_CONFIGURATION,
+        name: 'my app',
+        application_url: 'https://myapp.com',
+        access_scopes: {scopes: 'write_products'},
+      }
+      vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
 
-        // When
-        await link(options)
+      // When
+      await link(options)
 
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "my app"
@@ -190,65 +202,69 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-        expect(content).toEqual(expectedContent)
-        expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.staging.toml', directory: tmp})
-        expect(renderSuccess).toHaveBeenCalledWith({
-          headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
-          body: 'Using shopify.app.staging.toml as your default config.',
-          nextSteps: [
-            [`Make updates to shopify.app.staging.toml in your local project`],
-            ['To upload your config, run', {command: 'yarn shopify app deploy'}],
-          ],
-          reference: [
-            {
-              link: {
-                label: 'App configuration',
-                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
-              },
+      expect(content).toEqual(expectedContent)
+      expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.staging.toml', directory: tmp})
+      expect(renderSuccess).toHaveBeenCalledWith({
+        headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
+        body: 'Using shopify.app.staging.toml as your default config.',
+        nextSteps: [
+          [`Make updates to shopify.app.staging.toml in your local project`],
+          ['To upload your config, run', {command: 'yarn shopify app deploy'}],
+        ],
+        reference: [
+          {
+            link: {
+              label: 'App configuration',
+              url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
             },
-          ],
-        })
+          },
+        ],
       })
     })
+  })
 
-    test('the local configuration is discarded if the client_id is different from the remote one', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        const localApp = {
-          configuration: {
-            path: 'shopify.app.toml',
-            name: 'my app',
-            client_id: '12345',
-            scopes: 'write_products',
-            webhooks: {api_version: '2023-04'},
-            application_url: 'https://myapp.com',
-            embedded: true,
-            build: {
-              automatically_update_urls_on_dev: true,
-              dev_store_url: 'my-store.myshopify.com',
-            },
-          } as CurrentAppConfiguration,
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp, [], 'current'))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
-          testOrganizationApp({
-            apiKey: 'different-api-key',
-            applicationUrl: 'https://myapp.com',
-            title: 'my app',
-            requestedAccessScopes: ['write_products'],
-          }),
-        )
-        vi.mocked(selectConfigName).mockResolvedValue('staging')
+  test('the local configuration is discarded if the client_id is different from the remote one', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      const localApp = {
+        configuration: {
+          path: 'shopify.app.toml',
+          name: 'my app',
+          client_id: '12345',
+          scopes: 'write_products',
+          webhooks: {api_version: '2023-04'},
+          application_url: 'https://myapp.com',
+          embedded: true,
+          build: {
+            automatically_update_urls_on_dev: true,
+            dev_store_url: 'my-store.myshopify.com',
+          },
+        } as CurrentAppConfiguration,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp, [], 'current'))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
+        testOrganizationApp({
+          apiKey: 'different-api-key',
+        }),
+      )
+      const remoteConfiguration = {
+        ...DEFAULT_REMOTE_CONFIGURATION,
+        name: 'my app',
+        application_url: 'https://myapp.com',
+        access_scopes: {scopes: 'write_products'},
+      }
+      vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
+      vi.mocked(selectConfigName).mockResolvedValue('staging')
 
-        // When
-        await link(options)
+      // When
+      await link(options)
 
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "different-api-key"
 name = "my app"
@@ -268,29 +284,29 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-        expect(content).toEqual(expectedContent)
-      })
+      expect(content).toEqual(expectedContent)
     })
+  })
 
-    test('updates the shopify.app.toml when it already exists and is unlinked', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const filePath = joinPath(tmp, 'shopify.app.toml')
-        const initialContent = `scopes = ""
+  test('updates the shopify.app.toml when it already exists and is unlinked', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const filePath = joinPath(tmp, 'shopify.app.toml')
+      const initialContent = `scopes = ""
       `
-        writeFileSync(filePath, initialContent)
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
+      writeFileSync(filePath, initialContent)
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
 
-        // When
-        await link(options)
+      // When
+      await link(options)
 
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "app1"
@@ -310,167 +326,45 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-        expect(content).toEqual(expectedContent)
-        expect(renderSuccess).toHaveBeenCalledWith({
-          headline: 'shopify.app.toml is now linked to "app1" on Shopify',
-          body: 'Using shopify.app.toml as your default config.',
-          nextSteps: [
-            [`Make updates to shopify.app.toml in your local project`],
-            ['To upload your config, run', {command: 'yarn shopify app deploy'}],
-          ],
-          reference: [
-            {
-              link: {
-                label: 'App configuration',
-                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
-              },
+      expect(content).toEqual(expectedContent)
+      expect(renderSuccess).toHaveBeenCalledWith({
+        headline: 'shopify.app.toml is now linked to "app1" on Shopify',
+        body: 'Using shopify.app.toml as your default config.',
+        nextSteps: [
+          [`Make updates to shopify.app.toml in your local project`],
+          ['To upload your config, run', {command: 'yarn shopify app deploy'}],
+        ],
+        reference: [
+          {
+            link: {
+              label: 'App configuration',
+              url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
             },
-          ],
-        })
+          },
+        ],
       })
     })
+  })
 
-    test('does not render success banner if shouldRenderSuccess is false', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const filePath = joinPath(tmp, 'shopify.app.toml')
-        const initialContent = `scopes = ""
+  test('does not render success banner if shouldRenderSuccess is false', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const filePath = joinPath(tmp, 'shopify.app.toml')
+      const initialContent = `scopes = ""
       `
-        writeFileSync(filePath, initialContent)
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
+      writeFileSync(filePath, initialContent)
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
 
-        // When
-        await link(options, false)
+      // When
+      await link(options, false)
 
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
-
-client_id = "12345"
-name = "app1"
-application_url = "https://example.com"
-embedded = true
-
-[access_scopes]
-# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-use_legacy_install_flow = true
-
-[auth]
-redirect_urls = [ "https://example.com/callback1" ]
-
-[webhooks]
-api_version = "2023-07"
-
-[pos]
-embedded = false
-`
-        expect(content).toEqual(expectedContent)
-        expect(renderSuccess).not.toHaveBeenCalled()
-      })
-    })
-
-    test('fetches the app directly when an api key is provided', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-
-          apiKey: 'api-key',
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-        vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(mockRemoteApp())
-        vi.mocked(selectConfigName).mockResolvedValue('staging')
-
-        // When
-        await link(options)
-
-        // Then
-        expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith('api-key', 'token')
-      })
-    })
-
-    test('throws an error when an invalid api key is is provided', async () => {
-      vi.mocked(InvalidApiKeyErrorMessage).mockReturnValue({
-        message: outputContent`Invalid Client ID`,
-        tryMessage: outputContent`You can find the Client ID in the app settings in the Partners Dashboard.`,
-      })
-
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-
-          apiKey: '1234-5678',
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-        vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(undefined)
-        vi.mocked(selectConfigName).mockResolvedValue('staging')
-
-        // When
-        const result = link(options)
-
-        // Then
-        await expect(result).rejects.toThrow(/Invalid Client ID/)
-      })
-    })
-
-    test('skips config name question if re-linking to existing current app schema', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        const localApp = {
-          configuration: {
-            path: 'shopify.app.foo.toml',
-            name: 'my app',
-            client_id: '12345',
-            scopes: 'write_products',
-            webhooks: {api_version: '2023-04'},
-            application_url: 'https://myapp.com',
-            embedded: true,
-          } as CurrentAppConfiguration,
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
-          testOrganizationApp({
-            apiKey: '12345',
-            applicationUrl: 'https://myapp.com',
-            title: 'my app',
-            requestedAccessScopes: ['write_products'],
-          }),
-        )
-        vi.mocked(getCachedCommandInfo).mockReturnValue({askConfigName: false, selectedToml: 'shopify.app.foo.toml'})
-
-        // When
-        await link(options)
-
-        expect(selectConfigName).not.toHaveBeenCalled()
-        expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.foo.toml', directory: tmp})
-      })
-    })
-
-    test('generates the file when there is no shopify.app.toml', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        vi.mocked(loadApp).mockRejectedValue(new Error('Shopify.app.toml not found'))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
-
-        // When
-        await link(options)
-
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "app1"
@@ -490,28 +384,147 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-        expect(content).toEqual(expectedContent)
-      })
+      expect(content).toEqual(expectedContent)
+      expect(renderSuccess).not.toHaveBeenCalled()
+    })
+  })
+
+  test('fetches the app directly when an api key is provided', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+        apiKey: 'api-key',
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+      vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(mockRemoteApp())
+      vi.mocked(selectConfigName).mockResolvedValue('staging')
+
+      // When
+      await link(options)
+
+      // Then
+      expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith('api-key', 'token')
+    })
+  })
+
+  test('throws an error when an invalid api key is is provided', async () => {
+    vi.mocked(InvalidApiKeyErrorMessage).mockReturnValue({
+      message: outputContent`Invalid Client ID`,
+      tryMessage: outputContent`You can find the Client ID in the app settings in the Partners Dashboard.`,
     })
 
-    test('uses scopes on platform if defined', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({
-          ...mockRemoteApp(),
-          requestedAccessScopes: ['read_products', 'write_orders'],
-        })
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+        apiKey: '1234-5678',
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+      vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(undefined)
+      vi.mocked(selectConfigName).mockResolvedValue('staging')
 
-        // When
-        await link(options)
+      // When
+      const result = link(options)
 
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+      // Then
+      await expect(result).rejects.toThrow(/Invalid Client ID/)
+    })
+  })
+
+  test('skips config name question if re-linking to existing current app schema', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      const localApp = {
+        configuration: {
+          path: 'shopify.app.foo.toml',
+          name: 'my app',
+          client_id: '12345',
+          scopes: 'write_products',
+          webhooks: {api_version: '2023-04'},
+          application_url: 'https://myapp.com',
+          embedded: true,
+        } as CurrentAppConfiguration,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
+        testOrganizationApp({
+          apiKey: '12345',
+        }),
+      )
+      vi.mocked(getCachedCommandInfo).mockReturnValue({askConfigName: false, selectedToml: 'shopify.app.foo.toml'})
+
+      // When
+      await link(options)
+
+      expect(selectConfigName).not.toHaveBeenCalled()
+      expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.foo.toml', directory: tmp})
+    })
+  })
+
+  test('generates the file when there is no shopify.app.toml', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      vi.mocked(loadApp).mockRejectedValue(new Error('Shopify.app.toml not found'))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
+
+      // When
+      await link(options)
+
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "12345"
+name = "app1"
+application_url = "https://example.com"
+embedded = true
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+use_legacy_install_flow = true
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[webhooks]
+api_version = "2023-07"
+
+[pos]
+embedded = false
+`
+      expect(content).toEqual(expectedContent)
+    })
+  })
+
+  test('uses scopes on platform if defined', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
+      const remoteConfiguration = {
+        ...DEFAULT_REMOTE_CONFIGURATION,
+        access_scopes: {scopes: 'read_products,write_orders'},
+      }
+      vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
+
+      // When
+      await link(options)
+
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "app1"
@@ -531,117 +544,58 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-        expect(content).toEqual(expectedContent)
-      })
+      expect(content).toEqual(expectedContent)
     })
+  })
 
-    test('unset privacy compliance urls are undefined', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        vi.mocked(loadApp).mockRejectedValue('App not found')
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({
-          ...mockRemoteApp(),
-          gdprWebhooks: {customerDataRequestUrl: 'https://example.com/customer-data'},
-        })
-
-        // When
-        await link(options)
-
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
-
-client_id = "12345"
-name = "app1"
-application_url = "https://example.com"
-embedded = true
-
-[access_scopes]
-# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-use_legacy_install_flow = true
-
-[auth]
-redirect_urls = [ "https://example.com/callback1" ]
-
-[webhooks]
-api_version = "2023-07"
-
-  [webhooks.privacy_compliance]
-  customer_data_request_url = "https://example.com/customer-data"
-
-[pos]
-embedded = false
-`
-        expect(content).toEqual(expectedContent)
-        expect(saveCurrentConfig).toHaveBeenCalledWith({configFileName: 'shopify.app.toml', directory: tmp})
-        expect(renderSuccess).toHaveBeenCalledWith({
-          headline: 'shopify.app.toml is now linked to "app1" on Shopify',
-          body: 'Using shopify.app.toml as your default config.',
-          nextSteps: [
-            [`Make updates to shopify.app.toml in your local project`],
-            ['To upload your config, run', {command: 'npm run shopify app deploy'}],
-          ],
-          reference: [
-            {
-              link: {
-                label: 'App configuration',
-                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
-              },
-            },
-          ],
-        })
-      })
-    })
-
-    test('the api client configuration is deep merged with the remote app_config extension registrations', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        const localApp = {
-          configuration: {
-            path: 'shopify.app.development.toml',
-            name: 'my app',
-            client_id: '12345',
-            scopes: 'write_products',
-            webhooks: {
-              api_version: '2023-04',
-            },
-            application_url: 'https://myapp.com',
-            embedded: true,
-            pos: {
-              embedded: false,
-            },
-          } as CurrentAppConfiguration,
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
-          testOrganizationApp({
-            apiKey: '12345',
-            applicationUrl: 'https://myapp.com',
-            title: 'my app',
-            requestedAccessScopes: ['write_products'],
-          }),
-        )
-        vi.mocked(selectConfigName).mockResolvedValue('staging')
-        const remoteConfiguration = {
-          pos: {embedded: true},
+  test('the api client configuration is deep merged with the remote app_config extension registrations', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      const localApp = {
+        configuration: {
+          path: 'shopify.app.development.toml',
+          name: 'my app',
+          client_id: '12345',
+          scopes: 'write_products',
           webhooks: {
-            subscriptions: [{topics: ['products/create'], uri: 'https://my-app.com/webhooks'}],
+            api_version: '2023-04',
           },
-        }
-        vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
+          application_url: 'https://myapp.com',
+          embedded: true,
+          pos: {
+            embedded: false,
+          },
+        } as CurrentAppConfiguration,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, localApp))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
+        testOrganizationApp({
+          apiKey: '12345',
+        }),
+      )
+      vi.mocked(selectConfigName).mockResolvedValue('staging')
+      const remoteConfiguration = {
+        ...DEFAULT_REMOTE_CONFIGURATION,
+        name: 'my app',
+        application_url: 'https://myapp.com',
+        access_scopes: {scopes: 'write_products'},
+        pos: {embedded: true},
+        webhooks: {
+          api_version: '2023-07',
+          subscriptions: [{topics: ['products/create'], uri: 'https://my-app.com/webhooks'}],
+        },
+      }
+      vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
 
-        // When
-        await link(options)
+      // When
+      await link(options)
 
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "my app"
@@ -665,45 +619,45 @@ api_version = "2023-07"
 [pos]
 embedded = true
 `
-        expect(content).toEqual(expectedContent)
-        expect(renderSuccess).toHaveBeenCalledWith({
-          headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
-          body: 'Using shopify.app.staging.toml as your default config.',
-          nextSteps: [
-            [`Make updates to shopify.app.staging.toml in your local project`],
-            ['To upload your config, run', {command: 'yarn shopify app deploy'}],
-          ],
-          reference: [
-            {
-              link: {
-                label: 'App configuration',
-                url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
-              },
+      expect(content).toEqual(expectedContent)
+      expect(renderSuccess).toHaveBeenCalledWith({
+        headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
+        body: 'Using shopify.app.staging.toml as your default config.',
+        nextSteps: [
+          [`Make updates to shopify.app.staging.toml in your local project`],
+          ['To upload your config, run', {command: 'yarn shopify app deploy'}],
+        ],
+        reference: [
+          {
+            link: {
+              label: 'App configuration',
+              url: 'https://shopify.dev/docs/apps/tools/cli/configuration',
             },
-          ],
-        })
+          },
+        ],
       })
     })
+  })
 
-    test('when local app doesnt include build section and the remote app is new then include include_config_on_deploy is added', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const filePath = joinPath(tmp, 'shopify.app.toml')
-        const initialContent = `scopes = ""
+  test('when local app doesnt include build section and the remote app is new then include include_config_on_deploy is added', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const filePath = joinPath(tmp, 'shopify.app.toml')
+      const initialContent = `scopes = ""
     `
-        writeFileSync(filePath, initialContent)
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
+      writeFileSync(filePath, initialContent)
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
 
-        // When
-        await link(options)
+      // When
+      await link(options)
 
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "app1"
@@ -726,31 +680,32 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-        expect(content).toEqual(expectedContent)
-      })
+      expect(content).toEqual(expectedContent)
     })
+  })
 
-    test('replace arrays content with the remote one', async () => {
-      await inTemporaryDirectory(async (tmp) => {
-        // Given
-        const options: LinkOptions = {
-          directory: tmp,
-        }
-        vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-        vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
-        const remoteConfiguration = {
-          auth: {
-            redirect_urls: ['https://example.com/remote'],
-          },
-        }
-        vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
+  test('replace arrays content with the remote one', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
+      const remoteConfiguration = {
+        ...DEFAULT_REMOTE_CONFIGURATION,
+        auth: {
+          redirect_urls: ['https://example.com/remote'],
+        },
+      }
+      vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
 
-        // When
-        await link(options)
+      // When
+      await link(options)
 
-        // Then
-        const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
-        const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
 name = "app1"
@@ -770,8 +725,7 @@ api_version = "2023-07"
 [pos]
 embedded = false
 `
-        expect(content).toEqual(expectedContent)
-      })
+      expect(content).toEqual(expectedContent)
     })
   })
 })

--- a/packages/app/src/cli/services/app/select-app.test.ts
+++ b/packages/app/src/cli/services/app/select-app.test.ts
@@ -10,7 +10,7 @@ const webhooksActiveAppModule: AppModuleVersion = {
   registrationId: 'C_A',
   registrationUuid: 'UUID_C_A',
   registrationTitle: 'Registration title',
-  type: 'webhooks',
+  type: 'Module:Webhooks',
   config: JSON.stringify({api_version: '2023-04'}),
   specification: {
     identifier: 'webhooks',
@@ -25,7 +25,7 @@ const homeActiveAppModule: AppModuleVersion = {
   registrationId: 'C_B',
   registrationUuid: 'UUID_C_B',
   registrationTitle: 'Registration title',
-  type: 'app_home',
+  type: 'Module:AppHome',
   config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
   specification: {
     identifier: 'app_home',
@@ -40,7 +40,7 @@ const brandingActiveAppModule: AppModuleVersion = {
   registrationId: 'C_C',
   registrationUuid: 'UUID_C_C',
   registrationTitle: 'Registration title',
-  type: 'branding',
+  type: 'Module:Branding',
   config: JSON.stringify({name: 'name'}),
   specification: {
     identifier: 'branding',
@@ -83,7 +83,7 @@ describe('fetchAppRemoteConfiguration', () => {
       registrationId: 'C_B',
       registrationUuid: 'UUID_C_B',
       registrationTitle: 'Registration title',
-      type: 'privacy_compliance_webhooks',
+      type: 'Module:Privacy',
       config: JSON.stringify({
         customers_redact_url: 'https://myapp.com/redact',
         customers_data_request_url: 'https://myapp.com/data_request',

--- a/packages/app/src/cli/services/app/select-app.test.ts
+++ b/packages/app/src/cli/services/app/select-app.test.ts
@@ -6,30 +6,62 @@ import {describe, expect, test, vi} from 'vitest'
 
 vi.mock('../dev/fetch.js')
 
+const webhooksActiveAppModule: AppModuleVersion = {
+  registrationId: 'C_A',
+  registrationUuid: 'UUID_C_A',
+  registrationTitle: 'Registration title',
+  type: 'webhooks',
+  config: JSON.stringify({api_version: '2023-04'}),
+  specification: {
+    identifier: 'webhooks',
+    name: 'webhooks',
+    experience: 'configuration',
+    options: {
+      managementExperience: 'cli',
+    },
+  },
+}
+const homeActiveAppModule: AppModuleVersion = {
+  registrationId: 'C_B',
+  registrationUuid: 'UUID_C_B',
+  registrationTitle: 'Registration title',
+  type: 'app_home',
+  config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
+  specification: {
+    identifier: 'app_home',
+    name: 'App Home',
+    experience: 'configuration',
+    options: {
+      managementExperience: 'cli',
+    },
+  },
+}
+const brandingActiveAppModule: AppModuleVersion = {
+  registrationId: 'C_C',
+  registrationUuid: 'UUID_C_C',
+  registrationTitle: 'Registration title',
+  type: 'branding',
+  config: JSON.stringify({name: 'name'}),
+  specification: {
+    identifier: 'branding',
+    name: 'Branding',
+    experience: 'configuration',
+    options: {
+      managementExperience: 'cli',
+    },
+  },
+}
+const activeVersion = {
+  app: {
+    activeAppVersion: {
+      appModuleVersions: [webhooksActiveAppModule, homeActiveAppModule, brandingActiveAppModule],
+    },
+  },
+}
+
 describe('fetchAppRemoteConfiguration', () => {
   test('when configuration modules are present the remote configuration is returned ', async () => {
-    const configActiveAppModule: AppModuleVersion = {
-      registrationId: 'C_A',
-      registrationUuid: 'UUID_C_A',
-      registrationTitle: 'Registration title',
-      type: 'app_home',
-      config: JSON.stringify({app_url: 'https://myapp.com', embedded: true}),
-      specification: {
-        identifier: 'app_home',
-        name: 'App Ui',
-        experience: 'configuration',
-        options: {
-          managementExperience: 'cli',
-        },
-      },
-    }
-    const activeVersion = {
-      app: {
-        activeAppVersion: {
-          appModuleVersions: [configActiveAppModule],
-        },
-      },
-    }
+    // Given
     vi.mocked(fetchActiveAppVersion).mockResolvedValue(activeVersion)
 
     // When
@@ -37,58 +69,16 @@ describe('fetchAppRemoteConfiguration', () => {
 
     // Then
     expect(result).toEqual({
+      name: 'name',
       application_url: 'https://myapp.com',
       embedded: true,
+      webhooks: {
+        api_version: '2023-04',
+      },
     })
   })
 
-  test('when no configuration modules are present the remote configuration is returned empty', async () => {
-    const checkoutModule: AppModuleVersion = {
-      registrationId: 'A',
-      registrationUuid: 'UUID_A',
-      registrationTitle: 'Checkout post purchase',
-      type: 'post_purchase_ui_extension',
-      specification: {
-        identifier: 'post_purchase_ui_extension',
-        name: 'Post purchase UI extension',
-        experience: 'extension',
-        options: {
-          managementExperience: 'cli',
-        },
-      },
-    }
-    const activeVersion = {
-      app: {
-        activeAppVersion: {
-          appModuleVersions: [checkoutModule],
-        },
-      },
-    }
-    vi.mocked(fetchActiveAppVersion).mockResolvedValue(activeVersion)
-
-    // When
-    const result = await fetchAppRemoteConfiguration('token', 'apiKey', await configurationSpecifications())
-
-    // Then
-    expect(result).toEqual({})
-  })
-
   test('when two configuration modules are under the same section the remote configuration is returned deep merged', async () => {
-    const webhooksActiveAppModule: AppModuleVersion = {
-      registrationId: 'C_A',
-      registrationUuid: 'UUID_C_A',
-      registrationTitle: 'Registration title',
-      type: 'webhooks',
-      config: JSON.stringify({api_version: '2023-04'}),
-      specification: {
-        identifier: 'webhooks',
-        name: 'webhooks',
-        experience: 'configuration',
-        options: {
-          managementExperience: 'cli',
-        },
-      },
-    }
     const complianceActiveAppModule: AppModuleVersion = {
       registrationId: 'C_B',
       registrationUuid: 'UUID_C_B',
@@ -108,13 +98,7 @@ describe('fetchAppRemoteConfiguration', () => {
         },
       },
     }
-    const activeVersion = {
-      app: {
-        activeAppVersion: {
-          appModuleVersions: [webhooksActiveAppModule, complianceActiveAppModule],
-        },
-      },
-    }
+    activeVersion.app.activeAppVersion.appModuleVersions.push(complianceActiveAppModule)
     vi.mocked(fetchActiveAppVersion).mockResolvedValue(activeVersion)
 
     // When
@@ -122,6 +106,9 @@ describe('fetchAppRemoteConfiguration', () => {
 
     // Then
     expect(result).toEqual({
+      name: 'name',
+      application_url: 'https://myapp.com',
+      embedded: true,
       webhooks: {
         api_version: '2023-04',
         privacy_compliance: {

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -28,9 +28,8 @@ export async function fetchAppRemoteConfiguration(
     activeAppVersion.app.activeAppVersion?.appModuleVersions.filter(
       (module) => module.specification?.experience === 'configuration',
     ) || []
-  return buildSpecsAppConfiguration(
-    remoteAppConfigurationExtensionContent(appModuleVersionsConfig, specifications),
-  ) as SpecsAppConfiguration
+  const remoteAppConfiguration = remoteAppConfigurationExtensionContent(appModuleVersionsConfig, specifications)
+  return buildSpecsAppConfiguration(remoteAppConfiguration) as SpecsAppConfiguration
 }
 
 export function remoteAppConfigurationExtensionContent(
@@ -40,7 +39,9 @@ export function remoteAppConfigurationExtensionContent(
   let remoteAppConfig: {[key: string]: unknown} = {}
   const configSpecifications = specifications.filter((spec) => spec.experience === 'configuration')
   configRegistrations.forEach((module) => {
-    const configSpec = configSpecifications.find((spec) => spec.identifier === module.type.toLowerCase())
+    const configSpec = configSpecifications.find(
+      (spec) => spec.identifier === module.specification?.identifier.toLowerCase(),
+    )
     if (!configSpec) return
     const configString = module.config
     if (!configString) return

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -4,6 +4,8 @@ import {fetchPartnersSession} from '../context/partner-account-info.js'
 import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps, fetchActiveAppVersion} from '../dev/fetch.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {AppModuleVersion} from '../../api/graphql/app_active_version.js'
+import {buildSpecsAppConfiguration} from '../../models/app/app.js'
+import {SpecsAppConfiguration} from '../../models/extensions/specifications/types/app_config.js'
 import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 
 export async function selectApp(): Promise<OrganizationApp> {
@@ -26,7 +28,9 @@ export async function fetchAppRemoteConfiguration(
     activeAppVersion.app.activeAppVersion?.appModuleVersions.filter(
       (module) => module.specification?.experience === 'configuration',
     ) || []
-  return remoteAppConfigurationExtensionContent(appModuleVersionsConfig, specifications)
+  return buildSpecsAppConfiguration(
+    remoteAppConfigurationExtensionContent(appModuleVersionsConfig, specifications),
+  ) as SpecsAppConfiguration
 }
 
 export function remoteAppConfigurationExtensionContent(


### PR DESCRIPTION
### WHY are these changes introduced?
Versioned app configuration has been 100% rolled out altogether with the 3.55.0 release. That means that the CLI should not use `api client configuration` anymore

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- `link` command is not merging the remote API Client configuration
- Removed unused `API Client configuration` from the `app` API requests

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- `link` command should work as expected
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
