### PR TITLE
[3.59] Fix `shopify theme dev` proxy to use development theme

### DIFF
--- a/.changeset/clean-badgers-deny.md
+++ b/.changeset/clean-badgers-deny.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+- Fix the `shopify theme dev` proxy to use the development theme, even when users have a browser session with the live theme loaded

--- a/.github/workflows/cli-ruby.yml
+++ b/.github/workflows/cli-ruby.yml
@@ -59,7 +59,7 @@ jobs:
         version:
           - 3.1.0
         os:
-          - macos-latest
+          - macos-12
     steps:
       - uses: actions/checkout@v3
 

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_middleware.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_middleware.rb
@@ -17,7 +17,7 @@ module ShopifyCLI
           @env = env
           @env["PATH_INFO"] = PASSWORD_PAGE_PATH if redirect_to_password?(@env)
 
-          return @app.call(@env) if password_page?(@env)
+          return @app.call(@env) if password_page?(@env) || (storefront_session.nil? || secure_session.nil?)
 
           authenticate!
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fix the `shopify theme dev` proxy to use the development theme, even when users have a browser session with the live theme loaded. I noticed this edge case while conducting additional manual tests for https://github.com/Shopify/cli/pull/3769.

### WHAT is this pull request doing?

This PR updates the proxy to serve the 302 response when the development theme ID is set.

### How to test your changes?

**Before**
![before__](https://github.com/Shopify/cli/assets/1079279/eaccb847-140b-4ca6-b52c-e1b8032b5c98)


**After**
![after__](https://github.com/Shopify/cli/assets/1079279/52f94ea2-d688-4322-8ebf-eaed9e313f30)


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
