### PR TITLE
Align command token with UI kit

### DIFF
--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -45,7 +45,7 @@ describe('info', () => {
       // When
       const result = stringifyMessage(await info(app, infoOptions))
       // Then
-      expect(unstyled(result)).toMatch('Shopify CLI       2.2.2 💡 Version 2.2.3 available! Run yarn shopify upgrade')
+      expect(unstyled(result)).toMatch('Shopify CLI       2.2.2 💡 Version 2.2.3 available! Run `yarn shopify upgrade`')
     })
   })
 

--- a/packages/cli-kit/src/private/node/content-tokens.ts
+++ b/packages/cli-kit/src/private/node/content-tokens.ts
@@ -38,7 +38,7 @@ export class LinkContentToken extends ContentToken<OutputMessage> {
 
 export class CommandContentToken extends ContentToken<OutputMessage> {
   output(): string {
-    return colors.bold(colors.yellow(stringifyMessage(this.value)))
+    return `\`${colors.magentaBright(stringifyMessage(this.value))}\``
   }
 }
 

--- a/packages/cli/src/cli/services/commands/version.test.ts
+++ b/packages/cli/src/cli/services/commands/version.test.ts
@@ -23,7 +23,7 @@ describe('check CLI version', () => {
     // Then
     expect(outputMock.info()).toMatchInlineSnapshot(`
         "Current Shopify CLI version: 2.2.2
-        💡 Version 3.0.10 available! Run yarn shopify upgrade"
+        💡 Version 3.0.10 available! Run \`yarn shopify upgrade\`"
       `)
   })
 
@@ -39,7 +39,7 @@ describe('check CLI version', () => {
     // Then
     expect(outputMock.info()).toMatchInlineSnapshot(`
         "Current Shopify CLI version: 2.2.2
-        💡 Version 3.0.10 available! Run pnpm shopify upgrade"
+        💡 Version 3.0.10 available! Run \`pnpm shopify upgrade\`"
       `)
   })
 
@@ -55,7 +55,7 @@ describe('check CLI version', () => {
     // Then
     expect(outputMock.info()).toMatchInlineSnapshot(`
         "Current Shopify CLI version: 2.2.2
-        💡 Version 3.0.10 available! Run npm run shopify upgrade"
+        💡 Version 3.0.10 available! Run \`npm run shopify upgrade\`"
       `)
   })
 

--- a/packages/cli/src/cli/services/upgrade.test.ts
+++ b/packages/cli/src/cli/services/upgrade.test.ts
@@ -60,7 +60,7 @@ describe('upgrade global CLI', () => {
         {stdio: 'inherit'},
       )
       expect(outputMock.info()).toMatchInlineSnapshot(`
-        "Upgrading CLI from ${oldCliVersion} to ${currentCliVersion}...\nAttempting to upgrade via npm install -g @shopify/cli@latest @shopify/theme@latest..."
+        "Upgrading CLI from ${oldCliVersion} to ${currentCliVersion}...\nAttempting to upgrade via \`npm install -g @shopify/cli@latest @shopify/theme@latest\`..."
       `)
       expect(outputMock.success()).toMatchInlineSnapshot(`
         "Upgraded Shopify CLI to version ${currentCliVersion}"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The command tokens look different depending on whether we're using the output system vs. `cli-kit` UI kit. They should be aligned.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Changes the `output` system to align with UI kit, using `magentaBright` color and backticks.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`shopify version` should use the correct coloring for the upgrade command.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
