### PR TITLE
Allow empty names in link

### DIFF
--- a/.changeset/hot-points-obey.md
+++ b/.changeset/hot-points-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Allow empty names in config link

--- a/.changeset/tiny-cycles-doubt.md
+++ b/.changeset/tiny-cycles-doubt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Allow passing an initial value for TextPrompt

--- a/packages/app/src/cli/prompts/config.test.ts
+++ b/packages/app/src/cli/prompts/config.test.ts
@@ -20,7 +20,7 @@ describe('selectConfigName', () => {
       // Then
       expect(renderTextPrompt).toHaveBeenCalledOnce()
       expect(renderConfirmationPrompt).not.toHaveBeenCalled()
-      expect(result).toEqual('staging')
+      expect(result).toEqual('shopify.app.staging.toml')
     })
   })
 
@@ -37,7 +37,7 @@ describe('selectConfigName', () => {
       // Then
       expect(renderTextPrompt).toHaveBeenCalledOnce()
       expect(renderConfirmationPrompt).toHaveBeenCalledOnce()
-      expect(result).toEqual('staging')
+      expect(result).toEqual('shopify.app.staging.toml')
     })
   })
 
@@ -55,7 +55,7 @@ describe('selectConfigName', () => {
       // Then
       expect(renderTextPrompt).toHaveBeenCalledTimes(2)
       expect(renderConfirmationPrompt).toHaveBeenCalledOnce()
-      expect(result).toEqual('pro')
+      expect(result).toEqual('shopify.app.pro.toml')
     })
   })
 
@@ -68,11 +68,11 @@ describe('selectConfigName', () => {
       const result = await selectConfigName(tmp)
 
       // Then
-      expect(result).toEqual('my-app')
+      expect(result).toEqual('shopify.app.my-app.toml')
     })
   })
 
-  test('shows the default name as the placeholder when provided', async () => {
+  test('shows the default name as the initial text when provided', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
       vi.mocked(renderTextPrompt).mockResolvedValueOnce('staging')
@@ -82,7 +82,7 @@ describe('selectConfigName', () => {
 
       // Then
       expect(renderTextPrompt).toHaveBeenCalledWith({
-        defaultValue: 'My app',
+        initialAnswer: 'My app',
         message: 'Configuration file name:',
         preview: expect.any(Function),
         validate: expect.any(Function),
@@ -147,14 +147,6 @@ describe('validate', () => {
 
     // Then
     expect(result).toBeUndefined()
-  })
-
-  test('returns an error when the generated name is empty', () => {
-    // Given / When
-    const result = validate('- -')
-
-    // Then
-    expect(result).toEqual("The file name can't be empty.")
   })
 
   test('returns an error when the generated name is too long', () => {

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -47,12 +47,6 @@ function filenameFromName(name: string, highlight = false): string {
   return `shopify.app.${configName}.toml`
 }
 
-export function nameFromFilename(filename: string): string {
-  const match = filename.match(/^shopify\.app\.(.+)\.toml$/)
-  if (!match) return ''
-  return match[1] ? match[1] : ''
-}
-
 export async function findConfigFiles(directory: string): Promise<string[]> {
   return glob(joinPath(directory, 'shopify.app*.toml'))
 }

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -301,7 +301,7 @@ url = "https://api-client-config.com/preferences"
           developerPlatformClient,
         }),
       )
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
+      vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
       const remoteConfiguration = {
         ...DEFAULT_REMOTE_CONFIGURATION,
         name: 'my app',
@@ -398,7 +398,7 @@ embedded = false
         access_scopes: {scopes: 'write_products'},
       }
       vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(remoteConfiguration)
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
+      vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
 
       // When
       await link(options)
@@ -836,7 +836,7 @@ embedded = false
           developerPlatformClient,
         }),
       )
-      vi.mocked(selectConfigName).mockResolvedValue('staging')
+      vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
       const remoteConfiguration = {
         ...DEFAULT_REMOTE_CONFIGURATION,
         name: 'my app',

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -31,6 +31,7 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 import {deepMergeObjects, isEmpty} from '@shopify/cli-kit/common/object'
 import {joinPath} from '@shopify/cli-kit/node/path'
+import { getTomls } from '../../../utilities/app/config/getTomls.js'
 
 export interface LinkOptions {
   directory: string
@@ -168,6 +169,10 @@ async function loadConfigurationFileName(
   if (isLegacyAppSchema(localApp.configuration)) {
     return configurationFileNames.app
   }
+
+  const existingTomls = await getTomls(options.directory)
+  const currentToml = existingTomls[remoteApp.apiKey]
+  if (currentToml) return currentToml  
 
   const configName = await selectConfigName(localApp.directory || options.directory, remoteApp.title)
   return `shopify.app.${configName}.toml`

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -20,6 +20,7 @@ export interface TextPromptProps {
   emptyDisplayedValue?: string
   abortSignal?: AbortSignal
   preview?: (value: string) => TokenItem<InlineToken>
+  initialAnswer?: string
 }
 
 const TextPrompt: FunctionComponent<TextPromptProps> = ({
@@ -32,6 +33,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   emptyDisplayedValue = '(empty)',
   abortSignal,
   preview,
+  initialAnswer = '',
 }) => {
   if (password && defaultValue) {
     throw new Error("Can't use defaultValue with password")
@@ -52,7 +54,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
 
   const {oneThird} = useLayout()
   const {promptState, setPromptState, answer, setAnswer} = usePrompt<string>({
-    initialAnswer: '',
+    initialAnswer,
   })
   const answerOrDefault = answer.length > 0 ? answer : defaultValue
   const displayEmptyValue = answerOrDefault === ''


### PR DESCRIPTION
### WHY are these changes introduced?

If you have a `shopify.app.toml` and you want to update the file to point to a different app with `app config link`, the prompt to choose the config name doesn't allow to enter an empty value (so that the file is `shopify.app.toml`).

![30-59-p7eg5-3q2s7](https://github.com/Shopify/cli/assets/14979109/b6e63150-9985-462c-8332-91a321027e21)

### WHAT is this pull request doing?

- Allow selecting an empty name to overwrite an existing `shopify.app.toml`:
<img width="678" alt="empty" src="https://github.com/Shopify/cli/assets/14979109/c4ee892b-dde0-43cb-b59d-b9ddbeda1112">

- The name prompt now adds an initial value instead of a placeholder:

| Before                                                                                                                   | After                                                                                                                   |
|--------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
| <img width="293" alt="before" src="https://github.com/Shopify/cli/assets/14979109/6e2a54da-7ba7-4948-bbbf-f29ea6d702b2"> | <img width="290" alt="after" src="https://github.com/Shopify/cli/assets/14979109/95314204-e2e4-4fef-9725-bbb8c810f50c"> |

### How to test your changes?

`p shopify app config link`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
