### PR TITLE
Add support for pre-dev scripts

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -179,6 +179,7 @@ const baseWebConfigurationSchema = zod.object({
   port: zod.number().max(65536).min(0).optional(),
   commands: zod.object({
     build: zod.string().optional(),
+    predev: zod.string().optional(),
     dev: zod.string(),
   }),
   name: zod.string().optional(),

--- a/packages/app/src/cli/services/dev/processes/web.ts
+++ b/packages/app/src/cli/services/dev/processes/web.ts
@@ -146,7 +146,7 @@ export async function launchWebProcess(
 
   // Support for multiple sequential commands: `echo "hello" && echo "world"`
   // Pre-dev commands are run before the dev command, but without any output
-  await runArrayOfCommands({command: preDevCommand ?? '', signal, directory, port, env})
+  if (preDevCommand) await runArrayOfCommands({command: preDevCommand, signal, directory, port, env})
   await runArrayOfCommands({command: devCommand, signal, directory, port, env, stdout, stderr})
 }
 
@@ -164,6 +164,7 @@ async function runArrayOfCommands({command, signal, directory, port, env, stdout
   const commands = command.split('&&').map((cmd) => cmd.trim()) ?? []
   for (const command of commands) {
     const [cmd, ...args] = command.split(' ')
+    if (cmd?.length === 0) continue
     // eslint-disable-next-line no-await-in-loop
     await exec(cmd!, args, {
       cwd: directory,

--- a/packages/app/src/cli/services/dev/processes/web.ts
+++ b/packages/app/src/cli/services/dev/processes/web.ts
@@ -17,6 +17,7 @@ interface LaunchWebOptions {
   frontendServerPort?: number
   directory: string
   devCommand: string
+  preDevCommand?: string
   scopes?: string
   shopCustomDomain?: string
   hmrServerOptions?: {port: number; httpPaths: string[]}
@@ -60,7 +61,7 @@ export async function setupWebProcesses({
           }
         : undefined
 
-    return {
+    const process: WebProcess = {
       type: 'web',
       prefix: web.configuration.name ?? ['web', ...web.configuration.roles].join('-'),
       function: launchWebProcess,
@@ -75,11 +76,13 @@ export async function setupWebProcesses({
         frontendServerPort: frontendPort,
         directory: web.directory,
         devCommand: web.configuration.commands.dev,
+        preDevCommand: web.configuration.commands.predev,
         scopes,
         shopCustomDomain,
         hmrServerOptions,
       },
-    } as WebProcess
+    }
+    return process
   })
   return Promise.all(webProcessSetups)
 }
@@ -103,7 +106,7 @@ async function getWebProcessPort({
 }
 
 export async function launchWebProcess(
-  {stdout, stderr, abortSignal}: {stdout: Writable; stderr: Writable; abortSignal: AbortSignal},
+  {stdout, stderr, abortSignal: signal}: {stdout: Writable; stderr: Writable; abortSignal: AbortSignal},
   {
     port,
     apiKey,
@@ -113,6 +116,7 @@ export async function launchWebProcess(
     frontendServerPort,
     directory,
     devCommand,
+    preDevCommand,
     scopes,
     shopCustomDomain,
     hmrServerOptions,
@@ -141,15 +145,31 @@ export async function launchWebProcess(
   }
 
   // Support for multiple sequential commands: `echo "hello" && echo "world"`
-  const devCommands = devCommand.split('&&').map((cmd) => cmd.trim()) ?? []
-  for (const command of devCommands) {
+  // Pre-dev commands are run before the dev command, but without any output
+  await runArrayOfCommands({command: preDevCommand ?? '', signal, directory, port, env})
+  await runArrayOfCommands({command: devCommand, signal, directory, port, env, stdout, stderr})
+}
+
+interface RunArrayOfCommandsOptions {
+  command: string
+  signal: AbortSignal
+  directory: string
+  port: number
+  env: {[key: string]: string | undefined}
+  stdout?: Writable
+  stderr?: Writable
+}
+
+async function runArrayOfCommands({command, signal, directory, port, env, stdout, stderr}: RunArrayOfCommandsOptions) {
+  const commands = command.split('&&').map((cmd) => cmd.trim()) ?? []
+  for (const command of commands) {
     const [cmd, ...args] = command.split(' ')
     // eslint-disable-next-line no-await-in-loop
     await exec(cmd!, args, {
       cwd: directory,
       stdout,
       stderr,
-      signal: abortSignal,
+      signal,
       env: {
         ...env,
         PORT: `${port}`,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- We need a way to run multiple commands for the web dev process (aside from the main `npm exec remix vite:dev` one)
- We need some of those commands to not produce any output (because it pollutes our dev log)

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add a new `predev` command to the web process
- Anything defined in `predev` will be run before `dev` and the output will be ignored.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Create an app and in the `web.toml` write something like:
```
predev = "echo 'Test1' && touch itworks"
dev = "echo 'Test2' && npm exec remix vite:dev"
```

Then run `dev`.

You should see `Test2` in the logs (when remix starts).
You shouldn't see `Test1`, but a file called `itworks` will be created in your app folder, proving the predev command worked.


<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
