### PR TITLE
Fix hydrogen init

### DIFF
--- a/.changeset/red-zebras-heal.md
+++ b/.changeset/red-zebras-heal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Fix hydrogen init to always show the package manager selection prompt

--- a/packages/cli/src/cli/commands/hydrogen/init.ts
+++ b/packages/cli/src/cli/commands/hydrogen/init.ts
@@ -7,16 +7,14 @@ export default class Init extends Command {
   static strict = false
 
   async run(): Promise<void> {
-    const args = ['exec', '@shopify/create-hydrogen']
+    const args = ['exec', '@shopify/create-hydrogen@latest']
 
     // Remove everything before the `init` command
     const initIndex = process.argv.indexOf('init')
-    const flags = process.argv.slice(initIndex + 1)
 
-    if (flags.length > 0) {
-      args.push('--')
-      args.push(...flags)
-    }
+    // Force hydrogen to show a package manager selection prompt
+    const flags = ['--', '--package-manager', 'unknown'].concat(process.argv.slice(initIndex + 1))
+    args.push(...flags)
 
     try {
       await exec('npm', args, {stdio: 'inherit'})


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Hydrogen team wants to always show the package manager selection prompt when running `hydrogen init` from the global CLI. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Use `--package-manager unknown` in `hydrogen init` to force hydrogen to show a package manager selection prompt.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
`pnpm shopify hydrogen init` should show a package manager prompt.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
