### PR TITLE
Reword verbose flag description

### DIFF
--- a/docs-shopify.dev/commands/interfaces/app-build.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-build.interface.ts
@@ -31,7 +31,7 @@ export interface appbuild {
   '--skip-dependencies-installation'?: ''
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-config-link.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-config-link.interface.ts
@@ -25,7 +25,7 @@ export interface appconfiglink {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-config-use.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-config-use.interface.ts
@@ -19,7 +19,7 @@ export interface appconfiguse {
   '--reset'?: ''
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-deploy.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-deploy.interface.ts
@@ -55,7 +55,7 @@ export interface appdeploy {
   '--source-control-url <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-dev.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-dev.interface.ts
@@ -85,7 +85,7 @@ export interface appdev {
   '--tunnel-url <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-env-pull.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-env-pull.interface.ts
@@ -25,7 +25,7 @@ export interface appenvpull {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-env-show.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-env-show.interface.ts
@@ -19,7 +19,7 @@ export interface appenvshow {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-function-build.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-build.interface.ts
@@ -19,7 +19,7 @@ export interface appfunctionbuild {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-function-run.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-run.interface.ts
@@ -37,7 +37,7 @@ export interface appfunctionrun {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-function-schema.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-schema.interface.ts
@@ -31,7 +31,7 @@ export interface appfunctionschema {
   '--stdout'?: ''
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-function-typegen.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-typegen.interface.ts
@@ -19,7 +19,7 @@ export interface appfunctiontypegen {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-generate-extension.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-generate-extension.interface.ts
@@ -55,7 +55,7 @@ export interface appgenerateextension {
   '-t, --type <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-import-extensions.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-import-extensions.interface.ts
@@ -25,7 +25,7 @@ export interface appimportextensions {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-info.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-info.interface.ts
@@ -25,7 +25,7 @@ export interface appinfo {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-init.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-init.interface.ts
@@ -39,7 +39,7 @@ export interface appinit {
   '--template <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-release.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-release.interface.ts
@@ -37,7 +37,7 @@ export interface apprelease {
   '--reset'?: ''
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts
@@ -31,7 +31,7 @@ export interface appversionslist {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-check.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-check.interface.ts
@@ -64,7 +64,7 @@ export interface themecheck {
   '--print'?: ''
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-console.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-console.interface.ts
@@ -37,7 +37,7 @@ export interface themeconsole {
   '--url <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-delete.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-delete.interface.ts
@@ -49,7 +49,7 @@ export interface themedelete {
   '-t, --theme <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-dev.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-dev.interface.ts
@@ -100,7 +100,7 @@ export interface themedev {
   '--theme-editor-sync'?: ''
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-info.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-info.interface.ts
@@ -43,7 +43,7 @@ export interface themeinfo {
   '-t, --theme <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-init.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-init.interface.ts
@@ -25,7 +25,7 @@ export interface themeinit {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-language-server.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-language-server.interface.ts
@@ -7,7 +7,7 @@ export interface themelanguageserver {
   '--no-color'?: ''
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-list.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-list.interface.ts
@@ -49,7 +49,7 @@ export interface themelist {
   '-s, --store <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-open.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-open.interface.ts
@@ -49,7 +49,7 @@ export interface themeopen {
   '-t, --theme <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-package.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-package.interface.ts
@@ -13,7 +13,7 @@ export interface themepackage {
   '--path <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-publish.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-publish.interface.ts
@@ -37,7 +37,7 @@ export interface themepublish {
   '-t, --theme <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-pull.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-pull.interface.ts
@@ -67,7 +67,7 @@ export interface themepull {
   '-t, --theme <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-push.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-push.interface.ts
@@ -91,7 +91,7 @@ export interface themepush {
   '-u, --unpublished'?: ''
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-rename.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-rename.interface.ts
@@ -49,7 +49,7 @@ export interface themerename {
   '-t, --theme <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/commands/interfaces/theme-share.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-share.interface.ts
@@ -31,7 +31,7 @@ export interface themeshare {
   '-s, --store <value>'?: string
 
   /**
-   * Increase the verbosity of the logs.
+   * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */
   '--verbose'?: ''

--- a/docs-shopify.dev/generated/generated_docs_data.json
+++ b/docs-shopify.dev/generated/generated_docs_data.json
@@ -69,7 +69,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -83,7 +83,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appbuild {\n  /**\n   * Application's Client ID that will be exposed at build time.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Skips the installation of dependencies. Deprecated, use workspaces instead.\n   * @environment SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION\n   */\n  '--skip-dependencies-installation'?: ''\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appbuild {\n  /**\n   * Application's Client ID that will be exposed at build time.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Skips the installation of dependencies. Deprecated, use workspaces instead.\n   * @environment SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION\n   */\n  '--skip-dependencies-installation'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -152,7 +152,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -166,7 +166,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appconfiglink {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appconfiglink {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -235,12 +235,12 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               }
             ],
-            "value": "export interface appconfiguse {\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset current configuration.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appconfiguse {\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset current configuration.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -345,7 +345,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -377,7 +377,7 @@
                 "environmentValue": "SHOPIFY_FLAG_FORCE"
               }
             ],
-            "value": "export interface appdeploy {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Deploy without asking for confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Optional message that will be associated with this version. This is for internal use only and won't be available externally.\n   * @environment SHOPIFY_FLAG_MESSAGE\n   */\n  '--message <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Creates a version but doesn't release it - it's not made available to merchants.\n   * @environment SHOPIFY_FLAG_NO_RELEASE\n   */\n  '--no-release'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * URL associated with the new app version.\n   * @environment SHOPIFY_FLAG_SOURCE_CONTROL_URL\n   */\n  '--source-control-url <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Optional version tag that will be associated with this app version. If not provided, an auto-generated identifier will be generated for this app version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
+            "value": "export interface appdeploy {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Deploy without asking for confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Optional message that will be associated with this version. This is for internal use only and won't be available externally.\n   * @environment SHOPIFY_FLAG_MESSAGE\n   */\n  '--message <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Creates a version but doesn't release it - it's not made available to merchants.\n   * @environment SHOPIFY_FLAG_NO_RELEASE\n   */\n  '--no-release'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * URL associated with the new app version.\n   * @environment SHOPIFY_FLAG_SOURCE_CONTROL_URL\n   */\n  '--source-control-url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Optional version tag that will be associated with this app version. If not provided, an auto-generated identifier will be generated for this app version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
           }
         }
       }
@@ -518,7 +518,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -550,7 +550,7 @@
                 "environmentValue": "SHOPIFY_FLAG_THEME"
               }
             ],
-            "value": "export interface appdev {\n  /**\n   * Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"\n   * @environment SHOPIFY_FLAG_CHECKOUT_CART_URL\n   */\n  '--checkout-cart-url <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Skips the Partners Dashboard URL update step.\n   * @environment SHOPIFY_FLAG_NO_UPDATE\n   */\n  '--no-update'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Skips the installation of dependencies. Deprecated, use workspaces instead.\n   * @environment SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION\n   */\n  '--skip-dependencies-installation'?: ''\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Resource URL for subscription UI extension. Format: \"/products/{productId}\"\n   * @environment SHOPIFY_FLAG_SUBSCRIPTION_PRODUCT_URL\n   */\n  '--subscription-product-url <value>'?: string\n\n  /**\n   * Theme ID or name of the theme app extension host theme.\n   * @environment SHOPIFY_FLAG_THEME\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Local port of the theme app extension development server.\n   * @environment SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT\n   */\n  '--theme-app-extension-port <value>'?: string\n\n  /**\n   * Use a custom tunnel, it must be running before executing dev. Format: \"https://my-tunnel-url:port\".\n   * @environment SHOPIFY_FLAG_TUNNEL_URL\n   */\n  '--tunnel-url <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appdev {\n  /**\n   * Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"\n   * @environment SHOPIFY_FLAG_CHECKOUT_CART_URL\n   */\n  '--checkout-cart-url <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Skips the Partners Dashboard URL update step.\n   * @environment SHOPIFY_FLAG_NO_UPDATE\n   */\n  '--no-update'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Skips the installation of dependencies. Deprecated, use workspaces instead.\n   * @environment SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION\n   */\n  '--skip-dependencies-installation'?: ''\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Resource URL for subscription UI extension. Format: \"/products/{productId}\"\n   * @environment SHOPIFY_FLAG_SUBSCRIPTION_PRODUCT_URL\n   */\n  '--subscription-product-url <value>'?: string\n\n  /**\n   * Theme ID or name of the theme app extension host theme.\n   * @environment SHOPIFY_FLAG_THEME\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Local port of the theme app extension development server.\n   * @environment SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT\n   */\n  '--theme-app-extension-port <value>'?: string\n\n  /**\n   * Use a custom tunnel, it must be running before executing dev. Format: \"https://my-tunnel-url:port\".\n   * @environment SHOPIFY_FLAG_TUNNEL_URL\n   */\n  '--tunnel-url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -619,7 +619,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -633,7 +633,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appenvpull {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Specify an environment file to update if the update flag is set\n   * @environment SHOPIFY_FLAG_ENV_FILE\n   */\n  '--env-file <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appenvpull {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Specify an environment file to update if the update flag is set\n   * @environment SHOPIFY_FLAG_ENV_FILE\n   */\n  '--env-file <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -693,7 +693,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -707,7 +707,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appenvshow {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appenvshow {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -767,7 +767,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -781,7 +781,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appfunctionbuild {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appfunctionbuild {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -841,7 +841,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -882,7 +882,7 @@
                 "environmentValue": "SHOPIFY_FLAG_JSON"
               }
             ],
-            "value": "export interface appfunctionrun {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Name of the WebAssembly export to invoke.\n   * @environment SHOPIFY_FLAG_EXPORT\n   */\n  '-e, --export <value>'?: string\n\n  /**\n   * The input JSON to pass to the function. If omitted, standard input is used.\n   * @environment SHOPIFY_FLAG_INPUT\n   */\n  '-i, --input <value>'?: string\n\n  /**\n   * Log the run result as a JSON object.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appfunctionrun {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Name of the WebAssembly export to invoke.\n   * @environment SHOPIFY_FLAG_EXPORT\n   */\n  '-e, --export <value>'?: string\n\n  /**\n   * The input JSON to pass to the function. If omitted, standard input is used.\n   * @environment SHOPIFY_FLAG_INPUT\n   */\n  '-i, --input <value>'?: string\n\n  /**\n   * Log the run result as a JSON object.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -960,7 +960,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -974,7 +974,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appfunctionschema {\n  /**\n   * The Client ID to fetch the schema with.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Output the schema to stdout instead of writing to a file.\n   * @environment SHOPIFY_FLAG_STDOUT\n   */\n  '--stdout'?: ''\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appfunctionschema {\n  /**\n   * The Client ID to fetch the schema with.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Output the schema to stdout instead of writing to a file.\n   * @environment SHOPIFY_FLAG_STDOUT\n   */\n  '--stdout'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -1034,7 +1034,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -1048,7 +1048,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appfunctiontypegen {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appfunctiontypegen {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -1135,7 +1135,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -1176,7 +1176,7 @@
                 "environmentValue": "SHOPIFY_FLAG_EXTENSION_TYPE"
               }
             ],
-            "value": "export interface appgenerateextension {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Choose a starting template for your extension, where applicable\n   * @environment SHOPIFY_FLAG_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * name of your Extension\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Extension template\n   * @environment SHOPIFY_FLAG_EXTENSION_TEMPLATE\n   */\n  '-t, --template <value>'?: string\n\n  /**\n   * Deprecated. Please use --template\n   * @environment SHOPIFY_FLAG_EXTENSION_TYPE\n   */\n  '-t, --type <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appgenerateextension {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Choose a starting template for your extension, where applicable\n   * @environment SHOPIFY_FLAG_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * name of your Extension\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Extension template\n   * @environment SHOPIFY_FLAG_EXTENSION_TEMPLATE\n   */\n  '-t, --template <value>'?: string\n\n  /**\n   * Deprecated. Please use --template\n   * @environment SHOPIFY_FLAG_EXTENSION_TYPE\n   */\n  '-t, --type <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -1245,7 +1245,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -1259,7 +1259,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appimportextensions {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appimportextensions {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -1328,7 +1328,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -1351,7 +1351,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appinfo {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * format output as JSON\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Outputs environment variables necessary for running and deploying web/.\n   * @environment SHOPIFY_FLAG_OUTPUT_WEB_ENV\n   */\n  '--web-env'?: ''\n}"
+            "value": "export interface appinfo {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * format output as JSON\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Outputs environment variables necessary for running and deploying web/.\n   * @environment SHOPIFY_FLAG_OUTPUT_WEB_ENV\n   */\n  '--web-env'?: ''\n}"
           }
         }
       }
@@ -1420,7 +1420,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -1452,7 +1452,7 @@
                 "environmentValue": "SHOPIFY_FLAG_PATH"
               }
             ],
-            "value": "export interface appinit {\n  /**\n   * Which flavor of the given template to use.\n   * @environment SHOPIFY_FLAG_TEMPLATE_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PACKAGE_MANAGER\n   */\n  '-d, --package-manager <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '-p, --path <value>'?: string\n\n  /**\n   * The app template. Accepts one of the following:\n       - <remix|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]\n   * @environment SHOPIFY_FLAG_TEMPLATE\n   */\n  '--template <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appinit {\n  /**\n   * Which flavor of the given template to use.\n   * @environment SHOPIFY_FLAG_TEMPLATE_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PACKAGE_MANAGER\n   */\n  '-d, --package-manager <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '-p, --path <value>'?: string\n\n  /**\n   * The app template. Accepts one of the following:\n       - <remix|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]\n   * @environment SHOPIFY_FLAG_TEMPLATE\n   */\n  '--template <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -1530,7 +1530,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -1561,7 +1561,7 @@
                 "environmentValue": "SHOPIFY_FLAG_FORCE"
               }
             ],
-            "value": "export interface apprelease {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Release without asking for confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The name of the app version to release.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>': string\n}"
+            "value": "export interface apprelease {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Release without asking for confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The name of the app version to release.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>': string\n}"
           }
         }
       }
@@ -1639,7 +1639,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -1653,7 +1653,7 @@
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
               }
             ],
-            "value": "export interface appversionslist {\n  /**\n   * The Client ID to fetch versions for.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the versions list as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appversionslist {\n  /**\n   * The Client ID to fetch versions for.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the versions list as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -4122,7 +4122,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -4172,7 +4172,7 @@
                 "environmentValue": "SHOPIFY_FLAG_VERSION"
               }
             ],
-            "value": "export interface themecheck {\n  /**\n   * Automatically fix offenses\n   * @environment SHOPIFY_FLAG_AUTO_CORRECT\n   */\n  '-a, --auto-correct'?: ''\n\n  /**\n   * Use the config provided, overriding .theme-check.yml if present\n      Supports all theme-check: config values, e.g., theme-check:theme-app-extension,\n      theme-check:recommended, theme-check:all\n      For backwards compatibility, :theme_app_extension is also supported \n   * @environment SHOPIFY_FLAG_CONFIG\n   */\n  '-C, --config <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Minimum severity for exit with error code\n   * @environment SHOPIFY_FLAG_FAIL_LEVEL\n   */\n  '--fail-level <value>'?: string\n\n  /**\n   * Generate a .theme-check.yml file\n   * @environment SHOPIFY_FLAG_INIT\n   */\n  '--init'?: ''\n\n  /**\n   * List enabled checks\n   * @environment SHOPIFY_FLAG_LIST\n   */\n  '--list'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The output format to use\n   * @environment SHOPIFY_FLAG_OUTPUT\n   */\n  '-o, --output <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Output active config to STDOUT\n   * @environment SHOPIFY_FLAG_PRINT\n   */\n  '--print'?: ''\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Print Theme Check version\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '-v, --version'?: ''\n}"
+            "value": "export interface themecheck {\n  /**\n   * Automatically fix offenses\n   * @environment SHOPIFY_FLAG_AUTO_CORRECT\n   */\n  '-a, --auto-correct'?: ''\n\n  /**\n   * Use the config provided, overriding .theme-check.yml if present\n      Supports all theme-check: config values, e.g., theme-check:theme-app-extension,\n      theme-check:recommended, theme-check:all\n      For backwards compatibility, :theme_app_extension is also supported \n   * @environment SHOPIFY_FLAG_CONFIG\n   */\n  '-C, --config <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Minimum severity for exit with error code\n   * @environment SHOPIFY_FLAG_FAIL_LEVEL\n   */\n  '--fail-level <value>'?: string\n\n  /**\n   * Generate a .theme-check.yml file\n   * @environment SHOPIFY_FLAG_INIT\n   */\n  '--init'?: ''\n\n  /**\n   * List enabled checks\n   * @environment SHOPIFY_FLAG_LIST\n   */\n  '--list'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The output format to use\n   * @environment SHOPIFY_FLAG_OUTPUT\n   */\n  '-o, --output <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Output active config to STDOUT\n   * @environment SHOPIFY_FLAG_PRINT\n   */\n  '--print'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Print Theme Check version\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '-v, --version'?: ''\n}"
           }
         }
       }
@@ -4250,7 +4250,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -4273,7 +4273,7 @@
                 "environmentValue": "SHOPIFY_FLAG_STORE"
               }
             ],
-            "value": "export interface themeconsole {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Local port to serve authentication service.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themeconsole {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Local port to serve authentication service.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -4333,7 +4333,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -4392,7 +4392,7 @@
                 "environmentValue": "SHOPIFY_FLAG_THEME_ID"
               }
             ],
-            "value": "export interface themedelete {\n  /**\n   * Delete your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Include others development themes in theme list.\n   * @environment SHOPIFY_FLAG_SHOW_ALL\n   */\n  '-a, --show-all'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themedelete {\n  /**\n   * Delete your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Include others development themes in theme list.\n   * @environment SHOPIFY_FLAG_SHOW_ALL\n   */\n  '-a, --show-all'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -4524,7 +4524,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -4583,7 +4583,7 @@
                 "environmentValue": "SHOPIFY_FLAG_IGNORE"
               }
             ],
-            "value": "export interface themedev {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Set which network interface the web server listens on. The default value is 127.0.0.1.\n   * @environment SHOPIFY_FLAG_HOST\n   */\n  '--host <value>'?: string\n\n  /**\n   * Skip hot reloading any files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload\n   * @environment SHOPIFY_FLAG_LIVE_RELOAD\n   */\n  '--live-reload <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * Hot reload only files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Force polling to detect file changes.\n   * @environment SHOPIFY_FLAG_POLL\n   */\n  '--poll'?: ''\n\n  /**\n   * Local port to serve theme preview from.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Synchronize Theme Editor updates in the local theme files.\n   * @environment SHOPIFY_FLAG_THEME_EDITOR_SYNC\n   */\n  '--theme-editor-sync'?: ''\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themedev {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Set which network interface the web server listens on. The default value is 127.0.0.1.\n   * @environment SHOPIFY_FLAG_HOST\n   */\n  '--host <value>'?: string\n\n  /**\n   * Skip hot reloading any files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload\n   * @environment SHOPIFY_FLAG_LIVE_RELOAD\n   */\n  '--live-reload <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * Hot reload only files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Force polling to detect file changes.\n   * @environment SHOPIFY_FLAG_POLL\n   */\n  '--poll'?: ''\n\n  /**\n   * Local port to serve theme preview from.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Synchronize Theme Editor updates in the local theme files.\n   * @environment SHOPIFY_FLAG_THEME_EDITOR_SYNC\n   */\n  '--theme-editor-sync'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -4652,7 +4652,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -4693,7 +4693,7 @@
                 "environmentValue": "SHOPIFY_FLAG_THEME_ID"
               }
             ],
-            "value": "export interface themeinfo {\n  /**\n   * Retrieve info from your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the theme info as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themeinfo {\n  /**\n   * Retrieve info from your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the theme info as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -4753,7 +4753,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -4776,7 +4776,7 @@
                 "environmentValue": "SHOPIFY_FLAG_CLONE_URL"
               }
             ],
-            "value": "export interface themeinit {\n  /**\n   * The Git URL to clone from. Defaults to Shopify's example theme, Dawn: https://github.com/Shopify/dawn.git\n   * @environment SHOPIFY_FLAG_CLONE_URL\n   */\n  '-u, --clone-url <value>'?: string\n\n  /**\n   * Downloads the latest release of the `clone-url`\n   * @environment SHOPIFY_FLAG_LATEST\n   */\n  '-l, --latest'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themeinit {\n  /**\n   * The Git URL to clone from. Defaults to Shopify's example theme, Dawn: https://github.com/Shopify/dawn.git\n   * @environment SHOPIFY_FLAG_CLONE_URL\n   */\n  '-u, --clone-url <value>'?: string\n\n  /**\n   * Downloads the latest release of the `clone-url`\n   * @environment SHOPIFY_FLAG_LATEST\n   */\n  '-l, --latest'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -4827,12 +4827,12 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               }
             ],
-            "value": "export interface themelanguageserver {\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themelanguageserver {\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -4928,7 +4928,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -4951,7 +4951,7 @@
                 "environmentValue": "SHOPIFY_FLAG_STORE"
               }
             ],
