### PR TITLE
Show installation message in dev console if extensions contains customer account targets.

### DIFF
--- a/.changeset/plenty-pens-turn.md
+++ b/.changeset/plenty-pens-turn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-dev-console-app': patch
+---
+
+If your extension is calling the Customer Account API, you must install your app to preview your customer account extension.

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/Extensions.test.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/Extensions.test.tsx
@@ -43,6 +43,35 @@ describe('<Extensions/>', () => {
     expect(container).toContainReactComponent(AppHomeRow)
   })
 
+  test('renders contains app installation info if extensions contain customer account targets', async () => {
+    const extension1 = mockExtension({
+      type: 'ui_extension',
+      extensionPoints: [{target: 'customer-account.page.render'}],
+    })
+    const extension2 = mockExtension()
+    const extensions = [extension1, extension2]
+
+    const container = render(<Extensions />, withProviders(DefaultProviders), {
+      state: {extensions, store: 'shop1.myshopify.io'},
+    })
+    expect(container).toContainReactText(
+      'If your extension is calling the Customer Account API, you must install your app to preview your customer account extension.',
+    )
+  })
+
+  test('renders doesnt contain app installation info if extensions dont contain customer account targets', async () => {
+    const extension1 = mockExtension()
+    const extension2 = mockExtension()
+    const extensions = [extension1, extension2]
+
+    const container = render(<Extensions />, withProviders(DefaultProviders), {
+      state: {extensions, store: 'shop1.myshopify.io'},
+    })
+    expect(container).not.toContainReactText(
+      'If your extension is calling the Customer Account API, you must install your app to preview your customer account extension.',
+    )
+  })
+
   test('renders a <PostPurchaseRow/> for the checkout_post_purchase extension', async () => {
     const extension1 = {...mockExtension(), type: 'checkout_post_purchase'}
 

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/Extensions.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/Extensions.tsx
@@ -6,6 +6,7 @@ import {useExtensions} from './hooks/useExtensions'
 import {useExtensionServerOptions} from './hooks/useExtensionServerOptions'
 import {useApp} from './hooks/useApp'
 import {useI18n} from '@shopify/react-i18n'
+import {ExtensionPoint} from '@shopify/ui-extensions-server-kit'
 import React from 'react'
 import {isEmbedded} from '@/utilities/embedded'
 
@@ -27,7 +28,17 @@ export function Extensions() {
     )
   }
 
-  const introMessage = i18n.translate('intro', {
+  const customerAccountTarget = extensionIds.some((element) => {
+    return (element.extensionPoints as ExtensionPoint[])?.some((extensionPoint) => {
+      const target = extensionPoint.target
+      const domain = target.toLowerCase().replace(/(::|\.).+$/, '')
+      return domain === 'customer-account'
+    })
+  })
+
+  const intro = customerAccountTarget ? 'customerAccountTargetIntro' : 'intro'
+
+  const introMessage = i18n.translate(intro, {
     installLink: (
       <a href={app?.url} target={'_blank'} aria-label={i18n.translate('introInstallCta')}>
         {i18n.translate('introInstallCta')}

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/hooks/useExtensions.ts
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/hooks/useExtensions.ts
@@ -6,9 +6,10 @@ export function useExtensions() {
 
   return useMemo(
     () =>
-      extensionServer.state.extensions.map(({uuid, type}) => ({
+      extensionServer.state.extensions.map(({uuid, type, extensionPoints}) => ({
         uuid,
         type,
+        extensionPoints,
       })),
     [extensionServer.state.extensions.length],
   )

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/translations/en.json
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/translations/en.json
@@ -1,5 +1,6 @@
 {
   "intro": "{installLink} to see changes live. Share preview links with teammates or clients.",
+  "customerAccountTargetIntro": "{installLink} to see changes live. If your extension is calling the Customer Account API, you must install your app to preview your customer account extension. Share preview links with teammates or clients.",
   "introInstallCta": "Install your app",
   "extensionList": {
     "handle": "Handle",


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves: https://github.com/Shopify/core-issues/issues/69888


### WHAT is this pull request doing?

Context: If an extension contains customer account targets, we will remind developers to install the app to preview customer account targets

### How to test your changes?

1. Visit this preview link: https://blogs-law-extent-identifier.trycloudflare.com/extensions/dev-console
2. Check if you can see the message as below.

![image](https://github.com/Shopify/cli/assets/37116651/83bbad07-fe3e-4c40-8d93-e2b34a07f1b9)



### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
