### PR TITLE
Fix Rubocop CI

### DIFF
--- a/.github/workflows/cli-ruby.yml
+++ b/.github/workflows/cli-ruby.yml
@@ -59,7 +59,7 @@ jobs:
         version:
           - 3.1.0
         os:
-          - macos-latest
+          - macos-12
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
### WHY are these changes introduced?

Rubocop is failing on [`main`](https://github.com/Shopify/cli/commits/main/).

### WHAT is this pull request doing?

Updates the `.github/workflows/cli-ruby.yml` to make it pass.

### How to test your changes?

N/A

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

N/A

### Checklist

N/A
