### PR TITLE
[Themes] Fix Theme Push Execution when password flag is provided

### DIFF
--- a/.changeset/dull-tips-wait.md
+++ b/.changeset/dull-tips-wait.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix theme push execution when password flag is provided

--- a/.changeset/dull-tips-wait.md
+++ b/.changeset/dull-tips-wait.md
@@ -2,4 +2,5 @@
 '@shopify/theme': patch
 ---
 
-Fix theme push execution when password flag is provided
+- Theme Push: Fix issue with unresponsive server when password flag is provided
+- Theme Push: Add 'theme' key to root node of JSON output

--- a/packages/theme/src/cli/commands/theme/push.test.ts
+++ b/packages/theme/src/cli/commands/theme/push.test.ts
@@ -98,6 +98,17 @@ describe('Push', () => {
   })
 
   describe('run with CLI 2 implementation', () => {
+    test('should run the CLI 2 implementation if the password flag is provided', async () => {
+      // Given
+      const theme = buildTheme({id: 1, name: 'Theme', role: 'development'})!
+
+      // When
+      await runPushCommand(['--password', '123'], path, adminSession, theme)
+
+      // Then
+      expectCLI2ToHaveBeenCalledWith(`theme push ${path} --development-theme-id ${theme.id}`)
+    })
+
     test('should pass development theme from local storage to CLI 2', async () => {
       // Given
       const theme = buildTheme({id: 1, name: 'Theme', role: 'development'})!

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -152,7 +152,7 @@ export default class Push extends ThemeCommand {
 
     const developmentThemeManager = new DevelopmentThemeManager(adminSession)
 
-    if (!flags.stable) {
+    if (!flags.stable && !flags.password) {
       const {live, development, unpublished, path, nodelete, theme, publish, json, force, ignore, only} = flags
 
       let selectedTheme: Theme

--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -20,13 +20,15 @@ interface PushOptions {
 }
 
 interface JsonOutput {
-  id: number
-  name: string
-  role: string
-  shop: string
-  editor_url: string
-  preview_url: string
-  warning?: string
+  theme: {
+    id: number
+    name: string
+    role: string
+    shop: string
+    editor_url: string
+    preview_url: string
+    warning?: string
+  }
 }
 
 export async function push(theme: Theme, session: AdminSession, options: PushOptions) {
@@ -71,17 +73,19 @@ async function handlePushOutput(
 
 function handleJsonOutput(theme: Theme, hasErrors: boolean, session: AdminSession) {
   const output: JsonOutput = {
-    id: theme.id,
-    name: theme.name,
-    role: theme.role,
-    shop: session.storeFqdn,
-    editor_url: themeEditorUrl(theme, session),
-    preview_url: themePreviewUrl(theme, session),
+    theme: {
+      id: theme.id,
+      name: theme.name,
+      role: theme.role,
+      shop: session.storeFqdn,
+      editor_url: themeEditorUrl(theme, session),
+      preview_url: themePreviewUrl(theme, session),
+    },
   }
 
   if (hasErrors) {
     const message = `The theme ${themeComponent(theme).join(' ')} was pushed with errors`
-    output.warning = message
+    output.theme.warning = message
   }
   outputInfo(JSON.stringify(output))
 }


### PR DESCRIPTION
### WHY are these changes introduced?
- https://github.com/Shopify/develop-advanced-edits/issues/186
- Fixes the command execution when executed from environments such as CI
- Certain environments use the [Theme Access app](https://shopify.dev/docs/themes/tools/theme-access)) for authentication. Unfortunately, this app doesn't provide access to the bulk asset upload endpoint, which was causing nothing to get pushed (and errors to get swallowed)

### WHAT is this pull request doing?
- Calls the legacy (ruby) implementation of the `push command` when the `password` flag is provided
  - _This is a temporary solution to fix the `push command` and any CI consumers without needing to explicitly provide the `--stable` flag_
  - This PR will be reverted once ThemeKit adds support for calling the Bulk Upload endpoint in the Asset API

### How to test your changes?
1) Checkout `Main`
2) Install the [theme access app](https://shopify.dev/docs/themes/tools/theme-access)
3) Generate a password
4) Call `pnpm shopify theme push --password <PASSWORD>`
5) Checkout this branch
6) Repeat step 4

The first execution should have resulted in an empty theme being pushed
The second execution should result in the files being uploaded properly

### Post-release steps
- Patch release

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
