### PR TITLE
Add filter to webhooks app config

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2734,7 +2734,7 @@ describe('WebhooksSchema', () => {
     }
     const errorObj = {
       code: zod.ZodIssueCode.custom,
-      message: 'You can’t have duplicate subscriptions with the exact same `topic` and `uri`',
+      message: 'You can’t have duplicate subscriptions with the exact same `topic`, `uri` and `filter`',
       fatal: true,
       path: ['webhooks', 'subscriptions', 0, 'topics', 1, 'products/create'],
     }
@@ -2753,7 +2753,7 @@ describe('WebhooksSchema', () => {
     }
     const errorObj = {
       code: zod.ZodIssueCode.custom,
-      message: 'You can’t have duplicate subscriptions with the exact same `topic` and `uri`',
+      message: 'You can’t have duplicate subscriptions with the exact same `topic`, `uri` and `filter`',
       fatal: true,
       path: ['webhooks', 'subscriptions', 1, 'topics', 0, 'products/create'],
     }
@@ -2847,7 +2847,7 @@ describe('WebhooksSchema', () => {
     }
     const errorObj = {
       code: zod.ZodIssueCode.custom,
-      message: 'You can’t have duplicate subscriptions with the exact same `topic` and `uri`',
+      message: 'You can’t have duplicate subscriptions with the exact same `topic`, `uri` and `filter`',
       fatal: true,
       path: ['webhooks', 'subscriptions', 1, 'topics', 0, 'products/create'],
     }
@@ -2872,7 +2872,7 @@ describe('WebhooksSchema', () => {
     }
     const errorObj = {
       code: zod.ZodIssueCode.custom,
-      message: 'You can’t have duplicate subscriptions with the exact same `topic` and `uri`',
+      message: 'You can’t have duplicate subscriptions with the exact same `topic`, `uri` and `filter`',
       fatal: true,
       path: ['webhooks', 'subscriptions', 1, 'topics', 0, 'products/create'],
     }
@@ -2897,7 +2897,7 @@ describe('WebhooksSchema', () => {
     }
     const errorObj = {
       code: zod.ZodIssueCode.custom,
-      message: 'You can’t have duplicate subscriptions with the exact same `topic` and `uri`',
+      message: 'You can’t have duplicate subscriptions with the exact same `topic`, `uri` and `filter`',
       fatal: true,
       path: ['webhooks', 'subscriptions', 1, 'topics', 0, 'products/create'],
     }
@@ -2924,7 +2924,7 @@ describe('WebhooksSchema', () => {
     }
     const errorObj = {
       code: zod.ZodIssueCode.custom,
-      message: 'You can’t have duplicate subscriptions with the exact same `topic` and `uri`',
+      message: 'You can’t have duplicate subscriptions with the exact same `topic`, `uri` and `filter`',
       fatal: true,
       path: ['webhooks', 'subscriptions', 1, 'topics', 0, 'metaobjects/create'],
     }
@@ -2946,6 +2946,51 @@ describe('WebhooksSchema', () => {
           topics: ['products/create'],
           uri: 'https://example.com',
           sub_topic: 'type:metaobject_two',
+        },
+      ],
+    }
+  })
+
+  test('does not allow identical topic and uri and filter in different subscriptions', async () => {
+    const webhookConfig: WebhooksConfig = {
+      api_version: '2021-07',
+      subscriptions: [
+        {
+          topics: ['products/update'],
+          uri: 'https://example.com',
+          filter: 'title:shoes',
+        },
+        {
+          topics: ['products/update'],
+          uri: 'https://example.com',
+          filter: 'title:shoes',
+        },
+      ],
+    }
+    const errorObj = {
+      code: zod.ZodIssueCode.custom,
+      message: 'You can’t have duplicate subscriptions with the exact same `topic`, `uri` and `filter`',
+      fatal: true,
+      path: ['webhooks', 'subscriptions', 1, 'topics', 0, 'products/update'],
+    }
+
+    const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
+    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
+  })
+
+  test('allows identical topic and uri if filter is different', async () => {
+    const webhookConfig: WebhooksConfig = {
+      api_version: '2021-07',
+      subscriptions: [
+        {
+          topics: ['products/update'],
+          uri: 'https://example.com',
+          filter: 'title:shoes',
+        },
+        {
+          topics: ['products/update'],
+          uri: 'https://example.com',
+          filter: 'title:shirts',
         },
       ],
     }

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook.test.ts
@@ -38,6 +38,11 @@ describe('webhooks', () => {
               uri: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/1234567890/SOME_PATH',
               sub_topic: 'type:metaobject_one',
             },
+            {
+              topics: ['products/create', 'products/update'],
+              uri: 'https://example.com/webhooks/products',
+              filter: 'title:shoes',
+            },
           ],
         },
       }
@@ -101,6 +106,16 @@ describe('webhooks', () => {
             topic: 'metaobjects/delete',
             uri: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/1234567890/SOME_PATH',
           },
+          {
+            filter: 'title:shoes',
+            topic: 'products/create',
+            uri: 'https://example.com/webhooks/products',
+          },
+          {
+            filter: 'title:shoes',
+            topic: 'products/update',
+            uri: 'https://example.com/webhooks/products',
+          },
         ],
       })
     })
