### PR TITLE
Allow declarative webhooks template

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "window.title": "${activeEditorMedium}${separator}${rootName}",
   "javascript.validate.enable": false,
   "css.validate": false,
   "scss.validate": false,

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -9,6 +9,7 @@ import {EditorExtensionCollectionType} from '../extensions/specifications/editor
 import {UIExtensionSchema} from '../extensions/specifications/ui_extension.js'
 import {Flag} from '../../services/dev/fetch.js'
 import {AppAccessSpecIdentifier} from '../extensions/specifications/app_config_app_access.js'
+import {WebhookSubscriptionSchema} from '../extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.js'
 import {ZodObjectOf, zod} from '@shopify/cli-kit/node/schema'
 import {DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify/cli-kit/node/node-package-manager'
@@ -33,6 +34,12 @@ export const LegacyAppSchema = zod
       .default(''),
     extension_directories: zod.array(zod.string()).optional(),
     web_directories: zod.array(zod.string()).optional(),
+    webhooks: zod
+      .object({
+        api_version: zod.string({required_error: 'String is required'}),
+        subscriptions: zod.array(WebhookSubscriptionSchema).optional(),
+      })
+      .optional(),
   })
   .strict()
 


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/develop-app-inner-loop/issues/1504

We are adding declarative webhooks to the templates in https://github.com/Shopify/shopify-app-template-remix/pull/743 and https://github.com/Shopify/shopify-app-template-ruby/pull/131, but it's failing because not a valid schema in the CLI.

### WHAT is this pull request doing?

The templates include a very simple legacy app schema, and then the CLI transforms it to the new schema when linking. But the legacy schema doesn't support webhooks, so I'm adding it here to be able to load the app.

### How to test your changes?

- `p shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#declarative-webhooks`
- `p shopify app init --template=https://github.com/Shopify/shopify-app-template-ruby#declarative-webhooks`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
