### PR TITLE
Extend the test timeout for MacOS CI runs

### DIFF
--- a/configurations/vite.config.ts
+++ b/configurations/vite.config.ts
@@ -5,10 +5,26 @@
 import * as path from 'pathe'
 import {defineConfig} from 'vitest/config'
 
+const TIMEOUTS = {
+  normal: 5000,
+  windows: 13000,
+  macos: 13000,
+  debug: 180000,
+}
+
 export default function config(packagePath: string) {
   // always treat environment as one that doesn't support hyperlinks -- otherwise assertions are hard to keep consistent
   process.env['FORCE_HYPERLINK'] = '0'
   process.env['FORCE_COLOR'] = '1'
+
+  let testTimeout = TIMEOUTS.normal
+  if (process.env['VITEST_SKIP_TIMEOUT'] === '1') {
+    testTimeout = TIMEOUTS.debug
+  } else if (process.env['RUNNER_OS'] === 'Windows') {
+    testTimeout = TIMEOUTS.windows
+  } else if (process.env['RUNNER_OS'] === 'macOS') {
+    testTimeout = TIMEOUTS.macos
+  }
 
   return defineConfig({
     resolve: {
@@ -17,8 +33,7 @@ export default function config(packagePath: string) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     test: {
-      testTimeout:
-        process.env['VITEST_SKIP_TIMEOUT'] === '1' ? 180000 : process.env['RUNNER_OS'] === 'Windows' ? 13000 : 5000,
+      testTimeout,
       clearMocks: true,
       mockReset: true,
       setupFiles: [path.join(__dirname, './vitest/setup.js')],


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

See also https://github.com/Shopify/cli/pull/4082

Extends the test timeout for MacOS on CI/CD
