### PR TITLE
Store API key and app ID

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -50,6 +50,7 @@ export const LegacyAppSchema = zod
  */
 export const AppSchema = zod.object({
   client_id: zod.string(),
+  app_id: zod.string().optional(),
   organization_id: zod.string().optional(),
   build: zod
     .object({

--- a/packages/app/src/cli/services/app/config/link-service.test.ts
+++ b/packages/app/src/cli/services/app/config/link-service.test.ts
@@ -89,6 +89,7 @@ embedded = false
 `
       expect(configuration).toEqual({
         client_id: 'api-key',
+        app_id: '1',
         name: 'app1',
         application_url: '',
         embedded: true,

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -85,6 +85,7 @@ describe('link', () => {
       expect(fileExistsSync(joinPath(tmp, 'shopify.app.default-value.toml'))).toBeTruthy()
       expect(configuration).toEqual({
         client_id: '12345',
+        app_id: '1',
         name: 'app1',
         extension_directories: [],
         application_url: 'https://example.com',
@@ -153,6 +154,7 @@ embedded = false
 `
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       name: 'app1',
       extension_directories: [],
       application_url: 'https://example.com',
@@ -261,6 +263,7 @@ embedded = false
     })
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       name: 'app1',
       application_url: 'https://example.com',
       embedded: true,
@@ -385,6 +388,7 @@ url = "https://api-client-config.com/preferences"
     })
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       name: 'new-title',
       application_url: 'https://api-client-config.com',
       embedded: false,
@@ -516,6 +520,7 @@ embedded = false
     })
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       name: 'my app',
       application_url: 'https://myapp.com',
       embedded: true,
@@ -607,6 +612,7 @@ embedded = false
 `
     expect(configuration).toEqual({
       client_id: 'different-api-key',
+      app_id: '1',
       name: 'my app',
       application_url: 'https://myapp.com',
       embedded: true,
@@ -687,6 +693,7 @@ embedded = false
     })
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       extension_directories: [],
       name: 'app1',
       application_url: 'https://example.com',
@@ -753,6 +760,7 @@ embedded = false
     expect(renderSuccess).not.toHaveBeenCalled()
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       name: 'app1',
       application_url: 'https://example.com',
       embedded: true,
@@ -798,6 +806,7 @@ test('fetches the remote app when an api key is provided', async () => {
     expect(content).toContain('name = "app1"')
     expect(configuration).toEqual({
       client_id: 'api-key',
+      app_id: '1',
       extension_directories: [],
       name: 'app1',
       application_url: 'https://example.com',
@@ -905,6 +914,7 @@ embedded = false
 `
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       name: 'app1',
       application_url: 'https://example.com',
       embedded: true,
@@ -966,6 +976,7 @@ embedded = false
 
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       name: 'app1',
       application_url: 'https://example.com',
       embedded: true,
@@ -1032,6 +1043,7 @@ embedded = false
 
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       extension_directories: [],
       name: 'app1',
       application_url: 'https://example.com',
@@ -1154,6 +1166,7 @@ embedded = false
     })
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       name: 'app1',
       application_url: 'https://example.com',
       embedded: true,
