### PR TITLE
Fix validation for Pub/Sub URLs in webhook trigger

### DIFF
--- a/.changeset/healthy-yaks-design.md
+++ b/.changeset/healthy-yaks-design.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix validation for Pub/Sub URLs in webhook trigger

--- a/packages/app/src/cli/services/webhook/trigger-flags.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger-flags.test.ts
@@ -89,7 +89,7 @@ describe('isAddressAllowedForDeliveryMethod', () => {
 })
 
 describe('validateAddressMethod', () => {
-  test('returns an array with address-method when they are valid', async () => {
+  test('returns an array with address-method for http', async () => {
     // When Then
     expect(validateAddressMethod('https://example.org', 'http')).toEqual(['https://example.org', 'http'])
   })
@@ -99,6 +99,19 @@ describe('validateAddressMethod', () => {
     expect(validateAddressMethod('http://localhost:3000/webhooks', 'http')).toEqual([
       'http://localhost:3000/webhooks',
       'localhost',
+    ])
+  })
+
+  test('returns an array with address-method for pubsub', async () => {
+    // When Then
+    expect(validateAddressMethod(pubsubAddress, 'google-pub-sub')).toEqual([pubsubAddress, DELIVERY_METHOD.PUBSUB])
+  })
+
+  test('returns an array with address-method for event-bridge', async () => {
+    // When Then
+    expect(validateAddressMethod(eventbridgeAddress, 'event-bridge')).toEqual([
+      eventbridgeAddress,
+      DELIVERY_METHOD.EVENTBRIDGE,
     ])
   })
 

--- a/packages/app/src/cli/services/webhook/trigger-flags.ts
+++ b/packages/app/src/cli/services/webhook/trigger-flags.ts
@@ -54,6 +54,8 @@ export function isAddressAllowedForDeliveryMethod(address: string, deliveryMetho
 }
 
 function isLocal(address: string): boolean {
+  if (!isAnyHttp(address)) return false
+
   const url = new URL(address.toLowerCase())
   return url.hostname === 'localhost'
 }

--- a/packages/app/src/cli/services/webhook/trigger-flags.ts
+++ b/packages/app/src/cli/services/webhook/trigger-flags.ts
@@ -35,33 +35,17 @@ const PROTOCOL = {
  * @returns true if compatible (eg: pubsub://projectid/topicid and google-pub-sub), false otherwise
  */
 export function isAddressAllowedForDeliveryMethod(address: string, deliveryMethod: string): boolean {
-  if (deliveryMethod === DELIVERY_METHOD.PUBSUB) {
-    return PROTOCOL.PUBSUB.test(address)
-  }
+  const expectedDeliveryMethod = deliveryMethodForAddress(address)
+  if (expectedDeliveryMethod === DELIVERY_METHOD.LOCALHOST && deliveryMethod === DELIVERY_METHOD.HTTP) return true
 
-  if (deliveryMethod === DELIVERY_METHOD.EVENTBRIDGE) {
-    return PROTOCOL.EVENTBRIDGE.test(address)
-  }
-
-  if (deliveryMethod === DELIVERY_METHOD.HTTP && isAnyHttp(address)) {
-    if (isLocal(address)) {
-      return true
-    }
-    return PROTOCOL.HTTP.test(address)
-  }
-
-  return false
+  return expectedDeliveryMethod === deliveryMethod
 }
 
 function isLocal(address: string): boolean {
-  if (!isAnyHttp(address)) return false
+  if (!PROTOCOL.LOCALHOST.test(address)) return false
 
   const url = new URL(address.toLowerCase())
   return url.hostname === 'localhost'
-}
-
-function isAnyHttp(address: string): boolean {
-  return PROTOCOL.LOCALHOST.test(address) || PROTOCOL.HTTP.test(address)
 }
 
 /**
@@ -166,7 +150,7 @@ export function deliveryMethodForAddress(address: string | undefined): string | 
     return DELIVERY_METHOD.EVENTBRIDGE
   }
 
-  if (isAnyHttp(address) && isLocal(address)) {
+  if (isLocal(address)) {
     return DELIVERY_METHOD.LOCALHOST
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/3727 we introduced a regression, causing the URL validation to fail for Pub/Sub in `webhook trigger`.

<img width="650" alt="Monosnap -zsh 2024-06-04 08-56-25" src="https://github.com/Shopify/cli/assets/14979109/e8f2dcdb-c767-43e1-b135-5c659c6da9c8">

### WHAT is this pull request doing?

Ensure the validation works with Pub/Sub URLs

### How to test your changes?

`p shopify app webhook trigger --topic=products/update --address=pubsub://topic:subscription --api-version=2024-01 --path YOUR-APP`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
