### PR TITLE
Migrate webhooks code to Partners adapter

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -31,6 +31,9 @@ import {AppReleaseSchema, AppReleaseVariables} from '../../api/graphql/app_relea
 import {AppVersionByTagSchema, AppVersionByTagVariables} from '../../api/graphql/app_version_by_tag.js'
 import {AppVersionsDiffSchema, AppVersionsDiffVariables} from '../../api/graphql/app_versions_diff.js'
 import {AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
+import {SendSampleWebhookSchema, SendSampleWebhookVariables} from '../../services/webhook/request-sample.js'
+import {PublicApiVersionsSchema} from '../../services/webhook/request-api-versions.js'
+import {WebhookTopicsSchema, WebhookTopicsVariables} from '../../services/webhook/request-topics.js'
 import {vi} from 'vitest'
 
 export const DEFAULT_CONFIG = {
@@ -816,6 +819,23 @@ const organizationsResponse: AllOrganizationsQuerySchema = {
   },
 }
 
+const sendSampleWebhookResponse: SendSampleWebhookSchema = {
+  sendSampleWebhook: {
+    samplePayload: '{ "sampleField": "SampleValue" }',
+    headers: '{ "header": "Header Value" }',
+    success: true,
+    userErrors: [],
+  },
+}
+
+const apiVersionsResponse: PublicApiVersionsSchema = {
+  publicApiVersions: ['2022', 'unstable', '2023'],
+}
+
+const topicsResponse: WebhookTopicsSchema = {
+  webhookTopics: ['orders/create', 'shop/redact'],
+}
+
 export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClient> = {}): DeveloperPlatformClient {
   const clientStub = {
     session: () => Promise.resolve(testPartnersUserSession),
@@ -849,6 +869,9 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     updateDeveloperPreview: (_input: DevelopmentStorePreviewUpdateInput) =>
       Promise.resolve(updateDeveloperPreviewResponse),
     appPreviewMode: (_input: FindAppPreviewModeVariables) => Promise.resolve(appPreviewModeResponse),
+    sendSampleWebhook: (_input: SendSampleWebhookVariables) => Promise.resolve(sendSampleWebhookResponse),
+    apiVersions: () => Promise.resolve(apiVersionsResponse),
+    topics: (_input: WebhookTopicsVariables) => Promise.resolve(topicsResponse),
     ...stubs,
   }
   const retVal: Partial<DeveloperPlatformClient> = {}

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -30,7 +30,6 @@ import {FindAppPreviewModeSchema, FindAppPreviewModeVariables} from '../../api/g
 import {AppReleaseSchema, AppReleaseVariables} from '../../api/graphql/app_release.js'
 import {AppVersionByTagSchema, AppVersionByTagVariables} from '../../api/graphql/app_version_by_tag.js'
 import {AppVersionsDiffSchema, AppVersionsDiffVariables} from '../../api/graphql/app_versions_diff.js'
-import {AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
 import {SendSampleWebhookSchema, SendSampleWebhookVariables} from '../../services/webhook/request-sample.js'
 import {PublicApiVersionsSchema} from '../../services/webhook/request-api-versions.js'
 import {WebhookTopicsSchema, WebhookTopicsVariables} from '../../services/webhook/request-topics.js'
@@ -813,11 +812,7 @@ const appPreviewModeResponse: FindAppPreviewModeSchema = {
   },
 }
 
-const organizationsResponse: AllOrganizationsQuerySchema = {
-  organizations: {
-    nodes: [testOrganization()],
-  },
-}
+const organizationsResponse: Organization[] = [testOrganization()]
 
 const sendSampleWebhookResponse: SendSampleWebhookSchema = {
   sendSampleWebhook: {
@@ -845,7 +840,6 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     organizations: () => Promise.resolve(organizationsResponse),
     orgFromId: (_organizationId: string) => Promise.resolve(testOrganization()),
     appsForOrg: (_organizationId: string) => Promise.resolve({apps: [testOrganizationApp()], hasMorePages: false}),
-    selectOrg: () => Promise.resolve(testOrganization()),
     specifications: (_appId: string) => Promise.resolve([]),
     orgAndApps: (_orgId: string) =>
       Promise.resolve({organization: testOrganization(), apps: [testOrganizationApp()], hasMorePages: false}),

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -30,6 +30,7 @@ import {FindAppPreviewModeSchema, FindAppPreviewModeVariables} from '../../api/g
 import {AppReleaseSchema, AppReleaseVariables} from '../../api/graphql/app_release.js'
 import {AppVersionByTagSchema, AppVersionByTagVariables} from '../../api/graphql/app_version_by_tag.js'
 import {AppVersionsDiffSchema, AppVersionsDiffVariables} from '../../api/graphql/app_versions_diff.js'
+import {AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
 import {vi} from 'vitest'
 
 export const DEFAULT_CONFIG = {
@@ -809,13 +810,19 @@ const appPreviewModeResponse: FindAppPreviewModeSchema = {
   },
 }
 
+const organizationsResponse: AllOrganizationsQuerySchema = {
+  organizations: {
+    nodes: [testOrganization()],
+  },
+}
+
 export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClient> = {}): DeveloperPlatformClient {
   const clientStub = {
     session: () => Promise.resolve(testPartnersUserSession),
     refreshToken: () => Promise.resolve(testPartnersUserSession.token),
     accountInfo: () => Promise.resolve(testPartnersUserSession.accountInfo),
     appFromId: (_clientId: string) => Promise.resolve(testOrganizationApp()),
-    organizations: () => Promise.resolve([testOrganization()]),
+    organizations: () => Promise.resolve(organizationsResponse),
     orgFromId: (_organizationId: string) => Promise.resolve(testOrganization()),
     appsForOrg: (_organizationId: string) => Promise.resolve({apps: [testOrganizationApp()], hasMorePages: false}),
     selectOrg: () => Promise.resolve(testOrganization()),

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -1,6 +1,6 @@
 import {MinimalOrganizationApp, OrganizationApp} from '../../models/organization.js'
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
-import {BetaFlag} from '../dev/fetch.js'
+import {BetaFlag, fetchOrganizations} from '../dev/fetch.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {SpecsAppConfiguration} from '../../models/extensions/specifications/types/app_config.js'
 import {
@@ -12,7 +12,7 @@ import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 
 export async function selectApp(): Promise<OrganizationApp> {
   const developerPlatformClient = selectDeveloperPlatformClient()
-  const orgs = await developerPlatformClient.organizations()
+  const orgs = await fetchOrganizations(developerPlatformClient)
   const org = await selectOrganizationPrompt(orgs)
   const {apps, hasMorePages} = await developerPlatformClient.appsForOrg(org.id)
   const selectedAppApiKey = await selectAppPrompt(apps, hasMorePages, org.id, {developerPlatformClient})

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -1,5 +1,5 @@
 import {selectOrCreateApp} from './dev/select-app.js'
-import {fetchStoreByDomain} from './dev/fetch.js'
+import {fetchOrganizations, fetchStoreByDomain} from './dev/fetch.js'
 import {convertToTestStoreIfNeeded, selectStore} from './dev/select-store.js'
 import {ensureDeploymentIdsPresence} from './context/identifiers.js'
 import {createExtension} from './dev/create-extension.js'
@@ -792,7 +792,7 @@ export async function getAppContext({
  * @returns The selected organization ID
  */
 async function selectOrg(developerPlatformClient: DeveloperPlatformClient): Promise<string> {
-  const orgs = await developerPlatformClient.organizations()
+  const orgs = await fetchOrganizations(developerPlatformClient)
   const org = await selectOrganizationPrompt(orgs)
   return org.id
 }
@@ -809,10 +809,6 @@ interface ReusedValuesOptions {
  */
 function showReusedDevValues({organization, selectedApp, selectedStore, cachedInfo}: ReusedValuesOptions) {
   if (!cachedInfo) return
-
-  const usingDifferentSettings =
-    selectedApp.apiKey !== cachedInfo?.appId || selectedStore.shopDomain !== cachedInfo.storeFqdn
-  const configFileName = usingDifferentSettings ? undefined : cachedInfo.configFile
 
   let updateURLs = 'Not yet configured'
   if (cachedInfo.updateURLs !== undefined) updateURLs = cachedInfo.updateURLs ? 'Yes' : 'No'

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -157,7 +157,7 @@ export async function ensureDevContext(
     promptLinkingApp: !options.apiKey,
   })
 
-  const orgId = getOrganization() || cachedInfo?.orgId || (await developerPlatformClient.selectOrg()).id
+  const orgId = getOrganization() || cachedInfo?.orgId || (await selectOrg(developerPlatformClient))
 
   let {app: selectedApp, store: selectedStore} = await fetchDevDataFromOptions(options, orgId, developerPlatformClient)
   const organization = await developerPlatformClient.orgFromId(orgId)

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -81,7 +81,7 @@ describe('fetchOrganizations', async () => {
   test('returns fetched organizations', async () => {
     // Given
     const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
-      organizations: () => Promise.resolve({organizations: {nodes: [ORG1, ORG2]}}),
+      organizations: () => Promise.resolve([ORG1, ORG2]),
     })
     const {organizations} = developerPlatformClient
     const organizationsSpy = vi.spyOn(developerPlatformClient, 'organizations').mockImplementation(organizations)
@@ -97,7 +97,7 @@ describe('fetchOrganizations', async () => {
   test('throws if there are no organizations', async () => {
     // Given
     const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
-      organizations: () => Promise.resolve({organizations: {nodes: []}}),
+      organizations: () => Promise.resolve([]),
     })
     const {organizations} = developerPlatformClient
     const organizationsSpy = vi.spyOn(developerPlatformClient, 'organizations').mockImplementation(organizations)

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -7,7 +7,6 @@ import {
   NoOrgError,
 } from './fetch.js'
 import {Organization, OrganizationStore} from '../../models/organization.js'
-import {AllOrganizationsQuery} from '../../api/graphql/all_orgs.js'
 import {FindOrganizationQuery} from '../../api/graphql/find_org.js'
 import {AllDevStoresByOrganizationQuery} from '../../api/graphql/all_dev_stores_by_org.js'
 import {FindStoreByDomainSchema} from '../../api/graphql/find_store_by_domain.js'
@@ -81,26 +80,34 @@ afterEach(() => {
 describe('fetchOrganizations', async () => {
   test('returns fetched organizations', async () => {
     // Given
-    vi.mocked(partnersRequest).mockResolvedValue({organizations: {nodes: [ORG1, ORG2]}})
+    const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
+      organizations: () => Promise.resolve({organizations: {nodes: [ORG1, ORG2]}}),
+    })
+    const {organizations} = developerPlatformClient
+    const organizationsSpy = vi.spyOn(developerPlatformClient, 'organizations').mockImplementation(organizations)
 
     // When
-    const got = await fetchOrganizations(testPartnersUserSession)
+    const got = await fetchOrganizations(developerPlatformClient)
 
     // Then
     expect(got).toEqual([ORG1, ORG2])
-    expect(partnersRequest).toHaveBeenCalledWith(AllOrganizationsQuery, 'token')
+    expect(organizationsSpy).toHaveBeenCalledWith()
   })
 
   test('throws if there are no organizations', async () => {
     // Given
-    vi.mocked(partnersRequest).mockResolvedValue({organizations: {nodes: []}})
+    const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
+      organizations: () => Promise.resolve({organizations: {nodes: []}}),
+    })
+    const {organizations} = developerPlatformClient
+    const organizationsSpy = vi.spyOn(developerPlatformClient, 'organizations').mockImplementation(organizations)
 
     // When
-    const got = fetchOrganizations(testPartnersUserSession)
+    const got = fetchOrganizations(developerPlatformClient)
 
     // Then
     await expect(got).rejects.toThrow(new NoOrgError(testPartnersUserSession.accountInfo))
-    expect(partnersRequest).toHaveBeenCalledWith(AllOrganizationsQuery, 'token')
+    expect(organizationsSpy).toHaveBeenCalledWith()
   })
 })
 

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -3,7 +3,6 @@ import {
   AllAppExtensionRegistrationsQuery,
   AllAppExtensionRegistrationsQuerySchema,
 } from '../../api/graphql/all_app_extension_registrations.js'
-import {AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
 import {FindOrganizationQuery, FindOrganizationQuerySchema} from '../../api/graphql/find_org.js'
 import {FindAppQuery, FindAppQuerySchema} from '../../api/graphql/find_app.js'
 import {FindAppPreviewModeSchema} from '../../api/graphql/find_app_preview_mode.js'
@@ -113,8 +112,7 @@ export async function fetchAppExtensionRegistrations({
  * @returns List of organizations
  */
 export async function fetchOrganizations(developerPlatformClient: DeveloperPlatformClient): Promise<Organization[]> {
-  const result: AllOrganizationsQuerySchema = await developerPlatformClient.organizations()
-  const organizations = result.organizations.nodes
+  const organizations: Organization[] = await developerPlatformClient.organizations()
   if (organizations.length === 0) throw new NoOrgError(await developerPlatformClient.accountInfo())
   return organizations
 }

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -3,7 +3,7 @@ import {
   AllAppExtensionRegistrationsQuery,
   AllAppExtensionRegistrationsQuerySchema,
 } from '../../api/graphql/all_app_extension_registrations.js'
-import {AllOrganizationsQuery, AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
+import {AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
 import {FindOrganizationQuery, FindOrganizationQuerySchema} from '../../api/graphql/find_org.js'
 import {FindAppQuery, FindAppQuerySchema} from '../../api/graphql/find_app.js'
 import {FindAppPreviewModeSchema} from '../../api/graphql/find_app_preview_mode.js'
@@ -112,11 +112,10 @@ export async function fetchAppExtensionRegistrations({
  * @param token - Token to access partners API
  * @returns List of organizations
  */
-export async function fetchOrganizations(partnersSession: PartnersSession): Promise<Organization[]> {
-  const query = AllOrganizationsQuery
-  const result: AllOrganizationsQuerySchema = await partnersRequest(query, partnersSession.token)
+export async function fetchOrganizations(developerPlatformClient: DeveloperPlatformClient): Promise<Organization[]> {
+  const result: AllOrganizationsQuerySchema = await developerPlatformClient.organizations()
   const organizations = result.organizations.nodes
-  if (organizations.length === 0) throw new NoOrgError(partnersSession.accountInfo)
+  if (organizations.length === 0) throw new NoOrgError(await developerPlatformClient.accountInfo())
   return organizations
 }
 

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -224,7 +224,7 @@ describe('setup-dev-processes', () => {
         apiSecret: 'api-secret',
         deliveryPort: 111,
         storeFqdn: 'store.myshopify.io',
-        token: 'token',
+        developerPlatformClient,
         webhooksPath: '/webhooks',
       },
     })

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -76,8 +76,6 @@ export async function setupDevProcesses({
   const apiSecret = (remoteApp.apiSecret as string) ?? ''
   const appPreviewUrl = buildAppURLForWeb(storeFqdn, apiKey)
   const shouldRenderGraphiQL = !isTruthy(process.env[environmentVariableNames.disableGraphiQLExplorer])
-  const partnersSession = await developerPlatformClient.session()
-  const token = partnersSession.token
 
   const processes = [
     ...(await setupWebProcesses({
@@ -134,7 +132,7 @@ export async function setupDevProcesses({
       webs: localApp.webs,
       backendPort: network.backendPort,
       frontendPort: network.frontendPort,
-      token,
+      developerPlatformClient,
       storeFqdn,
       apiSecret,
       remoteAppUpdated,

--- a/packages/app/src/cli/services/dev/processes/uninstall-webhook.ts
+++ b/packages/app/src/cli/services/dev/processes/uninstall-webhook.ts
@@ -2,10 +2,11 @@ import {BaseProcess, DevProcessFunction} from './types.js'
 import {frontAndBackendConfig} from './utils.js'
 import {sendUninstallWebhookToAppServer} from '../../webhook/send-app-uninstalled-webhook.js'
 import {Web} from '../../../models/app/app.js'
+import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 
 export interface SendWebhookOptions {
   deliveryPort: number
-  token: string
+  developerPlatformClient: DeveloperPlatformClient
   storeFqdn: string
   apiSecret: string
   webhooksPath: string
@@ -18,7 +19,7 @@ export interface SendWebhookProcess extends BaseProcess<SendWebhookOptions> {
 export const sendWebhook: DevProcessFunction<SendWebhookOptions> = async ({stdout}, options) => {
   await sendUninstallWebhookToAppServer({
     stdout,
-    token: options.token,
+    developerPlatformClient: options.developerPlatformClient,
     address: `http://localhost:${options.deliveryPort}${options.webhooksPath}`,
     sharedSecret: options.apiSecret,
     storeFqdn: options.storeFqdn,
@@ -31,7 +32,7 @@ export function setupSendUninstallWebhookProcess({
   backendPort,
   frontendPort,
   ...options
-}: Pick<SendWebhookOptions, 'token' | 'storeFqdn' | 'apiSecret'> & {
+}: Pick<SendWebhookOptions, 'developerPlatformClient' | 'storeFqdn' | 'apiSecret'> & {
   remoteAppUpdated: boolean
   backendPort: number
   frontendPort: number

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -26,7 +26,7 @@ const CreateStoreLink = async (orgId: string) => {
  * If there are no stores, show a link to create a store and prompt the user to refresh the store list
  * If no store is finally selected, exit process
  * @param stores - List of available stores
- * @param org - Current organizatio
+ * @param org - Current organization
  * @param developerPlatformClient - The client to access the platform API
  * @returns The selected store
  */

--- a/packages/app/src/cli/services/webhook/find-app-info.test.ts
+++ b/packages/app/src/cli/services/webhook/find-app-info.test.ts
@@ -2,7 +2,7 @@ import {findInEnv, findApiKey, requestAppInfo} from './find-app-info.js'
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps, FetchResponse} from '../dev/fetch.js'
 import {MinimalOrganizationApp} from '../../models/organization.js'
-import {testPartnersUserSession, testOrganizationApp} from '../../models/app/app.test-data.js'
+import {testOrganizationApp, testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env'
 import {fileExists} from '@shopify/cli-kit/node/fs'
@@ -16,6 +16,8 @@ vi.mock('@shopify/cli-kit/node/dot-env')
 vi.mock('@shopify/cli-kit/node/path')
 vi.mock('../dev/fetch')
 vi.mock('../../prompts/dev')
+
+const developerPlatformClient = testDeveloperPlatformClient()
 
 describe('findInEnv', () => {
   test('.env file not available', async () => {
@@ -77,7 +79,7 @@ describe('findApiKey', () => {
     vi.mocked(fetchOrgAndApps).mockResolvedValue(buildFetchResponse([]))
 
     // When
-    const apiKey = await findApiKey(testPartnersUserSession)
+    const apiKey = await findApiKey(developerPlatformClient)
 
     // Then
     expect(apiKey).toEqual(undefined)
@@ -89,7 +91,7 @@ describe('findApiKey', () => {
     vi.mocked(basename).mockResolvedValue(`folder/${anAppName}`)
 
     // When
-    const apiKey = await findApiKey(testPartnersUserSession)
+    const apiKey = await findApiKey(developerPlatformClient)
 
     // Then
     expect(apiKey).toEqual(anApiKey)
@@ -101,7 +103,7 @@ describe('findApiKey', () => {
     vi.mocked(basename).mockResolvedValue(`folder/${anotherAppName}`)
 
     // When
-    const apiKey = await findApiKey(testPartnersUserSession)
+    const apiKey = await findApiKey(developerPlatformClient)
 
     // Then
     expect(apiKey).toEqual(anApiKey)
@@ -114,7 +116,7 @@ describe('findApiKey', () => {
     vi.mocked(selectAppPrompt).mockResolvedValue(anotherApp.apiKey)
 
     // When
-    const apiKey = await findApiKey(testPartnersUserSession)
+    const apiKey = await findApiKey(developerPlatformClient)
 
     // Then
     expect(selectAppPrompt).toHaveBeenCalledOnce()

--- a/packages/app/src/cli/services/webhook/find-app-info.test.ts
+++ b/packages/app/src/cli/services/webhook/find-app-info.test.ts
@@ -16,8 +16,6 @@ vi.mock('@shopify/cli-kit/node/path')
 vi.mock('../dev/fetch')
 vi.mock('../../prompts/dev')
 
-const developerPlatformClient = testDeveloperPlatformClient()
-
 describe('findInEnv', () => {
   test('.env file not available', async () => {
     // Given
@@ -78,7 +76,7 @@ describe('findApiKey', () => {
     vi.mocked(fetchOrgAndApps).mockResolvedValue(buildFetchResponse([]))
 
     // When
-    const apiKey = await findApiKey(developerPlatformClient)
+    const apiKey = await findApiKey(testDeveloperPlatformClient())
 
     // Then
     expect(apiKey).toEqual(undefined)
@@ -90,7 +88,7 @@ describe('findApiKey', () => {
     vi.mocked(basename).mockResolvedValue(`folder/${anAppName}`)
 
     // When
-    const apiKey = await findApiKey(developerPlatformClient)
+    const apiKey = await findApiKey(testDeveloperPlatformClient())
 
     // Then
     expect(apiKey).toEqual(anApiKey)
@@ -102,7 +100,7 @@ describe('findApiKey', () => {
     vi.mocked(basename).mockResolvedValue(`folder/${anotherAppName}`)
 
     // When
-    const apiKey = await findApiKey(developerPlatformClient)
+    const apiKey = await findApiKey(testDeveloperPlatformClient())
 
     // Then
     expect(apiKey).toEqual(anApiKey)
@@ -115,7 +113,7 @@ describe('findApiKey', () => {
     vi.mocked(selectAppPrompt).mockResolvedValue(anotherApp.apiKey)
 
     // When
-    const apiKey = await findApiKey(developerPlatformClient)
+    const apiKey = await findApiKey(testDeveloperPlatformClient())
 
     // Then
     expect(selectAppPrompt).toHaveBeenCalledOnce()
@@ -169,7 +167,7 @@ describe('requestAppInfo', () => {
     )
 
     // When
-    const credentials = await requestAppInfo(developerPlatformClient, anApiKey)
+    const credentials = await requestAppInfo(testDeveloperPlatformClient(), anApiKey)
 
     // Then
     expect(credentials).toEqual({clientId: '1', apiKey: anApiKey, clientSecret: 'api-secret'})

--- a/packages/app/src/cli/services/webhook/find-app-info.ts
+++ b/packages/app/src/cli/services/webhook/find-app-info.ts
@@ -1,6 +1,6 @@
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
-import {PartnersSession} from '../context/partner-account-info.js'
+import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env'
 import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath, basename, cwd} from '@shopify/cli-kit/node/path'
@@ -36,9 +36,10 @@ export async function findInEnv(): Promise<AppCredentials> {
  * @param token - partners token
  * @returns apiKey
  */
-export async function findApiKey(partnersSession: PartnersSession): Promise<string | undefined> {
-  const orgs = await fetchOrganizations(partnersSession)
+export async function findApiKey(developerPlatformClient: DeveloperPlatformClient): Promise<string | undefined> {
+  const orgs = await fetchOrganizations(developerPlatformClient)
   const org = await selectOrganizationPrompt(orgs)
+  const partnersSession = await developerPlatformClient.session()
   const {apps} = await fetchOrgAndApps(org.id, partnersSession)
 
   if (apps.nodes.length === 0) {

--- a/packages/app/src/cli/services/webhook/find-app-info.ts
+++ b/packages/app/src/cli/services/webhook/find-app-info.ts
@@ -1,5 +1,5 @@
 import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
-import {fetchAppDetailsFromApiKey, fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
+import {fetchOrganizations, fetchOrgAndApps} from '../dev/fetch.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env'
 import {fileExists} from '@shopify/cli-kit/node/fs'
@@ -66,12 +66,15 @@ export async function findApiKey(developerPlatformClient: DeveloperPlatformClien
 /**
  * Find the app api_key, if available
  *
- * @param token - partners token
+ * @param developerPlatformClient - The client to access the platform API
  * @param apiKey - app api_key
  * @returns client_id, client_secret, client_api_key
  */
-export async function requestAppInfo(token: string, apiKey: string): Promise<AppCredentials> {
-  const fullSelectedApp = await fetchAppDetailsFromApiKey(apiKey, token)
+export async function requestAppInfo(
+  developerPlatformClient: DeveloperPlatformClient,
+  apiKey: string,
+): Promise<AppCredentials> {
+  const fullSelectedApp = await developerPlatformClient.appFromId(apiKey)
   const credentials: AppCredentials = {}
   if (fullSelectedApp === undefined) {
     return credentials

--- a/packages/app/src/cli/services/webhook/request-api-versions.test.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.test.ts
@@ -1,21 +1,13 @@
 import {requestApiVersions} from './request-api-versions.js'
-import {describe, expect, vi, test} from 'vitest'
-import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
+import {describe, expect, test} from 'vitest'
 
-vi.mock('@shopify/cli-kit/node/api/partners')
-
-const aToken = 'A_TOKEN'
+const developerPlatformClient = testDeveloperPlatformClient()
 
 describe('requestApiVersions', () => {
   test('calls partners to request data and returns ordered array', async () => {
-    // Given
-    const graphQLResult = {
-      publicApiVersions: ['2022', 'unstable', '2023'],
-    }
-    vi.mocked(partnersRequest).mockResolvedValue(graphQLResult)
-
-    // When
-    const got = await requestApiVersions(aToken)
+    // Given - When
+    const got = await requestApiVersions(developerPlatformClient)
 
     // Then
     expect(got).toEqual(['2023', '2022', 'unstable'])

--- a/packages/app/src/cli/services/webhook/request-api-versions.test.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.test.ts
@@ -2,12 +2,10 @@ import {requestApiVersions} from './request-api-versions.js'
 import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {describe, expect, test} from 'vitest'
 
-const developerPlatformClient = testDeveloperPlatformClient()
-
 describe('requestApiVersions', () => {
   test('calls partners to request data and returns ordered array', async () => {
     // Given - When
-    const got = await requestApiVersions(developerPlatformClient)
+    const got = await requestApiVersions(testDeveloperPlatformClient())
 
     // Then
     expect(got).toEqual(['2023', '2022', 'unstable'])

--- a/packages/app/src/cli/services/webhook/request-api-versions.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.ts
@@ -4,7 +4,7 @@ export interface PublicApiVersionsSchema {
   publicApiVersions: string[]
 }
 
-export const getApiVersionsQuery = `
+export const GetApiVersionsQuery = `
   query getApiVersions {
     publicApiVersions
   }

--- a/packages/app/src/cli/services/webhook/request-api-versions.ts
+++ b/packages/app/src/cli/services/webhook/request-api-versions.ts
@@ -1,10 +1,10 @@
-import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 
 export interface PublicApiVersionsSchema {
   publicApiVersions: string[]
 }
 
-const getApiVersionsQuery = `
+export const getApiVersionsQuery = `
   query getApiVersions {
     publicApiVersions
   }
@@ -13,11 +13,11 @@ const getApiVersionsQuery = `
 /**
  * Requests available api-versions in order to validate flags or present a list of options
  *
- * @param token - Partners session token
+ * @param developerPlatformClient - The client to access the platform API
  * @returns List of public api-versions
  */
-export async function requestApiVersions(token: string): Promise<string[]> {
-  const {publicApiVersions: result}: PublicApiVersionsSchema = await partnersRequest(getApiVersionsQuery, token)
+export async function requestApiVersions(developerPlatformClient: DeveloperPlatformClient): Promise<string[]> {
+  const {publicApiVersions: result}: PublicApiVersionsSchema = await developerPlatformClient.apiVersions()
 
   const unstableIdx = result.indexOf('unstable')
   if (unstableIdx === -1) {

--- a/packages/app/src/cli/services/webhook/request-sample.test.ts
+++ b/packages/app/src/cli/services/webhook/request-sample.test.ts
@@ -1,91 +1,42 @@
-import {getWebhookSample} from './request-sample.js'
-import {describe, expect, vi, test} from 'vitest'
-import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {SendSampleWebhookVariables, getWebhookSample} from './request-sample.js'
+import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
+import {describe, expect, test} from 'vitest'
 
-const samplePayload = '{ "sampleField": "SampleValue" }'
-const sampleHeaders = '{ "header": "Header Value" }'
-
-vi.mock('@shopify/cli-kit/node/api/partners')
-
-const aToken = 'A_TOKEN'
-const anApiKey = 'AN_API_KEY'
-const inputValues = {
+const inputValues: SendSampleWebhookVariables = {
   topic: 'A_TOPIC',
-  apiVersion: 'A_VERSION',
-  value: 'A_DELIVERY_METHOD',
+  api_version: 'A_VERSION',
+  delivery_method: 'A_DELIVERY_METHOD',
   address: 'https://example.org',
-  clientSecret: 'A_SECRET',
+  shared_secret: 'A_SECRET',
 }
-const graphQLResult = {
-  sendSampleWebhook: {
-    samplePayload,
-    headers: sampleHeaders,
-    success: false,
-    userErrors: [
-      {message: 'Error 1', fields: ['field1']},
-      {message: 'Error 2', fields: ['field1']},
-    ],
-  },
-}
+const developerPlatformClient = testDeveloperPlatformClient()
 
 describe('getWebhookSample', () => {
   test('calls partners to request data without api-key', async () => {
-    // Given
-    const requestValues = {
-      topic: inputValues.topic,
-      api_version: inputValues.apiVersion,
-      address: inputValues.address,
-      delivery_method: inputValues.value,
-      shared_secret: inputValues.clientSecret,
-    }
-    vi.mocked(partnersRequest).mockResolvedValue(graphQLResult)
-
-    // When
-    const got = await getWebhookSample(
-      aToken,
-      inputValues.topic,
-      inputValues.apiVersion,
-      inputValues.value,
-      inputValues.address,
-      inputValues.clientSecret,
-    )
+    // Given/When
+    const got = await getWebhookSample(developerPlatformClient, inputValues)
 
     // Then
-    expect(partnersRequest).toHaveBeenCalledWith(expect.any(String), 'A_TOKEN', requestValues)
-    expect(got.samplePayload).toEqual(samplePayload)
-    expect(got.headers).toEqual(sampleHeaders)
-    expect(got.success).toEqual(graphQLResult.sendSampleWebhook.success)
-    expect(got.userErrors).toEqual(graphQLResult.sendSampleWebhook.userErrors)
+    expect(got.samplePayload).toEqual('{ "sampleField": "SampleValue" }')
+    expect(got.headers).toEqual('{ "header": "Header Value" }')
+    expect(got.success).toEqual(true)
+    expect(got.userErrors).toEqual([])
   })
 
   test('calls partners to request data with api-key', async () => {
     // Given
-    const requestValues = {
-      topic: inputValues.topic,
-      api_version: inputValues.apiVersion,
-      address: inputValues.address,
-      delivery_method: inputValues.value,
-      shared_secret: inputValues.clientSecret,
-      api_key: anApiKey,
+    const variables: SendSampleWebhookVariables = {
+      ...inputValues,
+      api_key: 'api-key',
     }
-    vi.mocked(partnersRequest).mockResolvedValue(graphQLResult)
 
     // When
-    const got = await getWebhookSample(
-      aToken,
-      inputValues.topic,
-      inputValues.apiVersion,
-      inputValues.value,
-      inputValues.address,
-      inputValues.clientSecret,
-      anApiKey,
-    )
+    const got = await getWebhookSample(developerPlatformClient, variables)
 
     // Then
-    expect(partnersRequest).toHaveBeenCalledWith(expect.any(String), 'A_TOKEN', requestValues)
-    expect(got.samplePayload).toEqual(samplePayload)
-    expect(got.headers).toEqual(sampleHeaders)
-    expect(got.success).toEqual(graphQLResult.sendSampleWebhook.success)
-    expect(got.userErrors).toEqual(graphQLResult.sendSampleWebhook.userErrors)
+    expect(got.samplePayload).toEqual('{ "sampleField": "SampleValue" }')
+    expect(got.headers).toEqual('{ "header": "Header Value" }')
+    expect(got.success).toEqual(true)
+    expect(got.userErrors).toEqual([])
   })
 })

--- a/packages/app/src/cli/services/webhook/request-sample.test.ts
+++ b/packages/app/src/cli/services/webhook/request-sample.test.ts
@@ -9,12 +9,10 @@ const inputValues: SendSampleWebhookVariables = {
   address: 'https://example.org',
   shared_secret: 'A_SECRET',
 }
-const developerPlatformClient = testDeveloperPlatformClient()
-
 describe('getWebhookSample', () => {
   test('calls partners to request data without api-key', async () => {
     // Given/When
-    const got = await getWebhookSample(developerPlatformClient, inputValues)
+    const got = await getWebhookSample(testDeveloperPlatformClient(), inputValues)
 
     // Then
     expect(got.samplePayload).toEqual('{ "sampleField": "SampleValue" }')
@@ -31,7 +29,7 @@ describe('getWebhookSample', () => {
     }
 
     // When
-    const got = await getWebhookSample(developerPlatformClient, variables)
+    const got = await getWebhookSample(testDeveloperPlatformClient(), variables)
 
     // Then
     expect(got.samplePayload).toEqual('{ "sampleField": "SampleValue" }')

--- a/packages/app/src/cli/services/webhook/request-topics.test.ts
+++ b/packages/app/src/cli/services/webhook/request-topics.test.ts
@@ -1,16 +1,13 @@
 import {requestTopics} from './request-topics.js'
 import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
-import {describe, expect, vi, test} from 'vitest'
+import {describe, expect, test} from 'vitest'
 
-vi.mock('@shopify/cli-kit/node/api/partners')
-
-const developerPlatformClient = testDeveloperPlatformClient()
 const aVersion = 'SOME_VERSION'
 
 describe('requestTopics', () => {
   test('calls partners to request topics data and returns array', async () => {
     // Given/When
-    const got = await requestTopics(developerPlatformClient, aVersion)
+    const got = await requestTopics(testDeveloperPlatformClient(), aVersion)
 
     // Then
     expect(got).toEqual(['orders/create', 'shop/redact'])

--- a/packages/app/src/cli/services/webhook/request-topics.test.ts
+++ b/packages/app/src/cli/services/webhook/request-topics.test.ts
@@ -1,22 +1,16 @@
 import {requestTopics} from './request-topics.js'
+import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {describe, expect, vi, test} from 'vitest'
-import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 
 vi.mock('@shopify/cli-kit/node/api/partners')
 
-const aToken = 'A_TOKEN'
+const developerPlatformClient = testDeveloperPlatformClient()
 const aVersion = 'SOME_VERSION'
 
 describe('requestTopics', () => {
   test('calls partners to request topics data and returns array', async () => {
-    // Given
-    const graphQLResult = {
-      webhookTopics: ['orders/create', 'shop/redact'],
-    }
-    vi.mocked(partnersRequest).mockResolvedValue(graphQLResult)
-
-    // When
-    const got = await requestTopics(aToken, aVersion)
+    // Given/When
+    const got = await requestTopics(developerPlatformClient, aVersion)
 
     // Then
     expect(got).toEqual(['orders/create', 'shop/redact'])

--- a/packages/app/src/cli/services/webhook/request-topics.ts
+++ b/packages/app/src/cli/services/webhook/request-topics.ts
@@ -1,10 +1,14 @@
-import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
+import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+
+export interface WebhookTopicsVariables {
+  api_version: string
+}
 
 export interface WebhookTopicsSchema {
   webhookTopics: string[]
 }
 
-const getTopicsQuery = `
+export const getTopicsQuery = `
   query getWebhookTopics($api_version: String!) {
     webhookTopics(apiVersion: $api_version)
   }
@@ -13,13 +17,16 @@ const getTopicsQuery = `
 /**
  * Requests topics for an api-version in order to validate flags or present a list of options
  *
- * @param token - Partners session token
+ * @param developerPlatformClient - The client to access the platform API
  * @param apiVersion - ApiVersion of the topics
  * @returns - Available webhook topics for the api-version
  */
-export async function requestTopics(token: string, apiVersion: string): Promise<string[]> {
-  const variables = {api_version: apiVersion}
-  const {webhookTopics: result}: WebhookTopicsSchema = await partnersRequest(getTopicsQuery, token, variables)
+export async function requestTopics(
+  developerPlatformClient: DeveloperPlatformClient,
+  apiVersion: string,
+): Promise<string[]> {
+  const variables: WebhookTopicsVariables = {api_version: apiVersion}
+  const {webhookTopics: result}: WebhookTopicsSchema = await developerPlatformClient.topics(variables)
 
   return result
 }

--- a/packages/app/src/cli/services/webhook/send-app-uninstalled-webhook.test.ts
+++ b/packages/app/src/cli/services/webhook/send-app-uninstalled-webhook.test.ts
@@ -1,35 +1,20 @@
 import {sendUninstallWebhookToAppServer} from './send-app-uninstalled-webhook.js'
 import {triggerLocalWebhook} from './trigger-local-webhook.js'
+import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {describe, expect, vi, test} from 'vitest'
-import {partnersRequest} from '@shopify/cli-kit/node/api/partners'
 import {FetchError} from '@shopify/cli-kit/node/http'
 import {Writable} from 'stream'
 
-vi.mock('@shopify/cli-kit/node/api/partners')
 vi.mock('./trigger-local-webhook.js')
 vi.mock('@shopify/cli-kit/node/system')
-
-const apiVersionsResponse = {
-  publicApiVersions: ['2022', '2023', 'unstable'],
-}
-const webhookSampleResponse = {
-  sendSampleWebhook: {
-    samplePayload: '{ "sampleField": "SampleValue" }',
-    headers: '{ "header": "Header Value" }',
-    success: false,
-    userErrors: [
-      {message: 'Error 1', fields: ['field1']},
-      {message: 'Error 2', fields: ['field1']},
-    ],
-  },
-}
 
 const address = 'http://localhost:3000/test/path'
 const storeFqdn = 'test-store.myshopify.io'
 
+const developerPlatformClient = testDeveloperPlatformClient()
+
 describe('sendUninstallWebhookToAppServer', () => {
   test('requests sample and API versions, triggers local webhook', async () => {
-    vi.mocked(partnersRequest).mockResolvedValueOnce(apiVersionsResponse).mockResolvedValueOnce(webhookSampleResponse)
     vi.mocked(triggerLocalWebhook).mockResolvedValueOnce(true)
     const stdout = {write: vi.fn()} as unknown as Writable
 
@@ -38,14 +23,13 @@ describe('sendUninstallWebhookToAppServer', () => {
       address,
       sharedSecret: 'sharedSecret',
       storeFqdn,
-      token: 'token',
+      developerPlatformClient,
     })
 
     expect(result).toBe(true)
-    expect(partnersRequest).toHaveBeenCalledTimes(2)
     expect(triggerLocalWebhook).toHaveBeenCalledWith(
       address,
-      webhookSampleResponse.sendSampleWebhook.samplePayload,
+      '{ "sampleField": "SampleValue" }',
       `{"header":"Header Value","X-Shopify-Shop-Domain":"${storeFqdn}"}`,
     )
     expect(stdout.write).toHaveBeenNthCalledWith(1, expect.stringMatching(/Sending APP_UNINSTALLED/))
@@ -53,7 +37,6 @@ describe('sendUninstallWebhookToAppServer', () => {
   })
 
   test('gracefully deals with the webhook delivery failing', async () => {
-    vi.mocked(partnersRequest).mockResolvedValueOnce(apiVersionsResponse).mockResolvedValueOnce(webhookSampleResponse)
     vi.mocked(triggerLocalWebhook).mockResolvedValueOnce(false)
     const stdout = {write: vi.fn()} as unknown as Writable
 
@@ -62,11 +45,10 @@ describe('sendUninstallWebhookToAppServer', () => {
       address,
       sharedSecret: 'sharedSecret',
       storeFqdn,
-      token: 'token',
+      developerPlatformClient,
     })
 
     expect(result).toBe(false)
-    expect(partnersRequest).toHaveBeenCalledTimes(2)
     expect(triggerLocalWebhook).toHaveBeenCalledTimes(1)
     expect(stdout.write).toHaveBeenNthCalledWith(1, expect.stringMatching(/Sending APP_UNINSTALLED/))
     expect(stdout.write).toHaveBeenNthCalledWith(2, expect.stringMatching(/failed/))
@@ -75,7 +57,6 @@ describe('sendUninstallWebhookToAppServer', () => {
   test("retries the webhook request if the app hasn't started yet", async () => {
     const fakeError = new FetchError('Fake error for testing', 'network')
     fakeError.code = 'ECONNREFUSED'
-    vi.mocked(partnersRequest).mockResolvedValueOnce(apiVersionsResponse).mockResolvedValueOnce(webhookSampleResponse)
     vi.mocked(triggerLocalWebhook).mockRejectedValueOnce(fakeError).mockResolvedValueOnce(true)
     const stdout = {write: vi.fn()} as unknown as Writable
 
@@ -84,11 +65,10 @@ describe('sendUninstallWebhookToAppServer', () => {
       address,
       sharedSecret: 'sharedSecret',
       storeFqdn,
-      token: 'token',
+      developerPlatformClient,
     })
 
     expect(result).toBe(true)
-    expect(partnersRequest).toHaveBeenCalledTimes(2)
     expect(triggerLocalWebhook).toHaveBeenCalledTimes(2)
     expect(stdout.write).toHaveBeenNthCalledWith(1, expect.stringMatching(/Sending APP_UNINSTALLED/))
     expect(stdout.write).toHaveBeenNthCalledWith(2, expect.stringMatching(/retrying/))

--- a/packages/app/src/cli/services/webhook/send-app-uninstalled-webhook.test.ts
+++ b/packages/app/src/cli/services/webhook/send-app-uninstalled-webhook.test.ts
@@ -11,8 +11,6 @@ vi.mock('@shopify/cli-kit/node/system')
 const address = 'http://localhost:3000/test/path'
 const storeFqdn = 'test-store.myshopify.io'
 
-const developerPlatformClient = testDeveloperPlatformClient()
-
 describe('sendUninstallWebhookToAppServer', () => {
   test('requests sample and API versions, triggers local webhook', async () => {
     vi.mocked(triggerLocalWebhook).mockResolvedValueOnce(true)
@@ -23,7 +21,7 @@ describe('sendUninstallWebhookToAppServer', () => {
       address,
       sharedSecret: 'sharedSecret',
       storeFqdn,
-      developerPlatformClient,
+      developerPlatformClient: testDeveloperPlatformClient(),
     })
 
     expect(result).toBe(true)
@@ -39,11 +37,7 @@ describe('sendUninstallWebhookToAppServer', () => {
   test('gracefully deals with the webhook delivery failing', async () => {
     vi.mocked(triggerLocalWebhook).mockResolvedValueOnce(false)
     const stdout = {write: vi.fn()} as unknown as Writable
-    const {apiVersions, sendSampleWebhook} = developerPlatformClient
-    const apiVersionsSpy = vi.spyOn(developerPlatformClient, 'apiVersions').mockImplementation(apiVersions)
-    const sendSampleWebhookSpy = vi
-      .spyOn(developerPlatformClient, 'sendSampleWebhook')
-      .mockImplementation(sendSampleWebhook)
+    const developerPlatformClient = testDeveloperPlatformClient()
 
     const result = await sendUninstallWebhookToAppServer({
       stdout,
@@ -54,8 +48,8 @@ describe('sendUninstallWebhookToAppServer', () => {
     })
 
     expect(result).toBe(false)
-    expect(apiVersionsSpy).toHaveBeenCalledOnce()
-    expect(sendSampleWebhookSpy).toHaveBeenCalledOnce()
+    expect(developerPlatformClient.apiVersions).toHaveBeenCalledOnce()
+    expect(developerPlatformClient.sendSampleWebhook).toHaveBeenCalledOnce()
     expect(triggerLocalWebhook).toHaveBeenCalledOnce()
     expect(stdout.write).toHaveBeenNthCalledWith(1, expect.stringMatching(/Sending APP_UNINSTALLED/))
     expect(stdout.write).toHaveBeenNthCalledWith(2, expect.stringMatching(/failed/))

--- a/packages/app/src/cli/services/webhook/trigger-flags.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger-flags.test.ts
@@ -8,6 +8,7 @@ import {
 } from './trigger-flags.js'
 import {requestApiVersions} from './request-api-versions.js'
 import {requestTopics} from './request-topics.js'
+import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {describe, expect, vi, test} from 'vitest'
 
@@ -17,8 +18,7 @@ const remoteHttpAddress = 'https://example.org/api/webhooks'
 const localHttpAddress = 'http://localhost:9090/api/webhooks'
 const ftpAddress = 'ftp://user:pass@host'
 
-const aToken = 'A_TOKEN'
-const aVersion = 'unstable'
+const developerPlatformClient = testDeveloperPlatformClient()
 
 vi.mock('./request-api-versions.js')
 vi.mock('./request-topics.js')
@@ -170,7 +170,7 @@ describe('validateAddressMethod', () => {
 describe('parseVersionAndTopic', () => {
   test('ignores when no flags', async () => {
     // When
-    const got = await parseVersionAndTopic(aToken, {})
+    const got = await parseVersionAndTopic(developerPlatformClient, {})
 
     // Then
     expect(got).toEqual([undefined, undefined])
@@ -178,7 +178,7 @@ describe('parseVersionAndTopic', () => {
 
   test('gets topic when no version', async () => {
     // When
-    const got = await parseVersionAndTopic(aToken, {topic: 'topic'})
+    const got = await parseVersionAndTopic(developerPlatformClient, {topic: 'topic'})
 
     // Then
     expect(got).toEqual([undefined, 'topic'])
@@ -189,7 +189,7 @@ describe('parseVersionAndTopic', () => {
     vi.mocked(requestApiVersions).mockResolvedValue(['2023-01', 'unstable'])
 
     // When
-    const got = await parseVersionAndTopic(aToken, {apiVersion: 'unstable'})
+    const got = await parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unstable'})
 
     // Then
     expect(got).toEqual(['unstable', undefined])
@@ -200,7 +200,7 @@ describe('parseVersionAndTopic', () => {
     vi.mocked(requestApiVersions).mockResolvedValue(['2023-01', 'unstable'])
 
     // When Then
-    await expect(parseVersionAndTopic(aToken, {apiVersion: 'unknown'})).rejects.toThrow(AbortError)
+    await expect(parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unknown'})).rejects.toThrow(AbortError)
   })
 
   test('validates the version and topic', async () => {
@@ -209,7 +209,7 @@ describe('parseVersionAndTopic', () => {
     vi.mocked(requestTopics).mockResolvedValue(['shop/redact', 'products/delete'])
 
     // When
-    const got = await parseVersionAndTopic(aToken, {apiVersion: 'unstable', topic: 'shop/redact'})
+    const got = await parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unstable', topic: 'shop/redact'})
 
     // Then
     expect(got).toEqual(['unstable', 'shop/redact'])
@@ -221,9 +221,9 @@ describe('parseVersionAndTopic', () => {
     vi.mocked(requestTopics).mockResolvedValue([])
 
     // When then
-    await expect(parseVersionAndTopic(aToken, {apiVersion: 'unstable', topic: 'shop/redact'})).rejects.toThrow(
-      AbortError,
-    )
+    await expect(
+      parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unstable', topic: 'shop/redact'}),
+    ).rejects.toThrow(AbortError)
   })
 
   test('validates the version and GraphQL-like topic', async () => {
@@ -232,7 +232,7 @@ describe('parseVersionAndTopic', () => {
     vi.mocked(requestTopics).mockResolvedValue(['shop/redact', 'orders/create', 'products/delete'])
 
     // When
-    const got = await parseVersionAndTopic(aToken, {apiVersion: 'unstable', topic: 'ORDERS_CREATE'})
+    const got = await parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unstable', topic: 'ORDERS_CREATE'})
 
     // Then
     expect(got).toEqual(['unstable', 'orders/create'])
@@ -244,19 +244,21 @@ describe('parseVersionAndTopic', () => {
     vi.mocked(requestTopics).mockResolvedValue(['shop/redact', 'orders/create', 'products/delete'])
 
     // Then when
-    await expect(parseVersionAndTopic(aToken, {apiVersion: 'unstable', topic: 'unknown'})).rejects.toThrow(AbortError)
-    await expect(parseVersionAndTopic(aToken, {apiVersion: 'unstable', topic: 'OrdERS_Create'})).rejects.toThrow(
-      AbortError,
-    )
-    await expect(parseVersionAndTopic(aToken, {apiVersion: 'unstable', topic: 'orders_create'})).rejects.toThrow(
-      AbortError,
-    )
-    await expect(parseVersionAndTopic(aToken, {apiVersion: 'unstable', topic: 'OrdERS/CreaTE'})).rejects.toThrow(
-      AbortError,
-    )
-    await expect(parseVersionAndTopic(aToken, {apiVersion: 'unstable', topic: 'ORDERS/CREATE'})).rejects.toThrow(
-      AbortError,
-    )
+    await expect(
+      parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unstable', topic: 'unknown'}),
+    ).rejects.toThrow(AbortError)
+    await expect(
+      parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unstable', topic: 'OrdERS_Create'}),
+    ).rejects.toThrow(AbortError)
+    await expect(
+      parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unstable', topic: 'orders_create'}),
+    ).rejects.toThrow(AbortError)
+    await expect(
+      parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unstable', topic: 'OrdERS/CreaTE'}),
+    ).rejects.toThrow(AbortError)
+    await expect(
+      parseVersionAndTopic(developerPlatformClient, {apiVersion: 'unstable', topic: 'ORDERS/CREATE'}),
+    ).rejects.toThrow(AbortError)
   })
 })
 

--- a/packages/app/src/cli/services/webhook/trigger-flags.ts
+++ b/packages/app/src/cli/services/webhook/trigger-flags.ts
@@ -1,6 +1,7 @@
 import {requestApiVersions} from './request-api-versions.js'
 import {requestTopics} from './request-topics.js'
 import {isValueSet} from './trigger.js'
+import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
 export interface WebhookTriggerFlags {
@@ -9,6 +10,7 @@ export interface WebhookTriggerFlags {
   deliveryMethod?: string
   address?: string
   clientSecret?: string
+  developerPlatformClient?: DeveloperPlatformClient
 }
 
 export const DELIVERY_METHOD = {

--- a/packages/app/src/cli/services/webhook/trigger-flags.ts
+++ b/packages/app/src/cli/services/webhook/trigger-flags.ts
@@ -90,26 +90,26 @@ export function parseAddressAndMethod(flags: WebhookTriggerFlags): [string | und
 /**
  * Returns valid api-version - topic pairs
  *
- * @param token - Partners session token
+ * @param developerPlatformClient - The client to access the platform API
  * @param flags - Command flags
  * @returns [apiVersion, topic]
  */
 export async function parseVersionAndTopic(
-  token: string,
+  developerPlatformClient: DeveloperPlatformClient,
   flags: WebhookTriggerFlags,
 ): Promise<[string | undefined, string | undefined]> {
   let topic
   let apiVersion
   const versionWasPassed = isValueSet(flags.apiVersion)
   if (versionWasPassed) {
-    apiVersion = parseApiVersionFlag(flags.apiVersion as string, await requestApiVersions(token))
+    apiVersion = parseApiVersionFlag(flags.apiVersion as string, await requestApiVersions(developerPlatformClient))
   }
   const topicWasPassed = isValueSet(flags.topic)
   if (topicWasPassed && versionWasPassed) {
     topic = parseTopicFlag(
       flags.topic as string,
       flags.apiVersion as string,
-      await requestTopics(token, flags.apiVersion as string),
+      await requestTopics(developerPlatformClient, flags.apiVersion as string),
     )
   } else if (topicWasPassed) {
     topic = flags.topic

--- a/packages/app/src/cli/services/webhook/trigger-options.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger-options.test.ts
@@ -28,7 +28,6 @@ vi.mock('./request-api-versions.js')
 vi.mock('./request-topics.js')
 vi.mock('./find-app-info.js')
 
-const aToken = 'token'
 const aSecret = 'A_SECRET'
 const anApiKey = 'AN_API_KEY'
 const developerPlatformClient = testDeveloperPlatformClient()
@@ -39,7 +38,7 @@ describe('collectApiVersion', () => {
     vi.mocked(apiVersionPrompt)
 
     // When
-    const version = await collectApiVersion(aToken, '2023-01')
+    const version = await collectApiVersion(developerPlatformClient, '2023-01')
 
     // Then
     expect(version).toEqual('2023-01')
@@ -52,7 +51,7 @@ describe('collectApiVersion', () => {
     vi.mocked(requestApiVersions).mockResolvedValue(['2023-01', 'unstable'])
 
     // When
-    const version = await collectApiVersion(aToken, undefined)
+    const version = await collectApiVersion(developerPlatformClient, undefined)
 
     // Then
     expect(version).toEqual('2023-01')
@@ -68,7 +67,7 @@ describe('collectTopic', () => {
     vi.mocked(requestTopics).mockResolvedValue(['shop/redact', 'orders/create'])
 
     // When
-    const method = await collectTopic(aToken, '2023-01', 'shop/redact')
+    const method = await collectTopic(developerPlatformClient, '2023-01', 'shop/redact')
 
     // Then
     expect(method).toEqual('shop/redact')
@@ -81,7 +80,7 @@ describe('collectTopic', () => {
     vi.mocked(requestTopics).mockResolvedValue(['shop/redact', 'orders/create'])
 
     // When then
-    await expect(collectTopic(aToken, '2023-01', 'unknown/topic')).rejects.toThrow(AbortError)
+    await expect(collectTopic(developerPlatformClient, '2023-01', 'unknown/topic')).rejects.toThrow(AbortError)
     expect(topicPrompt).toHaveBeenCalledTimes(0)
   })
 
@@ -91,7 +90,7 @@ describe('collectTopic', () => {
     vi.mocked(requestTopics).mockResolvedValue(['shop/redact', 'orders/create'])
 
     // When
-    const topic = await collectTopic(aToken, 'unstable', undefined)
+    const topic = await collectTopic(developerPlatformClient, 'unstable', undefined)
 
     // Then
     expect(topic).toEqual('orders/create')
@@ -242,7 +241,7 @@ describe('collectCredentials', () => {
     expect(clientSecretPrompt).toHaveBeenCalledTimes(0)
     expect(findInEnv).toHaveBeenCalledOnce()
     expect(findApiKey).toHaveBeenCalledOnce()
-    expect(requestAppInfo).toHaveBeenCalledWith(aToken, anApiKey)
+    expect(requestAppInfo).toHaveBeenCalledWith(developerPlatformClient, anApiKey)
     expect(outputInfo).toHaveBeenCalledWith('Reading client-secret from app settings in Partners')
   })
 
@@ -262,7 +261,7 @@ describe('collectCredentials', () => {
     expect(clientSecretPrompt).toHaveBeenCalledOnce()
     expect(findInEnv).toHaveBeenCalledOnce()
     expect(findApiKey).toHaveBeenCalledOnce()
-    expect(requestAppInfo).toHaveBeenCalledWith(aToken, anApiKey)
+    expect(requestAppInfo).toHaveBeenCalledWith(developerPlatformClient, anApiKey)
   })
 })
 

--- a/packages/app/src/cli/services/webhook/trigger-options.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger-options.test.ts
@@ -15,7 +15,7 @@ import {
   deliveryMethodPrompt,
   topicPrompt,
 } from '../../prompts/webhook/trigger.js'
-import {testPartnersUserSession} from '../../models/app/app.test-data.js'
+import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {describe, expect, vi, test} from 'vitest'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
@@ -31,6 +31,7 @@ vi.mock('./find-app-info.js')
 const aToken = 'token'
 const aSecret = 'A_SECRET'
 const anApiKey = 'AN_API_KEY'
+const developerPlatformClient = testDeveloperPlatformClient()
 
 describe('collectApiVersion', () => {
   test('uses the passed api-version', async () => {
@@ -156,7 +157,7 @@ describe('collectCredentials', () => {
     vi.mocked(requestAppInfo)
 
     // When
-    const credentials = await collectCredentials(testPartnersUserSession, aSecret)
+    const credentials = await collectCredentials(developerPlatformClient, aSecret)
 
     // Then
     expect(credentials).toEqual({clientSecret: aSecret})
@@ -176,7 +177,7 @@ describe('collectCredentials', () => {
     vi.mocked(requestAppInfo)
 
     // When
-    const credentials = await collectCredentials(testPartnersUserSession, undefined)
+    const credentials = await collectCredentials(developerPlatformClient, undefined)
 
     // Then
     expect(credentials).toEqual({clientSecret: aSecret})
@@ -195,7 +196,7 @@ describe('collectCredentials', () => {
     vi.mocked(requestAppInfo)
 
     // When
-    const secret = await collectCredentials(testPartnersUserSession, undefined)
+    const secret = await collectCredentials(developerPlatformClient, undefined)
 
     // Then
     expect(secret).toEqual({clientSecret: aSecret, apiKey: anApiKey})
@@ -215,7 +216,7 @@ describe('collectCredentials', () => {
     vi.mocked(requestAppInfo)
 
     // When
-    const secret = await collectCredentials(testPartnersUserSession, undefined)
+    const secret = await collectCredentials(developerPlatformClient, undefined)
 
     // Then
     expect(secret).toEqual({clientSecret: aSecret})
@@ -234,7 +235,7 @@ describe('collectCredentials', () => {
     vi.mocked(requestAppInfo).mockResolvedValue({clientSecret: aSecret, apiKey: anApiKey, clientId: 'Id'})
 
     // When
-    const secret = await collectCredentials(testPartnersUserSession, undefined)
+    const secret = await collectCredentials(developerPlatformClient, undefined)
 
     // Then
     expect(secret).toEqual({clientSecret: aSecret, apiKey: anApiKey, clientId: 'Id'})
@@ -254,7 +255,7 @@ describe('collectCredentials', () => {
     vi.mocked(requestAppInfo).mockResolvedValue({})
 
     // When
-    const secret = await collectCredentials(testPartnersUserSession, undefined)
+    const secret = await collectCredentials(developerPlatformClient, undefined)
 
     // Then
     expect(secret).toEqual({clientSecret: aSecret, apiKey: anApiKey})
@@ -272,7 +273,7 @@ describe('collectApiKey', () => {
     vi.mocked(findApiKey)
 
     // When
-    const apiKey = await collectApiKey(testPartnersUserSession)
+    const apiKey = await collectApiKey(developerPlatformClient)
 
     // Then
     expect(apiKey).toEqual(anApiKey)
@@ -287,7 +288,7 @@ describe('collectApiKey', () => {
     vi.mocked(findApiKey).mockResolvedValue(anApiKey)
 
     // When
-    const apiKey = await collectApiKey(testPartnersUserSession)
+    const apiKey = await collectApiKey(developerPlatformClient)
 
     // Then
     expect(apiKey).toEqual(anApiKey)
@@ -302,6 +303,6 @@ describe('collectApiKey', () => {
     vi.mocked(findApiKey).mockResolvedValue(undefined)
 
     // When Then
-    await expect(collectApiKey(testPartnersUserSession)).rejects.toThrow(AbortError)
+    await expect(collectApiKey(developerPlatformClient)).rejects.toThrow(AbortError)
   })
 })

--- a/packages/app/src/cli/services/webhook/trigger-options.ts
+++ b/packages/app/src/cli/services/webhook/trigger-options.ts
@@ -62,8 +62,7 @@ export async function collectCredentials(
     return credentials
   }
 
-  const partnersSession = await developerPlatformClient.session()
-  const appCredentials = await requestAppInfo(partnersSession.token, apiKey)
+  const appCredentials = await requestAppInfo(developerPlatformClient, apiKey)
   if (isValueSet(appCredentials.clientSecret)) {
     outputInfo('Reading client-secret from app settings in Partners')
   } else {
@@ -105,14 +104,17 @@ export async function collectApiKey(developerPlatformClient: DeveloperPlatformCl
 /**
  * Returns passed apiVersion or prompts for an existing one
  *
- * @param token - Partners session token
+ * @param developerPlatformClient - The client to access the platform API
  * @param apiVersion - VALID or undefined api-version
  * @returns api-version
  */
-export async function collectApiVersion(token: string, apiVersion: string | undefined): Promise<string> {
+export async function collectApiVersion(
+  developerPlatformClient: DeveloperPlatformClient,
+  apiVersion: string | undefined,
+): Promise<string> {
   const selected = isValueSet(apiVersion)
     ? (apiVersion as string)
-    : await apiVersionPrompt(await requestApiVersions(token))
+    : await apiVersionPrompt(await requestApiVersions(developerPlatformClient))
 
   return selected
 }
@@ -120,17 +122,21 @@ export async function collectApiVersion(token: string, apiVersion: string | unde
 /**
  * Returns passed topic if valid or prompts for an existing one
  *
- * @param token - Partners session token
+ * @param developerPlatformClient - The client to access the platform API
  * @param apiVersion - VALID api-version
  * @param topic - topic or undefined
  * @returns topic
  */
-export async function collectTopic(token: string, apiVersion: string, topic: string | undefined): Promise<string> {
+export async function collectTopic(
+  developerPlatformClient: DeveloperPlatformClient,
+  apiVersion: string,
+  topic: string | undefined,
+): Promise<string> {
   if (isValueSet(topic)) {
-    return parseTopicFlag(topic as string, apiVersion, await requestTopics(token, apiVersion))
+    return parseTopicFlag(topic as string, apiVersion, await requestTopics(developerPlatformClient, apiVersion))
   }
 
-  const selected = await topicPrompt(await requestTopics(token, apiVersion))
+  const selected = await topicPrompt(await requestTopics(developerPlatformClient, apiVersion))
 
   return selected
 }

--- a/packages/app/src/cli/services/webhook/trigger.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger.test.ts
@@ -6,7 +6,7 @@ import {WebhookTriggerFlags} from './trigger-flags.js'
 import {triggerLocalWebhook} from './trigger-local-webhook.js'
 import {findApiKey, findInEnv} from './find-app-info.js'
 import {fetchPartnersSession} from '../context/partner-account-info.js'
-import {testPartnersUserSession} from '../../models/app/app.test-data.js'
+import {testDeveloperPlatformClient, testPartnersUserSession} from '../../models/app/app.test-data.js'
 import {outputSuccess, consoleError, outputInfo} from '@shopify/cli-kit/node/output'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -48,6 +48,7 @@ const successEmptyResponse = {
   userErrors: [],
 }
 const aFullLocalAddress = `http://localhost:${aPort}${aUrlPath}`
+const developerPlatformClient = testDeveloperPlatformClient()
 
 describe('webhookTriggerService', () => {
   beforeEach(async () => {
@@ -204,6 +205,7 @@ describe('webhookTriggerService', () => {
       deliveryMethod: 'http',
       clientSecret: aSecret,
       address: anAddress,
+      developerPlatformClient,
     }
 
     return flags
@@ -216,6 +218,7 @@ describe('webhookTriggerService', () => {
       deliveryMethod: 'event-bridge',
       clientSecret: aSecret,
       address: anEventBridgeAddress,
+      developerPlatformClient,
     }
 
     return flags
@@ -228,6 +231,7 @@ describe('webhookTriggerService', () => {
       deliveryMethod: 'http',
       clientSecret: aSecret,
       address: aFullLocalAddress,
+      developerPlatformClient,
     }
 
     return flags

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -22,6 +22,9 @@ import {FindAppPreviewModeSchema, FindAppPreviewModeVariables} from '../api/grap
 import {AppReleaseSchema, AppReleaseVariables} from '../api/graphql/app_release.js'
 import {AppVersionByTagSchema, AppVersionByTagVariables} from '../api/graphql/app_version_by_tag.js'
 import {AppVersionsDiffSchema, AppVersionsDiffVariables} from '../api/graphql/app_versions_diff.js'
+import {SendSampleWebhookSchema, SendSampleWebhookVariables} from '../services/webhook/request-sample.js'
+import {PublicApiVersionsSchema} from '../services/webhook/request-api-versions.js'
+import {WebhookTopicsSchema, WebhookTopicsVariables} from '../services/webhook/request-topics.js'
 import {FunctionUploadUrlGenerateResponse} from '@shopify/cli-kit/node/api/partners'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 
@@ -94,4 +97,7 @@ export interface DeveloperPlatformClient {
   convertToTestStore: (input: ConvertDevToTestStoreVariables) => Promise<ConvertDevToTestStoreSchema>
   updateDeveloperPreview: (input: DevelopmentStorePreviewUpdateInput) => Promise<DevelopmentStorePreviewUpdateSchema>
   appPreviewMode: (input: FindAppPreviewModeVariables) => Promise<FindAppPreviewModeSchema>
+  sendSampleWebhook: (input: SendSampleWebhookVariables) => Promise<SendSampleWebhookSchema>
+  apiVersions: () => Promise<PublicApiVersionsSchema>
+  topics: (input: WebhookTopicsVariables) => Promise<WebhookTopicsSchema>
 }

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -75,7 +75,6 @@ export interface DeveloperPlatformClient {
   accountInfo: () => Promise<PartnersSession['accountInfo']>
   appFromId: (appId: string) => Promise<OrganizationApp | undefined>
   organizations: () => Promise<Organization[]>
-  selectOrg: () => Promise<Organization>
   orgFromId: (orgId: string) => Promise<Organization>
   orgAndApps: (orgId: string) => Promise<Paginateable<{organization: Organization; apps: MinimalOrganizationApp[]}>>
   appsForOrg: (orgId: string, term?: string) => Promise<Paginateable<{apps: MinimalOrganizationApp[]}>>

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -85,7 +85,7 @@ import {
   SendSampleWebhookVariables,
   sendSampleWebhookMutation,
 } from '../../services/webhook/request-sample.js'
-import {PublicApiVersionsSchema, getApiVersionsQuery} from '../../services/webhook/request-api-versions.js'
+import {PublicApiVersionsSchema, GetApiVersionsQuery} from '../../services/webhook/request-api-versions.js'
 import {WebhookTopicsSchema, WebhookTopicsVariables, getTopicsQuery} from '../../services/webhook/request-topics.js'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -312,7 +312,7 @@ export class PartnersClient implements DeveloperPlatformClient {
   }
 
   async apiVersions(): Promise<PublicApiVersionsSchema> {
-    return this.makeRequest(getApiVersionsQuery)
+    return this.makeRequest(GetApiVersionsQuery)
   }
 
   async topics(input: WebhookTopicsVariables): Promise<WebhookTopicsSchema> {

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -10,7 +10,6 @@ import {
   fetchAppDetailsFromApiKey,
   fetchOrgAndApps,
   fetchOrgFromId,
-  fetchOrganizations,
   filterDisabledBetas,
 } from '../../../cli/services/dev/fetch.js'
 import {MinimalOrganizationApp, Organization, OrganizationApp, OrganizationStore} from '../../models/organization.js'
@@ -171,12 +170,13 @@ export class PartnersClient implements DeveloperPlatformClient {
     return fetchAppDetailsFromApiKey(appId, await this.token())
   }
 
-  async organizations(): Promise<AllOrganizationsQuerySchema> {
-    return this.makeRequest(AllOrganizationsQuery)
+  async organizations(): Promise<Organization[]> {
+    const result: AllOrganizationsQuerySchema = await this.makeRequest(AllOrganizationsQuery)
+    return result.organizations.nodes
   }
 
   async selectOrg(): Promise<Organization> {
-    const organizations = await fetchOrganizations(this)
+    const organizations = await this.organizations()
     return selectOrganizationPrompt(organizations)
   }
 

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -8,9 +8,9 @@ import {ActiveAppVersion, DeveloperPlatformClient, Paginateable} from '../develo
 import {fetchPartnersSession, PartnersSession} from '../../../cli/services/context/partner-account-info.js'
 import {
   fetchAppDetailsFromApiKey,
-  fetchOrganizations,
   fetchOrgAndApps,
   fetchOrgFromId,
+  fetchOrganizations,
   filterDisabledBetas,
 } from '../../../cli/services/dev/fetch.js'
 import {MinimalOrganizationApp, Organization, OrganizationApp, OrganizationStore} from '../../models/organization.js'
@@ -79,6 +79,7 @@ import {
   AppVersionByTagSchema,
   AppVersionByTagVariables,
 } from '../../api/graphql/app_version_by_tag.js'
+import {AllOrganizationsQuery, AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {
@@ -163,12 +164,12 @@ export class PartnersClient implements DeveloperPlatformClient {
     return fetchAppDetailsFromApiKey(appId, await this.token())
   }
 
-  async organizations(): Promise<Organization[]> {
-    return fetchOrganizations(await this.session())
+  async organizations(): Promise<AllOrganizationsQuerySchema> {
+    return this.makeRequest(AllOrganizationsQuery)
   }
 
   async selectOrg(): Promise<Organization> {
-    const organizations = await this.organizations()
+    const organizations = await fetchOrganizations(this)
     return selectOrganizationPrompt(organizations)
   }
 

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -13,7 +13,6 @@ import {
   filterDisabledBetas,
 } from '../../../cli/services/dev/fetch.js'
 import {MinimalOrganizationApp, Organization, OrganizationApp, OrganizationStore} from '../../models/organization.js'
-import {selectOrganizationPrompt} from '../../prompts/dev.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {fetchSpecifications} from '../../services/generate/fetch-extension-specifications.js'
 import {
@@ -173,11 +172,6 @@ export class PartnersClient implements DeveloperPlatformClient {
   async organizations(): Promise<Organization[]> {
     const result: AllOrganizationsQuerySchema = await this.makeRequest(AllOrganizationsQuery)
     return result.organizations.nodes
-  }
-
-  async selectOrg(): Promise<Organization> {
-    const organizations = await this.organizations()
-    return selectOrganizationPrompt(organizations)
   }
 
   async orgFromId(orgId: string): Promise<Organization> {

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -80,6 +80,13 @@ import {
   AppVersionByTagVariables,
 } from '../../api/graphql/app_version_by_tag.js'
 import {AllOrganizationsQuery, AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
+import {
+  SendSampleWebhookSchema,
+  SendSampleWebhookVariables,
+  sendSampleWebhookMutation,
+} from '../../services/webhook/request-sample.js'
+import {PublicApiVersionsSchema, getApiVersionsQuery} from '../../services/webhook/request-api-versions.js'
+import {WebhookTopicsSchema, WebhookTopicsVariables, getTopicsQuery} from '../../services/webhook/request-topics.js'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {
@@ -298,5 +305,17 @@ export class PartnersClient implements DeveloperPlatformClient {
 
   async appPreviewMode(input: FindAppPreviewModeVariables): Promise<FindAppPreviewModeSchema> {
     return this.makeRequest(FindAppPreviewModeQuery, input)
+  }
+
+  async sendSampleWebhook(input: SendSampleWebhookVariables): Promise<SendSampleWebhookSchema> {
+    return this.makeRequest(sendSampleWebhookMutation, input)
+  }
+
+  async apiVersions(): Promise<PublicApiVersionsSchema> {
+    return this.makeRequest(getApiVersionsQuery)
+  }
+
+  async topics(input: WebhookTopicsVariables): Promise<WebhookTopicsSchema> {
+    return this.makeRequest(getTopicsQuery, input)
   }
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
@@ -16,7 +16,7 @@ import {
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {DeveloperPlatformClient, Paginateable, ActiveAppVersion} from '../developer-platform-client.js'
 import {PartnersSession} from '../../../cli/services/context/partner-account-info.js'
-import {filterDisabledBetas} from '../../../cli/services/dev/fetch.js'
+import {fetchOrganizations, filterDisabledBetas} from '../../../cli/services/dev/fetch.js'
 import {MinimalOrganizationApp, Organization, OrganizationApp, OrganizationStore} from '../../models/organization.js'
 import {selectOrganizationPrompt} from '../../prompts/dev.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
@@ -42,6 +42,10 @@ import {
 import {AppReleaseSchema, AppReleaseVariables} from '../../api/graphql/app_release.js'
 import {AppVersionByTagSchema, AppVersionByTagVariables} from '../../api/graphql/app_version_by_tag.js'
 import {AppVersionsDiffSchema, AppVersionsDiffVariables} from '../../api/graphql/app_versions_diff.js'
+import {AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
+import {SendSampleWebhookSchema, SendSampleWebhookVariables} from '../../services/webhook/request-sample.js'
+import {PublicApiVersionsSchema} from '../../services/webhook/request-api-versions.js'
+import {WebhookTopicsSchema, WebhookTopicsVariables} from '../../services/webhook/request-topics.js'
 import {FunctionUploadUrlGenerateResponse} from '@shopify/cli-kit/node/api/partners'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
@@ -93,12 +97,16 @@ export class ShopifyDevelopersClient implements DeveloperPlatformClient {
     throw new BugError('Not implemented: appFromId')
   }
 
-  async organizations(): Promise<Organization[]> {
-    return [ORG1]
+  async organizations(): Promise<AllOrganizationsQuerySchema> {
+    return {
+      organizations: {
+        nodes: [ORG1],
+      },
+    }
   }
 
   async selectOrg(): Promise<Organization> {
-    const organizations = await this.organizations()
+    const organizations = await fetchOrganizations(this)
     return selectOrganizationPrompt(organizations)
   }
 
@@ -272,6 +280,18 @@ export class ShopifyDevelopersClient implements DeveloperPlatformClient {
 
   async appPreviewMode(_input: FindAppPreviewModeVariables): Promise<FindAppPreviewModeSchema> {
     throw new BugError('Not implemented: appPreviewMode')
+  }
+
+  async sendSampleWebhook(_input: SendSampleWebhookVariables): Promise<SendSampleWebhookSchema> {
+    throw new BugError('Not implemented: sendSampleWebhook')
+  }
+
+  async apiVersions(): Promise<PublicApiVersionsSchema> {
+    throw new BugError('Not implemented: apiVersions')
+  }
+
+  async topics(_input: WebhookTopicsVariables): Promise<WebhookTopicsSchema> {
+    throw new BugError('Not implemented: topics')
   }
 }
 

--- a/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
@@ -16,9 +16,8 @@ import {
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {DeveloperPlatformClient, Paginateable, ActiveAppVersion} from '../developer-platform-client.js'
 import {PartnersSession} from '../../../cli/services/context/partner-account-info.js'
-import {fetchOrganizations, filterDisabledBetas} from '../../../cli/services/dev/fetch.js'
+import {filterDisabledBetas} from '../../../cli/services/dev/fetch.js'
 import {MinimalOrganizationApp, Organization, OrganizationApp, OrganizationStore} from '../../models/organization.js'
-import {selectOrganizationPrompt} from '../../prompts/dev.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {AllAppExtensionRegistrationsQuerySchema} from '../../api/graphql/all_app_extension_registrations.js'
 import {
@@ -98,11 +97,6 @@ export class ShopifyDevelopersClient implements DeveloperPlatformClient {
 
   async organizations(): Promise<Organization[]> {
     return [ORG1]
-  }
-
-  async selectOrg(): Promise<Organization> {
-    const organizations = await fetchOrganizations(this)
-    return selectOrganizationPrompt(organizations)
   }
 
   async orgFromId(orgId: string): Promise<Organization> {

--- a/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
@@ -42,7 +42,6 @@ import {
 import {AppReleaseSchema, AppReleaseVariables} from '../../api/graphql/app_release.js'
 import {AppVersionByTagSchema, AppVersionByTagVariables} from '../../api/graphql/app_version_by_tag.js'
 import {AppVersionsDiffSchema, AppVersionsDiffVariables} from '../../api/graphql/app_versions_diff.js'
-import {AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
 import {SendSampleWebhookSchema, SendSampleWebhookVariables} from '../../services/webhook/request-sample.js'
 import {PublicApiVersionsSchema} from '../../services/webhook/request-api-versions.js'
 import {WebhookTopicsSchema, WebhookTopicsVariables} from '../../services/webhook/request-topics.js'
@@ -97,12 +96,8 @@ export class ShopifyDevelopersClient implements DeveloperPlatformClient {
     throw new BugError('Not implemented: appFromId')
   }
 
-  async organizations(): Promise<AllOrganizationsQuerySchema> {
-    return {
-      organizations: {
-        nodes: [ORG1],
-      },
-    }
+  async organizations(): Promise<Organization[]> {
+    return [ORG1]
   }
 
   async selectOrg(): Promise<Organization> {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-management/issues/1642
Fixes https://github.com/Shopify/develop-app-management/issues/1643

### WHAT is this pull request doing?

- Migrate all the code related to webhooks to use Partners adapter
- Simplify organizations query as commented [here](https://github.com/Shopify/cli/pull/3510#discussion_r1511057202)

### How to test your changes?

dev, webhook trigger

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
