### PR TITLE
OCLIF flag typing

### DIFF
--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -153,7 +153,7 @@ If you're using the PHP or Ruby app template, then you need to complete the foll
     await addPublicMetadata(() => ({
       cmd_app_dependency_installation_skipped: flags['skip-dependencies-installation'],
       cmd_app_reset_used: flags.reset,
-      cmd_dev_tunnel_type: flags['tunnel-url'] ? 'custom' : flags.tunnel,
+      cmd_dev_tunnel_type: flags['tunnel-url'] ? 'custom' : 'cloudflare',
     }))
 
     const commandConfig = this.config

--- a/packages/app/src/cli/commands/app/function/replay.ts
+++ b/packages/app/src/cli/commands/app/function/replay.ts
@@ -72,7 +72,6 @@ export default class FunctionReplay extends Command {
           app,
           extension: ourFunction,
           apiKey,
-          stdout: flags.stdout,
           path: flags.path,
           json: flags.json,
           watch: flags.watch,

--- a/packages/app/src/cli/commands/app/function/schema.ts
+++ b/packages/app/src/cli/commands/app/function/schema.ts
@@ -49,7 +49,7 @@ export default class FetchSchema extends Command {
 
     await inFunctionContext({
       path: flags.path,
-      userProvidedConfigName: flags.configName,
+      userProvidedConfigName: flags.config,
       callback: async (app, ourFunction) => {
         await generateSchemaService({
           app,

--- a/packages/app/src/cli/commands/app/function/typegen.ts
+++ b/packages/app/src/cli/commands/app/function/typegen.ts
@@ -22,7 +22,7 @@ export default class FunctionTypegen extends Command {
     const {flags} = await this.parse(FunctionTypegen)
     await inFunctionContext({
       path: flags.path,
-      userProvidedConfigName: flags.configName,
+      userProvidedConfigName: flags.config,
       callback: async (app, ourFunction) => {
         await buildGraphqlTypes(ourFunction, {stdout: process.stdout, stderr: process.stderr, app})
         renderSuccess({headline: 'GraphQL types generated successfully.'})

--- a/packages/app/src/cli/services/function/replay.ts
+++ b/packages/app/src/cli/services/function/replay.ts
@@ -22,7 +22,7 @@ interface ReplayOptions {
   app: AppInterface
   extension: ExtensionInstance<FunctionConfigType>
   apiKey?: string
-  stdout: boolean
+  stdout?: boolean
   path: string
   json: boolean
   watch: boolean

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -19,6 +19,9 @@ interface EnvironmentFlags {
 }
 
 abstract class BaseCommand extends Command {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  static baseFlags: FlagInput<{}> = {}
+
   // Replace markdown links to plain text like: "link label" (url)
   public static descriptionWithoutMarkdown(): string | undefined {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -1,6 +1,6 @@
 import {themeFlags} from '../../flags.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
-import ThemeCommand from '../../utilities/theme-command.js'
+import ThemeCommand, {FlagValues} from '../../utilities/theme-command.js'
 import {dev, refreshTokens, showDeprecationWarnings} from '../../services/dev.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
 import {findOrSelectTheme} from '../../utilities/theme-selector.js'
@@ -143,7 +143,8 @@ You can run this command only in a directory that matches the [default Shopify t
     showEmbeddedCLIWarning()
     showDeprecationWarnings(this.argv)
 
-    let {flags} = await this.parse(Dev)
+    const parsed = await this.parse(Dev)
+    let flags = parsed.flags as typeof parsed.flags & FlagValues
     const store = ensureThemeStore(flags)
     const {ignore = [], only = []} = flags
 

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -1,6 +1,6 @@
 import {themeFlags} from '../../flags.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
-import ThemeCommand from '../../utilities/theme-command.js'
+import ThemeCommand, {FlagValues} from '../../utilities/theme-command.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
 import {showEmbeddedCLIWarning} from '../../utilities/embedded-cli-warning.js'
 import {pull} from '../../services/pull.js'
@@ -103,18 +103,20 @@ If no theme is specified, then you're prompted to select the theme to pull from 
       return
     }
 
+    const flagsForCli2 = flags as typeof flags & FlagValues
+
     if (developmentTheme) {
-      if (flags.development) {
-        flags.theme = `${developmentTheme.id}`
-        flags.development = false
+      if (flagsForCli2.development) {
+        flagsForCli2.theme = `${developmentTheme.id}`
+        flagsForCli2.development = false
       }
       if (useEmbeddedThemeCLI()) {
-        flags['development-theme-id'] = developmentTheme.id
+        flagsForCli2['development-theme-id'] = developmentTheme.id
       }
     }
 
-    const flagsToPass = this.passThroughFlags(flags, {allowedFlags: Pull.cli2Flags})
-    const command = ['theme', 'pull', flags.path, ...flagsToPass]
+    const flagsToPass = this.passThroughFlags(flagsForCli2, {allowedFlags: Pull.cli2Flags})
+    const command = ['theme', 'pull', flagsForCli2.path, ...flagsToPass]
 
     await execCLI2(command, {store, adminToken: adminSession.token})
   }

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -1,6 +1,6 @@
 import {themeFlags} from '../../flags.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
-import ThemeCommand from '../../utilities/theme-command.js'
+import ThemeCommand, {FlagValues} from '../../utilities/theme-command.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
 import {findOrSelectTheme} from '../../utilities/theme-selector.js'
 import {showEmbeddedCLIWarning} from '../../utilities/embedded-cli-warning.js'
@@ -171,28 +171,30 @@ export default class Push extends ThemeCommand {
       return
     }
 
+    const flagsForCli2 = flags as typeof flags & FlagValues
+
     showEmbeddedCLIWarning()
 
     const developmentThemeManager = new DevelopmentThemeManager(adminSession)
 
-    const targetTheme = await (flags.development
+    const targetTheme = await (flagsForCli2.development
       ? developmentThemeManager.findOrCreate()
       : developmentThemeManager.fetch())
 
     if (targetTheme) {
-      if (flags.development) {
-        flags.theme = `${targetTheme.id}`
-        flags.development = false
+      if (flagsForCli2.development) {
+        flagsForCli2.theme = `${targetTheme.id}`
+        flagsForCli2.development = false
       }
       if (useEmbeddedThemeCLI()) {
-        flags['development-theme-id'] = targetTheme.id
+        flagsForCli2['development-theme-id'] = targetTheme.id
       }
     }
 
-    const flagsToPass = this.passThroughFlags(flags, {
+    const flagsToPass = this.passThroughFlags(flagsForCli2, {
       allowedFlags: Push.cli2Flags,
     })
-    const command = ['theme', 'push', flags.path, ...flagsToPass]
+    const command = ['theme', 'push', flagsForCli2.path, ...flagsToPass]
 
     await execCLI2(command, {store, adminToken: adminSession.token})
   }

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -1,7 +1,7 @@
 import {configurationFileName} from '../constants.js'
 import Command from '@shopify/cli-kit/node/base-command'
 
-interface FlagValues {
+export interface FlagValues {
   [key: string]: boolean | string | string[] | number | undefined
 }
 interface PassThroughFlagsOptions {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue where `this.parse(CommandClass)` was returning a `flags` that included `{[string]: any}`, and hence wasn't really typed.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

- By setting some explicitly typed baseFlags on the base command class, we can get OCLIF's type system to behave the way we'd expect
- Fixed some issues this brought to light

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
