### PR TITLE
Remove accidental inclusion in 3.49 release notes

### DIFF
--- a/RELEASE_NOTES/3.49.md
+++ b/RELEASE_NOTES/3.49.md
@@ -11,9 +11,6 @@
 * ***Sourcemaps support in `dev`.*** Sourcemaps are now generated properly when runnning `dev`, creating better errors and a faster debugging experience.
 * ***Localization support in `dev`.*** Localization of UI extension descriptions is now reflected correctly in `dev`.
 * ***Support for old template names.*** Passing an old template alias (e.g., `node`) when creating an app will result in the correct template being pulled. This benefits users of public learning materials which haven’t been updated to work with Remix.
-# Not sure how/whether to include:
-* Added support for wasm export choice in `app function run`
-* Fix redirection issue for customer account UI extension
 
 
 # Theme


### PR DESCRIPTION
Pretty self-explanatory. Some non-thinking copypaste stuff here.