### PR TITLE
Avoid deploying draft webhook extensions on dev

### DIFF
--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -19,6 +19,7 @@ import {
   testPaymentsAppExtension,
   testDeveloperPlatformClient,
   testSingleWebhookSubscriptionExtension,
+  testAppAccessConfigExtension,
 } from '../../models/app/app.test-data.js'
 import {getUIExtensionsToMigrate, migrateExtensionsToUIExtension} from '../dev/migrate-to-ui-extension.js'
 import {OrganizationApp} from '../../models/organization.js'
@@ -928,7 +929,7 @@ describe('deployConfirmed: handle non existent uuid managed extensions', () => {
       uuid: 'UUID_C_A',
       id: 'C_A',
       title: 'C_A',
-      type: 'POINT_OF_SALE',
+      type: 'app-access',
     }
     const developerPlatformClient = testDeveloperPlatformClient({
       createExtension: () => createExtensionResult(REGISTRATION_CONFIG_A),
@@ -936,7 +937,7 @@ describe('deployConfirmed: handle non existent uuid managed extensions', () => {
 
     // When
 
-    const CONFIG_A = await testAppConfigExtensions()
+    const CONFIG_A = await testAppAccessConfigExtension()
     const ensureExtensionsIdsOptions = options([], [], {configExtensions: [CONFIG_A], developerPlatformClient})
     ensureExtensionsIdsOptions.includeDraftExtensions = true
     const got = await deployConfirmed(ensureExtensionsIdsOptions, [], [], {
@@ -948,8 +949,8 @@ describe('deployConfirmed: handle non existent uuid managed extensions', () => {
     expect(developerPlatformClient.createExtension).toBeCalledTimes(1)
     expect(got).toEqual({
       extensions: {},
-      extensionIds: {'point-of-sale': 'C_A'},
-      extensionsNonUuidManaged: {'point-of-sale': 'UUID_C_A'},
+      extensionIds: {'app-access': 'C_A'},
+      extensionsNonUuidManaged: {'app-access': 'UUID_C_A'},
     })
   })
   test('when the include config on deploy flag is disabled but draft extensions should be used configuration extensions are created with context', async () => {

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -204,7 +204,7 @@ export async function ensureNonUuidManagedExtensionsIds(
   includeDraftExtensions = false,
   developerPlatformClient: DeveloperPlatformClient,
 ) {
-  let localExtensionRegistrations = includeDraftExtensions ? app.realExtensions : app.allExtensions
+  let localExtensionRegistrations = includeDraftExtensions ? app.draftableExtensions : app.allExtensions
 
   localExtensionRegistrations = localExtensionRegistrations.filter((ext) => !ext.isUUIDStrategyExtension)
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/cli/issues/4139

### WHY are these changes introduced?

When running dev with declarative webhooks and relative paths, we are comparing the URLs with the server ones, which are absolute, so we are finally creating new extensions every time. They are only removed on deploy and there's a limit of 100 that can be reached if running dev multiple times. After reaching it, the server returns an error.

### WHAT is this pull request doing?

Related to changes in https://github.com/Shopify/cli/pull/3710 and https://github.com/Shopify/cli/pull/3846

Only deploy draftable extensions when running dev.

### How to test your changes?

`p shopify app dev --verbose` and check if it's creating a  WEBHOOK_SUBSCRIPTION extension

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
