### PR TITLE
Fix link with existing config

### DIFF
--- a/.changeset/clever-otters-call.md
+++ b/.changeset/clever-otters-call.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Skip name prompt in config link when the app is already linked

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -10,7 +10,7 @@ import {selectConfigName} from '../../../prompts/config.js'
 import {loadApp, loadAppConfiguration} from '../../../models/app/loader.js'
 import {InvalidApiKeyErrorMessage, fetchOrCreateOrganizationApp, appFromId} from '../../context.js'
 import {getCachedCommandInfo} from '../../local-storage.js'
-import {AppConfigurationInterface, AppInterface, CurrentAppConfiguration, EmptyApp} from '../../../models/app/app.js'
+import {AppInterface, CurrentAppConfiguration, EmptyApp} from '../../../models/app/app.js'
 import {fetchAppRemoteConfiguration} from '../select-app.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {MinimalAppIdentifiers, OrganizationApp} from '../../../models/organization.js'
@@ -84,6 +84,54 @@ describe('link', () => {
       // Then
       expect(selectConfigName).not.toHaveBeenCalled()
       expect(fileExistsSync(joinPath(tmp, 'shopify.app.default-value.toml'))).toBeTruthy()
+    })
+  })
+
+  test('does not ask for a name when the selected app is already linked', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const developerPlatformClient = buildDeveloperPlatformClient()
+      const options: LinkOptions = {
+        directory: tmp,
+        developerPlatformClient,
+      }
+      const remoteApp = mockRemoteApp({developerPlatformClient})
+      const filePath = joinPath(tmp, 'shopify.app.staging.toml')
+      const initialContent = `
+      client_id = "${remoteApp.apiKey}"
+      `
+      writeFileSync(filePath, initialContent)
+      vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp, undefined, [], 'current'))
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(remoteApp)
+
+      // When
+      await link(options)
+
+      // Then
+      expect(selectConfigName).not.toHaveBeenCalled()
+      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+      const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "12345"
+extension_directories = [ ]
+name = "app1"
+application_url = "https://example.com"
+embedded = true
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+use_legacy_install_flow = true
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[webhooks]
+api_version = "2023-07"
+
+[pos]
+embedded = false
+`
+      expect(content).toEqual(expectedContent)
     })
   })
 
@@ -1061,15 +1109,6 @@ async function mockApp(
   localApp.directory = directory
   setPathValue(localApp, 'remoteFlags', flags)
   return localApp
-}
-
-async function mockAppConfiguration(directory = ''): Promise<AppConfigurationInterface> {
-  const {schema: configSchema} = await buildVersionedAppSchema()
-  return {
-    directory,
-    configuration: {scopes: '', path: directory},
-    configSchema,
-  }
 }
 
 function mockRemoteApp(extraRemoteAppFields: Partial<OrganizationApp> = {}) {

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -26,6 +26,7 @@ import {selectDeveloperPlatformClient, DeveloperPlatformClient} from '../../../u
 import {fetchAppRemoteConfiguration} from '../select-app.js'
 import {fetchSpecifications} from '../../generate/fetch-extension-specifications.js'
 import {SpecsAppConfiguration} from '../../../models/extensions/specifications/types/app_config.js'
+import {getTomls} from '../../../utilities/app/config/getTomls.js'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
@@ -168,6 +169,10 @@ async function loadConfigurationFileName(
   if (isLegacyAppSchema(localApp.configuration)) {
     return configurationFileNames.app
   }
+
+  const existingTomls = await getTomls(options.directory)
+  const currentToml = existingTomls[remoteApp.apiKey]
+  if (currentToml) return currentToml
 
   const configName = await selectConfigName(localApp.directory || options.directory, remoteApp.title)
   return `shopify.app.${configName}.toml`


### PR DESCRIPTION
### WHY are these changes introduced?

When you run `app config link` and you choose a remote app currently linked to `shopify.app.toml`, we ask for a name, but it's not possible to leave it empty to overwrite the current one.

![30-59-p7eg5-3q2s7](https://github.com/Shopify/cli/assets/14979109/b6e63150-9985-462c-8332-91a321027e21)

### WHAT is this pull request doing?

- When the selected app is already linked, do not ask for a file name and use the existing one:
<img width="576" alt="skip-prompt" src="https://github.com/Shopify/cli/assets/14979109/2ac5d34c-6f5e-4b2c-8cb0-4192dc17e140">

### How to test your changes?

`p shopify app config link`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