@@ -1278,6 +1291,7 @@ embedded = false
 
     expect(configuration).toEqual({
       client_id: '12345',
+      app_id: '1',
       name: 'app1',
       application_url: 'https://my-app-url.com',
       embedded: true,

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -361,6 +361,7 @@ async function overwriteLocalConfigFileWithRemoteAppConfiguration(options: {
         scopes: undefined,
       },
       {
+        app_id: remoteApp.id,
         client_id: remoteApp.apiKey,
         path: configFilePath,
         ...(developerPlatformClient.requiresOrganization ? {organization_id: remoteApp.organizationId} : {}),

--- a/packages/app/src/cli/services/app/fetch-app-from-config-or-select.ts
+++ b/packages/app/src/cli/services/app/fetch-app-from-config-or-select.ts
@@ -13,7 +13,7 @@ export async function fetchAppFromConfigOrSelect(
   if (isCurrentAppSchema(app.configuration)) {
     const apiKey = app.configuration.client_id
     organizationApp = await developerPlatformClient.appFromId({
-      id: apiKey,
+      id: app.configuration.app_id ?? 'no-id-available',
       apiKey,
       organizationId: app.configuration.organization_id ?? '0',
     })

--- a/packages/app/src/cli/services/app/write-app-configuration-file.test.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.test.ts
@@ -143,4 +143,51 @@ url = "https://example.com/prefs"
       expect(content).toContain('redirect_urls')
     })
   })
+
+  test('includes app_id if organization_id is present', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const filePath = joinPath(tmp, 'shopify.app.toml')
+      const {schema} = await buildVersionedAppSchema()
+
+      // When
+      await writeAppConfigurationFile(
+        {
+          ...FULL_CONFIGURATION,
+          app_id: '1234',
+          organization_id: '1',
+          path: filePath,
+        } as CurrentAppConfiguration,
+        schema,
+      )
+
+      // Then
+      const content = await readFile(filePath)
+      expect(content).toContain('app_id')
+      expect(content).toContain('organization_id')
+    })
+  })
+
+  test('does not include app_id if organization_id is absent', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const filePath = joinPath(tmp, 'shopify.app.toml')
+      const {schema} = await buildVersionedAppSchema()
+
+      // When
+      await writeAppConfigurationFile(
+        {
+          ...FULL_CONFIGURATION,
+          app_id: '1234',
+          path: filePath,
+        } as CurrentAppConfiguration,
+        schema,
+      )
+
+      // Then
+      const content = await readFile(filePath)
+      expect(content).not.toContain('app_id')
+      expect(content).not.toContain('organization_id')
+    })
+  })
 })

