### PR TITLE
[Theme] Add error handling when development theme role gets mismatched

### DIFF
--- a/packages/theme/src/cli/utilities/development-theme-manager.test.ts
+++ b/packages/theme/src/cli/utilities/development-theme-manager.test.ts
@@ -2,13 +2,14 @@ import {
   DevelopmentThemeManager,
   NO_DEVELOPMENT_THEME_ID_SET,
   DEVELOPMENT_THEME_NOT_FOUND,
+  UNEXPECTED_ROLE_VALUE,
 } from './development-theme-manager.js'
 import {getDevelopmentTheme, setDevelopmentTheme, removeDevelopmentTheme} from '../services/local-storage.js'
 import {createTheme, fetchTheme} from '@shopify/cli-kit/node/themes/api'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
-import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
+import {DEVELOPMENT_THEME_ROLE, UNPUBLISHED_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
 
 vi.mock('@shopify/cli-kit/node/themes/api')
 vi.mock('../services/local-storage.js')
@@ -20,7 +21,7 @@ describe('DevelopmentThemeManager', () => {
   const newThemeId = 201
   const onlyLocallyExistingId = 404
   const themeTestDatabase: {[id: number]: Theme | undefined} = {
-    [existingId]: {id: existingId} as Theme,
+    [existingId]: {id: existingId, role: DEVELOPMENT_THEME_ROLE} as Theme,
     [onlyLocallyExistingId]: undefined,
   }
   let localDevelopmentThemeId: string | undefined
@@ -40,6 +41,7 @@ describe('DevelopmentThemeManager', () => {
         })!,
       ),
     )
+    themeTestDatabase[existingId]!.role = DEVELOPMENT_THEME_ROLE
   })
 
   function buildDevelopmentThemeManager() {
@@ -76,6 +78,19 @@ describe('DevelopmentThemeManager', () => {
       localDevelopmentThemeId = theme
       await expect(buildDevelopmentThemeManager().find()).resolves.toEqual(themeTestDatabase[existingId])
     })
+
+    test('should remove locally stored ID and throw Abort if API returns theme with unexpected role', async () => {
+      // Given
+      themeTestDatabase[existingId]!.role = UNPUBLISHED_THEME_ROLE
+      const theme = existingId.toString()
+      localDevelopmentThemeId = theme
+      const developmentThemeManager = buildDevelopmentThemeManager()
+
+      // When
+      // Then
+      await expect(() => developmentThemeManager.find()).rejects.toThrowError(UNEXPECTED_ROLE_VALUE)
+      expect(removeDevelopmentTheme).toHaveBeenCalledOnce()
+    })
   })
 
   describe('findOrCreate', () => {
@@ -107,6 +122,19 @@ describe('DevelopmentThemeManager', () => {
       // When
       // Then
       expect((await buildDevelopmentThemeManager().findOrCreate()).id.toString()).toEqual(newThemeId.toString())
+      expect(removeDevelopmentTheme).toHaveBeenCalledOnce()
+    })
+
+    test('should remove locally stored ID and throw Abort if API returns theme with unexpected role', async () => {
+      // Given
+      themeTestDatabase[existingId]!.role = UNPUBLISHED_THEME_ROLE
+      const theme = existingId.toString()
+      localDevelopmentThemeId = theme
+      const developmentThemeManager = buildDevelopmentThemeManager()
+
+      // When
+      // Then
+      await expect(() => developmentThemeManager.findOrCreate()).rejects.toThrowError(UNEXPECTED_ROLE_VALUE)
       expect(removeDevelopmentTheme).toHaveBeenCalledOnce()
     })
   })

--- a/packages/theme/src/cli/utilities/development-theme-manager.test.ts
+++ b/packages/theme/src/cli/utilities/development-theme-manager.test.ts
@@ -8,6 +8,7 @@ import {createTheme, fetchTheme} from '@shopify/cli-kit/node/themes/api'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
+import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
 
 vi.mock('@shopify/cli-kit/node/themes/api')
 vi.mock('../services/local-storage.js')
