### PR TITLE
[Refactor][Themes] Move local disk 'delete' and 'write' operations  behind the ThemeFileSystem interface

### DIFF
--- a/packages/cli-kit/src/public/node/themes/types.ts
+++ b/packages/cli-kit/src/public/node/themes/types.ts
@@ -16,6 +16,20 @@ export interface ThemeFileSystem {
    * Local theme files.
    */
   files: Map<Key, ThemeAsset>
+
+  /**
+   * Removes a file from the theme file system
+   *
+   * @param assetKey - the key of the file to remove
+   */
+  delete: (asset: ThemeAsset) => Promise<void>
+
+  /**
+   * Writes a file to the theme file system
+   *
+   * @param asset - the asset to write
+   */
+  write: (asset: ThemeAsset) => Promise<void>
 }
 
 /**

--- a/packages/cli-kit/src/public/node/themes/types.ts
+++ b/packages/cli-kit/src/public/node/themes/types.ts
@@ -18,18 +18,27 @@ export interface ThemeFileSystem {
   files: Map<Key, ThemeAsset>
 
   /**
-   * Removes a file from the theme file system
+   * Removes a file from the local disk and updates the themeFileSystem
    *
    * @param assetKey - The key of the file to remove
    */
   delete: (assetKey: string) => Promise<void>
 
   /**
-   * Writes a file to the theme file system
+   * Writes a file to the local disk and updates the themeFileSystem
    *
    * @param asset - The ThemeAsset representing the file to write
    */
   write: (asset: ThemeAsset) => Promise<void>
+
+  /**
+   * Reads a file from the local disk and updates the themeFileSystem
+   * Returns a ThemeAsset representing the file that was read
+   * Returns undefined if the file does not exist
+   *
+   * @param assetKey - The key of the file to read
+   */
+  read: (assetKey: string) => Promise<string | Buffer | undefined>
 }
 
 /**

--- a/packages/cli-kit/src/public/node/themes/types.ts
+++ b/packages/cli-kit/src/public/node/themes/types.ts
@@ -20,14 +20,14 @@ export interface ThemeFileSystem {
   /**
    * Removes a file from the theme file system
    *
-   * @param assetKey - the key of the file to remove
+   * @param assetKey - The key of the file to remove
    */
-  delete: (asset: ThemeAsset) => Promise<void>
+  delete: (assetKey: string) => Promise<void>
 
   /**
    * Writes a file to the theme file system
    *
-   * @param asset - the asset to write
+   * @param asset - The ThemeAsset representing the file to write
    */
   write: (asset: ThemeAsset) => Promise<void>
 }

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -1,7 +1,7 @@
 import {showDeprecationWarnings, refreshTokens, dev} from './dev.js'
 import {startDevServer} from '../utilities/theme-environment.js'
 import {mountThemeFileSystem} from '../utilities/theme-fs.js'
-import {mockThemeFileSystem} from '../utilities/theme-fs/theme-fs-mock-factory.js'
+import {fakeThemeFileSystem} from '../utilities/theme-fs/theme-fs-mock-factory.js'
 import {describe, expect, test, vi} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
