### PR TITLE
Add `appId` to customer account redirect parameters

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -100,12 +100,13 @@ describe('getExtensionPointRedirectUrl()', () => {
       storeFqdn: 'example.myshopify.com',
       storeId: '123456789',
       url: 'https://localhost:8081',
+      id: 123,
     } as unknown as ExtensionDevOptions
 
     const result = getExtensionPointRedirectUrl('customer-account.page.render', extension, options)
 
     expect(result).toBe(
-      'https://shopify.com/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&target=customer-account.page.render',
+      'https://shopify.com/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&appId=123&target=customer-account.page.render',
     )
   })
 
@@ -119,12 +120,13 @@ describe('getExtensionPointRedirectUrl()', () => {
       storeFqdn: 'shop1.shopify.spin-instance.us.spin.dev',
       storeId: '123456789',
       url: 'https://localhost:8081',
+      id: 123,
     } as unknown as ExtensionDevOptions
 
     const result = getExtensionPointRedirectUrl('customer-account.page.render', extension, options)
 
     expect(result).toBe(
-      'https://shopify.spin-instance.us.spin.dev/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&target=customer-account.page.render',
+      'https://shopify.spin-instance.us.spin.dev/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&appId=123&target=customer-account.page.render',
     )
   })
 
@@ -138,12 +140,13 @@ describe('getExtensionPointRedirectUrl()', () => {
       storeFqdn: 'example.myshopify.com',
       storeId: '123456789',
       url: 'https://localhost:8081',
+      id: 123,
     } as unknown as ExtensionDevOptions
 
     const result = getExtensionPointRedirectUrl('CustomerAccount::FullPage::RenderWithin', extension, options)
 
     expect(result).toBe(
-      'https://shopify.com/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&target=CustomerAccount%3A%3AFullPage%3A%3ARenderWithin',
+      'https://shopify.com/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&appId=123&target=CustomerAccount%3A%3AFullPage%3A%3ARenderWithin',
     )
   })
 

--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -67,6 +67,7 @@ function getCustomerAccountsRedirectUrl(
   rawUrl.searchParams.append('origin', origin)
   rawUrl.searchParams.append('extensionId', extension.devUUID)
   rawUrl.searchParams.append('source', 'CUSTOMER_ACCOUNT_EXTENSION')
+  rawUrl.searchParams.append('appId', options.id ?? '')
   if (requestedTarget !== '') {
     rawUrl.searchParams.append('target', requestedTarget)
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/core-issues/issues/69463

We need to ensure that an app has a corresponding `CustomerOAuthApplication` record when previewing customer account extensions from the CLI.

In order to create this record, we need to know the `appId` of the app that the extension belongs to.

### WHAT is this pull request doing?

Adds the `appId` querystring parameter to the the URL being constructed for Customer Accounts.

### How to test your changes?

* `spin up customer-accounts-ui-extension-dev -n {INSTANCE_NAME}`
* On your local machine, `dev clone customer-accounts-ui-extension-dev` (this is just to have an extension on your local machine)
* On your local machine, switch to this branch in the CLI
* `SHOPIFY_SERVICE_ENV=spin SPIN_INSTANCE={INSTANCE_NAME} pnpm shopify app dev --path {path_to_customer-accounts-ui-extension-dev}
* Follow the steps to start up the CLI preview. 
* Preview the extension and click on any target. In the network tab, filter requests to find the one going to `/extensions-development`. Ensure that `appId` is included in the querystring

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
