### PR TITLE
Improve link prompts

### DIFF
--- a/.changeset/hot-points-obey.md
+++ b/.changeset/hot-points-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Improve link prompts: do not ask when the app is linked and allow empty name

--- a/.changeset/tiny-cycles-doubt.md
+++ b/.changeset/tiny-cycles-doubt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Allow passing an initial value for TextPrompt

--- a/packages/app/src/cli/prompts/config.test.ts
+++ b/packages/app/src/cli/prompts/config.test.ts
@@ -20,7 +20,7 @@ describe('selectConfigName', () => {
       // Then
       expect(renderTextPrompt).toHaveBeenCalledOnce()
       expect(renderConfirmationPrompt).not.toHaveBeenCalled()
-      expect(result).toEqual('staging')
+      expect(result).toEqual('shopify.app.staging.toml')
     })
   })
 
@@ -37,7 +37,7 @@ describe('selectConfigName', () => {
       // Then
       expect(renderTextPrompt).toHaveBeenCalledOnce()
       expect(renderConfirmationPrompt).toHaveBeenCalledOnce()
-      expect(result).toEqual('staging')
+      expect(result).toEqual('shopify.app.staging.toml')
     })
   })
 
@@ -55,7 +55,7 @@ describe('selectConfigName', () => {
       // Then
       expect(renderTextPrompt).toHaveBeenCalledTimes(2)
       expect(renderConfirmationPrompt).toHaveBeenCalledOnce()
-      expect(result).toEqual('pro')
+      expect(result).toEqual('shopify.app.pro.toml')
     })
   })
 
@@ -68,11 +68,11 @@ describe('selectConfigName', () => {
       const result = await selectConfigName(tmp)
 
       // Then
-      expect(result).toEqual('my-app')
+      expect(result).toEqual('shopify.app.my-app.toml')
     })
   })
 
