### PR TITLE
Migrate fetchSpecifications to Partners adapter

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -659,6 +659,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     orgFromId: (_organizationId: string) => Promise.resolve(testOrganization()),
     appsForOrg: (_organizationId: string) => Promise.resolve({apps: [testOrganizationApp()], hasMorePages: false}),
     selectOrg: () => Promise.resolve(testOrganization()),
+    specifications: (_appId: string) => Promise.resolve([]),
     ...stubs,
   }
 }

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -1,21 +1,19 @@
 import link, {LinkOptions} from './link.js'
 import {saveCurrentConfig} from './use.js'
 import {
-  testPartnersUserSession,
   testApp,
   testOrganizationApp,
   buildVersionedAppSchema,
+  testDeveloperPlatformClient,
 } from '../../../models/app/app.test-data.js'
 import {selectConfigName} from '../../../prompts/config.js'
 import {loadApp} from '../../../models/app/loader.js'
 import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp} from '../../context.js'
-import {fetchAppDetailsFromApiKey} from '../../dev/fetch.js'
 import {getCachedCommandInfo} from '../../local-storage.js'
-import {fetchPartnersSession} from '../../context/partner-account-info.js'
 import {AppInterface, CurrentAppConfiguration} from '../../../models/app/app.js'
-import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
-import {fetchSpecifications} from '../../generate/fetch-extension-specifications.js'
 import {fetchAppRemoteConfiguration} from '../select-app.js'
+import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {OrganizationApp} from '../../../models/organization.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {fileExistsSync, inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -37,8 +35,6 @@ vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('../../context/partner-account-info.js')
 vi.mock('../../dev/fetch.js')
 vi.mock('../../context.js')
