### PR TITLE
Prompt to convert dev stores to transfer-disabled

### DIFF
--- a/.changeset/tough-rings-dress.md
+++ b/.changeset/tough-rings-dress.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/app': minor
+---
+
+Dev stores are no longer automatically made transfer-disabled

--- a/packages/app/src/cli/api/graphql/convert_dev_to_transfer_disabled_store.ts
+++ b/packages/app/src/cli/api/graphql/convert_dev_to_transfer_disabled_store.ts
@@ -1,6 +1,6 @@
 import {gql} from 'graphql-request'
 
-export const ConvertDevToTestStoreQuery = gql`
+export const ConvertDevToTransferDisabledStoreQuery = gql`
   mutation convertDevToTestStore($input: ConvertDevToTestStoreInput!) {
     convertDevToTestStore(input: $input) {
       convertedToTestStore
@@ -12,14 +12,14 @@ export const ConvertDevToTestStoreQuery = gql`
   }
 `
 
-export interface ConvertDevToTestStoreVariables {
+export interface ConvertDevToTransferDisabledStoreVariables {
   input: {
     organizationID: number
     shopId: string
   }
 }
 
-export interface ConvertDevToTestStoreSchema {
+export interface ConvertDevToTransferDisabledSchema {
   convertDevToTestStore: {
     convertedToTestStore: boolean
     userErrors: {

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -21,7 +21,7 @@ import {
   GenerateSignedUploadUrlVariables,
 } from '../../api/graphql/generate_signed_upload_url.js'
 import {ExtensionCreateSchema, ExtensionCreateVariables} from '../../api/graphql/extension_create.js'
-import {ConvertDevToTestStoreVariables} from '../../api/graphql/convert_dev_to_test_store.js'
+import {ConvertDevToTransferDisabledStoreVariables} from '../../api/graphql/convert_dev_to_transfer_disabled_store.js'
 import {
   DevelopmentStorePreviewUpdateInput,
   DevelopmentStorePreviewUpdateSchema,
@@ -909,7 +909,7 @@ const generateSignedUploadUrlResponse: GenerateSignedUploadUrlSchema = {
   },
 }
 
-const convertedToTestStoreResponse = {
+const convertedToTransferDisabledStoreResponse = {
   convertDevToTestStore: {
     convertedToTestStore: true,
     userErrors: [],
@@ -1017,7 +1017,8 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     release: (_input: AppReleaseVariables) => Promise.resolve(releaseResponse),
     generateSignedUploadUrl: (_input: GenerateSignedUploadUrlVariables) =>
       Promise.resolve(generateSignedUploadUrlResponse),
-    convertToTestStore: (_input: ConvertDevToTestStoreVariables) => Promise.resolve(convertedToTestStoreResponse),
+    convertToTransferDisabledStore: (_input: ConvertDevToTransferDisabledStoreVariables) =>
+      Promise.resolve(convertedToTransferDisabledStoreResponse),
     updateDeveloperPreview: (_input: DevelopmentStorePreviewUpdateInput) =>
       Promise.resolve(updateDeveloperPreviewResponse),
     appPreviewMode: (_input: FindAppPreviewModeVariables) => Promise.resolve(appPreviewModeResponse),

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -74,6 +74,15 @@ export async function selectStorePrompt(stores: OrganizationStore[]): Promise<Or
   return stores.find((store) => store.shopId === id)
 }
 
+export async function confirmConversionToTransferDisabledStorePrompt(): Promise<boolean> {
+  return renderConfirmationPrompt({
+    message: `Make this store transfer-disabled? For security, once you use a development store to preview an app locally, the store can never be transferred to a merchant to use as a production store.`,
+    confirmationMessage: 'Yes, make this store transfer-disabled permanently',
+    cancellationMessage: 'No, select another store',
+    defaultValue: false,
+  })
+}
+
 export async function appNamePrompt(currentName: string): Promise<string> {
   return renderTextPrompt({
     message: 'App name',

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -6,7 +6,7 @@ import {
   fetchStoreByDomain,
 } from './dev/fetch.js'
 import {selectOrCreateApp} from './dev/select-app.js'
-import {selectStore, convertToTestStoreIfNeeded} from './dev/select-store.js'
+import {selectStore, convertToTransferDisabledStoreIfNeeded} from './dev/select-store.js'
 import {ensureDeploymentIdsPresence} from './context/identifiers.js'
 import {
   DevContextOptions,
@@ -766,7 +766,7 @@ api_version = "2023-04"
   test('returns selected data and updates internal state, with inputs from flags', async () => {
     // Given
     vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
-    vi.mocked(convertToTestStoreIfNeeded).mockResolvedValueOnce()
+    vi.mocked(convertToTransferDisabledStoreIfNeeded).mockResolvedValueOnce()
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
     const options = devOptions({apiKey: 'key2', storeFqdn: 'domain1'})

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -766,7 +766,7 @@ api_version = "2023-04"
   test('returns selected data and updates internal state, with inputs from flags', async () => {
     // Given
     vi.mocked(getCachedAppInfo).mockReturnValue(undefined)
-    vi.mocked(convertToTransferDisabledStoreIfNeeded).mockResolvedValueOnce()
+    vi.mocked(convertToTransferDisabledStoreIfNeeded).mockResolvedValueOnce(true)
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
     vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
     const options = devOptions({apiKey: 'key2', storeFqdn: 'domain1'})

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -298,7 +298,8 @@ const storeFromFqdn = async (
 ): Promise<OrganizationStore> => {
   const result = await fetchStoreByDomain(orgId, storeFqdn, developerPlatformClient)
   if (result?.store) {
-    await convertToTransferDisabledStoreIfNeeded(result.store, orgId, developerPlatformClient)
+    // never automatically convert a store provided via the cache
+    await convertToTransferDisabledStoreIfNeeded(result.store, orgId, developerPlatformClient, 'never')
     return result.store
   } else {
     throw new AbortError(`Couldn't find the store with domain "${storeFqdn}".`, resetHelpMessage)
@@ -760,7 +761,13 @@ async function fetchDevDataFromOptions(
 
   if (options.storeFqdn) {
     selectedStore = orgWithStore!.store
-    await convertToTransferDisabledStoreIfNeeded(selectedStore, orgWithStore!.organization.id, developerPlatformClient)
+    // never automatically convert a store provided via the command line
+    await convertToTransferDisabledStoreIfNeeded(
+      selectedStore,
+      orgWithStore!.organization.id,
+      developerPlatformClient,
+      'never',
+    )
   }
 
   return {app: selectedApp, store: selectedStore}

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -1,6 +1,6 @@
 import {selectOrCreateApp} from './dev/select-app.js'
 import {fetchOrgFromId, fetchOrganizations, fetchStoreByDomain} from './dev/fetch.js'
-import {convertToTestStoreIfNeeded, selectStore} from './dev/select-store.js'
+import {convertToTransferDisabledStoreIfNeeded, selectStore} from './dev/select-store.js'
 import {ensureDeploymentIdsPresence} from './context/identifiers.js'
 import {createExtension} from './dev/create-extension.js'
 import {CachedAppInfo, clearCachedAppInfo, getCachedAppInfo, setCachedAppInfo} from './local-storage.js'
@@ -298,7 +298,7 @@ const storeFromFqdn = async (
 ): Promise<OrganizationStore> => {
   const result = await fetchStoreByDomain(orgId, storeFqdn, developerPlatformClient)
   if (result?.store) {
-    await convertToTestStoreIfNeeded(result.store, orgId, developerPlatformClient)
+    await convertToTransferDisabledStoreIfNeeded(result.store, orgId, developerPlatformClient)
     return result.store
   } else {
     throw new AbortError(`Couldn't find the store with domain "${storeFqdn}".`, resetHelpMessage)
@@ -760,7 +760,7 @@ async function fetchDevDataFromOptions(
 
   if (options.storeFqdn) {
     selectedStore = orgWithStore!.store
-    await convertToTestStoreIfNeeded(selectedStore, orgWithStore!.organization.id, developerPlatformClient)
+    await convertToTransferDisabledStoreIfNeeded(selectedStore, orgWithStore!.organization.id, developerPlatformClient)
   }
 
   return {app: selectedApp, store: selectedStore}

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -85,7 +85,7 @@ describe('selectStore', async () => {
 
     // Then
     expect(got).toEqual(STORE2)
-    expect(developerPlatformClient.convertToTestStore).not.toHaveBeenCalled()
+    expect(developerPlatformClient.convertToTransferDisabledStore).not.toHaveBeenCalled()
     expect(selectStorePrompt).toHaveBeenCalledWith([STORE1, STORE2])
   })
 

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -1,7 +1,11 @@
 import {selectStore} from './select-store.js'
 import {fetchAllDevStores} from './fetch.js'
 import {Organization, OrganizationStore} from '../../models/organization.js'
-import {reloadStoreListPrompt, selectStorePrompt} from '../../prompts/dev.js'
+import {
+  reloadStoreListPrompt,
+  selectStorePrompt,
+  confirmConversionToTransferDisabledStorePrompt,
+} from '../../prompts/dev.js'
 import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {isSpinEnvironment} from '@shopify/cli-kit/node/context/spin'
@@ -64,6 +68,7 @@ describe('selectStore', async () => {
   test('prompts user to convert store to non-transferable if selection is invalid', async () => {
     // Given
     vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE2)
+    vi.mocked(confirmConversionToTransferDisabledStorePrompt).mockResolvedValueOnce(true)
 
     // When
     const got = await selectStore([STORE1, STORE2], ORG1, testDeveloperPlatformClient())
@@ -71,6 +76,22 @@ describe('selectStore', async () => {
     // Then
     expect(got).toEqual(STORE2)
     expect(selectStorePrompt).toHaveBeenCalledWith([STORE1, STORE2])
+    expect(confirmConversionToTransferDisabledStorePrompt).toHaveBeenCalled()
+  })
+
+  test('choosing not to convert to transfer-disabled forces another prompt', async () => {
+    // Given
+    vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE2)
+    vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE1)
+    vi.mocked(confirmConversionToTransferDisabledStorePrompt).mockResolvedValueOnce(false)
+
+    // When
+    const got = await selectStore([STORE1, STORE2], ORG1, testDeveloperPlatformClient())
+
+    // Then
+    expect(got).toEqual(STORE1)
+    expect(selectStorePrompt).toHaveBeenCalledWith([STORE1, STORE2])
+    expect(confirmConversionToTransferDisabledStorePrompt).toHaveBeenCalled()
   })
 
   test('not prompts user to convert store to non-transferable if selection is invalid inside spin instance and first party', async () => {

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -133,33 +133,32 @@ export async function convertToTransferDisabledStoreIfNeeded(
    * Against production (!isSpinEnvironment()), this allows you to reference other shops in a TOML file even if some of
    * the dev experience isn't completely supported.
    */
-  if (firstPartyDev()) return true
+  if (store.transferDisabled || firstPartyDev()) return true
+
   if (!store.transferDisabled && !store.convertableToPartnerTest) {
     throw new AbortError(
       `The store you specified (${store.shopDomain}) is not a dev store`,
       'Run dev --reset and select an eligible dev store.',
     )
   }
-  if (!store.transferDisabled) {
-    switch (conversionMode) {
-      case 'prompt-first': {
-        const confirmed = await confirmConversionToTransferDisabledStorePrompt()
-        if (!confirmed) {
-          // tell caller the store is invalid and not converted. they may re-prompt etc.
-          return false
-        }
-        await convertStoreToTransferDisabled(store, orgId, developerPlatformClient)
-        break
+
+  switch (conversionMode) {
+    case 'prompt-first': {
+      const confirmed = await confirmConversionToTransferDisabledStorePrompt()
+      if (!confirmed) {
+        // tell caller the store is invalid and not converted. they may re-prompt etc.
+        return false
       }
-      case 'never': {
-        throw new AbortError(
-          'The store you specified is not transfer-disabled',
-          "Try running 'dev --reset' and selecting a different store, or choosing to convert this one.",
-        )
-      }
+      await convertStoreToTransferDisabled(store, orgId, developerPlatformClient)
+      return true
+    }
+    case 'never': {
+      throw new AbortError(
+        'The store you specified is not transfer-disabled',
+        "Try running 'dev --reset' and selecting a different store, or choosing to convert this one.",
+      )
     }
   }
-  return true
 }
 
 /**

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -1,5 +1,9 @@
 import {Organization, OrganizationStore} from '../../models/organization.js'
-import {reloadStoreListPrompt, selectStorePrompt} from '../../prompts/dev.js'
+import {
+  confirmConversionToTransferDisabledStorePrompt,
+  reloadStoreListPrompt,
+  selectStorePrompt,
+} from '../../prompts/dev.js'
 import {
   ConvertDevToTransferDisabledSchema,
   ConvertDevToTransferDisabledStoreVariables,
@@ -35,22 +39,39 @@ export async function selectStore(
   org: Organization,
   developerPlatformClient: DeveloperPlatformClient,
 ): Promise<OrganizationStore> {
-  const store = await selectStorePrompt(stores)
-  if (store) {
-    await convertToTransferDisabledStoreIfNeeded(store, org.id, developerPlatformClient)
-    return store
+  // If no stores, guide the developer through creating one
+  // Then, with a store selected, make sure its transfer-disabled, prompting to convert if needed
+  let store = await selectStorePrompt(stores)
+  if (!store) {
+    outputInfo(`\n${await CreateStoreLink(org.id)}`)
+    await sleep(5)
+
+    const reload = await reloadStoreListPrompt(org)
+    if (!reload) {
+      throw new CancelExecution()
+    }
+
+    const data = await waitForCreatedStore(org.id, developerPlatformClient)
+    store = await selectStore(data, org, developerPlatformClient)
   }
 
-  outputInfo(`\n${await CreateStoreLink(org.id)}`)
-  await sleep(5)
-
-  const reload = await reloadStoreListPrompt(org)
-  if (!reload) {
-    throw new CancelExecution()
+  let storeIsValid = await convertToTransferDisabledStoreIfNeeded(
+    store,
+    org.id,
+    developerPlatformClient,
+    'prompt-first',
+  )
+  while (!storeIsValid) {
+    // eslint-disable-next-line no-await-in-loop
+    store = await selectStorePrompt(stores)
+    if (!store) {
+      throw new CancelExecution()
+    }
+    // eslint-disable-next-line no-await-in-loop
+    storeIsValid = await convertToTransferDisabledStoreIfNeeded(store, org.id, developerPlatformClient, 'prompt-first')
   }
 
-  const data = await waitForCreatedStore(org.id, developerPlatformClient)
-  return selectStore(data, org, developerPlatformClient)
+  return store
 }
 
 /**
@@ -91,37 +112,58 @@ async function waitForCreatedStore(
 
 /**
  * Check if the store exists in the current organization and it is a valid store
- * To be valid, it must be non-transferable.
+ * To be valid, it must be non-transferable. This can't be undone, so we ask the user to confirm.
+ *
  * @param storeDomain - Store domain to check
  * @param stores - List of available stores
  * @param orgId - Current organization ID
  * @param developerPlatformClient - The client to access the platform API
- * @returns True if the store is valid
+ * @param conversionMode - Whether to prompt the user to convert the store to a transfer-disabled store, or fail if it's not
+ * @returns False, if the store is invalid and the user chose not to convert it. Otherwise true.
  * @throws If the store can't be found in the organization or we fail to make it a transfer-disabled store
  */
 export async function convertToTransferDisabledStoreIfNeeded(
   store: OrganizationStore,
   orgId: string,
   developerPlatformClient: DeveloperPlatformClient,
-): Promise<void> {
+  conversionMode: 'prompt-first' | 'never',
+): Promise<boolean> {
   /**
    * It's not possible to convert stores to dev ones in spin environments. Should be created directly as development.
    * Against production (!isSpinEnvironment()), this allows you to reference other shops in a TOML file even if some of
    * the dev experience isn't completely supported.
    */
-  if (firstPartyDev()) return
+  if (firstPartyDev()) return true
   if (!store.transferDisabled && !store.convertableToPartnerTest) {
     throw new AbortError(
       `The store you specified (${store.shopDomain}) is not a dev store`,
       'Run dev --reset and select an eligible dev store.',
     )
   }
-  if (!store.transferDisabled) await convertStoreToTransferDisabled(store, orgId, developerPlatformClient)
+  if (!store.transferDisabled) {
+    switch (conversionMode) {
+      case 'prompt-first': {
+        const confirmed = await confirmConversionToTransferDisabledStorePrompt()
+        if (!confirmed) {
+          // tell caller the store is invalid and not converted. they may re-prompt etc.
+          return false
+        }
+        await convertStoreToTransferDisabled(store, orgId, developerPlatformClient)
+        break
+      }
+      case 'never': {
+        throw new AbortError(
+          'The store you specified is not transfer-disabled',
+          "Try running 'dev --reset' and selecting a different store, or choosing to convert this one.",
+        )
+      }
+    }
+  }
+  return true
 }
 
 /**
  * Convert a store to a transfer-disabled store so development apps can be installed
- * This can't be undone, so we ask the user to confirm
  * @param store - Store to convert
  * @param orgId - Current organization ID
  * @param developerPlatformClient - The client to access the platform API

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -17,7 +17,10 @@ import {
   GenerateSignedUploadUrlVariables,
 } from '../api/graphql/generate_signed_upload_url.js'
 import {ExtensionCreateSchema, ExtensionCreateVariables} from '../api/graphql/extension_create.js'
-import {ConvertDevToTestStoreSchema, ConvertDevToTestStoreVariables} from '../api/graphql/convert_dev_to_test_store.js'
+import {
+  ConvertDevToTransferDisabledSchema,
+  ConvertDevToTransferDisabledStoreVariables,
+} from '../api/graphql/convert_dev_to_transfer_disabled_store.js'
 import {FindStoreByDomainSchema} from '../api/graphql/find_store_by_domain.js'
 import {AppVersionsQuerySchema} from '../api/graphql/get_versions_list.js'
 import {
@@ -147,7 +150,9 @@ export interface DeveloperPlatformClient {
   updateExtension: (input: ExtensionUpdateDraftInput) => Promise<ExtensionUpdateSchema>
   deploy: (input: AppDeployOptions) => Promise<AppDeploySchema>
   release: (input: AppReleaseVariables) => Promise<AppReleaseSchema>
-  convertToTestStore: (input: ConvertDevToTestStoreVariables) => Promise<ConvertDevToTestStoreSchema>
+  convertToTransferDisabledStore: (
+    input: ConvertDevToTransferDisabledStoreVariables,
+  ) => Promise<ConvertDevToTransferDisabledSchema>
   updateDeveloperPreview: (input: DevelopmentStorePreviewUpdateInput) => Promise<DevelopmentStorePreviewUpdateSchema>
   appPreviewMode: (input: FindAppPreviewModeVariables) => Promise<FindAppPreviewModeSchema>
   sendSampleWebhook: (input: SendSampleWebhookVariables) => Promise<SendSampleWebhookSchema>

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -47,10 +47,10 @@ import {
   ExtensionCreateVariables,
 } from '../../api/graphql/extension_create.js'
 import {
-  ConvertDevToTestStoreQuery,
-  ConvertDevToTestStoreSchema,
-  ConvertDevToTestStoreVariables,
-} from '../../api/graphql/convert_dev_to_test_store.js'
+  ConvertDevToTransferDisabledStoreQuery,
+  ConvertDevToTransferDisabledSchema,
+  ConvertDevToTransferDisabledStoreVariables,
+} from '../../api/graphql/convert_dev_to_transfer_disabled_store.js'
 import {
   FindStoreByDomainQuery,
   FindStoreByDomainQueryVariables,
@@ -369,8 +369,10 @@ export class PartnersClient implements DeveloperPlatformClient {
     return this.request(GenerateSignedUploadUrl, input)
   }
 
-  async convertToTestStore(input: ConvertDevToTestStoreVariables): Promise<ConvertDevToTestStoreSchema> {
-    return this.request(ConvertDevToTestStoreQuery, input)
+  async convertToTransferDisabledStore(
+    input: ConvertDevToTransferDisabledStoreVariables,
+  ): Promise<ConvertDevToTransferDisabledSchema> {
+    return this.request(ConvertDevToTransferDisabledStoreQuery, input)
   }
 
   async storeByDomain(orgId: string, shopDomain: string): Promise<FindStoreByDomainSchema> {

--- a/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/shopify-developers-client.ts
@@ -55,9 +55,9 @@ import {FindStoreByDomainSchema} from '../../api/graphql/find_store_by_domain.js
 import {AppVersionsQuerySchema} from '../../api/graphql/get_versions_list.js'
 import {ExtensionCreateSchema, ExtensionCreateVariables} from '../../api/graphql/extension_create.js'
 import {
-  ConvertDevToTestStoreSchema,
-  ConvertDevToTestStoreVariables,
-} from '../../api/graphql/convert_dev_to_test_store.js'
+  ConvertDevToTransferDisabledSchema,
+  ConvertDevToTransferDisabledStoreVariables,
+} from '../../api/graphql/convert_dev_to_transfer_disabled_store.js'
 import {FindAppPreviewModeSchema, FindAppPreviewModeVariables} from '../../api/graphql/find_app_preview_mode.js'
 import {
   DevelopmentStorePreviewUpdateInput,
@@ -449,8 +449,10 @@ export class ShopifyDevelopersClient implements DeveloperPlatformClient {
     throw new BugError('Not implemented: createExtension')
   }
 
-  async convertToTestStore(_input: ConvertDevToTestStoreVariables): Promise<ConvertDevToTestStoreSchema> {
-    throw new BugError('Not implemented: convertToTestStore')
+  async convertToTransferDisabledStore(
+    _input: ConvertDevToTransferDisabledStoreVariables,
+  ): Promise<ConvertDevToTransferDisabledSchema> {
+    throw new BugError('Not implemented: convertToTransferDisabledStore')
   }
 
   async updateDeveloperPreview(

--- a/packages/cli-kit/src/private/node/ui/utilities.ts
+++ b/packages/cli-kit/src/private/node/ui/utilities.ts
@@ -2,5 +2,7 @@ import {appendToTokenItem, TokenItem, tokenItemToString} from './components/Toke
 
 export function messageWithPunctuation(message: TokenItem) {
   const messageToString = tokenItemToString(message)
-  return messageToString.endsWith('?') || messageToString.endsWith(':') ? message : appendToTokenItem(message, ':')
+  return messageToString.endsWith('?') || messageToString.endsWith(':') || messageToString.endsWith('.')
+    ? message
+    : appendToTokenItem(message, ':')
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/develop-app-management/issues/1785 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

In the usual place where a dev store is selected, prompt prior to converting it to transfer-disabled (where that is required). The user can choose to select a different store if needed.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Internal video: https://share.descript.com/view/QtyPwXjPLEu (has a small snag which is corrected now)

- Create a dev store on partners. Choose the left-hand option, not the "I want to test apps" option. Give it a minute or so to become real, and follow the login prompt partners will send you to.
- Run `p shopify app dev --reset` and select that store.
- See the new warning

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
