### PR TITLE
Remove zod schemas from app info JSON format

### DIFF
--- a/.changeset/strange-drinks-move.md
+++ b/.changeset/strange-drinks-move.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Remove zod schemas from app info (JSON format)

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -45,29 +45,15 @@ export async function infoWeb(app: AppInterface, {format}: InfoOptions): Promise
 
 export async function infoApp(app: AppInterface, options: InfoOptions): Promise<OutputMessage> {
   if (options.format === 'json') {
-    function objectWithoutSchema<T extends {schema?: unknown}>(obj: T): Omit<T, 'schema'> {
-      const {schema, ...rest} = obj
-      return rest
-    }
-
-    function withPurgedSchemas<T extends {specification?: unknown}>(extensions: T[]): T[] {
-      return extensions.map((ext) => {
-        if ('specification' in ext) {
-          const specification = ext.specification!
-          const specificationWithoutSchema = objectWithoutSchema(specification)
-          return {...ext, specification: specificationWithoutSchema}
-        } else {
-          return ext
-        }
-      })
-    }
     const extensionsInfo = withPurgedSchemas(app.allExtensions.filter((ext) => ext.isReturnedAsInfo()))
     let appWithSupportedExtensions = {
       ...app,
       allExtensions: extensionsInfo,
     }
     if ('realExtensions' in appWithSupportedExtensions) {
-      appWithSupportedExtensions.realExtensions = withPurgedSchemas(appWithSupportedExtensions.realExtensions as ExtensionInstance[])
+      appWithSupportedExtensions.realExtensions = withPurgedSchemas(
+        appWithSupportedExtensions.realExtensions as ExtensionInstance[],
+      )
     }
     if ('specifications' in appWithSupportedExtensions) {
       appWithSupportedExtensions = {
@@ -76,20 +62,37 @@ export async function infoApp(app: AppInterface, options: InfoOptions): Promise<
           // We are choosing to leave appWithSupportedExtensions as close to the original as possible,
           // instead allowing this one change in the type specifically.
           //
-          // eslint-disable-next-line no-explicit-any
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           return objectWithoutSchema(spec) as any
-        })
+        }),
       }
     }
     return outputContent`${JSON.stringify(
-      Object.fromEntries(
-        Object.entries(appWithSupportedExtensions).filter(([key]) => key !== 'configSchema'),
-      )
-    , null, 2)}`
+      Object.fromEntries(Object.entries(appWithSupportedExtensions).filter(([key]) => key !== 'configSchema')),
+      null,
+      2,
+    )}`
   } else {
     const appInfo = new AppInfo(app, options)
     return appInfo.output()
   }
+}
+
+function objectWithoutSchema<T extends {schema?: unknown}>(obj: T): Omit<T, 'schema'> {
+  const {schema, ...rest} = obj
+  return rest
+}
+
+function withPurgedSchemas<T extends {specification?: {schema?: unknown}}>(extensions: T[]): T[] {
+  return extensions.map((ext) => {
+    if ('specification' in ext) {
+      const specification = ext.specification!
+      const specificationWithoutSchema = objectWithoutSchema(specification)
+      return {...ext, specification: specificationWithoutSchema}
+    } else {
+      return ext
+    }
+  })
 }
 
 const UNKNOWN_TEXT = outputContent`${outputToken.italic('unknown')}`.value


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

It's not valuable to the user, and it's 80% of output lines.

On a sample local app, we went from 2717 lines of JSON to 562.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Removes the Zod schemas from app info when you run `--json`

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Compare `npm run info --json` with and without this change.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