@@ -29,7 +29,7 @@ describe('dev', () => {
     'theme-editor-sync': false,
     'dev-preview': false,
   }
-  const localThemeFileSystem = mockThemeFileSystem('tmp', new Map())
+  const localThemeFileSystem = fakeThemeFileSystem('tmp', new Map())
 
   describe('Dev-Preview Implementation', async () => {
     test('calls startDevServer with the correct arguments when the `dev-preview` option is provided', async () => {

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -1,6 +1,7 @@
 import {showDeprecationWarnings, refreshTokens, dev} from './dev.js'
 import {startDevServer} from '../utilities/theme-environment.js'
 import {mountThemeFileSystem} from '../utilities/theme-fs.js'
+import {mockThemeFileSystem} from '../utilities/theme-fs/theme-fs-mock-factory.js'
 import {describe, expect, test, vi} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
@@ -28,12 +29,13 @@ describe('dev', () => {
     'theme-editor-sync': false,
     'dev-preview': false,
   }
+  const localThemeFileSystem = mockThemeFileSystem('tmp', new Map())
 
   describe('Dev-Preview Implementation', async () => {
     test('calls startDevServer with the correct arguments when the `dev-preview` option is provided', async () => {
       // Given
       vi.mocked(fetchChecksums).mockResolvedValue([])
-      vi.mocked(mountThemeFileSystem).mockResolvedValue({root: 'tmp', files: new Map()})
+      vi.mocked(mountThemeFileSystem).mockResolvedValue(localThemeFileSystem)
       vi.mocked(startDevServer).mockResolvedValue()
       const devOptions = {...options, 'dev-preview': true, 'theme-editor-sync': true}
 
@@ -46,7 +48,7 @@ describe('dev', () => {
         {
           session: {...adminSession, storefrontToken: 'my-storefront-token'},
           remoteChecksums: [],
-          localThemeFileSystem: {root: 'tmp', files: new Map()},
+          localThemeFileSystem,
           themeEditorSync: true,
         },
         expect.any(Function),

--- a/packages/theme/src/cli/utilities/asset-ignore.test.ts
+++ b/packages/theme/src/cli/utilities/asset-ignore.test.ts
@@ -1,5 +1,5 @@
 import {applyIgnoreFilters} from './asset-ignore.js'
-import {mockThemeFileSystem} from './theme-fs/theme-fs-mock-factory.js'
+import {fakeThemeFileSystem} from './theme-fs/theme-fs-mock-factory.js'
 import {ReadOptions, fileExists, readFile} from '@shopify/cli-kit/node/fs'
 import {outputWarn} from '@shopify/cli-kit/node/output'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -30,7 +30,7 @@ describe('applyIgnoreFilters', () => {
     {key: 'templates/404.json', checksum: '6666666666666666666666666666666'},
     {key: 'templates/customers/account.json', checksum: '7777777777777777777777777777777'},
   ]
-  const themeFileSystem = mockThemeFileSystem('tmp', new Map<string, ThemeAsset>())
+  const themeFileSystem = fakeThemeFileSystem('tmp', new Map<string, ThemeAsset>())
 
   /**
    * Explicitly defining the type of 'readFile' as it returns either

--- a/packages/theme/src/cli/utilities/asset-ignore.test.ts
+++ b/packages/theme/src/cli/utilities/asset-ignore.test.ts
@@ -1,7 +1,9 @@
 import {applyIgnoreFilters} from './asset-ignore.js'
+import {mockThemeFileSystem} from './theme-fs/theme-fs-mock-factory.js'
 import {ReadOptions, fileExists, readFile} from '@shopify/cli-kit/node/fs'
 import {outputWarn} from '@shopify/cli-kit/node/output'
 import {joinPath} from '@shopify/cli-kit/node/path'
+import {ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 import {test, describe, beforeEach, vi, expect} from 'vitest'
 
 vi.mock('@shopify/cli-kit/node/fs', async () => {
@@ -28,7 +30,7 @@ describe('applyIgnoreFilters', () => {
     {key: 'templates/404.json', checksum: '6666666666666666666666666666666'},
     {key: 'templates/customers/account.json', checksum: '7777777777777777777777777777777'},
   ]
-  const themeFileSystem = {root: '/tmp/', files: new Map()}
+  const themeFileSystem = mockThemeFileSystem('tmp', new Map<string, ThemeAsset>())
 
   /**
    * Explicitly defining the type of 'readFile' as it returns either

--- a/packages/theme/src/cli/utilities/theme-downloader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-downloader.test.ts
@@ -1,7 +1,7 @@
 import {downloadTheme} from './theme-downloader.js'
-import {removeThemeFile, writeThemeFile} from './theme-fs.js'
+import {mockThemeFileSystem} from './theme-fs/theme-fs-mock-factory.js'
 import {fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
-import {Checksum, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
+import {Checksum, ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 import {test, describe, expect, vi} from 'vitest'
 
 vi.mock('./theme-fs.js')
@@ -9,62 +9,70 @@ vi.mock('@shopify/cli-kit/node/themes/api')
 
 describe('theme-downloader', () => {
   describe('downloadTheme', () => {
+    const root = 'tmp'
     const remoteTheme = {id: 1, name: '', createdAtRuntime: false, processing: false, role: ''}
     const adminSession = {token: '', storeFqdn: ''}
     const downloadOptions = {nodelete: false}
 
     test('deletes new local files', async () => {
       // Given
-      const remote = [{key: 'keepme', checksum: '1'}]
-      const local = {
-        root: 'tmp',
-        files: new Map([
-          ['keepme', {checksum: '1'}],
-          ['deleteme', {checksum: '2'}],
-        ]),
-      } as ThemeFileSystem
+      const remote = [{key: 'assets/keepme.css', checksum: '1'}]
+      const files = new Map<string, ThemeAsset>([
+        ['assets/keepme.css', {key: 'assets/keepme.css', checksum: '1', value: 'content'}],
+        ['assets/deleteme.css', {key: 'assets/deleteme.css', checksum: '2', value: 'content'}],
+      ])
+      const fileSystem = mockThemeFileSystem(root, files)
+      const spy = vi.spyOn(fileSystem, 'delete')
 
       // When
-      await downloadTheme(remoteTheme, adminSession, remote, local, downloadOptions)
+      await downloadTheme(remoteTheme, adminSession, remote, fileSystem, downloadOptions)
 
       // Then
-      expect(vi.mocked(removeThemeFile)).toHaveBeenCalledOnce()
-      expect(vi.mocked(removeThemeFile)).toHaveBeenCalledWith('tmp', 'deleteme')
+      expect(spy).toHaveBeenCalledOnce()
+      expect(spy).toHaveBeenCalledWith('assets/deleteme.css')
     })
 
     test('does not delete files when nodelete is set', async () => {
       // Given
       const downloadOptions = {nodelete: true}
       const remote: Checksum[] = []
-      const local = {files: new Map([['keepme', {}]])} as ThemeFileSystem
+      const files = new Map<string, ThemeAsset>([
+        ['assets/keepme.css', {key: 'assets/keepme.css', checksum: '1', value: 'content'}],
+      ])
+      const fileSystem = mockThemeFileSystem(root, files)
+      const spy = vi.spyOn(fileSystem, 'delete')
 
       // When
-      await downloadTheme(remoteTheme, adminSession, remote, local, downloadOptions)
+      await downloadTheme(remoteTheme, adminSession, remote, fileSystem, downloadOptions)
 
       // Then
-      expect(vi.mocked(removeThemeFile)).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     test('downloads missing remote files', async () => {
       // Given
       const downloadOptions = {nodelete: false, only: ['release'], ignore: ['release/ignoreme']}
       const fileToDownload = {key: 'release/downloadme', checksum: '1'}
-      const local = {root: 'tmp', files: new Map([['release/alreadyexists', {checksum: '2'}]])} as ThemeFileSystem
+      const files = new Map<string, ThemeAsset>([
+        ['release/alreadyexists', {checksum: '2', value: 'content', key: 'release/alreadyexists'}],
+      ])
+      const fileSystem = mockThemeFileSystem(root, files)
       const remote = [
         fileToDownload,
         {key: 'release/alreadyexists', checksum: '2'},
         {key: 'ignoreme', checksum: '3'},
         {key: 'release/ignoreme', checksum: '4'},
       ]
+      const spy = vi.spyOn(fileSystem, 'write')
 
       vi.mocked(fetchThemeAsset).mockResolvedValue(fileToDownload)
 
       // When
-      await downloadTheme(remoteTheme, adminSession, remote, local, downloadOptions)
+      await downloadTheme(remoteTheme, adminSession, remote, fileSystem, downloadOptions)
 
       // Then
-      expect(vi.mocked(writeThemeFile)).toHaveBeenCalledOnce()
-      expect(vi.mocked(writeThemeFile)).toHaveBeenCalledWith('tmp', fileToDownload)
+      expect(spy).toHaveBeenCalledOnce()
+      expect(spy).toHaveBeenCalledWith(fileToDownload)
     })
   })
 })

--- a/packages/theme/src/cli/utilities/theme-downloader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-downloader.test.ts
@@ -1,5 +1,5 @@
 import {downloadTheme} from './theme-downloader.js'
-import {mockThemeFileSystem} from './theme-fs/theme-fs-mock-factory.js'
+import {fakeThemeFileSystem} from './theme-fs/theme-fs-mock-factory.js'
 import {fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
 import {Checksum, ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 import {test, describe, expect, vi} from 'vitest'
@@ -21,7 +21,7 @@ describe('theme-downloader', () => {
         ['assets/keepme.css', {key: 'assets/keepme.css', checksum: '1', value: 'content'}],
         ['assets/deleteme.css', {key: 'assets/deleteme.css', checksum: '2', value: 'content'}],
       ])
-      const fileSystem = mockThemeFileSystem(root, files)
+      const fileSystem = fakeThemeFileSystem(root, files)
       const spy = vi.spyOn(fileSystem, 'delete')
 
       // When
@@ -39,7 +39,7 @@ describe('theme-downloader', () => {
       const files = new Map<string, ThemeAsset>([
         ['assets/keepme.css', {key: 'assets/keepme.css', checksum: '1', value: 'content'}],
       ])
-      const fileSystem = mockThemeFileSystem(root, files)
+      const fileSystem = fakeThemeFileSystem(root, files)
       const spy = vi.spyOn(fileSystem, 'delete')
 
       // When
@@ -56,7 +56,7 @@ describe('theme-downloader', () => {
       const files = new Map<string, ThemeAsset>([
         ['release/alreadyexists', {checksum: '2', value: 'content', key: 'release/alreadyexists'}],
       ])
-      const fileSystem = mockThemeFileSystem(root, files)
+      const fileSystem = fakeThemeFileSystem(root, files)
       const remote = [
         fileToDownload,
         {key: 'release/alreadyexists', checksum: '2'},

--- a/packages/theme/src/cli/utilities/theme-downloader.ts
+++ b/packages/theme/src/cli/utilities/theme-downloader.ts
@@ -1,5 +1,4 @@
 import {applyIgnoreFilters} from './asset-ignore.js'
-import {removeThemeFile, writeThemeFile} from './theme-fs.js'
 
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
@@ -40,7 +39,7 @@ function buildDeleteTasks(remoteChecksums: Checksum[], themeFileSystem: ThemeFil
   return localFilesToBeDeleted.map((key) => {
     return {
       title: `Cleaning your local directory (removing ${key})`,
-      task: async () => removeThemeFile(themeFileSystem.root, key),
+      task: async () => themeFileSystem.delete(key),
     }
   })
 }
@@ -74,12 +73,12 @@ async function buildDownloadTasks(
     .filter(notNull)
 }
 
-async function downloadFile(theme: Theme, {root}: ThemeFileSystem, checksum: Checksum, session: AdminSession) {
+async function downloadFile(theme: Theme, fileSystem: ThemeFileSystem, checksum: Checksum, session: AdminSession) {
   const themeAsset = await fetchThemeAsset(theme.id, checksum.key, session)
 
   if (!themeAsset) return
 
-  await writeThemeFile(root, themeAsset)
+  await fileSystem.write(themeAsset)
 }
 
 function progressPct(themeChecksums: Checksum[], checksum: Checksum): number {

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -4,7 +4,6 @@ import {
   isTextFile,
   isThemeAsset,
   mountThemeFileSystem,
-  readThemeFile,
   partitionThemeFiles,
   readThemeFilesFromDisk,
 } from './theme-fs.js'
@@ -45,6 +44,7 @@ describe('theme-fs', () => {
         root,
         delete: expect.any(Function),
         write: expect.any(Function),
+        read: expect.any(Function),
       })
     })
 
@@ -61,6 +61,7 @@ describe('theme-fs', () => {
         root,
         delete: expect.any(Function),
         write: expect.any(Function),
+        read: expect.any(Function),
       })
     })
 
@@ -149,14 +150,15 @@ describe('theme-fs', () => {
     })
   })
 
-  describe('readThemeFile', () => {
+  describe('themeFileSystem.read', async () => {
     test('reads theme file when it exists', async () => {
       // Given
       const root = 'src/cli/utilities/fixtures'
       const key = 'templates/404.json'
+      const themeFileSystem = await mountThemeFileSystem(root)
 
       // When
-      const content = await readThemeFile(root, key)
+      const content = await themeFileSystem.read(key)
       const contentJson = JSON.parse(content?.toString() || '')
 
       // Then
@@ -175,9 +177,10 @@ describe('theme-fs', () => {
       // Given
       const root = 'src/cli/utilities/fixtures'
       const key = 'templates/invalid.json'
+      const themeFileSystem = await mountThemeFileSystem(root)
 
       // When
-      const content = await readThemeFile(root, key)
+      const content = await themeFileSystem.read(key)
 
       // Then
       expect(content).toBeUndefined()
@@ -187,9 +190,10 @@ describe('theme-fs', () => {
       // Given
       const root = 'src/cli/utilities/fixtures'
       const key = 'assets/sparkle.gif'
+      const themeFileSystem = await mountThemeFileSystem(root)
 
       // When
-      const content = await readThemeFile(root, key)
+      const content = await themeFileSystem.read(key)
 
       // Then
       expect(content).toBeDefined()

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -5,6 +5,7 @@ import {
   isThemeAsset,
   mountThemeFileSystem,
   partitionThemeFiles,
+  readThemeFile,
   readThemeFilesFromDisk,
 } from './theme-fs.js'
 import {removeFile, writeFile} from '@shopify/cli-kit/node/fs'
@@ -151,14 +152,37 @@ describe('theme-fs', () => {
   })
 
   describe('themeFileSystem.read', async () => {
-    test('reads theme file when it exists', async () => {
+    test('"read" returns returns the content from the local disk and updates the file map', async () => {
       // Given
       const root = 'src/cli/utilities/fixtures'
       const key = 'templates/404.json'
       const themeFileSystem = await mountThemeFileSystem(root)
+      expect(themeFileSystem.files.get(key)).toEqual({
+        key: 'templates/404.json',
+        checksum: 'f14a0bd594f4fee47b13fc09543098ff',
+      })
 
       // When
       const content = await themeFileSystem.read(key)
+
+      // Then
+      expect(themeFileSystem.files.get(key)).toEqual({
+        key: 'templates/404.json',
+        checksum: 'f14a0bd594f4fee47b13fc09543098ff',
+        value: content,
+        attachment: '',
+      })
+    })
+  })
+
+  describe('readThemeFile', () => {
+    test('reads theme file when it exists', async () => {
+      // Given
+      const root = 'src/cli/utilities/fixtures'
+      const key = 'templates/404.json'
+
+      // When
+      const content = await readThemeFile(root, key)
       const contentJson = JSON.parse(content?.toString() || '')
 
       // Then
@@ -177,10 +201,9 @@ describe('theme-fs', () => {
       // Given
       const root = 'src/cli/utilities/fixtures'
       const key = 'templates/invalid.json'
-      const themeFileSystem = await mountThemeFileSystem(root)
 
       // When
-      const content = await themeFileSystem.read(key)
+      const content = await readThemeFile(root, key)
 
       // Then
       expect(content).toBeUndefined()
@@ -190,10 +213,9 @@ describe('theme-fs', () => {
       // Given
       const root = 'src/cli/utilities/fixtures'
       const key = 'assets/sparkle.gif'
-      const themeFileSystem = await mountThemeFileSystem(root)
 
       // When
-      const content = await themeFileSystem.read(key)
+      const content = await readThemeFile(root, key)
 
       // Then
       expect(content).toBeDefined()

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -45,6 +45,8 @@ describe('theme-fs', () => {
           fsEntry({checksum: 'f14a0bd594f4fee47b13fc09543098ff', key: 'templates/404.json'}),
         ]),
         root,
+        delete: expect.any(Function),
+        write: expect.any(Function),
       })
     })
 
@@ -59,6 +61,40 @@ describe('theme-fs', () => {
       expect(themeFileSystem).toEqual({
         files: new Map([]),
         root,
+        delete: expect.any(Function),
+        write: expect.any(Function),
+      })
+    })
+
+    test('"delete" removes the file from the local disk and updates the file map', async () => {
+      // Given
+      const root = 'src/cli/utilities/fixtures'
+
+      // When
+      const themeFileSystem = await mountThemeFileSystem(root)
+      await themeFileSystem.delete({key: 'assets/base.css', checksum: 'b7fbe0ecff2a6c1d6e697a13096e2b17'})
+
+      // Then
+      expect(removeFile).toBeCalledWith(`${root}/assets/base.css`)
+      expect(themeFileSystem.files.has('assets/base.css')).toBe(false)
+    })
+
+    test('"write" creates a file on the local disk and updates the file map', async () => {
+      // Given
+      const root = 'src/cli/utilities/fixtures'
+
+      // When
+      const themeFileSystem = await mountThemeFileSystem(root)
+      expect(themeFileSystem.files.get('assets/new_file.css')).toBeUndefined()
+
+      await themeFileSystem.write({key: 'assets/new_file.css', checksum: '1010', value: 'content'})
+
+      // Then
+      expect(writeFile).toBeCalledWith(`${root}/assets/new_file.css`, 'content')
+      expect(themeFileSystem.files.get('assets/new_file.css')).toEqual({
+        key: 'assets/new_file.css',
+        checksum: '1010',
+        value: 'content',
       })
     })
   })

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -73,6 +73,9 @@ export async function mountThemeFileSystem(root: string): Promise<ThemeFileSyste
       await writeThemeFile(root, asset)
       files.set(asset.key, asset)
     },
+    read: async (assetKey: string) => {
+      return readThemeFile(root, assetKey)
+    },
   }
 }
 

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -65,9 +65,9 @@ export async function mountThemeFileSystem(root: string): Promise<ThemeFileSyste
   return {
     root,
     files,
-    delete: async (asset: ThemeAsset) => {
-      await removeThemeFile(root, asset.key)
-      files.delete(asset.key)
+    delete: async (assetKey: string) => {
+      await removeThemeFile(root, assetKey)
+      files.delete(assetKey)
     },
     write: async (asset: ThemeAsset) => {
       await writeThemeFile(root, asset)
@@ -76,7 +76,7 @@ export async function mountThemeFileSystem(root: string): Promise<ThemeFileSyste
   }
 }
 
-export async function writeThemeFile(root: string, {key, attachment, value}: ThemeAsset) {
+async function writeThemeFile(root: string, {key, attachment, value}: ThemeAsset) {
   const absolutePath = joinPath(root, key)
 
   await ensureDirExists(absolutePath)
@@ -103,7 +103,7 @@ export async function readThemeFile(root: string, path: Key): Promise<string | B
   return readFile(absolutePath, options)
 }
 
-export async function removeThemeFile(root: string, path: Key) {
+async function removeThemeFile(root: string, path: Key) {
   const absolutePath = joinPath(root, path)
 
   const themeFileExists = await fileExists(absolutePath)

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -65,6 +65,14 @@ export async function mountThemeFileSystem(root: string): Promise<ThemeFileSyste
   return {
     root,
     files,
+    delete: async (asset: ThemeAsset) => {
+      await removeThemeFile(root, asset.key)
+      files.delete(asset.key)
+    },
+    write: async (asset: ThemeAsset) => {
+      await writeThemeFile(root, asset)
+      files.set(asset.key, asset)
+    },
   }
 }
 

--- a/packages/theme/src/cli/utilities/theme-fs/theme-fs-mock-factory.ts
+++ b/packages/theme/src/cli/utilities/theme-fs/theme-fs-mock-factory.ts
@@ -4,8 +4,8 @@ export function mockThemeFileSystem(root: string, files: Map<string, ThemeAsset>
   return {
     root,
     files,
-    delete: async (asset: ThemeAsset) => {
-      files.delete(asset.key)
+    delete: async (assetKey: string) => {
+      files.delete(assetKey)
     },
     write: async (asset: ThemeAsset) => {
       files.set(asset.key, asset)

--- a/packages/theme/src/cli/utilities/theme-fs/theme-fs-mock-factory.ts
+++ b/packages/theme/src/cli/utilities/theme-fs/theme-fs-mock-factory.ts
@@ -1,6 +1,6 @@
 import {ThemeAsset, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 
-export function mockThemeFileSystem(root: string, files: Map<string, ThemeAsset>): ThemeFileSystem {
+export function fakeThemeFileSystem(root: string, files: Map<string, ThemeAsset>): ThemeFileSystem {
   return {
     root,
     files,

--- a/packages/theme/src/cli/utilities/theme-fs/theme-fs-mock-factory.ts
+++ b/packages/theme/src/cli/utilities/theme-fs/theme-fs-mock-factory.ts
@@ -10,5 +10,8 @@ export function fakeThemeFileSystem(root: string, files: Map<string, ThemeAsset>
     write: async (asset: ThemeAsset) => {
       files.set(asset.key, asset)
     },
+    read: async (assetKey: string) => {
+      return files.get(assetKey)?.value || files.get(assetKey)?.attachment
+    },
   }
 }

--- a/packages/theme/src/cli/utilities/theme-fs/theme-fs-mock-factory.ts
+++ b/packages/theme/src/cli/utilities/theme-fs/theme-fs-mock-factory.ts
@@ -1,0 +1,14 @@
+import {ThemeAsset, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
+
+export function mockThemeFileSystem(root: string, files: Map<string, ThemeAsset>): ThemeFileSystem {
+  return {
+    root,
+    files,
+    delete: async (asset: ThemeAsset) => {
+      files.delete(asset.key)
+    },
+    write: async (asset: ThemeAsset) => {
+      files.set(asset.key, asset)
+    },
+  }
+}


### PR DESCRIPTION
**WHY are these changes introduced?**
- Mise en place for adding polling for theme editor changes in the `theme dev` command
- Part of https://github.com/Shopify/develop-advanced-edits/issues/203

**WHAT is this pull request doing?**
- Adds `delete` and `write` methods to the `ThemeFileSystem` interface
- replaces the `removeThemeFile` and `writeThemeFile` functions with these new methods
- creates a mockThemeFileSystem fixture function for testing
- updates the tests accordingly

**How to test your changes?**
This is a refactor so no behaviour should change
`pnpm test`