-            "value": "export interface themelist {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Only list theme with the given ID.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Output the theme list as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Only list themes that contain the given name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Only list themes with the given role.\n   * @environment SHOPIFY_FLAG_ROLE\n   */\n  '--role <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themelist {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Only list theme with the given ID.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Output the theme list as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Only list themes that contain the given name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Only list themes with the given role.\n   * @environment SHOPIFY_FLAG_ROLE\n   */\n  '--role <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -5011,7 +5011,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -5070,7 +5070,7 @@
                 "environmentValue": "SHOPIFY_FLAG_THEME_ID"
               }
             ],
-            "value": "export interface themeopen {\n  /**\n   * Open your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Open the theme editor for the specified theme in the browser.\n   * @environment SHOPIFY_FLAG_EDITOR\n   */\n  '-E, --editor'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Open your live (published) theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themeopen {\n  /**\n   * Open your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Open the theme editor for the specified theme in the browser.\n   * @environment SHOPIFY_FLAG_EDITOR\n   */\n  '-E, --editor'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Open your live (published) theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -5130,12 +5130,12 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               }
             ],
-            "value": "export interface themepackage {\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themepackage {\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -5195,7 +5195,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -5236,7 +5236,7 @@
                 "environmentValue": "SHOPIFY_FLAG_THEME_ID"
               }
             ],
