### PR TITLE
[Themes] Theme Console - ensureReplEnv 1/2 - Storefront Password Prompting

### DIFF
--- a/docs-shopify.dev/commands/interfaces/theme-console.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-console.interface.ts
@@ -31,6 +31,12 @@ export interface themeconsole {
   '-s, --store <value>'?: string
 
   /**
+   * The password for the storefront.
+   * @environment SHOPIFY_FLAG_STORE_PASSWORD
+   */
+  '--store-password <value>'?: string
+
+  /**
    * The url to be used as context
    * @environment SHOPIFY_FLAG_URL
    */

--- a/docs-shopify.dev/generated/generated_docs_data.json
+++ b/docs-shopify.dev/generated/generated_docs_data.json
@@ -4258,6 +4258,15 @@
               {
                 "filePath": "docs-shopify.dev/commands/interfaces/theme-console.interface.ts",
                 "syntaxKind": "PropertySignature",
+                "name": "--store-password <value>",
+                "value": "string",
+                "description": "The password for the storefront.",
+                "isOptional": true,
+                "environmentValue": "SHOPIFY_FLAG_STORE_PASSWORD"
+              },
+              {
+                "filePath": "docs-shopify.dev/commands/interfaces/theme-console.interface.ts",
+                "syntaxKind": "PropertySignature",
                 "name": "--url <value>",
                 "value": "string",
                 "description": "The url to be used as context",
@@ -4292,7 +4301,7 @@
                 "environmentValue": "SHOPIFY_FLAG_STORE"
               }
             ],
-            "value": "export interface themeconsole {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Local port to serve authentication service.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themeconsole {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Local port to serve authentication service.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for the storefront.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1611,14 +1611,15 @@ USAGE
   $ shopify theme console --url /products/classic-leather-jacket
 
 FLAGS
-  -e, --environment=<value>  The environment to apply to the current command.
-  -s, --store=<value>        Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL
-                             (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).
-      --no-color             Disable color output.
-      --password=<value>     Password generated from the Theme Access app.
-      --port=<value>         [default: 9293] Local port to serve authentication service.
-      --url=<value>          [default: /] The url to be used as context
-      --verbose              Increase the verbosity of the output.
+  -e, --environment=<value>     The environment to apply to the current command.
+  -s, --store=<value>           Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL
+                                (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).
+      --no-color                Disable color output.
+      --password=<value>        Password generated from the Theme Access app.
+      --port=<value>            [default: 9293] Local port to serve authentication service.
+      --store-password=<value>  The password for the storefront.
+      --url=<value>             [default: /] The url to be used as context
+      --verbose                 Increase the verbosity of the output.
 
 DESCRIPTION
   Shopify Liquid REPL (read-eval-print loop) tool

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4688,6 +4688,14 @@
           "name": "store",
           "type": "option"
         },
