### PR TITLE
Use local create-app when generating local app

### DIFF
--- a/packages/create-app/src/utils/template/npm.ts
+++ b/packages/create-app/src/utils/template/npm.ts
@@ -18,6 +18,7 @@ export async function updateCLIDependencies({packageJSON, local}: UpdateCLIDepen
   if (local) {
     const cliPath = await packagePath('cli')
     const appPath = await packagePath('app')
+    const createAppPath = await packagePath('create-app')
     const cliKitPath = await packagePath('cli-kit')
     const pluginCloudflarePath = await packagePath('plugin-cloudflare')
     const didYouMeanPath = await packagePath('plugin-did-you-mean')
@@ -30,6 +31,7 @@ export async function updateCLIDependencies({packageJSON, local}: UpdateCLIDepen
     const dependencyOverrides = {
       '@shopify/cli': cliPath,
       '@shopify/app': appPath,
+      '@shopify/create-app': createAppPath,
       '@shopify/cli-kit': cliKitPath,
       '@shopify/plugin-did-you-mean': didYouMeanPath,
       '@shopify/plugin-cloudflare': pluginCloudflarePath,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We were getting a build error on `create-app --local` because we weren't pinning the local version of `create-app`.

This was broken by the addition of requiring `@shopify/create-app` as a dependency of `@shopify/app` [here](https://github.com/Shopify/cli/blame/66d0031064084d55001541c8354187d070a1e3d2/packages/app/package.json#L49).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Pins the package to local, like the other dependencies.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Acceptance tests should pass on the version packages PR. So, just gotta merge this!

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
