### PR TITLE
Avoid loop when users pass the `--theme-editor-sync` flag in the `shopify theme dev` command

### DIFF
--- a/.changeset/warm-chicken-sin.md
+++ b/.changeset/warm-chicken-sin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Avoid loop when users pass the `--theme-editor-sync` flag in the `shopify theme dev` command

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/file.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/file.rb
@@ -76,7 +76,8 @@ module ShopifyCLI
 
       def checksum
         content = read
-        if mime_type.json?
+
+        if mime_type.json? && !settings_schema?
           # Normalize JSON to match backend
           begin
             content = normalize_json(content)
@@ -84,6 +85,7 @@ module ShopifyCLI
             # Fallback to using the raw content
           end
         end
+
         Digest::MD5.hexdigest(content)
       end
 
@@ -111,40 +113,16 @@ module ShopifyCLI
 
       private
 
+      def settings_schema?
+        relative_path.end_with?("config/settings_schema.json")
+      end
+
       def normalize_json(content)
-        parsed = JSON.parse(content)
+        normalized = JSON.generate(JSON.parse(content))
 
-        if template?
-          JsonTemplateNormalizer.new.visit_document(parsed)
-        end
-
-        normalized = JSON.generate(parsed)
         # Backend escapes forward slashes
         normalized.gsub!(/\//, "\\/")
         normalized
-      end
-
-      class JsonTemplateNormalizer
-        def visit_document(value)
-          visit_hash(value["sections"])
-        end
-
-        def visit_hash(hash)
-          return unless hash.is_a?(Hash)
-          hash.each do |_, value|
-            visit_value(value)
-          end
-        end
-
-        def visit_value(value)
-          return unless value.is_a?(Hash)
-
-          # Reinsert settings to force the same ordering as in the backend
-          settings = value.delete("settings") || {}
-          value["settings"] = settings
-
-          visit_hash(value["blocks"])
-        end
       end
     end
   end

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/theme_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/theme_test.rb
@@ -94,31 +94,20 @@ module ShopifyCLI
         assert_equal(Digest::MD5.hexdigest(content), @theme["layout/theme.liquid"].checksum)
       end
 
-      def test_normalize_json_template_for_checksum
-        expected_content = <<~EOS
-          {
-            "name": "Blog",
-            "sections": {
-              "main": {
-                "type": "main-blog",
-                "settings": {}
-              }
-            },
-            "order": [
-              "main"
-            ]
-          }
+      def test_do_not_normalize_settings_schema_for_checksum
+        normalized = <<~EOS.rstrip
+          [
+            {
+              "name": "theme_info",
+              "theme_name": "Example",
+              "theme_version": "1.0.0",
+              "theme_author": "Shopify",
+              "theme_documentation_url": "https://shopify.com",
+              "theme_support_url": "https://support.shopify.com/"
+            }
+          ]
         EOS
-        normalized = JSON.parse(expected_content).to_json
-        assert_equal(Digest::MD5.hexdigest(normalized), @theme["templates/blog.json"].checksum)
-      end
 
-      def test_normalize_settings_schema_for_checksum
-        normalized =
-          "[{\"name\":\"theme_info\",\"theme_name\":\"Example\"," \
-          "\"theme_version\":\"1.0.0\",\"theme_author\":\"Shopify\"," \
-          "\"theme_documentation_url\":\"https:\\/\\/shopify.com\"," \
-          "\"theme_support_url\":\"https:\\/\\/support.shopify.com\\/\"}]"
         assert_equal(Digest::MD5.hexdigest(normalized), @theme["config/settings_schema.json"].checksum)
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

This PR updates the checksum calculation to avoid loops in when users run the `shopify theme dev --theme-editor-sync`, as before the values were never matching.

### WHAT is this pull request doing?

In the past, we introduced a visitor that was adding the `settings` key locally as the platform auto adds them ([context](https://github.com/Shopify/shopify-cli/commit/6d79724ca5a6516bf47e654feed98c61b668582f)):

<img src="https://github.com/Shopify/cli/assets/1079279/251d4245-4f9c-45cf-8c5d-6cfe7e08e5f6" width="70%"/>

That was a great, as we were avoiding unnecessary uploads when templates were only missing the `settings` key. However, now that we support themes blocks, that also have settings and may be deeply nested, that convenience is not longer ideal and keeping up locally may generate erratic behaviour.

Thus, this PR removes the visitor, and fixes the loop scenario that some users were facing with the `--theme-editor-sync` flag.

Additionally, the checksum logic no longer normalizes the `config/settings_schema.json` file as the platform now keeps user defined spacing on files that are not platform controlled.

### How to test your changes?

- Download [this zip file](https://github.com/user-attachments/files/16052340/Code.Base.Theme-4.0.0.zip)
- Run `shopify theme dev --theme-editor-sync`
- Notice that `config/settings_schema.json` and `templates/index.json` get into a `get`/`update` loop
- Update you local CLI to use this PR
- Notice the loop no longer happens


### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
