### PR TITLE
[3.58] Fix `shopify theme dev` issue to avoid previewing the live theme instead of the development one

### DIFF
--- a/.changeset/early-melons-joke.md
+++ b/.changeset/early-melons-joke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `shopify theme dev` issue to avoid previewing the live theme instead of the development one

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -106,6 +106,11 @@ module ShopifyCLI
         private
 
         def clean_sfr_cache(env, query, headers)
+          if env["PATH_INFO"].start_with?("/password")
+            @cache_cleaned = false
+            return
+          end
+
           return if @cache_cleaned
 
           @cache_cleaned = true


### PR DESCRIPTION
Backport https://github.com/Shopify/cli/pull/3706