### PR TITLE
Add support for auto-generated app-dev queries

### DIFF
--- a/bin/get-graphql-schemas.js
+++ b/bin/get-graphql-schemas.js
@@ -20,6 +20,11 @@ const schemas = [
     pathToFile: 'db/graphql/destinations_schema.graphql',
     localPath: './packages/app/src/cli/api/graphql/business-platform/destinations_schema.graphql',
   },
+  {
+    repo: 'shopify',
+    pathToFile: 'db/graphql/app_dev_schema_unstable_public.graphql',
+    localPath: './packages/app/src/cli/api/graphql/app-dev/app_dev_schema.graphql',
+  }
 ]
 
 function runCommand(command, args) {

--- a/graphql.config.ts
+++ b/graphql.config.ts
@@ -67,5 +67,6 @@ export default {
   projects: {
     partners: projectFactory('partners', 'cli_schema.graphql'),
     businessPlatform: projectFactory('business-platform', 'destinations_schema.graphql'),
+    appDev: projectFactory('app-dev', 'app_dev_schema.graphql'),
   },
 }

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -79,7 +79,8 @@
       "options": {
         "commands": [
           "pnpm eslint 'src/cli/api/graphql/partners/generated/**/*.{ts,tsx}' --fix",
-          "pnpm eslint 'src/cli/api/graphql/business-platform/generated/**/*.{ts,tsx}' --fix"
+          "pnpm eslint 'src/cli/api/graphql/business-platform/generated/**/*.{ts,tsx}' --fix",
+          "pnpm eslint 'src/cli/api/graphql/app-dev/generated/**/*.{ts,tsx}' --fix"
         ],
         "cwd": "packages/app"
       }
@@ -125,10 +126,13 @@
       "options": {
         "commands": [
           "find ./packages/app/src/cli/api/graphql/partners/generated/ -type f -name '*.ts' -exec sh -c 'sed -i \"\" \"s|import \\* as Types from '\\''./types'\\'';|import \\* as Types from '\\''./types.js'\\'';|g; s|export const \\([A-Za-z0-9_]*\\)Document =|export const \\1 =|g\" \"$0\"' {} \\;",
-          "find ./packages/app/src/cli/api/graphql/business-platform/generated/ -type f -name '*.ts' -exec sh -c 'sed -i \"\" \"s|import \\* as Types from '\\''./types'\\'';|import \\* as Types from '\\''./types.js'\\'';|g; s|export const \\([A-Za-z0-9_]*\\)Document =|export const \\1 =|g\" \"$0\"' {} \\;"
+          "find ./packages/app/src/cli/api/graphql/business-platform/generated/ -type f -name '*.ts' -exec sh -c 'sed -i \"\" \"s|import \\* as Types from '\\''./types'\\'';|import \\* as Types from '\\''./types.js'\\'';|g; s|export const \\([A-Za-z0-9_]*\\)Document =|export const \\1 =|g\" \"$0\"' {} \\;",
+          "find ./packages/app/src/cli/api/graphql/app-dev/generated/ -type f -name '*.ts' -exec sh -c 'sed -i \"\" \"s|import \\* as Types from '\\''./types'\\'';|import \\* as Types from '\\''./types.js'\\'';|g; s|export const \\([A-Za-z0-9_]*\\)Document =|export const \\1 =|g\" \"$0\"' {} \\;",
+          "echo '/* eslint-disable tsdoc/syntax */'|cat - ./packages/app/src/cli/api/graphql/app-dev/generated/types.d.ts > /tmp/out && mv /tmp/out ./packages/app/src/cli/api/graphql/app-dev/generated/types.d.ts"
         ],
         "cwd": "{workspaceRoot}"
       }
     }
   }
 }
+

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -106,9 +106,20 @@
         "cwd": "{workspaceRoot}"
       }
     },