@@ -146,6 +161,11 @@ describe('webhooks', () => {
             topic: 'orders/create',
             uri: 'https://valid-url',
           },
+          {
+            filter: 'title:shoes',
+            topic: 'products/create',
+            uri: 'https://example.com/webhooks/products',
+          },
         ],
       }
       const webhookSpec = spec
@@ -175,6 +195,11 @@ describe('webhooks', () => {
               include_fields: ['variants', 'title'],
               topics: ['orders/create'],
               uri: 'https://valid-url',
+            },
+            {
+              filter: 'title:shoes',
+              topics: ['products/create'],
+              uri: 'https://example.com/webhooks/products',
             },
           ],
         },
@@ -233,6 +258,21 @@ describe('webhooks', () => {
               sub_topic: 'subtopic',
               uri: 'https://example.com/webhooks',
             },
+            {
+              topics: ['products/create'],
+              uri: 'https://example.com/webhooks',
+              filter: 'title:shoes',
+            },
+            {
+              topics: ['products/update'],
+              uri: 'https://example.com/webhooks',
+              filter: 'title:shoes',
+            },
+            {
+              topics: ['products/update'],
+              uri: 'https://example.com/webhooks',
+              filter: 'title:shirts',
+            },
           ],
           privacy_compliance: undefined,
         },
@@ -267,6 +307,16 @@ describe('webhooks', () => {
               topics: ['metaobjects/create'],
               sub_topic: 'subtopic',
               uri: 'https://example.com/webhooks',
+            },
+            {
+              topics: ['products/create', 'products/update'],
+              uri: 'https://example.com/webhooks',
+              filter: 'title:shoes',
+            },
+            {
+              topics: ['products/update'],
+              uri: 'https://example.com/webhooks',
+              filter: 'title:shirts',
             },
           ],
           privacy_compliance: undefined,

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
@@ -37,7 +37,8 @@ function mergeAllWebhooks(subscriptions: WebhookSubscription[]): WebhookSubscrip
       (sub) =>
         sub.uri === subscription.uri &&
         sub.sub_topic === subscription.sub_topic &&
-        sub.include_fields === subscription.include_fields,
+        sub.include_fields === subscription.include_fields &&
+        sub.filter === subscription.filter,
     )
     if (existingSubscription) {
       if (subscription.compliance_topics) {

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
@@ -16,6 +16,7 @@ export const WebhookSubscriptionSchema = zod.object({
   uri: zod.preprocess(removeTrailingSlash, UriValidation, {required_error: 'Missing value at'}),
   sub_topic: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
   include_fields: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
+  filter: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
   compliance_topics: zod
     .array(
       zod.enum([ComplianceTopic.CustomersRedact, ComplianceTopic.CustomersDataRequest, ComplianceTopic.ShopRedact]),

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.test.ts
@@ -37,6 +37,11 @@ describe('webhook_subscription', () => {
               uri: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/1234567890/SOME_PATH',
               sub_topic: 'type:metaobject_one',
             },
+            {
+              topics: ['products/update'],
+              uri: 'https://example.com/webhooks/products',
+              filter: 'title:shoes',
+            },
           ],
         },
       }
@@ -110,6 +115,12 @@ describe('webhook_subscription', () => {
             topic: 'metaobjects/delete',
             uri: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/1234567890/SOME_PATH',
           },
+          {
+            api_version: '2024-01',
+            filter: 'title:shoes',
+            topic: 'products/update',
+            uri: 'https://example.com/webhooks/products',
+          },
         ],
       })
     })
