### PR TITLE
Migrate payment extensions in dev deploy if eligible

### DIFF
--- a/packages/app/src/cli/api/graphql/extension_migrate_app_module.ts
+++ b/packages/app/src/cli/api/graphql/extension_migrate_app_module.ts
@@ -1,0 +1,29 @@
+import {gql} from 'graphql-request'
+
+export const MigrateAppModuleMutation = gql`
+  mutation MigrateAppModule($apiKey: String!, $registrationId: ID!, $type: String!) {
+    migrateAppModule(input: {apiKey: $apiKey, registrationId: $registrationId, type: $type}) {
+      migratedAppModule
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`
+
+export interface MigrateAppModuleVariables {
+  apiKey: string
+  registrationId: string
+  type: string
+}
+
+export interface MigrateAppModuleSchema {
+  migrateAppModule: {
+    migratedAppModule: boolean
+    userErrors: {
+      field: string[]
+      message: string
+    }[]
+  }
+}

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -45,6 +45,7 @@ import {
   MigrateToUiExtensionSchema,
   MigrateToUiExtensionVariables,
 } from '../../api/graphql/extension_migrate_to_ui_extension.js'
+import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../../api/graphql/extension_migrate_app_module.js'
 import {vi} from 'vitest'
 
 export const DEFAULT_CONFIG = {
@@ -842,6 +843,13 @@ const migrateFlowExtensionResponse: MigrateFlowExtensionSchema = {
   },
 }
 
+const migrateAppModuleResponse: MigrateAppModuleSchema = {
+  migrateAppModule: {
+    migratedAppModule: true,
+    userErrors: [],
+  },
+}
+
 const apiVersionsResponse: PublicApiVersionsSchema = {
   publicApiVersions: ['2022', 'unstable', '2023'],
 }
@@ -910,6 +918,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     apiVersions: () => Promise.resolve(apiVersionsResponse),
     topics: (_input: WebhookTopicsVariables) => Promise.resolve(topicsResponse),
     migrateFlowExtension: (_input: MigrateFlowExtensionVariables) => Promise.resolve(migrateFlowExtensionResponse),
+    migrateAppModule: (_input: MigrateAppModuleVariables) => Promise.resolve(migrateAppModuleResponse),
     updateURLs: (_input: UpdateURLsVariables) => Promise.resolve(updateURLsResponse),
     currentAccountInfo: () => Promise.resolve(currentAccountInfoResponse),
     targetSchemaDefinition: (_input: TargetSchemaDefinitionQueryVariables) => Promise.resolve('schema'),

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -8,6 +8,7 @@ import {getUIExtensionsToMigrate, migrateExtensionsToUIExtension} from '../dev/m
 import {getFlowExtensionsToMigrate, migrateFlowExtensions} from '../dev/migrate-flow-extension.js'
 import {AppInterface} from '../../models/app/app.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {getPaymentsExtensionsToMigrate, migrateAppModules} from '../dev/migrate-app-module.js'
 import {outputCompleted} from '@shopify/cli-kit/node/output'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
 
