### PR TITLE
Create new remote only extension app includes the access scopes

### DIFF
--- a/.changeset/young-lamps-explode.md
+++ b/.changeset/young-lamps-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Create new remote only extension app includes the access scopes

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
@@ -78,12 +78,15 @@ describe('createApp', () => {
       title: LOCAL_APP.name,
       appUrl: 'https://shopify.dev/apps/default-app-home',
       redir: ['https://shopify.dev/apps/default-app-home/api/auth'],
-      requestedAccessScopes: [],
+      requestedAccessScopes: ['write_products'],
       type: 'undecided',
     }
 
     // When
-    const got = await partnersClient.createApp(ORG1, LOCAL_APP.name, {isLaunchable: false})
+    const got = await partnersClient.createApp(ORG1, LOCAL_APP.name, {
+      isLaunchable: false,
+      scopesArray: ['write_products'],
+    })
 
     // Then
     expect(got).toEqual({...APP1, newApp: true, developerPlatformClient: partnersClient})

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -170,7 +170,7 @@ function getAppVars(
       title: `${name}`,
       appUrl: MAGIC_URL,
       redir: [MAGIC_REDIRECT_URL],
-      requestedAccessScopes: [],
+      requestedAccessScopes: scopesArray ?? [],
       type: 'undecided',
     }
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When you create a new `Only extension app` using the CLI, then you modify the `toml` to add some scopes and finally run the `dev` or `deploy` command to create a new remote app, then the `scopes` in the resulting `toml` are empty

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- The scopes included in the `toml` are passed to the `CreateApp` mutation either for `launchable` apps or for `only extension apps`

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Create a new `only extension` app with the CLI
- Edit the `toml` to include `scopes = "write_products"`
- Run the `dev` or `deploy` command with `--reset` and create a new remote app
- Check the resulting `toml` and the `scopes = "write_products"` entry should be there
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
