### PR TITLE
Connect JSON schema contracts to CLI

### DIFF
--- a/packages/app/src/cli/api/graphql/extension_specifications.ts
+++ b/packages/app/src/cli/api/graphql/extension_specifications.ts
@@ -18,6 +18,9 @@ export const ExtensionSpecificationsQuery = gql`
           surface
         }
       }
+      validationSchema {
+        jsonSchema
+      }
     }
   }
 `
@@ -42,12 +45,14 @@ export interface RemoteSpecification {
       surface: string
     }
   }
+  validationSchema?: {
+    jsonSchema: string
+  }
 }
 
 export interface FlattenedRemoteSpecification extends RemoteSpecification {
   surface?: string
   registrationLimit: number
-  contract: never
 }
 
 export interface ExtensionSpecificationsQuerySchema {

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -103,6 +103,7 @@
     ]
   },
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "11.6.4",
     "@bugsnag/js": "7.21.0",
     "@iarna/toml": "2.2.5",
     "@oclif/core": "3.26.5",

--- a/packages/cli-kit/src/public/node/json-schema.ts
+++ b/packages/cli-kit/src/public/node/json-schema.ts
@@ -2,8 +2,24 @@ import {ParseConfigurationResult} from './schema.js'
 import {getPathValue} from '../common/object.js'
 import {capitalize} from '../common/string.js'
 import {Ajv, ErrorObject, SchemaObject} from 'ajv'
+import $RefParser from '@apidevtools/json-schema-ref-parser'
 
 type AjvError = ErrorObject<string, {[key: string]: unknown}, unknown>
