### PR TITLE
[Theme] Add handling when server does not respond to bulk asset upload

### DIFF
--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -399,7 +399,7 @@ describe('bulkUploadThemeAssets', async () => {
 
     vi.mocked(restRequest).mockResolvedValue({
       json: {},
-      status: 207,
+      status: 404,
       headers: {},
     })
 

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -389,4 +389,36 @@ describe('bulkUploadThemeAssets', async () => {
       asset: undefined,
     })
   })
+
+  test('returns an array of results with the same length as the assets array when the server does not respond', async () => {
+    const id = 123
+    const assets: AssetParams[] = [
+      {key: 'snippets/product-variant-picker.liquid', value: 'content'},
+      {key: 'templates/404.json', value: 'to_be_replaced_with_hash'},
+    ]
+
+    vi.mocked(restRequest).mockResolvedValue({
+      json: {results: []},
+      status: 207,
+      headers: {},
+    })
+
+    // When
+    const bulkUploadresults = await bulkUploadThemeAssets(id, assets, session)
+
+    // Then
+    expect(bulkUploadresults).toHaveLength(2)
+    expect(bulkUploadresults[0]).toEqual({
+      key: 'snippets/product-variant-picker.liquid',
+      success: false,
+      errors: {asset: ['Server did not respond.']},
+      operation: 'UPLOAD',
+    })
+    expect(bulkUploadresults[1]).toEqual({
+      key: 'templates/404.json',
+      success: false,
+      errors: {asset: ['Server did not respond.']},
+      operation: 'UPLOAD',
+    })
+  })
 })

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -390,7 +390,7 @@ describe('bulkUploadThemeAssets', async () => {
     })
   })
 
