### PR TITLE
Add --json flag to app logs

### DIFF
--- a/packages/app/src/cli/commands/app/logs.ts
+++ b/packages/app/src/cli/commands/app/logs.ts
@@ -32,6 +32,11 @@ export default class Logs extends Command {
       options: ['success', 'failure'],
       env: 'SHOPIFY_FLAG_STATUS',
     }),
+    json: Flags.boolean({
+      char: 'j',
+      description: 'Log the run result as a JSON object.',
+      env: 'SHOPIFY_FLAG_JSON',
+    }),
   }
 
   public async run(): Promise<void> {
@@ -53,6 +58,7 @@ export default class Logs extends Command {
       status: flags.status,
       configName: flags.config,
       reset: flags.reset,
+      json: flags.json,
     }
 
     await logs(logOptions)

--- a/packages/app/src/cli/commands/app/logs.ts
+++ b/packages/app/src/cli/commands/app/logs.ts
@@ -1,7 +1,7 @@
 import Dev from './dev.js'
 import Command from '../../utilities/app-command.js'
 import {checkFolderIsValidApp} from '../../models/app/loader.js'
-import {logs} from '../../services/logs.js'
+import {logs, Format} from '../../services/logs.js'
 import {appLogPollingEnabled} from '../../services/app-logs/utils.js'
 import {Flags} from '@oclif/core'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -58,7 +58,7 @@ export default class Logs extends Command {
       status: flags.status,
       configName: flags.config,
       reset: flags.reset,
-      json: flags.json,
+      format: (flags.json ? 'json' : 'text') as Format,
     }
 
     await logs(logOptions)

--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
@@ -339,7 +339,7 @@ describe('pollAppLogs', () => {
 
   test('calls resubscribe callback if a 401 is received', async () => {
     // Given
-    const response = new Response('errorMessage', {status: 401})
+    const response = new Response(JSON.stringify({errors: ['Unauthorized']}), {status: 401})
     const mockedFetch = vi.fn().mockResolvedValueOnce(response)
     vi.mocked(fetch).mockImplementation(mockedFetch)
 
@@ -357,7 +357,9 @@ describe('pollAppLogs', () => {
   test('displays throttle message, waits, and retries if status is 429', async () => {
     // Given
     const outputWarnSpy = vi.spyOn(output, 'outputWarn')
-    const mockedFetch = vi.fn().mockResolvedValueOnce(new Response('error for 429', {status: 429}))
+    const mockedFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({errors: ['error for 429']}), {status: 429}))
     vi.mocked(fetch).mockImplementation(mockedFetch)
 
     // When/Then
@@ -369,7 +371,6 @@ describe('pollAppLogs', () => {
     })
 
     expect(outputWarnSpy).toHaveBeenCalledWith('Request throttled while polling app logs.')
-    expect(outputWarnSpy).toHaveBeenCalledWith('Retrying in 60 seconds.')
     expect(vi.getTimerCount()).toEqual(1)
   })
 
@@ -379,7 +380,7 @@ describe('pollAppLogs', () => {
     const outputWarnSpy = vi.spyOn(output, 'outputWarn')
 
     // An unexpected error response
-    const response = new Response('errorMessage', {status: 422})
+    const response = new Response(JSON.stringify({errors: ['errorMessage']}), {status: 500})
     const mockedFetch = vi.fn().mockResolvedValueOnce(response)
     vi.mocked(fetch).mockImplementation(mockedFetch)
 
@@ -393,8 +394,6 @@ describe('pollAppLogs', () => {
 
     // Then
     expect(outputWarnSpy).toHaveBeenCalledWith('Error while polling app logs.')
-    expect(outputWarnSpy).toHaveBeenCalledWith('Retrying in 5 seconds.')
-    expect(outputDebugSpy).toHaveBeenCalledWith(expect.stringContaining(`Unhandled bad response: ${response.status}`))
     expect(vi.getTimerCount()).toEqual(1)
   })
 })

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
@@ -1,0 +1,79 @@
+import {renderJsonLogs} from './render-json-logs.js'
+import {pollAppLogs} from './poll-app-logs.js'
+import {handleFetchAppLogsError} from '../utils.js'
+import {testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
+import {outputInfo} from '@shopify/cli-kit/node/output'
+import {describe, expect, vi, test, beforeEach, afterEach} from 'vitest'
+
+vi.mock('./poll-app-logs')
+vi.mock('../utils', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../utils.js')>()
+  return {
+    ...mod,
+    fetchAppLogs: vi.fn(),
+    handleFetchAppLogsError: vi.fn(),
+  }
+})
+vi.mock('@shopify/cli-kit/node/output')
+
+describe('renderJsonLogs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+  })
+
+  test('should handle success response correctly', async () => {
+    const mockSuccessResponse = {
+      cursor: 'next-cursor',
+      appLogs: [{message: 'Log 1'}, {message: 'Log 2'}],
+    }
+    const pollAppLogsMock = vi.fn().mockResolvedValue(mockSuccessResponse)
+    vi.mocked(pollAppLogs).mockImplementation(pollAppLogsMock)
+
+    await renderJsonLogs({
+      pollOptions: {cursor: 'cursor', filters: {status: undefined, source: undefined}, jwtToken: 'jwtToken'},
+      options: {
+        variables: {shopIds: ['1'], apiKey: 'key', token: 'token'},
+        developerPlatformClient: testDeveloperPlatformClient(),
+      },
+    })
+
+    expect(outputInfo).toHaveBeenNthCalledWith(1, JSON.stringify({message: 'Log 1'}))
+    expect(outputInfo).toHaveBeenNthCalledWith(2, JSON.stringify({message: 'Log 2'}))
+    expect(pollAppLogs).toHaveBeenCalled()
+    expect(vi.getTimerCount()).toEqual(1)
+  })
+
+  test('should handle error response and retry as expected', async () => {
+    const mockErrorResponse = {
+      errors: [{status: 500, message: 'Server Error'}],
+    }
+    const pollAppLogsMock = vi.fn().mockResolvedValue(mockErrorResponse)
+    vi.mocked(pollAppLogs).mockImplementation(pollAppLogsMock)
+    const mockRetryInterval = 1000
+    const handleFetchAppLogsErrorMock = vi.fn((input) => {
+      input.onUnknownError(mockRetryInterval)
+      return new Promise<{retryIntervalMs: number; nextJwtToken: string | null}>((resolve, _reject) => {
+        resolve({nextJwtToken: 'new-jwt-token', retryIntervalMs: mockRetryInterval})
+      })
+    })
+    vi.mocked(handleFetchAppLogsError).mockImplementation(handleFetchAppLogsErrorMock)
+
+    await renderJsonLogs({
+      pollOptions: {cursor: 'cursor', filters: {status: undefined, source: undefined}, jwtToken: 'jwtToken'},
+      options: {
+        variables: {shopIds: [], apiKey: '', token: ''},
+        developerPlatformClient: testDeveloperPlatformClient(),
+      },
+    })
+
+    expect(outputInfo).toHaveBeenCalledWith(
+      JSON.stringify({message: 'Error while polling app logs.', retry_in_ms: mockRetryInterval}),
+    )
+    expect(pollAppLogs).toHaveBeenCalled()
+    expect(vi.getTimerCount()).toEqual(1)
+  })
+})

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
@@ -1,0 +1,59 @@
+import {pollAppLogs} from './poll-app-logs.js'
+import {PollOptions, SubscribeOptions, ErrorResponse, SuccessResponse} from '../types.js'
+import {POLLING_INTERVAL_MS, handleFetchAppLogsError, subscribeToAppLogs} from '../utils.js'
+import {outputInfo} from '@shopify/cli-kit/node/output'
+
+export async function renderJsonLogs({
+  pollOptions: {cursor, filters, jwtToken},
+  options: {variables, developerPlatformClient},
+}: {
+  pollOptions: PollOptions
+  options: SubscribeOptions
+}): Promise<void> {
+  const response = await pollAppLogs({cursor, filters, jwtToken})
+  let retryIntervalMs = POLLING_INTERVAL_MS
+  let nextJwtToken = jwtToken
+
+  const errorResponse = response as ErrorResponse
+
+  if (errorResponse.errors) {
+    const result = await handleFetchAppLogsError({
+      response: errorResponse,
+      onThrottle: (retryIntervalMs) => {
+        outputInfo(JSON.stringify({message: 'Request throttled while polling app logs.', retry_in_ms: retryIntervalMs}))
+      },
+      onUnknownError: (retryIntervalMs) => {
+        outputInfo(JSON.stringify({message: 'Error while polling app logs.', retry_in_ms: retryIntervalMs}))
+      },
+      onResubscribe: () => {
+        return subscribeToAppLogs(developerPlatformClient, variables)
+      },
+    })
+
+    if (result.nextJwtToken) {
+      nextJwtToken = result.nextJwtToken
+    }
+    retryIntervalMs = result.retryIntervalMs
+  }
+
+  const {cursor: nextCursor, appLogs} = response as SuccessResponse
+
+  if (appLogs) {
+    appLogs.forEach((log) => {
+      outputInfo(JSON.stringify(log))
+    })
+  }
+
+  setTimeout(() => {
+    renderJsonLogs({
+      options: {variables, developerPlatformClient},
+      pollOptions: {
+        jwtToken: nextJwtToken || jwtToken,
+        cursor: nextCursor || cursor,
+        filters,
+      },
+    }).catch((error) => {
+      throw error
+    })
+  }, retryIntervalMs)
+}

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
@@ -344,7 +344,7 @@ describe('usePollAppLogs', () => {
     expect(mockedPollAppLogs).toHaveBeenCalledTimes(1)
 
     expect(hook.lastResult?.appLogOutputs).toHaveLength(0)
-    expect(hook.lastResult?.errors[0]).toEqual('Error Message')
+    expect(hook.lastResult?.errors[0]).toEqual('Request throttled while polling app logs.')
     expect(hook.lastResult?.errors[1]).toEqual('Retrying in 60s')
 
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), POLLING_THROTTLE_RETRY_INTERVAL_MS)
@@ -378,7 +378,7 @@ describe('usePollAppLogs', () => {
     expect(mockedPollAppLogs).toHaveBeenCalledTimes(1)
 
     expect(hook.lastResult?.appLogOutputs).toHaveLength(0)
-    expect(hook.lastResult?.errors[0]).toEqual('Unprocessable')
+    expect(hook.lastResult?.errors[0]).toEqual('Error while polling app logs')
     expect(hook.lastResult?.errors[1]).toEqual('Retrying in 5s')
 
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), POLLING_ERROR_RETRY_INTERVAL_MS)

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -890,6 +890,32 @@ api_version = "2023-04"
     expect(link).toBeCalled()
   })
 
+  describe('when --json is in argv', () => {
+    let originalArgv: string[]
+
+    beforeEach(() => {
+      originalArgv = process.argv
+    })
+
+    // Restore the original process.argv
+    afterEach(() => {
+      process.argv = originalArgv
+    })
+
+    test('Does not display used dev values when using json output', async () => {
+      vi.mocked(getCachedAppInfo).mockReturnValue({...CACHED1, previousAppId: APP1.apiKey})
+      vi.mocked(fetchAppDetailsFromApiKey).mockResolvedValueOnce(APP1)
+      vi.mocked(fetchStoreByDomain).mockResolvedValue({organization: ORG1, store: STORE1})
+
+      // When
+      const options = devOptions()
+      process.argv = ['', '', '--json']
+      await ensureDevContext(options)
+
+      expect(renderInfo).not.toBeCalled()
+    })
+  })
+
   test('links app if no app configs exist & cache has a current config file defined', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -42,6 +42,7 @@ import {outputContent} from '@shopify/cli-kit/node/output'
 import {getOrganization} from '@shopify/cli-kit/node/environment'
 import {basename, joinPath} from '@shopify/cli-kit/node/path'
 import {glob} from '@shopify/cli-kit/node/fs'
+import {sniffForJson} from '@shopify/cli-kit/node/path'
 
 export const InvalidApiKeyErrorMessage = (apiKey: string) => {
   return {
@@ -816,6 +817,7 @@ interface ReusedValuesOptions {
  */
 function showReusedDevValues({organization, selectedApp, selectedStore, cachedInfo}: ReusedValuesOptions) {
   if (!cachedInfo) return
+  if (sniffForJson()) return
 
   let updateURLs = 'Not yet configured'
   if (cachedInfo.updateURLs !== undefined) updateURLs = cachedInfo.updateURLs ? 'Yes' : 'No'

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -40,9 +40,8 @@ import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent} from '@shopify/cli-kit/node/output'
 import {getOrganization} from '@shopify/cli-kit/node/environment'
-import {basename, joinPath} from '@shopify/cli-kit/node/path'
+import {basename, joinPath, sniffForJson} from '@shopify/cli-kit/node/path'
 import {glob} from '@shopify/cli-kit/node/fs'
-import {sniffForJson} from '@shopify/cli-kit/node/path'
 
 export const InvalidApiKeyErrorMessage = (apiKey: string) => {
   return {

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
@@ -45,7 +45,7 @@ export async function setupAppLogsPollingProcess({
 }
 
 export const subscribeAndStartPolling: DevProcessFunction<SubscribeAndStartPollingOptions> = async (
-  {stdout, stderr, abortSignal},
+  {stdout, stderr: _stderr, abortSignal: _abortSignal},
   {developerPlatformClient, appLogsSubscribeVariables},
 ) => {
   try {
@@ -59,10 +59,7 @@ export const subscribeAndStartPolling: DevProcessFunction<SubscribeAndStartPolli
       appLogsFetchInput: {jwtToken},
       apiKey,
       resubscribeCallback: () => {
-        return subscribeAndStartPolling(
-          {stdout, stderr, abortSignal},
-          {developerPlatformClient, appLogsSubscribeVariables},
-        )
+        return subscribeToAppLogs(developerPlatformClient, appLogsSubscribeVariables)
       },
     })
     // eslint-disable-next-line no-catch-all/no-catch-all,no-empty

--- a/packages/app/src/cli/services/logs.test.ts
+++ b/packages/app/src/cli/services/logs.test.ts
@@ -1,0 +1,83 @@
+import {logs} from './logs.js'
+import {subscribeToAppLogs} from './app-logs/utils.js'
+import {ensureDevContext} from './context.js'
+import * as renderLogs from './app-logs/logs-command/ui.js'
+import * as renderJsonLogs from './app-logs/logs-command/render-json-logs.js'
+import {loadAppConfiguration} from '../models/app/loader.js'
+import {buildVersionedAppSchema, testApp, testOrganizationApp} from '../models/app/app.test-data.js'
+import {describe, test, vi, expect} from 'vitest'
+
+vi.mock('../models/app/loader.js')
+vi.mock('./context.js')
+vi.mock('./app-logs/logs-command/ui.js')
+vi.mock('./app-logs/logs-command/render-json-logs.js')
+vi.mock('./app-logs/utils.js')
+
+describe('logs', () => {
+  test('should call json handler when format is json', async () => {
+    // Given
+    await setupDevContext()
+    const spy = vi.spyOn(renderJsonLogs, 'renderJsonLogs')
+
+    // When
+    await logs({
+      reset: false,
+      format: 'json',
+      directory: 'directory',
+      apiKey: 'api-key',
+      storeFqdn: 'store-fqdn',
+      source: 'source',
+      status: 'status',
+      configName: 'config-name',
+      userProvidedConfigName: 'user-provided-config-name',
+    })
+
+    // Then
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('should call text handler when format is texxt', async () => {
+    // Given
+    await setupDevContext()
+    const spy = vi.spyOn(renderLogs, 'renderLogs')
+
+    // When
+    await logs({
+      reset: false,
+      format: 'text',
+      apiKey: 'api-key',
+      directory: 'directory',
+      storeFqdn: 'store-fqdn',
+      source: 'source',
+      status: 'status',
+      configName: 'config-name',
+      userProvidedConfigName: 'user-provided-config-name',
+    })
+
+    // Then
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+async function setupDevContext() {
+  const {schema: configSchema} = await buildVersionedAppSchema()
+  vi.mocked(loadAppConfiguration).mockResolvedValue({
+    directory: '/app',
+    configuration: {
+      path: '/app/shopify.app.toml',
+      scopes: 'read_products',
+    },
+    configSchema,
+    specifications: [],
+    remoteFlags: [],
+  })
+  vi.mocked(ensureDevContext).mockResolvedValue({
+    localApp: testApp(),
+    remoteApp: testOrganizationApp(),
+    remoteAppUpdated: false,
+    updateURLs: false,
+    storeFqdn: 'store-fqdn',
+    storeId: '1',
+  })
+  vi.mocked(subscribeToAppLogs).mockResolvedValue('jwt-token')
+}

--- a/packages/app/src/cli/services/logs.ts
+++ b/packages/app/src/cli/services/logs.ts
@@ -4,6 +4,24 @@ import {subscribeToAppLogs} from './app-logs/utils.js'
 import {selectDeveloperPlatformClient, DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {loadAppConfiguration} from '../models/app/loader.js'
 import {AppInterface} from '../models/app/app.js'
+import {pollAppLogs} from './app-logs/logs-command/poll-app-logs.js'
+import {PollOptions, SubscribeOptions} from './app-logs/types.js'
+import {
+  POLLING_ERROR_RETRY_INTERVAL_MS,
+  ONE_MILLION,
+  POLLING_INTERVAL_MS,
+  POLLING_THROTTLE_RETRY_INTERVAL_MS,
+  parseFunctionRunPayload,
+  LOG_TYPE_FUNCTION_RUN,
+  LOG_TYPE_RESPONSE_FROM_CACHE,
+  parseNetworkAccessResponseFromCachePayload,
+  LOG_TYPE_REQUEST_EXECUTION_IN_BACKGROUND,
+  parseNetworkAccessRequestExecutionInBackgroundPayload,
+  LOG_TYPE_REQUEST_EXECUTION,
+  parseNetworkAccessRequestExecutedPayload,
+} from './app-logs/utils.js'
+import {ErrorResponse, SuccessResponse, AppLogOutput, PollFilters, AppLogPayload} from './app-logs/types.js'
+import {outputInfo} from '@shopify/cli-kit/node/output'
 
 interface LogsOptions {
   directory: string
@@ -37,13 +55,21 @@ export async function logs(commandOptions: LogsOptions) {
     filters,
   }
 
-  await renderLogs({
+  await renderJsonLogs({
     options: {
       variables,
       developerPlatformClient: logsConfig.developerPlatformClient,
     },
     pollOptions,
   })
+
+  // await renderLogs({
+  //   options: {
+  //     variables,
+  //     developerPlatformClient: logsConfig.developerPlatformClient,
+  //   },
+  //   pollOptions,
+  // })
 }
 
 async function prepareForLogs(commandOptions: LogsOptions): Promise<{
@@ -70,4 +96,56 @@ async function prepareForLogs(commandOptions: LogsOptions): Promise<{
     apiKey,
     localApp,
   }
+}
+
+async function renderJsonLogs({
+  pollOptions: {cursor, filters, jwtToken},
+  options: {variables, developerPlatformClient},
+}: {
+  pollOptions: PollOptions
+  options: SubscribeOptions
+}): Promise<void> {
+  const response = await pollAppLogs({cursor, filters, jwtToken})
+  let nextInterval = POLLING_INTERVAL_MS
+  let nextJwtToken = jwtToken
+
+  const {errors} = response as ErrorResponse
+
+  if (errors && errors.length > 0) {
+    if (errors.some((error) => error.status === 401)) {
+      const nextJwtToken = await subscribeToAppLogs(developerPlatformClient, variables)
+    } else if (errors.some((error) => error.status === 429)) {
+      nextInterval = POLLING_THROTTLE_RETRY_INTERVAL_MS
+    } else {
+      nextInterval = POLLING_ERROR_RETRY_INTERVAL_MS
+
+      outputInfo(
+        JSON.stringify({
+          errors: errors,
+          retrying_in_ms: nextInterval,
+        }),
+      )
+    }
+  }
+
+  const {cursor: nextCursor, appLogs} = response as SuccessResponse
+
+  if (appLogs) {
+    appLogs.forEach((log) => {
+      outputInfo(JSON.stringify(log))
+    })
+  }
+
+  setTimeout(() => {
+    renderJsonLogs({
+      options: {variables: variables, developerPlatformClient: developerPlatformClient},
+      pollOptions: {
+        jwtToken: nextJwtToken || jwtToken,
+        cursor: nextCursor || cursor,
+        filters,
+      },
+    }).catch((error) => {
+      throw error
+    })
+  }, nextInterval)
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -763,8 +763,8 @@ USAGE
     [--entry <value>] [--lockfile-check] [--path <value>] [--sourcemap] [--watch]
 
 FLAGS
-  --[no-]bundle-stats            [Classic Remix Compiler] Show a bundle size summary after building. Defaults to true,
-                                 use `--no-bundle-stats` to disable.
+  --[no-]bundle-stats            Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to
+                                 disable.
   --codegen                      Automatically generates GraphQL types for your project’s Storefront API queries.
   --codegen-config-path=<value>  Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if
                                  this file exists.
@@ -869,38 +869,44 @@ Builds and deploys a Hydrogen storefront to Oxygen.
 
 ```
 USAGE
-  $ shopify hydrogen deploy [--auth-bypass-token] [--build-command <value>] [--entry <value>] [--env <value> |
-    --env-branch <value>] [--env-file <value>] [-f] [--json-output] [--lockfile-check] [--metadata-description <value>]
-    [--metadata-user <value>] [--no-verify] [--path <value>] [--preview] [-s <value>] [-t <value>]
+  $ shopify hydrogen deploy [--auth-bypass-token-duration <value> --auth-bypass-token] [--build-command <value>]
+    [--entry <value>] [--env <value> | --env-branch <value>] [--env-file <value>] [-f] [--json-output]
+    [--lockfile-check] [--metadata-description <value>] [--metadata-user <value>] [--no-verify] [--path <value>]
+    [--preview] [-s <value>] [-t <value>]
 
 FLAGS
-  -f, --force                         Forces a deployment to proceed if there are uncommited changes in its Git
-                                      repository.
-  -s, --shop=<value>                  Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL
-                                      (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).
-  -t, --token=<value>                 Oxygen deployment token. Defaults to the linked storefront's token if available.
-      --auth-bypass-token             Generate an authentication bypass token, which can be used to perform end-to-end
-                                      tests against the deployment.
-      --build-command=<value>         Specify a build command to run before deploying. If not specified, `shopify
-                                      hydrogen build` will be used.
-      --entry=<value>                 Entry file for the worker. Defaults to `./server`.
-      --env=<value>                   Specifies the environment to perform the operation using its handle. Fetch the
-                                      handle using the `env list` command.
-      --env-branch=<value>            Specifies the environment to perform the operation using its Git branch name.
-      --env-file=<value>              Path to an environment file to override existing environment variables for the
-                                      deployment.
-      --[no-]json-output              Create a JSON file containing the deployment details in CI environments. Defaults
-                                      to true, use `--no-json-output` to disable.
-      --[no-]lockfile-check           Checks that there is exactly one valid lockfile in the project. Defaults to
-                                      `true`. Deactivate with `--no-lockfile-check`.
-      --metadata-description=<value>  Description of the changes in the deployment. Defaults to the commit message of
-                                      the latest commit if there are no uncommited changes.
-      --metadata-user=<value>         User that initiated the deployment. Will be saved and displayed in the Shopify
-                                      admin
-      --no-verify                     Skip the routability verification step after deployment.
-      --path=<value>                  The path to the directory of the Hydrogen storefront. Defaults to the current
-                                      directory where the command is run.
-      --preview                       Deploys to the Preview environment. Overrides --env-branch and Git metadata.
+  -f, --force                               Forces a deployment to proceed if there are uncommited changes in its Git
+                                            repository.
+  -s, --shop=<value>                        Shop URL. It can be the shop prefix (janes-apparel) or the full
+                                            myshopify.com URL (janes-apparel.myshopify.com,
+                                            https://janes-apparel.myshopify.com).
+  -t, --token=<value>                       Oxygen deployment token. Defaults to the linked storefront's token if
+                                            available.
+      --auth-bypass-token                   Generate an authentication bypass token, which can be used to perform
+                                            end-to-end tests against the deployment.
+      --auth-bypass-token-duration=<value>  Specify the duration (in hours) up to 12 hours for the authentication bypass
+                                            token. Defaults to `2`
+      --build-command=<value>               Specify a build command to run before deploying. If not specified, `shopify
+                                            hydrogen build` will be used.
+      --entry=<value>                       Entry file for the worker. Defaults to `./server`.
+      --env=<value>                         Specifies the environment to perform the operation using its handle. Fetch
+                                            the handle using the `env list` command.
+      --env-branch=<value>                  Specifies the environment to perform the operation using its Git branch
+                                            name.
+      --env-file=<value>                    Path to an environment file to override existing environment variables for
+                                            the deployment.
+      --[no-]json-output                    Create a JSON file containing the deployment details in CI environments.
+                                            Defaults to true, use `--no-json-output` to disable.
+      --[no-]lockfile-check                 Checks that there is exactly one valid lockfile in the project. Defaults to
+                                            `true`. Deactivate with `--no-lockfile-check`.
+      --metadata-description=<value>        Description of the changes in the deployment. Defaults to the commit message
+                                            of the latest commit if there are no uncommited changes.
+      --metadata-user=<value>               User that initiated the deployment. Will be saved and displayed in the
+                                            Shopify admin
+      --no-verify                           Skip the routability verification step after deployment.
+      --path=<value>                        The path to the directory of the Hydrogen storefront. Defaults to the
+                                            current directory where the command is run.
+      --preview                             Deploys to the Preview environment. Overrides --env-branch and Git metadata.
 
 DESCRIPTION
   Builds and deploys a Hydrogen storefront to Oxygen.
@@ -1053,7 +1059,7 @@ Creates a new Hydrogen storefront.
 ```
 USAGE
   $ shopify hydrogen init [-f] [--git] [--install-deps] [--language <value>] [--markets <value>] [--mock-shop]
-    [--path <value>] [--quickstart] [--routes] [--shortcut] [--template <value>]
+    [--path <value>] [--quickstart] [--routes] [--shortcut] [--styling <value>] [--template <value>]
 
 FLAGS
   -f, --force              Overwrites the destination directory and files if they already exist.
@@ -1070,6 +1076,8 @@ FLAGS
       --[no-]routes        Generate routes for all pages.
       --[no-]shortcut      Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with
                            `--no-shortcut`.
+      --styling=<value>    Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`,
+                           `postcss`, `none`.
       --template=<value>   Scaffolds project based on an existing template or example from the Hydrogen repository.
 
 DESCRIPTION
@@ -1208,8 +1216,8 @@ USAGE
   $ shopify hydrogen setup css [STRATEGY] [-f] [--install-deps] [--path <value>]
 
 ARGUMENTS
-  STRATEGY  (tailwind|css-modules|vanilla-extract|postcss) The CSS strategy to setup. One of
-            tailwind,css-modules,vanilla-extract,postcss
+  STRATEGY  (tailwind|vanilla-extract|css-modules|postcss) The CSS strategy to setup. One of
+            tailwind,vanilla-extract,css-modules,postcss
 
 FLAGS
   -f, --force              Overwrites the destination directory and files if they already exist.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -763,8 +763,8 @@ USAGE
     [--entry <value>] [--lockfile-check] [--path <value>] [--sourcemap] [--watch]
 
 FLAGS
-  --[no-]bundle-stats            Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to
-                                 disable.
+  --[no-]bundle-stats            [Classic Remix Compiler] Show a bundle size summary after building. Defaults to true,
+                                 use `--no-bundle-stats` to disable.
   --codegen                      Automatically generates GraphQL types for your project’s Storefront API queries.
   --codegen-config-path=<value>  Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if
                                  this file exists.
@@ -869,44 +869,38 @@ Builds and deploys a Hydrogen storefront to Oxygen.
 
 ```
 USAGE
-  $ shopify hydrogen deploy [--auth-bypass-token-duration <value> --auth-bypass-token] [--build-command <value>]
-    [--entry <value>] [--env <value> | --env-branch <value>] [--env-file <value>] [-f] [--json-output]
-    [--lockfile-check] [--metadata-description <value>] [--metadata-user <value>] [--no-verify] [--path <value>]
-    [--preview] [-s <value>] [-t <value>]
+  $ shopify hydrogen deploy [--auth-bypass-token] [--build-command <value>] [--entry <value>] [--env <value> |
+    --env-branch <value>] [--env-file <value>] [-f] [--json-output] [--lockfile-check] [--metadata-description <value>]
+    [--metadata-user <value>] [--no-verify] [--path <value>] [--preview] [-s <value>] [-t <value>]
 
 FLAGS
-  -f, --force                               Forces a deployment to proceed if there are uncommited changes in its Git
-                                            repository.
-  -s, --shop=<value>                        Shop URL. It can be the shop prefix (janes-apparel) or the full
-                                            myshopify.com URL (janes-apparel.myshopify.com,
-                                            https://janes-apparel.myshopify.com).
-  -t, --token=<value>                       Oxygen deployment token. Defaults to the linked storefront's token if
-                                            available.
-      --auth-bypass-token                   Generate an authentication bypass token, which can be used to perform
-                                            end-to-end tests against the deployment.
-      --auth-bypass-token-duration=<value>  Specify the duration (in hours) up to 12 hours for the authentication bypass
-                                            token. Defaults to `2`
-      --build-command=<value>               Specify a build command to run before deploying. If not specified, `shopify
-                                            hydrogen build` will be used.
-      --entry=<value>                       Entry file for the worker. Defaults to `./server`.
-      --env=<value>                         Specifies the environment to perform the operation using its handle. Fetch
-                                            the handle using the `env list` command.
-      --env-branch=<value>                  Specifies the environment to perform the operation using its Git branch
-                                            name.
-      --env-file=<value>                    Path to an environment file to override existing environment variables for
-                                            the deployment.
-      --[no-]json-output                    Create a JSON file containing the deployment details in CI environments.
-                                            Defaults to true, use `--no-json-output` to disable.
-      --[no-]lockfile-check                 Checks that there is exactly one valid lockfile in the project. Defaults to
-                                            `true`. Deactivate with `--no-lockfile-check`.
-      --metadata-description=<value>        Description of the changes in the deployment. Defaults to the commit message
-                                            of the latest commit if there are no uncommited changes.
-      --metadata-user=<value>               User that initiated the deployment. Will be saved and displayed in the
-                                            Shopify admin
-      --no-verify                           Skip the routability verification step after deployment.
-      --path=<value>                        The path to the directory of the Hydrogen storefront. Defaults to the
-                                            current directory where the command is run.
-      --preview                             Deploys to the Preview environment. Overrides --env-branch and Git metadata.
+  -f, --force                         Forces a deployment to proceed if there are uncommited changes in its Git
+                                      repository.
+  -s, --shop=<value>                  Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL
+                                      (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).
+  -t, --token=<value>                 Oxygen deployment token. Defaults to the linked storefront's token if available.
+      --auth-bypass-token             Generate an authentication bypass token, which can be used to perform end-to-end
+                                      tests against the deployment.
+      --build-command=<value>         Specify a build command to run before deploying. If not specified, `shopify
+                                      hydrogen build` will be used.
+      --entry=<value>                 Entry file for the worker. Defaults to `./server`.
+      --env=<value>                   Specifies the environment to perform the operation using its handle. Fetch the
+                                      handle using the `env list` command.
+      --env-branch=<value>            Specifies the environment to perform the operation using its Git branch name.
+      --env-file=<value>              Path to an environment file to override existing environment variables for the
+                                      deployment.
+      --[no-]json-output              Create a JSON file containing the deployment details in CI environments. Defaults
+                                      to true, use `--no-json-output` to disable.
+      --[no-]lockfile-check           Checks that there is exactly one valid lockfile in the project. Defaults to
+                                      `true`. Deactivate with `--no-lockfile-check`.
+      --metadata-description=<value>  Description of the changes in the deployment. Defaults to the commit message of
+                                      the latest commit if there are no uncommited changes.
+      --metadata-user=<value>         User that initiated the deployment. Will be saved and displayed in the Shopify
+                                      admin
+      --no-verify                     Skip the routability verification step after deployment.
+      --path=<value>                  The path to the directory of the Hydrogen storefront. Defaults to the current
+                                      directory where the command is run.
+      --preview                       Deploys to the Preview environment. Overrides --env-branch and Git metadata.
 
 DESCRIPTION
   Builds and deploys a Hydrogen storefront to Oxygen.
@@ -1059,7 +1053,7 @@ Creates a new Hydrogen storefront.
 ```
 USAGE
   $ shopify hydrogen init [-f] [--git] [--install-deps] [--language <value>] [--markets <value>] [--mock-shop]
-    [--path <value>] [--quickstart] [--routes] [--shortcut] [--styling <value>] [--template <value>]
+    [--path <value>] [--quickstart] [--routes] [--shortcut] [--template <value>]
 
 FLAGS
   -f, --force              Overwrites the destination directory and files if they already exist.
@@ -1076,8 +1070,6 @@ FLAGS
       --[no-]routes        Generate routes for all pages.
       --[no-]shortcut      Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with
                            `--no-shortcut`.
-      --styling=<value>    Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`,
-                           `postcss`, `none`.
       --template=<value>   Scaffolds project based on an existing template or example from the Hydrogen repository.
 
 DESCRIPTION
@@ -1216,8 +1208,8 @@ USAGE
   $ shopify hydrogen setup css [STRATEGY] [-f] [--install-deps] [--path <value>]
 
 ARGUMENTS
-  STRATEGY  (tailwind|vanilla-extract|css-modules|postcss) The CSS strategy to setup. One of
-            tailwind,vanilla-extract,css-modules,postcss
+  STRATEGY  (tailwind|css-modules|vanilla-extract|postcss) The CSS strategy to setup. One of
+            tailwind,css-modules,vanilla-extract,postcss
 
 FLAGS
   -f, --force              Overwrites the destination directory and files if they already exist.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -2522,7 +2522,7 @@
       "flags": {
         "bundle-stats": {
           "allowNo": true,
-          "description": "[Classic Remix Compiler] Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
+          "description": "Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
           "name": "bundle-stats",
           "type": "boolean"
         },
@@ -2815,9 +2815,22 @@
         "auth-bypass-token": {
           "allowNo": false,
           "description": "Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.",
+          "env": "AUTH_BYPASS_TOKEN",
           "name": "auth-bypass-token",
           "required": false,
           "type": "boolean"
+        },
+        "auth-bypass-token-duration": {
+          "dependsOn": [
+            "auth-bypass-token"
+          ],
+          "description": "Specify the duration (in hours) up to 12 hours for the authentication bypass token. Defaults to `2`",
+          "env": "AUTH_BYPASS_TOKEN_DURATION",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-bypass-token-duration",
+          "required": false,
+          "type": "option"
         },
         "build-command": {
           "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
@@ -3539,6 +3552,14 @@
           "name": "shortcut",
           "type": "boolean"
         },
+        "styling": {
+          "description": "Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`, `postcss`, `none`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_STYLING",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "styling",
+          "type": "option"
+        },
         "template": {
           "description": "Scaffolds project based on an existing template or example from the Hydrogen repository.",
           "env": "SHOPIFY_HYDROGEN_FLAG_TEMPLATE",
@@ -3907,12 +3928,12 @@
       ],
       "args": {
         "strategy": {
-          "description": "The CSS strategy to setup. One of tailwind,css-modules,vanilla-extract,postcss",
+          "description": "The CSS strategy to setup. One of tailwind,vanilla-extract,css-modules,postcss",
           "name": "strategy",
           "options": [
             "tailwind",
-            "css-modules",
             "vanilla-extract",
+            "css-modules",
             "postcss"
           ]
         }

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1620,6 +1620,14 @@
           "name": "graphiql-port",
           "type": "option"
         },
+        "json": {
+          "allowNo": false,
+          "char": "j",
+          "description": "Log the run result as a JSON object.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "name": "json",
+          "type": "boolean"
+        },
         "no-color": {
           "allowNo": false,
           "description": "Disable color output.",
@@ -2514,7 +2522,7 @@
       "flags": {
         "bundle-stats": {
           "allowNo": true,
-          "description": "Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
+          "description": "[Classic Remix Compiler] Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
           "name": "bundle-stats",
           "type": "boolean"
         },
@@ -2807,22 +2815,9 @@
         "auth-bypass-token": {
           "allowNo": false,
           "description": "Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.",
-          "env": "AUTH_BYPASS_TOKEN",
           "name": "auth-bypass-token",
           "required": false,
           "type": "boolean"
-        },
-        "auth-bypass-token-duration": {
-          "dependsOn": [
-            "auth-bypass-token"
-          ],
-          "description": "Specify the duration (in hours) up to 12 hours for the authentication bypass token. Defaults to `2`",
-          "env": "AUTH_BYPASS_TOKEN_DURATION",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "auth-bypass-token-duration",
-          "required": false,
-          "type": "option"
         },
         "build-command": {
           "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
@@ -3544,14 +3539,6 @@
           "name": "shortcut",
           "type": "boolean"
         },
-        "styling": {
-          "description": "Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`, `postcss`, `none`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_STYLING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "styling",
-          "type": "option"
-        },
         "template": {
           "description": "Scaffolds project based on an existing template or example from the Hydrogen repository.",
           "env": "SHOPIFY_HYDROGEN_FLAG_TEMPLATE",
@@ -3920,12 +3907,12 @@
       ],
       "args": {
         "strategy": {
-          "description": "The CSS strategy to setup. One of tailwind,vanilla-extract,css-modules,postcss",
+          "description": "The CSS strategy to setup. One of tailwind,css-modules,vanilla-extract,postcss",
           "name": "strategy",
           "options": [
             "tailwind",
-            "vanilla-extract",
             "css-modules",
+            "vanilla-extract",
             "postcss"
           ]
         }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-functions/issues/297

We need to support a `--json` flag for clients looking to plug into logs programatically with `jq` or similar. At the same time, we were reaching a critical mass (3) of poll clients each with their own unique error handling behaviour, and it was time to simplify and refactor them together.

### WHAT is this pull request doing?

- Adds `--json` flag
- Refactors poll clients to use a shared error handler
- Adds missing tests

### How to test your changes?

Tophatting is required for the three poll clients:
- `pnpm run shopify app dev`
- `pnpm run shopify app logs`
- `pnpm run shopify app logs --json`

For each, we'll need to test both with successful polling and errors returned from partners.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
  - Need to sync with product on this
