### PR TITLE
Limit the number of field definitions allowed for credit_card, custom_credit_card, and custom_onsite extensions

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
@@ -2,6 +2,7 @@ import {
   CreditCardPaymentsAppExtensionConfigType,
   CreditCardPaymentsAppExtensionSchema,
   creditCardPaymentsAppExtensionDeployConfig,
+  MAX_CHECKOUT_PAYMENT_METHOD_FIELDS,
 } from './credit_card_payments_app_extension_schema.js'
 import {describe, expect, test} from 'vitest'
 import {zod} from '@shopify/cli-kit/node/schema'
@@ -100,6 +101,59 @@ describe('CreditCardPaymentsAppExtensionSchema', () => {
           code: zod.ZodIssueCode.custom,
           message: 'supports_installments and supports_deferred_payments must be the same',
           path: [],
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if checkout_payment_method_fields has too many fields', async () => {
+    // When/Then
+    expect(() =>
+      CreditCardPaymentsAppExtensionSchema.parse({
+        ...config,
+        checkout_payment_method_fields: [
+          {
+            key: 'key1',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key2',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key3',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key4',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key5',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key6',
+            type: 'string',
+            required: true,
+          },
+        ],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.too_big,
+          maximum: MAX_CHECKOUT_PAYMENT_METHOD_FIELDS,
+          type: 'array',
+          inclusive: true,
+          exact: false,
+          message: `The extension can't have more than ${MAX_CHECKOUT_PAYMENT_METHOD_FIELDS} checkout_payment_method_fields`,
+          path: ['checkout_payment_method_fields'],
         },
       ]),
     )

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
@@ -12,6 +12,7 @@ import {zod} from '@shopify/cli-kit/node/schema'
 export type CreditCardPaymentsAppExtensionConfigType = zod.infer<typeof CreditCardPaymentsAppExtensionSchema>
 
 export const CREDIT_CARD_TARGET = 'payments.credit-card.render'
+export const MAX_CHECKOUT_PAYMENT_METHOD_FIELDS = 5
 
 export const CreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(DeferredPaymentsSchema)
   .merge(ConfirmationSchema)
@@ -33,6 +34,10 @@ export const CreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSche
           required: zod.boolean(),
           key: zod.string(),
         }),
+      )
+      .max(
+        MAX_CHECKOUT_PAYMENT_METHOD_FIELDS,
+        `The extension can't have more than ${MAX_CHECKOUT_PAYMENT_METHOD_FIELDS} checkout_payment_method_fields`,
       )
       .optional(),
   })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
@@ -2,6 +2,7 @@ import {
   CustomCreditCardPaymentsAppExtensionConfigType,
   customCreditCardPaymentsAppExtensionDeployConfig,
   CustomCreditCardPaymentsAppExtensionSchema,
+  MAX_CHECKOUT_PAYMENT_METHOD_FIELDS,
 } from './custom_credit_card_payments_app_extension_schema.js'
 import {describe, expect, test} from 'vitest'
 import {zod} from '@shopify/cli-kit/node/schema'
@@ -60,6 +61,59 @@ describe('CustomCreditCardPaymentsAppExtensionSchema', () => {
           expected: 'payments.custom-credit-card.render',
           path: ['targeting', 0, 'target'],
           message: 'Invalid literal value, expected "payments.custom-credit-card.render"',
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if checkout_payment_method_fields has too many fields', async () => {
+    // When/Then
+    expect(() =>
+      CustomCreditCardPaymentsAppExtensionSchema.parse({
+        ...config,
+        checkout_payment_method_fields: [
+          {
+            key: 'key1',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key2',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key3',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key4',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key5',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key6',
+            type: 'string',
+            required: true,
+          },
+        ],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.too_big,
+          maximum: MAX_CHECKOUT_PAYMENT_METHOD_FIELDS,
+          type: 'array',
+          inclusive: true,
+          exact: false,
+          message: `The extension can't have more than ${MAX_CHECKOUT_PAYMENT_METHOD_FIELDS} checkout_payment_method_fields`,
+          path: ['checkout_payment_method_fields'],
         },
       ]),
     )

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
@@ -12,6 +12,7 @@ export type CustomCreditCardPaymentsAppExtensionConfigType = zod.infer<
 >
 
 export const CUSTOM_CREDIT_CARD_TARGET = 'payments.custom-credit-card.render'
+export const MAX_CHECKOUT_PAYMENT_METHOD_FIELDS = 5
 
 export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(ConfirmationSchema)
   .required({
@@ -33,6 +34,10 @@ export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensi
           required: zod.boolean(),
           key: zod.string(),
         }),
+      )
+      .max(
+        MAX_CHECKOUT_PAYMENT_METHOD_FIELDS,
+        `The extension can't have more than ${MAX_CHECKOUT_PAYMENT_METHOD_FIELDS} checkout_payment_method_fields`,
       )
       .optional(),
   })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