-vi.mock('../../context/partner-account-info.js')
-vi.mock('../../generate/fetch-extension-specifications.js')
 vi.mock('../select-app.js')
 
 const DEFAULT_REMOTE_CONFIGURATION = {
@@ -51,9 +47,18 @@ const DEFAULT_REMOTE_CONFIGURATION = {
   access_scopes: {use_legacy_install_flow: true},
 }
 
+const DEVELOPER_PLATFORM_CLIENT: DeveloperPlatformClient = testDeveloperPlatformClient({
+  async appFromId(clientId: string): Promise<OrganizationApp> {
+    switch (clientId) {
+      case 'api-key':
+        return testOrganizationApp()
+      default:
+        throw new Error(`Invalid Client ID`)
+    }
+  },
+})
+
 beforeEach(async () => {
-  vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-  vi.mocked(fetchSpecifications).mockResolvedValue(await loadLocalExtensionsSpecifications())
   vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(DEFAULT_REMOTE_CONFIGURATION)
 })
 
@@ -64,6 +69,7 @@ describe('link', () => {
       const options: LinkOptions = {
         directory: tmp,
         configName: 'Default value',
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -82,6 +88,7 @@ describe('link', () => {
       // Given
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockRejectedValue('App not found')
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
@@ -140,6 +147,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       const localApp = {
         configuration: {
@@ -228,6 +236,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       const localApp = {
         configuration: {
@@ -297,6 +306,7 @@ embedded = false
       writeFileSync(filePath, initialContent)
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -355,6 +365,7 @@ embedded = false
       writeFileSync(filePath, initialContent)
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -389,23 +400,23 @@ embedded = false
     })
   })
 
-  test('fetches the app directly when an api key is provided', async () => {
+  test('fetches the remote app when an api key is provided', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       const options: LinkOptions = {
         directory: tmp,
         apiKey: 'api-key',
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-      vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(mockRemoteApp())
       vi.mocked(selectConfigName).mockResolvedValue('staging')
 
       // When
       await link(options)
 
       // Then
-      expect(fetchAppDetailsFromApiKey).toHaveBeenCalledWith('api-key', 'token')
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      expect(content).toContain('name = "app1"')
     })
   })
 
@@ -419,11 +430,10 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
-        apiKey: '1234-5678',
+        apiKey: 'wrong-api-key',
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
-      vi.mocked(fetchPartnersSession).mockResolvedValue(testPartnersUserSession)
-      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValue(undefined)
       vi.mocked(selectConfigName).mockResolvedValue('staging')
 
       // When
@@ -439,6 +449,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       const localApp = {
         configuration: {
@@ -472,6 +483,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockRejectedValue(new Error('Shopify.app.toml not found'))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -510,6 +522,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -553,6 +566,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       const localApp = {
         configuration: {
@@ -648,6 +662,7 @@ embedded = true
       writeFileSync(filePath, initialContent)
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
@@ -689,6 +704,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
+        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -47,7 +47,7 @@ const DEFAULT_REMOTE_CONFIGURATION = {
   access_scopes: {use_legacy_install_flow: true},
 }
 
-const DEVELOPER_PLATFORM_CLIENT: DeveloperPlatformClient = testDeveloperPlatformClient({
+const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
   async appFromId(clientId: string): Promise<OrganizationApp> {
     switch (clientId) {
       case 'api-key':
@@ -69,7 +69,7 @@ describe('link', () => {
       const options: LinkOptions = {
         directory: tmp,
         configName: 'Default value',
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -88,7 +88,7 @@ describe('link', () => {
       // Given
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockRejectedValue('App not found')
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
@@ -147,7 +147,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       const localApp = {
         configuration: {
@@ -236,7 +236,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       const localApp = {
         configuration: {
@@ -306,7 +306,7 @@ embedded = false
       writeFileSync(filePath, initialContent)
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -365,7 +365,7 @@ embedded = false
       writeFileSync(filePath, initialContent)
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -406,7 +406,7 @@ embedded = false
       const options: LinkOptions = {
         directory: tmp,
         apiKey: 'api-key',
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(selectConfigName).mockResolvedValue('staging')
@@ -431,7 +431,7 @@ embedded = false
       const options: LinkOptions = {
         directory: tmp,
         apiKey: 'wrong-api-key',
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(selectConfigName).mockResolvedValue('staging')
@@ -449,7 +449,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       const localApp = {
         configuration: {
@@ -483,7 +483,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockRejectedValue(new Error('Shopify.app.toml not found'))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -522,7 +522,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
@@ -566,7 +566,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       const localApp = {
         configuration: {
@@ -662,7 +662,7 @@ embedded = true
       writeFileSync(filePath, initialContent)
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue({...mockRemoteApp(), newApp: true})
@@ -704,7 +704,7 @@ embedded = false
       // Given
       const options: LinkOptions = {
         directory: tmp,
-        developerPlatformClient: DEVELOPER_PLATFORM_CLIENT,
+        developerPlatformClient,
       }
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -33,7 +33,6 @@ vi.mock('../../../models/app/loader.js', async () => {
 vi.mock('../../local-storage')
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('../../context/partner-account-info.js')
-vi.mock('../../dev/fetch.js')
 vi.mock('../../context.js')
 vi.mock('../select-app.js')
 
@@ -48,12 +47,12 @@ const DEFAULT_REMOTE_CONFIGURATION = {
 }
 
 const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
-  async appFromId(clientId: string): Promise<OrganizationApp> {
+  async appFromId(clientId: string): Promise<OrganizationApp | undefined> {
     switch (clientId) {
       case 'api-key':
         return testOrganizationApp()
       default:
-        throw new Error(`Invalid Client ID`)
+        return undefined
     }
   },
 })

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -33,14 +33,9 @@ export interface LinkOptions {
 }
 
 export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<AppConfiguration> {
-  const developerPlatformClient = options.developerPlatformClient || selectDeveloperPlatformClient()
-  const {remoteApp, directory} = await selectRemoteApp(options, developerPlatformClient)
-  const {localApp, configFileName, configFilePath} = await loadLocalApp(
-    options,
-    developerPlatformClient,
-    remoteApp,
-    directory,
-  )
+  const developerPlatformClient = options.developerPlatformClient ?? selectDeveloperPlatformClient()
+  const {remoteApp, directory} = await selectRemoteApp({...options, developerPlatformClient}, developerPlatformClient)
+  const {localApp, configFileName, configFilePath} = await loadLocalApp(options, remoteApp, directory)
 
   await logMetadataForLoadedContext(remoteApp)
 
@@ -75,13 +70,8 @@ async function selectRemoteApp(options: LinkOptions, developerPlatformClient: De
   }
 }
 
-async function loadLocalApp(
-  options: LinkOptions,
-  developerPlatformClient: DeveloperPlatformClient,
-  remoteApp: OrganizationApp,
-  directory: string,
-) {
-  const specifications = await developerPlatformClient.specifications(remoteApp.apiKey)
+async function loadLocalApp(options: LinkOptions, remoteApp: OrganizationApp, directory: string) {
+  const specifications = await options.developerPlatformClient!.specifications(remoteApp.apiKey)
   const localApp = await loadAppOrEmptyApp(options, specifications, remoteApp.betas, remoteApp)
   const configFileName = await loadConfigurationFileName(remoteApp, options, localApp)
   const configFilePath = joinPath(directory, configFileName)

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -937,7 +937,7 @@ describe('ensureDeployContext', () => {
     vi.mocked(loadApp).mockResolvedValue(app)
 
     // When
-    const got = await ensureDeployContext(options(app))
+    const got = await ensureDeployContext(options(app), buildDeveloperPlatformClient())
 
     // Then
     expect(selectOrCreateApp).not.toHaveBeenCalled()
@@ -967,7 +967,7 @@ describe('ensureDeployContext', () => {
     vi.mocked(loadApp).mockResolvedValue(app)
 
     // When
-    const got = await ensureDeployContext(options(app))
+    const got = await ensureDeployContext(options(app), buildDeveloperPlatformClient())
 
     // Then
     expect(selectOrCreateApp).not.toHaveBeenCalled()
@@ -997,7 +997,7 @@ describe('ensureDeployContext', () => {
       .mockResolvedValue()
 
     // When
-    const got = await ensureDeployContext(options(app))
+    const got = await ensureDeployContext(options(app), buildDeveloperPlatformClient())
 
     // Then
     expect(selectOrCreateApp).not.toHaveBeenCalled()
@@ -1026,7 +1026,7 @@ describe('ensureDeployContext', () => {
     vi.mocked(loadApp).mockResolvedValue(app)
 
     // When
-    const got = await ensureDeployContext(options(app))
+    const got = await ensureDeployContext(options(app), buildDeveloperPlatformClient())
 
     // Then
     expect(fetchOrganizations).toHaveBeenCalledWith(testPartnersUserSession)
@@ -1057,7 +1057,9 @@ describe('ensureDeployContext', () => {
     vi.mocked(loadApp).mockResolvedValue(app)
 
     // When
-    await expect(ensureDeployContext(options(app))).rejects.toThrow(/Couldn't find the app with Client ID key1/)
+    await expect(ensureDeployContext(options(app), buildDeveloperPlatformClient())).rejects.toThrow(
+      /Couldn't find the app with Client ID key1/,
+    )
   })
 
   test('prompts the user to create or select an app if reset is true', async () => {
@@ -1083,7 +1085,7 @@ describe('ensureDeployContext', () => {
     opts.reset = true
 
     // When
-    const got = await ensureDeployContext(opts)
+    const got = await ensureDeployContext(opts, buildDeveloperPlatformClient())
 
     // Then
     expect(fetchOrganizations).toHaveBeenCalledWith(testPartnersUserSession)
@@ -1126,7 +1128,7 @@ describe('ensureDeployContext', () => {
     vi.mocked(updateAppIdentifiers).mockResolvedValue(appWithExtensions)
 
     // When
-    const got = await ensureDeployContext(options(app))
+    const got = await ensureDeployContext(options(app), buildDeveloperPlatformClient())
 
     // Then
     expect(selectOrCreateApp).not.toHaveBeenCalled()
@@ -1160,7 +1162,7 @@ describe('ensureDeployContext', () => {
     const metadataSpyOn = vi.spyOn(metadata, 'addPublicMetadata').mockImplementation(async () => {})
 
     // When
-    await ensureDeployContext(options(app))
+    await ensureDeployContext(options(app), buildDeveloperPlatformClient())
 
     // Then
     expect(metadataSpyOn).toHaveBeenNthCalledWith(2, expect.any(Function))
@@ -1209,7 +1211,7 @@ describe('ensureDeployContext', () => {
       .mockResolvedValue()
 
     // When
-    await ensureDeployContext(options(app))
+    await ensureDeployContext(options(app), buildDeveloperPlatformClient())
 
     // Then
     expect(renderConfirmationPrompt).toHaveBeenCalled()
@@ -1255,7 +1257,7 @@ describe('ensureDeployContext', () => {
     const metadataSpyOn = vi.spyOn(metadata, 'addPublicMetadata').mockImplementation(async () => {})
 
     // When
-    await ensureDeployContext(options(app))
+    await ensureDeployContext(options(app), buildDeveloperPlatformClient())
 
     // Then
     expect(metadataSpyOn).toHaveBeenNthCalledWith(2, expect.any(Function))
@@ -1305,7 +1307,7 @@ describe('ensureDeployContext', () => {
     const metadataSpyOn = vi.spyOn(metadata, 'addPublicMetadata').mockImplementation(async () => {})
 
     // When
-    await ensureDeployContext(options(app, true))
+    await ensureDeployContext(options(app, true), buildDeveloperPlatformClient())
 
     // Then
     expect(metadataSpyOn).toHaveBeenNthCalledWith(2, expect.any(Function))
@@ -1354,7 +1356,7 @@ describe('ensureDeployContext', () => {
       .mockResolvedValue()
 
     // When
-    await ensureDeployContext(options(app, false, true))
+    await ensureDeployContext(options(app, false, true), buildDeveloperPlatformClient())
 
     // Then
     expect(renderConfirmationPrompt).not.toHaveBeenCalled()
@@ -1397,7 +1399,7 @@ describe('ensureDeployContext', () => {
       .mockResolvedValue()
 
     // When
-    await ensureDeployContext(options(app, false, true))
+    await ensureDeployContext(options(app, false, true), buildDeveloperPlatformClient())
 
     // Then
     expect(renderConfirmationPrompt).not.toHaveBeenCalled()

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -929,7 +929,7 @@ api_version = "2023-04"
       vi.mocked(loadApp).mockResolvedValue(app)
 
       // When
-      const got = await ensureDevContext({...INPUT}, )
+      const got = await ensureDevContext({...INPUT}, buildDeveloperPlatformClient())
 
       // Then
       expect(link).toBeCalled()

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -48,7 +48,7 @@ interface TasksContext {
 export async function deploy(options: DeployOptions) {
   const developerPlatformClient = selectDeveloperPlatformClient()
   // eslint-disable-next-line prefer-const
-  let {app, identifiers, partnersApp, token, release} = await ensureDeployContext(options, developerPlatformClient)
+  let {app, identifiers, partnersApp, token, release} = await ensureDeployContext({...options, developerPlatformClient})
   const apiKey = identifiers.app
 
   outputNewline()

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -5,6 +5,7 @@ import {ensureDeployContext} from './context.js'
 import {bundleAndBuildExtensions} from './deploy/bundle.js'
 import {AppInterface} from '../models/app/app.js'
 import {updateAppIdentifiers} from '../models/app/identifiers.js'
+import {selectDeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {renderInfo, renderSuccess, renderTasks} from '@shopify/cli-kit/node/ui'
 import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
@@ -45,8 +46,9 @@ interface TasksContext {
 }
 
 export async function deploy(options: DeployOptions) {
+  const developerPlatformClient = selectDeveloperPlatformClient()
   // eslint-disable-next-line prefer-const
-  let {app, identifiers, partnersApp, token, release} = await ensureDeployContext(options)
+  let {app, identifiers, partnersApp, token, release} = await ensureDeployContext(options, developerPlatformClient)
   const apiKey = identifiers.app
 
   outputNewline()

--- a/packages/app/src/cli/services/generate.ts
+++ b/packages/app/src/cli/services/generate.ts
@@ -1,6 +1,5 @@
 import {fetchExtensionTemplates} from './generate/fetch-template-specifications.js'
 import {ensureGenerateContext} from './context.js'
-import {fetchSpecifications} from './generate/fetch-extension-specifications.js'
 import {selectDeveloperPlatformClient, DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {AppInterface} from '../models/app/app.js'
 import {loadApp} from '../models/app/loader.js'
@@ -42,7 +41,7 @@ async function generate(options: GenerateOptions) {
   const partnersSession = await developerPlatformClient.session()
   const token = partnersSession.token
   const apiKey = await ensureGenerateContext({...options, developerPlatformClient, partnersSession})
-  const specifications = await fetchSpecifications({token, apiKey})
+  const specifications = await developerPlatformClient.specifications(apiKey)
   const app: AppInterface = await loadApp({
     directory: options.directory,
     configName: options.configName,

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -1,6 +1,7 @@
 import {PartnersClient} from './developer-platform-client/partners-client.js'
 import {PartnersSession} from '../../cli/services/context/partner-account-info.js'
 import {MinimalOrganizationApp, Organization, OrganizationApp} from '../models/organization.js'
+import {ExtensionSpecification} from '../models/extensions/specification.js'
 
 export type Paginateable<T> = T & {
   hasMorePages: boolean
@@ -18,4 +19,5 @@ export interface DeveloperPlatformClient {
   selectOrg: () => Promise<Organization>
   orgFromId: (orgId: string) => Promise<Organization>
   appsForOrg: (orgId: string, term?: string) => Promise<Paginateable<{apps: MinimalOrganizationApp[]}>>
+  specifications: (appId: string) => Promise<ExtensionSpecification[]>
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -8,6 +8,8 @@ import {
 } from '../../../cli/services/dev/fetch.js'
 import {MinimalOrganizationApp, Organization, OrganizationApp} from '../../models/organization.js'
 import {selectOrganizationPrompt} from '../../prompts/dev.js'
+import {ExtensionSpecification} from '../../models/extensions/specification.js'
+import {fetchSpecifications} from '../../services/generate/fetch-extension-specifications.js'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
@@ -59,5 +61,9 @@ export class PartnersClient implements DeveloperPlatformClient {
       apps: result.apps.nodes,
       hasMorePages: result.apps.pageInfo.hasNextPage,
     }
+  }
+
+  async specifications(appId: string): Promise<ExtensionSpecification[]> {
+    return fetchSpecifications({token: await this.token(), apiKey: appId})
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/develop-app-management/issues/1621 and https://github.com/Shopify/develop-app-management/issues/1622

### WHAT is this pull request doing?

Replace all the `fetchSpecifications` with the DeveloperPlatformClient adapter.

### How to test your changes?

- `p shopify app dev`
- `p shopify app deploy`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
