### PR TITLE
Renames default_placement_reference extension toml property to default_placement

### DIFF
--- a/.changeset/dirty-weeks-end.md
+++ b/.changeset/dirty-weeks-end.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': minor
+---
+
+Rename unreleased default_placement_reference extension property to default_placement.

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -31,7 +31,7 @@ const NewExtensionPointSchema = zod.object({
   target: zod.string(),
   module: zod.string(),
   metafields: zod.array(MetafieldSchema).optional(),
-  default_placement_reference: zod.string().optional(),
+  default_placement: zod.string().optional(),
 })
 
 export const NewExtensionPointsSchema = zod.array(NewExtensionPointSchema)

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -115,7 +115,7 @@ describe('ui_extension', async () => {
       ])
     })
 
-    test('targeting object accepts a default_placement_reference', async () => {
+    test('targeting object accepts a default_placement', async () => {
       const allSpecs = await loadLocalExtensionsSpecifications()
       const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
       const configuration = {
@@ -123,7 +123,7 @@ describe('ui_extension', async () => {
           {
             target: 'EXTENSION::POINT::A',
             module: './src/ExtensionPointA.js',
-            default_placement_reference: 'PLACEMENT_REFERENCE1',
+            default_placement: 'PLACEMENT_REFERENCE1',
           },
         ],
         api_version: '2023-01' as const,

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -29,7 +29,7 @@ export const UIExtensionSchema = BaseSchema.extend({
         target: targeting.target,
         module: targeting.module,
         metafields: targeting.metafields ?? config.metafields ?? [],
-        default_placement_reference: targeting.default_placement_reference,
+        default_placement_reference: targeting.default_placement,
       }
     })
     return {...config, extension_points: extensionPoints}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/core-issues/issues/70722
Homogenizing the terminology to "placement" instead of "placement_reference" et al.

### WHAT is this pull request doing?
Just renames the key used by developers. This is an unreleased feature (not yet enabled in core), so we want to get the terminology correct before release. Does not rename the values passed on to core.

### How to test your changes?

The process is to have a local copy of CLI point at an spin instance, and then to deploy a locally developed ui extension on that instance.
- use my instance "rename-default-placement-3"

```
SHOPIFY_CLI_1P_DEV=1 SPIN_INSTANCE=rename-default-placement-3 SHOPIFY_SERVICE_ENV=spin pnpm create @shopify/app 
```

In the new app directory:
 
```
SPIN_INSTANCE=rename-default-placement-3 SHOPIFY_SERVICE_ENV=spin pnpm shopify app generate extension 
```

Configure your extension toml to include `default_placement`. ex:

```
[[extensions.targeting]]
module = "./src/Banner.tsx"
target = "purchase.checkout.block.render"
default_placement = "order_summary2"
```

back in your CLI directory start the server. ex:

```
SPIN_INSTANCE=rename-default-placement-3 SHOPIFY_SERVICE_ENV=spin pnpm shopify app dev --path /Users/johnking/src/github.com/Shopify/cli/default-placements 
```

deploy the app

```
SPIN_INSTANCE=rename-default-placement-3 SHOPIFY_SERVICE_ENV=spin pnpm shopify app deploy --path /Users/johnking/src/github.com/Shopify/cli/default-placements 
```

The app should deploy successfully. Or if you use an invalid value for default_placement you should get an error.


### Post-release steps
n/a
### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
