### PR TITLE
Introduce new remote renderer for `shopify theme dev`

### DIFF
--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -8,7 +8,7 @@ import {debugLogResponseInfo} from '../../private/node/api.js'
 import FormData from 'form-data'
 import nodeFetch, {RequestInfo, RequestInit} from 'node-fetch'
 
-export {FetchError} from 'node-fetch'
+export {FetchError, Request} from 'node-fetch'
 
 /**
  * Create a new FormData object.

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -46,7 +46,7 @@ describe('dev', () => {
       expect(startDevServer).toHaveBeenCalledWith(
         options.theme,
         {
-          session: {...adminSession, storefrontToken: 'my-storefront-token'},
+          session: {...adminSession, storefrontToken: 'my-storefront-token', expiresAt: expect.any(Date)},
           remoteChecksums: [],
           localThemeFileSystem,
           themeEditorSync: true,

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -1,6 +1,7 @@
 import {hasRequiredThemeDirectories, mountThemeFileSystem} from '../utilities/theme-fs.js'
 import {currentDirectoryConfirmed} from '../utilities/theme-ui.js'
-import {DevServerSession, startDevServer} from '../utilities/theme-environment/theme-environment.js'
+import {startDevServer} from '../utilities/theme-environment/theme-environment.js'
+import {DevServerSession} from '../utilities/theme-environment/types.js'
 import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {AdminSession, ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
@@ -32,43 +33,47 @@ interface DevOptions {
 }
 
 export async function dev(options: DevOptions) {
+  if (!options['dev-preview']) {
+    await legacyDev(options)
+    return
+  }
+
   if (!(await hasRequiredThemeDirectories(options.directory)) && !(await currentDirectoryConfirmed(options.force))) {
     return
   }
 
-  if (options['dev-preview']) {
-    if (options.flagsToPass.includes('--poll')) {
-      renderWarning({
-        body: 'The CLI flag --[flag-name] is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
-      })
-    }
-
-    outputInfo('This feature is currently in development and is not ready for use or testing yet.')
-
-    const remoteChecksums = await fetchChecksums(options.theme.id, options.adminSession)
-    const localThemeFileSystem = await mountThemeFileSystem(options.directory)
-    const session: DevServerSession = {
-      ...options.adminSession,
-      storefrontToken: options.storefrontToken,
-    }
-    const ctx = {
-      session,
-      remoteChecksums,
-      localThemeFileSystem,
-      themeEditorSync: options['theme-editor-sync'],
-    }
-
-    await startDevServer(options.theme, ctx, () => {
-      renderLinks(options.store, options.theme.id.toString(), options.host, options.port)
+  if (options.flagsToPass.includes('--poll')) {
+    renderWarning({
+      body: 'The CLI flag --[flag-name] is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
     })
-
-    return
   }
 
-  await legacyDev(options)
+  outputInfo('This feature is currently in development and is not ready for use or testing yet.')
+
+  const remoteChecksums = await fetchChecksums(options.theme.id, options.adminSession)
+  const localThemeFileSystem = await mountThemeFileSystem(options.directory)
+  const session: DevServerSession = {
+    ...options.adminSession,
+    storefrontToken: options.storefrontToken,
+    expiresAt: new Date(),
+  }
+  const ctx = {
+    session,
+    remoteChecksums,
+    localThemeFileSystem,
+    themeEditorSync: options['theme-editor-sync'],
+  }
+
+  await startDevServer(options.theme, ctx, () => {
+    renderLinks(options.store, options.theme.id.toString(), options.host, options.port)
+  })
 }
 
 async function legacyDev(options: DevOptions) {
+  if (!(await hasRequiredThemeDirectories(options.directory)) && !(await currentDirectoryConfirmed(options.force))) {
+    return
+  }
+
   let adminToken: string | undefined = options.adminSession.token
   let storefrontToken: string | undefined = options.storefrontToken
 

--- a/packages/theme/src/cli/utilities/theme-environment/cookies.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/cookies.test.ts
@@ -1,0 +1,107 @@
+import {parseCookies, serializeCookies} from './cookies.js'
+import {describe, test, expect} from 'vitest'
+
+describe('cookies', () => {
+  describe('parseCookie', () => {
+    test('returns an empty object for an empty string', () => {
+      // Given
+      const input = ''
+
+      // When
+      const result = parseCookies(input)
+
+      // Then
+      expect(result).toEqual({})
+    })
+
+    test('parses a single cookie', () => {
+      // Given
+      const input = 'store=Snowdevil'
+
+      // When
+      const result = parseCookies(input)
+
+      // Then
+      expect(result).toEqual({store: 'Snowdevil'})
+    })
+
+    test('parses multiple cookies', () => {
+      // Given
+      const input = 'store=Snowdevil; tienda=Diablo de Nieve'
+
+      // When
+      const result = parseCookies(input)
+
+      // Then
+      expect(result).toEqual({store: 'Snowdevil', tienda: 'Diablo de Nieve'})
+    })
+
+    test('parses storefront cookies', () => {
+      // Given
+      const input = '_shopify_essential=:AA-bbb_ccc_DDD123-EEE_fff4G5ihj==:; other_cookie=:C=D=:'
+
+      // When
+      const result = parseCookies(input)
+
+      // Then
+      expect(result).toEqual({_shopify_essential: ':AA-bbb_ccc_DDD123-EEE_fff4G5ihj==:', other_cookie: ':C=D=:'})
+    })
+
+    test('trims whitespace from cookie names and values', () => {
+      // Given
+      const input = 'store = Snowdevil ; tienda = Diablo de Nieve '
+
+      // When
+      const result = parseCookies(input)
+
+      // Then
+      expect(result).toEqual({store: 'Snowdevil', tienda: 'Diablo de Nieve'})
+    })
+
+    test('handles cookies without a value', () => {
+      // Given
+      const input = 'store=; tienda=Diablo de Nieve'
+
+      // When
+      const result = parseCookies(input)
+
+      // Then
+      expect(result).toEqual({store: '', tienda: 'Diablo de Nieve'})
+    })
+  })
+
+  describe('serializeCookies', () => {
+    test('serializes an empty object to an empty string', () => {
+      // Given
+      const input = {}
+
+      // When
+      const result = serializeCookies(input)
+
+      // Then
+      expect(result).toBe('')
+    })
+
+    test('serializes a single cookie', () => {
+      // Given
+      const input = {store: 'Snowdevil'}
+
+      // When
+      const result = serializeCookies(input)
+
+      // Then
+      expect(result).toBe('store=Snowdevil')
+    })
+
+    test('serializes multiple cookies', () => {
+      // Given
+      const input = {store: 'Snowdevil', tienda: 'Diablo de Nieve'}
+
+      // When
+      const result = serializeCookies(input)
+
+      // Then
+      expect(result).toBe('store=Snowdevil; tienda=Diablo de Nieve')
+    })
+  })
+})

--- a/packages/theme/src/cli/utilities/theme-environment/cookies.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/cookies.ts
@@ -1,0 +1,22 @@
+export function parseCookies(cookies: string) {
+  const cookiesRecord: {[key: string]: string} = {}
+
+  cookies.split(';').forEach((cookie) => {
+    const parts = cookie.match(/(.*?)=(.*)$/) ?? []
+
+    const key = parts[1]?.trim()
+    const value = parts[2]?.trim() ?? ''
+
+    if (key) {
+      cookiesRecord[key] = value
+    }
+  })
+
+  return cookiesRecord
+}
+
+export function serializeCookies(cookies: {[key: string]: string}) {
+  return Object.entries(cookies)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('; ')
+}

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.test.ts
@@ -1,0 +1,159 @@
+import {render} from './storefront-renderer.js'
+import {getStorefrontSessionCookies} from './storefront-session.js'
+import {describe, expect, test, vi} from 'vitest'
+import {fetch} from '@shopify/cli-kit/node/http'
+import {ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
+
+vi.mock('./storefront-session.js')
+vi.mock('@shopify/cli-kit/node/session')
+vi.mock('@shopify/cli-kit/node/http', async () => {
+  const actual: any = await vi.importActual('@shopify/cli-kit/node/http')
+  return {
+    ...actual,
+    fetch: vi.fn(),
+  }
+})
+
+const successResponse = {status: 200, headers: {get: vi.fn()}} as any
+const sessionCookies = {
+  storefront_digest: '00001111222233334444',
+  _shopify_essential: ':00112233445566778899:',
+}
+
+const session = {
+  token: 'token_abc123',
+  storeFqdn: 'store.myshopify.com',
+  storefrontToken: 'token',
+  storefrontPassword: 'password',
+  expiresAt: new Date(),
+}
+
+const context = {
+  path: '/products/1',
+  themeId: '123',
+  query: [],
+  cookies: 'theme_cookie=abc;',
+  headers: {'Content-Length': '100', 'X-Special-Header': '200'},
+  replaceTemplates: {},
+  sectionId: '',
+}
+
+describe('render', () => {
+  test('renders using storefront API', async () => {
+    // Given
+    vi.mocked(fetch).mockResolvedValue(successResponse)
+    vi.mocked(getStorefrontSessionCookies).mockResolvedValue(sessionCookies)
+    vi.mocked(ensureAuthenticatedStorefront).mockResolvedValue('token_111222333')
+
+    // When
+    const response = await render(session, context)
+
+    // Then
+    expect(response.status).toEqual(200)
+    expect(fetch).toHaveBeenCalledWith(
+      'https://store.myshopify.com/products/1?_fd=0&pb=0',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token_111222333',
+          Cookie: 'theme_cookie=abc; storefront_digest=00001111222233334444; _shopify_essential=:00112233445566778899:',
+          'Content-Length': '100',
+          'X-Special-Header': '200',
+        }),
+      }),
+    )
+  })
+
+  test('renders using theme access API', async () => {
+    // Given
+    vi.mocked(fetch).mockResolvedValue(successResponse)
+    vi.mocked(getStorefrontSessionCookies).mockResolvedValue(sessionCookies)
+    const themeKitAccessSession = {...session, token: 'shptka_abc123'}
+
+    // When
+    const response = await render(themeKitAccessSession, context)
+
+    // Then
+    expect(response.status).toEqual(200)
+    expect(fetch).toHaveBeenCalledWith(
+      'https://theme-kit-access.shopifyapps.com/cli/sfr/products/1?_fd=0&pb=0',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Cookie: 'theme_cookie=abc; storefront_digest=00001111222233334444; _shopify_essential=:00112233445566778899:',
+          'X-Shopify-Shop': 'store.myshopify.com',
+          'X-Shopify-Access-Token': 'shptka_abc123',
+          'Content-Length': '100',
+        }),
+      }),
+    )
+    expect(fetch).toHaveBeenCalledWith(
+      'https://theme-kit-access.shopifyapps.com/cli/sfr/products/1?_fd=0&pb=0',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.not.objectContaining({
+          'X-Special-Header': '200',
+        }),
+      }),
+    )
+  })
+
+  test('renders using section ID', async () => {
+    // Given
+    vi.mocked(fetch).mockResolvedValue(successResponse)
+    vi.mocked(getStorefrontSessionCookies).mockResolvedValue(sessionCookies)
+    vi.mocked(ensureAuthenticatedStorefront).mockResolvedValue('token_111222333')
+
+    // When
+    const response = await render(session, {
+      ...context,
+      sectionId: 'sections--1__announcement-bar',
+    })
+
+    // Then
+    expect(response.status).toEqual(200)
+    expect(fetch).toHaveBeenCalledWith(
+      'https://store.myshopify.com/products/1?_fd=0&pb=0&section_id=sections--1__announcement-bar',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token_111222333',
+          Cookie: 'theme_cookie=abc; storefront_digest=00001111222233334444; _shopify_essential=:00112233445566778899:',
+          'Content-Length': '100',
+          'X-Special-Header': '200',
+        }),
+      }),
+    )
+  })
+
+  test('renders using query parameters', async () => {
+    // Given
+    vi.mocked(fetch).mockResolvedValue(successResponse)
+    vi.mocked(getStorefrontSessionCookies).mockResolvedValue(sessionCookies)
+    vi.mocked(ensureAuthenticatedStorefront).mockResolvedValue('token_111222333')
+
+    // When
+    const response = await render(session, {
+      ...context,
+      query: [
+        ['value', 'A'],
+        ['value', 'B'],
+      ],
+    })
+
+    // Then
+    expect(response.status).toEqual(200)
+    expect(fetch).toHaveBeenCalledWith(
+      'https://store.myshopify.com/products/1?_fd=0&pb=0&value=A&value=B',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token_111222333',
+          Cookie: 'theme_cookie=abc; storefront_digest=00001111222233334444; _shopify_essential=:00112233445566778899:',
+          'Content-Length': '100',
+          'X-Special-Header': '200',
+        }),
+      }),
+    )
+  })
+})

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
@@ -1,0 +1,120 @@
+import {getStorefrontSessionCookies} from './storefront-session.js'
+import {parseCookies, serializeCookies} from './cookies.js'
+import {defaultHeaders, storefrontReplaceTemplatesParams} from './storefront-utils.js'
+import {DevServerSession, DevServerRenderContext} from './types.js'
+import {outputDebug} from '@shopify/cli-kit/node/output'
+import {ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
+import {fetch, Response} from '@shopify/cli-kit/node/http'
+
+export async function render(session: DevServerSession, context: DevServerRenderContext): Promise<Response> {
+  const url = buildStorefrontUrl(session, context)
+
+  outputDebug(`→ Rendering ${url} (with ${Object.keys(context.replaceTemplates)})...`)
+
+  const bodyParams = storefrontReplaceTemplatesParams(context.replaceTemplates)
+  const headers = await buildHeaders(session, context)
+
+  const response = await fetch(url, {
+    method: 'POST',
+    body: bodyParams,
+    headers: {
+      ...headers,
+      ...defaultHeaders(),
+    },
+  })
+
+  outputDebug(`← ${response.status} (request_id: ${response.headers.get('x-request-id')})`)
+
+  return response
+}
+
+async function buildHeaders(session: DevServerSession, context: DevServerRenderContext) {
+  if (isThemeAccessSession(session)) {
+    return buildThemeAccessHeaders(session, context)
+  } else {
+    return buildStandardHeaders(session, context)
+  }
+}
+
+async function buildStandardHeaders(session: DevServerSession, context: DevServerRenderContext) {
+  const cookies = await buildCookies(session, context)
+  const storefrontToken = await ensureAuthenticatedStorefront([])
+
+  return {
+    Authorization: `Bearer ${storefrontToken}`,
+    Cookie: cookies,
+    ...context.headers,
+  }
+}
+
+async function buildThemeAccessHeaders(session: DevServerSession, context: DevServerRenderContext) {
+  const cookies = await buildCookies(session, context)
+  const storefrontToken = await ensureAuthenticatedStorefront([])
+  const filteredHeaders: {[key: string]: string} = {}
+  const filterKeys = ['ACCEPT', 'CONTENT-TYPE', 'CONTENT-LENGTH']
+
+  for (const [key, value] of Object.entries(context.headers)) {
+    if (filterKeys.includes(key.toUpperCase())) {
+      filteredHeaders[key] = value
+    }
+  }
+
+  return {
+    ...filteredHeaders,
+    ...themeAccessHeaders(session),
+    Authorization: `Bearer ${storefrontToken}`,
+    Cookie: cookies,
+  }
+}
+
+async function buildCookies(session: DevServerSession, {themeId, cookies: cookieString}: DevServerRenderContext) {
+  const cookies = parseCookies(cookieString)
+  const baseUrl = buildBaseStorefrontUrl(session)
+  const headers = isThemeAccessSession(session) ? themeAccessHeaders(session) : {}
+  const storefrontPassword = session.storefrontPassword
+
+  const sessionCookies = await getStorefrontSessionCookies(baseUrl, themeId, storefrontPassword, headers)
+
+  return serializeCookies({
+    ...cookies,
+    ...sessionCookies,
+  })
+}
+
+function buildStorefrontUrl(session: DevServerSession, {path, sectionId, query}: DevServerRenderContext) {
+  const baseUrl = buildBaseStorefrontUrl(session)
+  const url = `${baseUrl}${path}`
+  const params = new URLSearchParams({
+    _fd: '0',
+    pb: '0',
+  })
+
+  for (const [key, value] of query) {
+    params.append(key, value)
+  }
+
+  if (sectionId) {
+    params.append('section_id', sectionId)
+  }
+
+  return `${url}?${params}`
+}
+
+function buildBaseStorefrontUrl(session: DevServerSession) {
+  if (isThemeAccessSession(session)) {
+    return 'https://theme-kit-access.shopifyapps.com/cli/sfr'
+  } else {
+    return `https://${session.storeFqdn}`
+  }
+}
+
+function isThemeAccessSession(session: DevServerSession) {
+  return session.token.startsWith('shptka_')
+}
+
+function themeAccessHeaders(session: DevServerSession) {
+  return {
+    'X-Shopify-Shop': session.storeFqdn,
+    'X-Shopify-Access-Token': session.token,
+  }
+}

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -1,0 +1,132 @@
+import {getStorefrontSessionCookies, isStorefrontPasswordProtected} from './storefront-session.js'
+import {describe, expect, test, vi} from 'vitest'
+import {fetch} from '@shopify/cli-kit/node/http'
+
+vi.mock('@shopify/cli-kit/node/http')
+
+describe('Storefront API', () => {
+  describe('isStorefrontPasswordProtected', () => {
+    test('returns true when the store is password protected', async () => {
+      // Given
+      vi.mocked(fetch).mockResolvedValue(response({status: 302}))
+
+      // When
+      const isProtected = await isStorefrontPasswordProtected('https://store.myshopify.com')
+
+      // Then
+      expect(isProtected).toBe(true)
+    })
+
+    test('returns false when the store is not password protected', async () => {
+      // Given
+      vi.mocked(fetch).mockResolvedValue(response({status: 200}))
+
+      // When
+      const isProtected = await isStorefrontPasswordProtected('https://store.myshopify.com')
+
+      // Then
+      expect(isProtected).toBe(false)
+    })
+  })
+
+  describe('getStorefrontSessionCookies', () => {
+    test('retrieves only _shopify_essential cookie when no password is provided', async () => {
+      // Given
+      vi.mocked(fetch).mockResolvedValueOnce(
+        response({
+          status: 200,
+          headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
+        }),
+      )
+
+      // When
+      const cookies = await getStorefrontSessionCookies('https://example-store.myshopify.com', '123456')
+
+      // Then
+      expect(cookies).toEqual({_shopify_essential: ':AABBCCDDEEFFGGHH==123:'})
+    })
+
+    test('retrieves _shopify_essential and storefront_digest cookies when a password is provided', async () => {
+      // Given
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': 'storefront_digest=digest-value; path=/; HttpOnly'},
+          }),
+        )
+
+      // When
+      const cookies = await getStorefrontSessionCookies('https://example-store.myshopify.com', '123456', 'password')
+
+      // Then
+      expect(cookies).toEqual({_shopify_essential: ':AABBCCDDEEFFGGHH==123:', storefront_digest: 'digest-value'})
+    })
+
+    test(`throws an error when _shopify_essential can't be defined`, async () => {
+      // Given
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': ''},
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': 'storefront_digest=digest-value; path=/; HttpOnly'},
+          }),
+        )
+
+      // When
+      const cookies = getStorefrontSessionCookies('https://example-store.myshopify.com', '123456', 'password')
+
+      // Then
+      await expect(cookies).rejects.toThrow(
+        'Your development session could not be created because the "_shopify_essential" could not be defined. Please, check your internet connection.',
+      )
+    })
+
+    test('throws an error when the password is wrong', async () => {
+      // Given
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
+          }),
+        )
+        .mockResolvedValueOnce(response({status: 401}))
+
+      // When
+      const cookies = getStorefrontSessionCookies('https://example-store.myshopify.com', '123456', 'wrongpassword')
+
+      // Then
+      await expect(cookies).rejects.toThrow(
+        'Your development session could not be created because the store password is invalid. Please, retry with a different password.',
+      )
+    })
+  })
+
+  // Tests rely on this function because the 'packages/theme' package cannot
+  // directly access node-fetch and they use: new Response('OK', {status: 200})
+  function response(mock: {status: number; headers?: {[key: string]: string}}) {
+    const setCookieHeader = (mock.headers ?? {})['set-cookie'] ?? ''
+    const setCookieArray = [setCookieHeader]
+
+    return {
+      ...mock,
+      headers: {
+        ...mock.headers,
+        raw: vi.fn().mockReturnValue({'set-cookie': setCookieArray}),
+      },
+    } as any
+  }
+})

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -1,0 +1,116 @@
+import {parseCookies, serializeCookies} from './cookies.js'
+import {defaultHeaders} from './storefront-utils.js'
+import {fetch} from '@shopify/cli-kit/node/http'
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+export async function isStorefrontPasswordProtected(storeURL: string): Promise<boolean> {
+  const response = await fetch(storeURL, {
+    method: 'GET',
+    redirect: 'manual',
+  })
+
+  return response.status === 302
+}
+
+export async function getStorefrontSessionCookies(
+  storeUrl: string,
+  themeId: string,
+  password?: string,
+  headers: {[key: string]: string} = {},
+): Promise<{[key: string]: string}> {
+  const cookieRecord: {[key: string]: string} = {}
+  const shopifyEssential = await sessionEssentialCookie(storeUrl, themeId, headers)
+
+  if (!shopifyEssential) {
+    /**
+     * SFR should always define a _shopify_essential, so an error at this point
+     * is likely a Shopify error or firewall issue.
+     */
+    throw new AbortError(
+      'Your development session could not be created because the "_shopify_essential" could not be defined. Please, check your internet connection.',
+    )
+  }
+
+  cookieRecord._shopify_essential = shopifyEssential
+
+  if (!password) {
+    /**
+     * When the store is not password protected, storefront_digest is not
+     * required.
+     */
+    return cookieRecord
+  }
+
+  const storefrontDigest = await enrichSessionWithStorefrontPassword(shopifyEssential, storeUrl, password, headers)
+
+  if (!storefrontDigest) {
+    throw new AbortError(
+      'Your development session could not be created because the store password is invalid. Please, retry with a different password.',
+    )
+  }
+
+  cookieRecord.storefront_digest = storefrontDigest
+
+  return cookieRecord
+}
+
+async function sessionEssentialCookie(storeUrl: string, themeId: string, headers: {[key: string]: string}) {
+  const params = new URLSearchParams({
+    preview_theme_id: themeId,
+    _fd: '0',
+    pb: '0',
+  })
+
+  const url = `${storeUrl}?${params}`
+
+  const response = await fetch(url, {
+    method: 'HEAD',
+    redirect: 'manual',
+    headers: {
+      ...headers,
+      ...defaultHeaders(),
+    },
+  })
+
+  const setCookies = response.headers.raw()['set-cookie'] ?? []
+  const shopifyEssential = getCookie(setCookies, '_shopify_essential')
+
+  return shopifyEssential
+}
+
+async function enrichSessionWithStorefrontPassword(
+  shopifyEssential: string,
+  storeUrl: string,
+  password: string,
+  headers: {[key: string]: string},
+) {
+  const params = new URLSearchParams({password})
+
+  const response = await fetch(`${storeUrl}/password`, {
+    method: 'POST',
+    redirect: 'manual',
+    body: params,
+    headers: {
+      ...headers,
+      ...defaultHeaders(),
+      Cookie: serializeCookies({_shopify_essential: shopifyEssential}),
+    },
+  })
+
+  const setCookies = response.headers.raw()['set-cookie'] ?? []
+  const storefrontDigest = getCookie(setCookies, 'storefront_digest')
+
+  return storefrontDigest
+}
+
+function getCookie(setCookieArray: string[], cookieName: string) {
+  const cookie = setCookieArray.find((cookie) => {
+    return parseCookies(cookie)[cookieName]
+  })
+
+  if (!cookie) return
+
+  const parsedCookie = parseCookies(cookie)
+
+  return parsedCookie[cookieName]
+}

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-utils.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-utils.test.ts
@@ -1,0 +1,32 @@
+import {storefrontReplaceTemplatesParams} from './storefront-utils.js'
+import {describe, test, expect} from 'vitest'
+
+describe('storefrontFormData', () => {
+  test("returns the params string with correct mappings for section's content", () => {
+    // Given
+    const sections = {
+      'sections/announcement-bar.liquid': '<h1>Content</h1>',
+    }
+
+    // When
+    const formData = storefrontReplaceTemplatesParams(sections)
+
+    // Then
+    const formDataContent = formData.toString()
+    expect(formDataContent).toEqual(
+      'replace_templates%5Bsections%2Fannouncement-bar.liquid%5D=%3Ch1%3EContent%3C%2Fh1%3E&_method=GET',
+    )
+  })
+
+  test('handles empty sections record as expected', () => {
+    // Given
+    const sectionsContent = {}
+
+    // When
+    const formData = storefrontReplaceTemplatesParams(sectionsContent)
+
+    // Then
+    const formDataContent = formData.toString()
+    expect(formDataContent).toEqual('_method=GET')
+  })
+})

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-utils.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-utils.ts
@@ -1,0 +1,22 @@
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
+
+export function storefrontReplaceTemplatesParams(replaceTemplates: {[key: string]: string}): URLSearchParams {
+  /**
+   * Theme access proxy doesn't support FormData encoding.
+   */
+  const params = new URLSearchParams()
+
+  for (const [path, content] of Object.entries(replaceTemplates)) {
+    params.append(`replace_templates[${path}]`, content)
+  }
+
+  params.append('_method', 'GET')
+
+  return params
+}
+
+export function defaultHeaders() {
+  return {
+    'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
+  }
+}

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -1,5 +1,6 @@
-import {DevServerContext, startDevServer} from './theme-environment.js'
+import {startDevServer} from './theme-environment.js'
 import {reconcileAndPollThemeEditorChanges} from './remote-theme-watcher.js'
