### PR TITLE
Show prompt when running function command outside of function directory

### DIFF
--- a/packages/app/src/cli/services/function/common.ts
+++ b/packages/app/src/cli/services/function/common.ts
@@ -6,6 +6,8 @@ import {FunctionConfigType} from '../../models/extensions/specifications/functio
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {Flags} from '@oclif/core'
+import {isTerminalInteractive} from '@shopify/cli-kit/node/context/local'
+import {renderAutocompletePrompt} from '@shopify/cli-kit/node/ui'
 
 export const functionFlags = {
   path: Flags.string({
@@ -30,10 +32,20 @@ export async function inFunctionContext({
   const specifications = await loadLocalExtensionsSpecifications()
   const app: AppInterface = await loadApp({specifications, directory: path, userProvidedConfigName})
 
-  const allFunctions = app.allExtensions.filter((ext) => ext.isFunctionExtension)
-  const ourFunction = allFunctions.find((fun) => fun.directory === path) as ExtensionInstance<FunctionConfigType>
+  const allFunctions = app.allExtensions.filter(
+    (ext) => ext.isFunctionExtension,
+  ) as ExtensionInstance<FunctionConfigType>[]
+  const ourFunction = allFunctions.find((fun) => fun.directory === path)
+
   if (ourFunction) {
     return callback(app, ourFunction)
+  } else if (isTerminalInteractive()) {
+    const selectedFunction = await renderAutocompletePrompt({
+      message: 'Which function?',
+      choices: allFunctions.map((shopifyFunction) => ({label: shopifyFunction.handle, value: shopifyFunction})),
+    })
+
+    return callback(app, selectedFunction)
   } else {
     throw new AbortError('Run this command from a function directory or use `--path` to specify a function directory.')
   }


### PR DESCRIPTION
### WHY are these changes introduced?

If a function command is run outside of a function directory, the command simply fails. As an improvement to the UX, we should prompt the user to choose which function they'd like to run the command on.

Closes https://github.com/Shopify/shopify-functions/issues/229

### WHAT is this pull request doing?

This PR adds a prompt if the CLI is in an interactive terminal so that the user can choose the function to run a function command on (if they're not in a function directory).

### How to test your changes?

Run a function command (e.g. `function run`) outside of a function directory with an interactive terminal

<img width="406" alt="image" src="https://github.com/user-attachments/assets/bd4ad0bc-215c-4b5e-913d-c18769c7fc3e">

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
