### PR TITLE
Add wasm asset support for theme app extensions

### DIFF
--- a/.changeset/breezy-clouds-shave.md
+++ b/.changeset/breezy-clouds-shave.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': minor
+---
+
+
+Introduce `.wasm` asset support for theme app extensions

--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -42,7 +42,7 @@ const BUNDLE_SIZE_LIMIT = BUNDLE_SIZE_LIMIT_MB * megabytes
 const LIQUID_SIZE_LIMIT_KB = 500
 const LIQUID_SIZE_LIMIT = LIQUID_SIZE_LIMIT_KB * kilobytes
 
-const SUPPORTED_ASSET_EXTS = ['.jpg', '.jpeg', '.json', '.js', '.css', '.png', '.svg']
+const SUPPORTED_ASSET_EXTS = ['.jpg', '.jpeg', '.json', '.js', '.css', '.png', '.svg', '.wasm']
 const SUPPORTED_LOCALE_EXTS = ['.json']
 const SUPPORTED_EXTS: {[dirname: string]: FilenameValidation} = {
   assets: {

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -54,6 +54,7 @@ export async function fileServerMiddleware(
     '.html': 'text/html',
     '.js': 'text/javascript',
     '.json': 'application/json',
+    '.wasm': 'application/wasm',
     '.css': 'text/css',
     '.png': 'image/png',
     '.jpg': 'image/jpeg',

--- a/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -16,7 +16,7 @@ module Extension
         SUPPORTED_BUCKETS = %w(assets blocks snippets locales)
         BUNDLE_SIZE_LIMIT = 10 * 1024 * 1024 # 10MB
         LIQUID_SIZE_LIMIT = 100 * 1024 # 100kb
-        SUPPORTED_ASSET_EXTS = %w(.jpg .jpeg .js .json .css .png .svg)
+        SUPPORTED_ASSET_EXTS = %w(.jpg .jpeg .js .json .css .png .svg .wasm)
         SUPPORTED_LOCALE_EXTS = %w(.json)
 
         def create(directory_name, context, getting_started: false)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves #3893 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds `.wasm` asset support to theme app extensions. Another PR has already been shipped to enable this upstream



<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

* Create a new app with a theme app extension
* Add a .wasm file in the assets folder
* Run the app dev command
* Notice the theme app extension is pushed as expected


<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

None
<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