+import {DevServerContext} from './types.js'
 import {uploadTheme} from '../theme-uploader.js'
 import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
 import {describe, expect, test, vi} from 'vitest'
@@ -16,7 +17,7 @@ describe('startDevServer', () => {
     files: new Map([['templates/asset.json', {checksum: '1', key: 'templates/asset.json'}]]),
   } as ThemeFileSystem
   const defaultServerContext: DevServerContext = {
-    session: {storefrontToken: '', token: '', storeFqdn: ''},
+    session: {storefrontToken: '', token: '', storeFqdn: '', expiresAt: new Date()},
     remoteChecksums: [],
     localThemeFileSystem,
     themeEditorSync: false,

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -1,18 +1,7 @@
 import {reconcileAndPollThemeEditorChanges} from './remote-theme-watcher.js'
+import {DevServerContext} from './types.js'
 import {uploadTheme} from '../theme-uploader.js'
-import {AdminSession} from '@shopify/cli-kit/node/session'
-import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
-
-export interface DevServerSession extends AdminSession {
-  storefrontToken: string
-}
-
-export interface DevServerContext {
-  session: DevServerSession
-  remoteChecksums: Checksum[]
-  localThemeFileSystem: ThemeFileSystem
-  themeEditorSync: boolean
-}
+import {Theme} from '@shopify/cli-kit/node/themes/types'
 
 export async function startDevServer(theme: Theme, ctx: DevServerContext, onReady: () => void) {
   await ensureThemeEnvironmentSetup(theme, ctx)

--- a/packages/theme/src/cli/utilities/theme-environment/types.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/types.ts
@@ -1,0 +1,98 @@
+import {AdminSession} from '@shopify/cli-kit/node/session'
+import {Checksum, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
+
+/**
+ * Defines an authentication session for the theme development server.
+ *
+ * The AdminSession powers all API interactions with the Assets API, while
+ * storefrontToken and storefrontPassword enable interactions with the
+ * Storefront API.
+ *
+ * This session supports extended durations which can exceed 1h,
+ * and includes a field to track when the session was last refreshed.
+ */
+export interface DevServerSession extends AdminSession {
+  /**
+   * Token to authenticate section rendering API calls.
+   */
+  storefrontToken: string
+
+  /**
+   * Password for accessing password-protected stores.
+   */
+  storefrontPassword?: string
+
+  /**
+   * Timestamp marking when this session expires.
+   */
+  expiresAt: Date
+}
+
+/**
+ * Maintains the state of local and remote assets in theme development server.
+ */
+export interface DevServerContext {
+  /**
+   * Authentication session for development server operations.
+   */
+  session: DevServerSession
+
+  /**
+   * Checksums of remote assets.
+   */
+  remoteChecksums: Checksum[]
+
+  /**
+   * File system tracking local theme assets.
+   */
+  localThemeFileSystem: ThemeFileSystem
+
+  /**
+   * Indicates if theme editor changes are periodically pulled to the local
+   * theme.
+   */
+  themeEditorSync: boolean
+}
+
+/**
+ * Context for rendering pages in the development server.
+ *
+ * Holds properties that modify and influence how pages are rendered using
+ * different themes and settings, including section-specific rendering
+ */
+export interface DevServerRenderContext {
+  /**
+   * URL path to be rendered.
+   */
+  path: string
+
+  /**
+   * Theme identifier for rendering.
+   */
+  themeId: string
+
+  /**
+   * Query parameters to be used during rendering.
+   */
+  query: [string, string][]
+
+  /**
+   * Cookies to be used during rendering.
+   */
+  cookies: string
+
+  /**
+   * Optional identifier for rendering only a specific section.
+   */
+  sectionId?: string
+
+  /**
+   * Headers to be used in the rendering request.
+   */
+  headers: {[key: string]: string}
+
+  /**
+   * Custom content to be replaced during rendering.
+   */
+  replaceTemplates: {[key: string]: string}
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-advanced-edits/issues/210

This PR introduces the module that remotely renders storefronts and will power part of the `shopify theme dev` logic.

### WHAT is this pull request doing?

The public API introduced by this PR is:

```ts
render(session, renderContext)
```

Internally, the way it works is:
- `theme-environment/storefront-renderer.ts` - handles the rendering logic. It ensures that the request to render is authenticated, the session is refreshed*, and the required headers are being passed
- `theme-environment/storefront-session.ts` - handles the session/cookies creation to make sure the renderer is rendering the proper development theme with replace-templates capabilities

\* This will be introduced in a following PR

### How to test your changes?

This is an internal module and will be exposed by the proxy, so we need to manually call it:

- Open `packages/theme/src/cli/services/dev.ts` 
- Replace `dev` with this:
```ts
async function dev(options: DevOptions) {
  outputInfo('This feature is currently in development and is not ready for use or testing yet.')

  const session: DevServerSession = {
    ...options.adminSession,
    storefrontToken: options.storefrontToken,
    storefrontPassword: 'password', // <---------------------------------------- 1. YOUR STORE PASSWORD HERE
    expiresAt: new Date(),
  }

  const response = await render(session, {
    path: '/',
    query: [],
    themeId: options.theme.id.toString(),
    cookies: '',
    sectionId: 'sections--21614098907158__announcement-bar', // <-------------- 2. YOUR SECTION ID HERE
    headers: {},
    sections: {
      'sections/announcement-bar.liquid': '<h1>== Welcome ==/h1>',
    },
  })

  // eslint-disable-next-line no-console
  console.log('-----------------------')
  // eslint-disable-next-line no-console
  console.log(response.status)
  // eslint-disable-next-line no-console
  console.log(await response.text())
  // eslint-disable-next-line no-console
  console.log('-----------------------')
}
```
- Run `pnpm build`
- Run `shopify-dev theme dev --path ../dawn --dev-preview`

![image](https://github.com/Shopify/cli/assets/1079279/fa342925-6192-4272-9346-2add7bbb2f65)

### Post-release steps

None.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
