### PR TITLE
Use native fetch instead of node-fetch

### DIFF
--- a/packages/plugin-cloudflare/package.json
+++ b/packages/plugin-cloudflare/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@oclif/core": "3.15.1",
     "@shopify/cli-kit": "3.56.0",
-    "node-fetch": "3.3.2",
     "semver": "7.5.4"
   },
   "devDependencies": {

--- a/packages/plugin-cloudflare/scripts/postinstall.js
+++ b/packages/plugin-cloudflare/scripts/postinstall.js
@@ -6,7 +6,6 @@ import {pipeline} from 'stream'
 import {execSync, execFileSync} from 'child_process'
 import {createHash} from 'node:crypto'
 import {chmodSync, existsSync, mkdirSync, renameSync, unlinkSync, createWriteStream, readFileSync} from 'fs'
-import fetch from 'node-fetch'
 import semver from 'semver'
 
 const CLOUDFLARE_VERSION = '2023.5.1'
@@ -53,6 +52,10 @@ function getBinPathTarget() {
 }
 
 export default async function install() {
+  const [major, minor, patch] = process.versions.node.split('.').map(Number)
+  // Fetch API is not available for <18. Added this check because our release process uses node 16.
+  if (major < 18) return
+
   const fileName = URL[process.platform]
   if (fileName === undefined) {
     throw new Error(`Unsupported system platform: ${process.platform} or arch: ${process.arch}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,9 +687,6 @@ importers:
       '@shopify/cli-kit':
         specifier: 3.56.0
         version: link:../cli-kit
-      node-fetch:
-        specifier: 3.3.2
-        version: 3.3.2
       semver:
         specifier: 7.5.4
         version: 7.5.4


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
From node v18 it's possible to use node's native `fetch`, so we don't need the `node-fetch` dependency anymore. (because we require node >= 18.12.0

❗ This removes `node-fetch` and 5 other transitive dependencies.

### WHAT is this pull request doing?
- Remove node-fetch from plugin-cloudflare
- Add extra validation because our shipit release process uses node 16 and it'd crash.


### How to test your changes?
- Delete the cloudflare binary from the bin folder
- run `pnpm install` and check that it is installed
- run `pnpm install` again and check that it doesn't do anything (it's already installed)


<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
