### PR TITLE
Use CI environment to block CLI prompts

### DIFF
--- a/packages/cli-kit/src/private/node/context/utilities.ts
+++ b/packages/cli-kit/src/private/node/context/utilities.ts
@@ -51,6 +51,15 @@ export function getCIMetadata(envName: string, envs: NodeJS.ProcessEnv): Metadat
         run: envs.CI_RUNNER_ID,
         url: envs.CI_PIPELINE_URL,
       }
+    case 'buildkite':
+      return {
+        branch: envs.BUILDKITE_BRANCH,
+        build: envs.BUILDKITE_BUILD_NUMBER,
+        commitSha: envs.BUILDKITE_COMMIT,
+        commitMessage: envs.BUILDKITE_MESSAGE,
+        run: envs.BUILDKITE_BUILD_NUMBER,
+        url: envs.BUILDKITE_BUILD_URL,
+      }
     default:
       return {}
   }

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -246,6 +246,8 @@ export function ciPlatform(
       name = 'github'
     } else if (isTruthy(env.GITLAB_CI)) {
       name = 'gitlab'
+    } else if (isSet(env.BUILDKITE)) {
+      name = 'buildkite'
     }
 
     return {

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -2,6 +2,7 @@ import {AbortSignal} from './abort.js'
 import {ExternalError} from './error.js'
 import {cwd} from './path.js'
 import {treeKill} from './tree-kill.js'
+import {isTruthy} from './context/utilities.js'
 import {shouldDisplayColors, outputDebug} from '../../public/node/output.js'
 import {execa, ExecaChildProcess} from 'execa'
 import {ReadStream} from 'tty'
@@ -133,9 +134,13 @@ export async function sleep(seconds: number): Promise<void> {
  * will be used.
  *
  * @param stdin - The standard input stream to check.
+ * @param env - Environmemnt variables.
  * @returns True in the selected input stream support raw mode.
  */
-export function terminalSupportsRawMode(stdin?: ReadStream): boolean {
+export function terminalSupportsRawMode(stdin?: ReadStream, env = process.env): boolean {
+  if (isTruthy(env.CI)) {
+    return false
+  }
   if (stdin) return Boolean(stdin.isTTY)
   return process.stdin.isTTY
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue where CI runs that prompt on Buildkite cause the build to hang.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Buildkite's environment behaves differently to some other systems and this has revealed an issue around how we check for whether a terminal session is interactive or not. This PR adds a simpler path to that check: if the CLI is running in CI, don't prompt.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Run `CI=1 p shopify app dev --path="path to app" --reset` for a quick example.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
