### PR TITLE
Fix remove path from extension config

### DIFF
--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -99,7 +99,8 @@ export async function parseConfigurationFile<TSchema extends zod.ZodType>(
 
   if (!configurationObject) return fallbackOutput
 
-  return parseConfigurationObject(schema, filepath, configurationObject, abortOrReport)
+  const configuration = await parseConfigurationObject(schema, filepath, configurationObject, abortOrReport)
+  return {...configuration, path: filepath}
 }
 
 export async function parseConfigurationObject<TSchema extends zod.ZodType>(
@@ -107,7 +108,7 @@ export async function parseConfigurationObject<TSchema extends zod.ZodType>(
   filepath: string,
   configurationObject: unknown,
   abortOrReport: AbortOrReport,
-): Promise<zod.TypeOf<TSchema> & {path: string}> {
+): Promise<zod.TypeOf<TSchema>> {
   const fallbackOutput = {} as zod.TypeOf<TSchema>
 
   const parseResult = schema.safeParse(configurationObject)
@@ -120,7 +121,7 @@ export async function parseConfigurationObject<TSchema extends zod.ZodType>(
       parseResult.error.issues,
     )
   }
-  return {...parseResult.data, path: filepath}
+  return parseResult.data
 }
 
 export function findSpecificationForType(specifications: ExtensionSpecification[], type: string) {
@@ -434,8 +435,7 @@ class AppLoader {
           this.abortOrReport.bind(this),
         )
 
-        const {path, ...specConfigurationWithoutPath} = specConfiguration
-        if (Object.keys(specConfigurationWithoutPath).length === 0) return
+        if (Object.keys(specConfiguration).length === 0) return
 
         return this.createExtensionInstance(
           specification.identifier,


### PR DESCRIPTION
### WHY are these changes introduced?
An error is returned when you run the `deploy` command including the `point-of-interest` configuration

<img src="https://github.com/Shopify/cli/assets/105213827/b61f2529-97c6-4f6a-a3e1-71ce2c1a391a" width=400/>

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Parsing the configuration extensions modules doesn't include the `path`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Add this configuration to your `toml` file 
```
[pos]
embedded = false
````
- Run the `deploy` command and it should finish successfully
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
