### PR TITLE
Leave out web info when there is no web

### DIFF
--- a/.changeset/strong-glasses-thank.md
+++ b/.changeset/strong-glasses-thank.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Omit web info for extension-only apps

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -128,7 +128,8 @@ class AppInfo {
   async appComponentsSection(): Promise<[string, string]> {
     const title = 'Directory Components'
 
-    let body = this.webComponentsSection()
+    const webComponentsSection = this.webComponentsSection()
+    const body = webComponentsSection ? [webComponentsSection] : []
 
     function augmentWithExtensions<TExtension extends Configurable>(
       extensions: TExtension[],
@@ -138,10 +139,11 @@ class AppInfo {
       types.forEach((extensionType: string) => {
         const relevantExtensions = extensions.filter((extension: TExtension) => extension.type === extensionType)
         if (relevantExtensions[0]) {
-          body += `\n\n${outputContent`${outputToken.subheading(relevantExtensions[0].externalType)}`.value}`
+          let section = `${outputContent`${outputToken.subheading(relevantExtensions[0].externalType)}`.value}`
           relevantExtensions.forEach((extension: TExtension) => {
-            body += `${outputFormatter(extension)}`
+            section += `${outputFormatter(extension)}`
           })
+          body.push(section)
         }
       })
     }
@@ -150,15 +152,19 @@ class AppInfo {
     augmentWithExtensions(supportedExtensions, this.extensionSubSection.bind(this))
 
     if (this.app.errors?.isEmpty() === false) {
-      body += `\n\n${outputContent`${outputToken.subheading('Extensions with errors')}`.value}`
+      let section = `${outputContent`${outputToken.subheading('Extensions with errors')}`.value}`
       supportedExtensions.forEach((extension) => {
-        body += `${this.invalidExtensionSubSection(extension)}`
+        section += `${this.invalidExtensionSubSection(extension)}`
       })
     }
-    return [title, body]
+    return [title, body.join('\n\n')]
   }
 
   webComponentsSection(): string {
+    if (!this.app.webs[0]) {
+      return ''
+    }
+
     const errors: OutputMessage[] = []
     const subtitle = [outputContent`${outputToken.subheading('web')}`.value]
     const toplevel = ['📂 web', '']


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

It used to be we could always assume there's a web. That's not true anymore.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Don't show a web if there is none.

Before:

<img width="897" alt="Screenshot 2024-02-11 at 23 28 06" src="https://github.com/Shopify/cli/assets/6288426/88ca0cc5-40e9-4afc-ae19-b98b2f7eb7cf">

After:

<img width="893" alt="Screenshot 2024-02-11 at 23 27 28" src="https://github.com/Shopify/cli/assets/6288426/489ef1a2-7f04-4b79-8dce-acd5b91b4d3a">

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run `app info` on an extension-only app. It should correctly omit `web` and spacing should look normal.

It should also still work normally on an app with a home.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