@@ -29,6 +30,11 @@ export async function ensureExtensionsIds(
 
   const uiExtensionsToMigrate = getUIExtensionsToMigrate(localExtensions, remoteExtensions, validIdentifiers)
   const flowExtensionsToMigrate = getFlowExtensionsToMigrate(localExtensions, dashboardOnlyExtensions, validIdentifiers)
+  const paymentsExtensionsToMigrate = getPaymentsExtensionsToMigrate(
+    localExtensions,
+    dashboardOnlyExtensions,
+    validIdentifiers,
+  )
 
   if (uiExtensionsToMigrate.length > 0) {
     const confirmedMigration = await extensionMigrationPrompt(uiExtensionsToMigrate)
@@ -47,6 +53,19 @@ export async function ensureExtensionsIds(
     const newRemoteExtensions = await migrateFlowExtensions(
       flowExtensionsToMigrate,
       options.appId,
+      dashboardOnlyExtensions,
+      options.developerPlatformClient,
+    )
+    remoteExtensions = remoteExtensions.concat(newRemoteExtensions)
+  }
+
+  if (paymentsExtensionsToMigrate.length > 0) {
+    const confirmedMigration = await extensionMigrationPrompt(paymentsExtensionsToMigrate, false)
+    if (!confirmedMigration) throw new AbortSilentError()
+    const newRemoteExtensions = await migrateAppModules(
+      paymentsExtensionsToMigrate,
+      options.appId,
+      'payments_extension',
       dashboardOnlyExtensions,
       options.developerPlatformClient,
     )

--- a/packages/app/src/cli/services/dev/migrate-app-module.test.ts
+++ b/packages/app/src/cli/services/dev/migrate-app-module.test.ts
@@ -1,0 +1,146 @@
+import {getPaymentsExtensionsToMigrate, migrateAppModules} from './migrate-app-module.js'
+import {LocalSource, RemoteSource} from '../context/identifiers.js'
+import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
+import {describe, expect, test} from 'vitest'
+
+function getLocalExtension(attributes: Partial<LocalSource> = {}) {
+  return {
+    type: 'payments_extension',
+    localIdentifier: 'my-action',
+    configuration: {
+      name: 'my-action',
+    },
+    ...attributes,
+  } as unknown as LocalSource
+}
+
+function getRemoteExtension(attributes: Partial<RemoteSource> = {}) {
+  return {
+    uuid: '1234',
+    type: 'payments_app_credit_card',
+    title: 'a-different-extension',
+    ...attributes,
+  } as unknown as RemoteSource
+}
+
+describe('getPaymentsExtensionsToMigrate()', () => {
+  const defaultIds = {
+    'my-action': '1234',
+  }
+
+  test('matching my remote title and localIdentifier', () => {
+    // Given
+    const localExtension = getLocalExtension({type: 'payments_extension', localIdentifier: 'my-action'})
+    const remoteExtension = getRemoteExtension({type: 'payments_app_credit_card', title: 'my-action', uuid: 'yy'})
+
+    // When
+    const toMigrate = getPaymentsExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([{local: localExtension, remote: remoteExtension}])
+  })
+
+  test('matching my local and remote IDs', () => {
+    // Given
+    const localExtension = getLocalExtension({type: 'payments_extension', localIdentifier: 'my-action'})
+    const remoteExtension = getRemoteExtension({type: 'payments_app_credit_card', title: 'remote', uuid: '1234'})
+
+    // When
+    const toMigrate = getPaymentsExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([{local: localExtension, remote: remoteExtension}])
+  })
+
+  test('does not return extensions where local.type is not payments_extension', () => {
+    // Given
+    const localExtension = getLocalExtension({type: 'checkout_ui_extension'})
+    const remoteExtension = getRemoteExtension({type: 'payments_app_credit_card'})
+
+    // When
+    const toMigrate = getPaymentsExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([])
+  })
+
+  test('does not return extensions where remote.type is not payments_app_credit_card', () => {
+    // Given
+    const localExtension = getLocalExtension({type: 'payments_extension'})
+    const remoteExtension = getRemoteExtension({type: 'PRODUCT_SUBSCRIPTION_UI_EXTENSION'})
+
+    // When
+    const toMigrate = getPaymentsExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([])
+  })
+
+  test('if neither title/name or ids match, does not return any extensions', () => {
+    // Given
+    const localExtension = getLocalExtension({type: 'payments_extension'})
+    const remoteExtension = getRemoteExtension({
+      type: 'payments_app_credit_card',
+      uuid: '5678',
+    })
+
+    // When
+    const toMigrate = getPaymentsExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([])
+  })
+})
+
+describe('migrateAppModules()', () => {
+  test('performs a graphQL mutation for each extension', async () => {
+    // Given
+    const extensionsToMigrate = [
+      {local: getLocalExtension(), remote: getRemoteExtension({id: 'id1'})},
+      {local: getLocalExtension(), remote: getRemoteExtension({id: 'id2'})},
+    ]
+    const appId = '123abc'
+    const type = 'payments_extension'
+    const remoteExtensions = extensionsToMigrate.map(({remote}) => remote)
+    const developerPlatformClient = testDeveloperPlatformClient()
+
+    // When
+    await migrateAppModules(extensionsToMigrate, appId, type, remoteExtensions, developerPlatformClient)
+
+    // Then
+    expect(developerPlatformClient.migrateAppModule).toHaveBeenCalledTimes(extensionsToMigrate.length)
+    expect(developerPlatformClient.migrateAppModule).toHaveBeenCalledWith({
+      apiKey: appId,
+      registrationId: extensionsToMigrate[0]!.remote.id,
+      type,
+    })
+    expect(developerPlatformClient.migrateAppModule).toHaveBeenCalledWith({
+      apiKey: appId,
+      registrationId: extensionsToMigrate[1]!.remote.id,
+      type,
+    })
+  })
+
+  test('Returns updated remoteExensions', async () => {
+    // Given
+    const extensionsToMigrate = [
+      {local: getLocalExtension(), remote: getRemoteExtension({id: 'id1'})},
+      {local: getLocalExtension(), remote: getRemoteExtension({id: 'id2'})},
+    ]
+    const appId = '123abc'
+    const type = 'payments_extension'
+    const remoteExtensions = extensionsToMigrate.map(({remote}) => remote)
+
+    // When
+    const result = await migrateAppModules(
+      extensionsToMigrate,
+      appId,
+      type,
+      remoteExtensions,
+      testDeveloperPlatformClient(),
+    )
+
+    // Then
+    expect(result).toStrictEqual(remoteExtensions.map((remote) => ({...remote, type: 'PAYMENTS_EXTENSION'})))
+  })
+})

--- a/packages/app/src/cli/services/dev/migrate-app-module.ts
+++ b/packages/app/src/cli/services/dev/migrate-app-module.ts
@@ -1,0 +1,99 @@
+import {LocalSource, RemoteSource} from '../context/identifiers.js'
+import {IdentifiersExtensions} from '../../models/app/identifiers.js'
+import {getExtensionIds, LocalRemoteSource} from '../context/id-matching.js'
+import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../../api/graphql/extension_migrate_app_module.js'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {slugify} from '@shopify/cli-kit/common/string'
+
+export function getPaymentsExtensionsToMigrate(
+  localSources: LocalSource[],
+  remoteSources: RemoteSource[],
+  identifiers: IdentifiersExtensions,
+) {
+  const ids = getExtensionIds(localSources, identifiers)
+  const localExtensionTypesToMigrate = ['payments_extension']
+  const remoteExtensionTypesToMigrate = [
+    'payments_app',
+    'payments_app_credit_card',
+    'payments_app_custom_credit_card',
+    'payments_app_custom_onsite',
+    'payments_app_redeemable',
+  ]
+  const typesMap = new Map<string, string[]>()
+  typesMap.set('payments_extension', [
+    'payments_app',
+    'payments_app_credit_card',
+    'payments_app_custom_credit_card',
+    'payments_app_custom_onsite',
+    'payments_app_redeemable',
+  ])
+
+  const local = localSources.filter((source) => localExtensionTypesToMigrate.includes(source.type))
+  const remote = remoteSources.filter((source) => remoteExtensionTypesToMigrate.includes(source.type))
+
+  // Map remote sources by uuid and slugified title (the slugified title is used for matching with local folder)
+  const remoteSourcesMap = new Map<string, RemoteSource>()
+  remote.forEach((remoteSource) => {
+    remoteSourcesMap.set(remoteSource.uuid, remoteSource)
+    remoteSourcesMap.set(slugify(remoteSource.title), remoteSource)
+  })
+
+  return local.reduce<LocalRemoteSource[]>((accumulator, localSource) => {
+    const localSourceId = ids[localSource.localIdentifier] ?? 'unknown'
+    const remoteSource = remoteSourcesMap.get(localSourceId) || remoteSourcesMap.get(localSource.localIdentifier)
+    const typeMatch = typesMap.get(localSource.type)?.includes(remoteSource?.type ?? 'undefined')
+
+    if (remoteSource && typeMatch) {
+      accumulator.push({local: localSource, remote: remoteSource})
+    }
+    return accumulator
+  }, [])
+}
+
+export async function migrateAppModules(
+  extensionsToMigrate: LocalRemoteSource[],
+  appId: string,
+  type: string,
+  remoteExtensions: RemoteSource[],
+  developerPlatformClient: DeveloperPlatformClient,
+) {
+  const migratedIDs = await Promise.all(
+    extensionsToMigrate.map(({remote}) => migrateAppModule(appId, remote.id, type, developerPlatformClient)),
+  )
+
+  return remoteExtensions
+    .filter((extension) => migratedIDs.includes(extension.id))
+    .map((extension) => {
+      return {
+        ...extension,
+        type: type.toUpperCase(),
+      }
+    })
+}
+
+export async function migrateAppModule(
+  apiKey: MigrateAppModuleVariables['apiKey'],
+  registrationId: MigrateAppModuleVariables['registrationId'],
+  type: MigrateAppModuleVariables['type'],
+  developerPlatformClient: DeveloperPlatformClient,
+) {
+  const variables: MigrateAppModuleVariables = {
+    apiKey,
+    registrationId,
+    type,
+  }
+
+  const result: MigrateAppModuleSchema = await developerPlatformClient.migrateAppModule(variables)
+
+  if (result?.migrateAppModule?.userErrors?.length > 0) {
+    const errors = result.migrateAppModule.userErrors.map((error) => error.message).join(', ')
+    throw new AbortError(errors)
+  }
+
+  if (!result?.migrateAppModule?.migratedAppModule) {
+    throw new AbortError(`Couldn't migrate to app module ${type}`)
+  }
+
+  return registrationId
+}

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -44,6 +44,7 @@ import {
   MigrateToUiExtensionVariables,
 } from '../api/graphql/extension_migrate_to_ui_extension.js'
 import {RemoteSpecification} from '../api/graphql/extension_specifications.js'
+import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../api/graphql/extension_migrate_app_module.js'
 import {FunctionUploadUrlGenerateResponse} from '@shopify/cli-kit/node/api/partners'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 
@@ -126,6 +127,7 @@ export interface DeveloperPlatformClient {
   apiVersions: () => Promise<PublicApiVersionsSchema>
   topics: (input: WebhookTopicsVariables) => Promise<WebhookTopicsSchema>
   migrateFlowExtension: (input: MigrateFlowExtensionVariables) => Promise<MigrateFlowExtensionSchema>
+  migrateAppModule: (input: MigrateAppModuleVariables) => Promise<MigrateAppModuleSchema>
   updateURLs: (input: UpdateURLsVariables) => Promise<UpdateURLsSchema>
   currentAccountInfo: () => Promise<CurrentAccountInfoSchema>
   targetSchemaDefinition: (input: TargetSchemaDefinitionQueryVariables) => Promise<string | null>

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -128,6 +128,11 @@ import {
   FindOrganizationBasicQuerySchema,
   FindOrganizationBasicVariables,
 } from '../../api/graphql/find_org_basic.js'
+import {
+  MigrateAppModuleMutation,
+  MigrateAppModuleSchema,
+  MigrateAppModuleVariables,
+} from '../../api/graphql/extension_migrate_app_module.js'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {
@@ -380,6 +385,10 @@ export class PartnersClient implements DeveloperPlatformClient {
 
   async migrateFlowExtension(input: MigrateFlowExtensionVariables): Promise<MigrateFlowExtensionSchema> {
     return this.request(MigrateFlowExtensionMutation, input)
+  }
+
+  async migrateAppModule(input: MigrateAppModuleVariables): Promise<MigrateAppModuleSchema> {
+    return this.request(MigrateAppModuleMutation, input)
   }
 
   async updateURLs(input: UpdateURLsVariables): Promise<UpdateURLsSchema> {

--- a/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
@@ -81,6 +81,7 @@ import {
   MigrateToUiExtensionVariables,
   MigrateToUiExtensionSchema,
 } from '../../api/graphql/extension_migrate_to_ui_extension.js'
+import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../../api/graphql/extension_migrate_app_module.js'
 import {FunctionUploadUrlGenerateResponse} from '@shopify/cli-kit/node/api/partners'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
@@ -462,6 +463,10 @@ export class ShopifyDevelopersClient implements DeveloperPlatformClient {
 
   async migrateFlowExtension(_input: MigrateFlowExtensionVariables): Promise<MigrateFlowExtensionSchema> {
     throw new BugError('Not implemented: migrateFlowExtension')
+  }
+
+  async migrateAppModule(_input: MigrateAppModuleVariables): Promise<MigrateAppModuleSchema> {
+    throw new BugError('Not implemented: migrateAppModule')
   }
 
   async updateURLs(_input: UpdateURLsVariables): Promise<UpdateURLsSchema> {


### PR DESCRIPTION

To ensure dashboard payments extensions that are imported can be appropriately migrated over. 

### WHAT is this pull request doing?

Ensure payments extension that are eligible for migration are migrated during `app deploy`

How to test your changes?
```
Create app with npm init @shopify/app@latest
Pull this branch into your local cli copy
Run SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app config link --path {YOUR-APP-PATH}
Run SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={YOUR-SPIN-INSTANCE} NODE_TLS_REJECT_UNAUTHORIZED=0 SHOPIFY_CLI_VERSIONED_APP_CONFIG=1 pnpm shopify app deploy --path {YOUR-APP-PATH}
View Payments Extensions

```
### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
