### PR TITLE
fix deploy diff for relative declarative webhooks

### DIFF
--- a/packages/app/src/cli/services/context/breakdown-extensions.test.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.test.ts
@@ -210,6 +210,38 @@ const VERSION_DIFF_DELETED_CLI_WEBHOOK: AppVersionsDiffExtensionSchema = {
   },
 }
 
+const APP_URL_SPEC: AppModuleVersion = {
+  registrationId: 'C_A',
+  registrationUuid: 'UUID_C_A',
+  registrationTitle: 'Registration title',
+  type: 'app_home',
+  config: {app_url: 'https://myapp.com'},
+  specification: {
+    identifier: 'app_home',
+    name: 'App Ui',
+    experience: 'configuration',
+    options: {
+      managementExperience: 'cli',
+    },
+  },
+}
+
+const API_VERSION_SPEC: AppModuleVersion = {
+  registrationId: 'C_Z',
+  registrationUuid: 'UUID_C_Z',
+  registrationTitle: 'Registration title',
+  type: 'webhooks',
+  config: {api_version: '2023-04'},
+  specification: {
+    identifier: 'webhooks',
+    name: 'Webhooks',
+    experience: 'configuration',
+    options: {
+      managementExperience: 'cli',
+    },
+  },
+}
+
 const APP_CONFIGURATION: CurrentAppConfiguration = {
   path: 'shopify.app.development.toml',
   name: 'my app',
@@ -1325,6 +1357,208 @@ describe('configExtensionsIdentifiersBreakdown', () => {
         existingUpdatedFieldNames: [],
         newFieldNames: [],
         deletedFieldNames: ['pos'],
+      })
+    })
+
+    test('relative path declarative webhook subscriptions do not show up in the diff when not changed', async () => {
+      // Given
+      const configToReleaseAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'webhook_subscription',
+        config: {topics: ['products/create'], uri: '/webhooks'},
+        specification: {
+          identifier: 'webhook_subscription',
+          name: 'Webhook Subscription',
+          experience: 'extension',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const configActiveAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'webhook_subscription',
+        config: {
+          topics: ['products/create'],
+          uri: 'https://myapp.com/webhooks',
+        },
+        specification: {
+          identifier: 'webhook_subscription',
+          name: 'Webhook Subscription',
+          experience: 'extension',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const activeVersion = {appModuleVersions: [configActiveAppModule, APP_URL_SPEC, API_VERSION_SPEC]}
+      const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
+        activeAppVersion: (_app: MinimalAppIdentifiers) => Promise.resolve(activeVersion),
+      })
+
+      // When
+      const result = await configExtensionsIdentifiersBreakdown({
+        developerPlatformClient,
+        apiKey: 'apiKey',
+        remoteApp: testOrganizationApp(),
+        localApp: await LOCAL_APP([], APP_CONFIGURATION),
+        versionAppModules: [configToReleaseAppModule, APP_URL_SPEC, API_VERSION_SPEC],
+        release: true,
+      })
+
+      // Then
+      expect(result).toEqual({
+        existingFieldNames: ['webhooks', 'application_url'],
+        existingUpdatedFieldNames: [],
+        newFieldNames: [],
+        deletedFieldNames: [],
+      })
+    })
+    test('relative path declarative webhook subscriptions show up in the diff when changed', async () => {
+      // Given
+      const configToReleaseAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'webhook_subscription',
+        config: {topics: ['products/create'], uri: '/webhooks-new'},
+        specification: {
+          identifier: 'webhook_subscription',
+          name: 'Webhook Subscription',
+          experience: 'extension',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const configActiveAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'webhook_subscription',
+        config: {
+          topics: ['products/create'],
+          uri: 'https://myapp.com/webhooks',
+        },
+        specification: {
+          identifier: 'webhook_subscription',
+          name: 'Webhook Subscription',
+          experience: 'extension',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const activeVersion = {appModuleVersions: [configActiveAppModule, APP_URL_SPEC, API_VERSION_SPEC]}
+      const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
+        activeAppVersion: (_app: MinimalAppIdentifiers) => Promise.resolve(activeVersion),
+      })
+
+      // When
+      const result = await configExtensionsIdentifiersBreakdown({
+        developerPlatformClient,
+        apiKey: 'apiKey',
+        remoteApp: testOrganizationApp(),
+        localApp: await LOCAL_APP([], APP_CONFIGURATION),
+        versionAppModules: [configToReleaseAppModule, APP_URL_SPEC, API_VERSION_SPEC],
+        release: true,
+      })
+
+      // Then
+      expect(result).toEqual({
+        existingFieldNames: ['application_url'],
+        existingUpdatedFieldNames: ['webhooks'],
+        newFieldNames: [],
+        deletedFieldNames: [],
+      })
+    })
+    test('relative path declarative webhook subscriptions show up in the diff when application_url is changed', async () => {
+      // Given
+      const configToReleaseAppModule: AppModuleVersion = {
+        registrationId: 'C_Y',
+        registrationUuid: 'UUID_C_Y',
+        registrationTitle: 'Registration title',
+        type: 'app_home',
+        config: {app_url: 'https://myapp.com/new'},
+        specification: {
+          identifier: 'app_home',
+          name: 'App Ui',
+          experience: 'configuration',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const configActiveAppModule: AppModuleVersion = {
+        registrationId: 'C_Y',
+        registrationUuid: 'UUID_C_Y',
+        registrationTitle: 'Registration title',
+        type: 'app_home',
+        config: {app_url: 'https://myapp.com'},
+        specification: {
+          identifier: 'app_home',
+          name: 'App Ui',
+          experience: 'configuration',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const webhookConfigToReleaseAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'webhook_subscription',
+        config: {topics: ['products/create'], uri: '/webhooks'},
+        specification: {
+          identifier: 'webhook_subscription',
+          name: 'Webhook Subscription',
+          experience: 'extension',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const webhookConfigActiveAppModule: AppModuleVersion = {
+        registrationId: 'C_A',
+        registrationUuid: 'UUID_C_A',
+        registrationTitle: 'Registration title',
+        type: 'webhook_subscription',
+        config: {topics: ['products/create'], uri: 'https://myapp.com/webhooks'},
+        specification: {
+          identifier: 'webhook_subscription',
+          name: 'Webhook Subscription',
+          experience: 'extension',
+          options: {
+            managementExperience: 'cli',
+          },
+        },
+      }
+      const activeVersion = {appModuleVersions: [configActiveAppModule, API_VERSION_SPEC, webhookConfigActiveAppModule]}
+      const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
+        activeAppVersion: (_app: MinimalAppIdentifiers) => Promise.resolve(activeVersion),
+      })
+
+      // When
+      const result = await configExtensionsIdentifiersBreakdown({
+        developerPlatformClient,
+        apiKey: 'apiKey',
+        remoteApp: testOrganizationApp(),
+        localApp: await LOCAL_APP([], APP_CONFIGURATION),
+        versionAppModules: [configToReleaseAppModule, API_VERSION_SPEC, webhookConfigToReleaseAppModule],
+        release: true,
+      })
+
+      // Then
+      expect(result).toEqual({
+        existingFieldNames: [],
+        existingUpdatedFieldNames: ['application_url', 'webhooks'],
+        newFieldNames: [],
+        deletedFieldNames: [],
       })
     })
   })


### PR DESCRIPTION
As we suspected, the relative URI shows up in the baseline config when doing the deploy diff. This prepends the app url before we do the diff check. This is all temporary until we move this logic to the server.

closes: https://github.com/Shopify/develop-app-inner-loop/issues/1837

![image](https://github.com/Shopify/cli/assets/29992628/17350037-6e4b-40fb-aeec-1db28732d96a)

