### PR TITLE
QA for may 30 release

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -147,8 +147,12 @@ program
       await nodeExec(commands, args, { ...defaults, ...options });
     };
 
-    const appDev = async () => {
-      await appNodeExec(["shopify", "app", "dev"], []);
+    const appDev = async (reset=false) => {
+      if (reset) {
+        await appNodeExec(["shopify", "app", "dev"], ["--reset"]);
+      } else {
+        await appNodeExec(["shopify", "app", "dev"], []);
+      }
     };
 
     const installGlobally = async (packageManager, install) => {
@@ -273,7 +277,7 @@ program
         "--name=sub-ui-ext",
         "--flavor=vanilla-js",
       ]);
-      await appDev();
+      await appDev(true);
     }
 
     if (extensions.has("theme")) {

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/models/specifications.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/models/specifications.rb
@@ -82,7 +82,7 @@ module Extension
       end
 
       def select_cli_extensions(specification_attribute_sets)
-        specification_attribute_sets.select { |attributes| attributes.dig(:options, :management_experience) == "cli" }
+        specification_attribute_sets.select { |attributes| attributes.dig(:options, :management_experience) == "cli" && attributes[:identifier] != "data" }
       end
     end
   end


### PR DESCRIPTION
- release test script bug if restarting it
- if part of the `REDACTED` beta program, the specs list includes one called `data`, and the ruby gem crashes on this. It doesn't actually need to care about it