### PR TITLE
Extend the test timeout for Windows CI runs

### DIFF
--- a/configurations/vite.config.ts
+++ b/configurations/vite.config.ts
@@ -17,7 +17,8 @@ export default function config(packagePath: string) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     test: {
-      testTimeout: process.env['VITEST_SKIP_TIMEOUT'] === '1' ? 180000 : 5000,
+      testTimeout:
+        process.env['VITEST_SKIP_TIMEOUT'] === '1' ? 180000 : process.env['RUNNER_OS'] === 'Windows' ? 13000 : 5000,
       clearMocks: true,
       mockReset: true,
       setupFiles: [path.join(__dirname, './vitest/setup.js')],


### PR DESCRIPTION
See https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables:~:text=The%20operating%20system%20of%20the%20runner%20executing%20the%20job

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue where CI runs fail for Windows tests as they fall just short of the timeout limit.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Check RUNNER_OS (set by github actions), and dynamically adjust the test timeout

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

CI covers it

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
