### PR TITLE
Introduce support to Theme Access app in the new `shopify theme push` implementation

### DIFF
--- a/.changeset/lazy-maps-retire.md
+++ b/.changeset/lazy-maps-retire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Activate the new implementation of `shopify theme push` in CI/CD workflows to support contextual assets

--- a/packages/theme/src/cli/commands/theme/push.test.ts
+++ b/packages/theme/src/cli/commands/theme/push.test.ts
@@ -98,17 +98,6 @@ describe('Push', () => {
   })
 
   describe('run with CLI 2 implementation', () => {
-    test('should run the CLI 2 implementation if the password flag is provided', async () => {
-      // Given
-      const theme = buildTheme({id: 1, name: 'Theme', role: 'development'})!
-
-      // When
-      await runPushCommand(['--password', '123'], path, adminSession, theme)
-
-      // Then
-      expectCLI2ToHaveBeenCalledWith(`theme push ${path} --development-theme-id ${theme.id}`)
-    })
-
     test('should pass development theme from local storage to CLI 2', async () => {
       // Given
       const theme = buildTheme({id: 1, name: 'Theme', role: 'development'})!

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -151,7 +151,7 @@ export default class Push extends ThemeCommand {
 
     const developmentThemeManager = new DevelopmentThemeManager(adminSession)
 
-    if (!flags.stable && !flags.password) {
+    if (!flags.stable) {
       const {live, development, unpublished, path, nodelete, theme, publish, json, force, ignore, only} = flags
 
       let selectedTheme: Theme


### PR DESCRIPTION
### WHY are these changes introduced?

We've introduced support for the CLI in the Theme Access app supports the CLI, so we may rollback this change.

### WHAT is this pull request doing?

This PR updates the push command to no longer rely in the legacy implementation when the `--password` flag is passed

### How to test your changes?

<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/8b3164f0-283c-4ca1-b562-bc6c5b0c27c5">

<img width="70%" src="https://github.com/Shopify/cli/assets/1079279/37312168-03e1-4122-a508-72b1233e83c5">

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
