### PR TITLE
Fix issue with missing closing tag on code block.

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1452,22 +1452,22 @@ DESCRIPTION
 
   If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a
   machine-readable input for scripts or continuous integration.
+```
 
   Sample output:
 
   ```json
-  {
-  "theme": {
-  "id": 108267175958,
-  "name": "MyTheme",
-  "role": "unpublished",
-  "shop": "mystore.myshopify.com",
-  "editor_url": "https://mystore.myshopify.com/admin/themes/108267175958/editor",
-  "preview_url": "https://mystore.myshopify.com/?preview_theme_id=108267175958"
-  }
-  }
+    {
+      "theme": {
+        "id": 108267175958,
+        "name": "MyTheme",
+        "role": "unpublished",
+        "shop": "mystore.myshopify.com",
+        "editor_url": "https://mystore.myshopify.com/admin/themes/108267175958/editor",
+        "preview_url": "https://mystore.myshopify.com/?preview_theme_id=108267175958"
+      }
+    }
   ```
-```
 
 ## `shopify theme rename`
 


### PR DESCRIPTION
Fix an issue with a missing end tag to a code block which caused the headings following it to not be rendered correctly.