-            "value": "export interface themepublish {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themepublish {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -5305,7 +5305,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -5382,7 +5382,7 @@
                 "environmentValue": "SHOPIFY_FLAG_IGNORE"
               }
             ],
-            "value": "export interface themepull {\n  /**\n   * Pull theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Pull theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Runs the pull command without deleting local files.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themepull {\n  /**\n   * Pull theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Pull theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Runs the pull command without deleting local files.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -5451,7 +5451,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -5564,7 +5564,7 @@
                 "environmentValue": "SHOPIFY_FLAG_IGNORE"
               }
             ],
-            "value": "export interface themepush {\n  /**\n   * Allow push to a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Push theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output JSON instead of a UI.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Push theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Runs the push command without deleting local files.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themepush {\n  /**\n   * Allow push to a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Push theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output JSON instead of a UI.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Push theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Runs the push command without deleting local files.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -5624,7 +5624,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -5683,7 +5683,7 @@
                 "environmentValue": "SHOPIFY_FLAG_THEME_ID"
               }
             ],
-            "value": "export interface themerename {\n  /**\n   * Rename your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Rename your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * The new name for the theme.\n   * @environment SHOPIFY_FLAG_NEW_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themerename {\n  /**\n   * Rename your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Rename your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * The new name for the theme.\n   * @environment SHOPIFY_FLAG_NEW_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -5752,7 +5752,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "--verbose",
                 "value": "\"\"",
