### PR TITLE
Search for lockfile in project root to identify package manager in workspaces

### DIFF
--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -18,7 +18,7 @@ import {
   PackageJsonNotFoundError,
   UnknownPackageManagerError,
 } from './node-package-manager.js'
-import {exec} from './system.js'
+import {captureOutput, exec} from './system.js'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from './fs.js'
 import {joinPath, dirname, normalizePath} from './path.js'
 import latestVersion from 'latest-version'
@@ -29,6 +29,7 @@ vi.mock('./system.js')
 vi.mock('latest-version')
 
 const mockedExec = vi.mocked(exec)
+const mockedCaptureOutput = vi.mocked(captureOutput)
 
 describe('installNPMDependenciesRecursively', () => {
   test('runs install in all the directories containing a package.json', async () => {
@@ -603,6 +604,7 @@ describe('addResolutionOrOverride', () => {
   test('when no package.json then an abort exception is thrown', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given/When
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       const result = () => addResolutionOrOverride(tmpDir, {'@types/react': '17.0.30'})
 
       // Then
@@ -620,6 +622,7 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'yarn.lock'))
 
       // When
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -640,6 +643,7 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'pnpm-lock.yaml'))
 
       // When
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -660,6 +664,7 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'pnpm-workspace.yaml'))
 
       // When
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -680,6 +685,7 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'yarn.lock'))
 
       // When
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -700,6 +706,7 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'yarn.lock'))
 
       // When
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -733,10 +740,10 @@ describe('getPackageManager', () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const packageJSON = {name: 'mock name'}
-      const filePath = joinPath(tmpDir, 'package.json')
 
       // When
       await writePackageJSON(tmpDir, packageJSON)
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
 
       // Then
       const packageManager = await getPackageManager(tmpDir)
@@ -748,12 +755,12 @@ describe('getPackageManager', () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const packageJSON = {name: 'mock name'}
-      const filePath = joinPath(tmpDir, 'package.json')
       const yarnLock = joinPath(tmpDir, 'yarn.lock')
 
       // When
       await writePackageJSON(tmpDir, packageJSON)
       await writeFile(yarnLock, '')
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
 
       // Then
       const packageManager = await getPackageManager(tmpDir)
@@ -765,12 +772,12 @@ describe('getPackageManager', () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const packageJSON = {name: 'mock name'}
-      const filePath = joinPath(tmpDir, 'package.json')
       const pnpmLock = joinPath(tmpDir, 'pnpm-lock.yaml')
 
       // When
       await writePackageJSON(tmpDir, packageJSON)
       await writeFile(pnpmLock, '')
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
 
       // Then
       const packageManager = await getPackageManager(tmpDir)
@@ -783,6 +790,7 @@ describe('getPackageManager', () => {
       // Given
       const subDirectory = joinPath(tmpDir, 'subdir')
       await mkdir(subDirectory)
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
 
       // When/Then
       const packageManager = await getPackageManager(tmpDir)

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -1,6 +1,6 @@
 import {AbortError, BugError} from './error.js'
 import {AbortController, AbortSignal} from './abort.js'
-import {exec} from './system.js'
+import {captureOutput, exec} from './system.js'
 import {fileExists, readFile, writeFile, findPathUp, glob} from './fs.js'
 import {dirname, joinPath} from './path.js'
 import {runWithTimer} from './metadata.js'
@@ -101,12 +101,12 @@ export function packageManagerFromUserAgent(env = process.env): PackageManager {
  * @returns The dependency manager
  */
 export async function getPackageManager(fromDirectory: string): Promise<PackageManager> {
-  const packageJson = await findPathUp('package.json', {cwd: fromDirectory, type: 'file'})
-  if (!packageJson) {
+  const directory = await captureOutput('npm', ['prefix'], {cwd: fromDirectory})
+  outputDebug(outputContent`Obtaining the dependency manager in directory ${outputToken.path(directory)}...`)
+  const packageJson = joinPath(directory, 'package.json')
+  if (!(await fileExists(packageJson))) {
     return packageManagerFromUserAgent()
   }
-  const directory = dirname(packageJson)
-  outputDebug(outputContent`Obtaining the dependency manager in directory ${outputToken.path(directory)}...`)
   const yarnLockPath = joinPath(directory, yarnLockfile)
   const pnpmLockPath = joinPath(directory, pnpmLockfile)
   const bunLockPath = joinPath(directory, bunLockfile)

--- a/packages/cli/src/cli/services/upgrade.test.ts
+++ b/packages/cli/src/cli/services/upgrade.test.ts
@@ -3,7 +3,7 @@ import * as upgradeService from './upgrade.js'
 import {afterEach, beforeEach, describe, expect, vi, test} from 'vitest'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
 import * as nodePackageManager from '@shopify/cli-kit/node/node-package-manager'
-import {exec} from '@shopify/cli-kit/node/system'
+import {exec, captureOutput} from '@shopify/cli-kit/node/system'
 import {inTemporaryDirectory, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, normalizePath} from '@shopify/cli-kit/node/path'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
@@ -138,6 +138,7 @@ describe('upgrade local CLI', () => {
         ),
         touchFile(joinPath(tmpDir, 'shopify.app.toml')),
       ])
+      vi.mocked(captureOutput).mockResolvedValueOnce(tmpDir)
 
       const outputMock = mockAndCaptureOutput()
       vi.spyOn(nodePackageManager as any, 'checkForNewVersion').mockResolvedValueOnce(currentCliVersion)
@@ -149,6 +150,7 @@ describe('upgrade local CLI', () => {
       await upgradeService.upgrade(tmpDir, oldCliVersion, {env: {}})
 
       // Then
+      expect(captureOutput).toHaveBeenCalledWith('npm', ['prefix'], {cwd: tmpDir})
       expect(outputMock.info()).toMatchInlineSnapshot(`
         "Upgrading CLI from ${oldCliVersion} to ${currentCliVersion}..."
       `)
@@ -176,6 +178,8 @@ describe('upgrade local CLI', () => {
         ),
         touchFile(joinPath(tmpDir, 'shopify.app.nondefault.toml')),
       ])
+      vi.mocked(captureOutput).mockResolvedValueOnce(tmpDir)
+
       const outputMock = mockAndCaptureOutput()
       const checkMock = vi.spyOn(nodePackageManager as any, 'checkForNewVersion')
       checkMock.mockResolvedValueOnce(undefined).mockResolvedValueOnce(currentCliVersion)
@@ -187,6 +191,7 @@ describe('upgrade local CLI', () => {
       await upgradeService.upgrade(tmpDir, oldCliVersion, {env: {}})
 
       // Then
+      expect(captureOutput).toHaveBeenCalledWith('npm', ['prefix'], {cwd: tmpDir})
       expect(outputMock.info()).toMatchInlineSnapshot(`
         "Upgrading CLI from ${oldCliVersion} to ${currentCliVersion}..."
       `)

--- a/packages/cli/src/cli/services/upgrade.test.ts
+++ b/packages/cli/src/cli/services/upgrade.test.ts
@@ -150,7 +150,7 @@ describe('upgrade local CLI', () => {
       await upgradeService.upgrade(tmpDir, oldCliVersion, {env: {}})
 
       // Then
-      expect(captureOutput).toHaveBeenCalledWith('npm', ['prefix'], {cwd: tmpDir})
+      expect(captureOutput).toHaveBeenCalledWith('npm', ['prefix'], {cwd: normalizePath(tmpDir)})
       expect(outputMock.info()).toMatchInlineSnapshot(`
         "Upgrading CLI from ${oldCliVersion} to ${currentCliVersion}..."
       `)
@@ -191,7 +191,7 @@ describe('upgrade local CLI', () => {
       await upgradeService.upgrade(tmpDir, oldCliVersion, {env: {}})
 
       // Then
-      expect(captureOutput).toHaveBeenCalledWith('npm', ['prefix'], {cwd: tmpDir})
+      expect(captureOutput).toHaveBeenCalledWith('npm', ['prefix'], {cwd: normalizePath(tmpDir)})
       expect(outputMock.info()).toMatchInlineSnapshot(`
         "Upgrading CLI from ${oldCliVersion} to ${currentCliVersion}..."
       `)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4028 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

This is necessary for handling monorepos correctly.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

The existing mechanism finds the closest `package.json` file and determines the package manager for that directory.

With these changes, we use `npm prefix` to find the project root, then look for `package.json` and a lockfile in that directory.

If we fail to find a lockfile at any point, we still default to `npm`.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Create a monorepo with pnpm, and create a workspace inside it with a Shopify app.

Running commands inside the app, the package manager should be detected correctly.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
