### PR TITLE
Invoke types explicitly in Partners queries

### DIFF
--- a/packages/app/src/cli/api/graphql/all_dev_stores_by_org.ts
+++ b/packages/app/src/cli/api/graphql/all_dev_stores_by_org.ts
@@ -20,6 +20,10 @@ export const AllDevStoresByOrganizationQuery = gql`
   }
 `
 
+export interface AllDevStoresByOrganizationQueryVariables {
+  id: string
+}
+
 export interface AllDevStoresByOrganizationSchema {
   organizations: {
     nodes: {

--- a/packages/app/src/cli/api/graphql/find_store_by_domain.ts
+++ b/packages/app/src/cli/api/graphql/find_store_by_domain.ts
@@ -1,8 +1,8 @@
 import {gql} from 'graphql-request'
 
 export const FindStoreByDomainQuery = gql`
-  query FindOrganization($id: ID!, $shopDomain: String) {
-    organizations(id: $id, first: 1) {
+  query FindOrganization($orgId: ID!, $shopDomain: String) {
+    organizations(id: $orgId, first: 1) {
       nodes {
         id
         businessName
@@ -21,6 +21,11 @@ export const FindStoreByDomainQuery = gql`
     }
   }
 `
+
+export interface FindStoreByDomainQueryVariables {
+  orgId: string
+  shopDomain: string
+}
 
 export interface FindStoreByDomainSchema {
   organizations: {

--- a/packages/app/src/cli/api/graphql/get_versions_list.ts
+++ b/packages/app/src/cli/api/graphql/get_versions_list.ts
@@ -25,6 +25,10 @@ export const AppVersionsQuery = gql`
   }
 `
 
+export interface AppVersionsQueryVariables {
+  apiKey: string
+}
+
 export interface AppVersionsQuerySchema {
   app: {
     id: string


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This ensures we are leveraging type safety even for GraphQL where we can't automatically rely on the type system to catch errors for us.

We recently had a bug introduced due to the refactor, which was fixed [here](https://github.com/Shopify/cli/pull/3499). This strategy should prevent further regressions.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Specifies the type of the GraphQL variables in the code. So while nothing enforces the type being correct, we're closer to a guarantee that things will work as expected.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Exercise the various operations. `dev`, `deploy`, `versions list`, etc.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