-                "description": "Increase the verbosity of the logs.",
+                "description": "Increase the verbosity of the output.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_VERBOSE"
               },
@@ -5775,7 +5775,7 @@
                 "environmentValue": "SHOPIFY_FLAG_STORE"
               }
             ],
-            "value": "export interface themeshare {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the logs.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themeshare {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }

--- a/packages/app/src/cli/commands/app/draft-extensions/push.ts
+++ b/packages/app/src/cli/commands/app/draft-extensions/push.ts
@@ -11,7 +11,7 @@ export default class DraftExtensionsPush extends Command {
   static flags = {
     verbose: Flags.boolean({
       hidden: false,
-      description: 'Increase the verbosity of the logs.',
+      description: 'Increase the verbosity of the output.',
       env: 'SHOPIFY_FLAG_VERBOSE',
     }),
     path: Flags.string({

--- a/packages/cli-kit/src/public/node/cli.ts
+++ b/packages/cli-kit/src/public/node/cli.ts
@@ -198,7 +198,7 @@ export const globalFlags = {
   }),
   verbose: Flags.boolean({
     hidden: false,
-    description: 'Increase the verbosity of the logs.',
+    description: 'Increase the verbosity of the output.',
     env: 'SHOPIFY_FLAG_VERBOSE',
   }),
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -92,7 +92,7 @@ FLAGS
       --no-color                        Disable color output.
       --path=<value>                    The path to your app directory.
       --skip-dependencies-installation  Skips the installation of dependencies. Deprecated, use workspaces instead.
-      --verbose                         Increase the verbosity of the logs.
+      --verbose                         Increase the verbosity of the output.
 
 DESCRIPTION
   Build the app, including extensions.
@@ -119,7 +119,7 @@ FLAGS
       --client-id=<value>  The Client ID of your app.
       --no-color           Disable color output.
       --path=<value>       The path to your app directory.
-      --verbose            Increase the verbosity of the logs.
+      --verbose            Increase the verbosity of the output.
 
 DESCRIPTION
   Fetch your app configuration from the Partner Dashboard.
@@ -146,7 +146,7 @@ FLAGS
   --no-color      Disable color output.
   --path=<value>  The path to your app directory.
   --reset         Reset current configuration.
-  --verbose       Increase the verbosity of the logs.
+  --verbose       Increase the verbosity of the output.
 
 DESCRIPTION
   Activate an app configuration.
@@ -175,7 +175,7 @@ FLAGS
       --path=<value>                The path to your app directory.
       --reset                       Reset all your settings.
       --source-control-url=<value>  URL associated with the new app version.
-      --verbose                     Increase the verbosity of the logs.
+      --verbose                     Increase the verbosity of the output.
       --version=<value>             Optional version tag that will be associated with this app version. If not provided,
                                     an auto-generated identifier will be generated for this app version.
 
@@ -222,7 +222,7 @@ FLAGS
       --theme-app-extension-port=<value>  Local port of the theme app extension development server.
       --tunnel-url=<value>                Use a custom tunnel, it must be running before executing dev. Format:
                                           "https://my-tunnel-url:port".
-      --verbose                           Increase the verbosity of the logs.
+      --verbose                           Increase the verbosity of the output.
 
 DESCRIPTION
   Run the app.
@@ -278,7 +278,7 @@ FLAGS
       --env-file=<value>  Specify an environment file to update if the update flag is set
       --no-color          Disable color output.
       --path=<value>      The path to your app directory.
-      --verbose           Increase the verbosity of the logs.
+      --verbose           Increase the verbosity of the output.
 
 DESCRIPTION
   Pull app and extensions environment variables.
@@ -301,7 +301,7 @@ FLAGS
   -c, --config=<value>  The name of the app configuration.
       --no-color        Disable color output.
       --path=<value>    The path to your app directory.
-      --verbose         Increase the verbosity of the logs.
+      --verbose         Increase the verbosity of the output.
 
 DESCRIPTION
   Display app and extensions environment variables.
@@ -321,7 +321,7 @@ FLAGS
   -c, --config=<value>  The name of the app configuration.
       --no-color        Disable color output.
       --path=<value>    The path to your function directory.
-      --verbose         Increase the verbosity of the logs.
+      --verbose         Increase the verbosity of the output.
 
 DESCRIPTION
   Compile a function to wasm.
@@ -344,7 +344,7 @@ FLAGS
   -j, --json            Log the run result as a JSON object.
       --no-color        Disable color output.
       --path=<value>    The path to your function directory.
-      --verbose         Increase the verbosity of the logs.
+      --verbose         Increase the verbosity of the output.
 
 DESCRIPTION
   Run a function locally for testing.
@@ -368,7 +368,7 @@ FLAGS
       --no-color           Disable color output.
       --path=<value>       The path to your function directory.
       --stdout             Output the schema to stdout instead of writing to a file.
-      --verbose            Increase the verbosity of the logs.
+      --verbose            Increase the verbosity of the output.
 
 DESCRIPTION
   Fetch the latest GraphQL schema for a function.
@@ -392,7 +392,7 @@ FLAGS
   -c, --config=<value>  The name of the app configuration.
       --no-color        Disable color output.
       --path=<value>    The path to your function directory.
-      --verbose         Increase the verbosity of the logs.
+      --verbose         Increase the verbosity of the output.
 
 DESCRIPTION
   Generate GraphQL types for a JavaScript function.
@@ -422,7 +422,7 @@ FLAGS
       --no-color           Disable color output.
       --path=<value>       The path to your app directory.
       --reset              Reset all your settings.
-      --verbose            Increase the verbosity of the logs.
+      --verbose            Increase the verbosity of the output.
 
 DESCRIPTION
   Generate a new app Extension.
@@ -452,7 +452,7 @@ FLAGS
       --client-id=<value>  The Client ID of your app.
       --no-color           Disable color output.
       --path=<value>       The path to your app directory.
-      --verbose            Increase the verbosity of the logs.
+      --verbose            Increase the verbosity of the output.
 
 DESCRIPTION
   Import dashboard-managed extensions into your app.
@@ -471,7 +471,7 @@ FLAGS
       --json            format output as JSON
       --no-color        Disable color output.
       --path=<value>    The path to your app directory.
-      --verbose         Increase the verbosity of the logs.
+      --verbose         Increase the verbosity of the output.
       --web-env         Outputs environment variables necessary for running and deploying web/.
 
 DESCRIPTION
@@ -506,7 +506,7 @@ FLAGS
                                   - <remix|none>
                                   - Any GitHub repo with optional branch and subpath, e.g.,
                                   https://github.com/Shopify/<repository>/[subpath]#[branch]
-      --verbose                   Increase the verbosity of the logs.
+      --verbose                   Increase the verbosity of the output.
 ```
 
 ## `shopify app:release --version <version>`
@@ -524,7 +524,7 @@ FLAGS
       --no-color           Disable color output.
       --path=<value>       The path to your app directory.
       --reset              Reset all your settings.
-      --verbose            Increase the verbosity of the logs.
+      --verbose            Increase the verbosity of the output.
       --version=<value>    (required) The name of the app version to release.
 
 DESCRIPTION
@@ -548,7 +548,7 @@ FLAGS
       --json               Output the versions list as JSON.
       --no-color           Disable color output.
       --path=<value>       The path to your app directory.
-      --verbose            Increase the verbosity of the logs.
+      --verbose            Increase the verbosity of the output.
 
 DESCRIPTION
   List deployed versions of your app.
@@ -1583,7 +1583,7 @@ FLAGS
       --no-color             Disable color output.
       --path=<value>         The path to your theme directory.
       --print                Output active config to STDOUT
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Validate the theme.
@@ -1610,7 +1610,7 @@ FLAGS
       --password=<value>     Password generated from the Theme Access app.
       --port=<value>         [default: 9293] Local port to serve authentication service.
       --url=<value>          [default: /] The url to be used as context
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Shopify Liquid REPL (read-eval-print loop) tool
@@ -1640,7 +1640,7 @@ FLAGS
   -t, --theme=<value>...     Theme ID or name of the remote theme.
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Delete remote themes from the connected store. This command can't be undone.
@@ -1721,7 +1721,7 @@ FLAGS
       Synchronize Theme Editor updates in the local theme files.
 
   --verbose
-      Increase the verbosity of the logs.
+      Increase the verbosity of the output.
 
 DESCRIPTION
   Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to
@@ -1776,7 +1776,7 @@ FLAGS
       --json                 Output the theme info as JSON.
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Displays information about your theme environment, including your current store. Can also retrieve information about a
@@ -1800,7 +1800,7 @@ FLAGS
                            Shopify's example theme, Dawn: https://github.com/Shopify/dawn.git
       --no-color           Disable color output.
       --path=<value>       The path to your theme directory.
-      --verbose            Increase the verbosity of the logs.
+      --verbose            Increase the verbosity of the output.
 
 DESCRIPTION
   Clones a Git repository to use as a starting point for building a new theme.
@@ -1827,7 +1827,7 @@ USAGE
 
 FLAGS
   --no-color  Disable color output.
-  --verbose   Increase the verbosity of the logs.
+  --verbose   Increase the verbosity of the output.
 
 DESCRIPTION
   Start a Language Server Protocol server.
@@ -1855,7 +1855,7 @@ FLAGS
       --password=<value>     Password generated from the Theme Access app.
       --role=<option>        Only list themes with the given role.
                              <options: live|unpublished|development>
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Lists the themes in your store, along with their IDs and statuses.
@@ -1880,7 +1880,7 @@ FLAGS
   -t, --theme=<value>        Theme ID or name of the remote theme.
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Opens the preview of your remote theme.
@@ -1907,7 +1907,7 @@ USAGE
 FLAGS
   --no-color      Disable color output.
   --path=<value>  The path to your theme directory.
-  --verbose       Increase the verbosity of the logs.
+  --verbose       Increase the verbosity of the output.
 
 DESCRIPTION
   Package your theme into a .zip file, ready to upload to the Online Store.
@@ -1937,7 +1937,7 @@ FLAGS
   -t, --theme=<value>        Theme ID or name of the remote theme.
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Set a remote theme as the live theme.
@@ -1976,7 +1976,7 @@ FLAGS
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
       --path=<value>         The path to your theme directory.
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Download your remote theme files locally.
@@ -2012,7 +2012,7 @@ FLAGS
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
       --path=<value>         The path to your theme directory.
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Uploads your local theme files to the connected store, overwriting the remote version if specified.
@@ -2070,7 +2070,7 @@ FLAGS
   -t, --theme=<value>        Theme ID or name of the remote theme.
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Renames an existing theme.
@@ -2096,7 +2096,7 @@ FLAGS
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
       --path=<value>         The path to your theme directory.
-      --verbose              Increase the verbosity of the logs.
+      --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
   Creates a shareable, unpublished, and new theme on your theme library with a randomized name.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -69,7 +69,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -132,7 +132,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -188,7 +188,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -312,7 +312,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -524,7 +524,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -597,7 +597,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -660,7 +660,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -714,7 +714,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -769,7 +769,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -868,7 +868,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -953,7 +953,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -1040,7 +1040,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -1095,7 +1095,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -1247,7 +1247,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -1334,7 +1334,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -1399,7 +1399,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -1460,7 +1460,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -1559,7 +1559,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -1654,7 +1654,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -1756,7 +1756,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -4301,7 +4301,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -4389,7 +4389,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -4487,7 +4487,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -4691,7 +4691,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -4775,7 +4775,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -4841,7 +4841,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -4877,7 +4877,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -4973,7 +4973,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -5066,7 +5066,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -5110,7 +5110,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -5188,7 +5188,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -5344,7 +5344,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -5529,7 +5529,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -5629,7 +5629,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -5833,7 +5833,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
@@ -5915,7 +5915,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",

--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -74,7 +74,7 @@
         },
         "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the logs.",
+          "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/shopify-functions/issues/185

With the upcoming release of the `logs` feature, referring to the verbose CLI output as "logs" may be confusing to users.

### WHAT is this pull request doing?

This PR updates the `verbose` flag description to refer to the "output" instead of "logs".

### How to test your changes?

Run `--help` on various commands (e.g. `shopify app generate extension --help`) to see the updated description.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
