### PR TITLE
Clear cache on app init

### DIFF
--- a/.changeset/chilly-taxis-divide.md
+++ b/.changeset/chilly-taxis-divide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-app': patch
+---
+
+Clear cache on app init


### PR DESCRIPTION
### WHY are these changes introduced?

If you create a new project in a previously used folder, it doesn't run link because the folder may be cached, so the TOML doesn't get updated.

### WHAT is this pull request doing?

Clear cache on app init

### How to test your changes?

- `p shopify app init --name test-project --template none`
- `p shopify app dev --path test-project`
- `cat ~/Library/Preferences/shopify-cli-app-nodejs/config.json | grep test-project -A 3` => The cache should be there
- `rm -r test-project`
- `p shopify app init --name test-project --template none`
- `cat ~/Library/Preferences/shopify-cli-app-nodejs/config.json | grep test-project -A 3` => No cache
- `p shopify app dev --path test-project`
- `cat test-project/shopify.app.toml` => The TOML should be populated

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
