### PR TITLE
add deploy marketing activity extension logic

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -143,7 +143,7 @@
           "fulfillment_constraints",
           "local_pickup_delivery_option_generator",
           "pickup_point_delivery_option_generator",
-          "marketing_activity_extension_cli"
+          "marketing_activity"
         ],
         "default": "checkout_ui_extension",
     },

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -21,7 +21,7 @@ import paymentExtensionSpec from './specifications/payments_app_extension.js'
 import posUISpec from './specifications/pos_ui_extension.js'
 import productSubscriptionSpec from './specifications/product_subscription.js'
 import taxCalculationSpec from './specifications/tax_calculation.js'
-import marketingActivityExtensionSpec from './specifications/marketing_activity_extension.js'
+import marketingActivitySpec from './specifications/marketing_activity.js'
 import themeSpec from './specifications/theme.js'
 import uiExtensionSpec from './specifications/ui_extension.js'
 import webPixelSpec from './specifications/web_pixel_extension.js'
@@ -73,7 +73,7 @@ function loadSpecifications() {
     posUISpec,
     productSubscriptionSpec,
     taxCalculationSpec,
-    marketingActivityExtensionSpec,
+    marketingActivitySpec,
     themeSpec,
     uiExtensionSpec,
     webPixelSpec,

--- a/packages/app/src/cli/models/extensions/specifications/marketing_activity.ts
+++ b/packages/app/src/cli/models/extensions/specifications/marketing_activity.ts
@@ -1,22 +1,28 @@
-import {MarketingActivityExtensionSchema} from './marketing_activity_extension_schemas/marketing_activity_extension_schema.js'
+import {MarketingActivityExtensionSchema} from './marketing_activity_schemas/marketing_activity_schema.js'
 import {createExtensionSpecification} from '../specification.js'
+import {randomUUID} from '@shopify/cli-kit/node/crypto'
 
 const spec = createExtensionSpecification({
-  identifier: 'marketing_activity_extension_cli',
+  identifier: 'marketing_activity',
   schema: MarketingActivityExtensionSchema,
   appModuleFeatures: (_) => ['bundling'],
   deployConfig: async (config, _) => {
     return {
       title: config.title,
       description: config.description,
-      app_api_url: config.app_api_url,
+      api_path: config.api_path,
       tactic: config.tactic,
       marketing_channel: config.marketing_channel,
       referring_domain: config.referring_domain,
       is_automation: config.is_automation,
       use_external_editor: config.use_external_editor,
       preview_data: config.preview_data,
-      fields: config.fields,
+      fields: config.fields.map((field) => ({
+        ...field,
+        // NOTE: we're not using this id anywhere, generating it to satisfy the schema
+        // decided not to remove it from the schema for now to minimize the risk of breaking changes
+        id: randomUUID(),
+      })),
     }
   },
 })

--- a/packages/app/src/cli/models/extensions/specifications/marketing_activity_schemas/marketing_activity_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/marketing_activity_schemas/marketing_activity_schema.test.ts
@@ -1,4 +1,4 @@
-import {MarketingActivityExtensionSchema} from './marketing_activity_extension_schema.js'
+import {MarketingActivityExtensionSchema} from './marketing_activity_schema.js'
 import {describe, expect, test} from 'vitest'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -8,7 +8,7 @@ describe('MarketingActivityExtensionSchema', () => {
     type: 'marketing_activity_extension',
     title: 'test extension 123',
     description: 'test description 123',
-    app_api_url: 'http://foo.bar/api',
+    api_path: '/api',
     tactic: 'ad',
     marketing_channel: 'social',
     referring_domain: 'http://foo.bar',

--- a/packages/app/src/cli/models/extensions/specifications/marketing_activity_schemas/marketing_activity_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/marketing_activity_schemas/marketing_activity_schema.ts
@@ -2,7 +2,6 @@ import {BaseSchema} from '../../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const BaseFieldSchema = zod.object({
-  id: zod.string(),
   ui_type: zod.string(),
 })
 
@@ -122,7 +121,7 @@ const UISchemaMapping: {[key: string]: zod.Schema} = {
 export const MarketingActivityExtensionSchema = BaseSchema.extend({
   title: zod.string().min(1),
   description: zod.string().min(1),
-  app_api_url: zod.string(),
+  api_path: zod.string(),
   tactic: zod.enum([
     'ad',
     'retargeting',

--- a/packages/app/src/cli/services/dev/migrate-marketing-activity-extension.test.ts
+++ b/packages/app/src/cli/services/dev/migrate-marketing-activity-extension.test.ts
@@ -1,0 +1,103 @@
+import {getMarketingActivtyExtensionsToMigrate} from './migrate-marketing-activity-extension.js'
+import {LocalSource, RemoteSource} from '../context/identifiers.js'
+import {describe, expect, test} from 'vitest'
+
+function getLocalExtension(attributes: Partial<LocalSource> = {}) {
+  return {
+    type: 'marketing_activity',
+    localIdentifier: 'test-marketing',
+    configuration: {
+      name: 'test-marketing',
+    },
+    ...attributes,
+  } as unknown as LocalSource
+}
+
+function getRemoteExtension(attributes: Partial<RemoteSource> = {}) {
+  return {
+    uuid: '1234',
+    type: 'marketing_activity_extension',
+    title: 'test-marketing-2',
+    ...attributes,
+  } as unknown as RemoteSource
+}
+
+describe('getExtensionsToMigrate()', () => {
+  const defaultIds = {
+    'test-marketing': '1234',
+  }
+
+  test('matching my remote title and localIdentifier', () => {
+    // Given
+    const title = 'test123'
+    const localExtension = getLocalExtension({
+      type: 'marketing_activity',
+      localIdentifier: title,
+    })
+    const remoteExtension = getRemoteExtension({
+      type: 'marketing_activity_extension',
+      title,
+      uuid: 'yy',
+    })
+
+    // When
+    const toMigrate = getMarketingActivtyExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([{local: localExtension, remote: remoteExtension}])
+  })
+
+  test('matching my local and remote IDs', () => {
+    // Given
+    const localExtension = getLocalExtension({
+      type: 'marketing_activity',
+      localIdentifier: 'test-marketing',
+    })
+    const remoteExtension = getRemoteExtension({type: 'marketing_activity_extension', title: 'remote', uuid: '1234'})
+
+    // When
+    const toMigrate = getMarketingActivtyExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([{local: localExtension, remote: remoteExtension}])
+  })
+
+  test('does not return extensions where local.type is not marketing_activity', () => {
+    // Given
+    const localExtension = getLocalExtension({type: 'checkout_ui_extension'})
+    const remoteExtension = getRemoteExtension({type: 'flow_action_definition'})
+
+    // When
+    const toMigrate = getMarketingActivtyExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([])
+  })
+
+  test('does not return extensions where remote.type is not marketing_activity_extension', () => {
+    // Given
+    const localExtension = getLocalExtension({type: 'PRODUCT_SUBSCRIPTION_UI_EXTENSION'})
+    const remoteExtension = getRemoteExtension({type: 'PRODUCT_SUBSCRIPTION_UI_EXTENSION'})
+
+    // When
+    const toMigrate = getMarketingActivtyExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([])
+  })
+
+  test('if neither title/name or ids match, does not return any extensions', () => {
+    // Given
+    const localExtension = getLocalExtension({type: 'flow_action'})
+    const remoteExtension = getRemoteExtension({
+      type: 'flow_action_definition',
+      uuid: '5678',
+    })
+
+    // When
+    const toMigrate = getMarketingActivtyExtensionsToMigrate([localExtension], [remoteExtension], defaultIds)
+
+    // Then
+    expect(toMigrate).toStrictEqual([])
+  })
+})

--- a/packages/app/src/cli/services/dev/migrate-marketing-activity-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-marketing-activity-extension.ts
@@ -1,0 +1,36 @@
+import {LocalSource, RemoteSource} from '../context/identifiers.js'
+import {IdentifiersExtensions} from '../../models/app/identifiers.js'
+import {getExtensionIds, LocalRemoteSource} from '../context/id-matching.js'
+import {slugify} from '@shopify/cli-kit/common/string'
+
+export function getMarketingActivtyExtensionsToMigrate(
+  localSources: LocalSource[],
+  remoteSources: RemoteSource[],
+  identifiers: IdentifiersExtensions,
+) {
+  const ids = getExtensionIds(localSources, identifiers)
+  const localExtensionTypesToMigrate = ['marketing_activity']
+  const remoteExtensionTypesToMigrate = ['marketing_activity_extension']
+  const typesMap = new Map<string, string>([['marketing_activity', 'marketing_activity_extension']])
+
+  const local = localSources.filter((source) => localExtensionTypesToMigrate.includes(source.type))
+  const remote = remoteSources.filter((source) => remoteExtensionTypesToMigrate.includes(source.type))
+
+  // Map remote sources by uuid and slugified title (the slugified title is used for matching with local folder)
+  const remoteSourcesMap = new Map<string, RemoteSource>()
+  remote.forEach((remoteSource) => {
+    remoteSourcesMap.set(remoteSource.uuid, remoteSource)
+    remoteSourcesMap.set(slugify(remoteSource.title), remoteSource)
+  })
+
+  return local.reduce<LocalRemoteSource[]>((accumulator, localSource) => {
+    const localSourceId = ids[localSource.localIdentifier] ?? 'unknown'
+    const remoteSource = remoteSourcesMap.get(localSourceId) || remoteSourcesMap.get(localSource.localIdentifier)
+    const typeMatch = typesMap.get(localSource.type) === remoteSource?.type
+
+    if (remoteSource && typeMatch) {
+      accumulator.push({local: localSource, remote: remoteSource})
+    }
+    return accumulator
+  }, [])
+}

--- a/packages/app/src/cli/services/marketing_activity/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/marketing_activity/extension-to-toml.test.ts
@@ -5,7 +5,7 @@ import {describe, expect, test} from 'vitest'
 const defaultDashboardConfig: MarketingActivityDashboardConfig = {
   title: 'test mae',
   description: 'test mae description',
-  app_api_url: 'https://google.es',
+  app_api_url: 'https://google.es/api/v1',
   tactic: 'ad',
   platform: 'facebook',
   is_automation: false,
@@ -25,7 +25,7 @@ const defaultDashboardConfig: MarketingActivityDashboardConfig = {
   ],
 }
 describe('extension-to-toml', () => {
-  test('correctly builds a toml string for a marketing_activity_extension', () => {
+  test('converts the dashboard config to the new cli config', () => {
     // Given
     const extension: ExtensionRegistration = {
       id: '26237698049',
@@ -42,12 +42,12 @@ describe('extension-to-toml', () => {
 
     // Then
     expect(got).toEqual(`[[extensions]]
-type = "marketing_activity_extension_cli"
+type = "marketing_activity"
 name = "test mae"
 handle = "mae-test-123"
 title = "test mae"
 description = "test mae description"
-app_api_url = "https://google.es"
+api_path = "/api/v1"
 tactic = "ad"
 marketing_channel = "social"
 referring_domain = "facebook.com"
@@ -58,7 +58,6 @@ is_automation = false
   value = "test value"
 
   [[extensions.fields]]
-  id = "123"
   ui_type = "text-single-line"
   name = "test_field"
   label = "test field"
@@ -86,33 +85,7 @@ is_automation = false
     const got = buildTomlObject(extension)
 
     // Then
-    expect(got).toEqual(`[[extensions]]
-type = "marketing_activity_extension_cli"
-name = "test mae"
-handle = "mae-test-123455555555544444"
-title = "test mae"
-description = "test mae description"
-app_api_url = "https://google.es"
-tactic = "ad"
-marketing_channel = "social"
-referring_domain = "facebook.com"
-is_automation = false
-
-  [[extensions.preview_data]]
-  label = "test label"
-  value = "test value"
-
-  [[extensions.fields]]
-  id = "123"
-  ui_type = "text-single-line"
-  name = "test_field"
-  label = "test field"
-  help_text = "help text"
-  required = false
-  min_length = 1
-  max_length = 50
-  placeholder = "placeholder"
-`)
+    expect(got).toContain('handle = "mae-test-123455555555544444"')
   })
 
   test('sets the channel and referring domain to empty string if no platform mapping is found', () => {
@@ -131,32 +104,7 @@ is_automation = false
     const got = buildTomlObject(extension)
 
     // Then
-    expect(got).toEqual(`[[extensions]]
-type = "marketing_activity_extension_cli"
-name = "test mae"
-handle = "mae-test-123"
-title = "test mae"
-description = "test mae description"
-app_api_url = "https://google.es"
-tactic = "ad"
-marketing_channel = ""
-referring_domain = ""
-is_automation = false
-
-  [[extensions.preview_data]]
-  label = "test label"
-  value = "test value"
-
-  [[extensions.fields]]
-  id = "123"
-  ui_type = "text-single-line"
-  name = "test_field"
-  label = "test field"
-  help_text = "help text"
-  required = false
-  min_length = 1
-  max_length = 50
-  placeholder = "placeholder"
-`)
+    expect(got).toContain('marketing_channel = ""')
+    expect(got).toContain('referring_domain = ""')
   })
 })

--- a/packages/app/src/cli/services/marketing_activity/extension-to-toml.ts
+++ b/packages/app/src/cli/services/marketing_activity/extension-to-toml.ts
@@ -155,6 +155,11 @@ const PLATFORM_DOMAIN_MAP: {[key: string]: string | null} = {
   flow: null,
 }
 
+function getUrlPath(url: string) {
+  const urlObject = new URL(url)
+  return urlObject.pathname + urlObject.search + urlObject.hash
+}
+
 /**
  * Given a dashboard-built marketing activity extension config file, convert it to toml for the CLI extension
  */
@@ -166,19 +171,19 @@ export function buildTomlObject(extension: ExtensionRegistration): string {
   const localExtensionRepresentation = {
     extensions: [
       {
-        type: 'marketing_activity_extension_cli',
+        type: 'marketing_activity',
         name: config.title,
         handle: slugify(extension.title.substring(0, MAX_EXTENSION_HANDLE_LENGTH)),
         title: config.title,
         description: config.description,
-        app_api_url: config.app_api_url,
+        api_path: getUrlPath(config.app_api_url),
         tactic: config.tactic,
         marketing_channel: PLATFORM_CHANNEL_MAP[config.platform] ?? '',
         referring_domain: PLATFORM_DOMAIN_MAP[config.platform] ?? '',
         is_automation: config.is_automation,
         use_external_editor: config.use_external_editor,
         preview_data: config.preview_data,
-        fields: config.fields,
+        fields: config.fields.map(({id, ...field}) => field),
       },
     ],
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
✅ Needs to wait for this ticket to ship: https://github.com/Shopify/shopify/pull/536750
Addresses CLI portion of this ticket https://github.com/Shopify/marketing-automations/issues/2042

### WHAT is this pull request doing?
Adds logic to migrate marketing activity extensions on deploy. Some schema changes to note:
1. We are removing the id for the fields during migration and generating it on deploy. This is not currently being used, but we decided to keep it on the object to minimize the risk of breaking changes on the BE
2. We are converting `app_api_url` to `api_path` by simply stripping the host. We will be asking partners to verify the path is correct using the documentation. When looking at the currently stored `app_api_url` compared to the base url of the app, a lot of marketing partner's base url have deviated quite a bit from the stored `app_api_url` so there's no feasible way to migrate it accurately. 

### How to test your changes?

1. Follow instructions in this [PR](https://github.com/Shopify/cli/pull/4231) to import a marketing activity extension
3. checkout this branch in `shopify` repo: `mae_model_validation`
4. in CLI command prompt run: `pnpm shopify app deploy --path  <path to app>`

NOTE: this will fail right now until we update the validation in core

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
