### PR TITLE
Fix auth for 1p development in Spin

### DIFF
--- a/.changeset/wet-paws-smoke.md
+++ b/.changeset/wet-paws-smoke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix auth for 1p development in Spin

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -27,6 +27,7 @@ import {gql} from 'graphql-request'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {outputCompleted, outputInfo, outputWarn} from '@shopify/cli-kit/node/output'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
+import {isSpin} from '@shopify/cli-kit/node/context/spin'
 
 /**
  * A scope supported by the Shopify Admin API.
@@ -124,7 +125,7 @@ ${outputToken.json(applications)}
   let newSession = {}
 
   function throwOnNoPrompt() {
-    if (!noPrompt || firstPartyDev()) return
+    if (!noPrompt || (isSpin() && firstPartyDev())) return
     throw new AbortError(
       `The currently available CLI credentials are invalid.
 

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -124,7 +124,7 @@ ${outputToken.json(applications)}
   let newSession = {}
 
   function throwOnNoPrompt() {
-    if (!noPrompt) return
+    if (!noPrompt || firstPartyDev()) return
     throw new AbortError(
       `The currently available CLI credentials are invalid.
 

--- a/packages/cli-kit/src/private/node/session/identity-token-validation.ts
+++ b/packages/cli-kit/src/private/node/session/identity-token-validation.ts
@@ -5,9 +5,10 @@ import {cacheRetrieveOrRepopulate, IntrospectionUrlKey} from '../conf-store.js'
 import {err, ok, Result} from '../../../public/node/result.js'
 import {AbortError} from '../../../public/node/error.js'
 import {firstPartyDev} from '@shopify/cli-kit/node/context/local'
+import {isSpin} from '@shopify/cli-kit/node/context/spin'
 
 export async function validateIdentityToken(token: string): Promise<boolean> {
-  if (firstPartyDev()) return true
+  if (isSpin() && firstPartyDev()) return true
 
   try {
     return withIntrospectionURL<boolean>(async (introspectionURL: string) => {

--- a/packages/cli-kit/src/private/node/session/identity-token-validation.ts
+++ b/packages/cli-kit/src/private/node/session/identity-token-validation.ts
@@ -4,8 +4,11 @@ import {shopifyFetch} from '../../../public/node/http.js'
 import {cacheRetrieveOrRepopulate, IntrospectionUrlKey} from '../conf-store.js'
 import {err, ok, Result} from '../../../public/node/result.js'
 import {AbortError} from '../../../public/node/error.js'
+import {firstPartyDev} from '@shopify/cli-kit/node/context/local'
 
 export async function validateIdentityToken(token: string): Promise<boolean> {
+  if (firstPartyDev()) return true
+
   try {
     return withIntrospectionURL<boolean>(async (introspectionURL: string) => {
       const options = {


### PR DESCRIPTION
### WHY are these changes introduced?

Running dev with TAE in Spin was failing when trying to refresh the tokens:

```
The currently available CLI credentials are invalid.  
The CLI is currently unable to prompt for reauthentication.
Restart the CLI process you were running. If in an interactive terminal, you will be prompted to reauthenticate. If in a non-interactive terminal, ensure the correct credentials are available in the program environment. 
```

Original thread: https://shopify.slack.com/archives/C030LHFCA5T/p1714414263061029

### WHAT is this pull request doing?

Skip the error message thrown when the credentials are invalid and we can't run the auth flow, as it doesn't make sense for 1p dev in Spin.

### How to test your changes?

Try with `0.0.0-experimental-20240430140716` in Spin

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
