### PR TITLE
Fix `shopify theme dev` issue to avoid previewing the live theme instead of the development one

### DIFF
--- a/.changeset/early-melons-joke.md
+++ b/.changeset/early-melons-joke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `shopify theme dev` issue to avoid previewing the live theme instead of the development one

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -106,6 +106,11 @@ module ShopifyCLI
         private
 
         def clean_sfr_cache(env, query, headers)
+          if env["PATH_INFO"].start_with?("/password")
+            @cache_cleaned = false
+            return
+          end
+
           return if @cache_cleaned
 
           @cache_cleaned = true


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/3663

### WHAT is this pull request doing?

This PR changes the method that cleans SFR cache to disregard the password page.

### How to test your changes?

- Run `shopify theme dev` in a development store
- Open the development server in a incognito tab
- Type the password
- Notice the development theme appears instead of the live one

**Before**
<img width="60%" src="https://github.com/Shopify/cli/assets/1079279/6621affa-27b8-4bee-b8d1-d777dbc33d5b">

**After**
<img  width="60%" src="https://github.com/Shopify/cli/assets/1079279/d8589eee-0ad5-4cc5-93a0-bff9d26e5ea9">

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
