### PR TITLE
Add log polling to `dev` command

### DIFF
--- a/packages/app/src/cli/api/graphql/subscribe_to_app_logs.ts
+++ b/packages/app/src/cli/api/graphql/subscribe_to_app_logs.ts
@@ -1,0 +1,25 @@
+import {gql} from 'graphql-request'
+
+export interface AppLogsSubscribeVariables {
+  shopIds: string[]
+  apiKey: string
+  token: string
+}
+
+export interface AppLogsSubscribeResponse {
+  appLogsSubscribe: {
+    success: boolean
+    errors?: string[]
+    jwtToken: string
+  }
+}
+
+export const AppLogsSubscribeMutation = gql`
+  mutation AppLogsSubscribe($apiKey: String!, $shopIds: [ID!]!) {
+    appLogsSubscribe(input: {apiKey: $apiKey, shopIds: $shopIds}) {
+      jwtToken
+      success
+      errors
+    }
+  }
+`

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -2,6 +2,7 @@ export const environmentVariableNames = {
   skipEsbuildReactDedeuplication: 'SHOPIFY_CLI_SKIP_ESBUILD_REACT_DEDUPLICATION',
   disableGraphiQLExplorer: 'SHOPIFY_CLI_DISABLE_GRAPHIQL',
   useDynamicConfigSpecifications: 'SHOPIFY_CLI_DYNAMIC_CONFIG',
+  enableAppLogPolling: 'SHOPIFY_CLI_ENABLE_APP_LOG_POLLING',
 }
 
 export const configurationFileNames = {

--- a/packages/app/src/cli/services/app-logs/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.test.ts
@@ -1,0 +1,150 @@
+import {pollAppLogs} from './poll-app-logs.js'
+import {writeAppLogsToFile} from './write-app-logs.js'
+import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {describe, expect, test, vi, beforeEach, afterEach} from 'vitest'
+import {fetch} from '@shopify/cli-kit/node/http'
+
+const JWT_TOKEN = 'jwtToken'
+const API_KEY = 'apiKey'
+
+vi.mock('./write-app-logs.js')
+vi.mock('@shopify/cli-kit/node/http')
+
+const FQDN = await partnersFqdn()
+const LOGS = '1\\n2\\n3\\n4\\n'
+const INPUT = {
+  cart: {
+    lines: [
+      {
+        quantity: 3,
+        merchandise: {
+          __typename: 'ProductVariant',
+          id: 'gid:\\/\\/shopify\\/ProductVariant\\/2',
+        },
+      },
+    ],
+  },
+}
+const OUTPUT = {
+  discountApplicationStrategy: 'FIRST',
+  discounts: [
+    {
+      message: '10% off',
+      value: {
+        percentage: {
+          value: 10,
+        },
+      },
+      targets: [
+        {
+          productVariant: {
+            id: 'gid://shopify/ProductVariant/2',
+          },
+        },
+      ],
+    },
+  ],
+}
+const PAYLOAD = {
+  input: JSON.stringify(INPUT),
+  input_bytes: 123,
+  output: JSON.stringify(OUTPUT),
+  output_bytes: 182,
+  function_id: 'e57b4d31-2038-49ff-a0a1-1eea532414f7',
+  logs: LOGS,
+  fuel_consumed: 512436,
+}
+const RETURNED_CURSOR = '2024-05-23T19:17:02.321773Z'
+const RESPONSE_DATA = {
+  app_logs: [
+    {
+      shop_id: 1,
+      api_client_id: 1830457,
+      payload: JSON.stringify(PAYLOAD),
+      event_type: 'function_run',
+      cursor: '2024-05-23T19:17:02.321773Z',
+      status: 'success',
+      log_timestamp: '2024-05-23T19:17:00.240053Z',
+    },
+  ],
+  cursor: RETURNED_CURSOR,
+}
+
+describe('pollAppLogs', () => {
+  let stdout: any
+
+  beforeEach(() => {
+    stdout = {write: vi.fn()}
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllTimers()
+  })
+
+  test('polls and re-polls the endpoint', async () => {
+    const firstUrl = `https://${FQDN}/app_logs/poll`
+    const secondUrl = `${firstUrl}?cursor=${RETURNED_CURSOR}`
+
+    // Given
+    vi.mocked(writeAppLogsToFile)
+
+    const mockedFetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(RESPONSE_DATA))
+      .mockResolvedValueOnce(Response.json(RESPONSE_DATA))
+    vi.mocked(fetch).mockImplementation(mockedFetch)
+
+    // When
+    await pollAppLogs({stdout, appLogsFetchInput: {jwtToken: JWT_TOKEN}, apiKey: API_KEY})
+    await vi.advanceTimersToNextTimerAsync()
+
+    // Then
+    expect(fetch).toHaveBeenCalledWith(firstUrl, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${JWT_TOKEN}`,
+      },
+    })
+
+    expect(fetch).toHaveBeenCalledWith(secondUrl, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${JWT_TOKEN}`,
+      },
+    })
+
+    expect(writeAppLogsToFile).toHaveBeenCalledWith({
+      appLog: RESPONSE_DATA.app_logs[0],
+      apiKey: API_KEY,
+      stdout,
+    })
+
+    expect(stdout.write).toHaveBeenCalledWith('Function executed succesfully using 0.5124M instructions.')
+    expect(stdout.write).toHaveBeenCalledWith(LOGS)
+
+    expect(vi.getTimerCount()).toEqual(1)
+  })
+
+  test('throws error if response is not ok', async () => {
+    // Given
+    const url = `https://${FQDN}/app_logs/poll`
+
+    const response = new Response('errorMessage', {status: 500})
+    const mockedFetch = vi.fn().mockResolvedValueOnce(response)
+    vi.mocked(fetch).mockImplementation(mockedFetch)
+
+    // When/Then
+    await expect(() =>
+      pollAppLogs({stdout, appLogsFetchInput: {jwtToken: JWT_TOKEN}, apiKey: API_KEY}),
+    ).rejects.toThrowError('Error while fetching: errorMessage')
+
+    expect(fetch).toHaveBeenCalledWith(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${JWT_TOKEN}`,
+      },
+    })
+  })
+})

--- a/packages/app/src/cli/services/app-logs/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.ts
@@ -1,0 +1,97 @@
+import {writeAppLogsToFile} from './write-app-logs.js'
+import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {fetch} from '@shopify/cli-kit/node/http'
+import {Writable} from 'stream'
+
+const POLLING_INTERVAL_MS = 450
+const ONE_MILLION = 1000000
+
+const generateFetchAppLogUrl = async (cursor?: string) => {
+  const fqdn = await partnersFqdn()
+  const url = `https://${fqdn}/app_logs/poll`
+  return url + (cursor ? `?cursor=${cursor}` : '')
+}
+
+export interface AppEventData {
+  shop_id: number
+  api_client_id: number
+  payload: string
+  event_type: string
+  cursor: string
+  status: 'success' | 'failure'
+  log_timestamp: string
+}
+
+export const pollAppLogs = async ({
+  stdout,
+  appLogsFetchInput: {jwtToken, cursor},
+  apiKey,
+}: {
+  stdout: Writable
+  appLogsFetchInput: {jwtToken: string; cursor?: string}
+  apiKey: string
+}) => {
+  const url = await generateFetchAppLogUrl(cursor)
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${jwtToken}`,
+    },
+  })
+
+  if (!response.ok) {
+    // We should add some exponential backoff here to not spam partners
+
+    const responseText = await response.text()
+    throw new Error(`Error while fetching: ${responseText}`)
+  }
+
+  const data = (await response.json()) as {
+    app_logs?: AppEventData[]
+    cursor?: string
+    errors?: string[]
+  }
+
+  if (data.app_logs) {
+    const {app_logs: appLogs} = data
+
+    const functionLogs = appLogs.filter((appLog) => appLog.event_type === 'function_run')
+
+    for (const functionLog of functionLogs) {
+      const payload = JSON.parse(functionLog.payload)
+      const fuel = (payload.fuel_consumed / ONE_MILLION).toFixed(4)
+
+      if (functionLog.status === 'success') {
+        stdout.write(`Function executed succesfully using ${fuel}M instructions.`)
+      } else if (functionLog.status === 'failure') {
+        stdout.write(`❌ Function failed to execute with error: ${payload.error_type}`)
+      }
+
+      // print the logs from the appLogs as well
+      const logs = JSON.parse(functionLog.payload).logs
+      stdout.write(logs)
+
+      // eslint-disable-next-line no-await-in-loop
+      await writeAppLogsToFile({
+        appLog: functionLog,
+        apiKey,
+        stdout,
+      })
+    }
+  }
+
+  const cursorFromResponse = data?.cursor
+
+  setTimeout(() => {
+    pollAppLogs({
+      stdout,
+      appLogsFetchInput: {
+        jwtToken,
+        cursor: cursorFromResponse,
+      },
+      apiKey,
+    }).catch((error) => {
+      throw new Error(`${error} error while fetching.`)
+    })
+  }, POLLING_INTERVAL_MS)
+}

--- a/packages/app/src/cli/services/app-logs/write-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/write-app-logs.test.ts
@@ -1,0 +1,62 @@
+import {writeAppLogsToFile} from './write-app-logs.js'
+import {AppEventData} from './poll-app-logs.js'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {writeLog} from '@shopify/cli-kit/node/logs'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/logs')
+
+const APP_LOG: AppEventData = {
+  shop_id: 1,
+  api_client_id: 2,
+  payload: JSON.stringify({someJson: 'someJSOn'}),
+  event_type: 'function_run',
+  cursor: '2024-05-22T15:06:43.841156Z',
+  status: 'success',
+  log_timestamp: '2024-05-22T15:06:41.827379Z',
+}
+const API_KEY = 'apiKey'
+
+describe('writeAppLogsToFile', () => {
+  let stdout: any
+
+  beforeEach(() => {
+    stdout = {write: vi.fn()}
+  })
+
+  test('calls writeLog with the right data', async () => {
+    // Given
+    const logData = expectedLogDataFromAppEvent(APP_LOG)
+
+    // determine the fileName and path
+    const fileName = `app_logs_${APP_LOG.log_timestamp}.json`
+    const path = joinPath(API_KEY, fileName)
+
+    // When
+    await writeAppLogsToFile({appLog: APP_LOG, apiKey: API_KEY, stdout})
+
+    // Then
+    expect(writeLog).toHaveBeenCalledWith(path, logData)
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Log: '))
+  })
+
+  test('prints and re-throws parsing errors', async () => {
+    // Given
+    const appLog = {
+      ...APP_LOG,
+      payload: 'invalid JSON',
+    }
+
+    // When/Then
+    await expect(writeAppLogsToFile({appLog, apiKey: API_KEY, stdout})).rejects.toThrow()
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Error while writing log to file: '))
+  })
+})
+
+function expectedLogDataFromAppEvent(event: AppEventData): string {
+  const data = {
+    ...event,
+    payload: JSON.parse(event.payload),
+  }
+  return JSON.stringify(data, null, 2)
+}

--- a/packages/app/src/cli/services/app-logs/write-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/write-app-logs.ts
@@ -1,0 +1,34 @@
+import {AppEventData} from './poll-app-logs.js'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {writeLog, getLogsDir} from '@shopify/cli-kit/node/logs'
+
+import {Writable} from 'stream'
+
+export const writeAppLogsToFile = async ({
+  appLog,
+  apiKey,
+  stdout,
+}: {
+  appLog: AppEventData
+  apiKey: string
+  stdout: Writable
+}) => {
+  const fileName = `app_logs_${appLog.log_timestamp}.json`
+  const path = joinPath(apiKey, fileName)
+  const fullOutputPath = joinPath(getLogsDir, path)
+
+  try {
+    const toSaveData = {
+      ...appLog,
+      payload: JSON.parse(appLog.payload),
+    }
+
+    const logData = JSON.stringify(toSaveData, null, 2)
+
+    await writeLog(path, logData)
+    stdout.write(`Log: ${fullOutputPath}\n`)
+  } catch (error) {
+    stdout.write(`Error while writing log to file: ${error}\n`)
+    throw error
+  }
+}

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
@@ -1,0 +1,69 @@
+import {BaseProcess, DevProcessFunction} from './types.js'
+import {pollAppLogs} from '../../app-logs/poll-app-logs.js'
+import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {AppLogsSubscribeVariables} from '../../../api/graphql/subscribe_to_app_logs.js'
+
+import {createLogsDir} from '@shopify/cli-kit/node/logs'
+
+import {outputDebug} from '@shopify/cli-kit/node/output'
+
+interface SubscribeAndStartPollingOptions {
+  developerPlatformClient: DeveloperPlatformClient
+  appLogsSubscribeVariables: AppLogsSubscribeVariables
+}
+
+export interface AppLogsSubscribeProcess extends BaseProcess<SubscribeAndStartPollingOptions> {
+  type: 'app-logs-subscribe'
+}
+
+interface Props {
+  developerPlatformClient: DeveloperPlatformClient
+  subscription: {
+    shopIds: string[]
+    apiKey: string
+  }
+}
+
+export async function setupAppLogsPollingProcess({
+  developerPlatformClient,
+  subscription: {shopIds, apiKey},
+}: Props): Promise<AppLogsSubscribeProcess> {
+  const {token: partnersSessionToken} = await developerPlatformClient.session()
+
+  return {
+    type: 'app-logs-subscribe',
+    prefix: 'app-logs',
+    function: subscribeAndStartPolling,
+    options: {
+      developerPlatformClient,
+      appLogsSubscribeVariables: {
+        shopIds,
+        apiKey,
+        token: partnersSessionToken,
+      },
+    },
+  }
+}
+
+export const subscribeAndStartPolling: DevProcessFunction<SubscribeAndStartPollingOptions> = async (
+  {stdout},
+  {developerPlatformClient, appLogsSubscribeVariables},
+) => {
+  const result = await developerPlatformClient.subscribeToAppLogs(appLogsSubscribeVariables)
+  const {jwtToken, success, errors} = result.appLogsSubscribe
+  outputDebug(`Token: ${jwtToken}\n`)
+  outputDebug(`API Key: ${appLogsSubscribeVariables.apiKey}\n`)
+
+  if (errors && errors.length > 0) {
+    errors.forEach((error) => {
+      stdout.write(`Error: ${error}\n`)
+    })
+  } else {
+    outputDebug(`Subscribed to App Events for shop ID(s) ${appLogsSubscribeVariables.shopIds}`)
+    outputDebug(`Success: ${success}\n`)
+  }
+
+  const apiKey = appLogsSubscribeVariables.apiKey
+  await createLogsDir(apiKey)
+  await pollAppLogs({stdout, appLogsFetchInput: {jwtToken}, apiKey})
+}

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -1,4 +1,5 @@
 import {DevConfig, setupDevProcesses, startProxyServer} from './setup-dev-processes.js'
+import {subscribeAndStartPolling} from './app-logs-polling.js'
 import {sendWebhook} from './uninstall-webhook.js'
 import {WebProcess, launchWebProcess} from './web.js'
 import {PreviewableExtensionProcess, launchPreviewableExtensionProcess} from './previewable-extension.js'
@@ -22,10 +23,12 @@ import {DeveloperPlatformClient} from '../../../utilities/developer-platform-cli
 import {describe, test, expect, beforeEach, vi} from 'vitest'
 import {ensureAuthenticatedAdmin, ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
 import {Config} from '@oclif/core'
+import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
 
 vi.mock('../../context/identifiers.js')
 vi.mock('@shopify/cli-kit/node/session.js')
 vi.mock('../fetch.js')
+vi.mock('@shopify/cli-kit/node/environment')
 
 beforeEach(() => {
   // mocked for draft extensions
@@ -42,6 +45,7 @@ beforeEach(() => {
     token: 'admin-token',
   })
   vi.mocked(ensureAuthenticatedStorefront).mockResolvedValue('storefront-token')
+  vi.mocked(getEnvironmentVariables).mockReturnValue({})
 })
 
 describe('setup-dev-processes', () => {
@@ -234,6 +238,99 @@ describe('setup-dev-processes', () => {
           '/ping': `http://localhost:${hmrPort}`,
           default: `http://localhost:${webPort}`,
           websocket: `http://localhost:${hmrPort}`,
+        },
+      },
+    })
+  })
+
+  test('process list includes app polling when envVar is enabled', async () => {
+    vi.mocked(getEnvironmentVariables).mockReturnValue({SHOPIFY_CLI_ENABLE_APP_LOG_POLLING: '1'})
+
+    const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient()
+    const storeFqdn = 'store.myshopify.io'
+    const storeId = '123456789'
+    const remoteAppUpdated = true
+    const graphiqlPort = 1234
+    const commandOptions: DevConfig['commandOptions'] = {
+      subscriptionProductUrl: '/products/999999',
+      checkoutCartUrl: '/cart/999999:1',
+      theme: '1',
+      directory: '',
+      reset: false,
+      update: false,
+      commandConfig: new Config({root: ''}),
+      skipDependenciesInstallation: false,
+      noTunnel: false,
+    }
+    const network: DevConfig['network'] = {
+      proxyUrl: 'https://example.com/proxy',
+      proxyPort: 444,
+      backendPort: 111,
+      frontendPort: 222,
+      currentUrls: {
+        applicationUrl: 'https://example.com/application',
+        redirectUrlWhitelist: ['https://example.com/redirect'],
+      },
+    }
+    const previewable = await testUIExtension({type: 'checkout_ui_extension'})
+    const draftable = await testTaxCalculationExtension()
+    const theme = await testThemeExtensions()
+    const localApp = testAppWithConfig({
+      config: {},
+      app: {
+        webs: [
+          {
+            directory: 'web',
+            configuration: {
+              roles: [WebType.Backend, WebType.Frontend],
+              commands: {dev: 'npm exec remix dev'},
+              webhooks_path: '/webhooks',
+              hmr_server: {
+                http_paths: ['/ping'],
+              },
+            },
+          },
+        ],
+        allExtensions: [previewable, draftable, theme],
+      },
+    })
+
+    const remoteApp: DevConfig['remoteApp'] = {
+      apiKey: 'api-key',
+      apiSecret: 'api-secret',
+      id: '1234',
+      title: 'App',
+      organizationId: '5678',
+      grantedScopes: [],
+      flags: [],
+    }
+
+    const graphiqlKey = 'somekey'
+
+    const res = await setupDevProcesses({
+      localApp,
+      commandOptions,
+      network,
+      remoteApp,
+      remoteAppUpdated,
+      storeFqdn,
+      storeId,
+      developerPlatformClient,
+      partnerUrlsUpdated: true,
+      graphiqlPort,
+      graphiqlKey,
+    })
+
+    expect(res.processes[6]).toMatchObject({
+      type: 'app-logs-subscribe',
+      prefix: 'app-logs',
+      function: subscribeAndStartPolling,
+      options: {
+        developerPlatformClient,
+        appLogsSubscribeVariables: {
+          shopIds: ['123456789'],
+          apiKey: 'api-key',
+          token: 'token',
         },
       },
     })

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -5,6 +5,7 @@ import {DraftableExtensionProcess, setupDraftableExtensionsProcess} from './draf
 import {SendWebhookProcess, setupSendUninstallWebhookProcess} from './uninstall-webhook.js'
 import {GraphiQLServerProcess, setupGraphiQLServerProcess} from './graphiql.js'
 import {WebProcess, setupWebProcesses} from './web.js'
+import {AppLogsSubscribeProcess, setupAppLogsPollingProcess} from './app-logs-polling.js'
 import {environmentVariableNames} from '../../../constants.js'
 import {AppInterface, getAppScopes} from '../../../models/app/app.js'
 
@@ -16,6 +17,7 @@ import {PartnersURLs} from '../urls.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
+import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
 
 interface ProxyServerProcess extends BaseProcess<{port: number; rules: {[key: string]: string}}> {
   type: 'proxy-server'
@@ -29,6 +31,7 @@ type DevProcessDefinition =
   | PreviewableExtensionProcess
   | DraftableExtensionProcess
   | GraphiQLServerProcess
+  | AppLogsSubscribeProcess
 
 export type DevProcesses = DevProcessDefinition[]
 
@@ -75,7 +78,9 @@ export async function setupDevProcesses({
   const apiKey = remoteApp.apiKey
   const apiSecret = (remoteApp.apiSecret as string) ?? ''
   const appPreviewUrl = buildAppURLForWeb(storeFqdn, apiKey)
-  const shouldRenderGraphiQL = !isTruthy(process.env[environmentVariableNames.disableGraphiQLExplorer])
+  const env = getEnvironmentVariables()
+  const shouldRenderGraphiQL = !isTruthy(env[environmentVariableNames.disableGraphiQLExplorer])
+  const shouldPerformAppLogPolling = isTruthy(env[environmentVariableNames.enableAppLogPolling])
 
   const processes = [
     ...(await setupWebProcesses({
@@ -137,6 +142,15 @@ export async function setupDevProcesses({
       apiSecret,
       remoteAppUpdated,
     }),
+    shouldPerformAppLogPolling
+      ? await setupAppLogsPollingProcess({
+          developerPlatformClient,
+          subscription: {
+            shopIds: [storeId],
+            apiKey,
+          },
+        })
+      : undefined,
   ].filter(stripUndefineds)
 
   // Add http server proxy & configure ports, for processes that need it

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -44,6 +44,7 @@ import {
   MigrateToUiExtensionSchema,
   MigrateToUiExtensionVariables,
 } from '../api/graphql/extension_migrate_to_ui_extension.js'
+import {AppLogsSubscribeVariables, AppLogsSubscribeResponse} from '../api/graphql/subscribe_to_app_logs.js'
 import {RemoteSpecification} from '../api/graphql/extension_specifications.js'
 import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../api/graphql/extension_migrate_app_module.js'
 import {AppConfiguration, isCurrentAppSchema} from '../models/app/app.js'
@@ -212,4 +213,5 @@ export interface DeveloperPlatformClient {
   apiSchemaDefinition: (input: ApiSchemaDefinitionQueryVariables) => Promise<string | null>
   migrateToUiExtension: (input: MigrateToUiExtensionVariables) => Promise<MigrateToUiExtensionSchema>
   toExtensionGraphQLType: (input: string) => string
+  subscribeToAppLogs: (input: AppLogsSubscribeVariables) => Promise<AppLogsSubscribeResponse>
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -104,6 +104,8 @@ import {
   MigrateToUiExtensionSchema,
 } from '../../api/graphql/extension_migrate_to_ui_extension.js'
 import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../../api/graphql/extension_migrate_app_module.js'
+import {AppLogsSubscribeVariables, AppLogsSubscribeResponse} from '../../api/graphql/subscribe_to_app_logs.js'
+
 import {ensureAuthenticatedAppManagement, ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
 import {FunctionUploadUrlGenerateResponse} from '@shopify/cli-kit/node/api/partners'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
@@ -120,6 +122,10 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
   constructor(session?: PartnersSession) {
     this._session = session
+  }
+
+  async subscribeToAppLogs(input: AppLogsSubscribeVariables): Promise<AppLogsSubscribeResponse> {
+    throw new Error(`Not Implemented: ${input}`)
   }
 
   async session(): Promise<PartnersSession> {

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -136,6 +136,12 @@ import {
   MigrateAppModuleSchema,
   MigrateAppModuleVariables,
 } from '../../api/graphql/extension_migrate_app_module.js'
+import {
+  AppLogsSubscribeVariables,
+  AppLogsSubscribeMutation,
+  AppLogsSubscribeResponse,
+} from '../../api/graphql/subscribe_to_app_logs.js'
+
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {
@@ -458,5 +464,9 @@ export class PartnersClient implements DeveloperPlatformClient {
 
   toExtensionGraphQLType(input: string) {
     return input.toUpperCase()
+  }
+
+  async subscribeToAppLogs(input: AppLogsSubscribeVariables): Promise<AppLogsSubscribeResponse> {
+    return this.request(AppLogsSubscribeMutation, input)
   }
 }

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -8,6 +8,10 @@ const cacheFolder = () => {
   return envPaths(identifier).cache
 }
 
+export const logsFolder = () => {
+  return envPaths(identifier).log
+}
+
 export const environmentVariables = {
   alwaysLogAnalytics: 'SHOPIFY_CLI_ALWAYS_LOG_ANALYTICS',
   alwaysLogMetrics: 'SHOPIFY_CLI_ALWAYS_LOG_METRICS',

--- a/packages/cli-kit/src/public/node/logs.ts
+++ b/packages/cli-kit/src/public/node/logs.ts
@@ -1,0 +1,13 @@
+import {logsFolder} from '../../private/node/constants.js'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {mkdir, writeFile} from '@shopify/cli-kit/node/fs'
+
+export const getLogsDir = logsFolder()
+
+export const createLogsDir = async (path: string): Promise<void> => {
+  await mkdir(joinPath(logsFolder(), path))
+}
+
+export const writeLog = async (path: string, logData: string): Promise<void> => {
+  await writeFile(joinPath(logsFolder(), path), logData)
+}


### PR DESCRIPTION
### WHY are these changes introduced?

For https://github.com/Shopify/shopify-functions/issues/118

### WHAT is this pull request doing?

Adds log polling to the app dev command.
This listens for functionRuns 

### How to test your changes? 🎩 
- Have a dev store with your app installed and function deployed
- enable log polling flag on partners org
- set local envVar to enable the log polling, `export SHOPIFY_CLI_ENABLE_APP_LOG_POLLING=1`
- From the cli directory, run app dev, i.e. `pnpm shopify app dev --path /Users/lopert/code/log-streaming/app/log-streamer`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
