### PR TITLE
Only poll when app has functions

### DIFF
--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -82,9 +82,7 @@ export async function setupDevProcesses({
   const shouldRenderGraphiQL = !isTruthy(env[environmentVariableNames.disableGraphiQLExplorer])
   const shouldPerformAppLogPolling =
     isTruthy(env[environmentVariableNames.enableAppLogPolling]) &&
-    localApp.allExtensions.filter((extension) => {
-      return extension.specification.identifier === 'function'
-    }).length > 0
+    localApp.allExtensions.some((extension) => extension.isFunctionExtension)
 
   const processes = [
     ...(await setupWebProcesses({

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -80,7 +80,11 @@ export async function setupDevProcesses({
   const appPreviewUrl = buildAppURLForWeb(storeFqdn, apiKey)
   const env = getEnvironmentVariables()
   const shouldRenderGraphiQL = !isTruthy(env[environmentVariableNames.disableGraphiQLExplorer])
-  const shouldPerformAppLogPolling = isTruthy(env[environmentVariableNames.enableAppLogPolling])
+  const shouldPerformAppLogPolling =
+    isTruthy(env[environmentVariableNames.enableAppLogPolling]) &&
+    localApp.allExtensions.filter((extension) => {
+      return extension.specification.identifier === 'function'
+    }).length > 0
 
   const processes = [
     ...(await setupWebProcesses({


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-functions/issues/253

We only send app logs for function related events at the moment, so to save resources we will only poll if the user has a function.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
