### PR TITLE
Fix wrong mismatching scopes warning message running dev

### DIFF
--- a/.changeset/yellow-poems-tan.md
+++ b/.changeset/yellow-poems-tan.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix issue when you create a new remix app, include some scopes and run dev. A message saying scopes mismatch appeared.

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -15,12 +15,16 @@ import {fileRealPath, findPathUp} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {setPathValue} from '@shopify/cli-kit/common/object'
+import {normalizeDelimitedString} from '@shopify/cli-kit/common/string'
 
 export const LegacyAppSchema = zod
   .object({
     client_id: zod.number().optional(),
     name: zod.string().optional(),
-    scopes: zod.string().default(''),
+    scopes: zod
+      .string()
+      .transform((scopes) => normalizeDelimitedString(scopes) ?? '')
+      .default(''),
     extension_directories: zod.array(zod.string()).optional(),
     web_directories: zod.array(zod.string()).optional(),
   })


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Sometimes, when you run the `dev` command you receive a mismatching warn message even if the local scopes declared in the `toml` are equal to the remote configuratio

This issue could only appear running a specific use case:
- Create a new `Remix` app
- Edit the `toml` and set the following content (before running the first cli whatever `app` command for a new app the `toml` uses the legacy format)
```toml
scopes = "write_metaobject_definitions,write_metaobjects,write_products"
```
- Run the `dev` command and create a new app.
- You should see the following error message
![image](https://github.com/Shopify/cli/assets/105213827/5e17b3bd-39be-4903-a184-6b971eb3f61c)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Normalize the `scopes` entry in the `Legacy Schema` in the same way we were doing for the new schema. This means:
  - Trim the items
  - Remove empty values
  - Sort the items
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Retry the steps from the introduction and you should not see any error
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
