### PR TITLE
Add filters to SingleWebhookSubscriptionType

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -369,7 +369,7 @@ describe('draftMessages', async () => {
       const subscription = extensionInstance.configuration as unknown as SingleWebhookSubscriptionType
       let result = ''
       if (subscription) {
-        result = hashString(subscription.topic + subscription.uri).substring(0, 30)
+        result = hashString(subscription.topic + subscription.uri + subscription.filter).substring(0, 30)
       }
 
       // Then

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -351,7 +351,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
       case 'dynamic':
         // Hardcoded temporal solution for webhooks
         const subscription = this.configuration as unknown as SingleWebhookSubscriptionType
-        const handle = `${subscription.topic}${subscription.uri}`
+        const handle = `${subscription.topic}${subscription.uri}${subscription.filter}`
         return hashString(handle).substring(0, 30)
     }
   }

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
@@ -22,6 +22,7 @@ export const SingleWebhookSubscriptionSchema = zod.object({
   uri: zod.preprocess(removeTrailingSlash, UriValidation, {required_error: 'Missing value at'}),
   sub_topic: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
   include_fields: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
+  filter: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
 })
 
 /* this transforms webhooks remotely to be accepted by the TOML


### PR DESCRIPTION
### WHY are these changes introduced?
- This adds filter that was introduced in https://github.com/Shopify/cli/pull/3862 to the SingleWebhookSubscriptionType which was introduced in https://github.com/Shopify/cli/pull/3846.  As we're moving to multiple modules for webhook subscriptions this is required to enable filtering.

### WHAT is this pull request doing?
Adds filtering to SingleWebhookSubscriptionType so we can create webhook subscriptions with filters in the new module layout.

### How to test your changes?
- Enable the declarative webhooks beta flags
- Created an app with the following webhooks configuration in the TOML file
```
[webhooks]
api_version = "unstable"

  [[webhooks.subscriptions]]
  topics = [ "products/update" ]
  uri = "https://webhook.site/f8577819-9c7e-44ab-8012-b13f784ddc73"
  include_fields = [ "id" ]
  filter = "id:>100"
```

Ran the following command to deploy my app:
```
export SPIN_INSTANCE=constellation-partners-events-cli-k9kt
SHOPIFY_SERVICE_ENV=spin NODE_TLS_REJECT_UNAUTHORIZED=0 pnpm shopify app deploy --path ./test-filter-app
```

Validated that the subscription was set with the filter in the multi-module subscription's app module:
![image](https://github.com/Shopify/cli/assets/1899157/7bfa7eae-e35d-4af3-b7ed-6f90d065845e)
![image](https://github.com/Shopify/cli/assets/1899157/55a3be12-51a8-49be-b916-bf568faf1a31)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
