### PR TITLE
Dependabot schedule -> weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     versioning-strategy: increase
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     labels:
       - "dependencies"
     open-pull-requests-limit: 100
@@ -42,7 +42,7 @@ updates:
     versioning-strategy: increase
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     labels:
       - "dependencies"
     open-pull-requests-limit: 100


### PR DESCRIPTION
As per our internal policy, switch dependabot to operate on weekly checks instead of monthly.