### PR TITLE
Sanitize "api_key" from verbose log

### DIFF
--- a/packages/cli-kit/src/public/node/monorail.test.ts
+++ b/packages/cli-kit/src/public/node/monorail.test.ts
@@ -40,4 +40,11 @@ describe('monorail', () => {
       headers: expectedHeaders,
     })
   })
+
+  test('sanitizes the api_key from the debug log', async () => {
+    const outputMock = mockAndCaptureOutput()
+    const res = await publishMonorailEvent('fake_schema/0.0', {api_key: 'some-api-key'}, {baz: 'abc'})
+    expect(res.type).toEqual('ok')
+    expect(outputMock.debug()).toContain('"api_key": "****"')
+  })
 })

--- a/packages/cli-kit/src/public/node/monorail.test.ts
+++ b/packages/cli-kit/src/public/node/monorail.test.ts
@@ -46,5 +46,6 @@ describe('monorail', () => {
     const res = await publishMonorailEvent('fake_schema/0.0', {api_key: 'some-api-key'}, {baz: 'abc'})
     expect(res.type).toEqual('ok')
     expect(outputMock.debug()).toContain('"api_key": "****"')
+    expect(outputMock.debug()).not.toContain('some-api-key')
   })
 })

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -198,7 +198,7 @@ export async function publishMonorailEvent<TSchemaId extends keyof Schemas, TPay
     const response = await fetch(url, {method: 'POST', body, headers})
 
     if (response.status === 200) {
-      outputDebug(outputContent`Analytics event sent: ${outputToken.json(payload)}`)
+      outputDebug(outputContent`Analytics event sent: ${outputToken.json(sanitizePayload(payload))}`)
       return {type: 'ok'}
     } else {
       outputDebug(`Failed to report usage analytics: ${response.statusText}`)
@@ -213,6 +213,21 @@ export async function publishMonorailEvent<TSchemaId extends keyof Schemas, TPay
     outputDebug(message)
     return {type: 'error', message}
   }
+}
+
+/**
+ * Sanitizies the api_key from the payload.
+ *
+ * @param payload - The public and sensitive data.
+ * @returns The payload with the api_key sanitized.
+ */
+function sanitizePayload<T extends object>(payload: T): T {
+  const result = {...payload}
+  if ('api_key' in result) {
+    result.api_key = '****'
+  }
+
+  return result
 }
 
 const buildHeaders = (currentTime: number) => {

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -222,12 +222,11 @@ export async function publishMonorailEvent<TSchemaId extends keyof Schemas, TPay
  * @returns The payload with the api_key sanitized.
  */
 function sanitizePayload<T extends object>(payload: T): T {
-  const result = {...payload}
-  if ('api_key' in result) {
-    result.api_key = '****'
+  if ('api_key' in payload) {
+    payload.api_key = '****'
   }
 
-  return result
+  return payload
 }
 
 const buildHeaders = (currentTime: number) => {

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -216,17 +216,18 @@ export async function publishMonorailEvent<TSchemaId extends keyof Schemas, TPay
 }
 
 /**
- * Sanitizies the api_key from the payload.
+ * Sanitizies the api_key from the payload and returns a new hash.
  *
  * @param payload - The public and sensitive data.
- * @returns The payload with the api_key sanitized.
+ * @returns A copy of the payload with the api_key sanitized.
  */
 function sanitizePayload<T extends object>(payload: T): T {
-  if ('api_key' in payload) {
-    payload.api_key = '****'
+  const result = {...payload}
+  if ('api_key' in result) {
+    result.api_key = '****'
   }
 
-  return payload
+  return result
 }
 
 const buildHeaders = (currentTime: number) => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/3518 <!-- link to issue if one exists -->

The `api_key` is visible in the verbose log on `shopify app config link`. While this isn't critical as this is on the developers machine, these logs are required when opening a bug ticket.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Replaces the `api_key` with `****` for the logs output.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
