### PR TITLE
Dedup cli-kit when bundling hydrogen

### DIFF
--- a/bin/bundling/esbuild-plugin-dedup-cli-kit.js
+++ b/bin/bundling/esbuild-plugin-dedup-cli-kit.js
@@ -1,0 +1,13 @@
+const CliKitDedupPlugin = ({require}) => {
+  return {
+    name: 'CliKitDedupPlugin',
+    setup(build) {
+      // Resolve all imports of @shopify/cli-kit to the local dependency of the package.
+      build.onResolve({filter: /@shopify\/cli-kit/}, (args) => {
+        return {path: require.resolve(args.path)}
+      })
+    }
+  }
+}
+
+export default CliKitDedupPlugin

--- a/packages/cli/bin/bundle.js
+++ b/packages/cli/bin/bundle.js
@@ -3,6 +3,7 @@
 import ShopifyStacktraceyPlugin from '../../../bin/bundling/esbuild-plugin-stacktracey.js'
 import ShopifyVSCodePlugin from '../../../bin/bundling/esbuild-plugin-vscode.js'
 import GraphiQLImportsPlugin from '../../../bin/bundling/esbuild-plugin-graphiql-imports.js'
+import CliKitDedupPlugin from '../../../bin/bundling/esbuild-plugin-dedup-cli-kit.js'
 import {build as esBuild} from 'esbuild'
 import {copy} from 'esbuild-plugin-copy'
 import glob from 'fast-glob'
@@ -54,6 +55,7 @@ esBuild({
     ShopifyVSCodePlugin,
     GraphiQLImportsPlugin,
     ShopifyStacktraceyPlugin,
+    CliKitDedupPlugin({require}),
     copy({
       // this is equal to process.cwd(), which means we use cwd path as base path to resolve `to` path
       // if not specified, this plugin uses ESBuild.build outdir/outfile options as base path.


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Since `cli-hydrogen` is an external dependency that at the same time depends on `cli-kit` which exists in this repo, it creates a weird dependency tree that eventually causes esbuild to bundle 2 identical copies of `cli-kit`

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add a new ESBuild plugin to dedup `cli-kit` when bundling.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
See the snapshot in the comments, if you install that and try any app and hydrogen command, everything should work.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
