### PR TITLE
Improve error message for invalid custom token

### DIFF
--- a/.changeset/tricky-forks-grin.md
+++ b/.changeset/tricky-forks-grin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Improve the error message for invalid custom token

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -89,8 +89,12 @@ export async function refreshAccessToken(currentToken: IdentityToken): Promise<I
  */
 export async function exchangeCustomPartnerToken(token: string): Promise<ApplicationToken> {
   const appId = applicationId('partners')
-  const newToken = await requestAppToken('partners', token, ['https://api.shopify.com/auth/partners.app.cli.access'])
-  return newToken[appId]!
+  try {
+    const newToken = await requestAppToken('partners', token, ['https://api.shopify.com/auth/partners.app.cli.access'])
+    return newToken[appId]!
+  } catch (error) {
+    throw new AbortError('The custom token provided is invalid.', 'Ensure the token is correct and not expired.')
+  }
 }
 
 export type IdentityDeviceError =


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/3585

### WHAT is this pull request doing?

Shows a proper error message when the Partners token provided is not valid, instead of crashing with a stack trace:

<img width="574" alt="22-39-32ha7-5zy5h" src="https://github.com/Shopify/cli/assets/14979109/2f88391a-14fc-4f29-9089-02671cc89f12">

### How to test your changes?

`SHOPIFY_CLI_PARTNERS_TOKEN=wrong p shopify app deploy --path your-app`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
