### PR TITLE
fix: add flow team custom categories

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/flow_template.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_template.ts
@@ -22,13 +22,15 @@ const VALID_CATEGORIES = [
   'error_monitoring',
 ]
 
+const FLOW_TEAM_CATEGORIES = ['capture_at_fulfillment']
+
 const FlowTemplateExtensionSchema = BaseSchemaWithHandle.extend({
   type: zod.literal('flow_template'),
   description: zod.string().max(1024),
   template: zod.object({
     categories: zod.array(
       zod.string().refine(
-        (category) => VALID_CATEGORIES.includes(category),
+        (category) => VALID_CATEGORIES.concat(FLOW_TEAM_CATEGORIES).includes(category),
         (category) => ({
           message: `${category} is not a valid category. Valid categories include: ${VALID_CATEGORIES.join(', ')}.`,
         }),


### PR DESCRIPTION
### WHY are these changes introduced?
Follow up to https://github.com/Shopify/cli/pull/4093 just adding an additional category group that's used by the Flow team.

### WHAT is this pull request doing?

Adds secondary array of valid template categories. Error will print out categories minus the ones used by the flow team.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