@@ -50,14 +51,22 @@ describe('DevelopmentThemeManager', () => {
 
   describe('find', () => {
     test('should throw Abort if no ID is locally stored', async () => {
+      // Given
       localDevelopmentThemeId = undefined
+
+      // When
+      // Then
       await expect(() => buildDevelopmentThemeManager().find()).rejects.toThrowError(NO_DEVELOPMENT_THEME_ID_SET)
       expect(removeDevelopmentTheme).not.toHaveBeenCalled()
     })
 
     test('should remove locally stored ID and throw Abort if API could not return theme', async () => {
+      // Given
       const theme = onlyLocallyExistingId.toString()
       localDevelopmentThemeId = theme
+
+      // When
+      // Then
       await expect(() => buildDevelopmentThemeManager().find()).rejects.toThrowError(DEVELOPMENT_THEME_NOT_FOUND(theme))
       expect(removeDevelopmentTheme).toHaveBeenCalledOnce()
     })
@@ -71,22 +80,47 @@ describe('DevelopmentThemeManager', () => {
 
   describe('findOrCreate', () => {
     test('should not create a new development theme if API returns theme with locally stored ID', async () => {
+      // Given
       const theme = existingId.toString()
       localDevelopmentThemeId = theme
+
+      // When
+      // Then
       expect((await buildDevelopmentThemeManager().findOrCreate()).id.toString()).toEqual(theme)
     })
 
     test('should create a new development theme if no ID is locally stored', async () => {
+      // Given
       localDevelopmentThemeId = undefined
+
+      // When
+      // Then
       expect((await buildDevelopmentThemeManager().findOrCreate()).id.toString()).toEqual(newThemeId.toString())
       expect(removeDevelopmentTheme).not.toHaveBeenCalled()
     })
 
     test('should create a new development theme if locally existing ID points to nowhere', async () => {
+      // Given
       const theme = onlyLocallyExistingId.toString()
       localDevelopmentThemeId = theme
+
+      // When
+      // Then
       expect((await buildDevelopmentThemeManager().findOrCreate()).id.toString()).toEqual(newThemeId.toString())
       expect(removeDevelopmentTheme).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('create', () => {
+    test('should create a new development theme', async () => {
+      // Given
+      const developmentThemeManager = buildDevelopmentThemeManager()
+
+      // When
+      const theme = await developmentThemeManager.create()
+
+      // Then
+      expect(theme.role).toBe(DEVELOPMENT_THEME_ROLE)
     })
   })
 })

--- a/packages/theme/src/cli/utilities/development-theme-manager.ts
+++ b/packages/theme/src/cli/utilities/development-theme-manager.ts
@@ -3,11 +3,14 @@ import {ThemeManager} from '@shopify/cli-kit/node/themes/theme-manager'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
+import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
 
 export const DEVELOPMENT_THEME_NOT_FOUND = (themeId: string) =>
   `Development theme #${themeId} could not be found. Please create a new development theme.`
 export const NO_DEVELOPMENT_THEME_ID_SET =
   'No development theme ID has been set. Please create a development theme first.'
+export const UNEXPECTED_ROLE_VALUE =
+  'There was an issue finding your development theme. Please create a new one using `theme dev` or `theme push -d`.'
 
 export class DevelopmentThemeManager extends ThemeManager {
   protected context = 'Development'
@@ -17,11 +20,18 @@ export class DevelopmentThemeManager extends ThemeManager {
     this.themeId = getDevelopmentTheme()
   }
 
+  async findOrCreate(): Promise<Theme> {
+    const theme = await super.findOrCreate()
+    this.checkThemeRole(theme)
+    return theme
+  }
+
   async find(): Promise<Theme> {
     const theme = await this.fetch()
     if (!theme) {
       throw new AbortError(this.themeId ? DEVELOPMENT_THEME_NOT_FOUND(this.themeId) : NO_DEVELOPMENT_THEME_ID_SET)
     }
+    this.checkThemeRole(theme)
     return theme
   }
 
@@ -31,5 +41,12 @@ export class DevelopmentThemeManager extends ThemeManager {
 
   protected removeTheme(): void {
     removeDevelopmentTheme()
+  }
+
+  private checkThemeRole(theme: Theme) {
+    if (theme.role !== DEVELOPMENT_THEME_ROLE) {
+      this.removeTheme()
+      throw new AbortError(UNEXPECTED_ROLE_VALUE)
+    }
   }
 }

--- a/packages/theme/src/cli/utilities/unpublished-theme-manager.test.ts
+++ b/packages/theme/src/cli/utilities/unpublished-theme-manager.test.ts
@@ -1,0 +1,45 @@
+import {UnpublishedThemeManager} from './unpublished-theme-manager.js'
+import {createTheme} from '@shopify/cli-kit/node/themes/api'
+import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
+import {UNPUBLISHED_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/themes/api')
+
+describe('UnpublishedThemeManager', () => {
+  const storeFqdn = 'mystore.myshopify.com'
+  const token = 'token'
+  const newThemeId = 201
+
+  describe('create', () => {
+    beforeEach(() => {
+      vi.mocked(createTheme).mockImplementation(({name, role}) =>
+        Promise.resolve(
+          buildTheme({
+            id: newThemeId,
+            name: name!,
+            role: role!,
+          })!,
+        ),
+      )
+    })
+
+    test('creates an unbpublished theme by default', async () => {
+      // Given
+      const themeManager = buildThemeManager()
+
+      // When
+      const theme = await themeManager.create()
+
+      // Then
+      expect(theme.role).toBe(UNPUBLISHED_THEME_ROLE)
+    })
+  })
+
+  function buildThemeManager(): UnpublishedThemeManager {
+    return new UnpublishedThemeManager({
+      storeFqdn,
+      token,
+    })
+  }
+})

--- a/packages/theme/src/cli/utilities/unpublished-theme-manager.ts
+++ b/packages/theme/src/cli/utilities/unpublished-theme-manager.ts
@@ -1,0 +1,24 @@
+import {AdminSession} from '@shopify/cli-kit/node/session'
+import {ThemeManager} from '@shopify/cli-kit/node/themes/theme-manager'
+import {Role, UNPUBLISHED_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
+
+export class UnpublishedThemeManager extends ThemeManager {
+  protected context = 'Theme'
+
+  constructor(adminSession: AdminSession) {
+    super(adminSession)
+  }
+
+  async create(themeRole?: Role, themeName?: string) {
+    const role = themeRole || UNPUBLISHED_THEME_ROLE
+    return super.create(role, themeName)
+  }
+
+  protected setTheme(themeId: string): void {
+    this.themeId = themeId
+  }
+
+  protected removeTheme(): void {
+    this.themeId = undefined
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?
Following up on 
- https://github.com/Shopify/cli/issues/3715

I want to open this PR as a forum for discussion 
- Do we even want to add this code since its only purpose is to help reset ephemeral data? (The local data lasts 7 days AFAIK) [Docs](https://shopify.dev/docs/themes/tools/cli#features)
- Currently, I'm only adding this guard to `findAndCreate` which means that 

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
