### PR TITLE
Introduce support to the `blocks/` directory in the `shopify theme push` command

### DIFF
--- a/.changeset/shiny-trainers-ring.md
+++ b/.changeset/shiny-trainers-ring.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Introduce support to the `blocks/` directory in the `shopify theme push` command

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -29,6 +29,7 @@ const THEME_DIRECTORY_PATTERNS = [
   'layout/**/*.liquid',
   'locales/**/*.json',
   'sections/**/*.{liquid,json}',
+  'blocks/**/*.liquid',
   'snippets/**/*.liquid',
   'templates/**/*.{liquid,json}',
   'templates/customers/**/*.{liquid,json}',


### PR DESCRIPTION
### WHY are these changes introduced?

Introduce support to the [`blocks/`](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks) directory in the `shopify theme push` command

### WHAT is this pull request doing?

This PR updates the theme filesystem module to support the `blocks/` directory locally.

### How to test your changes?

- Create a theme with files in the `blocks/` directory
- Run `shopify-dev theme push -u -t test`
- Notice they get uploaded

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
