### PR TITLE
Only build flow template extensions during deploy

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -279,7 +279,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
       return buildFunctionExtension(this, options)
     } else if (this.features.includes('esbuild')) {
       return buildUIExtension(this, options)
-    } else if (this.specification.identifier === 'flow_template') {
+    } else if (this.specification.identifier === 'flow_template' && options.environment === 'production') {
       return buildFlowTemplateExtension(this, options)
     }
 

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -72,7 +72,7 @@ export async function buildFlowTemplateExtension(
   options: ExtensionBuildOptions,
 ): Promise<void> {
   options.stdout.write(`Building Flow Template extension ${extension.localIdentifier}...`)
-  await bundleFlowTemplateExtension(extension, options)
+  await bundleFlowTemplateExtension(extension)
   options.stdout.write(`${extension.localIdentifier} successfully built`)
 }
 

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -90,17 +90,14 @@ export async function bundleThemeExtension(
   )
 }
 
-export async function bundleFlowTemplateExtension(
-  extension: ExtensionInstance,
-  options: ExtensionBuildOptions,
-): Promise<void> {
-  options.stdout.write(`Bundling Flow Template extension ${extension.localIdentifier}...`)
+export async function bundleFlowTemplateExtension(extension: ExtensionInstance): Promise<void> {
   const files = await flowTemplateExtensionFiles(extension)
 
   await Promise.all(
     files.map(function (filepath) {
       const relativePathName = relativePath(extension.directory, filepath)
       const outputFile = joinPath(extension.outputPath, relativePathName)
+      if (filepath === outputFile) return
       return copyFile(filepath, outputFile)
     }),
   )


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- Flow templates introduced a new build step to include localization files in the bundled zip file.
- This build step is only meant for deploy and it currently fails during dev

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Don't build flow template extensions if env is `development`
- Even if we build, check that we are not building in the wrong path.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a flow template extension
- Try to `dev`, it should work (crashes on main)
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
