### PR TITLE
Run dev for 1p apps against production services

### DIFF
--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -9,7 +9,6 @@ import {
 import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {sleep} from '@shopify/cli-kit/node/system'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
-import {isSpinEnvironment} from '@shopify/cli-kit/node/context/spin'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {firstPartyDev} from '@shopify/cli-kit/node/context/local'
 import {AbortError, BugError, CancelExecution} from '@shopify/cli-kit/node/error'
@@ -107,7 +106,7 @@ export async function convertToTestStoreIfNeeded(
   /**
    * Is not possible to convert stores to dev ones in spin environmets. Should be created directly as development.
    */
-  if (isSpinEnvironment() && firstPartyDev()) return
+  if (firstPartyDev()) return
   if (!store.transferDisabled && !store.convertableToPartnerTest) {
     throw new AbortError(
       `The store you specified (${store.shopDomain}) is not a dev store`,

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -104,7 +104,9 @@ export async function convertToTestStoreIfNeeded(
   token: string,
 ): Promise<void> {
   /**
-   * Is not possible to convert stores to dev ones in spin environmets. Should be created directly as development.
+   * It's not possible to convert stores to dev ones in spin environments. Should be created directly as development.
+   * Against production (!isSpinEnvironment()), this allows you to reference other shops in a TOML file even if some of
+   * the dev experience isn't completely supported.
    */
   if (firstPartyDev()) return
   if (!store.transferDisabled && !store.convertableToPartnerTest) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Right now it's not possible to run the `dev` command for `1p apps` using the env variable `SHOPIFY_CLI_1P_DEV`

In that case the server is returning the following error is returned

```
─ error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│  The Partners GraphQL API responded unsuccessfully with errors:                                                                                                                           │
│                                                                                                                                                                                           │
│  [                                                                                                                                                                                        │
│    {                                                                                                                                                                                      │
│      "message": "Invalid input",                                                                                                                                                          │
│      "extensions": {                                                                                                                                                                      │
│        "code": "400"                                                                                                                                                                      │
│      }                                                                                                                                                                                    │
│    }                                                                                                                                                                                      │
│  ]                                                                                                                                                                                        │
│                                                                                                                                                                                           │
│  Request ID: 23f1f6dc-7a0e-40ac-b41f-5489facad302                                                                                                                                         │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│  To investigate the issue, examine this stack trace:                                                                                                                                      │
│    at makeRequest (@shopify/cli-kit/node_modules/graphql-request/src/index.ts:441)             
```

When you run the `dev` command using `SHOPIFY_CLI_1P_DEV` you will be logged in the selected store as an `employee` (using your own Shopify account). This `employee` user (or the access token granted for it) has lots of restrictions when interacting with the store. In this specific case, it's not possible to run the CLI mutation `convertDevToTestStore` which is simply checking that the `store` is ready to be used for deving

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Remove this `dev store` check for `1p devs`. A [PR](https://github.com/Shopify/vault-pages/pull/5810) ha been created to add specific documentation in `Vault` for running `dev` as `1P developers`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Follow the steps from the PR to create a new dev setup inside `Shopify` and run the `dev` command

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
