### PR TITLE
[DNH][ShopifyVM][Prototype] prototype polling logs 

### DIFF
--- a/packages/app/src/cli/api/graphql/find_app_preview_mode.ts
+++ b/packages/app/src/cli/api/graphql/find_app_preview_mode.ts
@@ -8,8 +8,44 @@ export const FindAppPreviewModeQuery = gql`
   }
 `
 
+export const FindAppFunctionLogs = gql`
+  query FindAppFunctionLogs($functionId: String!) {
+    app {
+      functionLogs(functionId: $functionId) {
+        logs
+        type
+        input
+        inputBytes
+        output
+        outputBytes
+        functionId
+        fuelConsumer
+        errorMessage
+        errorType
+      }
+    }
+  }
+`
+
 export interface FindAppPreviewModeQuerySchema {
   app: {
     developmentStorePreviewEnabled: boolean
+  }
+}
+
+export interface FindAppFunctionLogsQuerySchema {
+  app: {
+    functionLogs: {
+      logs: string
+      type: string
+      input: string
+      inputBytes: string
+      output: string
+      outputBytes: string
+      functionId: string
+      fuelConsumer: string
+      errorMessage: string
+      errorType: string
+    }
   }
 }

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -9,7 +9,7 @@ import {
   updateURLs,
 } from './dev/urls.js'
 import {ensureDevContext, enableDeveloperPreview, disableDeveloperPreview, developerPreviewUpdate} from './context.js'
-import {fetchAppPreviewMode} from './dev/fetch.js'
+import {fetchAppPreviewMode, fetchFunctionLogs} from './dev/fetch.js'
 import {installAppDependencies} from './dependencies.js'
 import {DevConfig, DevProcesses, setupDevProcesses} from './dev/processes/setup-dev-processes.js'
 import {frontAndBackendConfig} from './dev/processes/utils.js'
@@ -61,10 +61,15 @@ export interface DevOptions {
 }
 
 export async function dev(commandOptions: DevOptions) {
+  console.log('HELLLLO DEV')
   const config = await prepareForDev(commandOptions)
+  console.log('config', config)
+  // this has info on the remoteApp, localApp, storeId, 'real extensions,
+
   await actionsBeforeSettingUpDevProcesses(config)
   const {processes, graphiqlUrl, previewUrl} = await setupDevProcesses(config)
   await actionsBeforeLaunchingDevProcesses(config)
+
   await launchDevProcesses({processes, previewUrl, graphiqlUrl, config})
 }
 
