### PR TITLE
Filter env vars to always be valid for ESBuild

### DIFF
--- a/.changeset/clever-windows-count.md
+++ b/.changeset/clever-windows-count.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Filter env vars to always be valid for ESBuild, nothing beginning with a number

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -36,4 +36,4 @@ export const ports = {
   graphiql: 3457,
 } as const
 
-export const EsbuildEnvVarRegex = /^([a-zA-Z0-9_])*$/
+export const EsbuildEnvVarRegex = /^([a-zA-Z_$])([a-zA-Z0-9_$])*$/

--- a/packages/app/src/cli/services/extensions/bundle.test.ts
+++ b/packages/app/src/cli/services/extensions/bundle.test.ts
@@ -63,7 +63,7 @@ describe('bundleExtension()', () => {
         stdout,
         stderr,
       },
-      {VAR_FROM_RUNTIME: 'runtime_var', 'INVALID(VAR)': 'invalid_var'},
+      {VAR_FROM_RUNTIME: 'runtime_var', 'INVALID(VAR)': 'invalid_var', '123NUMERIC_VAR': 'invalid_var'},
     )
 
     // Then


### PR DESCRIPTION
Nothing beginning with a number!

More details at https://github.com/evanw/esbuild/blob/44e746965d783646f97daf3d0617ff816727e7fb/internal/js_ast/js_ident.go#L9-L25

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #3649 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->
ESBuild has [very strict rules](https://github.com/evanw/esbuild/blob/44e746965d783646f97daf3d0617ff816727e7fb/internal/js_ast/js_ident.go#L9-L25) about which ENV variables are allowed. One of the rules is no numeric characters at the beginning.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Disallows numeric characters at the start of the ENV variable name.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
For an app with an extension:

```
$ env '1VAR=value' p shopify app dev --path /path/to/your/app/with/ui/extensions
```

This should fail on `main` and succeed on this branch.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
