### PR TITLE
Fix link command for apps with empty scopes

### DIFF
--- a/.changeset/wise-houses-kick.md
+++ b/.changeset/wise-houses-kick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix link command for apps with empty scopes

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -5,7 +5,6 @@ import {isType} from '../../utilities/types.js'
 import {FunctionConfigType} from '../extensions/specifications/function.js'
 import {ExtensionSpecification} from '../extensions/specification.js'
 import {SpecsAppConfiguration} from '../extensions/specifications/types/app_config.js'
-import {WebhooksConfig} from '../extensions/specifications/types/app_config_webhook.js'
 import {BetaFlag} from '../../services/dev/fetch.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {DotEnvFile} from '@shopify/cli-kit/node/dot-env'
@@ -13,7 +12,6 @@ import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify
 import {fileRealPath, findPathUp} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {getPathValue} from '@shopify/cli-kit/common/object'
 
 export const LegacyAppSchema = zod
   .object({
@@ -293,68 +291,7 @@ export class App implements AppInterface {
 
   private configurationTyped(configuration: AppConfiguration) {
     if (isLegacyAppSchema(configuration)) return configuration
-    return {
-      ...configuration,
-      ...buildSpecsAppConfiguration(configuration),
-    } as CurrentAppConfiguration & SpecsAppConfiguration
-  }
-}
-
-export function buildSpecsAppConfiguration(content: object) {
-  return {
-    ...homeConfiguration(content),
-    ...appProxyConfiguration(content),
-    ...posConfiguration(content),
-    ...webhooksConfiguration(content),
-    ...accessConfiguration(content),
-  }
-}
-
-function appProxyConfiguration(configuration: object) {
-  if (!getPathValue(configuration, 'app_proxy')) return
-  return {
-    app_proxy: {
-      url: getPathValue<string>(configuration, 'app_proxy.url')!,
-      prefix: getPathValue<string>(configuration, 'app_proxy.prefix')!,
-      subpath: getPathValue<string>(configuration, 'app_proxy.subpath')!,
-    },
-  }
-}
-
-function homeConfiguration(configuration: object) {
-  const appPreferencesUrl = getPathValue<string>(configuration, 'app_preferences.url')
-  return {
-    name: getPathValue<string>(configuration, 'name')!,
-    application_url: getPathValue<string>(configuration, 'application_url')!,
-    embedded: getPathValue<boolean>(configuration, 'embedded')!,
-    ...(appPreferencesUrl ? {app_preferences: {url: appPreferencesUrl}} : {}),
-  }
-}
-
-function posConfiguration(configuration: object) {
-  const embedded = getPathValue<boolean>(configuration, 'pos.embedded')
-  return embedded === undefined
-    ? undefined
-    : {
-        pos: {
-          embedded,
-        },
-      }
-}
-
-function webhooksConfiguration(configuration: object) {
-  return {
-    webhooks: {...getPathValue<WebhooksConfig>(configuration, 'webhooks')},
-  }
-}
-
-function accessConfiguration(configuration: object) {
-  const scopes = getPathValue<string>(configuration, 'access_scopes.scopes')
-  const useLegacyInstallFlow = getPathValue<boolean>(configuration, 'access_scopes.use_legacy_install_flow')
-  const redirectUrls = getPathValue<string[]>(configuration, 'auth.redirect_urls')
-  return {
-    ...(scopes || useLegacyInstallFlow ? {access_scopes: {scopes, use_legacy_install_flow: useLegacyInstallFlow}} : {}),
-    ...(redirectUrls ? {auth: {redirect_urls: redirectUrls}} : {}),
+    return configuration as CurrentAppConfiguration & SpecsAppConfiguration
   }
 }
 

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -743,6 +743,51 @@ embedded = false
       expect(content).toEqual(expectedContent)
     })
   })