--- a/packages/app/src/cli/services/app/write-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.ts
@@ -42,6 +42,7 @@ export const rewriteConfiguration = <T extends zod.ZodTypeAny>(schema: T, config
   let configCopy = config
   if (typeof config === 'object' && config !== null && config !== undefined) {
     if ('app_id' in config && !('organization_id' in config)) {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       const {app_id, ...rest} = config
       configCopy = rest
     }

--- a/packages/app/src/cli/services/app/write-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.ts
@@ -37,18 +37,28 @@ export async function writeAppConfigurationFile(configuration: CurrentAppConfigu
 }
 
 export const rewriteConfiguration = <T extends zod.ZodTypeAny>(schema: T, config: unknown): unknown => {
+  // Remove app_id if organization_id is not present.
+  // This will become unnecessary when we remove app_id from App Management apps.
+  let configCopy = config
+  if (typeof config === 'object' && config !== null && config !== undefined) {
+    if ('app_id' in config && !('organization_id' in config)) {
+      const {app_id, ...rest} = config
+      configCopy = rest
+    }
+  }
+
   if (schema === null || schema === undefined) return null
   if (schema instanceof zod.ZodNullable || schema instanceof zod.ZodOptional)
-    return rewriteConfiguration(schema.unwrap(), config)
+    return rewriteConfiguration(schema.unwrap(), configCopy)
   if (schema instanceof zod.ZodArray) {
-    return (config as unknown[]).map((item) => rewriteConfiguration(schema.element, item))
+    return (configCopy as unknown[]).map((item) => rewriteConfiguration(schema.element, item))
   }
   if (schema instanceof zod.ZodEffects) {
-    return rewriteConfiguration(schema._def.schema, config)
+    return rewriteConfiguration(schema._def.schema, configCopy)
   }
   if (schema instanceof zod.ZodObject) {
     const entries = Object.entries(schema.shape)
-    const confObj = config as {[key: string]: unknown}
+    const confObj = configCopy as {[key: string]: unknown}
     let result: {[key: string]: unknown} = {}
     entries.forEach(([key, subSchema]) => {
       if (confObj !== undefined && confObj[key] !== undefined) {

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -1010,7 +1010,7 @@ describe('ensureDeployContext', () => {
     expect(selectOrCreateApp).not.toHaveBeenCalled()
     expect(reuseDevConfigPrompt).not.toHaveBeenCalled()
     expect(opts.developerPlatformClient.appFromId).toHaveBeenCalledWith({
-      id: APP2.apiKey,
+      id: 'no-id-available',
       apiKey: APP2.apiKey,
       organizationId: '0',
     })

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -75,6 +75,7 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appId: 'app-id',
       apiKey: 'app-id',
       name: app.name,
       organizationId: 'org-id',
@@ -163,6 +164,7 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appId: 'app-id',
       apiKey: 'app-id',
       name: app.name,
       organizationId: 'org-id',
@@ -185,6 +187,7 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appId: 'app-id',
       apiKey: 'app-id',
       name: app.name,
       organizationId: 'org-id',
@@ -217,6 +220,7 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appId: 'app-id',
       apiKey: 'app-id',
       name: app.name,
       organizationId: 'org-id',
@@ -270,6 +274,7 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appId: 'app-id',
       apiKey: 'app-id',
       name: app.name,
       organizationId: 'org-id',
@@ -304,6 +309,7 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appId: 'app-id',
       apiKey: 'app-id',
       name: app.name,
       organizationId: 'org-id',
@@ -350,6 +356,7 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appId: 'app-id',
       apiKey: 'app-id',
       name: app.name,
       organizationId: 'org-id',
@@ -383,6 +390,7 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appId: 'app-id',
       apiKey: 'app-id',
       name: app.name,
       organizationId: 'org-id',

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -103,6 +103,7 @@ export async function deploy(options: DeployOptions) {
             )
 
             uploadExtensionsBundleResult = await uploadExtensionsBundle({
+              appId: remoteApp.id,
               apiKey,
               name: app.name,
               organizationId: remoteApp.organizationId,

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -325,6 +325,7 @@ describe('uploadExtensionsBundle', () => {
       // When
       await writeFile(joinPath(tmpDir, 'test.zip'), '')
       await uploadExtensionsBundle({
+        appId: '1',
         apiKey: 'app-id',
         name: 'appName',
         organizationId: '1',
@@ -337,6 +338,7 @@ describe('uploadExtensionsBundle', () => {
 
       // Then
       expect(developerPlatformClient.deploy).toHaveBeenCalledWith({
+        appId: '1',
         apiKey: 'app-id',
         name: 'appName',
         organizationId: '1',
@@ -364,6 +366,7 @@ describe('uploadExtensionsBundle', () => {
       // When
       await writeFile(joinPath(tmpDir, 'test.zip'), '')
       await uploadExtensionsBundle({
+        appId: '1',
         apiKey: 'app-id',
         name: 'appName',
         organizationId: '1',
@@ -378,6 +381,7 @@ describe('uploadExtensionsBundle', () => {
 
       // Then
       expect(developerPlatformClient.deploy).toHaveBeenCalledWith({
+        appId: '1',
         apiKey: 'app-id',
         name: 'appName',
         organizationId: '1',
@@ -403,6 +407,7 @@ describe('uploadExtensionsBundle', () => {
     vi.mocked<any>(formData).mockReturnValue(mockedFormData)
     // When
     await uploadExtensionsBundle({
+      appId: '1',
       apiKey: 'app-id',
       name: 'appName',
       organizationId: '1',
@@ -415,6 +420,7 @@ describe('uploadExtensionsBundle', () => {
 
     // Then
     expect(developerPlatformClient.deploy).toHaveBeenCalledWith({
+      appId: '1',
       apiKey: 'app-id',
       name: 'appName',
       organizationId: '1',
@@ -514,6 +520,7 @@ describe('uploadExtensionsBundle', () => {
       // Then
       try {
         await uploadExtensionsBundle({
+          appId: '1',
           apiKey: 'app-id',
           name: 'appName',
           organizationId: '1',
@@ -615,6 +622,7 @@ describe('uploadExtensionsBundle', () => {
 
       // When
       const result = await uploadExtensionsBundle({
+        appId: '1',
         apiKey: 'app-id',
         name: 'appName',
         organizationId: '1',

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -57,6 +57,9 @@ export async function uploadThemeExtensions(
 }
 
 interface UploadExtensionsBundleOptions {
+  /** The ID of the application */
+  appId: string
+
   /** The application API key */
   apiKey: string
 
@@ -140,6 +143,7 @@ export async function uploadExtensionsBundle(
   }
 
   const variables: AppDeployOptions = {
+    appId: options.appId,
     apiKey: options.apiKey,
     name: options.name,
     organizationId: options.organizationId,

--- a/packages/app/src/cli/services/local-storage.ts
+++ b/packages/app/src/cli/services/local-storage.ts
@@ -7,6 +7,7 @@ export interface CachedAppInfo {
   directory: string
   configFile?: string
   appId?: string
+  appGid?: string
   title?: string
   orgId?: string
   storeFqdn?: string

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -159,6 +159,7 @@ export interface ActiveAppVersion {
 }
 
 export type AppDeployOptions = AppDeployVariables & {
+  appId: string
   organizationId: string
   name: string
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -201,12 +201,14 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const {name, appModules} = app.activeRelease.version
     const appAccessModule = appModules.find((mod) => mod.specification.externalIdentifier === 'app_access')
     const appHomeModule = appModules.find((mod) => mod.specification.externalIdentifier === 'app_home')
+    const apiSecretKeys = app.activeRoot.clientCredentials.secrets
+      .map((secret) => ({secret: secret.key}))
     return {
       id: app.id,
       title: name,
       apiKey: app.key,
+      apiSecretKeys,
       organizationId: appIdentifiers.organizationId,
-      apiSecretKeys: [],
       grantedScopes: (appAccessModule?.config?.scopes as string[] | undefined) ?? [],
       applicationUrl: appHomeModule?.config?.app_url as string | undefined,
       flags: [],

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -200,13 +200,15 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const {app} = await this.fetchApp(appIdentifiers)
     const {name, appModules} = app.activeRelease.version
     const appAccessModule = appModules.find((mod) => mod.specification.externalIdentifier === 'app_access')
+    const appHomeModule = appModules.find((mod) => mod.specification.externalIdentifier === 'app_home')
     return {
       id: app.id,
       title: name,
-      apiKey: app.id,
+      apiKey: app.key,
       organizationId: appIdentifiers.organizationId,
       apiSecretKeys: [],
       grantedScopes: (appAccessModule?.config?.scopes as string[] | undefined) ?? [],
+      applicationUrl: appHomeModule?.config?.app_url as string | undefined,
       flags: [],
       developerPlatformClient: this,
     }
@@ -257,7 +259,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const minimalOrganizationApps = result.apps.map((app) => {
       return {
         id: app.id,
-        apiKey: app.id,
+        apiKey: app.key,
         title: app.activeRelease.version.name,
         organizationId,
       }
@@ -342,7 +344,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return {
       ...createdApp,
       title: name,
-      apiKey: createdApp.id,
+      apiKey: createdApp.key,
       apiSecretKeys: [],
       grantedScopes: options?.scopesArray ?? [],
       organizationId: org.id,
@@ -457,7 +459,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
           uuid: versionInfo.id,
           versionTag: versionInfo.metadata.versionTag,
           location: [
-            await this.appDeepLink({organizationId, id: appId, apiKey: appId}),
+            await this.appDeepLink({organizationId, id: appId}),
             'versions',
             numberFromGid(versionInfo.id),
           ].join('/'),
@@ -570,7 +572,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   }
 
   async deploy({
-    apiKey,
+    appId,
     name,
     appModules,
     organizationId,
@@ -588,7 +590,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       updatedName = JSON.parse(brandingModule.config).name
     }
     const variables: CreateAppVersionMutationVariables = {
-      appId: apiKey,
+      appId,
       name: updatedName,
       appSource: {
         assetsUrl: bundleUrl,
@@ -620,7 +622,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
           // Need to deal with ID properly as it's expected to be a number... how do we use it?
           id: parseInt(version.id, 10),
           versionTag: version.metadata.versionTag,
-          location: [await this.appDeepLink({organizationId, id: apiKey, apiKey}), `versions/${version.id}`].join('/'),
+          location: [await this.appDeepLink({organizationId, id: appId}), `versions/${version.id}`].join('/'),
           appModuleVersions: version.appModules.map((mod) => {
             return {
               uuid: mod.uuid,
@@ -635,7 +637,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
     if (noRelease) return versionResult
 
-    const releaseVariables: ReleaseVersionMutationVariables = {appId: apiKey, versionId: version.id}
+    const releaseVariables: ReleaseVersionMutationVariables = {appId, versionId: version.id}
     const releaseResult = await appManagementRequest<ReleaseVersionMutationSchema>(
       organizationId,
       ReleaseVersionMutation,
@@ -671,7 +673,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
           versionTag: releaseResult.appReleaseCreate.release.version.metadata.versionTag,
           message: releaseResult.appReleaseCreate.release.version.metadata.message,
           location: [
-            await this.appDeepLink({organizationId, id: appId, apiKey: appId}),
+            await this.appDeepLink({organizationId, id: appId}),
             'versions',
             numberFromGid(releaseResult.appReleaseCreate.release.version.id),
           ].join('/'),
@@ -754,7 +756,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return input.toLowerCase()
   }
 
-  async appDeepLink({id, organizationId}: MinimalAppIdentifiers): Promise<string> {
+  async appDeepLink({id, organizationId}: Pick<MinimalAppIdentifiers, 'id' | 'organizationId'>): Promise<string> {
     return `https://${await developerDashboardFqdn()}/dashboard/${organizationId}/apps/${numberFromGid(id)}`
   }
 

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -201,8 +201,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const {name, appModules} = app.activeRelease.version
     const appAccessModule = appModules.find((mod) => mod.specification.externalIdentifier === 'app_access')
     const appHomeModule = appModules.find((mod) => mod.specification.externalIdentifier === 'app_home')
-    const apiSecretKeys = app.activeRoot.clientCredentials.secrets
-      .map((secret) => ({secret: secret.key}))
+    const apiSecretKeys = app.activeRoot.clientCredentials.secrets.map((secret) => ({secret: secret.key}))
     return {
       id: app.id,
       title: name,

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/active-app-release.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/active-app-release.ts
@@ -6,6 +6,13 @@ export const ActiveAppReleaseQuery = gql`
     app(id: $appId) {
       id
       key
+      activeRoot {
+        clientCredentials {
+          secrets {
+            key
+          }
+        }
+      }
       activeRelease {
         id
         version {
@@ -47,6 +54,13 @@ export interface ActiveAppReleaseQuerySchema {
   app: {
     id: string
     key: string
+    activeRoot: {
+      clientCredentials: {
+        secrets: {
+          key: string
+        }[]
+      }
+    }
     activeRelease: {
       id: string
       version: {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app.ts
@@ -6,6 +6,7 @@ export const CreateAppMutation = gql`
     appCreate(appSource: $appSource, name: $name) {
       app {
         id
+        key
       }
       userErrors {
         category
@@ -32,6 +33,7 @@ export interface CreateAppMutationSchema {
   appCreate: {
     app: {
       id: string
+      key: string
     }
     userErrors: {
       field: string[]


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Currently App Management is storing app ID in the place where API key should go, leading to a lot of general weirdness. It also breaks certain functional things.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Stores both the app ID and the API key in the app TOML. This is not ideal, and we should eventually replace it with API key only, especially given that we allow passing an API key as a flag for many commands.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

1. `config link`-ing an app to App Management adds `app_id` to the app TOML
2. `config link`-ing an app to Partners doesn't change
3. `USE_APP_MANAGEMENT_API=1 bin/spin pnpm shopify app info --web-env --path /path/to/your/app` works and displays API key and secret

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
