### PR TITLE
Wrap errors when first bundling draftable extensions in Abort

### DIFF
--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -6,7 +6,7 @@ import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {exec} from '@shopify/cli-kit/node/system'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
-import {AbortSilentError} from '@shopify/cli-kit/node/error'
+import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import {Writable} from 'stream'
 
 export interface ExtensionBuildOptions {
@@ -87,19 +87,26 @@ export async function buildUIExtension(extension: ExtensionInstance, options: Ex
     env.APP_URL = options.appURL
   }
 
-  await bundleExtension({
-    minify: true,
-    outputPath: extension.outputPath,
-    stdin: {
-      contents: extension.getBundleExtensionStdinContent(),
-      resolveDir: extension.directory,
-      loader: 'tsx',
-    },
-    environment: options.environment,
-    env,
-    stderr: options.stderr,
-    stdout: options.stdout,
-  })
+  try {
+    await bundleExtension({
+      minify: true,
+      outputPath: extension.outputPath,
+      stdin: {
+        contents: extension.getBundleExtensionStdinContent(),
+        resolveDir: extension.directory,
+        loader: 'tsx',
+      },
+      environment: options.environment,
+      env,
+      stderr: options.stderr,
+      stdout: options.stdout,
+    })
+  } catch (extensionBundlingError) {
+    // this fails if the app's own source code is broken; wrap such that this isn't flagged as a CLI bug
+    throw new AbortError(
+      `Failed to bundle extension ${extension.localIdentifier}. Please check the extension source code for errors.`,
+    )
+  }
 
   await extension.buildValidation()
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue where errors in developer's extension source code is reported as a CLI bug

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

In most cases, errors in source code is not treated as a CLI issue, being something under the developers control. An exception is if an extension is in a broken state prior to running `dev`/`deploy`. The failure to bundle was not correctly being treated as an expected error. These are now wrapped in AbortError -- the same behaviour is preserved as today (the command exits) -- but the logging is changed.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Make an app with a checkout extension, break the code, then run `dev`.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
