### PR TITLE
Make device auth the default authentication method

### DIFF
--- a/.changeset/chilly-walls-exist.md
+++ b/.changeset/chilly-walls-exist.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Device auth is the default authentication method

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -16,6 +16,7 @@ export const environmentVariables = {
   alwaysLogAnalytics: 'SHOPIFY_CLI_ALWAYS_LOG_ANALYTICS',
   alwaysLogMetrics: 'SHOPIFY_CLI_ALWAYS_LOG_METRICS',
   deviceAuth: 'SHOPIFY_CLI_DEVICE_AUTH',
+  accessCodeAuth: 'SHOPIFY_CLI_ACCESS_CODE_AUTH',
   enableCliRedirect: 'SHOPIFY_CLI_ENABLE_CLI_REDIRECT',
   env: 'SHOPIFY_CLI_ENV',
   firstPartyDev: 'SHOPIFY_CLI_1P_DEV',

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -191,9 +191,22 @@ describe('useDeviceAuth', () => {
     expect(got).toBe(true)
   })
 
-  test('returns false when SHOPIFY_CLI_DEVICE_AUTH, SPIN, CODESPACES or GITPOD_WORKSPACE_URL are missing', () => {
+  test('returns true by default', () => {
     // Given
     const env = {}
+
+    // When
+    const got = useDeviceAuth(env)
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('returns false if opted-out', () => {
+    // Given
+    const env = {
+      SHOPIFY_CLI_ACCESS_CODE_AUTH: '1',
+    }
 
     // When
     const got = useDeviceAuth(env)

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -116,11 +116,17 @@ export function firstPartyDev(env = process.env): boolean {
 /**
  * Returns true if the CLI should use device auth.
  *
+ * Device auth can be opted out by using SHOPIFY_CLI_ACCESS_CODE_AUTH.
+ *
  * @param env - The environment variables from the environment of the current process.
  * @returns True if SHOPIFY_CLI_DEVICE_AUTH is truthy or the CLI is run from a cloud environment.
  */
 export function useDeviceAuth(env = process.env): boolean {
-  return isTruthy(env[environmentVariables.deviceAuth]) || isCloudEnvironment(env)
+  return (
+    !isTruthy(env[environmentVariables.accessCodeAuth]) ||
+    isTruthy(env[environmentVariables.deviceAuth]) ||
+    isCloudEnvironment(env)
+  )
 }
 
 /**

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -55,7 +55,7 @@ export function getBackendPort(): number | undefined {
 }
 
 /**
- * Returns the information of the identity token.
+ * Returns the information of the identity & refresh tokens, provided by environment variables.
  *
  * @returns The identity token information in case it exists.
  */


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/develop-app-inner-loop/issues/1835

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Device auth is now the default, with an opt-out via an environment variable

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Log out of the CLI (shopify auth logout), and start using normal commands.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
