### PR TITLE
Fix the `shopify theme dev`/`shopify theme console` proxy to handle cookies as expected

### DIFF
--- a/.changeset/tough-kids-guess.md
+++ b/.changeset/tough-kids-guess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix the `shopify theme dev`/`shopify theme console` proxy to handle cookies as expected, and ensure they no longer render the live theme instead of the development theme

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -200,7 +200,7 @@ module ShopifyCLI
             +""
           end
 
-          expected_session_cookie = "#{SESSION_COOKIE_NAME}=#{secure_session_id}"
+          expected_session_cookie = "#{SESSION_COOKIE_NAME}=#{secure_session_id};"
 
           unless cookie_header.include?(expected_session_cookie)
             if cookie_header.include?(SESSION_COOKIE_NAME)

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_middleware.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/repl/auth_middleware.rb
@@ -17,7 +17,7 @@ module ShopifyCLI
           @env = env
           @env["PATH_INFO"] = PASSWORD_PAGE_PATH if redirect_to_password?(@env)
 
-          return @app.call(@env) if password_page?(@env) || (storefront_session.nil? || secure_session.nil?)
+          return @app.call(@env) if password_page?(@env) || secure_session.nil?
 
           authenticate!
 

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -10,7 +10,7 @@ module ShopifyCLI
   module Theme
     class DevServer
       class ProxyTest < Minitest::Test
-        SECURE_SESSION_ID = "deadbeef"
+        SECURE_SESSION_ID = ":deadbeef:"
 
         def setup
           super
@@ -110,7 +110,7 @@ module ShopifyCLI
             .with(
               headers: {
                 "Content-Length" => "0",
-                "Cookie" => "_shopify_essential=deadbeef",
+                "Cookie" => "_shopify_essential=#{SECURE_SESSION_ID};",
                 "X-Shopify-Shop" => store,
               },
             )