+        "store-password": {
+          "description": "The password for the storefront.",
+          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "store-password",
+          "type": "option"
+        },
         "url": {
           "default": "/",
           "description": "The url to be used as context",

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -46,18 +46,18 @@ export default class Console extends ThemeCommand {
   async run() {
     const {flags} = await this.parse(Console)
     const store = ensureThemeStore(flags)
-    const {password, url, port} = flags
+    const {url, port, password: passwordFlag} = flags
     const cliVersion = CLI_KIT_VERSION
     const theme = `liquid-console-repl-${cliVersion}`
 
-    const adminSession = await ensureAuthenticatedThemes(store, password, [], true)
-    const storefrontToken = await ensureAuthenticatedStorefront([], password)
+    const adminSession = await ensureAuthenticatedThemes(store, passwordFlag, [], true)
+    const storefrontToken = await ensureAuthenticatedStorefront([], passwordFlag)
     const authUrl = `http://localhost:${port}/password`
 
     if (flags['dev-preview']) {
       outputInfo('This feature is currently in development and is not ready for use or testing yet.')
-      await ensureReplEnv(store)
-      await repl(adminSession, storefrontToken, flags.password)
+      const {themeId, password} = await ensureReplEnv(store, passwordFlag)
+      await repl(adminSession, storefrontToken, themeId, password)
       return
     }
 

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -1,7 +1,7 @@
 import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
-import {repl} from '../../services/console.js'
+import {ensureReplEnv, repl} from '../../services/console.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
@@ -56,6 +56,7 @@ export default class Console extends ThemeCommand {
 
     if (flags['dev-preview']) {
       outputInfo('This feature is currently in development and is not ready for use or testing yet.')
+      await ensureReplEnv(store)
       await repl(adminSession, storefrontToken, flags.password)
       return
     }

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -36,6 +36,10 @@ export default class Console extends ThemeCommand {
       env: 'SHOPIFY_FLAG_PORT',
       default: '9293',
     }),
+    'store-password': Flags.string({
+      description: 'The password for the storefront.',
+      env: 'SHOPIFY_FLAG_STORE_PASSWORD',
+    }),
     'dev-preview': Flags.boolean({
       hidden: true,
       description: 'Enables the developer preview for the upcoming `theme console` implementation.',
@@ -46,18 +50,18 @@ export default class Console extends ThemeCommand {
   async run() {
     const {flags} = await this.parse(Console)
     const store = ensureThemeStore(flags)
-    const {url, port, password: passwordFlag} = flags
+    const {url, port, password: themeAccessPassword} = flags
     const cliVersion = CLI_KIT_VERSION
     const theme = `liquid-console-repl-${cliVersion}`
 
-    const adminSession = await ensureAuthenticatedThemes(store, passwordFlag, [], true)
-    const storefrontToken = await ensureAuthenticatedStorefront([], passwordFlag)
+    const adminSession = await ensureAuthenticatedThemes(store, themeAccessPassword, [], true)
+    const storefrontToken = await ensureAuthenticatedStorefront([], themeAccessPassword)
     const authUrl = `http://localhost:${port}/password`
 
     if (flags['dev-preview']) {
       outputInfo('This feature is currently in development and is not ready for use or testing yet.')
-      const {themeId, password} = await ensureReplEnv(store, passwordFlag)
-      await repl(adminSession, storefrontToken, themeId, password)
+      const {themeId, storePassword} = await ensureReplEnv(store, flags['store-password'])
+      await repl(adminSession, storefrontToken, themeId, storePassword)
       return
     }
 

--- a/packages/theme/src/cli/services/console.test.ts
+++ b/packages/theme/src/cli/services/console.test.ts
@@ -3,15 +3,15 @@ import {
   isStorefrontPasswordCorrect,
   isStorefrontPasswordProtected,
 } from '../utilities/theme-environment/storefront-session.js'
+import {ensureValidPassword} from '../utilities/prompts.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
-import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 vi.mock('../utilities/theme-environment/storefront-session.js')
-vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('../utilities/prompts.js')
 
 describe('ensureReplEnv', () => {
   beforeEach(() => {
-    vi.mocked(renderTextPrompt).mockResolvedValue('testPassword')
+    vi.mocked(ensureValidPassword).mockResolvedValue('testPassword')
   })
 
   test('should prompt for password when storefront is password protected', async () => {
@@ -23,7 +23,7 @@ describe('ensureReplEnv', () => {
     const {storePassword} = await ensureReplEnv('test-store')
 
     // Then
-    expect(renderTextPrompt).toHaveBeenCalledWith({message: 'Enter your theme password', password: true})
+    expect(ensureValidPassword).toHaveBeenCalled()
     expect(storePassword).toBe('testPassword')
   })
 
@@ -33,36 +33,10 @@ describe('ensureReplEnv', () => {
     vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)
 
     // When
-    await ensureReplEnv('test-store')
+    const {storePassword} = await ensureReplEnv('test-store')
 
     // Then
-    expect(renderTextPrompt).not.toHaveBeenCalled()
-  })
-
-  test('should skip prompt for password when correct storefront password is provided', async () => {
-    // Given
-    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
-    vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)
-
-    // When
-    await ensureReplEnv('test-store', 'password')
-
-    // Then
-    expect(renderTextPrompt).not.toHaveBeenCalled()
-  })
-
-  test('should prompt for correct password when incorrect password is provided', async () => {
-    // Given
-    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
-    vi.mocked(isStorefrontPasswordCorrect)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValue(true)
-
-    // When
-    await ensureReplEnv('test-store', 'asdf')
-
-    // Then
-    expect(renderTextPrompt).toHaveBeenCalledTimes(2)
+    expect(ensureValidPassword).not.toHaveBeenCalled()
+    expect(storePassword).toBeUndefined()
   })
 })

--- a/packages/theme/src/cli/services/console.test.ts
+++ b/packages/theme/src/cli/services/console.test.ts
@@ -1,0 +1,23 @@
+import {ensureReplEnv} from './console.js'
+import {isStorefrontPasswordProtected} from '../utilities/theme-environment/storefront-session.js'
+import {promptPassword} from '../utilities/theme-environment/theme-password.js'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../utilities/theme-environment/storefront-session.js')
+vi.mock('../utilities/theme-environment/theme-password.js')
+
+describe('ensureReplEnv', () => {
+  test('should prompt for password when password is not provided', async () => {
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
+    const store = 'test-store'
+    await ensureReplEnv(store)
+    expect(promptPassword).toHaveBeenCalled()
+  })
+
+  test('should skip prompt for password when password is not provided', async () => {
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
+    const store = 'test-store'
+    await ensureReplEnv(store)
+    expect(promptPassword).toHaveBeenCalled()
+  })
+})

--- a/packages/theme/src/cli/services/console.test.ts
+++ b/packages/theme/src/cli/services/console.test.ts
@@ -1,23 +1,62 @@
 import {ensureReplEnv} from './console.js'
-import {isStorefrontPasswordProtected} from '../utilities/theme-environment/storefront-session.js'
-import {promptPassword} from '../utilities/theme-environment/theme-password.js'
+import {
+  isStorefrontPasswordCorrect,
+  isStorefrontPasswordProtected,
+  promptPassword,
+} from '../utilities/theme-environment/storefront-session.js'
 import {describe, expect, test, vi} from 'vitest'
 
 vi.mock('../utilities/theme-environment/storefront-session.js')
-vi.mock('../utilities/theme-environment/theme-password.js')
 
 describe('ensureReplEnv', () => {
-  test('should prompt for password when password is not provided', async () => {
+  test('should prompt for password when storefront is password protected', async () => {
+    // Given
     vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
-    const store = 'test-store'
-    await ensureReplEnv(store)
+    vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)
+
+    // When
+    await ensureReplEnv('test-store')
+
+    // Then
     expect(promptPassword).toHaveBeenCalled()
   })
 
-  test('should skip prompt for password when password is not provided', async () => {
+  test('should skip prompt for password when storefront is not password protected', async () => {
+    // Given
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(false)
+    vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)
+
+    // When
+    await ensureReplEnv('test-store')
+
+    // Then
+    expect(promptPassword).not.toHaveBeenCalled()
+  })
+
+  test('should skip prompt for password when correct storefront password is provided', async () => {
+    // Given
     vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
-    const store = 'test-store'
-    await ensureReplEnv(store)
-    expect(promptPassword).toHaveBeenCalled()
+    vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)
+
+    // When
+    await ensureReplEnv('test-store', 'password')
+
+    // Then
+    expect(promptPassword).not.toHaveBeenCalled()
+  })
+
+  test('should prompt for correct password when incorrect password is provided', async () => {
+    // Given
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
+    vi.mocked(isStorefrontPasswordCorrect)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true)
+
+    // When
+    await ensureReplEnv('test-store', 'asdf')
+
+    // Then
+    expect(promptPassword).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/theme/src/cli/services/console.test.ts
+++ b/packages/theme/src/cli/services/console.test.ts
@@ -2,23 +2,29 @@ import {ensureReplEnv} from './console.js'
 import {
   isStorefrontPasswordCorrect,
   isStorefrontPasswordProtected,
-  promptPassword,
 } from '../utilities/theme-environment/storefront-session.js'
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 vi.mock('../utilities/theme-environment/storefront-session.js')
+vi.mock('@shopify/cli-kit/node/ui')
 
 describe('ensureReplEnv', () => {
+  beforeEach(() => {
+    vi.mocked(renderTextPrompt).mockResolvedValue('testPassword')
+  })
+
   test('should prompt for password when storefront is password protected', async () => {
     // Given
     vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
     vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)
 
     // When
-    await ensureReplEnv('test-store')
+    const {storePassword} = await ensureReplEnv('test-store')
 
     // Then
-    expect(promptPassword).toHaveBeenCalled()
+    expect(renderTextPrompt).toHaveBeenCalledWith({message: 'Enter your theme password', password: true})
+    expect(storePassword).toBe('testPassword')
   })
 
   test('should skip prompt for password when storefront is not password protected', async () => {
@@ -30,7 +36,7 @@ describe('ensureReplEnv', () => {
     await ensureReplEnv('test-store')
 
     // Then
-    expect(promptPassword).not.toHaveBeenCalled()
+    expect(renderTextPrompt).not.toHaveBeenCalled()
   })
 
   test('should skip prompt for password when correct storefront password is provided', async () => {
@@ -42,7 +48,7 @@ describe('ensureReplEnv', () => {
     await ensureReplEnv('test-store', 'password')
 
     // Then
-    expect(promptPassword).not.toHaveBeenCalled()
+    expect(renderTextPrompt).not.toHaveBeenCalled()
   })
 
   test('should prompt for correct password when incorrect password is provided', async () => {
@@ -57,6 +63,6 @@ describe('ensureReplEnv', () => {
     await ensureReplEnv('test-store', 'asdf')
 
     // Then
-    expect(promptPassword).toHaveBeenCalledTimes(2)
+    expect(renderTextPrompt).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -1,32 +1,18 @@
-import {
-  isStorefrontPasswordProtected,
-  isStorefrontPasswordCorrect,
-} from '../utilities/theme-environment/storefront-session.js'
+import {ensureValidPassword} from '../utilities/prompts.js'
+import {isStorefrontPasswordProtected} from '../utilities/theme-environment/storefront-session.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
-import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 export async function ensureReplEnv(store: string, storePasswordFlag?: string) {
   const themeId = await findOrCreateReplTheme()
 
   const storePassword = (await isStorefrontPasswordProtected(store))
-    ? await promptValidPassword(storePasswordFlag, store)
-    : storePasswordFlag
+    ? await ensureValidPassword(storePasswordFlag, store)
+    : undefined
 
   return {
     themeId,
     storePassword,
   }
-}
-
-async function promptValidPassword(password: string | undefined, store: string) {
-  let finalPassword = password || (await promptPassword('Enter your theme password'))
-
-  // eslint-disable-next-line no-await-in-loop
-  while (!(await isStorefrontPasswordCorrect(finalPassword, store))) {
-    // eslint-disable-next-line no-await-in-loop
-    finalPassword = await promptPassword('Incorrect password provided. Please try again')
-  }
-  return finalPassword
 }
 
 async function findOrCreateReplTheme(): Promise<string> {
@@ -39,10 +25,3 @@ export async function repl(
   _themeId: string,
   _password: string | undefined,
 ) {}
-
-async function promptPassword(prompt: string): Promise<string> {
-  return renderTextPrompt({
-    message: prompt,
-    password: true,
-  })
-}

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -1,3 +1,28 @@
+import {isStorefrontPasswordProtected} from '../utilities/theme-environment/storefront-session.js'
+import {consoleLog} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
+import {createInterface} from 'readline'
+
+export async function ensureReplEnv(store: string) {
+  const storefrontHasPassword = await isStorefrontPasswordProtected(store)
+  consoleLog(storefrontHasPassword.toString())
+  if (storefrontHasPassword) {
+    const password = await promptPassword()
+    consoleLog(password)
+  }
+}
 
 export async function repl(_adminSession: AdminSession, _storefrontToken: string, _password?: string) {}
+
+function promptPassword(): Promise<string> {
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise((resolve) => {
+    readline.question('Enter your theme password: ', (password) => {
+      resolve(password)
+    })
+  })
+}

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -1,9 +1,9 @@
 import {
   isStorefrontPasswordProtected,
-  promptPassword,
   isStorefrontPasswordCorrect,
 } from '../utilities/theme-environment/storefront-session.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
+import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 export async function ensureReplEnv(store: string, storePasswordFlag?: string) {
   const themeId = await findOrCreateReplTheme()
@@ -19,12 +19,12 @@ export async function ensureReplEnv(store: string, storePasswordFlag?: string) {
 }
 
 async function promptValidPassword(password: string | undefined, store: string) {
-  let finalPassword = password || (await promptPassword('Enter your theme password: '))
+  let finalPassword = password || (await promptPassword('Enter your theme password'))
 
   // eslint-disable-next-line no-await-in-loop
   while (!(await isStorefrontPasswordCorrect(finalPassword, store))) {
     // eslint-disable-next-line no-await-in-loop
-    finalPassword = await promptPassword('Incorrect password provided. Please try again: ')
+    finalPassword = await promptPassword('Incorrect password provided. Please try again')
   }
   return finalPassword
 }
@@ -39,3 +39,10 @@ export async function repl(
   _themeId: string,
   _password: string | undefined,
 ) {}
+
+async function promptPassword(prompt: string): Promise<string> {
+  return renderTextPrompt({
+    message: prompt,
+    password: true,
+  })
+}

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -5,16 +5,16 @@ import {
 } from '../utilities/theme-environment/storefront-session.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 
-export async function ensureReplEnv(store: string, password?: string) {
+export async function ensureReplEnv(store: string, storePasswordFlag?: string) {
   const themeId = await findOrCreateReplTheme()
 
-  const finalPassword = (await isStorefrontPasswordProtected(store))
-    ? await promptValidPassword(password, store)
-    : password
+  const storePassword = (await isStorefrontPasswordProtected(store))
+    ? await promptValidPassword(storePasswordFlag, store)
+    : storePasswordFlag
 
   return {
     themeId,
-    password: finalPassword,
+    storePassword,
   }
 }
 

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -1,11 +1,16 @@
-import {isStorefrontPasswordProtected} from '../utilities/theme-environment/storefront-session.js'
-import {promptPassword} from '../utilities/theme-environment/theme-password.js'
+import {
+  isStorefrontPasswordProtected,
+  promptPassword,
+  isStorefrontPasswordCorrect,
+} from '../utilities/theme-environment/storefront-session.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 
 export async function ensureReplEnv(store: string, password?: string) {
   const themeId = await findOrCreateReplTheme()
 
-  const finalPassword = (await shouldPromptForPassword(password, store)) ? await promptPassword() : password
+  const finalPassword = (await isStorefrontPasswordProtected(store))
+    ? await promptValidPassword(password, store)
+    : password
 
   return {
     themeId,
@@ -13,16 +18,19 @@ export async function ensureReplEnv(store: string, password?: string) {
   }
 }
 
-async function findOrCreateReplTheme(): Promise<string> {
-  return ''
+async function promptValidPassword(password: string | undefined, store: string) {
+  let finalPassword = password || (await promptPassword('Enter your theme password: '))
+
+  // eslint-disable-next-line no-await-in-loop
+  while (!(await isStorefrontPasswordCorrect(finalPassword, store))) {
+    // eslint-disable-next-line no-await-in-loop
+    finalPassword = await promptPassword('Incorrect password provided. Please try again: ')
+  }
+  return finalPassword
 }
 
-async function shouldPromptForPassword(password: string | undefined, store: string) {
-  if (password) {
-    return false
-  } else {
-    return isStorefrontPasswordProtected(store)
-  }
+async function findOrCreateReplTheme(): Promise<string> {
+  return ''
 }
 
 export async function repl(

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -1,28 +1,33 @@
 import {isStorefrontPasswordProtected} from '../utilities/theme-environment/storefront-session.js'
-import {consoleLog} from '@shopify/cli-kit/node/output'
+import {promptPassword} from '../utilities/theme-environment/theme-password.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
-import {createInterface} from 'readline'
 
-export async function ensureReplEnv(store: string) {
-  const storefrontHasPassword = await isStorefrontPasswordProtected(store)
-  consoleLog(storefrontHasPassword.toString())
-  if (storefrontHasPassword) {
-    const password = await promptPassword()
-    consoleLog(password)
+export async function ensureReplEnv(store: string, password?: string) {
+  const themeId = await findOrCreateReplTheme()
+
+  const finalPassword = (await shouldPromptForPassword(password, store)) ? await promptPassword() : password
+
+  return {
+    themeId,
+    password: finalPassword,
   }
 }
 
-export async function repl(_adminSession: AdminSession, _storefrontToken: string, _password?: string) {}
-
-function promptPassword(): Promise<string> {
-  const readline = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  })
-
-  return new Promise((resolve) => {
-    readline.question('Enter your theme password: ', (password) => {
-      resolve(password)
-    })
-  })
+async function findOrCreateReplTheme(): Promise<string> {
+  return ''
 }
+
+async function shouldPromptForPassword(password: string | undefined, store: string) {
+  if (password) {
+    return false
+  } else {
+    return isStorefrontPasswordProtected(store)
+  }
+}
+
+export async function repl(
+  _adminSession: AdminSession,
+  _storefrontToken: string,
+  _themeId: string,
+  _password: string | undefined,
+) {}

--- a/packages/theme/src/cli/utilities/prompts.test.ts
+++ b/packages/theme/src/cli/utilities/prompts.test.ts
@@ -1,0 +1,54 @@
+import {isStorefrontPasswordProtected, isStorefrontPasswordCorrect} from './theme-environment/storefront-session.js'
+import {ensureValidPassword} from './prompts.js'
+import {AdminSession} from '@shopify/cli-kit/node/session'
+import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
+import {describe, beforeEach, vi, test, expect} from 'vitest'
+
+vi.mock('../utilities/theme-environment/storefront-session.js')
+vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('../utilities/repl-theme-manager.js', () => {
+  const REPLThemeManager = vi.fn()
+  REPLThemeManager.prototype.findOrCreate = () => ({
+    id: 1,
+    name: 'theme',
+    role: 'development',
+    createdAtRuntime: true,
+    processing: true,
+  })
+  return {REPLThemeManager}
+})
+
+describe('ensureValidPassword', () => {
+  beforeEach(() => {
+    vi.mocked(renderTextPrompt).mockResolvedValue('testPassword')
+  })
+
+  const adminSession: AdminSession = {storeFqdn: 'test-store.myshopify.com', token: 'token'}
+
+  test('should skip prompt for password when correct storefront password is provided', async () => {
+    // Given
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
+    vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)
+
+    // When
+    await ensureValidPassword('correctPassword', 'test-store')
+
+    // Then
+    expect(renderTextPrompt).not.toHaveBeenCalled()
+  })
+
+  test('should prompt for correct password when incorrect password is provided', async () => {
+    // Given
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
+    vi.mocked(isStorefrontPasswordCorrect)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true)
+
+    // When
+    await ensureValidPassword('incorrectPassword', 'test-store')
+
+    // Then
+    expect(renderTextPrompt).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/theme/src/cli/utilities/prompts.ts
+++ b/packages/theme/src/cli/utilities/prompts.ts
@@ -1,0 +1,20 @@
+import {isStorefrontPasswordCorrect} from './theme-environment/storefront-session.js'
+import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
+
+export async function ensureValidPassword(password: string | undefined, store: string) {
+  let finalPassword = password || (await promptPassword('Enter your theme password'))
+
+  // eslint-disable-next-line no-await-in-loop
+  while (!(await isStorefrontPasswordCorrect(finalPassword, store))) {
+    // eslint-disable-next-line no-await-in-loop
+    finalPassword = await promptPassword('Incorrect password provided. Please try again')
+  }
+  return finalPassword
+}
+
+async function promptPassword(prompt: string): Promise<string> {
+  return renderTextPrompt({
+    message: prompt,
+    password: true,
+  })
+}

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -212,5 +212,23 @@ describe('Storefront API', () => {
       // Then
       expect(result).toBe(false)
     })
+
+    test('throws an error when the server responds with "Too Many Requests"', async () => {
+      // Given
+      vi.mocked(fetch).mockResolvedValueOnce(
+        response({
+          status: 429,
+          headers: {
+            'retry-after': '60',
+          },
+        }),
+      )
+
+      // When
+      const result = isStorefrontPasswordCorrect('wrong-password', 'store.myshopify.com')
+
+      // Then
+      await expect(result).rejects.toThrow('Too many incorrect password attempts. Please try again after 60 seconds.')
+    })
   })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -1,8 +1,10 @@
-import {getStorefrontSessionCookies, isStorefrontPasswordProtected} from './storefront-session.js'
-import {describe, expect, test, vi} from 'vitest'
+import {getStorefrontSessionCookies, isStorefrontPasswordProtected, promptPassword} from './storefront-session.js'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {fetch} from '@shopify/cli-kit/node/http'
+import {createInterface} from 'readline'
 
 vi.mock('@shopify/cli-kit/node/http')
+vi.mock('readline')
 
 describe('Storefront API', () => {
   describe('isStorefrontPasswordProtected', () => {
@@ -129,4 +131,27 @@ describe('Storefront API', () => {
       },
     } as any
   }
+
+  describe('promptPassword', () => {
+    let mockReadline: any
+
+    beforeEach(() => {
+      mockReadline = {
+        question: vi.fn().mockImplementation((_event, handler) => handler('testPassword')),
+        close: vi.fn(),
+      }
+      vi.mocked(createInterface).mockReturnValue(mockReadline)
+    })
+
+    test('should display the correct prompt message', async () => {
+      await promptPassword()
+      expect(mockReadline.question).toHaveBeenCalledWith('Enter your theme password: ', expect.any(Function))
+    })
+
+    test('should resolve with the password entered by the user', async () => {
+      const password = await promptPassword()
+      expect(mockReadline.close).toHaveBeenCalled()
+      expect(password).toBe('testPassword')
+    })
+  })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -174,7 +174,7 @@ describe('Storefront API', () => {
       )
 
       // When
-      const result = await isStorefrontPasswordCorrect('correct-password', 'https://store.myshopify.com')
+      const result = await isStorefrontPasswordCorrect('correct-password', 'store.myshopify.com')
 
       // Then
       expect(result).toBe(true)

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -2,14 +2,11 @@ import {
   getStorefrontSessionCookies,
   isStorefrontPasswordCorrect,
   isStorefrontPasswordProtected,
-  promptPassword,
 } from './storefront-session.js'
-import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
 import {fetch} from '@shopify/cli-kit/node/http'
-import {createInterface} from 'readline'
 
 vi.mock('@shopify/cli-kit/node/http')
-vi.mock('readline')
 
 describe('Storefront API', () => {
   describe('isStorefrontPasswordProtected', () => {
@@ -137,29 +134,6 @@ describe('Storefront API', () => {
       },
     } as any
   }
-
-  describe('promptPassword', () => {
-    let mockReadline: any
-
-    beforeEach(() => {
-      mockReadline = {
-        question: vi.fn().mockImplementation((_event, handler) => handler('testPassword')),
-        close: vi.fn(),
-      }
-      vi.mocked(createInterface).mockReturnValue(mockReadline)
-    })
-
-    test('should display the correct prompt message', async () => {
-      await promptPassword('Enter your theme password: ')
-      expect(mockReadline.question).toHaveBeenCalledWith('Enter your theme password: ', expect.any(Function))
-    })
-
-    test('should resolve with the password entered by the user', async () => {
-      const password = await promptPassword('Enter your theme password: ')
-      expect(mockReadline.close).toHaveBeenCalled()
-      expect(password).toBe('testPassword')
-    })
-  })
 
   describe('storefrontPasswordIsCorrect', () => {
     test('returns true when the password is correct', async () => {

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -2,8 +2,6 @@ import {parseCookies, serializeCookies} from './cookies.js'
 import {defaultHeaders} from './storefront-utils.js'
 import {fetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {consoleLog} from '@shopify/cli-kit/node/output'
-import {createInterface} from 'readline'
 
 export async function isStorefrontPasswordProtected(storeURL: string): Promise<boolean> {
   const response = await fetch(prependHttps(storeURL), {
@@ -12,20 +10,6 @@ export async function isStorefrontPasswordProtected(storeURL: string): Promise<b
   })
 
   return response.status === 302
-}
-
-export function promptPassword(prompt: string): Promise<string> {
-  const readline = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  })
-
-  return new Promise((resolve) => {
-    readline.question(prompt, (password) => {
-      readline.close()
-      resolve(password)
-    })
-  })
 }
 
 /**
@@ -48,8 +32,6 @@ export async function isStorefrontPasswordCorrect(password: string | undefined, 
       `Too many incorrect password attempts. Please try again after ${response.headers.get('retry-after')} seconds.`,
     )
   }
-  consoleLog(response.headers.get('location') || '')
-  consoleLog(`${prependHttps(store)}/`)
   return response.status === 302 && response.headers.get('location') === `${prependHttps(store)}/`
 }
 

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -2,6 +2,7 @@ import {parseCookies, serializeCookies} from './cookies.js'
 import {defaultHeaders} from './storefront-utils.js'
 import {fetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {createInterface} from 'readline'
 
 export async function isStorefrontPasswordProtected(storeURL: string): Promise<boolean> {
   const response = await fetch(ensureHttps(storeURL), {
@@ -115,9 +116,23 @@ function getCookie(setCookieArray: string[], cookieName: string) {
   return parsedCookie[cookieName]
 }
 
-function ensureHttps(url: string): string {
+export function ensureHttps(url: string): string {
   if (!url.startsWith('http://') && !url.startsWith('https://')) {
     return `https://${url}`
   }
   return url
+}
+
+export function promptPassword(): Promise<string> {
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise((resolve) => {
+    readline.question('Enter your theme password: ', (password) => {
+      readline.close()
+      resolve(password)
+    })
+  })
 }

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -4,7 +4,7 @@ import {fetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
 export async function isStorefrontPasswordProtected(storeURL: string): Promise<boolean> {
-  const response = await fetch(storeURL, {
+  const response = await fetch(ensureHttps(storeURL), {
     method: 'GET',
     redirect: 'manual',
   })
@@ -113,4 +113,11 @@ function getCookie(setCookieArray: string[], cookieName: string) {
   const parsedCookie = parseCookies(cookie)
 
   return parsedCookie[cookieName]
+}
+
+function ensureHttps(url: string): string {
+  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    return `https://${url}`
+  }
+  return url
 }

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -147,7 +147,7 @@ function getCookie(setCookieArray: string[], cookieName: string) {
   return parsedCookie[cookieName]
 }
 
-export function ensureHttps(url: string): string {
+function ensureHttps(url: string): string {
   if (!url.startsWith('http://') && !url.startsWith('https://')) {
     return `https://${url}`
   }


### PR DESCRIPTION
### WHY are these changes introduced?
- Part of https://github.com/Shopify/develop-advanced-edits/issues/257

### WHAT is this pull request doing?

```mermaid
graph LR
    A[Start] --> B{Is the storefront password protected?}
    B -- No --> I[End]
    B -- Yes --> D{Is the --store-password flag provided?}
    D -- No --> E[Prompt the user for a password]
    D -- Yes --> F[Validate the provided --store-password flag]
    E --> G[Validate the prompted password]
    F --> H{Is the password valid?}
    G --> H{Is the password valid?}
    H -- Yes --> I[End]
    H -- No --> E[Prompt the user for a password]
```

### How to test your changes?

1. Ensure your storefront is password protected via the admin
2. `pnpm shopify theme console --dev-preview`
3. You should see a password prompt
  a. Enter a couple of incorrect passwords, then the correct one
4. `pnpm shopify theme console --dev-preview --store-password=<PASSWORD>`
  a. Try with some valid and invalid passwords.


https://github.com/user-attachments/assets/7473062a-8f3b-4b89-8306-14f86e8f9f1f

<img width="613" alt="image" src="https://github.com/user-attachments/assets/b643f26b-4093-4d12-80db-acf25b6bfe89">

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