+    "graphql-codegen:generate:app-dev": {
+      "executor": "nx:run-commands",
+      "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/app-dev/**/*.graphql"],
+      "outputs": ["{projectRoot}/src/cli/api/graphql/app-dev/generated/**/*.ts"],
+      "options": {
+        "commands": [
+          "pnpm exec graphql-codegen --project=appDev"
+        ],
+        "cwd": "{workspaceRoot}"
+      }
+    },
     "graphql-codegen:postfix": {
       "executor": "nx:run-commands",
-      "dependsOn": ["graphql-codegen:generate:partners", "graphql-codegen:generate:business-platform"],
+      "dependsOn": ["graphql-codegen:generate:partners", "graphql-codegen:generate:business-platform", "graphql-codegen:generate:app-dev"],
       "inputs": [{ "dependentTasksOutputFiles": "**/*.ts" }],
       "outputs": ["{projectRoot}/src/cli/api/graphql/partners/generated/**/*.ts", "{projectRoot}/src/cli/api/graphql/business-platform/generated/**/*.ts"],
       "options": {

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type DevSessionCreateMutationVariables = Types.Exact<{
+  appId: Types.Scalars['String']['input']
+  assetsUrl: Types.Scalars['String']['input']
+}>
+
+export type DevSessionCreateMutation = {devSessionCreate?: {userErrors: {message: string}[]} | null}
+
+export const DevSessionCreateDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'DevSessionCreate'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'appId'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'assetsUrl'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'devSessionCreate'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'appId'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'appId'}},
+              },
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'assetsUrl'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'assetsUrl'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'userErrors'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DevSessionCreateMutation, DevSessionCreateMutationVariables>

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
@@ -10,7 +10,7 @@ export type DevSessionCreateMutationVariables = Types.Exact<{
 
 export type DevSessionCreateMutation = {devSessionCreate?: {userErrors: {message: string}[]} | null}
 
-export const DevSessionCreateDocument = {
+export const DevSessionCreate = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-delete.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-delete.ts
@@ -9,7 +9,7 @@ export type DevSessionDeleteMutationVariables = Types.Exact<{
 
 export type DevSessionDeleteMutation = {devSessionDelete?: {userErrors: {message: string}[]} | null}
 
-export const DevSessionDeleteDocument = {
+export const DevSessionDelete = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-delete.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-delete.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type DevSessionDeleteMutationVariables = Types.Exact<{
+  appId: Types.Scalars['String']['input']
+}>
+
+export type DevSessionDeleteMutation = {devSessionDelete?: {userErrors: {message: string}[]} | null}
+
+export const DevSessionDeleteDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'DevSessionDelete'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'appId'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'devSessionDelete'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'appId'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'appId'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'userErrors'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DevSessionDeleteMutation, DevSessionDeleteMutationVariables>

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type DevSessionUpdateMutationVariables = Types.Exact<{
+  appId: Types.Scalars['String']['input']
+  assetsUrl: Types.Scalars['String']['input']
+}>
+
+export type DevSessionUpdateMutation = {devSessionUpdate?: {userErrors: {message: string}[]} | null}
+
+export const DevSessionUpdateDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'DevSessionUpdate'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'appId'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'assetsUrl'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'devSessionUpdate'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'appId'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'appId'}},
+              },
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'assetsUrl'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'assetsUrl'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'userErrors'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DevSessionUpdateMutation, DevSessionUpdateMutationVariables>

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
@@ -10,7 +10,7 @@ export type DevSessionUpdateMutationVariables = Types.Exact<{
 
 export type DevSessionUpdateMutation = {devSessionUpdate?: {userErrors: {message: string}[]} | null}
 
-export const DevSessionUpdateDocument = {
+export const DevSessionUpdate = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-dev/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/types.d.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/no-explicit-any */
+export type Maybe<T> = T | null
+export type InputMaybe<T> = Maybe<T>
+export type Exact<T extends {[key: string]: unknown}> = {[K in keyof T]: T[K]}
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {[SubKey in K]?: Maybe<T[SubKey]>}
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {[SubKey in K]: Maybe<T[SubKey]>}
+export type MakeEmpty<T extends {[key: string]: unknown}, K extends keyof T> = {[_ in K]?: never}
+export type Incremental<T> = T | {[P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never}
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: {input: string; output: string}
+  String: {input: string; output: string}
+  Boolean: {input: boolean; output: boolean}
+  Int: {input: number; output: number}
+  Float: {input: number; output: number}
+  /**
+   * A [JSON](https://www.json.org/json-en.html) object.
+   */
+  JSON: {input: any; output: any}
+}

--- a/packages/app/src/cli/api/graphql/app-dev/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/types.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable tsdoc/syntax */
 /* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/no-explicit-any */
 export type Maybe<T> = T | null
 export type InputMaybe<T> = Maybe<T>
@@ -15,6 +16,18 @@ export type Scalars = {
   Float: {input: number; output: number}
   /**
    * A [JSON](https://www.json.org/json-en.html) object.
+   *
+   * Example value:
+   * `{
+   *   "product": {
+   *     "id": "gid://shopify/Product/1346443542550",
+   *     "title": "White T-shirt",
+   *     "options": [{
+   *       "name": "Size",
+   *       "values": ["M", "L"]
+   *     }]
+   *   }
+   * }`
    */
   JSON: {input: any; output: any}
 }

--- a/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-create.graphql
+++ b/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-create.graphql
@@ -1,0 +1,7 @@
+mutation DevSessionCreate($appId: String!, $assetsUrl: String!) {
+  devSessionCreate(appId: $appId, assetsUrl: $assetsUrl) {
+    userErrors {
+      message
+    }
+  }
+}

--- a/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-delete.graphql
+++ b/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-delete.graphql
@@ -1,0 +1,7 @@
+mutation DevSessionDelete($appId: String!) {
+  devSessionDelete(appId: $appId) {
+    userErrors {
+      message
+    }
+  }
+}

--- a/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-update.graphql
+++ b/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-update.graphql
@@ -1,0 +1,7 @@
+mutation DevSessionUpdate($appId: String!, $assetsUrl: String!) {
+  devSessionUpdate(appId: $appId, assetsUrl: $assetsUrl) {
+    userErrors {
+      message
+    }
+  }
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We need to support the new app-dev API
It makes sense to use the new `graphql-codegen` for it

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add support for the `app-dev` graphql schema in the `graphql-codegen` command
- Add some extra fixes in the `postfix` step
- Add queries to create, update and delete a dev session.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Nothing to test, everything is autogenerated.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