+
+  test('write in the toml configuration fields not typed', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const options: LinkOptions = {
+        directory: tmp,
+        developerPlatformClient,
+      }
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp())
+      const remoteConfiguration = {
+        ...DEFAULT_REMOTE_CONFIGURATION,
+        handle: 'handle',
+      }
+      vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
+
+      // When
+      await link(options)
+
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "12345"
+name = "app1"
+handle = "handle"
+application_url = "https://example.com"
+embedded = true
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+use_legacy_install_flow = true
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[webhooks]
+api_version = "2023-07"
+
+[pos]
+embedded = false
+`
+      expect(content).toEqual(expectedContent)
+    })
+  })
 })
 
 async function mockApp(

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -3,9 +3,8 @@ import {selectOrganizationPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {BetaFlag} from '../dev/fetch.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {AppModuleVersion} from '../../api/graphql/app_active_version.js'
-import {buildSpecsAppConfiguration} from '../../models/app/app.js'
-import {SpecsAppConfiguration} from '../../models/extensions/specifications/types/app_config.js'
 import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {SpecsAppConfiguration} from '../../models/extensions/specifications/types/app_config.js'
 import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 
 export async function selectApp(): Promise<OrganizationApp> {
@@ -29,8 +28,11 @@ export async function fetchAppRemoteConfiguration(
     activeAppVersion.app.activeAppVersion?.appModuleVersions.filter(
       (module) => module.specification?.experience === 'configuration',
     ) || []
-  const remoteAppConfiguration = remoteAppConfigurationExtensionContent(appModuleVersionsConfig, specifications, betas)
-  return buildSpecsAppConfiguration(remoteAppConfiguration) as SpecsAppConfiguration
+  return remoteAppConfigurationExtensionContent(
+    appModuleVersionsConfig,
+    specifications,
+    betas,
+  ) as unknown as SpecsAppConfiguration
 }
 
 export function remoteAppConfigurationExtensionContent(

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -1115,6 +1115,7 @@ describe('ensureDeployContext', () => {
 
     // There is a cached app but it will be ignored
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
+    vi.mocked(link).mockResolvedValue(app.configuration)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
     vi.mocked(loadApp).mockResolvedValue(app)
     const writeAppConfigurationFileSpy = vi
@@ -1638,6 +1639,7 @@ describe('ensureDraftExtensionsPushContext', () => {
     vi.mocked(loadApp).mockResolvedValue(app)
     // There is a cached app but it will be ignored
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
+    vi.mocked(link).mockResolvedValue(app.configuration)
     vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
 
     const opts = draftExtensionsPushOptions(app)

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -647,10 +647,8 @@ export async function fetchAppAndIdentifiers(
   if (options.reset) {
     envIdentifiers = {app: undefined, extensions: {}}
     reuseDevCache = false
-    if (isCurrentAppSchema(app.configuration)) {
-      const configuration = await link({directory: app.directory, developerPlatformClient})
-      app.configuration = configuration
-    }
+    const configuration = await link({directory: app.directory, developerPlatformClient})
+    app.configuration = configuration
   }
 
   if (isCurrentAppSchema(app.configuration)) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/temp-project-mover-Archetypically-20250319145332/issues/354

`managed installation` is mandatory for `only extension` apps, because they don't include a backend to negotiate the installation. To enable the `managed installation` flow the `scopes` entry should be included in the `toml` even if no specific `scopes` are required (setting them to an empty string `""`)

When a remote app has an app version with empty scopes (not `undefined` but empty string `""`) the `link` command was not writing the `scopes` entry in the `toml` so the `old installation` flow is used. This situation causes that `only extensions` app could not be installed is some specific use cases.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- The remote config content builder method includes a bug for the `app_access` section.
- Instead of using a builder method (which was just doing a 1:1 mapping) now the remote config content (parsed and validated using the `configuration` specs) will be simply casted to the typed class [SpecsAppConfiguration](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/models/extensions/specifications/types/app_config.ts#L3)
- Additionally, now the `link` logic is run when you run `deploy` with `--reset` using a `legacy schema` configuration
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new `only extension` app
```sh
pnpm create-app --path <YOUR_APPS_PATH> --template none --name 0308-only-extension;cd <YOUR_APPS_PATH>/0308-only-extension
```
- Run the command `deploy` and `create a new remote app` when prompted to
```
pnpm shopify app deploy --path <YOUR_APPS_PATH>/0308-only-extension
```
- Open the partners dashboard and generate a custom installation link 
  - Access `Apps -> <YOUR-REMOTE-APP> -> Distribution ->  Custom distribution`.
  - Use you `dev` store domain
- Copy the `installation link`, open a new tab and paste it. The installation prompt should be displayed

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
