### PR TITLE
Add editor extension collection spec

### DIFF
--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -21,6 +21,7 @@ import taxCalculationSpec from './specifications/tax_calculation.js'
 import themeSpec from './specifications/theme.js'
 import uiExtensionSpec from './specifications/ui_extension.js'
 import webPixelSpec from './specifications/web_pixel_extension.js'
+import editorExtensionCollectionSpecification from './specifications/editor_extension_collection.js'
 
 const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   BrandingSpecIdentifier,
@@ -66,6 +67,7 @@ function loadSpecifications() {
     themeSpec,
     uiExtensionSpec,
     webPixelSpec,
+    editorExtensionCollectionSpecification,
   ] as ExtensionSpecification[]
 
   return [...configModuleSpecs, ...moduleSpecs]

--- a/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.test.ts
@@ -1,0 +1,124 @@
+import {ExtensionInstance} from '../extension-instance.js'
+import {loadLocalExtensionsSpecifications} from '../load-specifications.js'
+import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {testDeveloperPlatformClient} from '../../app/app.test-data.js'
+import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {describe, expect, test} from 'vitest'
+
+const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient()
+
+describe('editor_extension_collection', async () => {
+  interface EditorExtensionCollectionProps {
+    directory: string
+    configuration: {name: string; handle: string; includes?: string[]; include?: {handle: string}[]}
+  }
+
+  async function getTestEditorExtensionCollection({
+    directory,
+    configuration: passedConfig,
+  }: EditorExtensionCollectionProps) {
+    const configurationPath = joinPath(directory, 'shopify.extension.toml')
+    const allSpecs = await loadLocalExtensionsSpecifications()
+    const specification = allSpecs.find((spec) => spec.identifier === 'editor_extension_collection')!
+    const configuration = {
+      ...passedConfig,
+      type: 'editor_extension_collection',
+      metafields: [],
+    }
+
+    return new ExtensionInstance({
+      configuration,
+      directory,
+      specification,
+      configurationPath,
+      entryPath: '',
+    })
+  }
+
+  describe('deployConfig()', () => {
+    test('returns the deploy config when includes and include is passed in', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const configuration = {
+          name: 'Order summary',
+          handle: 'order-summary-collection',
+          includes: ['handle1'],
+          include: [
+            {
+              handle: 'handle2',
+            },
+          ],
+        }
+        const extensionCollection = await getTestEditorExtensionCollection({
+          directory: tmpDir,
+          configuration,
+        })
+
+        const deployConfig = await extensionCollection.deployConfig({
+          apiKey: 'apiKey',
+          developerPlatformClient,
+        })
+
+        expect(deployConfig).toStrictEqual({
+          name: extensionCollection.configuration.name,
+          handle: extensionCollection.configuration.handle,
+          in_collection: [{handle: 'handle1'}, {handle: 'handle2'}],
+        })
+      })
+    })
+
+    test('returns the deploy config when only include is passed in', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const configuration = {
+          name: 'Order summary',
+          handle: 'order-summary-collection',
+          include: [
+            {
+              handle: 'handle2',
+            },
+          ],
+        }
+        const extensionCollection = await getTestEditorExtensionCollection({
+          directory: tmpDir,
+          configuration,
+        })
+
+        const deployConfig = await extensionCollection.deployConfig({
+          apiKey: 'apiKey',
+          developerPlatformClient,
+        })
+
+        expect(deployConfig).toStrictEqual({
+          name: extensionCollection.configuration.name,
+          handle: extensionCollection.configuration.handle,
+          in_collection: [{handle: 'handle2'}],
+        })
+      })
+    })
+
+    test('returns the deploy config when only includes is passed in', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const configuration = {
+          name: 'Order summary',
+          handle: 'order-summary-collection',
+          includes: ['handle1'],
+        }
+        const extensionCollection = await getTestEditorExtensionCollection({
+          directory: tmpDir,
+          configuration,
+        })
+
+        const deployConfig = await extensionCollection.deployConfig({
+          apiKey: 'apiKey',
+          developerPlatformClient,
+        })
+
+        expect(deployConfig).toStrictEqual({
+          name: extensionCollection.configuration.name,
+          handle: extensionCollection.configuration.handle,
+          in_collection: [{handle: 'handle1'}],
+        })
+      })
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.ts
+++ b/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.ts
@@ -1,0 +1,42 @@
+import {BaseSchema} from '../schemas.js'
+import {createExtensionSpecification} from '../specification.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+interface IncludeSchema {
+  handle: string
+}
+
+const IncludeSchema = zod.object({
+  handle: zod.string(),
+})
+
+export const EditorExtensionCollectionSchema = BaseSchema.extend({
+  include: zod.array(IncludeSchema).optional(),
+  includes: zod.array(zod.string()).optional(),
+  type: zod.literal('editor_extension_collection'),
+})
+
+const editorExtensionCollectionSpecification = createExtensionSpecification({
+  identifier: 'editor_extension_collection',
+  schema: EditorExtensionCollectionSchema,
+  appModuleFeatures: (_) => [],
+  deployConfig: async (config, _) => {
+    const includes =
+      config.includes?.map((handle) => {
+        return {handle}
+      }) ?? []
+    const include = config.include ?? []
+    const inCollection = [...includes, ...include]
+
+    // eslint-disable-next-line no-warning-comments
+    // TODO: Validation to check either one of include or includes was defined
+
+    return {
+      name: config.name,
+      handle: config.handle,
+      in_collection: inCollection,
+    }
+  },
+})
+
+export default editorExtensionCollectionSpecification


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/core-issues/issues/66051