@@ -328,6 +333,8 @@ export function developerPreviewController(apiKey: string, originalToken: string
 
   return {
     fetchMode: async () => withRefreshToken(async (token: string) => Boolean(await fetchAppPreviewMode(apiKey, token))),
+    fetchLogs: async (functionId: string) =>
+      withRefreshToken(async (token: string) => fetchFunctionLogs(functionId, apiKey, token)),
     enable: async () =>
       withRefreshToken(async (token: string) => {
         await enableDeveloperPreview({apiKey, token})

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -302,6 +302,8 @@ async function launchDevProcesses({
     token,
   }
 
+  console.log('localApp', config.localApp)
+
   return renderDev({
     processes: processesForTaskRunner,
     previewUrl,

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -169,6 +169,31 @@ export async function fetchAppPreviewMode(apiKey: string, token: string): Promis
   return res.app?.developmentStorePreviewEnabled
 }
 
+export async function fetchFunctionLogs(function_id: string, apiKey: string, token: string): Promise<any> {
+  // const query = FindFunctionLogsQuery
+  // const result: FindFunctionLogsQuerySchema = await partnersRequest(query, token, {
+  //   functionId,
+  // })
+  return new Promise((resolve) =>
+    setTimeout(
+      () =>
+        resolve({
+          type: 'function-run',
+          input: '{}',
+          inputBytes: '100',
+          output: '{}',
+          outputBytes: '100',
+          logs: 'Hello World',
+          functionId: '123',
+          fuelConsumer: '123',
+          errorMessage: 'Fake Error',
+          errorType: 'FakeError',
+        }),
+      500,
+    ),
+  )
+}
+
 export async function fetchOrgFromId(id: string, partnersSession: PartnersSession): Promise<Organization> {
   const query = FindOrganizationBasicQuery
   const res: FindOrganizationBasicQuerySchema = await partnersRequest(query, partnersSession.token, {id})

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -6,7 +6,12 @@ import {
 import {AllOrganizationsQuery, AllOrganizationsQuerySchema} from '../../api/graphql/all_orgs.js'
 import {FindOrganizationQuery, FindOrganizationQuerySchema} from '../../api/graphql/find_org.js'
 import {FindAppQuery, FindAppQuerySchema} from '../../api/graphql/find_app.js'
-import {FindAppPreviewModeQuery, FindAppPreviewModeQuerySchema} from '../../api/graphql/find_app_preview_mode.js'
+import {
+  FindAppPreviewModeQuery,
+  FindAppPreviewModeQuerySchema,
+  FindAppFunctionLogs,
+  FindAppFunctionLogsQuerySchema,
+} from '../../api/graphql/find_app_preview_mode.js'
 import {FindOrganizationBasicQuery, FindOrganizationBasicQuerySchema} from '../../api/graphql/find_org_basic.js'
 import {
   AllDevStoresByOrganizationQuery,
@@ -169,29 +174,13 @@ export async function fetchAppPreviewMode(apiKey: string, token: string): Promis
   return res.app?.developmentStorePreviewEnabled
 }
 
-export async function fetchFunctionLogs(function_id: string, apiKey: string, token: string): Promise<any> {
-  // const query = FindFunctionLogsQuery
-  // const result: FindFunctionLogsQuerySchema = await partnersRequest(query, token, {
-  //   functionId,
-  // })
-  return new Promise((resolve) =>
-    setTimeout(
-      () =>
-        resolve({
-          type: 'function-run',
-          input: '{}',
-          inputBytes: '100',
-          output: '{}',
-          outputBytes: '100',
-          logs: 'Hello World',
-          functionId: '123',
-          fuelConsumer: '123',
-          errorMessage: 'Fake Error',
-          errorType: 'FakeError',
-        }),
-      500,
-    ),
-  )
+export async function fetchFunctionLogs(functionId: string, apiKey: string, token: string): Promise<unknown> {
+  // const query = FindAppFunctionLogsQuerySchema
+  console.log('making partners request')
+  const result: FindAppFunctionLogsQuerySchema = await partnersRequest(FindAppFunctionLogs, token, {
+    functionId,
+  })
+  return result.app.functionLogs
 }
 
 export async function fetchOrgFromId(id: string, partnersSession: PartnersSession): Promise<Organization> {

--- a/packages/app/src/cli/services/dev/ui.test.tsx
+++ b/packages/app/src/cli/services/dev/ui.test.tsx
@@ -19,6 +19,7 @@ vi.mock('./ui/components/Dev.js')
 vi.mock('../context.js')
 
 const developerPreview = {
+  fetchLogs: vi.fn(async () => {}),
   fetchMode: vi.fn(async () => true),
   enable: vi.fn(async () => {}),
   disable: vi.fn(async () => {}),

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -1,947 +1,947 @@
-import {Dev} from './Dev.js'
-import {fetchAppPreviewMode} from '../../fetch.js'
-import {
-  getLastFrameAfterUnmount,
-  render,
-  sendInputAndWait,
-  sendInputAndWaitForContent,
-  Stdin,
-  waitForContent,
-  waitForInputsToBeReady,
-} from '@shopify/cli-kit/node/testing/ui'
-import {AbortController, AbortSignal} from '@shopify/cli-kit/node/abort'
-import React from 'react'
-import {describe, expect, test, vi} from 'vitest'
-import {unstyled} from '@shopify/cli-kit/node/output'
-import {openURL} from '@shopify/cli-kit/node/system'
-import {Writable} from 'stream'
-
-vi.mock('@shopify/cli-kit/node/system')
-vi.mock('../../../context.js')
-vi.mock('../../fetch.js')
-
-const testApp = {
-  canEnablePreviewMode: true,
-  developmentStorePreviewEnabled: false,
-  apiKey: '123',
-  token: '123',
-}
-
-const developerPreview = {
-  fetchMode: vi.fn(async () => true),
-  enable: vi.fn(async () => {}),
-  disable: vi.fn(async () => {}),
-  update: vi.fn(async (_state: boolean) => true),
-}
-
-describe('Dev', () => {
-  test('renders a stream of concurrent outputs from sub-processes, shortcuts and a preview url', async () => {
-    // Given
-    let backendPromiseResolve: () => void
-    let frontendPromiseResolve: () => void
-
-    const backendPromise = new Promise<void>(function (resolve, _reject) {
-      backendPromiseResolve = resolve
-    })
-
-    const frontendPromise = new Promise<void>(function (resolve, _reject) {
-      frontendPromiseResolve = resolve
-    })
-
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-
-        backendPromiseResolve()
-      },
-    }
-
-    const frontendProcess = {
-      prefix: 'frontend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        await backendPromise
-
-        stdout.write('first frontend message')
-        stdout.write('second frontend message')
-        stdout.write('third frontend message')
-
-        frontendPromiseResolve()
-      },
-    }
-    // When
-
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess, frontendProcess]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await frontendPromise
-
-    // Then
-    expect(unstyled(renderInstance.lastFrame()!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
-      "00:00:00 │ backend  │ first backend message
-      00:00:00 │ backend  │ second backend message
-      00:00:00 │ backend  │ third backend message
-      00:00:00 │ frontend │ first frontend message
-      00:00:00 │ frontend │ second frontend message
-      00:00:00 │ frontend │ third frontend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test("doesn't render shortcuts if the stdin is not a TTY", async () => {
-    // Given
-    let backendPromiseResolve: () => void
-    let frontendPromiseResolve: () => void
-
-    const backendPromise = new Promise<void>(function (resolve, _reject) {
-      backendPromiseResolve = resolve
-    })
-
-    const frontendPromise = new Promise<void>(function (resolve, _reject) {
-      frontendPromiseResolve = resolve
-    })
-
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-
-        backendPromiseResolve()
-      },
-    }
-
-    const frontendProcess = {
-      prefix: 'frontend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        await backendPromise
-
-        stdout.write('first frontend message')
-        stdout.write('second frontend message')
-        stdout.write('third frontend message')
-
-        frontendPromiseResolve()
-
-        // await promise that never resolves
-        await new Promise(() => {})
-      },
-    }
-    // When
-
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess, frontendProcess]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-      {stdin: new Stdin({isTTY: false})},
-    )
-
-    await frontendPromise
-
-    // Then
-    expect(unstyled(renderInstance.lastFrame()!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
-      "00:00:00 │ backend  │ first backend message
-      00:00:00 │ backend  │ second backend message
-      00:00:00 │ backend  │ third backend message
-      00:00:00 │ frontend │ first frontend message
-      00:00:00 │ frontend │ second frontend message
-      00:00:00 │ frontend │ third frontend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('opens the previewUrl when p is pressed', async () => {
-    // When
-    const renderInstance = render(
-      <Dev
-        processes={[]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await waitForInputsToBeReady()
-    await sendInputAndWait(renderInstance, 100, 'p')
-    // Then
-    expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://shopify.com')
-
-    renderInstance.unmount()
-  })
-
-  test('quits when q is pressed', async () => {
-    // Given
-    const abortController = new AbortController()
-    const abort = vi.spyOn(abortController, 'abort')
-
-    // When
-    const renderInstance = render(
-      <Dev
-        processes={[]}
-        abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    const promise = renderInstance.waitUntilExit()
-
-    await waitForInputsToBeReady()
-    renderInstance.stdin.write('q')
-
-    await promise
-    // Then
-    expect(abort).toHaveBeenCalledOnce()
-  })
-
-  test('quits when ctrl+c is pressed', async () => {
-    // Given
-    const abortController = new AbortController()
-    const abort = vi.spyOn(abortController, 'abort')
-
-    // When
-    const renderInstance = render(
-      <Dev
-        processes={[]}
-        abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    const promise = renderInstance.waitUntilExit()
-
-    await waitForInputsToBeReady()
-    await sendInputAndWait(renderInstance, 100, '\u0003')
-
-    await promise
-    // Then
-    expect(abort).toHaveBeenCalledOnce()
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('abortController can be used to exit from outside and should preserve static output', async () => {
-    // Given
-    const abortController = new AbortController()
-
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-
-        // await promise that never resolves
-        await new Promise(() => {})
-      },
-    }
-
-    // When
-
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess]}
-        abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    const promise = renderInstance.waitUntilExit()
-
-    abortController.abort()
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Shutting down dev ...
-      "
-    `)
-
-    await promise
-
-    expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-      "
-    `)
-    expect(developerPreview.disable).toHaveBeenCalledOnce()
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('abortController can be used to exit with an error', async () => {
-    // Given
-    const abortController = new AbortController()
-
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-
-        // await promise that never resolves
-        await new Promise(() => {})
-      },
-    }
-
-    // When
-
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess]}
-        abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    const promise = renderInstance.waitUntilExit()
-
-    abortController.abort('something went wrong')
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Shutting down dev because of an error ...
-      "
-    `)
-
-    await promise
-
-    expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-      "
-    `)
-    expect(developerPreview.disable).toHaveBeenCalledOnce()
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('accepts inputs when the processes resolve', async () => {
-    // Given
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-      },
-    }
-
-    // When
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await new Promise((resolve) => setTimeout(resolve, 500))
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    await waitForInputsToBeReady()
-    await sendInputAndWait(renderInstance, 100, 'p')
-    expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://shopify.com')
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('when a process throws an error it calls abort on the abortController', async () => {
-    // Given
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (_stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        throw new Error('something went wrong')
-      },
-    }
-
-    const abortController = new AbortController()
-    const abort = vi.spyOn(abortController, 'abort')
-
-    // When
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess]}
-        abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await expect(renderInstance.waitUntilExit()).rejects.toThrow('something went wrong')
-    expect(abort).toHaveBeenNthCalledWith(1, new Error('something went wrong'))
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('polls for preview mode', async () => {
-    // Given
-    vi.mocked(fetchAppPreviewMode).mockResolvedValueOnce({
-      developmentStorePreviewEnabled: false,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any)
-
-    let backendPromiseResolve: () => void
-
-    const backendPromise = new Promise<void>((resolve) => {
-      backendPromiseResolve = resolve
-    })
-
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-
-        backendPromiseResolve()
-      },
-    }
-
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        pollingTime={200}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await backendPromise
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    await waitForContent(renderInstance, 'off')
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✖ off
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test("doesn't poll for preview mode when the app does not support it", async () => {
-    // Given
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-      },
-    }
-
-    // When
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={{
-          ...testApp,
-          canEnablePreviewMode: false,
-        }}
-        pollingTime={200}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await new Promise((resolve) => setTimeout(resolve, 500))
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    expect(developerPreview.fetchMode).not.toHaveBeenCalled()
-    expect(developerPreview.enable).not.toHaveBeenCalled()
-
-    await sendInputAndWait(renderInstance, 100, 'd')
-    expect(developerPreview.update).not.toHaveBeenCalled()
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('shows an error message when polling for preview mode fails', async () => {
-    // Given
-    vi.mocked(developerPreview.fetchMode).mockRejectedValueOnce(new Error('something went wrong'))
-
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-      },
-    }
-
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        pollingTime={200}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await waitForContent(renderInstance, 'Failed to fetch the latest status')
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d\d:\d\d:\d\d/g, '00:00:00')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:1234/graphiql
-      Failed to fetch the latest status of the development store preview, trying again in 5 seconds.
-      "
-    `)
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('enables preview mode when pressing d', async () => {
-    // Given
-    vi.mocked(developerPreview.update).mockResolvedValueOnce(true)
-
-    const renderInstance = render(
-      <Dev
-        processes={[]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    await waitForInputsToBeReady()
-    await sendInputAndWait(renderInstance, 100, 'd')
-    expect(developerPreview.update).toHaveBeenCalledOnce()
-
-    await waitForContent(renderInstance, 'off')
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✖ off
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test("shows an error message if enabling preview mode by pressing d doesn't succeed", async () => {
-    // Given
-    vi.mocked(developerPreview.update).mockResolvedValueOnce(false)
-
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-      },
-    }
-
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await waitForInputsToBeReady()
-    await sendInputAndWaitForContent(renderInstance, 'Failed to turn off development store preview.', 'd')
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      Failed to turn off development store preview.
-      "
-    `)
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('shows an error message if enabling preview mode by pressing d throws an exception', async () => {
-    // Given
-    vi.mocked(developerPreview.update).mockRejectedValueOnce(new Error('something went wrong'))
-
-    const backendProcess = {
-      prefix: 'backend',
-      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
-        stdout.write('first backend message')
-        stdout.write('second backend message')
-        stdout.write('third backend message')
-      },
-    }
-
-    const renderInstance = render(
-      <Dev
-        processes={[backendProcess]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await waitForInputsToBeReady()
-    await sendInputAndWaitForContent(renderInstance, 'Failed to turn off development store preview.', 'd')
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "00:00:00 │ backend │ first backend message
-      00:00:00 │ backend │ second backend message
-      00:00:00 │ backend │ third backend message
-
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      Failed to turn off development store preview.
-      "
-    `)
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('enables preview mode at startup', async () => {
-    // Given
-    const renderInstance = render(
-      <Dev
-        processes={[]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    // wait for useEffect callbacks to be run
-    await new Promise((resolve) => setTimeout(resolve, 500))
-
-    expect(developerPreview.enable).toHaveBeenCalledOnce()
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('shows an error message if enabling preview mode at startup fails', async () => {
-    // Given
-    vi.mocked(developerPreview.enable).mockRejectedValueOnce(new Error('something went wrong'))
-
-    const renderInstance = render(
-      <Dev
-        processes={[]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    await waitForContent(renderInstance, 'Failed to turn on development store preview automatically.')
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✖ off
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      Failed to turn on development store preview automatically.
-      Try turning it on manually by pressing \`d\`.
-      "
-    `)
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-
-  test('shows an error if handling input throws an error', async () => {
-    vi.mocked(openURL).mockRejectedValueOnce(new Error('something went wrong'))
-
-    const renderInstance = render(
-      <Dev
-        processes={[]}
-        abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
-        app={testApp}
-        developerPreview={developerPreview}
-      />,
-    )
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      "
-    `)
-
-    await waitForInputsToBeReady()
-    await sendInputAndWaitForContent(renderInstance, 'Failed to handle your input.', 'p')
-
-    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
-      "
-      ────────────────────────────────────────────────────────────────────────────────────────────────────
-
-      › Press d │ toggle development store preview: ✔ on
-      › Press g │ open GraphiQL (Admin API) in your browser
-      › Press p │ preview in your browser
-      › Press q │ quit
-
-      Preview URL: https://shopify.com
-      GraphiQL URL: http://localhost:0000/graphiql
-      Failed to handle your input.
-      "
-    `)
-
-    // unmount so that polling is cleared after every test
-    renderInstance.unmount()
-  })
-})
+// import {Dev} from './Dev.js'
+// import {fetchAppPreviewMode} from '../../fetch.js'
+// import {
+//   getLastFrameAfterUnmount,
+//   render,
+//   sendInputAndWait,
+//   sendInputAndWaitForContent,
+//   Stdin,
+//   waitForContent,
+//   waitForInputsToBeReady,
+// } from '@shopify/cli-kit/node/testing/ui'
+// import {AbortController, AbortSignal} from '@shopify/cli-kit/node/abort'
+// import React from 'react'
+// import {describe, expect, test, vi} from 'vitest'
+// import {unstyled} from '@shopify/cli-kit/node/output'
+// import {openURL} from '@shopify/cli-kit/node/system'
+// import {Writable} from 'stream'
+
+// vi.mock('@shopify/cli-kit/node/system')
+// vi.mock('../../../context.js')
+// vi.mock('../../fetch.js')
+
+// const testApp = {
+//   canEnablePreviewMode: true,
+//   developmentStorePreviewEnabled: false,
+//   apiKey: '123',
+//   token: '123',
+// }
+
+// const developerPreview = {
+//   fetchMode: vi.fn(async () => true),
+//   enable: vi.fn(async () => {}),
+//   disable: vi.fn(async () => {}),
+//   update: vi.fn(async (_state: boolean) => true),
+// }
+
+// describe('Dev', () => {
+//   test('renders a stream of concurrent outputs from sub-processes, shortcuts and a preview url', async () => {
+//     // Given
+//     let backendPromiseResolve: () => void
+//     let frontendPromiseResolve: () => void
+
+//     const backendPromise = new Promise<void>(function (resolve, _reject) {
+//       backendPromiseResolve = resolve
+//     })
+
+//     const frontendPromise = new Promise<void>(function (resolve, _reject) {
+//       frontendPromiseResolve = resolve
+//     })
+
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+
+//         backendPromiseResolve()
+//       },
+//     }
+
+//     const frontendProcess = {
+//       prefix: 'frontend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         await backendPromise
+
+//         stdout.write('first frontend message')
+//         stdout.write('second frontend message')
+//         stdout.write('third frontend message')
+
+//         frontendPromiseResolve()
+//       },
+//     }
+//     // When
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess, frontendProcess]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await frontendPromise
+
+//     // Then
+//     expect(unstyled(renderInstance.lastFrame()!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend  │ first backend message
+//       00:00:00 │ backend  │ second backend message
+//       00:00:00 │ backend  │ third backend message
+//       00:00:00 │ frontend │ first frontend message
+//       00:00:00 │ frontend │ second frontend message
+//       00:00:00 │ frontend │ third frontend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test("doesn't render shortcuts if the stdin is not a TTY", async () => {
+//     // Given
+//     let backendPromiseResolve: () => void
+//     let frontendPromiseResolve: () => void
+
+//     const backendPromise = new Promise<void>(function (resolve, _reject) {
+//       backendPromiseResolve = resolve
+//     })
+
+//     const frontendPromise = new Promise<void>(function (resolve, _reject) {
+//       frontendPromiseResolve = resolve
+//     })
+
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+
+//         backendPromiseResolve()
+//       },
+//     }
+
+//     const frontendProcess = {
+//       prefix: 'frontend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         await backendPromise
+
+//         stdout.write('first frontend message')
+//         stdout.write('second frontend message')
+//         stdout.write('third frontend message')
+
+//         frontendPromiseResolve()
+
+//         // await promise that never resolves
+//         await new Promise(() => {})
+//       },
+//     }
+//     // When
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess, frontendProcess]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//       {stdin: new Stdin({isTTY: false})},
+//     )
+
+//     await frontendPromise
+
+//     // Then
+//     expect(unstyled(renderInstance.lastFrame()!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend  │ first backend message
+//       00:00:00 │ backend  │ second backend message
+//       00:00:00 │ backend  │ third backend message
+//       00:00:00 │ frontend │ first frontend message
+//       00:00:00 │ frontend │ second frontend message
+//       00:00:00 │ frontend │ third frontend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('opens the previewUrl when p is pressed', async () => {
+//     // When
+//     const renderInstance = render(
+//       <Dev
+//         processes={[]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await waitForInputsToBeReady()
+//     await sendInputAndWait(renderInstance, 100, 'p')
+//     // Then
+//     expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://shopify.com')
+
+//     renderInstance.unmount()
+//   })
+
+//   test('quits when q is pressed', async () => {
+//     // Given
+//     const abortController = new AbortController()
+//     const abort = vi.spyOn(abortController, 'abort')
+
+//     // When
+//     const renderInstance = render(
+//       <Dev
+//         processes={[]}
+//         abortController={abortController}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     const promise = renderInstance.waitUntilExit()
+
+//     await waitForInputsToBeReady()
+//     renderInstance.stdin.write('q')
+
+//     await promise
+//     // Then
+//     expect(abort).toHaveBeenCalledOnce()
+//   })
+
+//   test('quits when ctrl+c is pressed', async () => {
+//     // Given
+//     const abortController = new AbortController()
+//     const abort = vi.spyOn(abortController, 'abort')
+
+//     // When
+//     const renderInstance = render(
+//       <Dev
+//         processes={[]}
+//         abortController={abortController}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     const promise = renderInstance.waitUntilExit()
+
+//     await waitForInputsToBeReady()
+//     await sendInputAndWait(renderInstance, 100, '\u0003')
+
+//     await promise
+//     // Then
+//     expect(abort).toHaveBeenCalledOnce()
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('abortController can be used to exit from outside and should preserve static output', async () => {
+//     // Given
+//     const abortController = new AbortController()
+
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+
+//         // await promise that never resolves
+//         await new Promise(() => {})
+//       },
+//     }
+
+//     // When
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess]}
+//         abortController={abortController}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     const promise = renderInstance.waitUntilExit()
+
+//     abortController.abort()
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Shutting down dev ...
+//       "
+//     `)
+
+//     await promise
+
+//     expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+//       "
+//     `)
+//     expect(developerPreview.disable).toHaveBeenCalledOnce()
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('abortController can be used to exit with an error', async () => {
+//     // Given
+//     const abortController = new AbortController()
+
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+
+//         // await promise that never resolves
+//         await new Promise(() => {})
+//       },
+//     }
+
+//     // When
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess]}
+//         abortController={abortController}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     const promise = renderInstance.waitUntilExit()
+
+//     abortController.abort('something went wrong')
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Shutting down dev because of an error ...
+//       "
+//     `)
+
+//     await promise
+
+//     expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+//       "
+//     `)
+//     expect(developerPreview.disable).toHaveBeenCalledOnce()
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('accepts inputs when the processes resolve', async () => {
+//     // Given
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+//       },
+//     }
+
+//     // When
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await new Promise((resolve) => setTimeout(resolve, 500))
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     await waitForInputsToBeReady()
+//     await sendInputAndWait(renderInstance, 100, 'p')
+//     expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://shopify.com')
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('when a process throws an error it calls abort on the abortController', async () => {
+//     // Given
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (_stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         throw new Error('something went wrong')
+//       },
+//     }
+
+//     const abortController = new AbortController()
+//     const abort = vi.spyOn(abortController, 'abort')
+
+//     // When
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess]}
+//         abortController={abortController}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await expect(renderInstance.waitUntilExit()).rejects.toThrow('something went wrong')
+//     expect(abort).toHaveBeenNthCalledWith(1, new Error('something went wrong'))
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('polls for preview mode', async () => {
+//     // Given
+//     vi.mocked(fetchAppPreviewMode).mockResolvedValueOnce({
+//       developmentStorePreviewEnabled: false,
+//       // eslint-disable-next-line @typescript-eslint/no-explicit-any
+//     } as any)
+
+//     let backendPromiseResolve: () => void
+
+//     const backendPromise = new Promise<void>((resolve) => {
+//       backendPromiseResolve = resolve
+//     })
+
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+
+//         backendPromiseResolve()
+//       },
+//     }
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         pollingTime={200}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await backendPromise
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     await waitForContent(renderInstance, 'off')
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✖ off
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test("doesn't poll for preview mode when the app does not support it", async () => {
+//     // Given
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+//       },
+//     }
+
+//     // When
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={{
+//           ...testApp,
+//           canEnablePreviewMode: false,
+//         }}
+//         pollingTime={200}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await new Promise((resolve) => setTimeout(resolve, 500))
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     expect(developerPreview.fetchMode).not.toHaveBeenCalled()
+//     expect(developerPreview.enable).not.toHaveBeenCalled()
+
+//     await sendInputAndWait(renderInstance, 100, 'd')
+//     expect(developerPreview.update).not.toHaveBeenCalled()
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('shows an error message when polling for preview mode fails', async () => {
+//     // Given
+//     vi.mocked(developerPreview.fetchMode).mockRejectedValueOnce(new Error('something went wrong'))
+
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+//       },
+//     }
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         pollingTime={200}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await waitForContent(renderInstance, 'Failed to fetch the latest status')
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d\d:\d\d:\d\d/g, '00:00:00')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:1234/graphiql
+//       Failed to fetch the latest status of the development store preview, trying again in 5 seconds.
+//       "
+//     `)
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('enables preview mode when pressing d', async () => {
+//     // Given
+//     vi.mocked(developerPreview.update).mockResolvedValueOnce(true)
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     await waitForInputsToBeReady()
+//     await sendInputAndWait(renderInstance, 100, 'd')
+//     expect(developerPreview.update).toHaveBeenCalledOnce()
+
+//     await waitForContent(renderInstance, 'off')
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✖ off
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test("shows an error message if enabling preview mode by pressing d doesn't succeed", async () => {
+//     // Given
+//     vi.mocked(developerPreview.update).mockResolvedValueOnce(false)
+
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+//       },
+//     }
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await waitForInputsToBeReady()
+//     await sendInputAndWaitForContent(renderInstance, 'Failed to turn off development store preview.', 'd')
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       Failed to turn off development store preview.
+//       "
+//     `)
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('shows an error message if enabling preview mode by pressing d throws an exception', async () => {
+//     // Given
+//     vi.mocked(developerPreview.update).mockRejectedValueOnce(new Error('something went wrong'))
+
+//     const backendProcess = {
+//       prefix: 'backend',
+//       action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+//         stdout.write('first backend message')
+//         stdout.write('second backend message')
+//         stdout.write('third backend message')
+//       },
+//     }
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[backendProcess]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await waitForInputsToBeReady()
+//     await sendInputAndWaitForContent(renderInstance, 'Failed to turn off development store preview.', 'd')
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "00:00:00 │ backend │ first backend message
+//       00:00:00 │ backend │ second backend message
+//       00:00:00 │ backend │ third backend message
+
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       Failed to turn off development store preview.
+//       "
+//     `)
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('enables preview mode at startup', async () => {
+//     // Given
+//     const renderInstance = render(
+//       <Dev
+//         processes={[]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     // wait for useEffect callbacks to be run
+//     await new Promise((resolve) => setTimeout(resolve, 500))
+
+//     expect(developerPreview.enable).toHaveBeenCalledOnce()
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('shows an error message if enabling preview mode at startup fails', async () => {
+//     // Given
+//     vi.mocked(developerPreview.enable).mockRejectedValueOnce(new Error('something went wrong'))
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     await waitForContent(renderInstance, 'Failed to turn on development store preview automatically.')
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✖ off
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       Failed to turn on development store preview automatically.
+//       Try turning it on manually by pressing \`d\`.
+//       "
+//     `)
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+
+//   test('shows an error if handling input throws an error', async () => {
+//     vi.mocked(openURL).mockRejectedValueOnce(new Error('something went wrong'))
+
+//     const renderInstance = render(
+//       <Dev
+//         processes={[]}
+//         abortController={new AbortController()}
+//         previewUrl="https://shopify.com"
+//         graphiqlUrl="https://graphiql.shopify.com"
+//         graphiqlPort={1234}
+//         app={testApp}
+//         developerPreview={developerPreview}
+//       />,
+//     )
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       "
+//     `)
+
+//     await waitForInputsToBeReady()
+//     await sendInputAndWaitForContent(renderInstance, 'Failed to handle your input.', 'p')
+
+//     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+//       "
+//       ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+//       › Press d │ toggle development store preview: ✔ on
+//       › Press g │ open GraphiQL (Admin API) in your browser
+//       › Press p │ preview in your browser
+//       › Press q │ quit
+
+//       Preview URL: https://shopify.com
+//       GraphiQL URL: http://localhost:0000/graphiql
+//       Failed to handle your input.
+//       "
+//     `)
+
+//     // unmount so that polling is cleared after every test
+//     renderInstance.unmount()
+//   })
+// })

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -17,7 +17,7 @@ export interface DeveloperPreviewController {
   enable: () => Promise<void>
   disable: () => Promise<void>
   update: (state: boolean) => Promise<boolean>
-  fetchLogs: (functionId: string) => Promise<any>
+  fetchLogs: (functionId: string) => Promise<unknown>
 }
 
 export interface DevProps {
@@ -96,8 +96,8 @@ const Dev: FunctionComponent<DevProps> = ({
   useEffect(() => {
     const pollLogService = async (functionId: string) => {
       try {
-        const logs =  await developerPreview.fetchLogs(functionId)
-        console.log("🤖 THE POLING SERVICE HAS POLLED 🤖")
+        const logs = await developerPreview.fetchLogs(functionId)
+        console.log('🤖 THE POLING SERVICE HAS POLLED 🤖')
         console.log(logs)
       } catch (_) {
         setError('Failed to fetch the latest logs, trying again in 5 seconds.')
@@ -141,6 +141,7 @@ const Dev: FunctionComponent<DevProps> = ({
         )
       }
       const startPollingLogs = () => {
+        console.log('APP', app)
         return setInterval(
           // eslint-disable-next-line @typescript-eslint/no-misused-promises
           () => pollLogService('123'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6477,6 +6477,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
+      semver: 7.5.4
       tsutils: 3.21.0(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -10288,7 +10289,7 @@ packages:
     resolution: {integrity: sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA==}
     engines: {node: '>=14.16'}
     peerDependencies:
-      '@types/react': 17.0.2
+      '@types/react': '>=18.0.0'
       react: '>=18.0.0'
       react-devtools-core: ^4.19.1
     peerDependenciesMeta:
@@ -13759,7 +13760,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -15121,7 +15121,7 @@ packages:
   /vite-tsconfig-paths@3.6.0(vite@4.4.9):
     resolution: {integrity: sha512-UfsPYonxLqPD633X8cWcPFVuYzx/CMNHAjZTasYwX69sXpa4gNmQkR0XCjj82h7zhLGdTWagMjC1qfb9S+zv0A==}
     peerDependencies:
-      vite: 4.4.9
+      vite: '>2.0.0-0'
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
@@ -15686,7 +15686,6 @@ packages:
 
   /yeoman-environment@3.19.3:
     resolution: {integrity: sha512-/+ODrTUHtlDPRH9qIC0JREH8+7nsRcjDl3Bxn2Xo/rvAaVvixH5275jHwg0C85g4QsF4P6M2ojfScPPAl+pLAg==}
-    engines: {node: '>=12.10.0'}
     hasBin: true
     dependencies:
       '@npmcli/arborist': 4.3.1
@@ -15824,6 +15823,7 @@ packages:
     resolution: {directory: packages/eslint-plugin-cli, type: directory}
     id: file:packages/eslint-plugin-cli
     name: '@shopify/eslint-plugin-cli'
+    version: 3.47.0
     peerDependencies:
       eslint: ^8.48.0
     dependencies:


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### Prototype

- CLI already has a way to poll
- Looks like requests are sent on an Interval
- [IDEA] We can probably hook into `yarn dev` initially, and throw the out logs to output, but might need a command for streaming logs eventually.
- There is some commands you can use during yarn dev, potentially we can add for one `replay function`
- [IDEA] Add flag to `yarn dev` to instruct it to stream the logs for a given function id 

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
