### PR TITLE
Bump minimum ruby version requirement

### DIFF
--- a/docs-shopify.dev/generated/generated_static_pages.json
+++ b/docs-shopify.dev/generated/generated_static_pages.json
@@ -47,7 +47,7 @@
         "type": "Generic",
         "anchorLink": "requirements-themes",
         "title": "Requirements for themes",
-        "sectionContent": "\nTo work with themes, your system must meet the following additional requirements:\n- [Ruby](https://www.ruby-lang.org/en/) version 2.7.2 or higher\n\n> Note: Theme requirements are automatically installed on macOS when you use Homebrew to install Shopify CLI.\n",
+        "sectionContent": "\nTo work with themes, your system must meet the following additional requirements:\n- [Ruby](https://www.ruby-lang.org/en/) version 2.7.5 or higher\n\n> Note: Theme requirements are automatically installed on macOS when you use Homebrew to install Shopify CLI.\n",
         "codeblock": {
           "title": "Installation requirements for themes",
           "tabs": [

--- a/docs-shopify.dev/static/cli.doc.ts
+++ b/docs-shopify.dev/static/cli.doc.ts
@@ -55,7 +55,7 @@ const data: LandingTemplateSchema = {
       title: 'Requirements for themes',
       sectionContent: `
 To work with themes, your system must meet the following additional requirements:
-- [Ruby](https://www.ruby-lang.org/en/) version 2.7.2 or higher
+- [Ruby](https://www.ruby-lang.org/en/) version 2.7.5 or higher
 
 > Note: Theme requirements are automatically installed on macOS when you use Homebrew to install Shopify CLI.
 `,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3816 

Currently, the Shopify CLI's documentation indicates that, to work with themes, we need to have ruby version 2.7.2 or higher.

However, with ruby version 2.7.2 installed, running the command `shopify theme pull --store {store-name}` returns an error asking us to install ruby version 2.7.5 or higher.

### WHAT is this pull request doing?

Bumping the minimum ruby version requirement in the documentation.