### PR TITLE
App Management API authentication

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
@@ -83,12 +83,12 @@ import {
   MigrateToUiExtensionSchema,
 } from '../../api/graphql/extension_migrate_to_ui_extension.js'
 import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../../api/graphql/extension_migrate_app_module.js'
+import {ensureAuthenticatedAppManagement, ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
 import {FunctionUploadUrlGenerateResponse} from '@shopify/cli-kit/node/api/partners'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
 import {orgScopedShopifyDevelopersRequest} from '@shopify/cli-kit/node/api/shopify-developers'
 import {underscore} from '@shopify/cli-kit/common/string'
-import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
 import {businessPlatformRequest} from '@shopify/cli-kit/node/api/business-platform'
 import {shopifyDevelopersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
@@ -111,8 +111,7 @@ export class ShopifyDevelopersClient implements DeveloperPlatformClient {
         UserInfoQuery,
         await this.businessPlatformToken(),
       )
-      // Need to replace with actual auth token for developer platform
-      const token = 'token'
+      const token = await ensureAuthenticatedAppManagement()
       if (userInfoResult.currentUserAccount) {
         this._session = {
           token,

--- a/packages/cli-kit/src/private/node/api.ts
+++ b/packages/cli-kit/src/private/node/api.ts
@@ -5,9 +5,9 @@ import {Headers} from 'form-data'
 import {ClientError} from 'graphql-request'
 import {performance} from 'perf_hooks'
 
-export type API = 'admin' | 'storefront-renderer' | 'partners' | 'business-platform'
+export type API = 'admin' | 'storefront-renderer' | 'partners' | 'business-platform' | 'app-management'
 
-export const allAPIs: API[] = ['admin', 'storefront-renderer', 'partners', 'business-platform']
+export const allAPIs: API[] = ['admin', 'storefront-renderer', 'partners', 'business-platform', 'app-management']
 
 interface RequestOptions<T> {
   request: Promise<T>

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -54,6 +54,15 @@ interface PartnersAPIOAuthOptions {
 }
 
 /**
+ * A scope supported by the Developer Platform API.
+ */
+type AppManagementAPIScope = 'https://api.shopify.com/auth/organization.apps.manage' | string
+interface AppManagementAPIOauthOptions {
+  /** List of scopes to request permissions for. */
+  scopes: AppManagementAPIScope[]
+}
+
+/**
  * A scope supported by the Storefront Renderer API.
  */
 type StorefrontRendererScope = 'devtools' | string
@@ -78,6 +87,7 @@ export interface OAuthApplications {
   storefrontRendererApi?: StorefrontRendererAPIOAuthOptions
   partnersApi?: PartnersAPIOAuthOptions
   businessPlatformApi?: BusinessPlatformAPIOAuthOptions
+  appManagementApi?: AppManagementAPIOauthOptions
 }
 
 export interface OAuthSession {
@@ -85,6 +95,7 @@ export interface OAuthSession {
   partners?: string
   storefront?: string
   businessPlatform?: string
+  appManagement?: string
 }
 
 /**
@@ -345,6 +356,11 @@ async function tokensFor(applications: OAuthApplications, session: Session, fqdn
     tokens.businessPlatform = fqdnSession.applications[appId]?.accessToken
   }
 
+  if (applications.appManagementApi) {
+    const appId = applicationId('app-management')
+    tokens.appManagement = fqdnSession.applications[appId]?.accessToken
+  }
+
   return tokens
 }
 
@@ -360,7 +376,8 @@ function getFlattenScopes(apps: OAuthApplications): string[] {
   const partner = apps.partnersApi?.scopes || []
   const storefront = apps.storefrontRendererApi?.scopes || []
   const businessPlatform = apps.businessPlatformApi?.scopes || []
-  const requestedScopes = [...admin, ...partner, ...storefront, ...businessPlatform]
+  const appManagement = apps.appManagementApi?.scopes || []
+  const requestedScopes = [...admin, ...partner, ...storefront, ...businessPlatform, ...appManagement]
   return allDefaultScopes(requestedScopes)
 }
 
@@ -375,11 +392,13 @@ function getExchangeScopes(apps: OAuthApplications): ExchangeScopes {
   const partnerScope = apps.partnersApi?.scopes || []
   const storefrontScopes = apps.storefrontRendererApi?.scopes || []
   const businessPlatformScopes = apps.businessPlatformApi?.scopes || []
+  const appManagementScopes = apps.appManagementApi?.scopes || []
   return {
     admin: apiScopes('admin', adminScope),
     partners: apiScopes('partners', partnerScope),
     storefront: apiScopes('storefront-renderer', storefrontScopes),
     businessPlatform: apiScopes('business-platform', businessPlatformScopes),
+    appManagement: apiScopes('app-management', appManagementScopes),
   }
 }
 

--- a/packages/cli-kit/src/private/node/session/exchange.test.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.test.ts
@@ -83,7 +83,7 @@ describe('exchange code for identity token', () => {
 })
 
 describe('exchange identity token for application tokens', () => {
-  const scopes = {admin: [], partners: [], storefront: [], businessPlatform: []}
+  const scopes = {admin: [], partners: [], storefront: [], businessPlatform: [], appManagement: []}
 
   test('returns tokens for all APIs if a store is passed', async () => {
     // Given

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -155,7 +155,7 @@ async function requestAppToken(
   }
   const tokenResult = await tokenRequest(params)
   const value = tokenResult.mapError(tokenRequestErrorHandler).valueOrBug()
-  const appToken = await buildApplicationToken(value)
+  const appToken = buildApplicationToken(value)
   return {[identifier]: appToken}
 }
 
@@ -206,6 +206,6 @@ function buildApplicationToken(result: TokenRequestResult): ApplicationToken {
   return {
     accessToken: result.access_token,
     expiresAt: new Date(Date.now() + result.expires_in * 1000),
-    scopes: result.scope?.split(' ') || [],
+    scopes: result.scope.split(' '),
   }
 }

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -6,6 +6,7 @@ import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {shopifyFetch} from '../../../public/node/http.js'
 import {err, ok, Result} from '../../../public/node/result.js'
 import {AbortError, ExtendableError} from '../../../public/node/error.js'
+import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 
 export class InvalidGrantError extends ExtendableError {}
 export class InvalidRequestError extends ExtendableError {}
@@ -15,6 +16,7 @@ export interface ExchangeScopes {
   partners: string[]
   storefront: string[]
   businessPlatform: string[]
+  appManagement: string[]
 }
 /**
  * Given a valid authorization code, request an identity access token.
@@ -49,12 +51,14 @@ export async function exchangeAccessForApplicationTokens(
   store?: string,
 ): Promise<{[x: string]: ApplicationToken}> {
   const token = identityToken.accessToken
+  const appManagementEnabled = isTruthy(process.env.USE_SHOPIFY_DEVELOPERS_CLIENT)
 
-  const [partners, storefront, businessPlatform, admin] = await Promise.all([
+  const [partners, storefront, businessPlatform, admin, appManagement] = await Promise.all([
     requestAppToken('partners', token, scopes.partners),
     requestAppToken('storefront-renderer', token, scopes.storefront),
     requestAppToken('business-platform', token, scopes.businessPlatform),
     store ? requestAppToken('admin', token, scopes.admin, store) : {},
+    appManagementEnabled ? requestAppToken('app-management', token, scopes.appManagement) : {},
   ])
 
   return {
@@ -62,6 +66,7 @@ export async function exchangeAccessForApplicationTokens(
     ...storefront,
     ...businessPlatform,
     ...admin,
+    ...appManagement,
   }
 }
 
@@ -201,6 +206,6 @@ function buildApplicationToken(result: TokenRequestResult): ApplicationToken {
   return {
     accessToken: result.access_token,
     expiresAt: new Date(Date.now() + result.expires_in * 1000),
-    scopes: result.scope.split(' '),
+    scopes: result.scope?.split(' ') || [],
   }
 }

--- a/packages/cli-kit/src/private/node/session/identity.ts
+++ b/packages/cli-kit/src/private/node/session/identity.ts
@@ -55,6 +55,14 @@ export function applicationId(api: API): string {
         return 'ace6dc89-b526-456d-a942-4b8ef6acda4b'
       }
     }
+    case 'app-management': {
+      const environment = serviceEnvironment()
+      if (environment === Environment.Production) {
+        return '7ee65a63608843c577db8b23c4d7316ea0a01bd2f7594f8a9c06ea668c1b775c'
+      } else {
+        return 'e92482cebb9bfb9fb5a0199cc770fde3de6c8d16b798ee73e36c9d815e070e52'
+      }
+    }
     default:
       throw new BugError(`Application id for API of type: ${api}`)
   }

--- a/packages/cli-kit/src/private/node/session/scopes.test.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.test.ts
@@ -19,6 +19,7 @@ describe('allDefaultScopes', () => {
       'https://api.shopify.com/auth/shop.storefront-renderer.devtools',
       'https://api.shopify.com/auth/partners.app.cli.access',
       'https://api.shopify.com/auth/destinations.readonly',
+      'https://api.shopify.com/auth/organization.apps.manage',
       ...customScopes,
     ])
   })

--- a/packages/cli-kit/src/private/node/session/scopes.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.ts
@@ -35,6 +35,8 @@ function defaultApiScopes(api: API): string[] {
       return ['cli']
     case 'business-platform':
       return ['destinations']
+    case 'app-management':
+      return ['app-management']
     default:
       throw new BugError(`Unknown API: ${api}`)
   }
@@ -54,6 +56,8 @@ function scopeTransform(scope: string): string {
       return 'https://api.shopify.com/auth/shop.storefront-renderer.devtools'
     case 'destinations':
       return 'https://api.shopify.com/auth/destinations.readonly'
+    case 'app-management':
+      return 'https://api.shopify.com/auth/organization.apps.manage'
     default:
       return scope
   }

--- a/packages/cli-kit/src/private/node/session/validate.ts
+++ b/packages/cli-kit/src/private/node/session/validate.ts
@@ -44,6 +44,12 @@ export async function validateSession(
     tokensAreExpired = tokensAreExpired || isTokenExpired(token)
   }
 
+  if (applications.appManagementApi) {
+    const appId = applicationId('app-management')
+    const token = session.applications[appId]!
+    tokensAreExpired = tokensAreExpired || isTokenExpired(token)
+  }
+
   if (applications.storefrontRendererApi) {
     const appId = applicationId('storefront-renderer')
     const token = session.applications[appId]!

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -48,6 +48,29 @@ ${outputToken.json(scopes)}
 }
 
 /**
+ * Ensure that we have a valid session to access the App Management API.
+ *
+ * @param scopes - Optional array of extra scopes to authenticate with.
+ * @param env - Optional environment variables to use.
+ * @param options - Optional extra options to use.
+ * @returns The access token for the App Management API.
+ */
+export async function ensureAuthenticatedAppManagement(
+  scopes: string[] = [],
+  env = process.env,
+  options: EnsureAuthenticatedAdditionalOptions = {},
+): Promise<string> {
+  outputDebug(outputContent`Ensuring that the user is authenticated with the App Management API with the following scopes:
+${outputToken.json(scopes)}
+`)
+  const tokens = await ensureAuthenticated({appManagementApi: {scopes}}, env, options)
+  if (!tokens) {
+    throw new BugError('No App Management token found after ensuring authenticated')
+  }
+  return tokens.appManagement!
+}
+
+/**
  * Ensure that we have a valid session to access the Storefront API.
  *
  * @param scopes - Optional array of extra scopes to authenticate with.


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/develop-app-management/issues/1752

### WHAT is this pull request doing?

Authenticate against App Management API when `USE_SHOPIFY_DEVELOPERS_CLIENT` is enabled

### How to test your changes?

With and without `USE_SHOPIFY_DEVELOPERS_CLIENT=1`:
- `bin/spin p shopify auth logout`
- `bin/spin p shopify app config link --verbose`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
