### PR TITLE
Pass Development Server flags down to theme environment

### DIFF
--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -174,6 +174,7 @@ You can run this command only in a directory that matches the [default Shopify t
       theme,
       host: flags.host,
       port: flags.port,
+      'live-reload': flags['live-reload'],
       force: flags.force,
       open: flags.open,
       flagsToPass,

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -1,5 +1,5 @@
-import {showDeprecationWarnings, refreshTokens, dev} from './dev.js'
-import {startDevServer} from '../utilities/theme-environment/theme-environment.js'
+import {showDeprecationWarnings, refreshTokens, dev, DevOptions} from './dev.js'
+import {setupDevServer} from '../utilities/theme-environment/theme-environment.js'
 import {mountThemeFileSystem} from '../utilities/theme-fs.js'
 import {fakeThemeFileSystem} from '../utilities/theme-fs/theme-fs-mock-factory.js'
 import {describe, expect, test, vi} from 'vitest'
@@ -16,7 +16,7 @@ vi.mock('../utilities/theme-fs.js')
 
 describe('dev', () => {
   const adminSession = {storeFqdn: 'my-store.myshopify.com', token: 'my-token'}
-  const options = {
+  const options: DevOptions = {
     adminSession,
     storefrontToken: 'my-storefront-token',
     directory: 'my-directory',
@@ -28,6 +28,7 @@ describe('dev', () => {
     password: 'my-token',
     'theme-editor-sync': false,
     'dev-preview': false,
+    'live-reload': 'hot-reload',
     noDelete: false,
     ignore: [],
     only: [],
@@ -39,21 +40,25 @@ describe('dev', () => {
       // Given
       vi.mocked(fetchChecksums).mockResolvedValue([])
       vi.mocked(mountThemeFileSystem).mockResolvedValue(localThemeFileSystem)
-      vi.mocked(startDevServer).mockResolvedValue()
+      vi.mocked(setupDevServer).mockResolvedValue()
       const devOptions = {...options, 'dev-preview': true, 'theme-editor-sync': true}
 
       // When
       await dev(devOptions)
 
       // Then
-      expect(startDevServer).toHaveBeenCalledWith(
+      expect(setupDevServer).toHaveBeenCalledWith(
         options.theme,
         {
           session: {...adminSession, storefrontToken: 'my-storefront-token', expiresAt: expect.any(Date)},
           remoteChecksums: [],
           localThemeFileSystem,
-          themeEditorSync: true,
           options: {
+            themeEditorSync: true,
+            host: '127.0.0.1',
+            liveReload: 'hot-reload',
+            open: false,
+            port: '9292',
             ignore: [],
             noDelete: false,
             only: [],

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -1,6 +1,6 @@
-import {startDevServer} from './theme-environment.js'
 import {reconcileAndPollThemeEditorChanges} from './remote-theme-watcher.js'
 import {DevServerContext} from './types.js'
+import {setupDevServer} from './theme-environment.js'
 import {uploadTheme} from '../theme-uploader.js'
 import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
 import {describe, expect, test, vi} from 'vitest'
@@ -20,22 +20,26 @@ describe('startDevServer', () => {
     session: {storefrontToken: '', token: '', storeFqdn: '', expiresAt: new Date()},
     remoteChecksums: [],
     localThemeFileSystem,
-    themeEditorSync: false,
     options: {
       ignore: ['assets/*.json'],
       only: ['templates/*.liquid'],
       noDelete: true,
+      host: '127.0.0.1',
+      port: '9292',
+      liveReload: 'hot-reload',
+      open: false,
+      themeEditorSync: false,
     },
   }
 
   test('should upload the development theme to remote', async () => {
     // Given
-    const context = {
+    const context: DevServerContext = {
       ...defaultServerContext,
     }
 
     // When
-    await startDevServer(developmentTheme, context, () => {})
+    await setupDevServer(developmentTheme, context, () => {})
 
     // Then
     expect(uploadTheme).toHaveBeenCalledWith(
@@ -53,13 +57,16 @@ describe('startDevServer', () => {
 
   test('should initialize theme editor sync if themeEditorSync flag is passed', async () => {
     // Given
-    const context = {
+    const context: DevServerContext = {
       ...defaultServerContext,
-      themeEditorSync: true,
+      options: {
+        ...defaultServerContext.options,
+        themeEditorSync: true,
+      },
     }
 
     // When
-    await startDevServer(developmentTheme, context, () => {})
+    await setupDevServer(developmentTheme, context, () => {})
 
     // Then
     expect(reconcileAndPollThemeEditorChanges).toHaveBeenCalledWith(
@@ -80,7 +87,7 @@ describe('startDevServer', () => {
     const context = {...defaultServerContext, options: {...defaultServerContext.options, noDelete: true}}
 
     // When
-    await startDevServer(developmentTheme, context, () => {})
+    await setupDevServer(developmentTheme, context, () => {})
 
     // Then
     expect(uploadTheme).toHaveBeenCalledWith(developmentTheme, context.session, [], context.localThemeFileSystem, {

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -3,26 +3,27 @@ import {DevServerContext} from './types.js'
 import {uploadTheme} from '../theme-uploader.js'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 
-export async function startDevServer(theme: Theme, ctx: DevServerContext, onReady: () => void) {
+export async function setupDevServer(theme: Theme, ctx: DevServerContext, onReady: () => void) {
   await ensureThemeEnvironmentSetup(theme, ctx)
+  await startDevelopmentServer(theme, ctx)
 
   onReady()
 }
 
 async function ensureThemeEnvironmentSetup(theme: Theme, ctx: DevServerContext) {
-  if (ctx.themeEditorSync) {
-    await reconcileAndPollThemeEditorChanges(
-      theme,
-      ctx.session,
-      ctx.remoteChecksums,
-      ctx.localThemeFileSystem,
-      ctx.options,
-    )
+  if (ctx.options.themeEditorSync) {
+    await reconcileAndPollThemeEditorChanges(theme, ctx.session, ctx.remoteChecksums, ctx.localThemeFileSystem, {
+      noDelete: ctx.options.noDelete,
+      ignore: ctx.options.ignore,
+      only: ctx.options.only,
+    })
   }
 
   await uploadTheme(theme, ctx.session, ctx.remoteChecksums, ctx.localThemeFileSystem, {
     nodelete: ctx.options.noDelete,
-    ignore: ctx.options?.ignore,
-    only: ctx.options?.only,
+    ignore: ctx.options.ignore,
+    only: ctx.options.only,
   })
 }
+
+async function startDevelopmentServer(_theme: Theme, _ctx: DevServerContext) {}

--- a/packages/theme/src/cli/utilities/theme-environment/types.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/types.ts
@@ -48,15 +48,15 @@ export interface DevServerContext {
   localThemeFileSystem: ThemeFileSystem
 
   /**
-   * Indicates if theme editor changes are periodically pulled to the local
-   * theme.
-   */
-  themeEditorSync: boolean
-
-  /**
    * Additional options for the development server.
    */
   options: {
+    /**
+     * Indicates if theme editor changes are periodically pulled to the local
+     * theme.
+     */
+    themeEditorSync: boolean
+
     /**
      * Prevents deletion of local files.
      */
@@ -71,6 +71,26 @@ export interface DevServerContext {
      * Glob patterns allow-list for file reconciliation and sychronization.
      */
     only: string[]
+
+    /**
+     * Network interface to bind the development server to.
+     */
+    host: string
+
+    /**
+     * Port to bind the development server to.
+     */
+    port: string
+
+    /**
+     * Mode for live reload behavior. Options: ['hot-reload', 'full-page', 'off']
+     */
+    liveReload: string
+
+    /**
+     * Automatically open the theme preview in the default browser.
+     */
+    open: boolean
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?
- https://github.com/Shopify/develop-advanced-edits/issues/205

### WHAT is this pull request doing?
Plumbing work for starting the development server 

### How to test your changes?
This doesn't do anything yet but you can `p test`