### PR TITLE
Fix link refactor

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -34,8 +34,9 @@ export interface LinkOptions {
 
 export default async function link(options: LinkOptions, shouldRenderSuccess = true): Promise<AppConfiguration> {
   const developerPlatformClient = options.developerPlatformClient ?? selectDeveloperPlatformClient()
-  const {remoteApp, directory} = await selectRemoteApp({...options, developerPlatformClient}, developerPlatformClient)
-  const {localApp, configFileName, configFilePath} = await loadLocalApp(options, remoteApp, directory)
+  const updatedOptions = {...options, developerPlatformClient}
+  const {remoteApp, directory} = await selectRemoteApp(updatedOptions)
+  const {localApp, configFileName, configFilePath} = await loadLocalApp(updatedOptions, remoteApp, directory)
 
   await logMetadataForLoadedContext(remoteApp)
 
@@ -60,10 +61,10 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
   return configuration
 }
 
-async function selectRemoteApp(options: LinkOptions, developerPlatformClient: DeveloperPlatformClient) {
+async function selectRemoteApp(options: LinkOptions) {
   const localApp = await loadAppOrEmptyApp(options)
   const directory = localApp?.directory || options.directory
-  const remoteApp = await loadRemoteApp(localApp, options.apiKey, developerPlatformClient, directory)
+  const remoteApp = await loadRemoteApp(localApp, options.apiKey, options.developerPlatformClient!, directory)
   return {
     remoteApp,
     directory,


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/3456 we made a refactor, but there's an issue in the Link service, where `loadLocalApp` could be receiving an undefined `developerPlatformClient`.

Spotted by @oluwatimio 

### WHAT is this pull request doing?

Pass the initialized `developerPlatformClient` to all the functions in the Link service

### How to test your changes?

`p shopify app config link`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
