### PR TITLE
add a root <Text> element to log files to fix wrapping

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -192,15 +192,17 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
           <Box flexDirection="column" key={index}>
             {chunk.lines.map((line, index) => (
               <Box key={index} flexDirection="row">
-                {showTimestamps ? (
-                  <Text>
-                    {currentTime()} {lineVertical}{' '}
-                  </Text>
-                ) : null}
-                <Text color={chunk.color}>{formatPrefix(chunk.prefix)}</Text>
                 <Text>
-                  {' '}
-                  {lineVertical} {line}
+                  {showTimestamps ? (
+                    <Text>
+                      {currentTime()} {lineVertical}{' '}
+                    </Text>
+                  ) : null}
+                  <Text color={chunk.color}>{formatPrefix(chunk.prefix)}</Text>
+                  <Text>
+                    {' '}
+                    {lineVertical} {line}
+                  </Text>
                 </Text>
               </Box>
             ))}


### PR DESCRIPTION
Fixed a wrapping issue introduced in `ConcurrentOutput` in #3797 

## Before
![image](https://github.com/Shopify/cli/assets/27013789/1cd71da5-1cda-4775-a50b-5334fb9dfa09)

## After
![image](https://github.com/Shopify/cli/assets/27013789/02775187-4bd4-4ec5-b272-3f8cbef4368d)