Also check your spin branch out to 

https://github.com/Shopify/shopify/pull/490149
https://github.com/Shopify/partners/pull/53863

### WHAT is this pull request doing?

Adding new extension collection spec to the cli


### How to test your changes?

To have an extension code locally clone Shopify/customer-accounts-ui-extension-dev and also clone CLI locally

1. Clone CLI locally
2. Run `spin up customer-accounts-ui-extension-dev`
3. Checkout my branches in partners and shopify core
4. Run dev refresh on both shopify core and partners in spin.
5. Go to partners org internal, and for your org enable the beta flag `'editor_extension_collection'` for example the link looks like https://partners.build-extension-collections.oluwatimi-owoturo.us.spin.dev/internal/organizations/1

<img width="2557" alt="Screenshot 2024-03-14 at 2 45 52 PM" src="https://github.com/Shopify/cli/assets/13557893/09c5a872-a689-4b5f-8740-e7f3d0387adb">

6. In the CLI run the following command

```
SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=${your-spin-instance} pnpm shopify app generate extension --path ${pathToYourApp}
```

You should see 

<img width="940" alt="Screenshot 2024-03-15 at 11 38 05 AM" src="https://github.com/Shopify/cli/assets/13557893/d04f79c1-b9f2-40c5-bdcf-66e4ebc50b7c">

7. Generate the Editor extension collection under the admin group
9. Go to the extension in `customer-accounts-ui-extension-dev`
10. You can generate another extension to reference the handle of that extension inside `in_collection` array. You can also try using the other method (extensions.in_collection) in the template to reference the extension handle and make sure both are not included at the same time.
11. Try and deploy the extension collection by running

```
SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE=${your-spin-instance} pnpm shopify app deploy --path ${pathToYourApp}
```

12. Click on the DB Icon in shopify core spin service and open Sequel Ace. 
13. Select shopify_dev as the db
14. Search for the `shopify_dev.app_static_extension_configs` table
15. You should see the extension collection config there

<img width="1791" alt="Screenshot 2024-03-15 at 11 34 46 AM" src="https://github.com/Shopify/cli/assets/13557893/a877cf61-1851-4579-9909-51032f044004">



### Post-release steps

This will not be visible in prod because it is behind a beta flag

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
