### PR TITLE
Fix `shopify theme dev` issue to avoid previewing the live theme instead of the development one

### DIFF
--- a/.changeset/fair-goats-sip.md
+++ b/.changeset/fair-goats-sip.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `shopify theme dev` issue to avoid previewing the live theme instead of the development one

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -33,7 +33,7 @@ module ShopifyCLI
             .with_theme(@theme)
             .with_syncer(@syncer)
 
-          @proxy = Proxy.new(@ctx, @theme, param_builder)
+          @proxy = Proxy.new(@ctx, @theme, param_builder, true)
         end
 
         def test_get_is_proxied_to_online_store


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/3466

### WHAT is this pull request doing?

It seems like the caching policy at SFR has changed, so we're implementing this temporary solution to clean it and mitigate the issue.

### How to test your changes?

- Delete your current development theme with `shopify-dev theme delete -t <development_theme_id>`
- Run `shopify theme dev`
- Notice that the localhost no longer loads the live theme; and the theme in localhost matches with the preview theme

**Before**
<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/a6345831-8fba-4e20-930e-a56e197d0d02">

**After**
<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/4d07954f-8433-4c6a-b0d7-9b5662558591">


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
