### PR TITLE
Fix issue that prevents `shopify theme console` from evaluating results when another 'preview_theme_id' is set

### DIFF
--- a/.changeset/late-flowers-yell.md
+++ b/.changeset/late-flowers-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix issue that prevents `shopify theme console` from evaluating results when another 'preview_theme_id' is set

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_middleware.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_middleware.rb
@@ -26,6 +26,9 @@ module ShopifyCLI
           # from shutting down the server.
           shutdown if index_page?(@env)
 
+          # Set preview_theme_id into the session.
+          @app.call(@env)
+
           [
             200,
             {


### PR DESCRIPTION
### WHY are these changes introduced?

When another theme is set in the session, `shopify theme console` tries to evaluate Liquid snippets using the wrong remote theme.

### WHAT is this pull request doing?

This PR adopts [this fix](https://github.com/Shopify/cli/pull/3771) to make sure that Liquid snippets are evaluated using the expected remote theme.

### How to test your changes?

**Before**
<img width="80%" src="https://github.com/Shopify/cli/assets/1079279/028bbc93-f835-4a5d-8caf-a6fed083de58">

**After**
<img width="80%" src="https://github.com/Shopify/cli/assets/1079279/0bbc3cf7-ac2b-49bc-9da4-c4e4935975a9">

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
