### PR TITLE
Fix issue that prevents `shopify theme console` from evaluating results when another 'preview_theme_id' is set

### DIFF
--- a/.changeset/late-flowers-yell.md
+++ b/.changeset/late-flowers-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix issue that prevents `shopify theme console` from evaluating results when another 'preview_theme_id' is set

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_middleware.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_middleware.rb
@@ -26,6 +26,9 @@ module ShopifyCLI
           # from shutting down the server.
           shutdown if index_page?(@env)
 
+          # Set preview_theme_id into the session.
+          @app.call(@env)
+
           [
             200,
             {


### PR DESCRIPTION
Back-port: https://github.com/Shopify/cli/pull/3811