### PR TITLE
Print input before running function-runner in replay command

### DIFF
--- a/packages/app/src/cli/services/function/replay.ts
+++ b/packages/app/src/cli/services/function/replay.ts
@@ -15,6 +15,7 @@ import {AbortController} from '@shopify/cli-kit/node/abort'
 import {outputInfo, outputWarn} from '@shopify/cli-kit/node/output'
 import {renderFatalError} from '@shopify/cli-kit/node/ui'
 import {readdirSync} from 'fs'
+import chalk from '@shopify/cli-kit/node/colors'
 
 const LOG_SELECTOR_LIMIT = 100
 
@@ -100,6 +101,8 @@ async function runFunctionRunnerWithLogInput(
   exportName: string,
 ) {
   const outputAsJson = options.json ? ['--json'] : []
+
+  printInputForFunctionRunner(input);
 
   return exec(
     'npm',
@@ -220,4 +223,11 @@ async function getFunctionRunData(functionRunsDir: string, functionHandle: strin
 
 function getIdentifierFromFilename(fileName: string): string {
   return fileName.split('_').pop()!.substring(0, 6)
+}
+
+function printInputForFunctionRunner(input: string) {
+  const title = chalk.black.bgRgb(150, 191, 72)('             Input            ');
+
+  console.log(`${title}\n`);
+  console.log(`${JSON.stringify(JSON.parse(input), null, 2)}\n`);
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Idea to address: https://github.com/Shopify/shopify-functions/issues/242

As per the issue, when running the replay command, it is useful to see the input being used. The output from `function-runner` comes from[here](https://github.com/Shopify/function-runner/blob/0f823c40de466bcd3c0ed43b678da25007015a1e/src/function_run_result.rs#L73-L90).


### WHAT is this pull request doing?

One option to address this issue is we can print the input before running `function-runner` from the CLI. When printing the input we can display it in similar to how function runner does. (code linked above)

Pro: The will only display input for replay command, leaving function-runner unchanged (maybe we dont always want to see the input printed out)
Con: We are just minicing how function runner prints the data, if this changes, we need to keep replay aligned. 

This sollution would look like this:
<img width="734" alt="Screenshot 2024-07-03 at 2 23 39 PM" src="https://github.com/Shopify/cli/assets/16329347/ddcfe398-f60d-45ef-a639-a6577df60dc5">

Alternatively, we could update `function-runner` , to also print the input to the function run. Which after thinking about this, seems like a better option. Any thoughts?


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
