### PR TITLE
Print non-function log payloads directly to the terminal

### DIFF
--- a/packages/app/src/cli/services/app-logs/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.test.ts
@@ -47,7 +47,7 @@ const OUTPUT = {
   ],
 }
 const SOURCE = 'my-function'
-const PAYLOAD = {
+const FUNCTION_PAYLOAD = {
   input: JSON.stringify(INPUT),
   input_bytes: 123,
   output: JSON.stringify(OUTPUT),
@@ -56,18 +56,28 @@ const PAYLOAD = {
   logs: LOGS,
   fuel_consumed: 512436,
 }
+const OTHER_PAYLOAD = {some: 'arbitrary payload'}
 const RETURNED_CURSOR = '2024-05-23T19:17:02.321773Z'
 const RESPONSE_DATA = {
   app_logs: [
     {
       shop_id: 1,
       api_client_id: 1830457,
-      payload: JSON.stringify(PAYLOAD),
+      payload: JSON.stringify(FUNCTION_PAYLOAD),
       event_type: 'function_run',
       cursor: '2024-05-23T19:17:02.321773Z',
       status: 'success',
       source: SOURCE,
       source_namespace: 'extensions',
+      log_timestamp: '2024-05-23T19:17:00.240053Z',
+    },
+    {
+      shop_id: 1,
+      api_client_id: 1830457,
+      payload: JSON.stringify(OTHER_PAYLOAD),
+      event_type: 'some arbitrary event type',
+      cursor: '2024-05-23T19:17:02.321773Z',
+      status: 'failure',
       log_timestamp: '2024-05-23T19:17:00.240053Z',
     },
   ],
@@ -132,11 +142,18 @@ describe('pollAppLogs', () => {
       apiKey: API_KEY,
       stdout,
     })
+    expect(writeAppLogsToFile).toHaveBeenCalledWith({
+      appLog: RESPONSE_DATA.app_logs[1],
+      apiKey: API_KEY,
+      stdout,
+    })
 
     expect(stdout.write).toHaveBeenCalledWith('Function executed successfully using 0.5124M instructions.')
     expect(stdout.write).toHaveBeenCalledWith(LOGS)
 
     expect(components.useConcurrentOutputContext).toHaveBeenCalledWith({outputPrefix: SOURCE}, expect.any(Function))
+
+    expect(stdout.write).toHaveBeenCalledWith(JSON.stringify(OTHER_PAYLOAD))
 
     expect(vi.getTimerCount()).toEqual(1)
   })

--- a/packages/app/src/cli/services/app-logs/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.ts
@@ -65,28 +65,29 @@ export const pollAppLogs = async ({
   if (data.app_logs) {
     const {app_logs: appLogs} = data
 
-    const functionLogs = appLogs.filter((appLog) => appLog.event_type === 'function_run')
+    for (const log of appLogs) {
+      const payload = JSON.parse(log.payload)
 
-    for (const functionLog of functionLogs) {
-      const payload = JSON.parse(functionLog.payload)
-      const fuel = (payload.fuel_consumed / ONE_MILLION).toFixed(4)
+      await useConcurrentOutputContext({outputPrefix: log.source}, async () => {
+        if (log.event_type === 'function_run') {
+          const fuel = (payload.fuel_consumed / ONE_MILLION).toFixed(4)
 
-      // eslint-disable-next-line no-await-in-loop
-      await useConcurrentOutputContext({outputPrefix: functionLog.source}, async () => {
-        if (functionLog.status === 'success') {
-          stdout.write(`Function executed successfully using ${fuel}M instructions.`)
-        } else if (functionLog.status === 'failure') {
-          stdout.write(`❌ Function failed to execute with error: ${payload.error_type}`)
-        }
+          if (log.status === 'success') {
+            stdout.write(`Function executed successfully using ${fuel}M instructions.`)
+          } else if (log.status === 'failure') {
+            stdout.write(`❌ Function failed to execute with error: ${payload.error_type}`)
+          }
 
-        // print the logs from the appLogs as well
-        const logs = JSON.parse(functionLog.payload).logs
-        if (logs.length > 0) {
-          stdout.write(logs)
+          const logs = payload.logs
+          if (logs.length > 0) {
+            stdout.write(logs)
+          }
+        } else {
+          stdout.write(JSON.stringify(payload))
         }
 
         await writeAppLogsToFile({
-          appLog: functionLog,
+          appLog: log,
           apiKey,
           stdout,
         })

--- a/packages/app/src/cli/services/app-logs/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.ts
@@ -68,6 +68,7 @@ export const pollAppLogs = async ({
     for (const log of appLogs) {
       const payload = JSON.parse(log.payload)
 
+      // eslint-disable-next-line no-await-in-loop
       await useConcurrentOutputContext({outputPrefix: log.source}, async () => {
         if (log.event_type === 'function_run') {
           const fuel = (payload.fuel_consumed / ONE_MILLION).toFixed(4)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-functions/issues/222

Currently dev is set to ignore all non-function logs, which filters out the throttle event being sent.

### WHAT is this pull request doing?

Instead of ignoring those logs, it just prints out the log's payload as prettified JSON.

🎩 
- Ran [a chronograma tes](https://cronograma.shopify.io/tests/38351)t to spam a test shop with huge logs
- Ran a dev session in my terminal for that shop and app
- Received the throttle log once the throttle was hit, once for each request that occurred after the throttle was hit:
```
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:14.100110Z.json
13:47:15 │ app-logs   │ ❌ Function failed to execute with error: InputSizeLimitExceededError
13:47:15 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:14.988601Z.json
13:47:16 │ app-logs   │ ❌ Function failed to execute with error: InputSizeLimitExceededError
13:47:16 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:15.749514Z.json
13:47:17 │ app-logs   │ ❌ Function failed to execute with error: InputSizeLimitExceededError
13:47:17 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:16.699409Z.json
13:47:18 │ app-logs   │ ❌ Function failed to execute with error: InputSizeLimitExceededError
13:47:18 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:17.510814Z.json
13:47:19 │ app-logs   │ {"reason":"Reached log bytesize limit, dropping logs for 1 minute."}
13:47:19 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:18.344791Z.json
13:47:19 │ app-logs   │ {"reason":"Reached log bytesize limit, dropping logs for 1 minute."}
13:47:19 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:19.090943Z.json
13:47:20 │ app-logs   │ {"reason":"Reached log bytesize limit, dropping logs for 1 minute."}
13:47:20 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:19.952479Z.json
13:47:21 │ app-logs   │ {"reason":"Reached log bytesize limit, dropping logs for 1 minute."}
13:47:21 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:20.688094Z.json
13:47:22 │ app-logs   │ {"reason":"Reached log bytesize limit, dropping logs for 1 minute."}
13:47:22 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:21.654352Z.json
13:47:23 │ app-logs   │ {"reason":"Reached log bytesize limit, dropping logs for 1 minute."}
13:47:23 │ app-logs   │ Log:
/Users/duncanuszkay/Library/Logs/shopify-cli-nodejs/38a85423c1f66c3123ed92fa74fea697/app_logs_2024-06-06T17:47:22.486809Z.json
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
