### PR TITLE
Return full app from selectApp

### DIFF
--- a/.changeset/honest-lamps-itch.md
+++ b/.changeset/honest-lamps-itch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix selection of apps beyond the initial result set

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -89,13 +89,13 @@ describe('selectApp', () => {
   test('returns app if user selects one', async () => {
     // Given
     const apps = [APP1, APP2]
-    vi.mocked(renderAutocompletePrompt).mockResolvedValue('key2')
+    vi.mocked(renderAutocompletePrompt).mockResolvedValue(APP2.apiKey)
 
     // When
     const got = await selectAppPrompt(apps, true, ORG1.id, {developerPlatformClient: testDeveloperPlatformClient()})
 
     // Then
-    expect(got).toEqual(APP2.apiKey)
+    expect(got).toEqual(APP2)
     expect(renderAutocompletePrompt).toHaveBeenCalledWith({
       message: 'Which existing app is this for?',
       choices: [
@@ -114,14 +114,14 @@ describe('selectApp', () => {
     })
 
     const apps = [APP1, APP2]
-    vi.mocked(renderAutocompletePrompt).mockResolvedValue('key2')
+    vi.mocked(renderAutocompletePrompt).mockResolvedValue(APP2.apiKey)
 
     const got = await selectAppPrompt(apps, true, ORG1.id, {
       directory: '/',
       developerPlatformClient: testDeveloperPlatformClient(),
     })
 
-    expect(got).toEqual(APP2.apiKey)
+    expect(got).toEqual(APP2)
     expect(renderAutocompletePrompt).toHaveBeenCalledWith({
       message: 'Which existing app is this for?',
       choices: [

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -15,8 +15,7 @@ export async function selectApp(): Promise<OrganizationApp> {
   const orgs = await fetchOrganizations(developerPlatformClient)
   const org = await selectOrganizationPrompt(orgs)
   const {apps, hasMorePages} = await developerPlatformClient.appsForOrg(org.id)
-  const selectedAppApiKey = await selectAppPrompt(apps, hasMorePages, org.id, {developerPlatformClient})
-  const selectedApp = apps.find((app) => app.apiKey === selectedAppApiKey)!
+  const selectedApp = await selectAppPrompt(apps, hasMorePages, org.id, {developerPlatformClient})
   const fullSelectedApp = await developerPlatformClient.appFromId(selectedApp)
   return fullSelectedApp!
 }

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -53,7 +53,7 @@ function mockDeveloperPlatformClient() {
 describe('selectOrCreateApp', () => {
   test('prompts user to select', async () => {
     // Given
-    vi.mocked(selectAppPrompt).mockResolvedValueOnce(APP1.apiKey)
+    vi.mocked(selectAppPrompt).mockResolvedValueOnce(APP1)
     vi.mocked(createAsNewAppPrompt).mockResolvedValue(false)
 
     // When

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -34,13 +34,12 @@ export async function selectOrCreateApp(
     const name = await appNamePrompt(localAppName)
     return developerPlatformClient.createApp(org, name, options)
   } else {
-    const selectedAppApiKey = await selectAppPrompt(apps, hasMorePages, org.id, {directory: options?.directory})
-    const app = apps.find((app) => app.apiKey === selectedAppApiKey)!
+    const app = await selectAppPrompt(apps, hasMorePages, org.id, {directory: options?.directory})
 
     const data = getCachedCommandInfo()
     const tomls = (data?.tomls as {[key: string]: unknown}) ?? {}
 
-    if (tomls[selectedAppApiKey]) setCachedCommandInfo({selectedToml: tomls[selectedAppApiKey], askConfigName: false})
+    if (tomls[app.apiKey]) setCachedCommandInfo({selectedToml: tomls[app.apiKey], askConfigName: false})
 
     const fullSelectedApp = await developerPlatformClient.appFromId(app)
     return fullSelectedApp!

--- a/packages/app/src/cli/services/webhook/find-app-info.test.ts
+++ b/packages/app/src/cli/services/webhook/find-app-info.test.ts
@@ -112,7 +112,7 @@ describe('findOrganizationApp', () => {
     // Given
     vi.mocked(fetchOrgAndApps).mockResolvedValue(buildFetchResponse([anApp, anotherApp]))
     vi.mocked(basename).mockResolvedValue(`folder/somewhere-else`)
-    vi.mocked(selectAppPrompt).mockResolvedValue(anotherApp.apiKey)
+    vi.mocked(selectAppPrompt).mockResolvedValue(anotherApp)
 
     // When
     const {apiKey} = await findOrganizationApp(testDeveloperPlatformClient())

--- a/packages/app/src/cli/services/webhook/find-app-info.ts
+++ b/packages/app/src/cli/services/webhook/find-app-info.ts
@@ -52,18 +52,17 @@ export async function findOrganizationApp(
   // Try to infer from current folder
   const currentDir = basename(cwd())
   const appFromDir = apps.nodes.find((elm) => elm.title === currentDir)
-  let apiKey
   if (appFromDir === undefined) {
     if (apps.nodes.length === 1 && apps.nodes[0]?.apiKey) {
-      apiKey = apps.nodes[0].apiKey
+      const apiKey = apps.nodes[0].apiKey
+      return {id: apiKey, apiKey, organizationId: org.id}
     } else {
-      apiKey = await selectAppPrompt(apps.nodes, apps.pageInfo.hasNextPage, org.id)
+      return selectAppPrompt(apps.nodes, apps.pageInfo.hasNextPage, org.id)
     }
   } else {
-    apiKey = appFromDir.apiKey
+    const apiKey = appFromDir.apiKey
+    return {id: apiKey, apiKey, organizationId: org.id}
   }
-
-  return {id: apiKey, apiKey, organizationId: org.id}
 }
 
 /**


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #3626 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

If an app was found after searching, it won't be sufficient to return the API key, as the app may not be in the original list which the caller has access to.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Returns the full selected `OrganizationApp` from `selectApp` instead of just the API key.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Select something past the first 25 in the list of apps. It shouldn't get the error: `Cannot destructure property 'apiKey' of 'undefined' as it is undefined.`

NOTE: We have another open issue around older apps predating versioned app config, so you may see a TOML validation error. That isn't related.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
