### PR TITLE
Throw error early if active directory is not an app folder

### DIFF
--- a/packages/app/src/cli/commands/app/config/link.ts
+++ b/packages/app/src/cli/commands/app/config/link.ts
@@ -1,4 +1,5 @@
 import {appFlags} from '../../../flags.js'
+import {loadApp} from '../../../models/app/loader.js'
 import link, {LinkOptions} from '../../../services/app/config/link.js'
 import Command from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
@@ -31,6 +32,10 @@ export default class ConfigLink extends Command {
       directory: flags.path,
       apiKey: flags['client-id'],
     }
+
+    // Try to load the app before doing anything, to fail early if the directory doesn't contain an app
+    await loadApp({directory: flags.path, configName: flags.config})
+
     await link(options)
   }
 }

--- a/packages/app/src/cli/commands/app/config/link.ts
+++ b/packages/app/src/cli/commands/app/config/link.ts
@@ -1,5 +1,5 @@
 import {appFlags} from '../../../flags.js'
-import {loadApp} from '../../../models/app/loader.js'
+import {checkFolderIsValidApp} from '../../../models/app/loader.js'
 import link, {LinkOptions} from '../../../services/app/config/link.js'
 import Command from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
@@ -33,8 +33,7 @@ export default class ConfigLink extends Command {
       apiKey: flags['client-id'],
     }
 
-    // Try to load the app before doing anything, to fail early if the directory doesn't contain an app
-    await loadApp({directory: flags.path, configName: flags.config})
+    await checkFolderIsValidApp(flags.path)
 
     await link(options)
   }

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -2,6 +2,7 @@ import {appFlags} from '../../flags.js'
 import {dev} from '../../services/dev.js'
 import Command from '../../utilities/app-command.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
+import {loadApp} from '../../models/app/loader.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -156,6 +157,9 @@ If you're using the PHP or Ruby app template, then you need to complete the foll
     }))
 
     const commandConfig = this.config
+
+    // Try to load the app before doing anything, to fail early if the directory doesn't contain an app
+    await loadApp({directory: flags.path, configName: flags.config})
 
     const devOptions = {
       directory: flags.path,

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -2,7 +2,7 @@ import {appFlags} from '../../flags.js'
 import {dev} from '../../services/dev.js'
 import Command from '../../utilities/app-command.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
-import {loadApp} from '../../models/app/loader.js'
+import {checkFolderIsValidApp} from '../../models/app/loader.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -158,8 +158,7 @@ If you're using the PHP or Ruby app template, then you need to complete the foll
 
     const commandConfig = this.config
 
-    // Try to load the app before doing anything, to fail early if the directory doesn't contain an app
-    await loadApp({directory: flags.path, configName: flags.config})
+    await checkFolderIsValidApp(flags.path)
 
     const devOptions = {
       directory: flags.path,

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -3,6 +3,7 @@ import metadata from '../../../metadata.js'
 import Command from '../../../utilities/app-command.js'
 import generate from '../../../services/generate.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
+import {loadApp} from '../../../models/app/loader.js'
 import {Args, Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
@@ -101,6 +102,9 @@ export default class AppGenerateExtension extends Command {
       })
       return
     }
+
+    // Try to load the app before doing anything, to fail early if the directory doesn't contain an app
+    await loadApp({directory: flags.path, configName: flags.config})
 
     await generate({
       directory: flags.path,

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -3,7 +3,7 @@ import metadata from '../../../metadata.js'
 import Command from '../../../utilities/app-command.js'
 import generate from '../../../services/generate.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
-import {loadApp} from '../../../models/app/loader.js'
+import {checkFolderIsValidApp} from '../../../models/app/loader.js'
 import {Args, Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
@@ -103,8 +103,7 @@ export default class AppGenerateExtension extends Command {
       return
     }
 
-    // Try to load the app before doing anything, to fail early if the directory doesn't contain an app
-    await loadApp({directory: flags.path, configName: flags.config})
+    await checkFolderIsValidApp(flags.path)
 
     await generate({
       directory: flags.path,

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -6,6 +6,7 @@ import {
   parseConfigurationObject,
   parseHumanReadableError,
   loadAppConfiguration,
+  checkFolderIsValidApp,
 } from './loader.js'
 import {LegacyAppSchema, WebConfigurationSchema} from './app.js'
 import {DEFAULT_CONFIG, buildVersionedAppSchema, getWebhookConfig} from './app.test-data.js'
@@ -2472,6 +2473,31 @@ describe('loadDotEnv', () => {
       // Then
       expect(got).toBeDefined()
       expect(got!.variables.FOO).toEqual('bar')
+    })
+  })
+})
+
+describe('checkFolderIsValidApp', () => {
+  test('throws an error if the folder does not contain a shopify.app.toml file', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // When
+      const result = checkFolderIsValidApp(tmp)
+
+      // Then
+      await expect(result).rejects.toThrow(/Couldn't find an app toml file at/)
+    })
+  })
+
+  test('doesnt throw an error if the folder does contains a shopify.app.toml file', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      await writeFile(joinPath(tmp, 'shopify.app.toml'), '')
+
+      // When
+      const result = checkFolderIsValidApp(tmp)
+
+      // Then
+      await expect(result).resolves.toBeUndefined()
     })
   })
 })

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -159,7 +159,7 @@ automatically_update_urls_on_dev = true
 
     // When/Then
     await expect(loadApp({directory: currentDir, specifications})).rejects.toThrow(
-      `Couldn't find the configuration file for ${currentDir}`,
+      `Couldn't find an app toml file at ${currentDir}`,
     )
   })
 