+
+/**
+ * Normalises a JSON Schema by standardising it's internal implementation.
+ *
+ * We prefer to not use $ref elements in our schemas, so we inline them; it's easier then to process errors.
+ *
+ * @param schema - The JSON schema (as a string) to normalise.
+ * @returns The normalised JSON schema.
+ */
+export async function normaliseJsonSchema(schema: string): Promise<SchemaObject> {
+  // we want to modify the schema, removing any $ref elements and inlining with their source
+  const parsedSchema = JSON.parse(schema)
+  await $RefParser.dereference(parsedSchema, {resolve: {external: false}})
+  return parsedSchema
+}
 
 /**
  * Given a subject object and a JSON schema contract, validate the subject against the contract.

--- a/packages/cli-kit/src/public/node/json-schema.ts
+++ b/packages/cli-kit/src/public/node/json-schema.ts
@@ -172,51 +172,52 @@ function simplifyUnionErrors(rawErrors: AjvError[], subject: object, schema: Sch
 
     // get the schema list from where the union issue occured
     const dottedSchemaPath = unionError.schemaPath.replace('#/', '').replace(/\//g, '.')
-    const unionSchemas = getPathValue(schema, dottedSchemaPath) as SchemaObject[]
-
+    const unionSchemas = getPathValue<SchemaObject[]>(schema, dottedSchemaPath)
     // and the slice of the subject that caused the issue
-    const subjectValue = getPathValue(subject, unionError.instancePath.split('/').slice(1).join('.')) as object
+    const subjectValue = getPathValue(subject, unionError.instancePath.split('/').slice(1).join('.'))
 
-    // we know that none of the union schemas are correct, but for each of them we can measure how wrong they are
-    const correctValuesAndErrors = unionSchemas
-      .map((candidateSchemaFromUnion: SchemaObject) => {
-        const candidateSchemaValidator = ajv.compile(candidateSchemaFromUnion)
-        candidateSchemaValidator(subjectValue)
+    if (unionSchemas !== undefined && subjectValue !== undefined) {
+      // we know that none of the union schemas are correct, but for each of them we can measure how wrong they are
+      const correctValuesAndErrors = unionSchemas
+        .map((candidateSchemaFromUnion: SchemaObject) => {
+          const candidateSchemaValidator = ajv.compile(candidateSchemaFromUnion)
+          candidateSchemaValidator(subjectValue)
 
-        let score = 0
-        if (candidateSchemaFromUnion.type === 'object') {
-          // provided the schema is an object, we can measure how many properties are good
-          const candidatesObjectProperties = Object.keys(candidateSchemaFromUnion.properties)
-          score = candidatesObjectProperties.reduce((acc, propertyName) => {
-            const subSchema = candidateSchemaFromUnion.properties[propertyName] as SchemaObject
-            const subjectValueSlice = getPathValue(subjectValue, propertyName)
+          let score = 0
+          if (candidateSchemaFromUnion.type === 'object') {
+            // provided the schema is an object, we can measure how many properties are good
+            const candidatesObjectProperties = Object.keys(candidateSchemaFromUnion.properties)
+            score = candidatesObjectProperties.reduce((acc, propertyName) => {
+              const subSchema = candidateSchemaFromUnion.properties[propertyName] as SchemaObject
+              const subjectValueSlice = getPathValue(subjectValue, propertyName)
 
-            const subValidator = ajv.compile(subSchema)
-            if (subValidator(subjectValueSlice)) {
-              return acc + 1
-            }
-            return acc
-          }, score)
+              const subValidator = ajv.compile(subSchema)
+              if (subValidator(subjectValueSlice)) {
+                return acc + 1
+              }
+              return acc
+            }, score)
+          }
+
+          return [score, candidateSchemaValidator.errors!] as const
+        })
+        .sort(([scoreA], [scoreB]) => scoreA - scoreB)
+
+      if (correctValuesAndErrors.length >= 2) {
+        const [bestScore, bestErrors] = correctValuesAndErrors[correctValuesAndErrors.length - 1]!
+        const [penultimateScore] = correctValuesAndErrors[correctValuesAndErrors.length - 2]!
+
+        if (bestScore !== penultimateScore) {
+          // If there's a winner, show the errors for the best schema as they'll likely be actionable.
+          // We got these through a nested schema, so we need to adjust the instance path
+          simplifiedUnionRelatedErrors = [
+            unionError,
+            ...bestErrors.map((bestError) => ({
+              ...bestError,
+              instancePath: unionError.instancePath + bestError.instancePath,
+            })),
+          ]
         }
-
-        return [score, candidateSchemaValidator.errors!] as const
-      })
-      .sort(([scoreA], [scoreB]) => scoreA - scoreB)
-
-    if (correctValuesAndErrors.length >= 2) {
-      const [bestScore, bestErrors] = correctValuesAndErrors[correctValuesAndErrors.length - 1]!
-      const [penultimateScore] = correctValuesAndErrors[correctValuesAndErrors.length - 2]!
-
-      if (bestScore !== penultimateScore) {
-        // If there's a winner, show the errors for the best schema as they'll likely be actionable.
-        // We got these through a nested schema, so we need to adjust the instance path
-        simplifiedUnionRelatedErrors = [
-          unionError,
-          ...bestErrors.map((bestError) => ({
-            ...bestError,
-            instancePath: unionError.instancePath + bestError.instancePath,
-          })),
-        ]
       }
     }
     errors = [...unrelatedErrors, ...simplifiedUnionRelatedErrors]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
 
   packages/cli-kit:
     dependencies:
+      '@apidevtools/json-schema-ref-parser':
+        specifier: 11.6.4
+        version: 11.6.4
       '@bugsnag/js':
         specifier: 7.21.0
         version: 7.21.0
@@ -884,6 +887,15 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+
+  /@apidevtools/json-schema-ref-parser@11.6.4:
+    resolution: {integrity: sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==}
+    engines: {node: '>= 16'}
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.0
+    dev: false
 
   /@ast-grep/napi-darwin-arm64@0.11.0:
     resolution: {integrity: sha512-IxY3b102tNNm+cYLngZvUKzM1fNKCpDDWz69Yt+QnKCZNx10Hvd7mqrYE2aXTtkaNalmg/p1n6kMA8KmshGgCA==}
@@ -3935,6 +3947,10 @@ packages:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
+
+  /@jsdevtools/ono@7.1.3:
+    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+    dev: false
 
   /@juggle/resize-observer@3.4.0:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Connects the new JSON Schema contracts feature to the CLI

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
1. Updates specification loading to include pulling in and using JSON schema contracts
2. Normalises contracts: in particular, we would rather have less `$ref` usage in the schema, as it makes remapping errors harder. We dereference them here. There's zero functional or behavioural difference in the validation afterward (AJV was already dereferencing, just silently)
3. Added a layer of defence to error remapping

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

With flag enabled, add
```
[metaobjects.author.fields]
not_good = true
```
to an app and running deploy should do it.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
