### PR TITLE
Fix the output for unhandled errors

### DIFF
--- a/.changeset/cuddly-starfishes-tickle.md
+++ b/.changeset/cuddly-starfishes-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix the output for unhandled errors

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -19,6 +19,7 @@ export class GraphQLClientError extends RequestClientError {
   public constructor(message: string, statusCode: number, errors?: any[]) {
     super(message, statusCode)
     this.errors = errors
+    this.stack = undefined
   }
 }
 

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -33,7 +33,8 @@ abstract class BaseCommand extends Command {
     return undefined
   }
 
-  async catch(error: Error & {exitCode?: number | undefined}): Promise<void> {
+  async catch(error: Error & {skipOclifErrorHandling: boolean}): Promise<void> {
+    error.skipOclifErrorHandling = true
     await errorHandler(error, this.config)
     return Errors.handle(error)
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Unhandled errors are shown twice:

<img width="1393" alt="Monosnap -zsh 2024-06-04 13-31-48" src="https://github.com/Shopify/cli/assets/14979109/0f2ef3ad-a950-4fb8-9aac-da371b09079d">

### WHAT is this pull request doing?

- Sets the flag `skipOclifErrorHandling` to [prevent Oclif from printing the error](https://github.com/oclif/core/blob/63b6e59204718f8871f0d05e1a493777476886d0/src/errors/handle.ts#L35), which is already shown by the CLI
- Skips the stacktrace for API errors, which is not useful (it always points to the code where the request is made)

### How to test your changes?

- Edit `packages/cli/src/cli/commands/version.ts` and add `throw new Error('Boom!')` at the beginning of `run()`
- `p shopify version`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
