### PR TITLE
Load module specifications statically

### DIFF
--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -1,16 +1,26 @@
 import {ExtensionSpecification} from './specification.js'
-import {AppHomeSpecIdentifier} from './specifications/app_config_app_home.js'
-import {AppProxySpecIdentifier} from './specifications/app_config_app_proxy.js'
-import {PosSpecIdentifier} from './specifications/app_config_point_of_sale.js'
-import {WebhooksSpecIdentifier} from './specifications/app_config_webhook.js'
-import {BrandingSpecIdentifier} from './specifications/app_config_branding.js'
-import {AppAccessSpecIdentifier} from './specifications/app_config_app_access.js'
-import {PrivacyComplianceWebbhooksSpecIdentifier} from './specifications/app_config_privacy_compliance_webhooks.js'
-import {platformAndArch} from '@shopify/cli-kit/node/os'
-import {memoize} from '@shopify/cli-kit/common/function'
-import {joinPath, dirname} from '@shopify/cli-kit/node/path'
-import {glob} from '@shopify/cli-kit/node/fs'
-import {fileURLToPath} from 'url'
+import appHomeSpec, {AppHomeSpecIdentifier} from './specifications/app_config_app_home.js'
+import appProxySpec, {AppProxySpecIdentifier} from './specifications/app_config_app_proxy.js'
+import appPOSSpec, {PosSpecIdentifier} from './specifications/app_config_point_of_sale.js'
+import appWebhooksSpec, {WebhooksSpecIdentifier} from './specifications/app_config_webhook.js'
+import appBrandingSpec, {BrandingSpecIdentifier} from './specifications/app_config_branding.js'
+import appAccessSpec, {AppAccessSpecIdentifier} from './specifications/app_config_app_access.js'
+import appPrivacyComplienceSpec, {
+  PrivacyComplianceWebbhooksSpecIdentifier,
+} from './specifications/app_config_privacy_compliance_webhooks.js'
+import checkoutPostPurchaseSpec from './specifications/checkout_post_purchase.js'
+import checkoutSpec from './specifications/checkout_ui_extension.js'
+import flowActionSpecification from './specifications/flow_action.js'
+import flowTemplateSpec from './specifications/flow_template.js'
+import flowTriggerSpecification from './specifications/flow_trigger.js'
+import functionSpec from './specifications/function.js'
+import paymentExtensionSpec from './specifications/payments_app_extension.js'
+import posUISpec from './specifications/pos_ui_extension.js'
+import productSubscriptionSpec from './specifications/product_subscription.js'
+import taxCalculationSpec from './specifications/tax_calculation.js'
+import themeSpec from './specifications/theme.js'
+import uiExtensionSpec from './specifications/ui_extension.js'
+import webPixelSpec from './specifications/web_pixel_extension.js'
 
 const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   BrandingSpecIdentifier,
@@ -29,28 +39,34 @@ export async function loadLocalExtensionsSpecifications(): Promise<ExtensionSpec
   const sortConfigModules = (specA: ExtensionSpecification, specB: ExtensionSpecification) =>
     SORTED_CONFIGURATION_SPEC_IDENTIFIERS.indexOf(specA.identifier) -
     SORTED_CONFIGURATION_SPEC_IDENTIFIERS.indexOf(specB.identifier)
-  return (await memoizedLoadSpecs('specifications')).sort(sortConfigModules)
+  return loadSpecifications().sort(sortConfigModules)
 }
 
