### PR TITLE
supported buyer context: disallow mixed definition types

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
@@ -290,6 +290,23 @@ describe('SupportedBuyerContextSchema', async () => {
     )
   })
 
+  test('throws an error if an unexpected key is present', async () => {
+    expect(() =>
+      SupportedBuyerContextsSchema.parse({
+        supported_buyer_contexts: [{currency: 'USD', random: 123}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.unrecognized_keys,
+          keys: ['random'],
+          path: ['supported_buyer_contexts', 0],
+          message: "Unrecognized key(s) in object: 'random'",
+        },
+      ]),
+    )
+  })
+
   test('is valid if countries are not provided', async () => {
     const {success} = SupportedBuyerContextsSchema.safeParse({
       supported_buyer_contexts: [{currency: 'USD'}],

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
@@ -307,9 +307,26 @@ describe('SupportedBuyerContextSchema', async () => {
     )
   })
 
+  test('throws an error if a mixture of currency and currency plus countries provided', async () => {
+    expect(() =>
+      SupportedBuyerContextsSchema.parse({
+        supported_buyer_contexts: [{currency: 'USD'}, {currency: 'EUR', countries: ['DE']}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.custom,
+          message:
+            'Must all be defined with only a currency, or must all be defined with a currency plus countries -- a mixture of the two is not allowed',
+          path: ['supported_buyer_contexts'],
+        },
+      ]),
+    )
+  })
+
   test('is valid if countries are not provided', async () => {
     const {success} = SupportedBuyerContextsSchema.safeParse({
-      supported_buyer_contexts: [{currency: 'USD'}],
+      supported_buyer_contexts: [{currency: 'USD'}, {currency: 'CAD'}],
     })
 
     expect(success).toBe(true)
@@ -317,7 +334,10 @@ describe('SupportedBuyerContextSchema', async () => {
 
   test('is valid if currrency and countries are provided', async () => {
     const {success} = SupportedBuyerContextsSchema.safeParse({
-      supported_buyer_contexts: [{currency: 'USD', countries: ['US']}],
+      supported_buyer_contexts: [
+        {currency: 'USD', countries: ['US']},
+        {currency: 'EUR', countries: ['FR', 'DE']},
+      ],
     })
 
     expect(success).toBe(true)

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
@@ -72,5 +72,16 @@ export const SupportedBuyerContextsSchema = zod.object({
         })
         .strict(),
     )
-    .optional(),
+    .optional()
+    .refine(
+      (values) => {
+        return (
+          values === undefined || values.every((value) => value.countries) || values.every((value) => !value.countries)
+        )
+      },
+      {
+        message:
+          'Must all be defined with only a currency, or must all be defined with a currency plus countries -- a mixture of the two is not allowed',
+      },
+    ),
 })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
@@ -65,10 +65,12 @@ export const ConfirmationSchema = zod.object({
 export const SupportedBuyerContextsSchema = zod.object({
   supported_buyer_contexts: zod
     .array(
-      zod.object({
-        currency: zod.string(),
-        countries: zod.array(zod.string()).nonempty().optional(),
-      }),
+      zod
+        .object({
+          currency: zod.string(),
+          countries: zod.array(zod.string()).nonempty().optional(),
+        })
+        .strict(),
     )
     .optional(),
 })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
@@ -20,11 +20,7 @@ const config: CreditCardPaymentsAppExtensionConfigType = {
   merchant_label: 'some-label',
   supported_countries: ['CA'],
   supported_payment_methods: ['PAYMENT_METHOD'],
-  supported_buyer_contexts: [
-    {currency: 'USD'},
-    {currency: 'CAD', countries: ['CA']},
-    {currency: 'EUR', countries: ['DE', 'FR']},
-  ],
+  supported_buyer_contexts: [{currency: 'USD'}, {currency: 'CAD'}],
   supports_3ds: false,
   test_mode_available: true,
   supports_deferred_payments: false,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
@@ -21,7 +21,6 @@ const config: CustomCreditCardPaymentsAppExtensionConfigType = {
   supported_countries: ['CA'],
   supported_payment_methods: ['visa'],
   supported_buyer_contexts: [
-    {currency: 'USD'},
     {currency: 'CAD', countries: ['CA']},
     {currency: 'EUR', countries: ['DE', 'FR']},
   ],

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
@@ -21,11 +21,7 @@ const config: CustomOnsitePaymentsAppExtensionConfigType = {
   merchant_label: 'some-label',
   supported_countries: ['CA'],
   supported_payment_methods: ['visa'],
-  supported_buyer_contexts: [
-    {currency: 'USD'},
-    {currency: 'CAD', countries: ['CA']},
-    {currency: 'EUR', countries: ['DE', 'FR']},
-  ],
+  supported_buyer_contexts: [{currency: 'EUR', countries: ['DE', 'FR']}],
   supports_oversell_protection: true,
   supports_3ds: true,
   supports_installments: true,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.test.ts
@@ -17,11 +17,7 @@ const config: OffsitePaymentsAppExtensionConfigType = {
   merchant_label: 'some-label',
   supported_countries: ['CA'],
   supported_payment_methods: ['PAYMENT_METHOD'],
-  supported_buyer_contexts: [
-    {currency: 'USD'},
-    {currency: 'CAD', countries: ['CA']},
-    {currency: 'EUR', countries: ['DE', 'FR']},
-  ],
+  supported_buyer_contexts: [{currency: 'USD'}],
   supports_3ds: false,
   supports_oversell_protection: false,
   test_mode_available: true,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/redeemable_payments_app_extension_schema.test.ts
@@ -17,11 +17,7 @@ const config: RedeemablePaymentsAppExtensionConfigType = {
   merchant_label: 'some-label',
   supported_countries: ['CA'],
   supported_payment_methods: ['gift-card'],
-  supported_buyer_contexts: [
-    {currency: 'USD'},
-    {currency: 'CAD', countries: ['CA']},
-    {currency: 'EUR', countries: ['DE', 'FR']},
-  ],
+  supported_buyer_contexts: [{currency: 'CAD'}],
   test_mode_available: true,
   ui_extension_handle: 'sample-ui-extension',
   targeting: [{target: 'payments.redeemable.render'}],


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

* Modified the `supported_buyer_context` schema to either allow an array of currency definitions, or an array of currency plus countries. A mixture of the two is no longer allowed.
* Use `refine` to give a user friendly error message.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

```
pnpm shopify app init --name test --template none
pnpm shopify app generate extension --path test --name "Offsite Payment Extension" --template offsite_payments
```

Edit `test/extensions/offsite-payment-extension/shopify.extension.toml` with your test configuration, e.g.

```
[[extensions.supported_buyer_contexts]]
currency = "USD"

[[extensions.supported_buyer_contexts]]
currency = "CAD"
countries = ["CA"]
```

Then trigger the validation:

```
pnpm shopify app build --path test
```

### Test results

<details>
<summary>✅ Validation passes when only using currency definitions</summary>

```toml
[[extensions.supported_buyer_contexts]]
currency = "USD"

[[extensions.supported_buyer_contexts]]
currency = "CAD"
```

![image](https://github.com/Shopify/cli/assets/179072/245748a1-ddca-4bce-b145-8e95f1534c1d)

</details>

<details>
<summary>✅ Validation passes when only using currency plus countries definitions</summary>

```toml
[[extensions.supported_buyer_contexts]]
currency = "USD"
countries = ["US"]

[[extensions.supported_buyer_contexts]]
currency = "CAD"
countries = ["CA"]
```

![image](https://github.com/Shopify/cli/assets/179072/a7f1c22f-32cb-4d06-a010-ac0f91e075a9)

</details>

<details>
<summary>✅ Validation fails when using a mixture of currency and currency plus countries definitions</summary>

```toml
[[extensions.supported_buyer_contexts]]
currency = "USD"

[[extensions.supported_buyer_contexts]]
currency = "CAD"
countries = ["CA"]
```

![image](https://github.com/Shopify/cli/assets/179072/dca0c047-10e6-4c10-add3-115f5aa1759d)

</details>

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
