### PR TITLE
Retry app log polling after 429 or 5XX

### DIFF
--- a/packages/app/src/cli/services/app-logs/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.ts
@@ -49,7 +49,6 @@ export const pollAppLogs = async ({
     const responseText = await response.text()
     if (response.status === 401) {
       await resubscribeCallback()
-      return
     } else if (response.status === 429 || response.status >= 500) {
       stdout.write(`Received an error while polling for app logs.`)
       stdout.write(`${response.status}: ${response.statusText}`)
@@ -68,9 +67,10 @@ export const pollAppLogs = async ({
           throw new Error(`${error} error while fetching.`)
         })
       }, POLLING_BACKOFF_INTERVAL_MS)
-      return
+    } else {
+      throw new Error(`Error while fetching: ${responseText}`)
     }
-    throw new Error(`Error while fetching: ${responseText}`)
+    return
   }
 
   const data = (await response.json()) as {

--- a/packages/app/src/cli/services/app-logs/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.ts
@@ -2,6 +2,7 @@ import {writeAppLogsToFile} from './write-app-logs.js'
 import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {fetch} from '@shopify/cli-kit/node/http'
+import {outputDebug} from '@shopify/cli-kit/node/output'
 import {Writable} from 'stream'
 
 const POLLING_INTERVAL_MS = 450
@@ -37,95 +38,102 @@ export const pollAppLogs = async ({
   apiKey: string
   resubscribeCallback: () => Promise<void>
 }) => {
-  const url = await generateFetchAppLogUrl(cursor)
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${jwtToken}`,
-    },
-  })
-
-  if (!response.ok) {
-    const responseText = await response.text()
-    if (response.status === 401) {
-      await resubscribeCallback()
-    } else if (response.status === 429 || response.status >= 500) {
-      stdout.write(`Received an error while polling for app logs.`)
-      stdout.write(`${response.status}: ${response.statusText}`)
-      stdout.write(responseText)
-      stdout.write(`Retrying in 10 seconds`)
-      setTimeout(() => {
-        pollAppLogs({
-          stdout,
-          appLogsFetchInput: {
-            jwtToken,
-            cursor: undefined,
-          },
-          apiKey,
-          resubscribeCallback,
-        }).catch((error) => {
-          throw new Error(`${error} error while fetching.`)
-        })
-      }, POLLING_BACKOFF_INTERVAL_MS)
-    } else {
-      throw new Error(`Error while fetching: ${responseText}`)
-    }
-    return
-  }
-
-  const data = (await response.json()) as {
-    app_logs?: AppEventData[]
-    cursor?: string
-    errors?: string[]
-  }
-
-  if (data.app_logs) {
-    const {app_logs: appLogs} = data
-
-    for (const log of appLogs) {
-      const payload = JSON.parse(log.payload)
-
-      // eslint-disable-next-line no-await-in-loop
-      await useConcurrentOutputContext({outputPrefix: log.source}, async () => {
-        if (log.event_type === 'function_run') {
-          const fuel = (payload.fuel_consumed / ONE_MILLION).toFixed(4)
-
-          if (log.status === 'success') {
-            stdout.write(`Function executed successfully using ${fuel}M instructions.`)
-          } else if (log.status === 'failure') {
-            stdout.write(`❌ Function failed to execute with error: ${payload.error_type}`)
-          }
-
-          const logs = payload.logs
-          if (logs.length > 0) {
-            stdout.write(logs)
-          }
-        } else {
-          stdout.write(JSON.stringify(payload))
-        }
-
-        await writeAppLogsToFile({
-          appLog: log,
-          apiKey,
-          stdout,
-        })
-      })
-    }
-  }
-
-  const cursorFromResponse = data?.cursor
-
-  setTimeout(() => {
-    pollAppLogs({
-      stdout,
-      appLogsFetchInput: {
-        jwtToken,
-        cursor: cursorFromResponse,
+  try {
+    const url = await generateFetchAppLogUrl(cursor)
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
       },
-      apiKey,
-      resubscribeCallback,
-    }).catch((error) => {
-      throw new Error(`${error} error while fetching.`)
     })
-  }, POLLING_INTERVAL_MS)
+
+    if (!response.ok) {
+      const responseText = await response.text()
+      if (response.status === 401) {
+        await resubscribeCallback()
+      } else if (response.status === 429 || response.status >= 500) {
+        stdout.write(`Received an error while polling for app logs.`)
+        stdout.write(`${response.status}: ${response.statusText}`)
+        stdout.write(responseText)
+        stdout.write(`Retrying in ${POLLING_BACKOFF_INTERVAL_MS / 1000} seconds`)
+        setTimeout(() => {
+          pollAppLogs({
+            stdout,
+            appLogsFetchInput: {
+              jwtToken,
+              cursor: undefined,
+            },
+            apiKey,
+            resubscribeCallback,
+          }).catch((error) => {
+            outputDebug(`Unexpected error during polling: ${error}}\n`)
+          })
+        }, POLLING_BACKOFF_INTERVAL_MS)
+      } else {
+        throw new Error(`Error while fetching: ${responseText}`)
+      }
+      return
+    }
+
+    const data = (await response.json()) as {
+      app_logs?: AppEventData[]
+      cursor?: string
+      errors?: string[]
+    }
+
+    if (data.app_logs) {
+      const {app_logs: appLogs} = data
+
+      for (const log of appLogs) {
+        const payload = JSON.parse(log.payload)
+
+        // eslint-disable-next-line no-await-in-loop
+        await useConcurrentOutputContext({outputPrefix: log.source}, async () => {
+          if (log.event_type === 'function_run') {
+            const fuel = (payload.fuel_consumed / ONE_MILLION).toFixed(4)
+
+            if (log.status === 'success') {
+              stdout.write(`Function executed successfully using ${fuel}M instructions.`)
+            } else if (log.status === 'failure') {
+              stdout.write(`❌ Function failed to execute with error: ${payload.error_type}`)
+            }
+
+            const logs = payload.logs
+            if (logs.length > 0) {
+              stdout.write(logs)
+            }
+          } else {
+            stdout.write(JSON.stringify(payload))
+          }
+
+          await writeAppLogsToFile({
+            appLog: log,
+            apiKey,
+            stdout,
+          })
+        })
+      }
+    }
+
+    const cursorFromResponse = data?.cursor
+
+    setTimeout(() => {
+      pollAppLogs({
+        stdout,
+        appLogsFetchInput: {
+          jwtToken,
+          cursor: cursorFromResponse,
+        },
+        apiKey,
+        resubscribeCallback,
+      }).catch((error) => {
+        outputDebug(`Unexpected error during polling: ${error}}\n`)
+      })
+    }, POLLING_INTERVAL_MS)
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (error) {
+    stdout.write(`Error while retrieving app logs.`)
+    stdout.write('App log streaming is no longer available in this `dev` session.')
+    outputDebug(`${error}}\n`)
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-functions/issues/206

### WHAT is this pull request doing?

In the event of a 429 or 5XX error, enqueues another attempt at polling.
This prevents `dev` from crashing whenever there's a server error, and also allows the server time to recover instead of continuing to poll with the regular frequency.

### How to test your changes?
Set the app logs controller in partners to always return an error during polling. You can even do this while polling to see different error messages / handling.
My 🎩 
![](https://screenshot.click/07-51-rl7i6-f2gpo.png)

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