-  test('returns an array of results with the same length as the assets array when the server does not respond', async () => {
+  test('throws an error when the server does not respond', async () => {
     const id = 123
     const assets: AssetParams[] = [
       {key: 'snippets/product-variant-picker.liquid', value: 'content'},
@@ -404,21 +404,9 @@ describe('bulkUploadThemeAssets', async () => {
     })
 
     // When
-    const bulkUploadresults = await bulkUploadThemeAssets(id, assets, session)
-
-    // Then
-    expect(bulkUploadresults).toHaveLength(2)
-    expect(bulkUploadresults[0]).toEqual({
-      key: 'snippets/product-variant-picker.liquid',
-      success: false,
-      errors: {asset: ['Server did not respond.']},
-      operation: 'UPLOAD',
-    })
-    expect(bulkUploadresults[1]).toEqual({
-      key: 'templates/404.json',
-      success: false,
-      errors: {asset: ['Server did not respond.']},
-      operation: 'UPLOAD',
-    })
+    await expect(async () => {
+      return bulkUploadThemeAssets(id, assets, session)
+      // Then
+    }).rejects.toThrowError(AbortError)
   })
 })

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -398,7 +398,7 @@ describe('bulkUploadThemeAssets', async () => {
     ]
 
     vi.mocked(restRequest).mockResolvedValue({
-      json: {results: []},
+      json: {},
       status: 207,
       headers: {},
     })

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -53,6 +53,9 @@ export async function bulkUploadThemeAssets(
   session: AdminSession,
 ): Promise<Result[]> {
   const response = await request('PUT', `/themes/${id}/assets/bulk`, session, {assets})
+  if (response.status !== 207) {
+    throw new AbortError('Upload failed, could not reach the server')
+  }
   return buildBulkUploadResults(response.json.results, assets)
 }
 

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -56,7 +56,7 @@ export function buildBulkUploadResults(
   bulkUploadResponse: RemoteBulkUploadResponse[],
   assets: AssetParams[],
 ): Result[] {
-  if (bulkUploadResponse.length === 0 && assets.length !== 0) {
+  if (bulkUploadResponse === undefined) {
     return assets.map((asset) => ({
       key: asset.key,
       success: false,

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -1,4 +1,5 @@
 import {AssetParams} from './api.js'
+import {AbortError} from '../error.js'
 import {Result, Checksum, Theme, ThemeAsset, Operation} from '@shopify/cli-kit/node/themes/types'
 
 interface RemoteThemeResponse {
@@ -57,12 +58,7 @@ export function buildBulkUploadResults(
   assets: AssetParams[],
 ): Result[] {
   if (bulkUploadResponse === undefined) {
-    return assets.map((asset) => ({
-      key: asset.key,
-      success: false,
-      errors: {asset: ['Server did not respond.']},
-      operation: Operation.Upload,
-    }))
+    throw new AbortError('Bulk Upload Error - No response from server.')
   }
 
   return bulkUploadResponse.map((bulkUpload, index) => {

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -1,5 +1,4 @@
 import {AssetParams} from './api.js'
-import {AbortError} from '../error.js'
 import {Result, Checksum, Theme, ThemeAsset, Operation} from '@shopify/cli-kit/node/themes/types'
 
 interface RemoteThemeResponse {
@@ -57,8 +56,8 @@ export function buildBulkUploadResults(
   bulkUploadResponse: RemoteBulkUploadResponse[],
   assets: AssetParams[],
 ): Result[] {
-  if (bulkUploadResponse === undefined) {
-    throw new AbortError('Bulk Upload Error - No response from server.')
+  if (!bulkUploadResponse) {
+    return []
   }
 
   return bulkUploadResponse.map((bulkUpload, index) => {

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -56,18 +56,22 @@ export function buildBulkUploadResults(
   bulkUploadResponse: RemoteBulkUploadResponse[],
   assets: AssetParams[],
 ): Result[] {
-  const results: Result[] = []
-  if (!bulkUploadResponse) return results
+  if (bulkUploadResponse.length === 0 && assets.length !== 0) {
+    return assets.map((asset) => ({
+      key: asset.key,
+      success: false,
+      errors: {asset: ['Server did not respond.']},
+      operation: Operation.Upload,
+    }))
+  }
 
-  bulkUploadResponse.forEach((bulkUpload, index) => {
-    const asset = assets[index]
-    results.push({
-      key: asset?.key || '',
+  return bulkUploadResponse.map((bulkUpload, index) => {
+    return {
+      key: assets[index]!.key,
       success: bulkUpload.code === 200,
       errors: bulkUpload.body.errors || {},
       asset: bulkUpload.body.asset,
       operation: Operation.Upload,
-    })
+    }
   })
-  return results
 }

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -328,6 +328,9 @@ async function handleBulkUpload(
   session: AdminSession,
   count = 0,
 ): Promise<Result[]> {
+  if (uploadParams.length === 0) {
+    return []
+  }
   if (count > 0) {
     outputDebug(
       `Retry Attempt ${count}/${MAX_UPLOAD_RETRY_COUNT} for the following files:


### PR DESCRIPTION
### WHY are these changes introduced?
- https://github.com/Shopify/develop-advanced-edits/issues/187
- This PR adds error handling for the case when the bulk asset upload endpoint responds with an empty object
  - See https://github.com/Shopify/cli/pull/3645 for more context 

### WHAT is this pull request doing?
- Rather than failing silently, we should return a response to the user that indicates an issue
  - I've chosen to Abort the operation rather than continuing to execute.
  - Another option is to try to execute the remaining uploads, but there is little value in doing so as this type of response indicates a larger issue (in the case linked above, bulk uploads are not supported by the theme access proxy) - this means that all the subsequent requests will also fail.

### How to test your changes?
- Checkout main
- run `pnpm shopify theme push -u --password <PASSWORD> --verbose`
- Observe that the pushed theme is empty, but the command output will indicate success
- Checkout this branch
- run `pnpm shopify theme push -u --password <PASSWORD> --verbose`
- This time, the command should fail and be aborted


<img width="1072" alt="image" src="https://github.com/Shopify/cli/assets/35415298/fd063b39-6277-4536-8215-879eeec1e188">

