### PR TITLE
Function log differentiation and file linking

### DIFF
--- a/packages/app/src/cli/services/app-logs/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.ts
@@ -100,17 +100,24 @@ export const pollAppLogs = async ({
 
             const logs = payload.logs
             if (logs.length > 0) {
-              stdout.write(logs)
+              stdout.write(
+                logs
+                  .split('\n')
+                  .filter(Boolean)
+                  .map((line: string) => `├ ${line}`)
+                  .join('\n'),
+              )
             }
           } else {
             stdout.write(JSON.stringify(payload))
           }
 
-          await writeAppLogsToFile({
+          const logPath = await writeAppLogsToFile({
             appLog: log,
             apiKey,
             stdout,
           })
+          stdout.write(`└ Log: ${logPath}\n`)
         })
       }
     }

--- a/packages/app/src/cli/services/app-logs/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.ts
@@ -2,7 +2,7 @@ import {writeAppLogsToFile} from './write-app-logs.js'
 import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {fetch} from '@shopify/cli-kit/node/http'
-import {outputDebug} from '@shopify/cli-kit/node/output'
+import {outputContent, outputDebug, outputToken} from '@shopify/cli-kit/node/output'
 import {Writable} from 'stream'
 
 const POLLING_INTERVAL_MS = 450
@@ -88,7 +88,7 @@ export const pollAppLogs = async ({
         const payload = JSON.parse(log.payload)
 
         // eslint-disable-next-line no-await-in-loop
-        await useConcurrentOutputContext({outputPrefix: log.source}, async () => {
+        await useConcurrentOutputContext({outputPrefix: log.source, stripAnsi: false}, async () => {
           if (log.event_type === 'function_run') {
             const fuel = (payload.fuel_consumed / ONE_MILLION).toFixed(4)
 
@@ -117,7 +117,9 @@ export const pollAppLogs = async ({
             apiKey,
             stdout,
           })
-          stdout.write(`└ Log: ${logPath}\n`)
+          stdout.write(
+            outputContent`└ ${outputToken.link('Open log file', `file://${logPath}`, `Log: ${logPath}`)}\n`.value,
+          )
         })
       }
     }

--- a/packages/app/src/cli/services/app-logs/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.ts
@@ -104,7 +104,7 @@ export const pollAppLogs = async ({
                 logs
                   .split('\n')
                   .filter(Boolean)
-                  .map((line: string) => `├ ${line}`)
+                  .map((line: string) => outputContent`${outputToken.gray('│ ')}${line}`.value)
                   .join('\n'),
               )
             }
@@ -118,7 +118,11 @@ export const pollAppLogs = async ({
             stdout,
           })
           stdout.write(
-            outputContent`└ ${outputToken.link('Open log file', `file://${logPath}`, `Log: ${logPath}`)}\n`.value,
+            outputContent`${outputToken.gray('└ ')}${outputToken.link(
+              'Open log file',
+              `file://${logPath}`,
+              `Log: ${logPath}`,
+            )}\n`.value,
           )
         })
       }

--- a/packages/app/src/cli/services/app-logs/write-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/write-app-logs.test.ts
@@ -35,11 +35,11 @@ describe('writeAppLogsToFile', () => {
     const path = joinPath(API_KEY, fileName)
 
     // When
-    await writeAppLogsToFile({appLog: APP_LOG, apiKey: API_KEY, stdout})
+    const returnedPath = await writeAppLogsToFile({appLog: APP_LOG, apiKey: API_KEY, stdout})
 
     // Then
+    expect(returnedPath.startsWith(path)).toBe(true)
     expect(writeLog).toHaveBeenCalledWith(expect.stringContaining(path), logData)
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Log: '))
   })
 
   test('prints and re-throws parsing errors', async () => {

--- a/packages/app/src/cli/services/app-logs/write-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/write-app-logs.ts
@@ -12,7 +12,7 @@ export const writeAppLogsToFile = async ({
   appLog: AppEventData
   apiKey: string
   stdout: Writable
-}) => {
+}): Promise<string> => {
   const identifier = randomUUID().substring(0, 6)
 
   const formattedTimestamp = formatTimestampToFilename(appLog.log_timestamp)
@@ -29,7 +29,7 @@ export const writeAppLogsToFile = async ({
     const logData = JSON.stringify(toSaveData, null, 2)
 
     await writeLog(path, logData)
-    stdout.write(`Log: ${fullOutputPath}\n`)
+    return fullOutputPath
   } catch (error) {
     stdout.write(`Error while writing log to file: ${error}\n`)
     throw error

--- a/packages/cli-kit/src/private/node/content-tokens.test.ts
+++ b/packages/cli-kit/src/private/node/content-tokens.test.ts
@@ -9,4 +9,14 @@ describe('LinkContentToken', () => {
     // Then
     expect(got.output()).toEqual('\u001b[32mShopify Web\u001b[39m ( https://shopify.com )')
   })
+
+  test('uses the explicit fallback when provided and terminal does not support links', () => {
+    const fallback = 'foo'
+
+    // When
+    const got = new LinkContentToken('Nothing', 'https://doesntmatter.com', fallback)
+
+    // Then
+    expect(got.output()).toEqual(fallback)
+  })
 })

--- a/packages/cli-kit/src/private/node/content-tokens.ts
+++ b/packages/cli-kit/src/private/node/content-tokens.ts
@@ -23,16 +23,18 @@ export class RawContentToken extends ContentToken<string> {
 
 export class LinkContentToken extends ContentToken<OutputMessage> {
   link: string
+  fallback: string | undefined
 
-  constructor(value: OutputMessage, link: string) {
+  constructor(value: OutputMessage, link: string, fallback?: string) {
     super(value)
     this.link = link
+    this.fallback = fallback
   }
 
   output() {
     const text = colors.green(stringifyMessage(this.value))
     const url = this.link ?? ''
-    return terminalLink(text, url, {fallback: () => `${text} ( ${url} )`})
+    return terminalLink(text, url, {fallback: () => this.fallback ?? `${text} ( ${url} )`})
   }
 }
 

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -3,8 +3,8 @@ import {AbortSignal} from '../../../../public/node/abort.js'
 import {addOrUpdateConcurrentUIEventOutput} from '../../demo-recorder.js'
 import React, {FunctionComponent, useCallback, useEffect, useMemo, useState} from 'react'
 import {Box, Static, Text, TextProps, useApp} from 'ink'
-import stripAnsi from 'strip-ansi'
 import figures from 'figures'
+import stripAnsi from 'strip-ansi'
 import {Writable} from 'stream'
 import {AsyncLocalStorage} from 'node:async_hooks'
 
@@ -40,6 +40,7 @@ function currentTime() {
 
 interface ConcurrentOutputContext {
   outputPrefix: string
+  stripAnsi?: boolean
 }
 
 const outputContextStore = new AsyncLocalStorage<ConcurrentOutputContext>()
@@ -127,10 +128,12 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
         write(chunk, _encoding, next) {
           const context = outputContextStore.getStore()
           const prefix = context?.outputPrefix ?? process.prefix
-          const log = chunk.toString('utf8')
+          const shouldStripAnsi = context?.stripAnsi ?? true
+          const log = chunk.toString('utf8').replace(/(\n)$/, '')
 
           const index = addPrefix(prefix, prefixes)
-          const lines = stripAnsi(log.replace(/(\n)$/, '')).split(/\n/)
+
+          const lines = shouldStripAnsi ? stripAnsi(log).split(/\n/) : log.split(/\n/)
           addOrUpdateConcurrentUIEventOutput({prefix, index, output: lines.join('\n')})
           setProcessOutput((previousProcessOutput) => [
             ...previousProcessOutput,

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -39,7 +39,7 @@ function currentTime() {
 }
 
 interface ConcurrentOutputContext {
-  outputPrefix: string
+  outputPrefix?: string
   stripAnsi?: boolean
 }
 

--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -50,8 +50,8 @@ export const outputToken = {
   path(value: OutputMessage): PathContentToken {
     return new PathContentToken(value)
   },
-  link(value: OutputMessage, link: string): LinkContentToken {
-    return new LinkContentToken(value, link)
+  link(value: OutputMessage, link: string, fallback?: string | undefined): LinkContentToken {
+    return new LinkContentToken(value, link, fallback)
   },
   heading(value: OutputMessage): HeadingContentToken {
     return new HeadingContentToken(value)

--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -77,6 +77,9 @@ export const outputToken = {
   green(value: OutputMessage): ColorContentToken {
     return new ColorContentToken(value, colors.green)
   },
+  gray(value: OutputMessage): ColorContentToken {
+    return new ColorContentToken(value, colors.gray)
+  },
   packagejsonScript(packageManager: PackageManager, scriptName: string, ...scriptArgs: string[]): CommandContentToken {
     return new CommandContentToken(formatPackageManagerCommand(packageManager, scriptName, ...scriptArgs))
   },


### PR DESCRIPTION
### WHY are these changes introduced?

Multiple runs of the same function run together visually:
![image](https://github.com/Shopify/cli/assets/27013789/8ea58b8b-e8ca-4188-88c8-ec3e7bfdcf81)

Additionally, the log file path is a bit long and frequently wraps, limiting its usefulness.

### WHAT is this pull request doing?
* Prefix function log output with box drawing characters, to better group related lines.
* Output function log file as a link instead of a file path, on terminals that support hyperlinks.

_VS Code_
![image](https://github.com/Shopify/cli/assets/27013789/e1e9974b-ac4e-46c5-b99c-94453fa80c53)

_MacOS Terminal (no hyperlink support)_
![image](https://github.com/Shopify/cli/assets/27013789/da773200-7bfc-4f3c-bbd3-58350d8cf8de)

_Windows Terminal (hyperlink disabled by default in `supports-hyperlink`_
![windows terminal](https://github.com/Shopify/cli/assets/27013789/3ee1f3f4-3c18-4e2e-bdf6-c38ec760c0b1)

_Windows Terminal w/ hyperlinks forced_
![windows terminal FORCE_HYPERLINK](https://github.com/Shopify/cli/assets/27013789/41d023dd-53e1-4383-a358-0be8452abe03)


#### Supporting changes
* Allow hyperlink tokens to provide an explicit fallback value.
* Added a `gray` coloring output token.
* Allow disabling of ansi stripping in `ConcurrentOutput` via `useConcurrentOutputContext`.

### How to test your changes?
Run `app dev` in an app w/ functions and function log streaming enabled. Execute the function.

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
- [X] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
