### PR TITLE
Add exemption labels in stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: 'stale-exempt'
+          exempt-pr-labels: 'stale-exempt'
           days-before-issue-stale: 42
           days-before-pr-stale: 30
           days-before-close: 7


### PR DESCRIPTION
Certain issues and PRs may not have frequent activity, but it may be desirable to keep them open. A simple label will prevent stale-bot from acting on them.


### WHY are these changes introduced?

Issues like #2000 shouldn't be auto-closed by stale bot, because the community has the desire for them but activity is infrequent.


### WHAT is this pull request doing?

It adds exemption labels in stale.yml based on actions/stale@v4 documentation.


### How to test your changes?

Set the label on an issue and a PR. (Both should be open.) Wait the prerequisite number of days needed for stale bot to act on them. Avoid any activity on them. Observe that stale bot has ignored them despite having no activity on them.

### Post-release steps

Create the label `stale-exempt` in the [GitHub Labels page of this repository](https://github.com/Shopify/cli/labels).

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).

_I don't see how this checklist is applicable here. Just checking them off, but please ignore it._