### PR TITLE
Remove lock files from .gitignore after app init

### DIFF
--- a/.changeset/ninety-bottles-whisper.md
+++ b/.changeset/ninety-bottles-whisper.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': patch
+---
+
+Lock files are removed from .gitignore after app init

--- a/packages/create-app/src/commands/init.ts
+++ b/packages/create-app/src/commands/init.ts
@@ -83,6 +83,9 @@ export default class Init extends Command {
       local: flags.local,
       directory: flags.path,
       useGlobalCLI: promptAnswers.globalCLIResult.alreadyInstalled || promptAnswers.globalCLIResult.install,
+      postCloneActions: {
+        removeLockfilesFromGitignore: promptAnswers.templateType !== 'custom',
+      },
     })
   }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/develop-app-management/issues/1786

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

After cloning an app template, lock files are removed from .gitignore, provided one of our built-in templates was used. If you used a custom url we assume you know what you're doing.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

`pnpm create-app --path="<somewhere>"` will exercise this

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
