### PR TITLE
[3.56] Fix `shopify theme dev` issue to avoid previewing the live theme instead of the development one

### DIFF
--- a/.changeset/fair-goats-sip.md
+++ b/.changeset/fair-goats-sip.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `shopify theme dev` issue to avoid previewing the live theme instead of the development one

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -33,7 +33,7 @@ module ShopifyCLI
             .with_theme(@theme)
             .with_syncer(@syncer)
 
-          @proxy = Proxy.new(@ctx, @theme, param_builder)
+          @proxy = Proxy.new(@ctx, @theme, param_builder, true)
         end
 
         def test_get_is_proxied_to_online_store


### PR DESCRIPTION
Backport https://github.com/Shopify/cli/pull/3471
