### PR TITLE
[DNM] Example of locking the dev command based on a TOML option

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -51,6 +51,7 @@ const CORRECT_CURRENT_APP_SCHEMA: CurrentAppConfiguration = {
     automatically_update_urls_on_dev: true,
     dev_store_url: 'https://google.com',
     include_config_on_deploy: true,
+    app_type: 'dev',
   },
 }
 

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -54,6 +54,7 @@ export const AppSchema = zod.object({
       automatically_update_urls_on_dev: zod.boolean().optional(),
       dev_store_url: zod.string().optional(),
       include_config_on_deploy: zod.boolean().optional(),
+      app_type: zod.enum(['dev', 'prod']).optional(),
     })
     .optional(),
   extension_directories: zod.array(zod.string()).optional(),

--- a/packages/app/src/cli/models/extensions/specifications/types/app_config.ts
+++ b/packages/app/src/cli/models/extensions/specifications/types/app_config.ts
@@ -26,4 +26,7 @@ export interface AppConfigurationUsedByCli {
   auth?: {
     redirect_urls: string[]
   }
+  build?: {
+    app_type?: 'dev' | 'prod'
+  }
 }


### PR DESCRIPTION
Depending on an option in the TOML file being used, the `dev` command will put a dangerous confirmation prompt in the developer's way.