### PR TITLE
[Theme] Update theme push theme selection text

### DIFF
--- a/packages/theme/src/cli/commands/theme/push.test.ts
+++ b/packages/theme/src/cli/commands/theme/push.test.ts
@@ -48,7 +48,7 @@ describe('Push', () => {
 
       // Then
       expect(findOrSelectTheme).toHaveBeenCalledWith(adminSession, {
-        header: 'Select a theme to open',
+        header: 'Select a theme to push to:',
         filter: {
           live: true,
           development: true,

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -161,7 +161,7 @@ export default class Push extends ThemeCommand {
         selectedTheme = await developmentThemeManager.create(UNPUBLISHED_THEME_ROLE, themeName)
       } else {
         selectedTheme = await findOrSelectTheme(adminSession, {
-          header: 'Select a theme to open',
+          header: 'Select a theme to push to:',
           filter: {
             live,
             unpublished,


### PR DESCRIPTION
### WHY are these changes introduced?
- Updates text to be more accurate for the push command


### How to test your changes?
`pnpm shopify theme push --path <PATH_TO_THEME>`
<img width="241" alt="image" src="https://github.com/Shopify/cli/assets/35415298/47d3051a-511d-4b05-9219-37e5726ff5fb">


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
