### PR TITLE
Only request App Management scope when needed

### DIFF
--- a/packages/cli-kit/src/private/node/session/scopes.test.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.test.ts
@@ -19,8 +19,27 @@ describe('allDefaultScopes', () => {
       'https://api.shopify.com/auth/shop.storefront-renderer.devtools',
       'https://api.shopify.com/auth/partners.app.cli.access',
       'https://api.shopify.com/auth/destinations.readonly',
-      'https://api.shopify.com/auth/organization.apps.manage',
       ...customScopes,
+    ])
+  })
+
+  test('includes the App Management one when the required env var is defined', async () => {
+    // Given
+    const envVars = {USE_APP_MANAGEMENT_API: 'true'}
+
+    // When
+    const got = allDefaultScopes([], envVars)
+
+    // Then
+    expect(got).toEqual([
+      'openid',
+      'https://api.shopify.com/auth/shop.admin.graphql',
+      'https://api.shopify.com/auth/shop.admin.themes',
+      'https://api.shopify.com/auth/partners.collaborator-relationships.readonly',
+      'https://api.shopify.com/auth/shop.storefront-renderer.devtools',
+      'https://api.shopify.com/auth/partners.app.cli.access',
+      'https://api.shopify.com/auth/destinations.readonly',
+      'https://api.shopify.com/auth/organization.apps.manage',
     ])
   })
 })

--- a/packages/cli-kit/src/private/node/session/scopes.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.ts
@@ -1,5 +1,6 @@
 import {allAPIs, API} from '../api.js'
 import {BugError} from '../../../public/node/error.js'
+import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 
 /**
  * Generate a flat array with all the default scopes for all the APIs plus
@@ -36,7 +37,7 @@ function defaultApiScopes(api: API): string[] {
     case 'business-platform':
       return ['destinations']
     case 'app-management':
-      return ['app-management']
+      return isTruthy(process.env.USE_APP_MANAGEMENT_API) ? ['app-management'] : []
     default:
       throw new BugError(`Unknown API: ${api}`)
   }

--- a/packages/cli-kit/src/private/node/session/scopes.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.ts
@@ -8,8 +8,8 @@ import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
  * @param extraScopes - custom user-defined scopes
  * @returns Array of scopes
  */
-export function allDefaultScopes(extraScopes: string[] = []): string[] {
-  let scopes = allAPIs.map(defaultApiScopes).flat()
+export function allDefaultScopes(extraScopes: string[] = [], systemEnvironment = process.env): string[] {
+  let scopes = allAPIs.map((api) => defaultApiScopes(api, systemEnvironment)).flat()
   scopes = ['openid', ...scopes, ...extraScopes].map(scopeTransform)
   return Array.from(new Set(scopes))
 }
@@ -21,12 +21,12 @@ export function allDefaultScopes(extraScopes: string[] = []): string[] {
  * @param extraScopes - custom user-defined scopes
  * @returns Array of scopes
  */
-export function apiScopes(api: API, extraScopes: string[] = []): string[] {
-  const scopes = [...defaultApiScopes(api), ...extraScopes.map(scopeTransform)].map(scopeTransform)
+export function apiScopes(api: API, extraScopes: string[] = [], systemEnvironment = process.env): string[] {
+  const scopes = [...defaultApiScopes(api, systemEnvironment), ...extraScopes.map(scopeTransform)].map(scopeTransform)
   return Array.from(new Set(scopes))
 }
 
-function defaultApiScopes(api: API): string[] {
+function defaultApiScopes(api: API, systemEnvironment = process.env): string[] {
   switch (api) {
     case 'admin':
       return ['graphql', 'themes', 'collaborator']
@@ -37,7 +37,7 @@ function defaultApiScopes(api: API): string[] {
     case 'business-platform':
       return ['destinations']
     case 'app-management':
-      return isTruthy(process.env.USE_APP_MANAGEMENT_API) ? ['app-management'] : []
+      return isTruthy(systemEnvironment.USE_APP_MANAGEMENT_API) ? ['app-management'] : []
     default:
       throw new BugError(`Unknown API: ${api}`)
   }


### PR DESCRIPTION
### WHY are these changes introduced?

To avoid issues like:
- https://github.com/Shopify/cli/issues/3962
- https://github.com/Shopify/cli/issues/3963

### WHAT is this pull request doing?

Only request App Management scope when `USE_APP_MANAGEMENT_API` is present

### How to test your changes?

- `p shopify auth logout`
- `p shopify app generate extension --path /your-app --verbose`
- `USE_APP_MANAGEMENT_API=1 p shopify app generate extension --path /your-app --verbose`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
