### PR TITLE
Add esbuild back, improve esbuild plugin import, fix app info

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bugsnag-build-reporter": "^2.0.0",
     "commander": "^9.4.0",
     "cross-env": "^7.0.3",
+    "esbuild": "0.19.8",
     "eslint": "^8.48.0",
     "execa": "^7.2.0",
     "fast-glob": "^3.3.1",
@@ -107,7 +108,8 @@
     },
     "ignoreDependencies": [
       "eslint-plugin-react",
-      "eslint-plugin-react-hooks"
+      "eslint-plugin-react-hooks",
+      "esbuild"
     ],
     "ignoreWorkspaces": [
       "packages/eslint-plugin-cli"

--- a/packages/app/src/cli/services/extensions/bundle.test.ts
+++ b/packages/app/src/cli/services/extensions/bundle.test.ts
@@ -16,6 +16,14 @@ vi.mock('esbuild', async () => {
   }
 })
 
+vi.mock('@luckycatfactory/esbuild-graphql-loader', () => ({
+  default: {
+    default: () => {
+      return {name: 'graphql-loader', setup: vi.fn()}
+    },
+  },
+}))
+
 describe('bundleExtension()', () => {
   test('invokes ESBuild with the right options and forwards the logs', async () => {
     // Given

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -158,7 +158,9 @@ function getESBuildOptions(options: BundleOptions, processEnv = process.env): Pa
  * @returns List of plugins.
  */
 function getPlugins(resolveDir: string | undefined, processEnv = process.env): Plugin[] {
-  const plugins: Plugin[] = [graphqlLoaderPlugin.default()]
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const plugins: Plugin[] = [graphqlLoaderPlugin()]
 
   const skipReactDeduplication = isTruthy(processEnv[environmentVariableNames.skipEsbuildReactDedeuplication])
   if (resolveDir && !skipReactDeduplication) {

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -160,7 +160,7 @@ function getESBuildOptions(options: BundleOptions, processEnv = process.env): Pa
 function getPlugins(resolveDir: string | undefined, processEnv = process.env): Plugin[] {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  const plugins: Plugin[] = [graphqlLoaderPlugin()]
+  const plugins: Plugin[] = [graphqlLoaderPlugin.default()]
 
   const skipReactDeduplication = isTruthy(processEnv[environmentVariableNames.skipEsbuildReactDedeuplication])
   if (resolveDir && !skipReactDeduplication) {

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -10,10 +10,8 @@ import {outputDebug} from '@shopify/cli-kit/node/output'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {pickBy} from '@shopify/cli-kit/common/object'
 import {Writable} from 'stream'
-import {createRequire} from 'module'
 import type {StdinOptions, build as esBuild, Plugin} from 'esbuild'
-
-const require = createRequire(import.meta.url)
+import graphqlLoaderPlugin from '@luckycatfactory/esbuild-graphql-loader'
 
 interface BundleOptions {
   minify: boolean
@@ -155,19 +153,12 @@ function getESBuildOptions(options: BundleOptions, processEnv = process.env): Pa
   return esbuildOptions
 }
 
-type ESBuildPlugins = Parameters<typeof esContext>[0]['plugins']
-
 /**
  * It returns the plugins that should be used with ESBuild.
  * @returns List of plugins.
  */
-function getPlugins(resolveDir: string | undefined, processEnv = process.env): ESBuildPlugins {
-  const plugins = []
-
-  if (isGraphqlPackageAvailable()) {
-    const {default: graphqlLoader} = require('@luckycatfactory/esbuild-graphql-loader')
-    plugins.push(graphqlLoader())
-  }
+function getPlugins(resolveDir: string | undefined, processEnv = process.env): Plugin[] {
+  const plugins: Plugin[] = [graphqlLoaderPlugin.default()]
 
   const skipReactDeduplication = isTruthy(processEnv[environmentVariableNames.skipEsbuildReactDedeuplication])
   if (resolveDir && !skipReactDeduplication) {

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -9,9 +9,9 @@ import {joinPath, relativePath} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {pickBy} from '@shopify/cli-kit/common/object'
+import graphqlLoaderPlugin from '@luckycatfactory/esbuild-graphql-loader'
 import {Writable} from 'stream'
 import type {StdinOptions, build as esBuild, Plugin} from 'esbuild'
-import graphqlLoaderPlugin from '@luckycatfactory/esbuild-graphql-loader'
 
 interface BundleOptions {
   minify: boolean
@@ -190,22 +190,5 @@ function deduplicateReactPlugin(resolvedReactPath: string): Plugin {
         }
       })
     },
-  }
-}
-
-/**
- * Returns true if the "graphql" and "graphql-tag" packages can be
- * resolved. This information is used to determine whether we should
- * or not include the esbuild-graphql-loader plugin when invoking ESBuild
- * @returns Returns true if the "graphql" and "graphql-tag" can be resolved.
- */
-function isGraphqlPackageAvailable(): boolean {
-  try {
-    // eslint-disable-next-line @babel/no-unused-expressions
-    require.resolve('graphql') && require.resolve('graphql-tag')
-    return true
-    // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch {
-    return false
   }
 }

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -18,6 +18,7 @@ import {checkForNewVersion} from '@shopify/cli-kit/node/node-package-manager'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {TokenizedString, stringifyMessage, unstyled} from '@shopify/cli-kit/node/output'
 import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 
 vi.mock('./local-storage.js')
 vi.mock('./app/fetch-app-from-config-or-select.js')
@@ -90,7 +91,9 @@ describe('info', () => {
       // When
       const result = stringifyMessage(await info(app, infoOptions()))
       // Then
-      expect(unstyled(result)).toMatch('Shopify CLI       2.2.2 💡 Version 2.2.3 available! Run `yarn shopify upgrade`')
+      expect(unstyled(result)).toMatch(
+        `Shopify CLI       ${CLI_KIT_VERSION} 💡 Version 2.2.3 available! Run \`yarn shopify upgrade\``,
+      )
     })
   })
 
@@ -197,7 +200,7 @@ describe('info', () => {
       // When
       const result = stringifyMessage(await info(app, infoOptions()))
       // Then
-      expect(unstyled(result)).toMatch('Shopify CLI       2.2.2')
+      expect(unstyled(result)).toMatch(`Shopify CLI       ${CLI_KIT_VERSION}`)
       expect(unstyled(result)).not.toMatch('CLI reminder')
     })
   })

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -17,6 +17,7 @@ import {
   stringifyMessage,
   getOutputUpdateCLIReminder,
 } from '@shopify/cli-kit/node/output'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 
 export type Format = 'json' | 'text'
 export interface InfoOptions {
@@ -263,7 +264,7 @@ class AppInfo {
     const title = 'Tooling and System'
     const {platform, arch} = platformAndArch()
     const versionUpgradeMessage = await this.versionUpgradeMessage()
-    const cliVersionInfo = [this.currentCliVersion(), versionUpgradeMessage].join(' ').trim()
+    const cliVersionInfo = [CLI_KIT_VERSION, versionUpgradeMessage].join(' ').trim()
     const lines: string[][] = [
       ['Shopify CLI', cliVersionInfo],
       ['Package manager', this.app.packageManager],
@@ -274,13 +275,9 @@ class AppInfo {
     return [title, `${linesToColumns(lines)}`]
   }
 
-  currentCliVersion(): string {
-    return this.app.nodeDependencies['@shopify/cli']!
-  }
-
   async versionUpgradeMessage(): Promise<string> {
     const cliDependency = '@shopify/cli'
-    const newestVersion = await checkForNewVersion(cliDependency, this.currentCliVersion())
+    const newestVersion = await checkForNewVersion(cliDependency, CLI_KIT_VERSION)
     if (newestVersion) {
       return getOutputUpdateCLIReminder(this.app.packageManager, newestVersion)
     }

--- a/packages/features/steps/app.steps.ts
+++ b/packages/features/steps/app.steps.ts
@@ -40,7 +40,7 @@ Then(
   async function (extName: string, extType: string, flavor: string) {
     const appInfo: AppInfo = await this.appInfo()
     const extension = this.findExtension(appInfo, extName)
-    if (!extension) assert.fail(`Extension not created! Config:\n${JSON.stringify(appInfo, null, 2)}`)
+    if (!extension) assert.fail(`Extension not created! Config:\n${JSON.stringify(appInfo.allExtensions, null, 2)}`)
     assert.equal(extension.configuration.type, extType)
 
     let fileExtension

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      esbuild:
+        specifier: 0.19.8
+        version: 0.19.8
       eslint:
         specifier: ^8.48.0
         version: 8.49.0
@@ -3357,7 +3360,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm@0.18.17:
@@ -3374,7 +3376,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-x64@0.18.17:
@@ -3391,7 +3392,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-arm64@0.18.17:
@@ -3408,7 +3408,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-x64@0.18.17:
@@ -3425,7 +3424,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-arm64@0.18.17:
@@ -3442,7 +3440,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-x64@0.18.17:
@@ -3459,7 +3456,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm64@0.18.17:
@@ -3476,7 +3472,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm@0.18.17:
@@ -3493,7 +3488,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ia32@0.18.17:
@@ -3510,7 +3504,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-loong64@0.18.17:
@@ -3527,7 +3520,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-mips64el@0.18.17:
@@ -3544,7 +3536,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ppc64@0.18.17:
@@ -3561,7 +3552,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-riscv64@0.18.17:
@@ -3578,7 +3568,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-s390x@0.18.17:
@@ -3595,7 +3584,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-x64@0.18.17:
@@ -3612,7 +3600,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/netbsd-x64@0.18.17:
@@ -3629,7 +3616,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/openbsd-x64@0.18.17:
@@ -3646,7 +3632,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/sunos-x64@0.18.17:
@@ -3663,7 +3648,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-arm64@0.18.17:
@@ -3680,7 +3664,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-ia32@0.18.17:
@@ -3697,7 +3680,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-x64@0.18.17:
@@ -3714,7 +3696,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.49.0):
@@ -8682,7 +8663,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.8
       '@esbuild/win32-ia32': 0.19.8
       '@esbuild/win32-x64': 0.19.8
-    dev: false
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
In preparation for Global CLI this PR introduces 3 minor fixes.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add back `esbuild` as a top-level dependency, it will be used in the bundling scripts
- Improve how the graphql esbuild plugin is loaded to use ESM
- Fix `app info` showing an incorrect CLI version

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- App info shows the real version and not what you have in your package.json.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
