### PR TITLE
Remove subtopic from webhooks app config

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3055,51 +3055,6 @@ describe('WebhooksSchema', () => {
     expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
   })
 
-  test('does not allow identical topic and uri and sub_topic in different subscriptions', async () => {
-    const webhookConfig: WebhooksConfig = {
-      api_version: '2021-07',
-      subscriptions: [
-        {
-          topics: ['metaobjects/create'],
-          uri: 'https://example.com',
-          sub_topic: 'type:metaobject_one',
-        },
-        {
-          topics: ['metaobjects/create'],
-          uri: 'https://example.com',
-          sub_topic: 'type:metaobject_one',
-        },
-      ],
-    }
-    const errorObj = {
-      code: zod.ZodIssueCode.custom,
-      message: 'You can’t have duplicate subscriptions with the exact same `topic`, `uri` and `filter`',
-      fatal: true,
-      path: ['webhooks', 'subscriptions', 0, 'topics', 1, 'metaobjects/create'],
-    }
-
-    const {abortOrReport, expectedFormatted} = await setupParsing(errorObj, webhookConfig)
-    expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp', [errorObj])
-  })
-
-  test('allows identical topic and uri if sub_topic is different', async () => {
-    const webhookConfig: WebhooksConfig = {
-      api_version: '2021-07',
-      subscriptions: [
-        {
-          topics: ['metaobjects/create'],
-          uri: 'https://example.com',
-          sub_topic: 'type:metaobject_one',
-        },
-        {
-          topics: ['products/create'],
-          uri: 'https://example.com',
-          sub_topic: 'type:metaobject_two',
-        },
-      ],
-    }
-  })
-
   test('does not allow identical topic and uri and filter in different subscriptions', async () => {
     const webhookConfig: WebhooksConfig = {
       api_version: '2021-07',

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook.test.ts
@@ -20,13 +20,13 @@ describe('webhooks', () => {
             },
             {
               uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
-              sub_topic: 'type:metaobject_one',
+              filter: 'type:metaobject_one',
               topics: ['metaobjects/create', 'metaobjects/update'],
             },
             {
               topics: ['metaobjects/create', 'metaobjects/update'],
               uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
-              sub_topic: 'type:metaobject_two',
+              filter: 'type:metaobject_two',
             },
             {
               topics: ['orders/create'],
@@ -36,7 +36,7 @@ describe('webhooks', () => {
             {
               topics: ['metaobjects/create', 'metaobjects/delete'],
               uri: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/1234567890/SOME_PATH',
-              sub_topic: 'type:metaobject_one',
+              filter: 'type:metaobject_one',
             },
             {
               topics: ['products/create', 'products/update'],
@@ -72,22 +72,22 @@ describe('webhooks', () => {
             uri: 'https://example.com/webhooks/products',
           },
           {
-            sub_topic: 'type:metaobject_one',
+            filter: 'type:metaobject_one',
             topic: 'metaobjects/create',
             uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
           },
           {
-            sub_topic: 'type:metaobject_one',
+            filter: 'type:metaobject_one',
             topic: 'metaobjects/update',
             uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
           },
           {
-            sub_topic: 'type:metaobject_two',
+            filter: 'type:metaobject_two',
             topic: 'metaobjects/create',
             uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
           },
           {
-            sub_topic: 'type:metaobject_two',
+            filter: 'type:metaobject_two',
             topic: 'metaobjects/update',
             uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
           },
@@ -97,12 +97,12 @@ describe('webhooks', () => {
             uri: 'https://valid-url',
           },
           {
-            sub_topic: 'type:metaobject_one',
+            filter: 'type:metaobject_one',
             topic: 'metaobjects/create',
             uri: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/1234567890/SOME_PATH',
           },
           {
-            sub_topic: 'type:metaobject_one',
+            filter: 'type:metaobject_one',
             topic: 'metaobjects/delete',
             uri: 'arn:aws:events:us-west-2::event-source/aws.partner/shopify.com/1234567890/SOME_PATH',
           },
@@ -156,7 +156,7 @@ describe('webhooks', () => {
             uri: 'https://example.com/webhooks/products',
           },
           {
-            sub_topic: 'type:metaobject_one',
+            filter: 'type:metaobject_one',
             topic: 'metaobjects/create',
             uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
           },
@@ -201,7 +201,7 @@ describe('webhooks', () => {
               uri: 'https://valid-url',
             },
             {
-              sub_topic: 'type:metaobject_one',
+              filter: 'type:metaobject_one',
               topics: ['metaobjects/create'],
               uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
             },

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
@@ -14,7 +14,6 @@ export const WebhookSubscriptionSchema = zod.object({
     })
     .optional(),
   uri: zod.preprocess(removeTrailingSlash, WebhookSubscriptionUriValidation, {required_error: 'Missing value at'}),
-  sub_topic: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
   include_fields: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
   filter: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
   compliance_topics: zod

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.test.ts
@@ -21,12 +21,6 @@ describe('webhook_subscription', () => {
           },
           {
             api_version: '2024-01',
-            sub_topic: 'type:metaobject_one',
-            topic: 'metaobjects/create',
-            uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
-          },
-          {
-            api_version: '2024-01',
             include_fields: ['variants', 'title'],
             topic: 'orders/create',
             uri: 'https://valid-url',
@@ -69,12 +63,6 @@ describe('webhook_subscription', () => {
               include_fields: ['variants', 'title'],
               topics: ['orders/create'],
               uri: 'https://valid-url',
-            },
-            {
-              api_version: '2024-01',
-              sub_topic: 'type:metaobject_one',
-              topics: ['metaobjects/create'],
-              uri: 'pubsub://absolute-feat-test:pub-sub-topic2',
             },
           ],
         },

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
@@ -13,7 +13,6 @@ interface TransformedWebhookSubscription {
   uri: string
   topic: string
   compliance_topics?: string[]
-  sub_topic?: string
   include_fields?: string[]
   filter?: string
 }
@@ -22,7 +21,6 @@ export const SingleWebhookSubscriptionSchema = zod.object({
   topic: zod.string(),
   api_version: zod.string(),
   uri: zod.preprocess(removeTrailingSlash, WebhookSubscriptionUriValidation, {required_error: 'Missing value at'}),
-  sub_topic: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
   include_fields: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
   filter: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
 })

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.ts
@@ -95,7 +95,6 @@ function findSubscription(subscriptions: WebhookSubscription[], subscription: We
   return subscriptions.find(
     (sub) =>
       sub.uri === subscription.uri &&
-      sub.sub_topic === subscription.sub_topic &&
       deepCompare(sub.include_fields ?? [], subscription.include_fields ?? []) &&
       sub.filter === subscription.filter,
   )

--- a/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
@@ -2,7 +2,6 @@ export interface WebhookSubscription {
   uri: string
   topics?: string[]
   compliance_topics?: string[]
-  sub_topic?: string
   include_fields?: string[]
   filter?: string
 }

--- a/packages/app/src/cli/models/extensions/specifications/validation/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/validation/app_config_webhook.ts
@@ -38,7 +38,7 @@ function validateSubscriptions(webhookConfig: WebhooksConfig) {
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  for (const [i, {uri, topics = [], compliance_topics = [], sub_topic = '', filter = ''}] of subscriptions.entries()) {
+  for (const [i, {uri, topics = [], compliance_topics = [], filter = ''}] of subscriptions.entries()) {
     const path = ['subscriptions', i]
 
     if (!topics.length && !compliance_topics.length) {
@@ -50,7 +50,7 @@ function validateSubscriptions(webhookConfig: WebhooksConfig) {
     }
 
     for (const [j, topic] of topics.entries()) {
-      const key = `${topic}::${sub_topic}::${uri}::${filter}`
+      const key = `${topic}::${uri}::${filter}`
 
       if (uniqueSubscriptionSet.has(key)) {
         return {


### PR DESCRIPTION
### WHY are these changes introduced?
Subtopics are being deprecated in favor of filters.

### WHAT is this pull request doing?
Removing subtopic references from the CLI.

### How to test your changes?
Ran `SHOPIFY_SERVICE_ENV=spin NODE_TLS_REJECT_UNAUTHORIZED=0 pnpm shopify app deploy --path ./test-filter-app`

Confirmed subTopic isn't set in the distributed app module:
![image](https://github.com/Shopify/cli/assets/1899157/bb43c223-7222-415d-b8f8-1502618a5926)

For TOML with these webhooks:
```
[webhooks]
api_version = "2024-04"

  [[webhooks.subscriptions]]
  topics = [ "products/update" ]
  uri = "https://webhook.site/848d85d1-d86f-4d7e-b412-59465aa69d43"
  sub_topic = "type:color-swatch"
  filter = "type:color-swatch"
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
