### PR TITLE
Remove CLI 2.0 reference from the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,3 @@ contact_links:
   - name: Shopify Partners Community 🙌
     url: https://community.shopify.com/c/partners-and-developers/ct-p/appdev
     about: Connect with Shopify and other Shopify Partners through our online communities!
-  - name: Shopify CLI 2.0 issues 📝
-    url: https://www.github.com/Shopify/shopify-cli/issues/new/choose
-    about: |-
-      You're about to open an issue about Shopify CLI 3.0. Are you actually using our previous CLI? If so, please create an issue there instead.


### PR DESCRIPTION
### WHY are these changes introduced?

We are still linking to the CLI 2.0 repo in the issue template, but it's now deprecated

<img width="1180" alt="29-08-kxuti-aeavb" src="https://github.com/Shopify/cli/assets/14979109/ed680468-9227-4a92-b6f9-7a3e082f6fe2">

### WHAT is this pull request doing?

Removes the last option

### How to test your changes?

Merge and check https://github.com/Shopify/cli/issues/new/choose

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
