### PR TITLE
Fix the error title for invalid webhook subscriptions

### DIFF
--- a/packages/app/src/cli/api/graphql/app_deploy.ts
+++ b/packages/app/src/cli/api/graphql/app_deploy.ts
@@ -68,6 +68,7 @@ export interface AppDeployVariables {
 interface ErrorDetail {
   extension_id: number
   extension_title: string
+  specification_identifier: string
 }
 
 export interface AppDeploySchema {

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -441,6 +441,7 @@ describe('uploadExtensionsBundle', () => {
                 {
                   extension_id: 123,
                   extension_title: 'amortizable-marketplace-ext',
+                  specification_identifier: 'ui_extension',
                 },
               ],
             },
@@ -452,6 +453,7 @@ describe('uploadExtensionsBundle', () => {
                 {
                   extension_id: 456,
                   extension_title: 'amortizable-marketplace-ext-2',
+                  specification_identifier: 'ui_extension',
                 },
               ],
             },
@@ -463,6 +465,7 @@ describe('uploadExtensionsBundle', () => {
                 {
                   extension_id: 123,
                   extension_title: 'amortizable-marketplace-ext',
+                  specification_identifier: 'ui_extension',
                 },
               ],
             },
@@ -474,6 +477,7 @@ describe('uploadExtensionsBundle', () => {
                 {
                   extension_id: 456,
                   extension_title: 'amortizable-marketplace-ext-2',
+                  specification_identifier: 'ui_extension',
                 },
               ],
             },
@@ -485,6 +489,7 @@ describe('uploadExtensionsBundle', () => {
                 {
                   extension_id: 999,
                   extension_title: 'admin-link',
+                  specification_identifier: 'ui_extension',
                 },
               ],
             },
@@ -642,6 +647,7 @@ describe('deploymentErrorsToCustomSections', () => {
           {
             extension_id: 123,
             extension_title: 't:remote-title',
+            specification_identifier: 'ui_extension',
           },
         ],
       },
@@ -653,6 +659,7 @@ describe('deploymentErrorsToCustomSections', () => {
           {
             extension_id: 123,
             extension_title: 't:remote-title',
+            specification_identifier: 'ui_extension',
           },
         ],
       },
@@ -664,6 +671,7 @@ describe('deploymentErrorsToCustomSections', () => {
           {
             extension_id: 456,
             extension_title: 'amortizable-marketplace-ext-2',
+            specification_identifier: 'ui_extension',
           },
         ],
       },
@@ -675,6 +683,7 @@ describe('deploymentErrorsToCustomSections', () => {
           {
             extension_id: 456,
             extension_title: 'amortizable-marketplace-ext-2',
+            specification_identifier: 'ui_extension',
           },
         ],
       },
@@ -686,6 +695,7 @@ describe('deploymentErrorsToCustomSections', () => {
           {
             extension_id: 999,
             extension_title: 'admin-link',
+            specification_identifier: 'ui_extension',
           },
         ],
       },
@@ -832,6 +842,44 @@ describe('deploymentErrorsToCustomSections', () => {
           {userInput: 'already-taken-version'},
           'already exists. Deploy again with a different version name.',
         ],
+      },
+    ])
+  })
+
+  test('returns Webhook Subscription as the title for webhook subscription extensions', () => {
+    // Given
+    const errors = [
+      {
+        field: ['webhook_subscription'],
+        message: 'The following topic is invalid: products/wrong',
+        category: 'invalid',
+        details: [
+          {
+            extension_id: 686809612289,
+            extension_title: 'b05ef3d6a573863fa3b21fae7689f1',
+            specification_identifier: 'webhook_subscription',
+          },
+        ],
+      },
+    ]
+
+    // When
+    const customSections = deploymentErrorsToCustomSections(errors, {
+      b05ef3d6a573863fa3b21fae7689f1: '686809612289',
+    })
+
+    // Then
+    expect(customSections).toEqual([
+      {
+        body: [
+          {
+            list: {
+              items: ['webhook_subscription: The following topic is invalid: products/wrong'],
+              title: '\nValidation errors',
+            },
+          },
+        ],
+        title: 'Webhook Subscription',
       },
     ])
   })

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -265,12 +265,20 @@ function cliErrorsSections(errors: AppDeploySchema['appDeploy']['userErrors'], i
     const errorMessage = field === 'base' ? error.message : `${field}: ${error.message}`
 
     const remoteTitle = error.details.find((detail) => typeof detail.extension_title !== 'undefined')?.extension_title
+    const specificationIdentifier = error.details.find(
+      (detail) => typeof detail.specification_identifier !== 'undefined',
+    )?.specification_identifier
     const extensionIdentifier = error.details
       .find((detail) => typeof detail.extension_id !== 'undefined')
       ?.extension_id.toString()
 
     const handle = Object.keys(identifiers).find((key) => identifiers[key] === extensionIdentifier)
-    const extensionName = handle ?? remoteTitle
+    let extensionName = handle ?? remoteTitle
+
+    if (specificationIdentifier === 'webhook_subscription') {
+      // The remote title is a random identifier in this case
+      extensionName = 'Webhook Subscription'
+    }
 
     const existingSection = sections.find((section) => section.title === extensionName)
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/1819

Validation errors for webhook subscriptions include a useless ramdom ID (the remote title):

<img width="1002" alt="Monosnap -zsh 2024-06-14 19-46-40" src="https://github.com/Shopify/cli/assets/14979109/c02f3596-f1b8-4f32-9c23-b3a53ae49599">

### WHAT is this pull request doing?

Show `Webhook Subscription` as the title for webhook subscription errros.

<img width="1006" alt="Monosnap -zsh 2024-06-14 19-45-20" src="https://github.com/Shopify/cli/assets/14979109/ee9800dc-8d82-42ac-93d8-940136a832a1">

### How to test your changes?

Add a webhook subscription with an invalid topic and deploy

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
