### PR TITLE
Revamp missing export behaviour

### DIFF
--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -4,6 +4,10 @@ import {appFlags} from '../../../flags.js'
 import Command from '@shopify/cli-kit/node/base-command'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
+import {renderAutocompletePrompt, isTTY} from '@shopify/cli-kit/node/ui'
+import {outputDebug} from '@shopify/cli-kit/node/output'
+
+const DEFAULT_FUNCTION_EXPORT = '_start'
 
 export default class FunctionRun extends Command {
   static summary = 'Run a function locally for testing.'
@@ -25,7 +29,6 @@ export default class FunctionRun extends Command {
       char: 'e',
       hidden: false,
       description: 'Name of the WebAssembly export to invoke.',
-      default: '_start',
       env: 'SHOPIFY_FLAG_EXPORT',
     }),
     json: Flags.boolean({
@@ -42,10 +45,43 @@ export default class FunctionRun extends Command {
       path: flags.path,
       userProvidedConfigName: flags.config,
       callback: async (_app, ourFunction) => {
+        let functionExport = DEFAULT_FUNCTION_EXPORT
+
+        if (flags.export !== undefined) {
+          outputDebug(`Using export ${flags.export} from the --export flag.`)
+          functionExport = flags.export
+        } else if (
+          ourFunction.configuration.targeting !== undefined &&
+          ourFunction.configuration.targeting.length > 0
+        ) {
+          const targeting = ourFunction.configuration.targeting
+
+          if (targeting.length > 1 && isTTY({})) {
+            const targets = targeting.map((target) => ({
+              label: target.target,
+              value: target.export || DEFAULT_FUNCTION_EXPORT,
+            }))
+
+            functionExport = await renderAutocompletePrompt({
+              message: `Which target would you like to execute?`,
+              choices: targets,
+            })
+          } else {
+            functionExport = targeting?.[0]?.export || DEFAULT_FUNCTION_EXPORT
+            outputDebug(
+              `Using export '${functionExport}'. Use the --export flag or an interactive terminal to select a different export.`,
+            )
+          }
+        } else {
+          outputDebug(
+            `No targeting information found. Using the default export '${functionExport}'. Use the --export flag or an interactive terminal to select a different export.`,
+          )
+        }
+
         await runFunctionRunner(ourFunction, {
           json: flags.json,
           input: flags.input,
-          export: flags.export,
+          export: functionExport,
         })
       },
     })

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -686,6 +686,15 @@ export const keypress = async (stdin = process.stdin, uiDebugOptions: UIDebugOpt
   })
 }
 
+interface IsTTYOptions {
+  stdin?: NodeJS.ReadStream
+  uiDebugOptions?: UIDebugOptions
+}
+
+export function isTTY({stdin = undefined, uiDebugOptions = defaultUIDebugOptions}: IsTTYOptions) {
+  return Boolean(uiDebugOptions.skipTTYCheck || stdin || terminalSupportsRawMode())
+}
+
 interface ThrowInNonTTYOptions {
   message: TokenItem
   stdin?: NodeJS.ReadStream
@@ -693,7 +702,7 @@ interface ThrowInNonTTYOptions {
 
 // eslint-disable-next-line max-params
 function throwInNonTTY({message, stdin = undefined}: ThrowInNonTTYOptions, uiDebugOptions: UIDebugOptions) {
-  if (uiDebugOptions.skipTTYCheck || stdin || terminalSupportsRawMode()) return
+  if (isTTY({stdin, uiDebugOptions})) return
 
   const promptText = tokenItemToString(message)
   const errorMessage = `Failed to prompt:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -339,7 +339,7 @@ USAGE
 
 FLAGS
   -c, --config=<value>  The name of the app configuration.
-  -e, --export=<value>  [default: _start] Name of the WebAssembly export to invoke.
+  -e, --export=<value>  Name of the WebAssembly export to invoke.
   -i, --input=<value>   The input JSON to pass to the function. If omitted, standard input is used.
   -j, --json            Log the run result as a JSON object.
       --no-color        Disable color output.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -906,7 +906,6 @@
         },
         "export": {
           "char": "e",
-          "default": "_start",
           "description": "Name of the WebAssembly export to invoke.",
           "env": "SHOPIFY_FLAG_EXPORT",
           "hasDynamicHelp": false,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/function-runner/issues/270

Our current behaviour for a missing import is rather confusing- it defaults to `_start`, and if `_start` isn't present it fails, tries to read the output, and returns a JSON parsing error.

### WHAT is this pull request doing?

The behaviour proposed here is as follows:
- When the user has passed in the export flag, that's always used over anything else
- When the function has a list of targets which have exports
  - If they have a list of targets and an interactive terminal, show them a prompt to pick one
  - If the terminal isn't interactive, or if there's only one option to select, select the first option
  - When exports are missing, default to `_start`
- When there's no targeting information or flag, use `_start`

I've added log statements to explain to the user why a particular export was selected.

### How to test your changes?

Pending

### Post-release steps

None, as far as I know.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
