### PR TITLE
Use source for prefix

### DIFF
--- a/packages/app/src/cli/services/app-logs/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.test.ts
@@ -3,6 +3,7 @@ import {writeAppLogsToFile} from './write-app-logs.js'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {describe, expect, test, vi, beforeEach, afterEach} from 'vitest'
 import {fetch} from '@shopify/cli-kit/node/http'
+import * as components from '@shopify/cli-kit/node/ui/components'
 
 const JWT_TOKEN = 'jwtToken'
 const API_KEY = 'apiKey'
@@ -45,6 +46,7 @@ const OUTPUT = {
     },
   ],
 }
+const SOURCE = 'my-function'
 const PAYLOAD = {
   input: JSON.stringify(INPUT),
   input_bytes: 123,
@@ -64,6 +66,8 @@ const RESPONSE_DATA = {
       event_type: 'function_run',
       cursor: '2024-05-23T19:17:02.321773Z',
       status: 'success',
+      source: SOURCE,
+      source_namespace: 'extensions',
       log_timestamp: '2024-05-23T19:17:00.240053Z',
     },
   ],
@@ -89,6 +93,8 @@ describe('pollAppLogs', () => {
 
     // Given
     vi.mocked(writeAppLogsToFile)
+
+    vi.spyOn(components, 'useConcurrentOutputContext')
 
     const mockedFetch = vi
       .fn()
@@ -123,6 +129,8 @@ describe('pollAppLogs', () => {
 
     expect(stdout.write).toHaveBeenCalledWith('Function executed successfully using 0.5124M instructions.')
     expect(stdout.write).toHaveBeenCalledWith(LOGS)
+
+    expect(components.useConcurrentOutputContext).toHaveBeenCalledWith({outputPrefix: SOURCE}, expect.any(Function))
 
     expect(vi.getTimerCount()).toEqual(1)
   })

--- a/packages/app/src/cli/services/app-logs/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.ts
@@ -1,4 +1,5 @@
 import {writeAppLogsToFile} from './write-app-logs.js'
+import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {fetch} from '@shopify/cli-kit/node/http'
 import {Writable} from 'stream'
@@ -17,6 +18,8 @@ export interface AppEventData {
   api_client_id: number
   payload: string
   event_type: string
+  source: string
+  source_namespace: string
   cursor: string
   status: 'success' | 'failure'
   log_timestamp: string
@@ -61,23 +64,25 @@ export const pollAppLogs = async ({
       const payload = JSON.parse(functionLog.payload)
       const fuel = (payload.fuel_consumed / ONE_MILLION).toFixed(4)
 
-      if (functionLog.status === 'success') {
-        stdout.write(`Function executed successfully using ${fuel}M instructions.`)
-      } else if (functionLog.status === 'failure') {
-        stdout.write(`❌ Function failed to execute with error: ${payload.error_type}`)
-      }
-
-      // print the logs from the appLogs as well
-      const logs = JSON.parse(functionLog.payload).logs
-      if (logs.length > 0) {
-        stdout.write(logs)
-      }
-
       // eslint-disable-next-line no-await-in-loop
-      await writeAppLogsToFile({
-        appLog: functionLog,
-        apiKey,
-        stdout,
+      await useConcurrentOutputContext({outputPrefix: functionLog.source}, async () => {
+        if (functionLog.status === 'success') {
+          stdout.write(`Function executed successfully using ${fuel}M instructions.`)
+        } else if (functionLog.status === 'failure') {
+          stdout.write(`❌ Function failed to execute with error: ${payload.error_type}`)
+        }
+
+        // print the logs from the appLogs as well
+        const logs = JSON.parse(functionLog.payload).logs
+        if (logs.length > 0) {
+          stdout.write(logs)
+        }
+
+        await writeAppLogsToFile({
+          appLog: functionLog,
+          apiKey,
+          stdout,
+        })
       })
     }
   }

--- a/packages/app/src/cli/services/app-logs/write-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/write-app-logs.test.ts
@@ -13,6 +13,8 @@ const APP_LOG: AppEventData = {
   event_type: 'function_run',
   cursor: '2024-05-22T15:06:43.841156Z',
   status: 'success',
+  source: 'my-function',
+  source_namespace: 'extensions',
   log_timestamp: '2024-05-22T15:06:41.827379Z',
 }
 const API_KEY = 'apiKey'


### PR DESCRIPTION
### WHY are these changes introduced?

Issue: https://github.com/Shopify/shopify-functions/issues/216
Blocked on the other PRs linked in that issue.

Once we have the source available to us, we want to use it to place the extension's handle as the log prefix.

### WHAT is this pull request doing?

I'm using the pre-existing `useConcurrentOutputContext` method to set the context to match the supplied `source` value in the function log.

🎩 
- Poll for app logs with two different handles
- See them render with their handles in the terminal:
![Screenshot 2024-06-05 at 2 58 38 PM](https://github.com/Shopify/cli/assets/8670351/8a67fe39-6649-4153-b089-eae130fe2c87)


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
