### PR TITLE
Do not show api-key flag deprecation warning when using SHOPIFY_API_KEY

### DIFF
--- a/.changeset/smooth-bobcats-reflect.md
+++ b/.changeset/smooth-bobcats-reflect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Do not show api-key flag deprecation warning when using SHOPIFY_API_KEY

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -88,13 +88,10 @@ export default class Deploy extends Command {
     validateVersion(flags.version)
     validateMessage(flags.message)
 
-    if (!flags['api-key']) {
-      if (process.env.SHOPIFY_API_KEY) {
-        flags['api-key'] = process.env.SHOPIFY_API_KEY
-      }
-    }
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
+    } else if (process.env.SHOPIFY_API_KEY) {
+      flags['api-key'] = process.env.SHOPIFY_API_KEY
     }
     const apiKey = flags['client-id'] || flags['api-key']
 


### PR DESCRIPTION
### WHY are these changes introduced?

When the `SHOPIFY_API_KEY` environment variable is provided, the deploy command shows this wrong warning:

<img width="644" alt="09-50-5vwuq-xttof" src="https://github.com/Shopify/cli/assets/14979109/01730207-9bd1-4229-ad36-46473a0501f2">

### WHAT is this pull request doing?

Fixes it to only show the warning when the `api-key` flag is provided.

### How to test your changes?

- `SHOPIFY_API_KEY=wadus p shopify app deploy`
- `p shopify app deploy --api-key wadus`
- `p shopify app deploy --client-id wadus`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
