### PR TITLE
Add field to monorail to track global usage

### DIFF
--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -7,6 +7,7 @@ import {platformAndArch} from '../../public/node/os.js'
 import {Command, Interfaces} from '@oclif/core'
 import {ciPlatform, cloudEnvironment, macAddress} from '@shopify/cli-kit/node/context/local'
 import {cwd} from '@shopify/cli-kit/node/path'
+import {currentProcessIsGlobal} from '@shopify/cli-kit/node/is-global'
 
 interface StartOptions {
   commandContent: CommandContent
@@ -54,6 +55,7 @@ interface EnvironmentData {
   env_device_id: string
   env_cloud: string
   env_package_manager: string
+  env_is_global: boolean
 }
 
 export async function getEnvironmentData(config: Interfaces.Config): Promise<EnvironmentData> {
@@ -75,6 +77,7 @@ export async function getEnvironmentData(config: Interfaces.Config): Promise<Env
     env_device_id: hashString(await macAddress()),
     env_cloud: cloudEnvironment().platform,
     env_package_manager: await getPackageManager(cwd()),
+    env_is_global: currentProcessIsGlobal(),
   }
 }
 

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -10,7 +10,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 type Optional<T> = T | null
 
 // This is the topic name of the main event we log to Monorail, the command tracker
-export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.11' as const
+export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.12' as const
 
 export interface Schemas {
   [MONORAIL_COMMAND_TOPIC]: {
@@ -153,6 +153,7 @@ export interface Schemas {
       env_shell?: Optional<string>
       env_web_ide?: Optional<string>
       env_cloud?: Optional<string>
+      env_is_global?: Optional<boolean>
     }
   }
   [schemaId: string]: {sensitive: JsonMap; public: JsonMap}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Adding a new field: `env_is_global` to track the usage of the global vs local CLI

Fixes https://github.com/Shopify/develop-app-management/issues/1702

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
