### PR TITLE
For github actions, prefer streamed NX output

### DIFF
--- a/.github/actions/run-and-save-test-coverage/action.yml
+++ b/.github/actions/run-and-save-test-coverage/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Unit tests with coverage
-      run: pnpm nx run-many --all --skip-nx-cache --target=test:coverage --exclude=features
+      run: pnpm nx run-many --all --skip-nx-cache --target=test:coverage --exclude=features --output-style=stream
       shell: bash
     - name: Combine Jest coverages
       run: npx istanbul-merge --out="coverage.raw.json" "packages/*/coverage/coverage-final.json"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Build
-        run: pnpm nx run-many --all --skip-nx-cache --target=build --exclude=features
+        run: pnpm nx run-many --all --skip-nx-cache --target=build --exclude=features --output-style=stream
       - name: Type-diff
         working-directory: workspace
         id: type-diff

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -71,19 +71,19 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Build
-        run: pnpm nx run-many --all --skip-nx-cache  --target=build
+        run: pnpm nx run-many --all --skip-nx-cache  --target=build --output-style=stream
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.20.3' }}
       - name: Lint
-        run: pnpm nx run-many --all --skip-nx-cache  --target=lint
+        run: pnpm nx run-many --all --skip-nx-cache  --target=lint --output-style=stream
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.20.3' }}
       - name: Type-check
-        run: pnpm nx run-many --all --skip-nx-cache  --target=type-check
+        run: pnpm nx run-many --all --skip-nx-cache  --target=type-check --output-style=stream
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.20.3' }}
       - name: Bundle
-        run: pnpm nx run-many --all --skip-nx-cache  --target=bundle
+        run: pnpm nx run-many --all --skip-nx-cache  --target=bundle --output-style=stream
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.20.3' }}
       - name: Unit tests
-        run: pnpm nx run-many --all --skip-nx-cache --target=test --exclude=features
+        run: pnpm nx run-many --all --skip-nx-cache --target=test --exclude=features --output-style=stream
       - name: Acceptance tests
         if: ${{ matrix.node == '18.20.3' }}
         run: pnpm nx run features:test
@@ -124,7 +124,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: ${{ matrix.target }}
-        run: pnpm nx run-many --all --skip-nx-cache --target=${{ matrix.target }}
+        run: pnpm nx run-many --all --skip-nx-cache --target=${{ matrix.target }} --output-style=stream
 
   pr-platform-agnostic-bundle:
     name: '[PR] Run bundle with Node ${{ matrix.node }} in ${{ matrix.os }}'
@@ -146,9 +146,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: 'Build'
-        run: pnpm nx run-many --all --skip-nx-cache --target=build
+        run: pnpm nx run-many --all --skip-nx-cache --target=build --output-style=stream
       - name: 'Bundle'
-        run: pnpm nx run-many --all --skip-nx-cache --target=bundle
+        run: pnpm nx run-many --all --skip-nx-cache --target=bundle --output-style=stream
 
   pr-platform-agnostic-knip:
     name: '[PR] Run knip with Node ${{ matrix.node }} in ${{ matrix.os }}'
@@ -190,7 +190,7 @@ jobs:
         with:
           node-version: 18.20.3
       - name: Build
-        run: pnpm build
+        run: pnpm build --output-style=stream
       - name: Refresh manifests
         run: pnpm refresh-manifests
       - name: Check if there are changes
@@ -228,7 +228,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Unit tests
-        run: pnpm test:unit
+        run: pnpm test:unit --output-style=stream
 
   pr-acceptance-tests:
     name: '[PR] Accept. Test with Node ${{ matrix.node }} in ${{ matrix.os }}'
@@ -250,7 +250,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Acceptance tests
-        run: pnpm test:features
+        run: pnpm test:features --output-style=stream
 
   pr-test-coverage:
     name: '[PR] Run Test Coverage with Node ${{ matrix.node }} in ${{ matrix.os }}'
@@ -272,7 +272,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Build
-        run: pnpm nx run-many --all --skip-nx-cache --target=build
+        run: pnpm nx run-many --all --skip-nx-cache --target=build --output-style=stream
       - name: Run and save test coverage
         uses: ./.github/actions/run-and-save-test-coverage
         with:
@@ -298,9 +298,9 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
       - name: Unit tests
-        run: pnpm test:unit
+        run: pnpm test:unit --output-style=stream
       - name: Acceptance tests
-        run: pnpm test:features
+        run: pnpm test:features --output-style=stream
       - name: Setup tmate session
         if: ${{ failure() && inputs.debug-enabled }}
         uses: mxschmitt/action-tmate@1005f9c9db5f1b055a495e72c6e589764984baf6 # pin@v3


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue where a failing CI run doesn't output the reason for the failure. What's happening is nx holds off from outputting what happens with a task for as long as it can -- then when the task completes (in failure in this case) it outputs a huge amount in one go and exits with a 1. Github actions ends the job before this huge output has flushed.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Uses nx's `--output-style=stream` option on CI jobs that are doing `run-many`. This output style means nx doesn't buffer any output.

The downside of this is that nx does try to pretend that the tasks being run happened sequentially -- app's test results all together, cli-kit's all together -- but the reality is messier as they are run interleaved. That's what's shown in the output.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

It's a CI change, but you can look at the github actions here.


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