@@ -385,7 +385,7 @@ wrong = "property"
     await makeBlockDir({name: 'my-extension'})
 
     // When
-    await expect(loadApp({directory: tmpDir, specifications})).rejects.toThrow(/Couldn't find the configuration file/)
+    await expect(loadApp({directory: tmpDir, specifications})).rejects.toThrow(/Couldn't find an app toml file at/)
   })
 
   test('throws an error if the extension configuration file is invalid', async () => {
@@ -835,7 +835,7 @@ wrong = "property"
     await makeBlockDir({name: 'my-functions'})
 
     // When
-    await expect(loadApp({directory: tmpDir, specifications})).rejects.toThrow(/Couldn't find the configuration file/)
+    await expect(loadApp({directory: tmpDir, specifications})).rejects.toThrow(/Couldn't find an app toml file at/)
   })
 
   test('throws an error if the function configuration file is invalid', async () => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -788,7 +788,7 @@ class AppConfigurationLoader {
       return appDirectory
     } else {
       throw new AbortError(
-        outputContent`Couldn't find the configuration file for ${outputToken.path(
+        outputContent`Couldn't find an app toml file at ${outputToken.path(
           this.directory,
         )}, are you in an app directory?`,
       )

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -784,9 +784,7 @@ class AppConfigurationLoader {
       return appDirectory
     } else {
       throw new AbortError(
-        outputContent`Couldn't find an app toml file at ${outputToken.path(
-          this.directory,
-        )}, are you in an app directory?`,
+        outputContent`Couldn't find an app toml file at ${outputToken.path(this.directory)}, is this an app directory?`,
       )
     }
   }

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -67,11 +67,7 @@ export async function loadConfigurationFileContent(
   decode: (input: string) => object = decodeToml,
 ): Promise<unknown> {
   if (!(await fileExists(filepath))) {
-    return abortOrReport(
-      outputContent`Couldn't find the configuration file at ${outputToken.path(filepath)}`,
-      '',
-      filepath,
-    )
+    return abortOrReport(outputContent`Couldn't find an app toml file at ${outputToken.path(filepath)}`, '', filepath)
   }
 
   try {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -22,6 +22,7 @@ import {getCachedAppInfo} from '../../services/local-storage.js'
 import use from '../../services/app/config/use.js'
 import {loadLocalExtensionsSpecifications} from '../extensions/load-specifications.js'
 import {Flag} from '../../services/dev/fetch.js'
+import {findConfigFiles} from '../../prompts/config.js'
 import {deepStrict, zod} from '@shopify/cli-kit/node/schema'
 import {fileExists, readFile, glob, findPathUp, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
@@ -173,6 +174,14 @@ interface AppLoaderConstructorArgs {
   configName?: string
   specifications?: ExtensionSpecification[]
   remoteFlags?: Flag[]
+}
+
+export async function checkFolderIsValidApp(directory: string) {
+  const thereAreConfigFiles = (await findConfigFiles(directory)).length > 0
+  if (thereAreConfigFiles) return
+  throw new AbortError(
+    outputContent`Couldn't find an app toml file at ${outputToken.path(directory)}, is this an app directory?`,
+  )
 }
 
 /**

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -43,8 +43,12 @@ export async function selectConfigName(directory: string, defaultName = ''): Pro
   return configName
 }
 
+export async function findConfigFiles(directory: string): Promise<string[]> {
+  return glob(joinPath(directory, 'shopify.app*.toml'))
+}
+
 export async function selectConfigFile(directory: string): Promise<Result<string, string>> {
-  const files = (await glob(joinPath(directory, 'shopify.app*.toml'))).map((path) => basename(path))
+  const files = (await findConfigFiles(directory)).map((path) => basename(path))
 
   if (files.length === 0) return err('Could not find any shopify.app.toml file in the directory.')
   if (files.length === 1) return ok(files[0]!)

--- a/packages/cli/src/cli/services/upgrade.ts
+++ b/packages/cli/src/cli/services/upgrade.ts
@@ -36,7 +36,7 @@ export async function upgrade(
     throw new AbortError(
       outputContent`Couldn't find an app toml file at ${outputToken.path(
         directory,
-      )}, are you in a Shopify project directory?`,
+      )}, is this a Shopify project directory?`,
     )
   } else {
     newestVersion = await upgradeGlobalShopify(currentVersion, {env})

--- a/packages/cli/src/cli/services/upgrade.ts
+++ b/packages/cli/src/cli/services/upgrade.ts
@@ -34,7 +34,7 @@ export async function upgrade(
     newestVersion = await upgradeLocalShopify(projectDir, currentVersion)
   } else if (usingPackageManager({env})) {
     throw new AbortError(
-      outputContent`Couldn't find the configuration file for ${outputToken.path(
+      outputContent`Couldn't find an app toml file at ${outputToken.path(
         directory,
       )}, are you in a Shopify project directory?`,
     )


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Some `app` commands start doing work or presenting prompts before validating if the current directory is a valid app directory, which eventually will fail.

We should fail early if we are not working in an app directory.


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Look in the active directory for app toml files, if there aren't any, throw an error.
- Update the error message to be more clear that an app toml file couldn't be found.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Try to run this both in main and this branch:
`pnpm shopify app dev --path ../invalid-path`

It should show prompts in main, and an early error in this branch
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
