### PR TITLE
create CLI version 3.60.0 release notes

### DIFF
--- a/RELEASE_NOTES/3.60.md
+++ b/RELEASE_NOTES/3.60.md
@@ -1,0 +1,21 @@
+# CLI
+
+- Fix bug with plugins installation https://github.com/Shopify/cli/pull/3853
+
+# App
+
+- Adds validations for editor extension collection https://github.com/Shopify/cli/pull/3728
+- Adds localization support for editor extension collection https://github.com/Shopify/cli/pull/3717
+- Webhook trigger now reads from the configuration instead of .env and accepts more flags https://github.com/Shopify/cli/pull/3727
+
+# CLI-kit
+
+- Introduce .json support for theme app extensions https://github.com/Shopify/cli/pull/3842
+
+# Theme
+
+- Render progress bar for theme uploads to stderr https://github.com/Shopify/cli/pull/3765
+- Fix the shopify theme dev proxy to use the development theme, even when users have a browser session with the live theme loaded https://github.com/Shopify/cli/pull/3791
+- Fix unpublished themes being marked as development themes https://github.com/Shopify/cli/pull/3798
+- Fix issue that prevents shopify theme console from evaluating results when another 'preview_theme_id' is set https://github.com/Shopify/cli/pull/3811
+-  Fix the shopify theme dev/shopify theme console proxy to handle cookies as expected, and ensure they no longer render the live theme instead of the development theme https://github.com/Shopify/cli/pull/3851


### PR DESCRIPTION
CLI [3.60.0](https://github.com/Shopify/cli/releases/tag/3.60.0) release notes