-const memoizedLoadSpecs = memoize(loadSpecifications)
+function loadSpecifications() {
+  const configModuleSpecs = [
+    appAccessSpec,
+    appHomeSpec,
+    appProxySpec,
+    appBrandingSpec,
+    appPOSSpec,
+    appPrivacyComplienceSpec,
+    appWebhooksSpec,
+  ]
+  const moduleSpecs = [
+    checkoutPostPurchaseSpec,
+    checkoutSpec,
+    flowActionSpecification,
+    flowTemplateSpec,
+    flowTriggerSpecification,
+    functionSpec,
+    paymentExtensionSpec,
+    posUISpec,
+    productSubscriptionSpec,
+    taxCalculationSpec,
+    themeSpec,
+    uiExtensionSpec,
+    webPixelSpec,
+  ] as ExtensionSpecification[]
 
-async function loadSpecifications(directoryName: string) {
-  /**
-   * When running tests, "await import('.../spec..ts')" is handled by Vitest which does
-   * transform the TS module into a JS one before loading it. Hence the inclusion of .ts
-   * in the list of files.
-   */
-  const url = joinPath(dirname(fileURLToPath(import.meta.url)), joinPath(directoryName, '*.{js,ts}'))
-  let files = await glob(url, {ignore: ['**.d.ts', '**.test.ts']})
-
-  // From Node 18, all windows paths must start with file://
-  const {platform} = platformAndArch()
-  if (platform === 'windows') {
-    files = files.map((file) => `file://${file}`)
-  }
-
-  const promises = files.map((file) => import(file))
-  const modules = await Promise.all(promises)
-  const specs = modules.map((module) => module.default)
-  return specs
+  return [...configModuleSpecs, ...moduleSpecs]
 }

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -37,10 +37,10 @@ const AppAccessTransformConfig: TransformationConfig = {
   redirect_url_allowlist: 'auth.redirect_urls',
 }
 
-const spec = createConfigExtensionSpecification({
+const appAccessSpec = createConfigExtensionSpecification({
   identifier: AppAccessSpecIdentifier,
   schema: AppAccessSchema,
   transformConfig: AppAccessTransformConfig,
 })
 
-export default spec
+export default appAccessSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
@@ -20,10 +20,10 @@ const AppHomeTransformConfig: TransformationConfig = {
 
 export const AppHomeSpecIdentifier = 'app_home'
 
-const spec = createConfigExtensionSpecification({
+const appHomeSpec = createConfigExtensionSpecification({
   identifier: AppHomeSpecIdentifier,
   schema: AppHomeSchema,
   transformConfig: AppHomeTransformConfig,
 })
 
-export default spec
+export default appHomeSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
@@ -14,9 +14,9 @@ const AppProxySchema = zod.object({
 
 export const AppProxySpecIdentifier = 'app_proxy'
 
-const spec: ExtensionSpecification = createConfigExtensionSpecification({
+const appProxySpec: ExtensionSpecification = createConfigExtensionSpecification({
   identifier: AppProxySpecIdentifier,
   schema: AppProxySchema,
 })
 
-export default spec
+export default appProxySpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
@@ -17,10 +17,10 @@ const BrandingTransformConfig: TransformationConfig = {
 
 export const BrandingSpecIdentifier = 'branding'
 
-const spec = createConfigExtensionSpecification({
+const appBrandingSpec = createConfigExtensionSpecification({
   identifier: BrandingSpecIdentifier,
   schema: BrandingSchema,
   transformConfig: BrandingTransformConfig,
 })
 
-export default spec
+export default appBrandingSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.ts
@@ -11,9 +11,9 @@ const PosConfigurationSchema = zod.object({
 
 export const PosSpecIdentifier = 'point_of_sale'
 
-const spec = createConfigExtensionSpecification({
+const appPOSSpec = createConfigExtensionSpecification({
   identifier: PosSpecIdentifier,
   schema: PosConfigurationSchema,
 })
 
-export default spec
+export default appPOSSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.ts
@@ -11,13 +11,13 @@ const PrivacyComplianceWebbhooksTransformConfig: CustomTransformationConfig = {
 export const PrivacyComplianceWebbhooksSpecIdentifier = 'privacy_compliance_webhooks'
 
 // Uses the same schema as the webhooks specs because its content is nested under the same webhooks section
-const spec = createConfigExtensionSpecification({
+const appPrivacyComplienceSpec = createConfigExtensionSpecification({
   identifier: PrivacyComplianceWebbhooksSpecIdentifier,
   schema: WebhookSchema,
   transformConfig: PrivacyComplianceWebbhooksTransformConfig,
 })
 
-export default spec
+export default appPrivacyComplienceSpec
 
 function transformToPrivacyComplianceWebhooksModule(content: object) {
   const webhooks = getPathValue(content, 'webhooks') as WebhooksConfig

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
@@ -38,10 +38,10 @@ const WebhookTransformConfig: CustomTransformationConfig = {
   reverse: (content: object) => transformToWebhookConfig(content),
 }
 
-const spec = createConfigExtensionSpecification({
+const appWebhooksSpec = createConfigExtensionSpecification({
   identifier: WebhooksSpecIdentifier,
   schema: WebhookSchema,
   transformConfig: WebhookTransformConfig,
 })
 
-export default spec
+export default appWebhooksSpec

--- a/packages/app/src/cli/models/extensions/specifications/checkout_post_purchase.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_post_purchase.ts
@@ -3,7 +3,7 @@ import {createExtensionSpecification} from '../specification.js'
 
 const dependency = '@shopify/post-purchase-ui-extensions'
 
-const spec = createExtensionSpecification({
+const checkoutPostPurchaseSpec = createExtensionSpecification({
   identifier: 'checkout_post_purchase',
   dependency,
   partnersWebIdentifier: 'post_purchase',
@@ -14,4 +14,4 @@ const spec = createExtensionSpecification({
   },
 })
 
-export default spec
+export default checkoutPostPurchaseSpec

--- a/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
@@ -14,7 +14,7 @@ const CheckoutSchema = BaseSchema.extend({
     .optional(),
 })
 
-const spec = createExtensionSpecification({
+const checkoutSpec = createExtensionSpecification({
   identifier: 'checkout_ui_extension',
   dependency,
   schema: CheckoutSchema,
@@ -31,4 +31,4 @@ const spec = createExtensionSpecification({
   },
 })
 
-export default spec
+export default checkoutSpec

--- a/packages/app/src/cli/models/extensions/specifications/flow_template.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_template.ts
@@ -20,7 +20,7 @@ const FlowTemplateExtensionSchema = BaseSchemaWithHandle.extend({
   }),
 })
 
-const spec = createExtensionSpecification({
+const flowTemplateSpec = createExtensionSpecification({
   identifier: 'flow_template',
   schema: FlowTemplateExtensionSchema,
   appModuleFeatures: (_) => ['bundling'],
@@ -49,4 +49,4 @@ async function loadWorkflow(path: string, workflowPath: string) {
   return fs.readFileSync(flowFilePath, 'base64')
 }
 
-export default spec
+export default flowTemplateSpec

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -60,7 +60,7 @@ export const FunctionExtensionSchema = BaseSchema.extend({
     .optional(),
 })
 
-const spec = createExtensionSpecification({
+const functionSpec = createExtensionSpecification({
   identifier: 'function',
   additionalIdentifiers: [
     'order_discounts',
@@ -157,4 +157,4 @@ async function readInputQuery(path: string): Promise<string> {
   }
 }
 
-export default spec
+export default functionSpec

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
@@ -41,7 +41,7 @@ const PaymentsAppExtensionSchema = zod.union([
 
 export type PaymentsAppExtensionConfigType = zod.infer<typeof PaymentsAppExtensionSchema>
 
-const spec = createExtensionSpecification({
+const paymentExtensionSpec = createExtensionSpecification({
   identifier: 'payments_extension',
   schema: PaymentsAppExtensionSchema,
   appModuleFeatures: (_) => [],
@@ -66,4 +66,4 @@ const spec = createExtensionSpecification({
   },
 })
 
-export default spec
+export default paymentExtensionSpec

--- a/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
@@ -5,7 +5,7 @@ import {BugError} from '@shopify/cli-kit/node/error'
 
 const dependency = '@shopify/retail-ui-extensions'
 
-const spec = createExtensionSpecification({
+const posUISpec = createExtensionSpecification({
   identifier: 'pos_ui_extension',
   dependency,
   schema: BaseSchema,
@@ -21,4 +21,4 @@ const spec = createExtensionSpecification({
   },
 })
 
-export default spec
+export default posUISpec

--- a/packages/app/src/cli/models/extensions/specifications/product_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/product_subscription.ts
@@ -5,7 +5,7 @@ import {BugError} from '@shopify/cli-kit/node/error'
 
 const dependency = '@shopify/admin-ui-extensions'
 
-const spec = createExtensionSpecification({
+const productSubscriptionSpec = createExtensionSpecification({
   identifier: 'product_subscription',
   dependency,
   graphQLType: 'subscription_management',
@@ -18,4 +18,4 @@ const spec = createExtensionSpecification({
   },
 })
 
-export default spec
+export default productSubscriptionSpec

--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -8,7 +8,7 @@ import {dirname, relativePath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 
-const spec = createExtensionSpecification({
+const themeSpec = createExtensionSpecification({
   identifier: 'theme',
   schema: BaseSchema,
   partnersWebIdentifier: 'theme_app_extension',
@@ -26,7 +26,7 @@ const spec = createExtensionSpecification({
   },
 })
 
-export default spec
+export default themeSpec
 
 // Theme extension validation helpers
 interface FilenameValidation {

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -31,7 +31,7 @@ const UIExtensionSchema = BaseSchema.extend({
     return {...config, extension_points: extensionPoints}
   })
 
-const spec = createExtensionSpecification({
+const uiExtensionSpec = createExtensionSpecification({
   identifier: 'ui_extension',
   dependency,
   schema: UIExtensionSchema,
@@ -113,4 +113,4 @@ Please check the module path for ${target}`.value,
   return ok({})
 }
 
-export default spec
+export default uiExtensionSpec

--- a/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
@@ -25,7 +25,7 @@ const WebPixelSchema = BaseSchema.extend({
   settings: zod.any(),
 })
 
-const spec = createExtensionSpecification({
+const webPixelSpec = createExtensionSpecification({
   identifier: 'web_pixel_extension',
   dependency,
   partnersWebIdentifier: 'web_pixel',
@@ -59,4 +59,4 @@ const spec = createExtensionSpecification({
   },
 })
 
-export default spec
+export default webPixelSpec


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We currently load module specifications dynamically by looking for all files inside `/specifications`.
This has 2 issues:
- It doesn't work when bundling the code
- Some users are reporting that the CLI is not loading any spec (due to some issues with the filesystem probably)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Load all extensions statically
- This is a temporary solution until we move all specs out of the CLI.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- `app generate extension` shows all options
- running `dev` in an app with multiple extensions works fine
- Running `app generate extension` inside a dropbox folder works (apparently it doesn't work now)

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
