### PR TITLE
Download javy and function-runner directly

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -59,6 +59,7 @@
     "@shopify/polaris-icons": "8.0.0",
     "@shopify/theme-check-node": "2.8.0",
     "body-parser": "1.20.2",
+    "cachedir": "2.4.0",
     "chokidar": "3.5.3",
     "diff": "5.1.0",
     "esbuild": "0.19.8",

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -1,4 +1,13 @@
-import {buildGraphqlTypes, bundleExtension, runFunctionRunner, runJavy, ExportJavyBuilder, jsExports} from './build.js'
+import {
+  javy,
+  buildGraphqlTypes,
+  bundleExtension,
+  runFunctionRunner,
+  runJavy,
+  ExportJavyBuilder,
+  jsExports,
+  functionRunner,
+} from './build.js'
 import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
@@ -141,17 +150,8 @@ describe('runJavy', () => {
     // Then
     await expect(got).resolves.toBeUndefined()
     expect(exec).toHaveBeenCalledWith(
-      'npm',
-      [
-        'exec',
-        '--',
-        'javy-cli',
-        'compile',
-        '-d',
-        '-o',
-        joinPath(ourFunction.directory, 'dist/index.wasm'),
-        'dist/function.js',
-      ],
+      javy.path,
+      ['compile', '-d', '-o', joinPath(ourFunction.directory, 'dist/index.wasm'), 'dist/function.js'],
       {
         cwd: ourFunction.directory,
         stderr: 'inherit',
@@ -172,16 +172,12 @@ describe('runFunctionRunner', () => {
 
     // Then
     await expect(got).resolves.toBeUndefined()
-    expect(exec).toHaveBeenCalledWith(
-      'npm',
-      ['exec', '--', 'function-runner', '-f', joinPath(ourFunction.directory, 'dist/index.wasm')],
-      {
-        cwd: ourFunction.directory,
-        stderr: 'inherit',
-        stdin: 'inherit',
-        stdout: 'inherit',
-      },
-    )
+    expect(exec).toHaveBeenCalledWith(functionRunner.path, ['-f', joinPath(ourFunction.directory, 'dist/index.wasm')], {
+      cwd: ourFunction.directory,
+      stderr: 'inherit',
+      stdin: 'inherit',
+      stdout: 'inherit',
+    })
   })
 
   test('calls function runner to execute function locally and return json', async () => {
@@ -194,8 +190,8 @@ describe('runFunctionRunner', () => {
     // Then
     await expect(got).resolves.toBeUndefined()
     expect(exec).toHaveBeenCalledWith(
-      'npm',
-      ['exec', '--', 'function-runner', '-f', joinPath(ourFunction.directory, 'dist/index.wasm'), '--json'],
+      functionRunner.path,
+      ['-f', joinPath(ourFunction.directory, 'dist/index.wasm'), '--json'],
       {
         cwd: ourFunction.directory,
         stderr: 'inherit',
@@ -215,16 +211,8 @@ describe('runFunctionRunner', () => {
     // Then
     await expect(got).resolves.toBeUndefined()
     expect(exec).toHaveBeenCalledWith(
-      'npm',
-      [
-        'exec',
-        '--',
-        'function-runner',
-        '-f',
-        joinPath(ourFunction.directory, 'dist/index.wasm'),
-        '--input',
-        'input.json',
-      ],
+      functionRunner.path,
+      ['-f', joinPath(ourFunction.directory, 'dist/index.wasm'), '--input', 'input.json'],
       {
         cwd: ourFunction.directory,
         stderr: 'inherit',
@@ -244,8 +232,8 @@ describe('runFunctionRunner', () => {
     // Then
     await expect(got).resolves.toBeUndefined()
     expect(exec).toHaveBeenCalledWith(
-      'npm',
-      ['exec', '--', 'function-runner', '-f', joinPath(ourFunction.directory, 'dist/index.wasm'), '--export', 'foo'],
+      functionRunner.path,
+      ['-f', joinPath(ourFunction.directory, 'dist/index.wasm'), '--export', 'foo'],
       {
         cwd: ourFunction.directory,
         stderr: 'inherit',
@@ -325,11 +313,8 @@ describe('ExportJavyBuilder', () => {
         // Then
         await expect(got).resolves.toBeUndefined()
         expect(exec).toHaveBeenCalledWith(
-          'npm',
+          javy.path,
           [
-            'exec',
-            '--',
-            'javy-cli',
             'compile',
             '-d',
             '-o',
@@ -442,5 +427,205 @@ describe('jsExports', () => {
     expect(() => {
       jsExports(ourFunction)
     }).toThrow(/Invalid export names: 'fooBar', 'foo\*baz'[.\n]*The TOML's exports must be kebab-case/)
+  })
+})
+
+describe('javy', () => {
+  test('properties are set correctly', () => {
+    expect(javy.name).toBe('javy')
+    expect(javy.version).match(/^v\d\.\d\.\d$/)
+    expect(javy.directory).toBeDefined()
+    expect(javy.path).toMatch(/(\/|\\)javy-v\d\.\d\.\d$/)
+  })
+
+  describe('downloadUrl returns the correct URL', () => {
+    test('for Apple Silicon MacOS', () => {
+      // When
+      const url = javy.downloadUrl('darwin', 'arm64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/bytecodealliance\/javy\/releases\/download\/v\d\.\d\.\d\/javy-arm-macos-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for Intel MacOS', () => {
+      // When
+      const url = javy.downloadUrl('darwin', 'x64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/bytecodealliance\/javy\/releases\/download\/v\d\.\d\.\d\/javy-x86_64-macos-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for Arm Linux', () => {
+      // When
+      const url = javy.downloadUrl('linux', 'arm64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/bytecodealliance\/javy\/releases\/download\/v\d\.\d\.\d\/javy-arm-linux-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for x86 Linux', () => {
+      // When
+      const url = javy.downloadUrl('linux', 'x64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/bytecodealliance\/javy\/releases\/download\/v\d\.\d\.\d\/javy-x86_64-linux-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for a 32-bit installation of NodeJS on Windows', () => {
+      // When
+      const url = javy.downloadUrl('win32', 'ia32')
+
+      // Uses the 64-bit version since we assume the operating system actually uses 64-bits and its just a 32-bit
+      // installation of NodeJS.
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/bytecodealliance\/javy\/releases\/download\/v\d\.\d\.\d\/javy-x86_64-windows-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for a 64-bit installation of NodeJS on Windows', () => {
+      // When
+      const url = javy.downloadUrl('win32', 'x64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/bytecodealliance\/javy\/releases\/download\/v\d\.\d\.\d\/javy-x86_64-windows-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('aix (or any other unsupported platform) throws an error', () => {
+      // When
+      const platform = 'aix'
+
+      // Then
+      expect(() => javy.downloadUrl(platform, 'x64')).toThrowError('Unsupported platform aix')
+    })
+
+    test('ppc architecture (or any other unsupported architecture) throws an error', () => {
+      // When
+      const arch = 'ppc'
+
+      // Then
+      expect(() => javy.downloadUrl('darwin', arch)).toThrowError('Unsupported architecture ppc')
+    })
+
+    test('Unsupported combination throws an error', () => {
+      // When
+      const arch = 'arm'
+      const platform = 'win32'
+
+      // Then
+      expect(() => javy.downloadUrl(platform, arch)).toThrowError(
+        'Unsupported platform/architecture combination win32/arm',
+      )
+    })
+  })
+})
+
+describe('functionRunner', () => {
+  test('properties are set correctly', () => {
+    expect(functionRunner.name).toBe('function-runner')
+    expect(functionRunner.version).match(/^v\d\.\d\.\d$/)
+    expect(functionRunner.directory).toBeDefined()
+    expect(functionRunner.path).toMatch(/(\/|\\)function-runner-v\d\.\d\.\d$/)
+  })
+
+  describe('downloadUrl returns the correct URL', () => {
+    test('for Apple Silicon MacOS', () => {
+      // When
+      const url = functionRunner.downloadUrl('darwin', 'arm64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/Shopify\/function-runner\/releases\/download\/v\d\.\d\.\d\/function-runner-arm-macos-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for Intel MacOS', () => {
+      // When
+      const url = functionRunner.downloadUrl('darwin', 'x64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/Shopify\/function-runner\/releases\/download\/v\d\.\d\.\d\/function-runner-x86_64-macos-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for Arm Linux', () => {
+      // When
+      const url = functionRunner.downloadUrl('linux', 'arm64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/Shopify\/function-runner\/releases\/download\/v\d\.\d\.\d\/function-runner-arm-linux-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for x86 Linux', () => {
+      // When
+      const url = functionRunner.downloadUrl('linux', 'x64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/Shopify\/function-runner\/releases\/download\/v\d\.\d\.\d\/function-runner-x86_64-linux-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for a 32-bit installation of NodeJS on Windows', () => {
+      // When
+      const url = functionRunner.downloadUrl('win32', 'ia32')
+
+      // Uses the 64-bit version since we assume the operating system actually uses 64-bits and its just a 32-bit
+      // installation of NodeJS.
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/Shopify\/function-runner\/releases\/download\/v\d\.\d\.\d\/function-runner-x86_64-windows-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('for a 64-bit installation of NodeJS on Windows', () => {
+      // When
+      const url = functionRunner.downloadUrl('win32', 'x64')
+
+      // Then
+      expect(url).toMatch(
+        /https:\/\/github.com\/Shopify\/function-runner\/releases\/download\/v\d\.\d\.\d\/function-runner-x86_64-windows-v\d\.\d\.\d\.gz/,
+      )
+    })
+
+    test('aix (or any other unsupported platform) throws an error', () => {
+      // When
+      const platform = 'aix'
+
+      // Then
+      expect(() => functionRunner.downloadUrl(platform, 'x64')).toThrowError('Unsupported platform aix')
+    })
+
+    test('ppc architecture (or any other unsupported architecture) throws an error', () => {
+      // When
+      const arch = 'ppc'
+
+      // Then
+      expect(() => functionRunner.downloadUrl('darwin', arch)).toThrowError('Unsupported architecture ppc')
+    })
+
+    test('Unsupported combination throws an error', () => {
+      // When
+      const arch = 'arm'
+      const platform = 'win32'
+
+      // Then
+      expect(() => functionRunner.downloadUrl(platform, arch)).toThrowError(
+        'Unsupported platform/architecture combination win32/arm',
+      )
+    })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
+      cachedir:
+        specifier: 2.4.0
+        version: 2.4.0
       chokidar:
         specifier: 3.5.3
         version: 3.5.3


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The current approach for working with Javy and function-runner is the Shopify CLI unconditionally downloads the latest released version of each tool. This means it's impossible to make breaking changes to the command line interface for these tools. Any bugs introduced in the latest released versions of these tools are also rolled out to all users of the Shopify CLI at the same time.

This change makes the Shopify CLI depend on a specific version of Javy and a specific version of function-runner. That way we can be certain that the way the Shopify CLI is invoking tools is compatible with command line interface these tools expose. This also means that if users find a regression in the version of Javy or funtion-runner that the Shopify CLI is using, they can downgrade their Shopify CLI version to use an older version of Javy or function-runner. Similarly, when a new version of Javy or function-runner is released, nightly versions of the Shopify CLI depend on these versions of Javy and function-runner and users can use a nightly version of the Shopify CLI and let us know if there are any issues that weren't caught when releasing the new versions of Javy or the function-runner.

### WHAT is this pull request doing?

Instead of using `npm exec javy-cli -- [args...]` or `npm exec @shopify/function-runner -- [args...]` to download and install Javy and function-runner, perform the download in the Shopify CLI, and exec the downloaded binary.

### How to test your changes?

Assuming you are using MacOS or Linux:

1. Create a Shopify app containing at least one JS Function extension if you do not already have one.
2. `pnpm shopify app build --path <path_to_app>` will perform the initial download of Javy.
3. Verify there are no errors reported.
4. `pnpm shopify app build --path <path_to_app>` will test that it uses the downloaded version of Javy.
5. Verify there are no errors reported.
6. `echo "{}" | pnpm shopify app function run --path <path_to_js_function_extension>` will test the initial download of function-runner.
7. Verify there are no errors reported.
8. `echo "{}" | pnpm shopify app function run --path <path_to_js_function_extension>` will it uses the downloaded version of function-runner.
9. Verify there are no errors reported.

If you need to re-test the original downloads and are using MacOS, run `rm -r ~/Library/Caches/javy && rm -r ~/Library/Caches/function-runner`.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
