### PR TITLE
Handle transient failures during app log polling

### DIFF
--- a/packages/app/src/cli/services/app-logs/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/poll-app-logs.test.ts
@@ -165,8 +165,6 @@ describe('pollAppLogs', () => {
 
   test('calls resubscribe callback if a 401 is received', async () => {
     // Given
-    const url = `https://${FQDN}/app_logs/poll`
-
     const response = new Response('errorMessage', {status: 401})
     const mockedFetch = vi.fn().mockResolvedValueOnce(response)
     vi.mocked(fetch).mockImplementation(mockedFetch)
@@ -182,14 +180,10 @@ describe('pollAppLogs', () => {
     expect(MOCKED_RESUBSCRIBE_CALLBACK).toHaveBeenCalled()
   })
 
-  test('displays error, waits, and retries if status is 429 or >500', async () => {
+  test('displays throttle message, waits, and retries if status is 429', async () => {
     // Given
-    const url = `https://${FQDN}/app_logs/poll`
-
-    const mockedFetch = vi
-      .fn()
-      .mockResolvedValueOnce(new Response('error for 429', {status: 429}))
-      .mockResolvedValueOnce(new Response('error for 500', {status: 500}))
+    const outputWarnSpy = vi.spyOn(output, 'outputWarn')
+    const mockedFetch = vi.fn().mockResolvedValueOnce(new Response('error for 429', {status: 429}))
     vi.mocked(fetch).mockImplementation(mockedFetch)
 
     // When/Then
@@ -199,17 +193,16 @@ describe('pollAppLogs', () => {
       apiKey: API_KEY,
       resubscribeCallback: MOCKED_RESUBSCRIBE_CALLBACK,
     })
-    await vi.advanceTimersToNextTimerAsync()
 
-    expect(stdout.write).toHaveBeenCalledWith('error for 429')
-    expect(stdout.write).toHaveBeenCalledWith('error for 500')
+    expect(outputWarnSpy).toHaveBeenCalledWith('Request throttled while polling app logs.')
+    expect(outputWarnSpy).toHaveBeenCalledWith('Retrying in 60 seconds.')
     expect(vi.getTimerCount()).toEqual(1)
   })
 
-  test('stops polling when unexpected error occurs instead of throwing ', async () => {
+  test('displays error message, waits, and retries if error occured', async () => {
     // Given
-    const url = `https://${FQDN}/app_logs/poll`
     const outputDebugSpy = vi.spyOn(output, 'outputDebug')
+    const outputWarnSpy = vi.spyOn(output, 'outputWarn')
 
     // An unexpected error response
     const response = new Response('errorMessage', {status: 422})
@@ -225,15 +218,9 @@ describe('pollAppLogs', () => {
     })
 
     // Then
-    expect(fetch).toHaveBeenCalledWith(url, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-      },
-    })
-    expect(stdout.write).toHaveBeenCalledWith('Error while retrieving app logs.')
-    expect(stdout.write).toHaveBeenCalledWith('App log streaming is no longer available in this `dev` session.')
-    expect(outputDebugSpy).toHaveBeenCalledWith(expect.stringContaining('errorMessage'))
-    expect(vi.getTimerCount()).toEqual(0)
+    expect(outputWarnSpy).toHaveBeenCalledWith('Error while polling app logs.')
+    expect(outputWarnSpy).toHaveBeenCalledWith('Retrying in 5 seconds.')
+    expect(outputDebugSpy).toHaveBeenCalledWith(expect.stringContaining(`Unhandled bad response: ${response.status}`))
+    expect(vi.getTimerCount()).toEqual(1)
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-editor/issues/4145

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Changes the behaviour when we encounter an unexpected error.
Previously, we would catch the error and stop the polling.
Now, we always enqueue another polling attempt regardless of the error.

### How to test your changes?

- run dev targetting your spin instance
- change partners app logs controller to return various errors, i.e.
```ruby
return render json: { errors: ['some text'] }, status: 422
```

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
