### PR TITLE
Bump Shopify/theme-tools packages

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -48,7 +48,7 @@
     "@shopify/plugin-cloudflare": "3.56.0",
     "@shopify/polaris": "12.10.0",
     "@shopify/polaris-icons": "8.0.0",
-    "@shopify/theme-check-node": "2.0.2",
+    "@shopify/theme-check-node": "2.0.3",
     "abort-controller": "3.0.0",
     "body-parser": "1.20.2",
     "chokidar": "3.5.3",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -48,7 +48,7 @@
     "@shopify/plugin-cloudflare": "3.56.0",
     "@shopify/polaris": "12.10.0",
     "@shopify/polaris-icons": "8.0.0",
-    "@shopify/theme-check-node": "2.0.1",
+    "@shopify/theme-check-node": "2.0.2",
     "abort-controller": "3.0.0",
     "body-parser": "1.20.2",
     "chokidar": "3.5.3",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -35,8 +35,8 @@
   "dependencies": {
     "@oclif/core": "3.15.1",
     "@shopify/cli-kit": "3.56.0",
-    "@shopify/theme-check-node": "2.0.2",
-    "@shopify/theme-language-server-node": "1.7.5",
+    "@shopify/theme-check-node": "2.0.3",
+    "@shopify/theme-language-server-node": "1.7.6",
     "yaml": "2.3.2"
   },
   "devDependencies": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -35,8 +35,8 @@
   "dependencies": {
     "@oclif/core": "3.15.1",
     "@shopify/cli-kit": "3.56.0",
-    "@shopify/theme-check-node": "2.0.1",
-    "@shopify/theme-language-server-node": "1.7.4",
+    "@shopify/theme-check-node": "2.0.2",
+    "@shopify/theme-language-server-node": "1.7.5",
     "yaml": "2.3.2"
   },
   "devDependencies": {

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -86,8 +86,10 @@ export default class Check extends ThemeCommand {
     const {flags} = await this.parse(Check)
 
     // Its not clear to typescript that path will always be defined
-
     const path = flags.path
+    // To support backwards compatibility for legacy configs
+    const isLegacyConfig = flags.config?.startsWith(':') && LegacyIdentifiers.has(flags.config.slice(1))
+    const config = isLegacyConfig ? LegacyIdentifiers.get(flags.config!.slice(1)) : flags.config
 
     if (flags.init) {
       await initConfig(path)
@@ -114,22 +116,19 @@ export default class Check extends ThemeCommand {
     }
 
     if (flags.print) {
-      await outputActiveConfig(flags.config, path)
+      await outputActiveConfig(path, config)
 
       // --print should not trigger full theme check operation
       return
     }
 
     if (flags.list) {
-      await outputActiveChecks(flags.config, path)
+      await outputActiveChecks(path, config)
 
       // --list should not trigger full theme check operation
       return
     }
 
-    // To support backwards compatibility for legacy configs
-    const isLegacyConfig = flags.config?.startsWith(':') && LegacyIdentifiers.has(flags.config.slice(1))
-    const config = isLegacyConfig ? LegacyIdentifiers.get(flags.config!.slice(1)) : flags.config
     const {offenses, theme} = await themeCheckRun(path, config)
 
     const offensesByFile = sortOffenses(offenses)

--- a/packages/theme/src/cli/services/check.ts
+++ b/packages/theme/src/cli/services/check.ts
@@ -286,13 +286,12 @@ export async function performAutoFixes(sourceCodes: Theme, offenses: Offense[]) 
   await autofix(sourceCodes, offenses, saveToDiskFixApplicator)
 }
 
-export async function outputActiveConfig(configPath?: string, themeRoot?: string) {
+export async function outputActiveConfig(themeRoot: string, configPath?: string) {
   const {ignore, settings, root} = await loadConfig(configPath, themeRoot)
 
   const config = {
-    // loadConfig has no clear idea of where to extend the config from.
-    // We can default to recommended to be safe.
-    extends: 'theme-check:recommended',
+    // loadConfig flattens all configs, it doesn't extend anything
+    extends: [],
 
     // Depending on how the configs were merged during loadConfig, there may be
     // duplicate patterns to ignore. We can clean them before outputting.
@@ -306,7 +305,7 @@ export async function outputActiveConfig(configPath?: string, themeRoot?: string
   outputInfo(YAML.stringify(config))
 }
 
-export async function outputActiveChecks(configPath?: string, root?: string) {
+export async function outputActiveChecks(root: string, configPath?: string) {
   const {settings, ignore, checks} = await loadConfig(configPath, root)
   // Depending on how the configs were merged during loadConfig, there may be
   // duplicate patterns to ignore. We can clean them before outputting.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0
       '@shopify/theme-check-node':
-        specifier: 2.0.1
-        version: 2.0.1
+        specifier: 2.0.2
+        version: 2.0.2
       abort-controller:
         specifier: 3.0.0
         version: 3.0.0
@@ -738,11 +738,11 @@ importers:
         specifier: 3.56.0
         version: link:../cli-kit
       '@shopify/theme-check-node':
-        specifier: 2.0.1
-        version: 2.0.1
+        specifier: 2.0.2
+        version: 2.0.2
       '@shopify/theme-language-server-node':
-        specifier: 1.7.4
-        version: 1.7.4
+        specifier: 1.7.5
+        version: 1.7.5
       yaml:
         specifier: 2.3.2
         version: 2.3.2
@@ -4618,8 +4618,8 @@ packages:
     engines: {node: '>=12.14.0'}
     dev: false
 
-  /@shopify/liquid-html-parser@2.0.2:
-    resolution: {integrity: sha512-rxwdiEdwDkfolPEsHS9B4DVe2UO+qU7FDWj4GBBeFh9+f+bms/r7kvxT05BWx0znCJleFnrZMsX5G8X4jiKCbQ==}
+  /@shopify/liquid-html-parser@2.0.3:
+    resolution: {integrity: sha512-aIkZ5TJWG7/ztd1sZm5XNpBNTG3B+Q0gv3WN/QahmNQzm2wmKYSHiRLOA8JALAnOGTmH0uqOJ7jzdqoATcZSxw==}
     dependencies:
       line-column: 1.0.2
       ohm-js: 16.6.0
@@ -4720,10 +4720,10 @@ packages:
       react-reconciler: 0.26.2(react@17.0.2)
     dev: true
 
-  /@shopify/theme-check-common@2.0.1:
-    resolution: {integrity: sha512-iZeHsYayqIK3Q0EduZlehOSEO6SRwt5J84MQv7cqKNNvPNqtNNWML366MtkntJHLpzAVtcmt7TJUoIT1Vo+s0g==}
+  /@shopify/theme-check-common@2.0.2:
+    resolution: {integrity: sha512-KErBxm7b1AmSmfZx0ve/novromjlNMyvq+6e9dOMNQuGD8zMMkqouLOjft5wtAh0wE3aQbhpQ6OvetrWU+Dr6g==}
     dependencies:
-      '@shopify/liquid-html-parser': 2.0.2
+      '@shopify/liquid-html-parser': 2.0.3
       cross-fetch: 4.0.0
       json-to-ast: 2.1.0
       line-column: 1.0.2
@@ -4733,11 +4733,11 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-check-docs-updater@2.0.1:
-    resolution: {integrity: sha512-04+ZezbuUTBd0YpRPgM3Mo4Rjio6MciL17oRWYCHLhENvavo2KyS0nVyUOMpgZJlyb7jf4/JB8fp3gBYGhvmcw==}
+  /@shopify/theme-check-docs-updater@2.0.2:
+    resolution: {integrity: sha512-j6IzGZyEJz842wBf5YjPIUcfIqfINhC0aoA/go0Omp56E6a8clwH8jren1ExpKuNVeith9wJR/lV1ifMv8Xxww==}
     hasBin: true
     dependencies:
-      '@shopify/theme-check-common': 2.0.1
+      '@shopify/theme-check-common': 2.0.2
       ajv: 8.12.0
       env-paths: 2.2.1
       node-fetch: 2.7.0
@@ -4745,22 +4745,22 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-check-node@2.0.1:
-    resolution: {integrity: sha512-21OqwRRswQERbZamW/6FDEyB9dRiduS2YCwcLiAznXn7yYRZbRq3RPQuyK9iTpaFnDIBf2q6hmPldo9a33aTYg==}
+  /@shopify/theme-check-node@2.0.2:
+    resolution: {integrity: sha512-/5gfZNdCQcM5/Igu8C1ZlPzdjJLTbo3ekjsruUHo2Cv7NrO4Ptp4KUWnUzYTsjvNvzvlqFsveD5ULcX0CBFhMg==}
     dependencies:
-      '@shopify/theme-check-common': 2.0.1
-      '@shopify/theme-check-docs-updater': 2.0.1
+      '@shopify/theme-check-common': 2.0.2
+      '@shopify/theme-check-docs-updater': 2.0.2
       glob: 8.1.0
-      yaml: 2.3.4
+      yaml: 2.3.2
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@shopify/theme-language-server-common@1.7.4:
-    resolution: {integrity: sha512-t9JFxFesW92z1zAPlUVdGKfs6PHJofZo476uYTR2k4clUYEM5NlvWnC9BmfGET5tO88weQp64NAQP7DbNM+H5Q==}
+  /@shopify/theme-language-server-common@1.7.5:
+    resolution: {integrity: sha512-Z0U2jvwTe3RAgs1JAcfx0kPKVbaPgprm/R04ngHCx92l8ZMPjsCSQua6lVtU0sIrIjj8vRhInTk2ENFqKXYtjA==}
     dependencies:
-      '@shopify/liquid-html-parser': 2.0.2
-      '@shopify/theme-check-common': 2.0.1
+      '@shopify/liquid-html-parser': 2.0.3
+      '@shopify/theme-check-common': 2.0.2
       '@vscode/web-custom-data': 0.4.9
       vscode-languageserver: 8.1.0
       vscode-languageserver-textdocument: 1.0.11
@@ -4769,12 +4769,12 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-language-server-node@1.7.4:
-    resolution: {integrity: sha512-SrjvFOT+wIDXW8qBHaNdzrklZPIuVd7sr1bQRpnQ+yGUzpuGycBB/Krm3gK7LqOCHGOuSVcrvYqYfdxcIIhCcw==}
+  /@shopify/theme-language-server-node@1.7.5:
+    resolution: {integrity: sha512-IoMZk80Hhp2L9N8sQQ6uS5e9B3xa2jtKQn/erslxiOKgp1XQzndA5nGlv2weF4xYeamigolHGAj/xJCCOu87+A==}
     dependencies:
-      '@shopify/theme-check-docs-updater': 2.0.1
-      '@shopify/theme-check-node': 2.0.1
-      '@shopify/theme-language-server-common': 1.7.4
+      '@shopify/theme-check-docs-updater': 2.0.2
+      '@shopify/theme-check-node': 2.0.2
+      '@shopify/theme-language-server-common': 1.7.5
       glob: 8.1.0
       node-fetch: 2.7.0
       vscode-languageserver: 8.1.0
@@ -14577,11 +14577,6 @@ packages:
   /yaml@2.3.2:
     resolution: {integrity: sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==}
     engines: {node: '>= 14'}
-
-  /yaml@2.3.4:
-    resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
-    engines: {node: '>= 14'}
-    dev: false
 
   /yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0
       '@shopify/theme-check-node':
-        specifier: 2.0.2
-        version: 2.0.2
+        specifier: 2.0.3
+        version: 2.0.3
       abort-controller:
         specifier: 3.0.0
         version: 3.0.0
@@ -738,11 +738,11 @@ importers:
         specifier: 3.56.0
         version: link:../cli-kit
       '@shopify/theme-check-node':
-        specifier: 2.0.2
-        version: 2.0.2
+        specifier: 2.0.3
+        version: 2.0.3
       '@shopify/theme-language-server-node':
-        specifier: 1.7.5
-        version: 1.7.5
+        specifier: 1.7.6
+        version: 1.7.6
       yaml:
         specifier: 2.3.2
         version: 2.3.2
@@ -4720,8 +4720,8 @@ packages:
       react-reconciler: 0.26.2(react@17.0.2)
     dev: true
 
-  /@shopify/theme-check-common@2.0.2:
-    resolution: {integrity: sha512-KErBxm7b1AmSmfZx0ve/novromjlNMyvq+6e9dOMNQuGD8zMMkqouLOjft5wtAh0wE3aQbhpQ6OvetrWU+Dr6g==}
+  /@shopify/theme-check-common@2.0.3:
+    resolution: {integrity: sha512-QrFPC7ruUZlw6YQNRXcTwsVDIHtCis2cNJhk4v9iR+rKEWmeg3F9uTFlmoUF6A3tH7pCF/Bp0wEv0KmkTMeo1g==}
     dependencies:
       '@shopify/liquid-html-parser': 2.0.3
       cross-fetch: 4.0.0
@@ -4733,11 +4733,11 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-check-docs-updater@2.0.2:
-    resolution: {integrity: sha512-j6IzGZyEJz842wBf5YjPIUcfIqfINhC0aoA/go0Omp56E6a8clwH8jren1ExpKuNVeith9wJR/lV1ifMv8Xxww==}
+  /@shopify/theme-check-docs-updater@2.0.3:
+    resolution: {integrity: sha512-DBIxMRQdgGkh2vc2zQyuQ1wBIixiWbx/WTPYpfS4xsMqDFfrz2eVMdzQZhkkYt8O0DNvotVl1ZiidBIaZfX6SA==}
     hasBin: true
     dependencies:
-      '@shopify/theme-check-common': 2.0.2
+      '@shopify/theme-check-common': 2.0.3
       ajv: 8.12.0
       env-paths: 2.2.1
       node-fetch: 2.7.0
@@ -4745,22 +4745,22 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-check-node@2.0.2:
-    resolution: {integrity: sha512-/5gfZNdCQcM5/Igu8C1ZlPzdjJLTbo3ekjsruUHo2Cv7NrO4Ptp4KUWnUzYTsjvNvzvlqFsveD5ULcX0CBFhMg==}
+  /@shopify/theme-check-node@2.0.3:
+    resolution: {integrity: sha512-lw2ez7kMNeX3ogNOpPtqPFNkMgZXuUtxrZEuWDs90D7E8BGgEJm8UGULFH9Fi3bpjokFkUT0DWMOkxy2G4+FKw==}
     dependencies:
-      '@shopify/theme-check-common': 2.0.2
-      '@shopify/theme-check-docs-updater': 2.0.2
+      '@shopify/theme-check-common': 2.0.3
+      '@shopify/theme-check-docs-updater': 2.0.3
       glob: 8.1.0
       yaml: 2.3.2
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@shopify/theme-language-server-common@1.7.5:
-    resolution: {integrity: sha512-Z0U2jvwTe3RAgs1JAcfx0kPKVbaPgprm/R04ngHCx92l8ZMPjsCSQua6lVtU0sIrIjj8vRhInTk2ENFqKXYtjA==}
+  /@shopify/theme-language-server-common@1.7.6:
+    resolution: {integrity: sha512-6xRX2BD91Gr7+OUmKcgvyuQ45IvsQJQZJMjrsMUtCyaVKOxlvzvarON6rvBJBGeqjcWgg6eALJe+ib3auPkS8w==}
     dependencies:
       '@shopify/liquid-html-parser': 2.0.3
-      '@shopify/theme-check-common': 2.0.2
+      '@shopify/theme-check-common': 2.0.3
       '@vscode/web-custom-data': 0.4.9
       vscode-languageserver: 8.1.0
       vscode-languageserver-textdocument: 1.0.11
@@ -4769,12 +4769,12 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-language-server-node@1.7.5:
-    resolution: {integrity: sha512-IoMZk80Hhp2L9N8sQQ6uS5e9B3xa2jtKQn/erslxiOKgp1XQzndA5nGlv2weF4xYeamigolHGAj/xJCCOu87+A==}
+  /@shopify/theme-language-server-node@1.7.6:
+    resolution: {integrity: sha512-RInsxHzCvKWzvLiJ/Cbv4aM4HD/m9RMTaFomR+NSiqzluoyK0/BE9g4kcLBP+9rtdanD1If+xrDdA677KJPhfw==}
     dependencies:
-      '@shopify/theme-check-docs-updater': 2.0.2
-      '@shopify/theme-check-node': 2.0.2
-      '@shopify/theme-language-server-common': 1.7.5
+      '@shopify/theme-check-docs-updater': 2.0.3
+      '@shopify/theme-check-node': 2.0.3
+      '@shopify/theme-language-server-common': 1.7.6
       glob: 8.1.0
       node-fetch: 2.7.0
       vscode-languageserver: 8.1.0


### PR DESCRIPTION
### In this PR

- Bump Shopify/theme-tools packages
- Fixes a couple of CLI issues

### How to test your changes?

- `pnpm shopify theme check --path ../dawn` should pickup the `.theme-check.yml` file
- `pnpm shopify theme check --path ../dawn --config :theme_app_extensions --print` should not print `extends: theme-check:recommended`
- `pnpm shopify theme check --path ../dawn --print` should not print `extends: theme-check:recommended`
- `pnpm shopify theme check --path ../dawn --list` should not show stuff that shouldn't be loaded if the .theme-check.yml file has extends nothing in it

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