@@ -169,7 +169,7 @@ module ShopifyCLI
           stub_request(:post, "https://dev-theme-server-store.myshopify.com/account/login?_fd=0&pb=0")
             .with(
               headers: {
-                "Cookie" => "_shopify_essential=#{SECURE_SESSION_ID}",
+                "Cookie" => "_shopify_essential=#{SECURE_SESSION_ID};",
               },
             )
             .to_return(
@@ -184,7 +184,7 @@ module ShopifyCLI
           stub_request(:get, "https://dev-theme-server-store.myshopify.com/?_fd=0&pb=0")
             .with(
               headers: {
-                "Cookie" => "_shopify_essential=#{new_shopify_essential}",
+                "Cookie" => "_shopify_essential=#{new_shopify_essential};",
               },
             )
             .to_return(status: 200)
@@ -323,7 +323,7 @@ module ShopifyCLI
           stub_request(:get, "https://dev-theme-server-store.myshopify.com/?_fd=0&pb=0")
             .with(
               headers: {
-                "Cookie" => "_shopify_essential=#{SECURE_SESSION_ID}",
+                "Cookie" => "_shopify_essential=#{SECURE_SESSION_ID};",
               },
             )
 
@@ -336,13 +336,26 @@ module ShopifyCLI
           stub_request(:get, "https://dev-theme-server-store.myshopify.com/?_fd=0&pb=0")
             .with(
               headers: {
-                "Cookie" => "cart_currency=CAD; secure_customer_sig=; _shopify_essential=#{SECURE_SESSION_ID}",
+                "Cookie" => "cart_currency=CAD; secure_customer_sig=; _shopify_essential=#{SECURE_SESSION_ID};",
               },
             )
 
           stub_session_id_request
           request.get("/",
             "HTTP_COOKIE" => "cart_currency=CAD; secure_customer_sig=")
+        end
+
+        def test_shopify_essential_cookie_in_the_middle_of_the_cookie_string
+          stub_request(:get, "https://dev-theme-server-store.myshopify.com/?_fd=0&pb=0")
+            .with(
+              headers: {
+                "Cookie" => "cart_currency=CAD; _shopify_essential=#{SECURE_SESSION_ID}; secure_customer_sig=",
+              },
+            )
+
+          stub_session_id_request
+          request.get("/",
+            "HTTP_COOKIE" => "cart_currency=CAD; _shopify_essential=:expired:; secure_customer_sig=")
         end
 
         def test_pass_pending_templates_to_storefront
@@ -373,7 +386,7 @@ module ShopifyCLI
                 "Accept-Encoding" => "none",
                 "Authorization" => "Bearer TOKEN",
                 "Content-Type" => "application/x-www-form-urlencoded",
-                "Cookie" => "_shopify_essential=#{SECURE_SESSION_ID}",
+                "Cookie" => "_shopify_essential=#{SECURE_SESSION_ID};",
                 "Host" => "dev-theme-server-store.myshopify.com",
                 "X-Forwarded-For" => "",
                 "User-Agent" => "Shopify CLI",
@@ -597,7 +610,7 @@ module ShopifyCLI
         def default_proxy_headers(domain = "myshopify.com")
           {
             "Accept-Encoding" => "none",
-            "Cookie" => "_shopify_essential=#{SECURE_SESSION_ID}",
+            "Cookie" => "_shopify_essential=#{SECURE_SESSION_ID};",
             "Host" => "dev-theme-server-store.#{domain}",
             "X-Forwarded-For" => "",
             "User-Agent" => "Shopify CLI",


### PR DESCRIPTION
### WHY are these changes introduced?

Fixed the `shopify theme dev`/`shopify theme console` proxy to handle cookies as expected, and ensured they no longer render the live theme instead of the development theme.

### WHAT is this pull request doing?

With the session cookie being renamed, the CLI needed to follow that change [[1]](https://github.com/Shopify/cli/pull/3791/files#diff-4a33c3fb0b66e923abaaf8d530a2303552bf820cda31bf47d88961d2caba1d57L28) [[2]](https://github.com/Shopify/cli/pull/3791/files#diff-4a33c3fb0b66e923abaaf8d530a2303552bf820cda31bf47d88961d2caba1d57L28). However, the new regular expression captures the `;`, which was creating a scenario like this:

<img width="80%" src="https://github.com/Shopify/cli/assets/1079279/068ac521-b4b9-482e-8116-49bc09018074"/>

**This is not an issue when the session cookie is the last one** in the cookie string, but when it's in the middle of the string, it depends on the client's fallback behavior, which creates an intermittent behavior.
 
The browser sometimes is able to infer the cookie correctly, but in scenarios like when the `--password` flag is passed, where we have the Theme Access app in the middle, the proxy was consistently failing on passing the cookie. Now, we're always appending the `;` even when the trailing semicolon is supported.

This PR also removes the `storefront_session.nil?` from the `auth_middleware.rb`, which is related to the behavior of rendering the live theme in the context of `shopify theme console`. Removing this is important because stores that are not password protected don't have that cookie.

### How to test your changes?

#### `shopify theme dev`

To test this change in the `shopify theme dev` command, you may run it with the `--password` flag, or reduce the expiration date on the proxy (to force the cookie update) as the video shows:

| Before | After   |
|--------|---------|
| ![before__dev](https://github.com/Shopify/cli/assets/1079279/6d8e42f3-bad5-4356-b9c0-f6f6918cfa67)  | ![after__dev](https://github.com/Shopify/cli/assets/1079279/ea916345-5d62-4746-bfd7-b27c0375c8bf) |


#### `shopify theme console`

To test this change in the `shopify theme console` command, you may run the command on a store that is not password-protected:

| Before | After   |
|--------|---------|
| ![before_console](https://github.com/Shopify/cli/assets/1079279/18abf307-14da-40b8-abe1-064a49e5c976)  | ![after_console](https://github.com/Shopify/cli/assets/1079279/f6afd10c-ad5e-4dff-adcb-00cf89c9dfaa) |


### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
