### PR TITLE
Add press-key-to-login to device auth flow

### DIFF
--- a/packages/cli-kit/src/private/node/content-tokens.ts
+++ b/packages/cli-kit/src/private/node/content-tokens.ts
@@ -25,16 +25,17 @@ export class LinkContentToken extends ContentToken<OutputMessage> {
   link: string
   fallback: string | undefined
 
-  constructor(value: OutputMessage, link: string, fallback?: string) {
+  constructor(value: OutputMessage, link?: string, fallback?: string) {
     super(value)
-    this.link = link
+    this.link = link ?? stringifyMessage(value)
     this.fallback = fallback
   }
 
   output() {
     const text = colors.green(stringifyMessage(this.value))
     const url = this.link ?? ''
-    return terminalLink(text, url, {fallback: () => this.fallback ?? `${text} ( ${url} )`})
+    const defaultFallback = this.value === this.link ? text : `${text} ( ${url} )`
+    return terminalLink(text, url, {fallback: () => this.fallback ?? defaultFallback})
   }
 }
 

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -41,7 +41,7 @@ describe('requestDeviceAuthorization', () => {
     const response = new Response(JSON.stringify(data))
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
-    vi.mocked(clientId).mockResolvedValue('clientId')
+    vi.mocked(clientId).mockReturnValue('clientId')
 
     // When
     const got = await requestDeviceAuthorization(['scope1', 'scope2'])

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -8,14 +8,20 @@ import {IdentityToken} from './schema.js'
 import {exchangeDeviceCodeForAccessToken} from './exchange.js'
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {shopifyFetch} from '../../../public/node/http.js'
+import {isTTY} from '../../../public/node/ui.js'
 import {err, ok} from '../../../public/node/result.js'
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {Response} from 'node-fetch'
 
 vi.mock('../../../public/node/context/fqdn.js')
 vi.mock('./identity')
 vi.mock('../../../public/node/http.js')
+vi.mock('../../../public/node/ui.js')
 vi.mock('./exchange.js')
+
+beforeEach(() => {
+  vi.mocked(isTTY).mockReturnValue(true)
+})
 
 describe('requestDeviceAuthorization', () => {
   const data: any = {

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -4,7 +4,7 @@ import {IdentityToken} from './schema.js'
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {shopifyFetch} from '../../../public/node/http.js'
 import {outputContent, outputDebug, outputInfo, outputToken} from '../../../public/node/output.js'
-import {BugError} from '../../../public/node/error.js'
+import {AbortError, BugError} from '../../../public/node/error.js'
 import {isCloudEnvironment} from '../../../public/node/context/local.js'
 import {openURL} from '../../../public/node/system.js'
 import {isTTY, keypress} from '../../../public/node/ui.js'
@@ -49,18 +49,27 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
   }
 
   outputInfo('\nTo run this command, log in to Shopify.')
+
+  if (!isTTY()) {
+    throw new AbortError(
+      'Authorization is required to continue, but the current environment does not support interactive prompts.',
+      'To resolve this, specify credentials in your environment, or run the command in an interactive environment such as your local terminal.',
+    )
+  }
+
   outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
   const linkToken = outputToken.link(jsonResult.verification_uri_complete)
-  if (isTTY() && !isCloudEnvironment()) {
+
+  if (isCloudEnvironment()) {
+    outputInfo(
+      outputContent`👉 Open this link to start the auth process: ${linkToken}`,
+    )
+  } else {
     outputInfo('👉 Press any key to open the login page on your browser')
     await keypress()
     await openURL(jsonResult.verification_uri_complete)
     outputInfo(
       outputContent`Opened link to start the auth process: ${linkToken}`,
-    )
-  } else {
-    outputInfo(
-      outputContent`👉 Open this link to start the auth process: ${linkToken}`,
     )
   }
 

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -5,8 +5,9 @@ import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {shopifyFetch} from '../../../public/node/http.js'
 import {outputContent, outputDebug, outputInfo, outputToken} from '../../../public/node/output.js'
 import {BugError} from '../../../public/node/error.js'
-import {isTTY, keypress} from '../../../public/node/ui.js'
+import {isCloudEnvironment} from '../../../public/node/context/local.js'
 import {openURL} from '../../../public/node/system.js'
+import {isTTY, keypress} from '../../../public/node/ui.js'
 
 export interface DeviceAuthorizationResponse {
   deviceCode: string
@@ -49,7 +50,7 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
 
   outputInfo('\nTo run this command, log in to Shopify.')
   outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
-  if (isTTY()) {
+  if (isTTY() && !isCloudEnvironment()) {
     outputInfo('👉 Press any key to open the login page on your browser')
     await keypress()
     await openURL(jsonResult.verification_uri_complete)

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -50,23 +50,17 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
 
   outputInfo('\nTo run this command, log in to Shopify.')
   outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
+  const linkToken = outputToken.link(jsonResult.verification_uri_complete)
   if (isTTY() && !isCloudEnvironment()) {
     outputInfo('👉 Press any key to open the login page on your browser')
     await keypress()
     await openURL(jsonResult.verification_uri_complete)
     outputInfo(
-      outputContent`Opened link to start the auth process: ${outputToken.link(
-        'Login link',
-        jsonResult.verification_uri_complete,
-      )}`,
+      outputContent`Opened link to start the auth process: ${linkToken}`,
     )
   } else {
-    outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
     outputInfo(
-      outputContent`👉 Open this link to start the auth process: ${outputToken.link(
-        'Login link',
-        jsonResult.verification_uri_complete,
-      )}`,
+      outputContent`👉 Open this link to start the auth process: ${linkToken}`,
     )
   }
 

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -5,6 +5,8 @@ import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {shopifyFetch} from '../../../public/node/http.js'
 import {outputContent, outputDebug, outputInfo, outputToken} from '../../../public/node/output.js'
 import {BugError} from '../../../public/node/error.js'
+import {isTTY, keypress} from '../../../public/node/ui.js'
+import {openURL} from '../../../public/node/system.js'
 
 export interface DeviceAuthorizationResponse {
   deviceCode: string
@@ -47,11 +49,23 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
 
   outputInfo('\nTo run this command, log in to Shopify.')
   outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
-  outputInfo(
-    outputContent`👉 Open this link to start the auth process: ${outputToken.green(
-      jsonResult.verification_uri_complete,
-    )}`,
-  )
+  if (isTTY()) {
+    outputInfo('👉 Press any key to open the login page on your browser')
+    await keypress()
+    await openURL(jsonResult.verification_uri_complete)
+    outputInfo(
+      outputContent`Opened link to start the auth process: ${outputToken.green(
+        jsonResult.verification_uri_complete,
+      )}`,
+    )
+  } else {
+    outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
+    outputInfo(
+      outputContent`👉 Open this link to start the auth process: ${outputToken.green(
+        jsonResult.verification_uri_complete,
+      )}`,
+    )
+  }
 
   return {
     deviceCode: jsonResult.device_code,

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -55,14 +55,16 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
     await keypress()
     await openURL(jsonResult.verification_uri_complete)
     outputInfo(
-      outputContent`Opened link to start the auth process: ${outputToken.green(
+      outputContent`Opened link to start the auth process: ${outputToken.link(
+        'Login link',
         jsonResult.verification_uri_complete,
       )}`,
     )
   } else {
     outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
     outputInfo(
-      outputContent`👉 Open this link to start the auth process: ${outputToken.green(
+      outputContent`👉 Open this link to start the auth process: ${outputToken.link(
+        'Login link',
         jsonResult.verification_uri_complete,
       )}`,
     )

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -27,7 +27,7 @@ export interface DeviceAuthorizationResponse {
  */
 export async function requestDeviceAuthorization(scopes: string[]): Promise<DeviceAuthorizationResponse> {
   const fqdn = await identityFqdn()
-  const identityClientId = await clientId()
+  const identityClientId = clientId()
   const queryParams = {client_id: identityClientId, scope: scopes.join(' ')}
   const url = `https://${fqdn}/oauth/device_authorization`
 

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -61,16 +61,12 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
   const linkToken = outputToken.link(jsonResult.verification_uri_complete)
 
   if (isCloudEnvironment()) {
-    outputInfo(
-      outputContent`👉 Open this link to start the auth process: ${linkToken}`,
-    )
+    outputInfo(outputContent`👉 Open this link to start the auth process: ${linkToken}`)
   } else {
     outputInfo('👉 Press any key to open the login page on your browser')
     await keypress()
     await openURL(jsonResult.verification_uri_complete)
-    outputInfo(
-      outputContent`Opened link to start the auth process: ${linkToken}`,
-    )
+    outputInfo(outputContent`Opened link to start the auth process: ${linkToken}`)
   }
 
   return {

--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -50,7 +50,7 @@ export const outputToken = {
   path(value: OutputMessage): PathContentToken {
     return new PathContentToken(value)
   },
-  link(value: OutputMessage, link: string, fallback?: string | undefined): LinkContentToken {
+  link(value: OutputMessage, link?: string, fallback?: string | undefined): LinkContentToken {
     return new LinkContentToken(value, link, fallback)
   },
   heading(value: OutputMessage): HeadingContentToken {

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -47,7 +47,7 @@ type PartialBy<T, TKey extends keyof T> = Omit<T, TKey> & Partial<Pick<T, TKey>>
 
 interface UIDebugOptions {
   /** If true, don't check if the current terminal is interactive or not */
-  skipTTYCheck: boolean
+  skipTTYCheck?: boolean
 }
 const defaultUIDebugOptions: UIDebugOptions = {
   skipTTYCheck: false,

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -691,7 +691,7 @@ interface IsTTYOptions {
   uiDebugOptions?: UIDebugOptions
 }
 
-export function isTTY({stdin = undefined, uiDebugOptions = defaultUIDebugOptions}: IsTTYOptions) {
+export function isTTY({stdin = undefined, uiDebugOptions = defaultUIDebugOptions}: IsTTYOptions = {}) {
   return Boolean(uiDebugOptions.skipTTYCheck || stdin || terminalSupportsRawMode())
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Recently we switched to device auth by default, which has added some friction to login. This restores the simplicity of pressing any key to log in.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Before:

<img width="1496" alt="Screenshot 2024-07-17 at 16 51 24" src="https://github.com/user-attachments/assets/0547a388-2cbf-425d-a9e7-5f1e3b9d2844">

After:

<img width="1492" alt="Screenshot 2024-07-17 at 16 50 32" src="https://github.com/user-attachments/assets/c4e551c6-0ec5-4ce7-85f5-6e1991c1aa6a">

We only use this flow in non-cloud TTY environments.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Logout and do anything that requires login, e.g. `config link`

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
