### PR TITLE
[Feature] Pass input through liquid renderer before parsing as TOML

### DIFF
--- a/packages/cli-kit/src/public/node/toml.ts
+++ b/packages/cli-kit/src/public/node/toml.ts
@@ -1,17 +1,33 @@
 import {JsonMap} from '../../private/common/json.js'
 import * as toml from '@iarna/toml'
+import {Liquid} from 'liquidjs';
+import {readAndParseDotEnv } from './dot-env.js'
+import {fileExists} from './fs.js'
+import {joinPath, cwd} from './path.js'
 
 export type JsonMapType = JsonMap
 
 /**
  * Given a TOML string, it returns a JSON object.
+ * Before parsing as TOML the string is passed through a
+ * Liquid renderer with access to environment variables.
  *
  * @param input - TOML string.
  * @returns JSON object.
  */
-export function decodeToml(input: string): object {
+export async function decodeToml(input: string): object {
+  const engine = new Liquid()
   const normalizedInput = input.replace(/\r\n$/g, '\n')
-  return toml.parse(normalizedInput)
+
+  let envData = process.env;
+  const envFile = joinPath(cwd(), '.env');
+  if (await fileExists(envFile)) {
+    const dotenv = await readAndParseDotEnv(envFile);
+    envData = { ...envData, ...dotenv.variables };
+  }
+
+  const renderedInput = await engine.render(engine.parse(normalizedInput), { env: envData });
+  return toml.parse(renderedInput);
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

There is currently no way to template toml file if you want to supply some of the values via environment variables. I believe the recommended approach to handling multiple environments is to have multiple named configuration files. While this works, I still think it is risky to include the working production config in a repo and would rather supply the production key at deploy time in an isolated environment.

### WHAT is this pull request doing?

Since this project already uses Liquid I opted to use that as the templating language that can be used within the toml files. This PR passes all toml files through a Liquid renderer providing the environment variables as data to the rendered before parsing the toml file.

### How to test your changes?

I have not yet added tests to this PR, but I can if this is a feature the team is willing to accept. To test this you can use this PR and run any command that reads a toml file and verify the resulting rendered config is used.

Given shopify.app.toml:
``` toml
client_id = "{{ env.SHOPIFY_APP_API_KEY }}"
name = "{{ env.SHOPIFY_APP_NAME }}"
# the rest of the file
```

``` bash
SHOPIFY_APP_API_KEY=key SHOPIFY_APP_NAME=test npm run deploy
```

I also set this up using https://github.com/ds300/patch-package so you could use that along with [this patch file](https://gist.github.com/jduff/a88fc49b76c42cfc2332ad1f6468ee62) to test these changes locally by adding it to your `patches` folder.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
