### PR TITLE
Fix missing ts-node warning

### DIFF
--- a/bin/bundling/esbuild-plugin-graphiql-imports.js
+++ b/bin/bundling/esbuild-plugin-graphiql-imports.js
@@ -3,7 +3,8 @@ import { readFile } from 'fs/promises'
 const GraphiQLImportsPlugin = {
   name: 'GraphiQLImportsPlugin',
   setup(build) {
-    // GraphiQL uses require.resolve with paths that doesn't work well with esbuild
+    // GraphiQL uses require.resolve with paths that won't work with esbuild
+    // We need to replace them with valid paths
     build.onLoad({filter: /.*server\.js/}, async (args) => {
       const contents = await readFile(args.path, 'utf8')
       return {

--- a/packages/cli/bin/bundle.js
+++ b/packages/cli/bin/bundle.js
@@ -44,8 +44,6 @@ esBuild({
     ShopifyVSCodePlugin,
     GraphiQLImportsPlugin,
     ShopifyStacktraceyPlugin,
-    // To allow using require.resolve in esbuild (we use it for graphiql)
-    // requireResolvePlugin(),
     copy({
       // this is equal to process.cwd(), which means we use cwd path as base path to resolve `to` path
       // if not specified, this plugin uses ESBuild.build outdir/outfile options as base path.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -108,7 +108,6 @@
     "zod-to-json-schema": "3.21.4"
   },
   "devDependencies": {
-    "@chialab/esbuild-plugin-require-resolve": "^0.18.0",
     "@shopify/app": "3.59.0",
     "@shopify/theme": "3.59.0",
     "@types/node": "18.19.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,9 +265,6 @@ importers:
         specifier: 3.21.4
         version: 3.21.4(zod@3.22.3)
     devDependencies:
-      '@chialab/esbuild-plugin-require-resolve':
-        specifier: ^0.18.0
-        version: 0.18.0
       '@types/node':
         specifier: 18.19.3
         version: 18.19.3
@@ -3255,34 +3252,6 @@ packages:
       prettier: 2.8.8
     dev: true
 
-  /@chialab/esbuild-plugin-require-resolve@0.18.0:
-    resolution: {integrity: sha512-5xDQBqgwx+biV8m7lqRsiwBh9pPa0rWslLZ9h10QgpeYDhX/xigY2miEc4QueTjmhMWdvE+WPHnPXl4ViBn4/g==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@chialab/esbuild-rna': 0.18.2
-      '@chialab/estransform': 0.18.1
-    dev: true
-
-  /@chialab/esbuild-rna@0.18.2:
-    resolution: {integrity: sha512-ckzskez7bxstVQ4c5cxbx0DRP2teldzrcSGQl2KPh1VJGdO2ZmRrb6vNkBBD5K3dx9tgTyvskWp4dV+Fbg07Ag==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@chialab/estransform': 0.18.1
-      '@chialab/node-resolve': 0.18.0
-    dev: true
-
-  /@chialab/estransform@0.18.1:
-    resolution: {integrity: sha512-W/WmjpQL2hndD0/XfR0FcPBAUj+aLNeoAVehOjV/Q9bSnioz0GVSAXXhzp59S33ZynxJBBfn8DNiMTVNJmk4Aw==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@parcel/source-map': 2.1.1
-    dev: true
-
-  /@chialab/node-resolve@0.18.0:
-    resolution: {integrity: sha512-eV1m70Qn9pLY9xwFmZ2FlcOzwiaUywsJ7NB/ud8VB7DouvCQtIHkQ3Om7uPX0ojXGEG1LCyO96kZkvbNTxNu0Q==}
-    engines: {node: '>=18'}
-    dev: true
-
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -4877,13 +4846,6 @@ packages:
     resolution: {integrity: sha512-xbR2U+2YjauIuo42qmE8XyJK6dYeRMLJuOlUP5SO4auET4VtOHOzgkRVOq+Ik18N+Xf3YPcqJs9dZMiDddz1eQ==}
     engines: {node: '>=14'}
     dev: false
-
-  /@parcel/source-map@2.1.1:
-    resolution: {integrity: sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==}
-    engines: {node: ^12.18.3 || >=14}
-    dependencies:
-      detect-libc: 1.0.3
-    dev: true
 
   /@parcel/watcher-android-arm64@2.4.1:
     resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
@@ -8254,6 +8216,8 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
     requiresBuild: true
+    dev: false
+    optional: true
 
   /detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Some users are seeing a warning about `ts-node` being missing, it's not a blocker but it shouldn't appear.

Fixes https://github.com/Shopify/cli/issues/3729

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Remove the esbuild plugin `require-resolve`, it was added to support `require.resolve` in the graphiql server, but apparently it was affecting some codepaths that load some ts-node stuff. 
- Added a custom esbuild plugin to solve the GraphiQL imports
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Running `shopify hydrogen dev` with version 3.59.1 should show a `ts-node` warning.

If you install `npm i -g @shopify/cli@0.0.0-experimental-20240424160324` and run the same command, the warning should be gone.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
