### PR TITLE
feat: Add flow template category validation

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_template.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_template.ts
@@ -7,11 +7,33 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {glob} from '@shopify/cli-kit/node/fs'
 import fs from 'fs'
 
+const VALID_CATEGORIES = [
+  'buyer_experience',
+  'customers',
+  'fulfillment',
+  'inventory_and_merch',
+  'loyalty',
+  'orders',
+  'promotion',
+  'risk',
+  'b2b',
+  'payment_reminders',
+  'custom_data',
+  'error_monitoring',
+]
+
 const FlowTemplateExtensionSchema = BaseSchemaWithHandle.extend({
   type: zod.literal('flow_template'),
   description: zod.string().max(1024),
   template: zod.object({
-    categories: zod.array(zod.string()),
+    categories: zod.array(
+      zod.string().refine(
+        (category) => VALID_CATEGORIES.includes(category),
+        (category) => ({
+          message: `${category} is not a valid category. Valid categories include: ${VALID_CATEGORIES.join(', ')}.`,
+        }),
+      ),
+    ),
     module: zod.string(),
     require_app: zod.boolean().optional(),
     discoverable: zod.boolean().optional(),


### PR DESCRIPTION
### WHY are these changes introduced?

With the existing flow template extension schema we were just checking that the category was there and it's an array of strings. This leaves the validation of whether the categories in the array are valid up to the reviewer _after_ the template extension had been deployed. This is not great for bother the reviewer and the template author.

### WHAT is this pull request doing?

Adds another layer of validation to the schema to check if the categories in the array are in fact valid

### How to test your changes?

Local test: https://screenshot.click/19-38-0xvyn-gvwpr.mp4

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
