### PR TITLE
Indicate `pnpm` version for node options

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,6 +3,7 @@ name: shopify-cli-next
 up:
   - node:
       version: v18.16.1
+      pnpm: 8.15.7
       package_mananager: pnpm@8.15.7
       packages: []
   - ruby:


### PR DESCRIPTION
See https://github.com/Shopify/cli/pull/3740

A further nudge over the PNPM version used internally.