### PR TITLE
[stable] Match webhooks by comparing relative and absolute paths

### DIFF
--- a/.changeset/metal-bikes-smell.md
+++ b/.changeset/metal-bikes-smell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix an issue with webhooks being recreated during deploy

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -1154,7 +1154,7 @@ describe('ensureNonUuidManagedExtensionsIds: for extensions managed in the TOML'
     const config = {
       topic: 'orders/delete',
       api_version: '2024-01',
-      uri: 'https://my-app.com/webhooks',
+      uri: '/webhooks',
       include_fields: ['id'],
       filter: 'id:*',
     }
@@ -1172,7 +1172,8 @@ describe('ensureNonUuidManagedExtensionsIds: for extensions managed in the TOML'
       title: 'Webhook Subscription',
       type: 'WEBHOOK_SUBSCRIPTION',
       activeVersion: {
-        config: JSON.stringify(config),
+        // use absolute path here to test that it matches both absolute and relative paths from the local config
+        config: JSON.stringify({...config, uri: 'https://my-app.com/webhooks'}),
       },
     }
 

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -161,9 +161,10 @@ function matchWebhooks(remoteSource: RemoteSource, extension: ExtensionInstance)
   const remoteVersionConfig = remoteSource.activeVersion?.config
   const remoteVersionConfigObj = remoteVersionConfig ? JSON.parse(remoteVersionConfig) : {}
   const localConfig = extension.configuration as unknown as SingleWebhookSubscriptionType
+  const remoteUri: string = remoteVersionConfigObj.uri || ''
   return (
     remoteVersionConfigObj.topic === localConfig.topic &&
-    remoteVersionConfigObj.uri === localConfig.uri &&
+    (remoteUri === localConfig.uri || remoteUri.endsWith(localConfig.uri)) &&
     remoteVersionConfigObj.filter === localConfig.filter
   )
 }

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -164,7 +164,7 @@ function matchWebhooks(remoteSource: RemoteSource, extension: ExtensionInstance)
   const remoteUri: string = remoteVersionConfigObj.uri || ''
   return (
     remoteVersionConfigObj.topic === localConfig.topic &&
-    (remoteUri === localConfig.uri || remoteUri.endsWith(localConfig.uri)) &&
+    remoteUri.endsWith(localConfig.uri) &&
     remoteVersionConfigObj.filter === localConfig.filter
   )
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
The backend always returns an absolute path, but the CLI might only have relative ones.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Use `endsWith` to compare relative and absolute URIs
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