@@ -160,6 +171,12 @@ describe('webhook_subscription', () => {
             topic: 'orders/create',
             uri: 'https://valid-url',
           },
+          {
+            api_version: '2024-01',
+            filter: 'title:shoes',
+            topic: 'products/update',
+            uri: 'https://example.com/webhooks/products',
+          },
         ],
       }
       const webhookSpec = spec
@@ -188,6 +205,11 @@ describe('webhook_subscription', () => {
               include_fields: ['variants', 'title'],
               topics: ['orders/create'],
               uri: 'https://valid-url',
+            },
+            {
+              filter: 'title:shoes',
+              topics: ['products/update'],
+              uri: 'https://example.com/webhooks/products',
             },
           ],
         },

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
@@ -13,6 +13,7 @@ interface TransformedWebhookSubscription {
   compliance_topics?: string[]
   sub_topic?: string
   include_fields?: string[]
+  filter?: string
 }
 
 /* this transforms webhooks from the TOML config to be parsed remotely

--- a/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
@@ -4,6 +4,7 @@ export interface WebhookSubscription {
   compliance_topics?: string[]
   sub_topic?: string
   include_fields?: string[]
+  filter?: string
 }
 
 interface PrivacyComplianceConfig {

--- a/packages/app/src/cli/models/extensions/specifications/validation/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/validation/app_config_webhook.ts
@@ -38,7 +38,7 @@ function validateSubscriptions(webhookConfig: WebhooksConfig) {
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  for (const [i, {uri, topics = [], compliance_topics = [], sub_topic = ''}] of subscriptions.entries()) {
+  for (const [i, {uri, topics = [], compliance_topics = [], sub_topic = '', filter = ''}] of subscriptions.entries()) {
     const path = ['subscriptions', i]
 
     if (!topics.length && !compliance_topics.length) {
@@ -50,12 +50,12 @@ function validateSubscriptions(webhookConfig: WebhooksConfig) {
     }
 
     for (const [j, topic] of topics.entries()) {
-      const key = `${topic}::${sub_topic}::${uri}`
+      const key = `${topic}::${sub_topic}::${uri}::${filter}`
 
       if (uniqueSubscriptionSet.has(key)) {
         return {
           code: zod.ZodIssueCode.custom,
-          message: 'You can’t have duplicate subscriptions with the exact same `topic` and `uri`',
+          message: 'You can’t have duplicate subscriptions with the exact same `topic`, `uri` and `filter`',
           fatal: true,
           path: [...path, 'topics', j, topic],
         }


### PR DESCRIPTION
### WHY are these changes introduced?
We need to add filters to declarative webhooks for the [customizable filters project](https://vault.shopify.io/gsd/projects/38737).

### WHAT is this pull request doing?
The PR adds an optional filter value to the webhook subscription configuration.  The filter is treated as a uniqueness constraint on the subscription (i.e. you can't have two subscriptions with the same uri/topic/filter) and performs grouping on the field.  Used the existing includeFields/subTopics as reference for these changes.

### How to test your changes?
- Tested against https://github.com/Shopify/shopify/pull/504278

- Created an app with the following webhooks configuration in the TOML file
```
[webhooks]
api_version = "2024-04"

  [[webhooks.subscriptions]]
  topics = [ "products/update" ]
  uri = "https://shopify.com/7bf98a69-f616-49d9-a7b1-868d58deafbc"
  filter = "field:value"
```

Ran the following command to deploy my app:
```
export SPIN_INSTANCE=partners-webhooks-dvww
SHOPIFY_SERVICE_ENV=spin NODE_TLS_REJECT_UNAUTHORIZED=0 pnpm shopify app deploy --path ./test-filter-app
```
![image](https://github.com/Shopify/cli/assets/1899157/750fe476-f508-4eb7-a058-bbc62fa35f25)

Also tested with invalid values for filter (i.e. numeric to fail local validation and "invalid" to fail remote validation).
![image](https://github.com/Shopify/cli/assets/1899157/7b46c1d0-4d01-4f0b-a3c2-0c19714e2108)
![image](https://github.com/Shopify/cli/assets/1899157/8424e39f-77e5-4ec5-99fb-f9bee4819196)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition - Behind beta flag, but will be measured in filter project once released
- [ ] PR includes analytics changes to measure impact

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
