### PR TITLE
Don't load the old app config when running app config use

### DIFF
--- a/packages/app/src/cli/commands/app/config/use.ts
+++ b/packages/app/src/cli/commands/app/config/use.ts
@@ -1,5 +1,5 @@
 import {appFlags} from '../../../flags.js'
-import {loadAppConfiguration} from '../../../models/app/loader.js'
+import {checkFolderIsValidApp} from '../../../models/app/loader.js'
 import use from '../../../services/app/config/use.js'
 import Command from '../../../utilities/app-command.js'
 import {Args, Flags} from '@oclif/core'
@@ -38,11 +38,7 @@ export default class ConfigUse extends Command {
   public async run(): Promise<void> {
     const {flags, args} = await this.parse(ConfigUse)
 
-    const localApp = await loadAppConfiguration({
-      directory: flags.path,
-      userProvidedConfigName: undefined,
-    })
-
-    await use({directory: localApp.directory, configName: args.config, reset: flags.reset})
+    await checkFolderIsValidApp(flags.path)
+    await use({directory: flags.path, configName: args.config, reset: flags.reset})
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- When running `app config use`, the user wants to change the current active configuration
- For this, we were loading the current active configuration first, to validate that this is a valid app, and then do the switch
- This caused issues when the current configuration is not valid, but it shouldn't prevent you from changing to a new one!

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Don't load the current active configuration on `app config use`
- Just validate that the current path is an app folder.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
From `main` or a released version:
- Create an app
- `app config link`
- Duplicate the toml with a different name `shopify.app.new-config.toml`
- Remote the `application_url` field from the first toml
- Run `app config use new-config`
- It should crash.

Now, from this branch, do the same, it should work.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
