### PR TITLE
[Feature] Add ability to include liquid in TOML files, pass through liquid renderer before parsing as TOML

### DIFF
--- a/packages/cli-kit/src/public/node/toml.test.ts
+++ b/packages/cli-kit/src/public/node/toml.test.ts
@@ -27,4 +27,57 @@ describe('decodeToml', () => {
     const result = decodeToml(input)
     expect(result).toStrictEqual({access: {admin: {direct_api_mode: 'online'}}})
   })
+
+  test('evaluates liquid if given in the input', () => {
+    const input = `
+    [webhooks]
+    api_version = "{{ 2024 | minus: 1 }}-07"
+    `
+    const result = decodeToml(input)
+    expect(result).toStrictEqual({webhooks: {api_version: '2023-07'}})
+  })
+
+  test('evaluates environment variables from the process in liquid if given in the input', () => {
+    vi.stubEnv('YEAR', 2024)
+
+    const input = `
+    [webhooks]
+    api_version = "{{ env.YEAR | minus: 1 }}-07"
+    `
+    const result = decodeToml(input)
+    expect(result).toStrictEqual({webhooks: {api_version: '2023-07'}})
+    vi.unstubAllEnvs()
+  })
+
+  test('evaluates environment variables from .env in liquid if given in the input', () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const dotEnvPath = joinPath(tmpDir, '.env')
+      await writeFile(dotEnvPath, 'YEAR=2024')
+
+      const input = `
+      [webhooks]
+      api_version = "{{ env.YEAR | minus: 1 }}-07"
+      `
+      const result = decodeToml(input)
+      expect(result).toStrictEqual({webhooks: {api_version: '2023-07'}})
+    })
+  })
+
+  test('evaluates environment variables from .env over process.env in liquid if given in the input', () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      vi.stubEnv('YEAR', 2025)
+
+      const dotEnvPath = joinPath(tmpDir, '.env')
+      await writeFile(dotEnvPath, 'YEAR=2024')
+
+      const input = `
+      [webhooks]
+      api_version = "{{ env.YEAR | minus: 1 }}-07"
+      `
+      const result = decodeToml(input)
+      expect(result).toStrictEqual({webhooks: {api_version: '2023-07'}})
+
+      vi.unstubAllEnvs()
+    })
+  })
 })

--- a/packages/cli-kit/src/public/node/toml.ts
+++ b/packages/cli-kit/src/public/node/toml.ts
@@ -1,17 +1,33 @@
 import {JsonMap} from '../../private/common/json.js'
 import * as toml from '@iarna/toml'
+import {Liquid} from 'liquidjs';
+import {readAndParseDotEnv } from './dot-env.js'
+import {fileExists} from './fs.js'
+import {joinPath, cwd} from './path.js'
 
 export type JsonMapType = JsonMap
 
 /**
  * Given a TOML string, it returns a JSON object.
+ * Before parsing as TOML the string is passed through a
+ * Liquid renderer with access to environment variables.
  *
  * @param input - TOML string.
  * @returns JSON object.
  */
-export function decodeToml(input: string): JsonMapType {
+export async function decodeToml(input: string): JsonMapType {
+  const engine = new Liquid()
   const normalizedInput = input.replace(/\r\n$/g, '\n')
-  return toml.parse(normalizedInput)
+
+  let envData = process.env;
+  const envFile = joinPath(cwd(), '.env');
+  if (await fileExists(envFile)) {
+    const dotenv = await readAndParseDotEnv(envFile);
+    envData = { ...envData, ...dotenv.variables };
+  }
+
+  const renderedInput = await engine.render(engine.parse(normalizedInput), { env: envData });
+  return toml.parse(renderedInput);
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

There is currently no way to template toml file if you want to supply some of the values via environment variables. I believe the recommended approach to handling multiple environments is to have multiple named configuration files. While this works, I still think it is risky to include the working production config in a repo and would rather supply the production key at deploy time in an isolated environment.

### WHAT is this pull request doing?

Since this project already uses Liquid I opted to use that as the templating language that can be used within the toml files. This PR passes all toml files through a Liquid renderer providing the environment variables as data to the rendered before parsing the toml file.

### How to test your changes?

I have added tests to this PR but I am not able to test them as I can't install the development dependencies. You can also test this PR by using a TOML file with liquid in it and running any of the cli commands.

Example shopify.app.toml:

``` toml
client_id = "{{ env.SHOPIFY_APP_API_KEY }}"
name = "{{ env.SHOPIFY_APP_NAME }}"
# the rest of the file
```

Running the cli deploy command should succeed if given valid environment variables ex.

`SHOPIFY_APP_API_KEY=key SHOPIFY_APP_NAME=test npm run deploy`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
