### PR TITLE
Update `@shopify/shopify_function@v0.2.0`

### DIFF
--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -250,7 +250,7 @@ function getSrcFileExtension(extensionFlavor: ExtensionFlavorValue): SrcFileExte
 export function getFunctionRuntimeDependencies(templateLanguage: string): DependencyVersion[] {
   const dependencies: DependencyVersion[] = []
   if (templateLanguage === 'javascript') {
-    dependencies.push({name: '@shopify/shopify_function', version: '0.1.0'}, {name: 'javy', version: '0.1.1'})
+    dependencies.push({name: '@shopify/shopify_function', version: '0.2.0'}, {name: 'javy', version: '0.1.1'})
   }
   return dependencies
 }


### PR DESCRIPTION

### WHY are these changes introduced?
Updates `@shopify/function_javascript` npm pacakge so that the new version is included by default when generating JavaScript functions. 


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
