### PR TITLE
[Themes] Render deprecation warning when poll flag is provided to TS dev command

### DIFF
--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -37,6 +37,12 @@ export async function dev(options: DevOptions) {
   }
 
   if (options['dev-preview']) {
+    if (options.flagsToPass.includes('--poll')) {
+      renderWarning({
+        body: 'The CLI flag --[flag-name] is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
+      })
+    }
+
     outputInfo('This feature is currently in development and is not ready for use or testing yet.')
 
     const remoteChecksums = await fetchChecksums(options.theme.id, options.adminSession)


### PR DESCRIPTION
### WHY are these changes introduced?
- https://github.com/Shopify/develop-advanced-edits/issues/199

### WHAT is this pull request doing?
Renders a warning to the user when they provide the poll flag in the TS flow

<img width="988" alt="Screenshot 2024-05-16 at 10 11 24 AM" src="https://github.com/Shopify/cli/assets/35415298/5d18c356-2c95-4b4b-8aa2-650e202933df">

### How to test your changes?
`pnpm shopify theme dev --path=<PATH_TO_THEME> --dev-preview --poll`

If you run into issues on the build step relating to authentication, you may need to remove `app-management` from `allAPIs` in `packages/cli-kit/src/private/node/api.ts`

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
