### PR TITLE
Deploy app manifest

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -345,6 +345,7 @@ export class App<
           handle: module.handle,
           uid: module.uid,
           assets: module.uid,
+          target: module.contextValue,
           config: (config ?? {}) as JsonMapType,
         }
       }),

--- a/packages/app/src/cli/services/deploy/bundle.test.ts
+++ b/packages/app/src/cli/services/deploy/bundle.test.ts
@@ -1,0 +1,110 @@
+import {bundleAndBuildExtensions} from './bundle.js'
+import {testApp, testThemeExtensions, testUIExtension} from '../../models/app/app.test-data.js'
+import {AppInterface} from '../../models/app/app.js'
+import {describe, expect, test, vi} from 'vitest'
+import * as file from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+
+describe('bundleAndBuildExtensions', () => {
+  let app: AppInterface
+
+  test('generates a manifest.json when USE_APP_MANAGEMENT_API is enabled', async () => {
+    await file.inTemporaryDirectory(async (tmpDir: string) => {
+      // Given
+      vi.spyOn(file, 'writeFileSync').mockResolvedValue(undefined)
+      const envVars = {USE_APP_MANAGEMENT_API: 'true'}
+      const bundlePath = joinPath(tmpDir, 'bundle.zip')
+
+      const uiExtension = await testUIExtension({type: 'web_pixel_extension'})
+      const extensionBundleMock = vi.fn()
+      uiExtension.buildForBundle = extensionBundleMock
+      const themeExtension = await testThemeExtensions()
+      themeExtension.buildForBundle = extensionBundleMock
+      app = testApp({allExtensions: [uiExtension, themeExtension]})
+
+      const extensions: {[key: string]: string} = {}
+      for (const extension of app.allExtensions) {
+        extensions[extension.localIdentifier] = extension.localIdentifier
+      }
+      const identifiers = {
+        app: 'app-id',
+        extensions,
+        extensionIds: {},
+        extensionsNonUuidManaged: {},
+      }
+      const expectedManifest = {
+        name: 'App',
+        handle: '',
+        modules: [
+          {
+            type: 'web_pixel_extension_external',
+            handle: 'test-ui-extension',
+            uid: 'test-ui-extension-uid',
+            assets: 'test-ui-extension-uid',
+            target: '',
+            config: {},
+          },
+          {
+            type: 'theme_external',
+            handle: 'theme-extension-name',
+            uid: themeExtension.uid,
+            assets: themeExtension.uid,
+            target: '',
+            config: {
+              theme_extension: {
+                files: {},
+              },
+            },
+          },
+        ],
+      }
+
+      // When
+      await bundleAndBuildExtensions({app, identifiers, bundlePath}, envVars)
+
+      // Then
+      expect(extensionBundleMock).toHaveBeenCalledTimes(2)
+      expect(file.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('manifest.json'),
+        JSON.stringify(expectedManifest, null, 2),
+      )
+
+      await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
+    })
+  })
+
+  test('does not generate the manifest.json when USE_APP_MANAGEMENT_API is disabled', async () => {
+    await file.inTemporaryDirectory(async (tmpDir: string) => {
+      // Given
+      vi.spyOn(file, 'writeFileSync').mockResolvedValue(undefined)
+      const bundlePath = joinPath(tmpDir, 'bundle.zip')
+
+      const uiExtension = await testUIExtension({type: 'web_pixel_extension'})
+      const extensionBundleMock = vi.fn()
+      uiExtension.buildForBundle = extensionBundleMock
+      const themeExtension = await testThemeExtensions()
+      themeExtension.buildForBundle = extensionBundleMock
+      app = testApp({allExtensions: [uiExtension, themeExtension]})
+
+      const extensions: {[key: string]: string} = {}
+      for (const extension of app.allExtensions) {
+        extensions[extension.localIdentifier] = extension.localIdentifier
+      }
+      const identifiers = {
+        app: 'app-id',
+        extensions,
+        extensionIds: {},
+        extensionsNonUuidManaged: {},
+      }
+
+      // When
+      await bundleAndBuildExtensions({app, identifiers, bundlePath}, {})
+
+      // Then
+      expect(extensionBundleMock).toHaveBeenCalledTimes(2)
+      expect(file.writeFileSync).not.toHaveBeenCalled()
+
+      await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
+    })
+  })
+})

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -2,10 +2,11 @@ import {AppInterface} from '../../models/app/app.js'
 import {Identifiers} from '../../models/app/identifiers.js'
 import {installJavy} from '../function/build.js'
 import {zip} from '@shopify/cli-kit/node/archiver'
-import {renderConcurrent} from '@shopify/cli-kit/node/ui'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
-import {inTemporaryDirectory, mkdirSync, touchFile} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, mkdirSync, touchFile, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
+import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
+import {renderConcurrent} from '@shopify/cli-kit/node/ui'
 import {Writable} from 'stream'
 
 interface BundleOptions {
@@ -14,11 +15,18 @@ interface BundleOptions {
   identifiers: Identifiers
 }
 
-export async function bundleAndBuildExtensions(options: BundleOptions) {
+export async function bundleAndBuildExtensions(options: BundleOptions, systemEnvironment = process.env) {
   await inTemporaryDirectory(async (tmpDir) => {
     const bundleDirectory = joinPath(tmpDir, 'bundle')
-    await mkdirSync(bundleDirectory)
+    mkdirSync(bundleDirectory)
     await touchFile(joinPath(bundleDirectory, '.shopify'))
+
+    if (isTruthy(systemEnvironment.USE_APP_MANAGEMENT_API)) {
+      // Include manifest in bundle
+      const appManifest = await options.app.manifest()
+      const manifestPath = joinPath(bundleDirectory, 'manifest.json')
+      writeFileSync(manifestPath, JSON.stringify(appManifest, null, 2))
+    }
 
     // Force the download of the javy binary in advance to avoid later problems,
     // as it might be done multiple times in parallel. https://github.com/Shopify/cli/issues/2877


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/1849

### WHAT is this pull request doing?

The deploy command generates a manifest with all the extensions content and includes it in the bundle to upload

Part of the work extracted from https://github.com/Shopify/cli/pull/4101

### How to test your changes?

- Replace the `tmpDir` [here](https://github.com/Shopify/cli/compare/manifest-api?expand=1#diff-02c8891dbc51e66a73680b8d021fcfa80d34576835781908282434eaba6e9920R20) to `/tmp` to be able to check generated the bundle
- Generate some extensions and run `USE_APP_MANAGEMENT_API=1 bin/spin p shopify app deploy` 
- `cat /tmp/bundle/manifest.json`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