-  test('shows the default name as the placeholder when provided', async () => {
+  test('shows the default name as the initial text when provided', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       vi.mocked(renderTextPrompt).mockResolvedValueOnce('staging')
@@ -82,7 +82,7 @@ describe('selectConfigName', () => {
 
       // Then
       expect(renderTextPrompt).toHaveBeenCalledWith({
-        defaultValue: 'My app',
+        initialAnswer: 'My app',
         message: 'Configuration file name:',
         preview: expect.any(Function),
         validate: expect.any(Function),
@@ -147,14 +147,6 @@ describe('validate', () => {
 
     // Then
     expect(result).toBeUndefined()
-  })
-
-  test('returns an error when the generated name is empty', () => {
-    // Given / When
-    const result = validate('- -')
-
-    // Then
-    expect(result).toEqual("The file name can't be empty.")
   })
 
   test('returns an error when the generated name is too long', () => {

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -47,12 +47,6 @@ function filenameFromName(name: string, highlight = false): string {
   return `shopify.app.${configName}.toml`
 }
 
-export function nameFromFilename(filename: string): string {
-  const match = filename.match(/^shopify\.app\.(.+)\.toml$/)
-  if (!match) return ''
-  return match[1] ? match[1] : ''
-}
-
 export async function findConfigFiles(directory: string): Promise<string[]> {
   return glob(joinPath(directory, 'shopify.app*.toml'))
 }

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -349,7 +349,7 @@ url = "https://api-client-config.com/preferences"
           developerPlatformClient,
         }),
       )
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
+      vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
       const remoteConfiguration = {
         ...DEFAULT_REMOTE_CONFIGURATION,
         name: 'my app',
@@ -446,7 +446,7 @@ embedded = false
         access_scopes: {scopes: 'write_products'},
       }
       vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
+      vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
 
       // When
       await link(options)
@@ -884,7 +884,7 @@ embedded = false
           developerPlatformClient,
         }),
       )
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
+      vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
       const remoteConfiguration = {
         ...DEFAULT_REMOTE_CONFIGURATION,
         name: 'my app',

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -10,7 +10,7 @@ import {selectConfigName} from '../../../prompts/config.js'
 import {loadApp, loadAppConfiguration} from '../../../models/app/loader.js'
 import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp, appFromId} from '../../context.js'
 import {getCachedCommandInfo} from '../../local-storage.js'
-import {AppConfigurationInterface, AppInterface, CurrentAppConfiguration, EmptyApp} from '../../../models/app/app.js'
+import {AppInterface, CurrentAppConfiguration, EmptyApp} from '../../../models/app/app.js'
 import {fetchAppRemoteConfiguration} from '../select-app.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {MinimalAppIdentifiers, OrganizationApp} from '../../../models/organization.js'
@@ -84,6 +84,54 @@ describe('link', () => {
       // Then
       expect(selectConfigName).not.toHaveBeenCalled()
       expect(fileExistsSync(joinPath(tmp, 'shopify.app.default-value.toml'))).toBeTruthy()
+    })
+  })
+
+  test('does not ask for a name when the selected app is already linked', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const developerPlatformClient = buildDeveloperPlatformClient()
+      const options: LinkOptions = {
+        directory: tmp,
+        developerPlatformClient,
+      }
+      const remoteApp = mockRemoteApp({developerPlatformClient})
+      const filePath = joinPath(tmp, 'shopify.app.staging.toml')
+      const initialContent = `
+      client_id = "${remoteApp.apiKey}"
+      `
+      writeFileSync(filePath, initialContent)
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, undefined, [], 'current'))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(remoteApp)
+
+      // When
+      await link(options)
+
+      // Then
+      expect(selectConfigName).not.toHaveBeenCalled()
+      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "12345"
+extension_directories = [ ]
+name = "app1"
+application_url = "https://example.com"
+embedded = true
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+use_legacy_install_flow = true
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[webhooks]
+api_version = "2023-07"
+
+[pos]
+embedded = false
+`
+      expect(content).toEqual(expectedContent)
     })
   })
 
@@ -1061,15 +1109,6 @@ async function mockApp(
   localApp.directory = directory
   setPathValue(localApp, 'remoteFlags', flags)
   return localApp
-}
-
-async function mockAppConfiguration(directory = ''): Promise<AppConfigurationInterface> {
-  const {schema: configSchema} = await buildVersionedAppSchema()
-  return {
-    directory,
-    configuration: {scopes: '', path: directory},
-    configSchema,
-  }
 }
 
 function mockRemoteApp(extraRemoteAppFields: Partial<OrganizationApp> = {}) {

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -26,6 +26,7 @@ import {selectDeveloperPlatformClient, DeveloperPlatformClient} from '../../../u
 import {fetchAppRemoteConfiguration} from '../select-app.js'
 import {fetchSpecifications} from '../../generate/fetch-extension-specifications.js'
 import {SpecsAppConfiguration} from '../../../models/extensions/specifications/types/app_config.js'
+import {getTomls} from '../../../utilities/app/config/getTomls.js'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
@@ -168,6 +169,10 @@ async function loadConfigurationFileName(
   if (isLegacyAppSchema(localApp.configuration)) {
     return configurationFileNames.app
   }
+
+  const existingTomls = await getTomls(options.directory)
+  const currentToml = existingTomls[remoteApp.apiKey]
+  if (currentToml) return currentToml
 
   const configName = await selectConfigName(localApp.directory || options.directory, remoteApp.title)
   return `shopify.app.${configName}.toml`

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -174,8 +174,7 @@ async function loadConfigurationFileName(
   const currentToml = existingTomls[remoteApp.apiKey]
   if (currentToml) return currentToml
 
-  const configName = await selectConfigName(localApp.directory || options.directory, remoteApp.title)
-  return `shopify.app.${configName}.toml`
+  return selectConfigName(localApp.directory || options.directory, remoteApp.title)
 }
 
 function addLocalAppConfig(appConfiguration: AppConfiguration, remoteApp: OrganizationApp, configFilePath: string) {

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -20,6 +20,7 @@ export interface TextPromptProps {
   emptyDisplayedValue?: string
   abortSignal?: AbortSignal
   preview?: (value: string) => TokenItem<InlineToken>
+  initialAnswer?: string
 }
 
 const TextPrompt: FunctionComponent<TextPromptProps> = ({
@@ -32,6 +33,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   emptyDisplayedValue = '(empty)',
   abortSignal,
   preview,
+  initialAnswer = '',
 }) => {
   if (password && defaultValue) {
     throw new Error("Can't use defaultValue with password")
@@ -52,7 +54,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
 
   const {oneThird} = useLayout()
   const {promptState, setPromptState, answer, setAnswer} = usePrompt<string>({
-    initialAnswer: '',
+    initialAnswer,
   })
   const answerOrDefault = answer.length > 0 ? answer : defaultValue
   const displayEmptyValue = answerOrDefault === ''


### PR DESCRIPTION
### WHY are these changes introduced?

When you run link and you choose a remote app currently linked to `shopify.app.toml`, we ask for a name, but it's not possible to leave it empty to overwrite the current one.

![30-59-p7eg5-3q2s7](https://github.com/Shopify/cli/assets/14979109/b6e63150-9985-462c-8332-91a321027e21)

### WHAT is this pull request doing?

- When the selected app is already linked, do not ask for a file name and use the existing one:
<img width="576" alt="skip-prompt" src="https://github.com/Shopify/cli/assets/14979109/2ac5d34c-6f5e-4b2c-8cb0-4192dc17e140">

- Allow selecting an empty name to overwrite an existing `shopify.app.toml`:
<img width="678" alt="empty" src="https://github.com/Shopify/cli/assets/14979109/c4ee892b-dde0-43cb-b59d-b9ddbeda1112">

- The name prompt now adds an initial value instead of a placeholder:

| Before                                                                                                                   | After                                                                                                                   |
|--------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
| <img width="293" alt="before" src="https://github.com/Shopify/cli/assets/14979109/6e2a54da-7ba7-4948-bbbf-f29ea6d702b2"> | <img width="290" alt="after" src="https://github.com/Shopify/cli/assets/14979109/95314204-e2e4-4fef-9725-bbb8c810f50c"> |

### How to test your changes?

`p shopify app config link`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
