### PR TITLE
[App logs streaming] Add function network access events to the app logs cmd

### DIFF
--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
@@ -1,11 +1,20 @@
 import {usePollAppLogs} from './usePollAppLogs.js'
 import {pollAppLogs} from '../../../poll-app-logs.js'
 import {
+  LOG_TYPE_REQUEST_EXECUTION,
+  LOG_TYPE_REQUEST_EXECUTION_IN_BACKGROUND,
+  LOG_TYPE_RESPONSE_FROM_CACHE,
   POLLING_ERROR_RETRY_INTERVAL_MS,
   POLLING_INTERVAL_MS,
   POLLING_THROTTLE_RETRY_INTERVAL_MS,
   parseFunctionRunPayload,
 } from '../../../../utils.js'
+import {
+  BackgroundExecutionReason,
+  NetworkAccessRequestExecutedLog,
+  NetworkAccessRequestExecutionInBackgroundLog,
+  NetworkAccessResponseFromCacheLog,
+} from '../../../../types.js'
 import {render} from '@shopify/cli-kit/node/testing/ui'
 import {test, describe, vi, beforeEach, afterEach, expect} from 'vitest'
 import React from 'react'
@@ -19,7 +28,7 @@ const FUNCTION_ID = 'e57b4d31-2038-49ff-a0a1-1eea532414f7'
 const FUEL_CONSUMED = 512436
 const TIME = '2024-06-18 16:02:04.868'
 
-const LOG_TYPE = 'function-run'
+const LOG_TYPE = 'function_run'
 const STATUS = 'success'
 const SOURCE = 'my-function'
 const LOGS = 'test logs'
@@ -28,6 +37,53 @@ const INPUT = {test: 'input'}
 const INPUT_BYTES = 10
 const OUTPUT_BYTES = 10
 
