### PR TITLE
Right align 2nd column in ConcurrentOutput

### DIFF
--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -93,9 +93,9 @@ describe('Dev', () => {
 
     // Then
     expect(unstyled(renderInstance.lastFrame()!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
-      "00:00:00 │ backend  │ first backend message
-      00:00:00 │ backend  │ second backend message
-      00:00:00 │ backend  │ third backend message
+      "00:00:00 │  backend │ first backend message
+      00:00:00 │  backend │ second backend message
+      00:00:00 │  backend │ third backend message
       00:00:00 │ frontend │ first frontend message
       00:00:00 │ frontend │ second frontend message
       00:00:00 │ frontend │ third frontend message
@@ -174,9 +174,9 @@ describe('Dev', () => {
 
     // Then
     expect(unstyled(renderInstance.lastFrame()!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
-      "00:00:00 │ backend  │ first backend message
-      00:00:00 │ backend  │ second backend message
-      00:00:00 │ backend  │ third backend message
+      "00:00:00 │  backend │ first backend message
+      00:00:00 │  backend │ second backend message
+      00:00:00 │  backend │ third backend message
       00:00:00 │ frontend │ first frontend message
       00:00:00 │ frontend │ second frontend message
       00:00:00 │ frontend │ third frontend message

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
@@ -60,9 +60,9 @@ describe('ConcurrentOutput', () => {
 
     // Then
     expect(unstyled(renderInstance.lastFrame()!.replace(/\d/g, '0'))).toMatchInlineSnapshot(`
-      "00:00:00 │ backend  │ first backend message
-      00:00:00 │ backend  │ second backend message
-      00:00:00 │ backend  │ third backend message
+      "00:00:00 │  backend │ first backend message
+      00:00:00 │  backend │ second backend message
+      00:00:00 │  backend │ third backend message
       00:00:00 │ frontend │ first frontend message
       00:00:00 │ frontend │ second frontend message
       00:00:00 │ frontend │ third frontend message

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -153,7 +153,7 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
       return prefix.substring(0, calculatedPrefixColumnSize)
     }
 
-    return `${prefix}${' '.repeat(calculatedPrefixColumnSize - prefix.length)}`
+    return `${' '.repeat(calculatedPrefixColumnSize - prefix.length)}${prefix}`
   }
 
   useEffect(() => {

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -60,9 +60,9 @@ export interface RenderConcurrentOptions extends PartialBy<ConcurrentOutputProps
 /**
  * Renders output from concurrent processes to the terminal with {@link ConcurrentOutput}.
  * @example
- * 00:00:00 │ backend  │ first backend message
- * 00:00:00 │ backend  │ second backend message
- * 00:00:00 │ backend  │ third backend message
+ * 00:00:00 │  backend │ first backend message
+ * 00:00:00 │  backend │ second backend message
+ * 00:00:00 │  backend │ third backend message
  * 00:00:00 │ frontend │ first frontend message
  * 00:00:00 │ frontend │ second frontend message
  * 00:00:00 │ frontend │ third frontend message


### PR DESCRIPTION
Implement some UX feedback to reduce required eye travel in CLI output.

## Before

![image](https://github.com/Shopify/cli/assets/27013789/bd1be658-e64c-453a-9779-95704cfb5a96)

## After

![image](https://github.com/Shopify/cli/assets/27013789/b3bd4c16-541b-4312-9d8e-ecb2aac41cd4)


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
