### PR TITLE
Exclude webhook subscription modules from removed extensions list

### DIFF
--- a/packages/app/src/cli/services/context/breakdown-extensions.test.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.test.ts
@@ -198,6 +198,18 @@ const VERSION_DIFF_DELETED_CLI_B: AppVersionsDiffExtensionSchema = {
   },
 }
 
+const VERSION_DIFF_DELETED_CLI_WEBHOOK: AppVersionsDiffExtensionSchema = {
+  uuid: 'UUID_WEBOOK',
+  registrationTitle: 'Webhook Subscription Deleted',
+  specification: {
+    identifier: 'webhook_subscription',
+    experience: 'extension',
+    options: {
+      managementExperience: 'cli',
+    },
+  },
+}
+
 const APP_CONFIGURATION: CurrentAppConfiguration = {
   path: 'shopify.app.development.toml',
   name: 'my app',
@@ -633,6 +645,39 @@ describe('extensionsIdentifiersReleaseBreakdown', () => {
         onlyRemote: [buildExtensionBreakdownInfo('Checkout post purchase Deleted B')],
         toCreate: [buildExtensionBreakdownInfo('Checkout post purchase')],
         toUpdate: [buildDashboardBreakdownInfo('Dashboard A')],
+      },
+      versionDetails: versionDiff.versionDetails,
+    })
+  })
+
+  test('exclude webhook subscription modules from the version diff', async () => {
+    // Given
+    const versionDiff = {
+      versionsDiff: {
+        added: [],
+        updated: [],
+        removed: [VERSION_DIFF_DELETED_CLI_B, VERSION_DIFF_DELETED_CLI_WEBHOOK],
+      },
+      versionDetails: {
+        id: 1,
+        uuid: 'uuid',
+        location: 'location',
+        versionTag: '1.0.0',
+        message: 'message',
+        appModuleVersions: [],
+      },
+    }
+    vi.mocked(versionDiffByVersion).mockResolvedValue(versionDiff)
+
+    // When
+    const result = await extensionsIdentifiersReleaseBreakdown(developerPlatformClient, testOrganizationApp(), ' 1.0.0')
+
+    // Then
+    expect(result).toEqual({
+      extensionIdentifiersBreakdown: {
+        toCreate: [],
+        toUpdate: [],
+        onlyRemote: [buildExtensionBreakdownInfo('Checkout post purchase Deleted B')],
       },
       versionDetails: versionDiff.versionDetails,
     })

--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -92,7 +92,11 @@ export async function extensionsIdentifiersReleaseBreakdown(
 
   const mapIsExtension = (extensions: AppVersionsDiffExtensionSchema[]) =>
     extensions
-      .filter((extension) => extension.specification.experience === 'extension')
+      .filter(
+        (extension) =>
+          extension.specification.experience === 'extension' &&
+          extension.specification.identifier !== 'webhook_subscription',
+      )
       .map((extension) => buildExtensionBreakdownInfo(extension.registrationTitle))
   const mapIsDashboard = (extensions: AppVersionsDiffExtensionSchema[]) =>
     extensions


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->
Fixes https://github.com/Shopify/develop-app-inner-loop/issues/1824

### WHY are these changes introduced?

When an app developer executes `app release` that results in removal of webhook subscriptions, the webhook subscriptions will end up in a list of removed extensions. This is not the correct behaviour, as webhook changes should be grouped with the configuration section already.

#### Before
<img width="932" alt="Screenshot 2024-06-19 at 5 53 54 PM" src="https://github.com/Shopify/cli/assets/2709526/6dca2dd1-901e-44d9-83df-2cad96dbbba5">

#### After
<img width="927" alt="Screenshot 2024-06-19 at 5 55 45 PM" src="https://github.com/Shopify/cli/assets/2709526/9d45564d-68df-42a1-b311-e7080d63a648">

### WHAT is this pull request doing?
This PR filters out webhook subscriptions from the list of removed extensions.

### How to test your changes?

#### Setup
Follow the [Build Convergence script](https://docs.google.com/document/d/1pkpZ67iUs8CpGGrU1hjGvqSko2ip3z7PMsZGlMF7kvA/edit#heading=h.ar5psg26028c) for setup steps

#### Steps
1. Create a new app and update the Webhook API version and deploy the changes
3. Update the app with a new webhook subscription and deploy the changes
4. Use the CLI to release an older version of the app
5. Ensure nothing shows up in the list of extensions to be removed

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've made sure that any changes to `dev` or `deploy` have been reflected in the [internal flowchart](https://www.figma.com/file/7vqUp50u6dm48Zfb4JRRn8/CLI3-Internals).
