### PR TITLE
[Themes] Theme Console - Handle the REPL lifecycle

### DIFF
--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -1,7 +1,7 @@
 import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
-import {ensureReplEnv, repl} from '../../services/console.js'
+import {ensureReplEnv, initializeRepl} from '../../services/console.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
@@ -61,7 +61,7 @@ export default class Console extends ThemeCommand {
     if (flags['dev-preview']) {
       outputInfo('This feature is currently in development and is not ready for use or testing yet.')
       const {themeId, storePassword} = await ensureReplEnv(adminSession, flags['store-password'])
-      await repl(adminSession, storefrontToken, themeId, storePassword)
+      await initializeRepl(adminSession, storefrontToken, themeId, storePassword)
       return
     }
 

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -61,7 +61,7 @@ export default class Console extends ThemeCommand {
     if (flags['dev-preview']) {
       outputInfo('This feature is currently in development and is not ready for use or testing yet.')
       const {themeId, storePassword} = await ensureReplEnv(adminSession, flags['store-password'])
-      await initializeRepl(adminSession, storefrontToken, themeId, storePassword)
+      await initializeRepl(adminSession, storefrontToken, themeId, url, storePassword)
       return
     }
 

--- a/packages/theme/src/cli/services/console.test.ts
+++ b/packages/theme/src/cli/services/console.test.ts
@@ -54,7 +54,7 @@ describe('ensureReplEnv', () => {
     expect(storePassword).toBeUndefined()
   })
 
-  test('shoul return undefined for storePassword when password is provided but storefront is not password protected', async () => {
+  test('should return undefined for storePassword when password is provided but storefront is not password protected', async () => {
     // Given
     vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(false)
     vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -4,8 +4,8 @@ import {ensureValidPassword} from '../utilities/prompts.js'
 import {DevServerSession} from '../utilities/theme-environment/types.js'
 import {render} from '../utilities/theme-environment/storefront-renderer.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
-import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 import {consoleLog} from '@shopify/cli-kit/node/output'
+import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 export async function ensureReplEnv(adminSession: AdminSession, storePasswordFlag?: string) {
   const themeId = await findOrCreateReplTheme(adminSession)
@@ -33,6 +33,16 @@ export async function repl(
   themeId: string,
   password: string | undefined,
 ) {
+  consoleLog('Welcome to Shopify Liquid console\n(press Ctrl + C to exit)')
+  return replLoop(adminSession, storefrontToken, themeId, password)
+}
+
+async function replLoop(
+  adminSession: AdminSession,
+  storefrontToken: string,
+  themeId: string,
+  password: string | undefined,
+) {
   const inputValue = await renderTextPrompt({message: 'Enter a value'})
   const evaluatedValue = await evaluate(inputValue, adminSession, storefrontToken, themeId, password)
   const regex = />([^<]+)</
@@ -41,7 +51,7 @@ export async function repl(
   if (match && match[1]) {
     consoleLog(match[1])
   }
-  return repl(adminSession, storefrontToken, themeId, password)
+  return replLoop(adminSession, storefrontToken, themeId, password)
 }
 
 export async function evaluate(

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -30,6 +30,7 @@ export async function initializeRepl(
   adminSession: AdminSession,
   storefrontToken: string,
   themeId: string,
+  url: string,
   password: string | undefined,
 ) {
   consoleLog('Welcome to Shopify Liquid console\n(press Ctrl + C to exit)')
@@ -39,5 +40,5 @@ export async function initializeRepl(
     storefrontPassword: password,
     expiresAt: new Date(),
   }
-  return replLoop(themeSession, storefrontToken, themeId, password)
+  return replLoop(themeSession, storefrontToken, themeId, url)
 }

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -40,5 +40,5 @@ export async function initializeRepl(
     storefrontPassword: password,
     expiresAt: new Date(),
   }
-  return replLoop(themeSession, storefrontToken, themeId, url)
+  return replLoop(themeSession, themeId, url)
 }

--- a/packages/theme/src/cli/services/console.ts
+++ b/packages/theme/src/cli/services/console.ts
@@ -1,7 +1,11 @@
 import {isStorefrontPasswordProtected} from '../utilities/theme-environment/storefront-session.js'
 import {REPLThemeManager} from '../utilities/repl-theme-manager.js'
 import {ensureValidPassword} from '../utilities/prompts.js'
+import {DevServerSession} from '../utilities/theme-environment/types.js'
+import {render} from '../utilities/theme-environment/storefront-renderer.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
+import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
+import {consoleLog} from '@shopify/cli-kit/node/output'
 
 export async function ensureReplEnv(adminSession: AdminSession, storePasswordFlag?: string) {
   const themeId = await findOrCreateReplTheme(adminSession)
@@ -24,8 +28,48 @@ async function findOrCreateReplTheme(adminSession: AdminSession): Promise<string
 }
 
 export async function repl(
-  _adminSession: AdminSession,
-  _storefrontToken: string,
-  _themeId: string,
-  _password: string | undefined,
-) {}
+  adminSession: AdminSession,
+  storefrontToken: string,
+  themeId: string,
+  password: string | undefined,
+) {
+  const inputValue = await renderTextPrompt({message: 'Enter a value'})
+  const evaluatedValue = await evaluate(inputValue, adminSession, storefrontToken, themeId, password)
+  const regex = />([^<]+)</
+  const match = evaluatedValue.match(regex)
+
+  if (match && match[1]) {
+    consoleLog(match[1])
+  }
+  return repl(adminSession, storefrontToken, themeId, password)
+}
+
+export async function evaluate(
+  snippet: string,
+  adminSession: AdminSession,
+  storefrontToken: string,
+  themeId: string,
+  password: string | undefined,
+) {
+  const session: DevServerSession = {
+    ...adminSession,
+    storefrontToken,
+    storefrontPassword: password,
+    expiresAt: new Date(),
+  }
+
+  const response = await render(session, {
+    path: '/',
+    query: [],
+    themeId,
+    cookies: '',
+    sectionId: 'announcement-bar',
+
+    headers: {},
+    replaceTemplates: {
+      'sections/announcement-bar.liquid': `{{ ${snippet} }}`,
+    },
+  })
+
+  return response.text()
+}

--- a/packages/theme/src/cli/utilities/repl.test.ts
+++ b/packages/theme/src/cli/utilities/repl.test.ts
@@ -1,0 +1,44 @@
+import {replLoop} from './repl.js'
+import {DevServerSession} from './theme-environment/types.js'
+import {evaluate} from './repl/evaluater.js'
+import {consoleWarn, outputDebug, outputInfo} from '@shopify/cli-kit/node/output'
+import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
+import {describe, expect, test, vi} from 'vitest'
+import {AbortSilentError} from '@shopify/cli-kit/node/error'
+
+vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('@shopify/cli-kit/node/output')
+vi.mock('./repl/evaluater')
+
+describe('repl', () => {
+  const themeSession = {} as DevServerSession
+  const themeId = 'themeId'
+  const url = 'url'
+
+  test('replLoop should call consoleWarn and return when inputValue has delimiter', async () => {
+    // Given
+    vi.mocked(renderTextPrompt).mockResolvedValueOnce('{{ collections.first }}')
+    vi.mocked(evaluate).mockRejectedValueOnce(new Error('Some error'))
+
+    // When
+    await expect(replLoop(themeSession, themeId, url)).rejects.toThrowError()
+
+    // Then
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "Liquid Console doesn't support Liquid delimiters such as '{{ ... }}' or '{% ... %}'.\nPlease use 'collections.first' instead of '{{ collections.first }}'.",
+    )
+  })
+
+  test('replLoop should call shutdownReplSession and throw AbortSilentError on error', async () => {
+    // Given
+    vi.mocked(renderTextPrompt).mockResolvedValueOnce('some value')
+    vi.mocked(evaluate).mockRejectedValueOnce(new Error('Some error'))
+
+    // When
+    await expect(replLoop(themeSession, themeId, url)).rejects.toThrow(AbortSilentError)
+
+    // Then
+    expect(outputInfo).toHaveBeenCalled()
+    expect(outputDebug).toHaveBeenCalled()
+  })
+})

--- a/packages/theme/src/cli/utilities/repl.ts
+++ b/packages/theme/src/cli/utilities/repl.ts
@@ -1,28 +1,50 @@
 import {DevServerSession} from './theme-environment/types.js'
-import {presentValue} from './repl/presenter.js'
 import {evaluate} from './repl/evaluater.js'
+import {presentValue} from './repl/presenter.js'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
 import {consoleWarn, outputContent, outputDebug, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
-import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
+import {createInterface, Interface} from 'readline'
 
 export async function replLoop(themeSession: DevServerSession, themeId: string, url: string) {
   try {
-    const inputValue = await renderTextPrompt({message: 'Enter a value'})
-    if (hasDelimiter(inputValue)) {
-      consoleWarn(
-        "Liquid Console doesn't support Liquid delimiters such as '{{ ... }}' or '{% ... %}'.\nPlease use 'collections.first' instead of '{{ collections.first }}'.",
-      )
-      return replLoop(themeSession, themeId, url)
+    if (process.stdin.isTTY) {
+      // We want to indicate that we're still using stdin, so that the process
+      // doesn't exit early.
+      process.stdin.ref()
     }
 
-    const evaluatedValue = await evaluate(themeSession, inputValue, themeId, url)
-    presentValue(evaluatedValue)
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    })
 
-    return replLoop(themeSession, themeId, url)
+    rl.on('line', (input) => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      handleInput(input, themeSession, themeId, url, rl)
+    })
+    rl.prompt()
   } catch (error) {
     shutdownReplSession(error)
     throw new AbortSilentError()
   }
+}
+
+export async function handleInput(
+  inputValue: string,
+  themeSession: DevServerSession,
+  themeId: string,
+  url: string,
+  rl: Interface,
+) {
+  if (hasDelimiter(inputValue)) {
+    consoleWarn(
+      "Liquid Console doesn't support Liquid delimiters such as '{{ ... }}' or '{% ... %}'.\nPlease use 'collections.first' instead of '{{ collections.first }}'.",
+    )
+    return rl.prompt()
+  }
+  const evaluatedValue = await evaluate(themeSession, inputValue, themeId, url)
+  presentValue(evaluatedValue)
+  rl.prompt()
 }
 
 function shutdownReplSession(error: unknown) {

--- a/packages/theme/src/cli/utilities/repl.ts
+++ b/packages/theme/src/cli/utilities/repl.ts
@@ -1,15 +1,11 @@
 import {render} from './theme-environment/storefront-renderer.js'
 import {DevServerSession} from './theme-environment/types.js'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
-import {consoleWarn, consoleError, outputDebug} from '@shopify/cli-kit/node/output'
+import {consoleWarn, consoleError, outputDebug, consoleLog} from '@shopify/cli-kit/node/output'
 import {renderText, renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
-export async function replLoop(
-  themeSession: DevServerSession,
-  storefrontToken: string,
-  themeId: string,
-  password: string | undefined,
-) {
+// todo - combine config into a single arg
+export async function replLoop(themeSession: DevServerSession, storefrontToken: string, themeId: string, url: string) {
   try {
     const inputValue = await renderTextPrompt({message: 'Enter a value'})
     if (hasDelimiter(inputValue)) {
@@ -17,25 +13,29 @@ export async function replLoop(
         "Liquid Console doesn't support Liquid delimiters such as '{{ ... }}' or '{% ... %}'.\nPlease use 'collections.first' instead of '{{ collections.first }}'.",
       )
     }
-    const evaluatedValue = await evaluate(themeSession, inputValue, themeId)
+    const evaluatedValue = await evaluate(themeSession, inputValue, themeId, url)
     presentEvaluatedValue(evaluatedValue)
-    return replLoop(themeSession, storefrontToken, themeId, password)
+    return replLoop(themeSession, storefrontToken, themeId, url)
   } catch (error) {
     shutdownReplSession(error)
     throw new AbortSilentError()
   }
 }
 
+// todo - figure out how to print cyan
+// todo - handle JSON errors
 function presentEvaluatedValue(evaluatedValue: string) {
   if (evaluatedValue === 'null') {
     renderText({text: 'null'})
     return
   }
+
   const regex = />([^<]+)</
   const match = evaluatedValue.match(regex)
 
   if (match && match[1]) {
-    renderText({text: match[1]})
+    const jsonValue = JSON.parse(match[1])
+    consoleLog(jsonValue)
   }
 }
 
@@ -52,14 +52,14 @@ function hasDelimiter(input: string): boolean {
   return /\{\{|\}\}|\{%|%\}/.test(input)
 }
 
-export async function evaluate(themeSession: DevServerSession, snippet: string, themeId: string) {
-  return evaluateResult(themeSession, themeId, snippet)
+export async function evaluate(themeSession: DevServerSession, snippet: string, themeId: string, url: string) {
+  return evaluateResult(themeSession, themeId, snippet, url)
 }
 
-async function evaluateResult(themeSession: DevServerSession, themeId: string, snippet: string) {
+async function evaluateResult(themeSession: DevServerSession, themeId: string, snippet: string, url: string) {
   outputDebug(`Evaluating snippet - ${snippet}`)
   const response = await render(themeSession, {
-    path: '/',
+    path: url,
     query: [],
     themeId,
     cookies: '',

--- a/packages/theme/src/cli/utilities/repl.ts
+++ b/packages/theme/src/cli/utilities/repl.ts
@@ -1,0 +1,74 @@
+import {render} from './theme-environment/storefront-renderer.js'
+import {DevServerSession} from './theme-environment/types.js'
+import {AbortSilentError} from '@shopify/cli-kit/node/error'
+import {consoleWarn, consoleError, outputDebug} from '@shopify/cli-kit/node/output'
+import {renderText, renderTextPrompt} from '@shopify/cli-kit/node/ui'
+
+export async function replLoop(
+  themeSession: DevServerSession,
+  storefrontToken: string,
+  themeId: string,
+  password: string | undefined,
+) {
+  try {
+    const inputValue = await renderTextPrompt({message: 'Enter a value'})
+    if (hasDelimiter(inputValue)) {
+      consoleWarn(
+        "Liquid Console doesn't support Liquid delimiters such as '{{ ... }}' or '{% ... %}'.\nPlease use 'collections.first' instead of '{{ collections.first }}'.",
+      )
+    }
+    const evaluatedValue = await evaluate(themeSession, inputValue, themeId)
+    presentEvaluatedValue(evaluatedValue)
+    return replLoop(themeSession, storefrontToken, themeId, password)
+  } catch (error) {
+    shutdownReplSession(error)
+    throw new AbortSilentError()
+  }
+}
+
+function presentEvaluatedValue(evaluatedValue: string) {
+  if (evaluatedValue === 'null') {
+    renderText({text: 'null'})
+    return
+  }
+  const regex = />([^<]+)</
+  const match = evaluatedValue.match(regex)
+
+  if (match && match[1]) {
+    renderText({text: match[1]})
+  }
+}
+
+function shutdownReplSession(error: unknown) {
+  if (error instanceof Error) {
+    const errorMessage = `Shopify Liquid console error: ${error.message}`
+    const backtrace = error.stack || 'Error backtrace not found'
+    consoleError(errorMessage)
+    outputDebug(backtrace)
+  }
+}
+
+function hasDelimiter(input: string): boolean {
+  return /\{\{|\}\}|\{%|%\}/.test(input)
+}
+
+export async function evaluate(themeSession: DevServerSession, snippet: string, themeId: string) {
+  return evaluateResult(themeSession, themeId, snippet)
+}
+
+async function evaluateResult(themeSession: DevServerSession, themeId: string, snippet: string) {
+  outputDebug(`Evaluating snippet - ${snippet}`)
+  const response = await render(themeSession, {
+    path: '/',
+    query: [],
+    themeId,
+    cookies: '',
+    sectionId: 'announcement-bar',
+    headers: {},
+    replaceTemplates: {
+      'sections/announcement-bar.liquid': `{{ ${snippet} | json }}`,
+    },
+  })
+
+  return response.text()
+}

--- a/packages/theme/src/cli/utilities/repl.ts
+++ b/packages/theme/src/cli/utilities/repl.ts
@@ -1,6 +1,6 @@
-import {render} from './theme-environment/storefront-renderer.js'
 import {DevServerSession} from './theme-environment/types.js'
 import {presentValue} from './repl/presenter.js'
+import {evaluate} from './repl/evaluater.js'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
 import {consoleWarn, consoleError, outputDebug} from '@shopify/cli-kit/node/output'
 import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
@@ -36,37 +36,4 @@ function shutdownReplSession(error: unknown) {
 
 function hasDelimiter(input: string): boolean {
   return /\{\{|\}\}|\{%|%\}/.test(input)
-}
-
-async function evaluate(
-  themeSession: DevServerSession,
-  snippet: string,
-  themeId: string,
-  url: string,
-): Promise<string | undefined> {
-  const result = await evaluateResult(themeSession, themeId, snippet, url)
-
-  const regex = />([^<]+)</
-  const match = result.match(regex)
-
-  if (match && match[1]) {
-    return JSON.parse(match[1])
-  }
-}
-
-async function evaluateResult(themeSession: DevServerSession, themeId: string, snippet: string, url: string) {
-  outputDebug(`Evaluating snippet - ${snippet}`)
-  const response = await render(themeSession, {
-    path: url,
-    query: [],
-    themeId,
-    cookies: '',
-    sectionId: 'announcement-bar',
-    headers: {},
-    replaceTemplates: {
-      'sections/announcement-bar.liquid': `{{ ${snippet} | json }}`,
-    },
-  })
-
-  return response.text()
 }

--- a/packages/theme/src/cli/utilities/repl.ts
+++ b/packages/theme/src/cli/utilities/repl.ts
@@ -2,7 +2,7 @@ import {DevServerSession} from './theme-environment/types.js'
 import {presentValue} from './repl/presenter.js'
 import {evaluate} from './repl/evaluater.js'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
-import {consoleWarn, consoleError, outputDebug} from '@shopify/cli-kit/node/output'
+import {consoleWarn, outputContent, outputDebug, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
 import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 export async function replLoop(themeSession: DevServerSession, themeId: string, url: string) {
@@ -27,10 +27,8 @@ export async function replLoop(themeSession: DevServerSession, themeId: string, 
 
 function shutdownReplSession(error: unknown) {
   if (error instanceof Error) {
-    const errorMessage = `Shopify Liquid console error: ${error.message}`
-    const backtrace = error.stack || 'Error backtrace not found'
-    consoleError(errorMessage)
-    outputDebug(backtrace)
+    outputInfo(outputContent`${outputToken.errorText(`Shopify Liquid console error: ${error.message}`)}`)
+    outputDebug(error.stack || 'Error backtrace not found')
   }
 }
 

--- a/packages/theme/src/cli/utilities/repl.ts
+++ b/packages/theme/src/cli/utilities/repl.ts
@@ -11,12 +11,7 @@ import {
 } from '@shopify/cli-kit/node/output'
 import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
-interface ErrorOutput {
-  error?: string
-}
-
-// todo - combine config into a single arg
-export async function replLoop(themeSession: DevServerSession, storefrontToken: string, themeId: string, url: string) {
+export async function replLoop(themeSession: DevServerSession, themeId: string, url: string) {
   try {
     const inputValue = await renderTextPrompt({message: 'Enter a value'})
     if (hasDelimiter(inputValue)) {
@@ -26,7 +21,7 @@ export async function replLoop(themeSession: DevServerSession, storefrontToken: 
     }
     const evaluatedValue = await evaluate(themeSession, inputValue, themeId, url)
     presentEvaluatedValue(evaluatedValue)
-    return replLoop(themeSession, storefrontToken, themeId, url)
+    return replLoop(themeSession, themeId, url)
   } catch (error) {
     shutdownReplSession(error)
     throw new AbortSilentError()
@@ -73,7 +68,7 @@ function hasJsonError(output: unknown): boolean {
       if (Array.isArray(output)) {
         return hasJsonError(output[0])
       } else if (output !== null) {
-        const errorOutput = output as ErrorOutput
+        const errorOutput = output as {error?: string}
         return errorOutput.error?.includes('json not allowed for this object') ?? false
       }
       return false
@@ -82,7 +77,7 @@ function hasJsonError(output: unknown): boolean {
   }
 }
 
-export async function evaluate(
+async function evaluate(
   themeSession: DevServerSession,
   snippet: string,
   themeId: string,

--- a/packages/theme/src/cli/utilities/repl/evaluater.ts
+++ b/packages/theme/src/cli/utilities/repl/evaluater.ts
@@ -14,6 +14,7 @@ export async function evaluate(
     // eslint-disable-next-line no-catch-all/no-catch-all, @typescript-eslint/no-explicit-any
   } catch (error: any) {
     outputInfo(outputContent`${outputToken.errorText(error.message)}`)
+    outputDebug(error.stack || 'Error backtrace not found')
   }
 }
 

--- a/packages/theme/src/cli/utilities/repl/evaluater.ts
+++ b/packages/theme/src/cli/utilities/repl/evaluater.ts
@@ -1,0 +1,44 @@
+import {render} from '../theme-environment/storefront-renderer.js'
+import {DevServerSession} from '../theme-environment/types.js'
+import {outputContent, outputDebug, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
+
+export async function evaluate(
+  themeSession: DevServerSession,
+  snippet: string,
+  themeId: string,
+  url: string,
+): Promise<string | undefined> {
+  const result = await evaluateResult(themeSession, themeId, snippet, url)
+  try {
+    return sanitizeResult(result)
+    // eslint-disable-next-line no-catch-all/no-catch-all, @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    outputInfo(outputContent`${outputToken.errorText(error.message)}`)
+  }
+}
+
+async function evaluateResult(themeSession: DevServerSession, themeId: string, snippet: string, url: string) {
+  outputDebug(`Evaluating snippet - ${snippet}`)
+  const response = await render(themeSession, {
+    path: url,
+    query: [],
+    themeId,
+    cookies: '',
+    sectionId: 'announcement-bar',
+    headers: {},
+    replaceTemplates: {
+      'sections/announcement-bar.liquid': `{{ ${snippet} | json }}`,
+    },
+  })
+
+  return response.text()
+}
+
+function sanitizeResult(result: string) {
+  const regex = />([^<]+)</
+  const match = result.match(regex)
+
+  if (match && match[1]) {
+    return JSON.parse(match[1])
+  }
+}

--- a/packages/theme/src/cli/utilities/repl/presenter.test.ts
+++ b/packages/theme/src/cli/utilities/repl/presenter.test.ts
@@ -1,0 +1,59 @@
+import {presentValue} from './presenter.js'
+import {consoleWarn, outputContent, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/output')
+
+describe('presentValue', () => {
+  test('should print a warning message if value has a JSON error', () => {
+    // Given
+    const value = {error: 'json not allowed for this object'}
+
+    // When
+    presentValue(value)
+
+    // Then
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "Object can't be printed, but you can access its fields. Read more at https://shopify.dev/docs/api/liquid.",
+    )
+    expect(outputInfo).not.toHaveBeenCalled()
+  })
+
+  test('should print "null" if value is undefined', () => {
+    // Given
+    const value = undefined
+
+    // When
+    presentValue(value)
+
+    // Then
+    expect(outputInfo).toHaveBeenCalledWith(outputContent`${outputToken.cyan('null')}`)
+    expect(consoleWarn).not.toHaveBeenCalled()
+  })
+
+  // if null
+  test('should print "null" if value is null', () => {
+    // Given
+    const value = null
+
+    // When
+    presentValue(value)
+
+    // Then
+    expect(outputInfo).toHaveBeenCalledWith(outputContent`${outputToken.cyan('null')}`)
+    expect(consoleWarn).not.toHaveBeenCalled()
+  })
+
+  test('should print the formatted output if value is not undefined, null, or has a JSON error', () => {
+    // Given
+    const value = {foo: 'bar'}
+    const formattedOutput = JSON.stringify(value, null, 2)
+
+    // When
+    presentValue(value)
+
+    // Then
+    expect(outputInfo).toHaveBeenCalledWith(outputContent`${outputToken.cyan(formattedOutput)}`)
+    expect(consoleWarn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/theme/src/cli/utilities/repl/presenter.ts
+++ b/packages/theme/src/cli/utilities/repl/presenter.ts
@@ -1,0 +1,37 @@
+import {consoleWarn, outputContent, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
+
+export function presentValue(value?: unknown) {
+  if (hasJsonError(value)) {
+    consoleWarn(
+      "Object can't be printed, but you can access its fields. Read more at https://shopify.dev/docs/api/liquid.",
+    )
+    return
+  }
+
+  if (value === undefined || value === null) {
+    renderValue('null')
+    return
+  }
+
+  const formattedOutput = JSON.stringify(value, null, 2)
+  renderValue(formattedOutput)
+}
+
+function hasJsonError(output: unknown): boolean {
+  switch (typeof output) {
+    case 'object':
+      if (Array.isArray(output)) {
+        return hasJsonError(output[0])
+      } else if (output !== null) {
+        const errorOutput = output as {error?: string}
+        return errorOutput.error?.includes('json not allowed for this object') ?? false
+      }
+      return false
+    default:
+      return false
+  }
+}
+
+function renderValue(value: string) {
+  return outputInfo(outputContent`${outputToken.cyan(value)}`)
+}


### PR DESCRIPTION
### WHY are these changes introduced?
- https://github.com/Shopify/develop-advanced-edits/issues/259

### WHAT is this pull request doing?
EDIT - _This has been modified to use `readline` to accept console inputs _
https://github.com/user-attachments/assets/0645b141-be79-4c82-aff9-84797e1fb9fb


### How to test your changes?
1) Checkout the branch
2) `pnpm shopify theme console --dev-preview`
3) Play around with the console. Note that the error messages will change as the evaluator is implemented. (There are also different layers - the shutdown message, which stops the loop (hard to trigger) and the graceful message which catches the error and keeps the loop going.

Some ideas
- Delimiter - `{{ collections.first }}` or `{% x %}`
- Null value - `f`
- Something that will error out - `JSON(`
- Please feel free to suggest more cases!


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
