### PR TITLE
Use valid redeemable_type value

### DIFF
--- a/packages/app/src/cli/services/payments/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/payments/extension-to-toml.test.ts
@@ -11,7 +11,7 @@ const SAMPLE_CUSTOM_CREDIT_CARD_CONFIG =
 const SAMPLE_CUSTOM_ONSITE_CONFIG =
   '{"start_payment_session_url":"https://test-domain.com/startsession/bogus-pay","start_refund_session_url":"https://test-domain.com/refund","start_capture_session_url":"https://test-domain.com/capture","start_void_session_url":"https://test-domain.com/void","confirmation_callback_url":null,"checkout_payment_method_fields":[{"key":"bogus_customer_document","type":"string","required":true}],"supported_payment_methods":["bogus-pay"],"supported_countries":["BR"],"test_mode_available":true,"merchant_label":"Test Label","default_buyer_label": "Bogus Pay Buyer Label","buyer_label_to_locale":[],"supports_3ds":false,"supports_oversell_protection":false,"api_version":"unstable","multiple_capture":false,"supports_installments":false,"supports_deferred_payments":false}'
 const SAMPLE_REDEEMABLE_CONFIG =
-  '{"start_payment_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/payment_sessions","start_refund_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/refund_sessions","start_capture_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/capture_sessions","start_void_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/void_sessions","supported_countries":["CA","MX","US"],"test_mode_available":true,"merchant_label":"Bogus Redeemable Payments App","default_buyer_label":null,"buyer_label_to_locale":null,"api_version":"unstable","supported_payment_methods":["gift-card"],"redeemable_type":"gift_card","balance_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/retrieve_balance","checkout_payment_method_fields":[{"key":"card_number","type":"string","required":true},{"key":"pin","type":"string","required":true}]}'
+  '{"start_payment_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/payment_sessions","start_refund_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/refund_sessions","start_capture_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/capture_sessions","start_void_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/void_sessions","supported_countries":["CA","MX","US"],"test_mode_available":true,"merchant_label":"Bogus Redeemable Payments App","default_buyer_label":null,"buyer_label_to_locale":null,"api_version":"unstable","supported_payment_methods":["gift-card"],"redeemable_type":"gift-card","balance_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/retrieve_balance","checkout_payment_method_fields":[{"key":"card_number","type":"string","required":true},{"key":"pin","type":"string","required":true}]}'
 
 const translateDeployConfigKeyToCLI = (deployConfigKey: string): string => {
   switch (deployConfigKey) {
@@ -313,7 +313,7 @@ merchant_label = "Bogus Redeemable Payments App"
 supported_countries = [ "CA", "MX", "US" ]
 supported_payment_methods = [ "gift-card" ]
 test_mode_available = true
-redeemable_type = "gift_card"
+redeemable_type = "gift-card"
 balance_url = "https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/retrieve_balance"
 
   [[extensions.checkout_payment_method_fields]]


### PR DESCRIPTION
Use valid redeemable_type (`gift-card` vs `gift_card`) in the `extension-to-toml` tests

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
