### PR TITLE
Encourage scope granting in GraphiQL

### DIFF
--- a/.changeset/heavy-camels-invent.md
+++ b/.changeset/heavy-camels-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Encourage scope granting for GraphiQL when they're changed

--- a/.nxignore
+++ b/.nxignore
@@ -1,2 +1,2 @@
-**/templates/**
+packages/app/templates/**
 docs/**

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -110,6 +110,7 @@ export function testApp(app: Partial<AppInterface> = {}, schemaType: 'current' |
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     configSchema: (app.configSchema ?? AppConfigurationSchema) as any,
     remoteFlags: app.remoteFlags ?? [],
+    appConfigurationFilePath: app.configuration?.path ?? getConfig().path,
   })
 
   if (app.updateDependencies) {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -255,6 +255,11 @@ export interface AppInterface<
    */
   creationDefaultOptions(): AppCreationDefaultOptions
 
+  /**
+   * Get an event emitter that monitors for changes to an app's access scopes, monitoring the configuration file.
+   *
+   * The event emitter fires an 'accessChange' event when the scopes change.
+   */
   watchForAccessChange(): Promise<EventEmitter>
 }
 

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -13,7 +13,7 @@ import {WebhookSubscriptionSchema} from '../extensions/specifications/app_config
 import {ZodObjectOf, zod} from '@shopify/cli-kit/node/schema'
 import {DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify/cli-kit/node/node-package-manager'
-import {fileRealPath, findPathUp, readFile} from '@shopify/cli-kit/node/fs'
+import {fileExists, fileRealPath, findPathUp, readFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {setPathValue} from '@shopify/cli-kit/common/object'
@@ -408,6 +408,12 @@ export class App<
 
   async watchForAccessChange(): Promise<EventEmitter> {
     const accessChangeEmitter = new EventEmitter()
+
+    if (!(await fileExists(this.appConfigurationFilePath))) {
+      // if the config isn't present -- it doesn't need to be -- just have an idle emitter
+      return accessChangeEmitter
+    }
+
     const sniffScopes = async () => {
       const fileContent = await readFile(this.appConfigurationFilePath)
       const content = decodeToml(fileContent)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -301,6 +301,7 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
       specifications: this.specifications,
       configSchema,
       remoteFlags: this.remoteFlags,
+      appConfigurationFilePath: configuration.path,
     })
 
     if (!this.errors.isEmpty()) appClass.errors = this.errors

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -941,7 +941,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
 
     // When
@@ -969,7 +969,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(getCachedAppInfo).mockReturnValue({...CACHED1, appId: 'key2'})
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(reuseDevConfigPrompt).mockResolvedValueOnce(true)
     vi.mocked(loadApp).mockResolvedValue(app)
 
@@ -996,7 +996,7 @@ describe('ensureDeployContext', () => {
       extensionsNonUuidManaged: {},
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
@@ -1033,7 +1033,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
     const developerPlatformClient = buildDeveloperPlatformClient({
       async orgAndApps(_orgId: string) {
@@ -1102,7 +1102,7 @@ describe('ensureDeployContext', () => {
     // There is a cached app but it will be ignored
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
     vi.mocked(link).mockResolvedValue((app as any).configuration)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
     const writeAppConfigurationFileSpy = vi
       .spyOn(writeAppConfigurationFile, 'writeAppConfigurationFile')
@@ -1161,7 +1161,7 @@ describe('ensureDeployContext', () => {
     })
     vi.mocked(getAppIdentifiers).mockReturnValue({app: APP2.apiKey})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(appWithExtensions)
     vi.mocked(updateAppIdentifiers).mockResolvedValue(appWithExtensions)
 
@@ -1190,7 +1190,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
     vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.toml')
@@ -1240,7 +1240,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
     vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.toml')
@@ -1286,7 +1286,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
     vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.toml')
     const writeAppConfigurationFileSpy = vi
@@ -1334,7 +1334,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
     vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.toml')
@@ -1385,7 +1385,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
     vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.toml')
@@ -1428,7 +1428,7 @@ describe('ensureDeployContext', () => {
     }
     vi.mocked(getAppIdentifiers).mockReturnValue({app: undefined})
     vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP2)
-    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue(identifiers)
+    vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({identifiers, scopesWereChanged: false})
     vi.mocked(loadApp).mockResolvedValue(app)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
     vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.toml')

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -342,6 +342,7 @@ interface DeployContextOutput {
   remoteApp: Omit<OrganizationApp, 'apiSecretKeys'>
   identifiers: Identifiers
   release: boolean
+  scopesWereChanged: boolean
 }
 
 /**
@@ -437,7 +438,7 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
 
   await ensureIncludeConfigOnDeploy({org, app, remoteApp, reset, force})
 
-  const identifiers = await ensureDeploymentIdsPresence({
+  const {identifiers, scopesWereChanged} = await ensureDeploymentIdsPresence({
     app,
     appId: remoteApp.apiKey,
     appName: remoteApp.title,
@@ -468,6 +469,7 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
     },
     identifiers,
     release: !noRelease,
+    scopesWereChanged,
   }
 
   await logMetadataForLoadedContext({

--- a/packages/app/src/cli/services/context/identifiers.test.ts
+++ b/packages/app/src/cli/services/context/identifiers.test.ts
@@ -62,12 +62,51 @@ describe('ensureDeploymentIdsPresence', () => {
 
     // Then
     expect(result).toEqual({
-      app: params.appId,
+      identifiers: {
+        app: params.appId,
+        extensions: {
+          EXTENSION_A: 'UUID_A',
+        },
+        extensionIds: {EXTENSION_A: 'A'},
+        extensionsNonUuidManaged: {},
+      },
+      scopesWereChanged: false,
+    })
+  })
+
+  test('if talk about access scopes being changed, reflect that in the result', async () => {
+    // Given
+    vi.mocked(extensionsIdentifiersDeployBreakdown).mockResolvedValue(buildExtensionsBreakdown())
+    vi.mocked(configExtensionsIdentifiersBreakdown).mockResolvedValue({
+      ...buildConfigBreakdown(),
+      newFieldNames: ['access_scopes'],
+    })
+    vi.mocked(deployOrReleaseConfirmationPrompt).mockResolvedValue(true)
+    vi.mocked(deployConfirmed).mockResolvedValue({
       extensions: {
         EXTENSION_A: 'UUID_A',
       },
       extensionIds: {EXTENSION_A: 'A'},
       extensionsNonUuidManaged: {},
+    })
+
+    // When
+    const params = {
+      app: testApp(),
+      developerPlatformClient,
+      appId: 'appId',
+      appName: 'appName',
+      remoteApp: testOrganizationApp(),
+      envIdentifiers: {},
+      force: false,
+      release: true,
+    }
+    const result = await ensureDeploymentIdsPresence(params)
+
+    // Then
+    expect(result).toEqual({
+      identifiers: expect.any(Object),
+      scopesWereChanged: true,
     })
   })
 })

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -53,6 +53,11 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     release: options.release,
   })
 
+  const scopesWereChanged =
+    (configExtensionIdentifiersBreakdown?.existingUpdatedFieldNames.includes('access_scopes') ||
+      configExtensionIdentifiersBreakdown?.newFieldNames.includes('access_scopes')) ??
+    false
+
   const confirmed = await deployOrReleaseConfirmationPrompt({
     extensionIdentifiersBreakdown,
     configExtensionIdentifiersBreakdown,
@@ -70,9 +75,12 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
   )
 
   return {
-    app: options.appId,
-    extensions: result.extensions,
-    extensionIds: result.extensionIds,
-    extensionsNonUuidManaged: result.extensionsNonUuidManaged,
+    identifiers: {
+      app: options.appId,
+      extensions: result.extensions,
+      extensionIds: result.extensionIds,
+      extensionsNonUuidManaged: result.extensionsNonUuidManaged,
+    },
+    scopesWereChanged,
   }
 }

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -565,6 +565,7 @@ async function testDeployBundle({
         organizationId: 'org-id',
       }),
     release: !options?.noRelease,
+    scopesWereChanged: false,
   })
 
   vi.mocked(useThemebundling).mockReturnValue(true)

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -102,7 +102,6 @@ export function setupGraphiQLServer({
         },
       })
       const tokenResponseObject = await tokenResponse.json()
-      console.log(tokenResponseObject)
 
       const {scope: approvedScopes} = tokenResponseObject as {scope: string}
 
@@ -115,10 +114,8 @@ export function setupGraphiQLServer({
       const areSetsEqual = (left: Set<string>, right: Set<string>) =>
         left.size === right.size && [...left].every((value) => right.has(value))
       if (areSetsEqual(approvedScopesSet, scopesSet)) {
-        console.log('setting that scopes are ok')
         scopeMismatch = false
       } else {
-        console.log('setting that scopes are mismatched')
         scopeMismatch = true
       }
 
@@ -131,7 +128,6 @@ export function setupGraphiQLServer({
 
   accessChangeEvent.on('accessChange', ({scopes}) => {
     const hardRefresh = async () => {
-      console.log(`Refreshing token due to file change, new expected scopes are ${scopes}`)
       _token = await refreshToken(scopes)
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -108,12 +108,13 @@ export function setupGraphiQLServer({
       // break and trim by commas put the approved scopes into a set
       const approvedScopesSet = new Set(approvedScopes.split(',').map((scope) => scope.trim()))
       // same for scopes
-      const scopesSet = new Set(expectedScopes.split(',').map((scope) => scope.trim()))
+      const expectedScopesSet = new Set(expectedScopes.split(',').map((scope) => scope.trim()))
+
+      // check if everything in expectedScopesSet is in approvedScopesSet
+      const allExpectedInApproved = [...expectedScopesSet].every((scope) => approvedScopesSet.has(scope))
 
       // if these sets don't match exactly... log something
-      const areSetsEqual = (left: Set<string>, right: Set<string>) =>
-        left.size === right.size && [...left].every((value) => right.has(value))
-      if (areSetsEqual(approvedScopesSet, scopesSet)) {
+      if (allExpectedInApproved) {
         scopeMismatch = false
       } else {
         scopeMismatch = true

--- a/packages/app/src/cli/services/dev/graphiql/templates/unauthorized.tsx
+++ b/packages/app/src/cli/services/dev/graphiql/templates/unauthorized.tsx
@@ -61,10 +61,11 @@ const polarisUnauthorizedContent = renderToStaticMarkup(
                   Install your app to access GraphiQL
                 </Text>
                 <p>
-                  The GraphiQL Explorer relies on your app being installed on your development store to access its data.
+                  The GraphiQL Explorer relies on your app being installed and access scopes approved on your
+                  development store to access its data.
                 </p>
                 <p id="card-cta">
-                  <Button id="app-install-button">Install your app</Button>
+                  <Button id="app-install-button">Install your app/Approve scopes</Button>
                 </p>
               </BlockStack>
             </div>

--- a/packages/app/src/cli/services/dev/processes/draftable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/draftable-extension.ts
@@ -112,7 +112,9 @@ export async function setupDraftableExtensionsProcess({
 
   const prodEnvIdentifiers = getAppIdentifiers({app: localApp}, developerPlatformClient)
 
-  const {extensionIds: remoteExtensionIds, extensions: extensionsUuids} = await ensureDeploymentIdsPresence({
+  const {
+    identifiers: {extensionIds: remoteExtensionIds, extensions: extensionsUuids},
+  } = await ensureDeploymentIdsPresence({
     app: localApp,
     remoteApp,
     appId: apiKey,

--- a/packages/app/src/cli/services/dev/processes/graphiql.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql.ts
@@ -1,5 +1,6 @@
 import {BaseProcess, DevProcessFunction} from './types.js'
 import {setupGraphiQLServer} from '../graphiql/server.js'
+import EventEmitter from 'node:events'
 
 interface GraphiQLServerProcessOptions {
   appName: string
@@ -9,6 +10,7 @@ interface GraphiQLServerProcessOptions {
   storeFqdn: string
   key?: string
   port: number
+  accessChangeEvent: EventEmitter
 }
 
 export interface GraphiQLServerProcess extends BaseProcess<GraphiQLServerProcessOptions> {

--- a/packages/app/src/cli/services/dev/processes/graphiql.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql.ts
@@ -11,6 +11,7 @@ interface GraphiQLServerProcessOptions {
   key?: string
   port: number
   accessChangeEvent: EventEmitter
+  initialExpectedScopes: string
 }
 
 export interface GraphiQLServerProcess extends BaseProcess<GraphiQLServerProcessOptions> {

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -34,10 +34,13 @@ vi.mock('@shopify/cli-kit/node/environment')
 beforeEach(() => {
   // mocked for draft extensions
   vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({
-    extensionIds: {},
-    app: 'app-id',
-    extensions: {},
-    extensionsNonUuidManaged: {},
+    identifiers: {
+      extensionIds: {},
+      app: 'app-id',
+      extensions: {},
+      extensionsNonUuidManaged: {},
+    },
+    scopesWereChanged: false,
   })
 
   // mocked for theme app extensions

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -106,6 +106,7 @@ export async function setupDevProcesses({
           key: graphiqlKey,
           storeFqdn,
           accessChangeEvent,
+          initialExpectedScopes: getAppScopes(localApp.configuration),
         })
       : undefined,
     await setupPreviewableExtensionsProcess({

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -84,6 +84,8 @@ export async function setupDevProcesses({
     isTruthy(env[environmentVariableNames.enableAppLogPolling]) &&
     localApp.allExtensions.some((extension) => extension.isFunctionExtension)
 
+  const accessChangeEvent = await localApp.watchForAccessChange()
+
   const processes = [
     ...(await setupWebProcesses({
       webs: localApp.webs,
@@ -103,6 +105,7 @@ export async function setupDevProcesses({
           apiSecret,
           key: graphiqlKey,
           storeFqdn,
+          accessChangeEvent,
         })
       : undefined,
     await setupPreviewableExtensionsProcess({


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

When a developer changes the access scopes for their app, and wants to continue to prototype and build, they almost certainly will need the merchant of their dev store -- themselves! -- to grant said access. For the app home, a refresh will do the job with declarative scopes. But lots of building now happens in GraphiQL, and this doesn't have the same behaviour. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Firstly the token used by GraphiQL is refreshed often now, so its scopes should always be up to date with those granted by the dev store.

This PR adds a couple of helpful nudges:
- if the access scopes in the in-use app toml don't match those that GraphiQL's access token is attempting to use, this is a sign that the developer has changed them. we show a message in the top-bar of GraphiQL encouraging the dev to run `shopify app deploy`
- after running `shopify app deploy`, if the developer has changed their access scopes within their newly released app version, we show a next step about granting these new access scopes in their dev store

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

<img width="600" alt="image" src="https://github.com/Shopify/cli/assets/234027/0e6fb18b-4af9-4c82-be03-f8d0829f706d">
<img width="1800" alt="image" src="https://github.com/Shopify/cli/assets/234027/8f5b338d-b2e0-475e-b695-b69635019468">


### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

1. Run `shopify app dev`, and launch GraphiQL
2. Leaving dev running, go to your app toml, and add a new scope, save the file
3. The banner shown above should appear. If you change the scopes back, it will disappear.
4. With changed scopes, run `shopify app deploy`. Choose to create and release a new version
5. The confirmation message should mention going to your dev store, as per the above

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

n/a

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
