### PR TITLE
Update duplicate print action message

### DIFF
--- a/.changeset/metal-chefs-yell.md
+++ b/.changeset/metal-chefs-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update duplicate print action message

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -514,7 +514,7 @@ wrong = "property"
 
     // When
     await expect(loadTestingApp()).rejects.toThrow(
-      'Duplicated print action target "admin.product-details.print-action.render" in extensions "my_extension_1" and "my_extension_2". You can only have one print action extension per target in an app. Please remove the duplicates.',
+      `A single target can't support two print action extensions from the same app. Point your extensions at different targets, or remove an extension.\n\nThe following extensions both target admin.product-details.print-action.render:\n  · handle-1\n  · handle-2`,
     )
   })
 

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -720,9 +720,9 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
           duplicates[target] = targetExtensions
 
           if (targetExtensions.length > 1) {
-            const extensionNames = joinWithAnd(targetExtensions.map((ext) => ext.configuration.name))
+            const extensionHandles = ['', ...targetExtensions.map((ext) => ext.configuration.handle)].join('\n  · ')
             this.abortOrReport(
-              outputContent`Duplicated print action target "${target}" in extensions ${extensionNames}. You can only have one print action extension per target in an app. Please remove the duplicates.`,
+              outputContent`A single target can't support two print action extensions from the same app. Point your extensions at different targets, or remove an extension.\n\nThe following extensions both target ${target}:${extensionHandles}`,
               undefined,
               extension.configurationPath,
             )


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-ui/issues/1192

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Updating the error message shown when dev'ing or deploying multiple print extensions with the same target. Also updated to use the handle rather than app name as it is unique.

Before: 
<img width="648" alt="Screenshot 2024-06-06 at 12 57 25 PM" src="https://github.com/Shopify/cli/assets/5873610/ba5a5c25-87c3-48ea-a1c8-761f4ab4af4c">

After:
<img width="647" alt="Screenshot 2024-06-06 at 1 00 05 PM" src="https://github.com/Shopify/cli/assets/5873610/1b46bba0-cbee-4f13-a6f7-2ed21d676872">


### How to test your changes?

1. Have an app with multiple print extensions for the same target ([wiki](https://github.com/Shopify/app-ui/wiki/print-extensions))
2. From this repo, run `cli-spin pnpm shopify app dev --path ../to-your-app`
3. Assert that you see the expected message.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
