### PR TITLE
[Feature] Introduce `.json` asset support in theme app extensions

### DIFF
--- a/.changeset/curvy-deers-wink.md
+++ b/.changeset/curvy-deers-wink.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/app': minor
+---
+
+Introduce `.json` support for theme app extensions

--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -42,7 +42,7 @@ const BUNDLE_SIZE_LIMIT = BUNDLE_SIZE_LIMIT_MB * megabytes
 const LIQUID_SIZE_LIMIT_KB = 500
 const LIQUID_SIZE_LIMIT = LIQUID_SIZE_LIMIT_KB * kilobytes
 
-const SUPPORTED_ASSET_EXTS = ['.jpg', '.jpeg', '.js', '.css', '.png', '.svg']
+const SUPPORTED_ASSET_EXTS = ['.jpg', '.jpeg', '.json', '.js', '.css', '.png', '.svg']
 const SUPPORTED_LOCALE_EXTS = ['.json']
 const SUPPORTED_EXTS: {[dirname: string]: FilenameValidation} = {
   assets: {

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -16,7 +16,7 @@ module Extension
         SUPPORTED_BUCKETS = %w(assets blocks snippets locales)
         BUNDLE_SIZE_LIMIT = 10 * 1024 * 1024 # 10MB
         LIQUID_SIZE_LIMIT = 100 * 1024 # 100kb
-        SUPPORTED_ASSET_EXTS = %w(.jpg .jpeg .js .css .png .svg)
+        SUPPORTED_ASSET_EXTS = %w(.jpg .jpeg .js .json .css .png .svg)
         SUPPORTED_LOCALE_EXTS = %w(.json)
 
         def create(directory_name, context, getting_started: false)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1962 

### WHAT is this pull request doing?

Adds `.json` asset support to theme app extensions. Another PR has already been shipped to enable this upstream

### How to test your changes?

- Create a new app with a theme app extension
- Add a .json file in the assets folder
- Run the app dev command
- Notice the theme app extension is pushed as expected

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