@@ -2,6 +2,7 @@ import {
   CustomOnsitePaymentsAppExtensionConfigType,
   CustomOnsitePaymentsAppExtensionSchema,
   customOnsitePaymentsAppExtensionDeployConfig,
+  MAX_CHECKOUT_PAYMENT_METHOD_FIELDS,
 } from './custom_onsite_payments_app_extension_schema.js'
 import {describe, expect, test} from 'vitest'
 import {zod} from '@shopify/cli-kit/node/schema'
@@ -83,6 +84,59 @@ describe('CustomOnsitePaymentsAppExtensionSchema', () => {
           received: 'undefined',
           path: ['buyer_label_translations', 0, 'locale'],
           message: 'Required',
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if checkout_payment_method_fields has too many fields', async () => {
+    // When/Then
+    expect(() =>
+      CustomOnsitePaymentsAppExtensionSchema.parse({
+        ...config,
+        checkout_payment_method_fields: [
+          {
+            key: 'key1',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key2',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key3',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key4',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key5',
+            type: 'string',
+            required: true,
+          },
+          {
+            key: 'key6',
+            type: 'string',
+            required: true,
+          },
+        ],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.too_big,
+          maximum: MAX_CHECKOUT_PAYMENT_METHOD_FIELDS,
+          type: 'array',
+          inclusive: true,
+          exact: false,
+          message: `The extension can't have more than ${MAX_CHECKOUT_PAYMENT_METHOD_FIELDS} checkout_payment_method_fields`,
+          path: ['checkout_payment_method_fields'],
         },
       ]),
     )

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
@@ -12,6 +12,7 @@ import {zod} from '@shopify/cli-kit/node/schema'
 export type CustomOnsitePaymentsAppExtensionConfigType = zod.infer<typeof CustomOnsitePaymentsAppExtensionSchema>
 
 export const CUSTOM_ONSITE_TARGET = 'payments.custom-onsite.render'
+export const MAX_CHECKOUT_PAYMENT_METHOD_FIELDS = 5
 
 export const CustomOnsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(BuyerLabelSchema)
   .merge(DeferredPaymentsSchema)
@@ -30,6 +31,10 @@ export const CustomOnsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSc
           required: zod.boolean(),
           key: zod.string(),
         }),
+      )
+      .max(
+        MAX_CHECKOUT_PAYMENT_METHOD_FIELDS,
+        `The extension can't have more than ${MAX_CHECKOUT_PAYMENT_METHOD_FIELDS} checkout_payment_method_fields`,
       )
       .optional(),
   })


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/payments-platform/issues/4594

We want to limit the number of checkout_payment_method_fields we allow on the credit_card, custom_credit_card, and custom_onsite extensions to allow the partners from abusing this.

Backend PR: https://github.com/Shopify/shopify/pull/503013

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR is putting a max validation on the checkouy_payment_method_fields array in the relevant extension schemas.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->


1. Create a new spin instance using constellation `payment-apps:with-cli` e.g. `spin up payment-apps:with-cli –name cli-testing`
2. From cli directory on your spin instance, create a new directory one level up for cli app development (in the Shopify/ base directory). You should then run any `pnpm *` commands in the CLI directory using a path flag.

```
cd Shopify/cli
mkdir ../cli-apps/
```
3. Create a new app and generate a payment app extension of type Credit Card, Custom Credit Card or Custom Onsite.
```
cd Shopify/cli
pnpm create-app --path=../cli-apps/
pnpm shopify app generate extension --path=../cli-apps/my-app
```
4. Generating the extension should create a new directory containing a `.toml` file. Make modifications to the TOML file (adding checkout_payment_method_fields that has more than 5 items).
5. Run `pnpm shopify app dev --path="../cli-apps/my-app"`- this should generate an error similar to the one below.

![tophat-cli-max-fields-custom-onsite](https://github.com/Shopify/cli/assets/64809607/8a89658a-46db-4ba0-a631-7d712d624ce6)

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
