### PR TITLE
feat: Add prop to renderTextPrompt to hide prompt message and bottom bar

### DIFF
--- a/docs/cli-kit/ui-kit/readme.md
+++ b/docs/cli-kit/ui-kit/readme.md
@@ -193,6 +193,8 @@ Very similar to `renderSelectPrompt` with the difference that you can provide a 
 
 Shows a text field and waits for the user to input something and press `Enter` to submit.
 
+This requires a `message` to display a prompt for user input. If `skipPromptMessage` is `true`, the prompt will not be displayed.
+
 Unless `allowEmpty` is set to `true` the user will see a validation error if they attempt to press `Enter` without having typed anything. If `allowEmpty` is `true` then an empty string will be returned in case they immediately press `Enter`. This can be useful for optional fields.
 
 `defaultValue` can be used to show a default value with a dimmed text style. The user can either press `Enter` immediately if they wish to submit the default value or start typing in order to override it.

--- a/docs/cli-kit/ui-kit/readme.md
+++ b/docs/cli-kit/ui-kit/readme.md
@@ -193,15 +193,15 @@ Very similar to `renderSelectPrompt` with the difference that you can provide a 
 
 Shows a text field and waits for the user to input something and press `Enter` to submit.
 
-This requires a `message` to display a prompt for user input. If `skipPromptMessage` is `true`, the prompt will not be displayed.
-
 Unless `allowEmpty` is set to `true` the user will see a validation error if they attempt to press `Enter` without having typed anything. If `allowEmpty` is `true` then an empty string will be returned in case they immediately press `Enter`. This can be useful for optional fields.
 
 `defaultValue` can be used to show a default value with a dimmed text style. The user can either press `Enter` immediately if they wish to submit the default value or start typing in order to override it.
 
 The validation logic can also be customized by passing the `validate` function which has to return either a `string` in case of error or `undefined` in case validation passes.
 
-Finally, if you want to mask the user input with asterisks you can set the `password` param to `true`. This can be useful for sensitive inputs that the user might not want to reveal while typing.
+If you want to mask the user input with asterisks you can set the `password` param to `true`. This can be useful for sensitive inputs that the user might not want to reveal while typing.
+
+Finally, the `minimal` flag can be used to render a text input without the underline and prompt message.
 
 ### Async tasks
 

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
@@ -254,4 +254,14 @@ describe('TextPrompt', () => {
       "
     `)
   })
+
+  test('skip the prompt message when provided', async () => {
+    const {lastFrame} = render(<TextPrompt message="this will get skipped" onSubmit={() => {}} skipPromptMessage />)
+
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      ">  █
+         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+      "
+      `)
+  })
 })

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
@@ -255,12 +255,11 @@ describe('TextPrompt', () => {
     `)
   })
 
-  test('skip the prompt message when provided', async () => {
-    const {lastFrame} = render(<TextPrompt message="this will get skipped" onSubmit={() => {}} skipPromptMessage />)
+  test('render without text prompt or underline when minimal prop is provided', async () => {
+    const {lastFrame} = render(<TextPrompt message="this will get skipped" onSubmit={() => {}} minimal />)
 
     expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
       ">  █
-         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
       "
       `)
   })

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -21,7 +21,7 @@ export interface TextPromptProps {
   abortSignal?: AbortSignal
   preview?: (value: string) => TokenItem<InlineToken>
   initialAnswer?: string
-  skipPromptMessage?: boolean
+  minimal?: boolean
 }
 
 const TextPrompt: FunctionComponent<TextPromptProps> = ({
@@ -35,7 +35,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   abortSignal,
   preview,
   initialAnswer = '',
-  skipPromptMessage = false,
+  minimal = false,
 }) => {
   if (password && defaultValue) {
     throw new Error("Can't use defaultValue with password")
@@ -91,7 +91,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
 
   return isAborted ? null : (
     <Box flexDirection="column" marginBottom={1} width={oneThird}>
-      {skipPromptMessage ? null : (
+      {minimal ? null : (
         <Box>
           <Box marginRight={2}>
             <Text>?</Text>
@@ -130,9 +130,11 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
               />
             </Box>
           </Box>
-          <Box marginLeft={3}>
-            <Text color={color}>{underline}</Text>
-          </Box>
+          {minimal ? null : (
+            <Box marginLeft={3}>
+              <Text color={color}>{underline}</Text>
+            </Box>
+          )}
           {promptState === PromptState.Error ? (
             <Box marginLeft={3}>
               <Text color={color}>{error}</Text>

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -21,6 +21,7 @@ export interface TextPromptProps {
   abortSignal?: AbortSignal
   preview?: (value: string) => TokenItem<InlineToken>
   initialAnswer?: string
+  skipPromptMessage?: boolean
 }
 
 const TextPrompt: FunctionComponent<TextPromptProps> = ({
@@ -34,6 +35,7 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   abortSignal,
   preview,
   initialAnswer = '',
+  skipPromptMessage = false,
 }) => {
   if (password && defaultValue) {
     throw new Error("Can't use defaultValue with password")
@@ -89,12 +91,14 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
 
   return isAborted ? null : (
     <Box flexDirection="column" marginBottom={1} width={oneThird}>
-      <Box>
-        <Box marginRight={2}>
-          <Text>?</Text>
+      {skipPromptMessage ? null : (
+        <Box>
+          <Box marginRight={2}>
+            <Text>?</Text>
+          </Box>
+          <TokenizedText item={messageWithPunctuation(message)} />
         </Box>
-        <TokenizedText item={messageWithPunctuation(message)} />
-      </Box>
+      )}
       {promptState === PromptState.Submitted ? (
         <Box>
           <Box marginRight={2}>


### PR DESCRIPTION
### WHY are these changes introduced?

The existing implementation was not a great fit for cases when we want to accept numerous inputs such as in an REPL loop. A required `prompt` message and `bottom bar` added noise to every evaluated expression (example in video below)

This change allows us to:
- accept user input in an interactive console style while staying consistent with CLI Style guidelines on accepting input
- avoid adding additional noise in the `theme console` command
- maintain visual parity with the ruby implementation

### WHAT is this pull request doing?
- Provides a prop that allows users to hide the prompt message and bottom bar when calling `renderTextPrompt`
_- Note: Isaac and I have aligned on using a `minimal` prop to hide both rather than individual props for the prompt message and bottom bar, though this stance is not written in stone_

**Before**
![image](https://github.com/user-attachments/assets/8319d6d4-e897-4093-a8b6-c6d83b30bd82)

**After**
<img width="682" alt="image" src="https://github.com/user-attachments/assets/c40babb5-711a-45e3-ae57-c2205e841189">

### How to test your changes?
- You can run `pnpm test` 
OR
1. Add the following snippet [here](https://github.com/Shopify/cli/blob/main/packages/theme/src/cli/commands/theme/console.ts#L40)

```
async function recursiveRenderTextPrompt() {
      await renderTextPrompt({message: '', minimal: true})
      await recursiveRenderTextPrompt()
}
    await recursiveRenderTextPrompt()
``` 
2. Execute the command `pnpm shopify theme console`
3. Notice that the prompt message (`? <MESSAGE><Punctuation>`) and bottom bar does not render

### Post-release steps
Documentation is updated in this PR
Feel free to let me know if there are additional updates needed!


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows
- [x] I've considered possible [documentation](https://shopify.dev) changes 