+const NETWORK_ACCESS_HTTP_REQUEST = {
+  url: 'https://api.example.com/hello',
+  method: 'GET',
+  headers: {},
+  body: null,
+  policy: {
+    read_timeout_ms: 500,
+  },
+}
+const NETWORK_ACCESS_HTTP_RESPONSE = {
+  status: 200,
+  body: 'Success',
+  headers: {
+    header1: 'value1',
+  },
+}
+
+const NETWORK_ACCESS_REQUEST_EXECUTION_SUCCESS_PAYLOAD = {
+  attempt: 1,
+  connect_time_ms: 40,
+  write_read_time_ms: 40,
+  http_request: NETWORK_ACCESS_HTTP_REQUEST,
+  http_response: NETWORK_ACCESS_HTTP_RESPONSE,
+}
+const NETWORK_ACCESS_REQUEST_EXECUTION_FAILURE_PAYLOAD = {
+  attempt: 1,
+  http_request: NETWORK_ACCESS_HTTP_REQUEST,
+  error: 'Timeout Error',
+}
+
+const NETWORK_ACCESS_RESPONSE_FROM_CACHE_PAYLOAD = {
+  cache_entry_epoch_ms: 1683904621000,
+  cache_ttl_ms: 300000,
+  http_request: NETWORK_ACCESS_HTTP_REQUEST,
+  http_response: NETWORK_ACCESS_HTTP_RESPONSE,
+}
+
+const NETWORK_ACCESS_REQUEST_EXECUTION_IN_BACKGROUND_NO_CACHE_PAYLOAD = {
+  reason: 'no_cached_response',
+  http_request: NETWORK_ACCESS_HTTP_REQUEST,
+}
+
+const NETWORK_ACCESS_REQUEST_EXECUTION_IN_BACKGROUND_CACHE_ABOUT_TO_EXPIRE_PAYLOAD = {
+  reason: 'cached_response_about_to_expire',
+  http_request: NETWORK_ACCESS_HTTP_REQUEST,
+}
+
 const POLL_APP_LOGS_FOR_LOGS_RESPONSE = {
   cursor: RETURNED_CURSOR,
   appLogs: [
@@ -35,6 +91,7 @@ const POLL_APP_LOGS_FOR_LOGS_RESPONSE = {
       shop_id: 1,
       api_client_id: 1830457,
       payload: JSON.stringify({
+        export: 'run',
         input: INPUT,
         input_bytes: INPUT_BYTES,
         output: OUTPUT,
@@ -44,6 +101,61 @@ const POLL_APP_LOGS_FOR_LOGS_RESPONSE = {
         fuel_consumed: FUEL_CONSUMED,
       }),
       log_type: LOG_TYPE,
+      cursor: RETURNED_CURSOR,
+      status: STATUS,
+      source: SOURCE,
+      source_namespace: 'extensions',
+      log_timestamp: TIME,
+    },
+    {
+      shop_id: 1,
+      api_client_id: 1830457,
+      payload: JSON.stringify(NETWORK_ACCESS_RESPONSE_FROM_CACHE_PAYLOAD),
+      log_type: LOG_TYPE_RESPONSE_FROM_CACHE,
+      cursor: RETURNED_CURSOR,
+      status: STATUS,
+      source: SOURCE,
+      source_namespace: 'extensions',
+      log_timestamp: TIME,
+    },
+    {
+      shop_id: 1,
+      api_client_id: 1830457,
+      payload: JSON.stringify(NETWORK_ACCESS_REQUEST_EXECUTION_SUCCESS_PAYLOAD),
+      log_type: LOG_TYPE_REQUEST_EXECUTION,
+      cursor: RETURNED_CURSOR,
+      status: STATUS,
+      source: SOURCE,
+      source_namespace: 'extensions',
+      log_timestamp: TIME,
+    },
+    {
+      shop_id: 1,
+      api_client_id: 1830457,
+      payload: JSON.stringify(NETWORK_ACCESS_REQUEST_EXECUTION_FAILURE_PAYLOAD),
+      log_type: LOG_TYPE_REQUEST_EXECUTION,
+      cursor: RETURNED_CURSOR,
+      status: 'failure',
+      source: SOURCE,
+      source_namespace: 'extensions',
+      log_timestamp: TIME,
+    },
+    {
+      shop_id: 1,
+      api_client_id: 1830457,
+      payload: JSON.stringify(NETWORK_ACCESS_REQUEST_EXECUTION_IN_BACKGROUND_NO_CACHE_PAYLOAD),
+      log_type: LOG_TYPE_REQUEST_EXECUTION_IN_BACKGROUND,
+      cursor: RETURNED_CURSOR,
+      status: STATUS,
+      source: SOURCE,
+      source_namespace: 'extensions',
+      log_timestamp: TIME,
+    },
+    {
+      shop_id: 1,
+      api_client_id: 1830457,
+      payload: JSON.stringify(NETWORK_ACCESS_REQUEST_EXECUTION_IN_BACKGROUND_CACHE_ABOUT_TO_EXPIRE_PAYLOAD),
+      log_type: LOG_TYPE_REQUEST_EXECUTION_IN_BACKGROUND,
       cursor: RETURNED_CURSOR,
       status: STATUS,
       source: SOURCE,
@@ -91,15 +203,90 @@ describe('usePollAppLogs', () => {
 
     expect(mockedPollAppLogs).toHaveBeenCalledTimes(1)
 
-    expect(hook.lastResult?.appLogOutputs).toHaveLength(1)
+    expect(hook.lastResult?.appLogOutputs).toHaveLength(6)
+
     expect(hook.lastResult?.appLogOutputs[0]!.appLog).toEqual(
       parseFunctionRunPayload(POLL_APP_LOGS_FOR_LOGS_RESPONSE.appLogs[0]!.payload),
     )
-
     expect(hook.lastResult?.appLogOutputs[0]!.prefix).toEqual({
       status: 'Success',
       source: SOURCE,
-      description: `in ${(FUEL_CONSUMED / 1000000).toFixed(4)} M instructions`,
+      description: `export "run" executed in ${(FUEL_CONSUMED / 1000000).toFixed(4)} M instructions`,
+      logTimestamp: TIME,
+    })
+
+    expect(hook.lastResult?.appLogOutputs[1]!.appLog).toEqual(
+      new NetworkAccessResponseFromCacheLog({
+        cacheEntryEpochMs: 1683904621000,
+        cacheTtlMs: 300000,
+        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+        httpResponse: NETWORK_ACCESS_HTTP_RESPONSE,
+      }),
+    )
+    expect(hook.lastResult?.appLogOutputs[1]!.prefix).toEqual({
+      status: 'Success',
+      source: SOURCE,
+      description: `network access response retrieved from cache`,
+      logTimestamp: TIME,
+    })
+
+    expect(hook.lastResult?.appLogOutputs[2]!.appLog).toEqual(
+      new NetworkAccessRequestExecutedLog({
+        attempt: 1,
+        connectTimeMs: 40,
+        writeReadTimeMs: 40,
+        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+        httpResponse: NETWORK_ACCESS_HTTP_RESPONSE,
+        error: null,
+      }),
+    )
+    expect(hook.lastResult?.appLogOutputs[2]!.prefix).toEqual({
+      status: 'Success',
+      source: SOURCE,
+      description: `network access request executed in 80 ms`,
+      logTimestamp: TIME,
+    })
+
+    expect(hook.lastResult?.appLogOutputs[3]!.appLog).toEqual(
+      new NetworkAccessRequestExecutedLog({
+        attempt: 1,
+        connectTimeMs: null,
+        writeReadTimeMs: null,
+        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+        httpResponse: null,
+        error: 'Timeout Error',
+      }),
+    )
+    expect(hook.lastResult?.appLogOutputs[3]!.prefix).toEqual({
+      status: 'Failure',
+      source: SOURCE,
+      description: `network access request executed`,
+      logTimestamp: TIME,
+    })
+
+    expect(hook.lastResult?.appLogOutputs[4]!.appLog).toEqual(
+      new NetworkAccessRequestExecutionInBackgroundLog({
+        reason: BackgroundExecutionReason.NoCachedResponse,
+        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+      }),
+    )
+    expect(hook.lastResult?.appLogOutputs[4]!.prefix).toEqual({
+      status: 'Success',
+      source: SOURCE,
+      description: `network access request executing in background`,
+      logTimestamp: TIME,
+    })
+
+    expect(hook.lastResult?.appLogOutputs[5]!.appLog).toEqual(
+      new NetworkAccessRequestExecutionInBackgroundLog({
+        reason: BackgroundExecutionReason.CacheAboutToExpire,
+        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+      }),
+    )
+    expect(hook.lastResult?.appLogOutputs[5]!.prefix).toEqual({
+      status: 'Success',
+      source: SOURCE,
+      description: `network access request executing in background`,
       logTimestamp: TIME,
     })
 
@@ -197,7 +384,7 @@ describe('usePollAppLogs', () => {
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), POLLING_ERROR_RETRY_INTERVAL_MS)
 
     await vi.advanceTimersToNextTimerAsync()
-    expect(hook.lastResult?.appLogOutputs).toHaveLength(1)
+    expect(hook.lastResult?.appLogOutputs).toHaveLength(6)
     expect(hook.lastResult?.errors).toHaveLength(0)
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), POLLING_INTERVAL_MS)
 

--- a/packages/app/src/cli/services/app-logs/types.ts
+++ b/packages/app/src/cli/services/app-logs/types.ts
@@ -26,7 +26,8 @@ export interface AppLogData {
   log_timestamp: string
 }
 
-export interface FunctionRunLog {
+export class FunctionRunLog {
+  export: string
   input: unknown
   inputBytes: number
   output: unknown
@@ -36,7 +37,120 @@ export interface FunctionRunLog {
   fuelConsumed: number
   errorMessage: string | null
   errorType: string | null
+
+  constructor({
+    export: exportValue,
+    input,
+    inputBytes,
+    output,
+    outputBytes,
+    logs,
+    functionId,
+    fuelConsumed,
+    errorMessage,
+    errorType,
+  }: {
+    export: string
+    input: unknown
+    inputBytes: number
+    output: unknown
+    outputBytes: number
+    logs: string
+    functionId: string
+    fuelConsumed: number
+    errorMessage: string | null
+    errorType: string | null
+  }) {
+    this.export = exportValue
+    this.input = input
+    this.inputBytes = inputBytes
+    this.output = output
+    this.outputBytes = outputBytes
+    this.logs = logs
+    this.functionId = functionId
+    this.fuelConsumed = fuelConsumed
+    this.errorMessage = errorMessage
+    this.errorType = errorType
+  }
 }
+
+export class NetworkAccessResponseFromCacheLog {
+  cacheEntryEpochMs: number
+  cacheTtlMs: number
+  httpRequest: unknown
+  httpResponse: unknown
+
+  constructor({
+    cacheEntryEpochMs,
+    cacheTtlMs,
+    httpRequest,
+    httpResponse,
+  }: {
+    cacheEntryEpochMs: number
+    cacheTtlMs: number
+    httpRequest: unknown
+    httpResponse: unknown
+  }) {
+    this.cacheEntryEpochMs = cacheEntryEpochMs
+    this.cacheTtlMs = cacheTtlMs
+    this.httpRequest = httpRequest
+    this.httpResponse = httpResponse
+  }
+}
+
+export enum BackgroundExecutionReason {
+  NoCachedResponse,
+  CacheAboutToExpire,
+  Unknown,
+}
+
+export class NetworkAccessRequestExecutionInBackgroundLog {
+  reason: BackgroundExecutionReason
+  httpRequest: unknown
+
+  constructor({reason, httpRequest}: {reason: BackgroundExecutionReason; httpRequest: unknown}) {
+    this.reason = reason
+    this.httpRequest = httpRequest
+  }
+}
+
+export class NetworkAccessRequestExecutedLog {
+  attempt: number
+  connectTimeMs: number | null
+  writeReadTimeMs: number | null
+  httpRequest: unknown
+  httpResponse: unknown | null
+  error: string | null
+
+  constructor({
+    attempt,
+    connectTimeMs,
+    writeReadTimeMs,
+    httpRequest,
+    httpResponse,
+    error,
+  }: {
+    attempt: number
+    connectTimeMs: number | null
+    writeReadTimeMs: number | null
+    httpRequest: unknown
+    httpResponse: unknown | null
+    error: string | null
+  }) {
+    this.attempt = attempt
+    this.connectTimeMs = connectTimeMs
+    this.writeReadTimeMs = writeReadTimeMs
+    this.httpRequest = httpRequest
+    this.httpResponse = httpResponse
+    this.error = error
+  }
+}
+
+export type AppLogPayload =
+  | FunctionRunLog
+  | NetworkAccessResponseFromCacheLog
+  | NetworkAccessRequestExecutionInBackgroundLog
+  | NetworkAccessRequestExecutedLog
 
 export interface SubscribeOptions {
   developerPlatformClient: DeveloperPlatformClient
@@ -66,5 +180,5 @@ export interface AppLogPrefix {
 
 export interface AppLogOutput {
   prefix: AppLogPrefix
-  appLog: FunctionRunLog
+  appLog: AppLogPayload
 }


### PR DESCRIPTION
This PR adds support of [function network access](https://shopify.dev/docs/apps/build/functions/input-output/network-access) within the app logs command:
- Add the export to the function run events description
- Add the function network access [events](https://github.com/Shopify/functions-externals-project/issues/133)

### How to test your changes?

1. **Deploy a Function with Network Access:**
   - Use the following command to add a pickup point function that has network access:
     ```sh
     shopify app generate extension --template pickup_point_delivery_option_generator --name pickup-points-generator
     ```
   - Follow the instructions in the extension README for enabling and testing pickup points.

2. **Verify Network Access Events:**
   - Run the logs command  
   ```sh 
    SHOPIFY_CLI_ENABLE_APP_LOG_POLLING=1  pnpm shopify app logs --path /path/to/your/app
   ```

   - Search for pickup points in Checkout.
   - Observe the network access events in the logs.

### Logs examples

#### Successful network access request execution

![pickup point](https://github.com/Shopify/cli/assets/60748655/d19e1c15-f8af-467c-aa6b-71c4e4848add)

#### Failed network access request execution

![error](https://github.com/Shopify/cli/assets/60748655/ab656f7b-a453-4864-a5b5-19af1b0fcf00)

#### Network access response from cache
![fromcache](https://github.com/Shopify/cli/assets/60748655/793e4077-cc85-4256-bc56-ebebe5306891)

#### Network access requesting executing in background
![Screenshot 2024-07-10 at 3 10 16 PM](https://github.com/Shopify/cli/assets/60748655/9c126698-8748-434f-be6c-eded4d0d5be6)

