### PR TITLE
Add marketing activity extension migration logic

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -143,6 +143,7 @@
           "fulfillment_constraints",
           "local_pickup_delivery_option_generator",
           "pickup_point_delivery_option_generator",
+          "marketing_activity_extension_cli"
         ],
         "default": "checkout_ui_extension",
     },

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -21,6 +21,7 @@ import paymentExtensionSpec from './specifications/payments_app_extension.js'
 import posUISpec from './specifications/pos_ui_extension.js'
 import productSubscriptionSpec from './specifications/product_subscription.js'
 import taxCalculationSpec from './specifications/tax_calculation.js'
+import marketingActivityExtensionSpec from './specifications/marketing_activity_extension.js'
 import themeSpec from './specifications/theme.js'
 import uiExtensionSpec from './specifications/ui_extension.js'
 import webPixelSpec from './specifications/web_pixel_extension.js'
@@ -72,6 +73,7 @@ function loadSpecifications() {
     posUISpec,
     productSubscriptionSpec,
     taxCalculationSpec,
+    marketingActivityExtensionSpec,
     themeSpec,
     uiExtensionSpec,
     webPixelSpec,

--- a/packages/app/src/cli/models/extensions/specifications/marketing_activity_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/marketing_activity_extension.ts
@@ -1,0 +1,24 @@
+import {MarketingActivityExtensionSchema} from './marketing_activity_extension_schemas/marketing_activity_extension_schema.js'
+import {createExtensionSpecification} from '../specification.js'
+
+const spec = createExtensionSpecification({
+  identifier: 'marketing_activity_extension_cli',
+  schema: MarketingActivityExtensionSchema,
+  appModuleFeatures: (_) => ['bundling'],
+  deployConfig: async (config, _) => {
+    return {
+      title: config.title,
+      description: config.description,
+      app_api_url: config.app_api_url,
+      tactic: config.tactic,
+      marketing_channel: config.marketing_channel,
+      referring_domain: config.referring_domain,
+      is_automation: config.is_automation,
+      use_external_editor: config.use_external_editor,
+      preview_data: config.preview_data,
+      fields: config.fields,
+    }
+  },
+})
+
+export default spec

--- a/packages/app/src/cli/models/extensions/specifications/marketing_activity_extension_schemas/marketing_activity_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/marketing_activity_extension_schemas/marketing_activity_extension_schema.test.ts
@@ -1,0 +1,159 @@
+import {MarketingActivityExtensionSchema} from './marketing_activity_extension_schema.js'
+import {describe, expect, test} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+describe('MarketingActivityExtensionSchema', () => {
+  const config = {
+    name: 'test extension',
+    type: 'marketing_activity_extension',
+    title: 'test extension 123',
+    description: 'test description 123',
+    app_api_url: 'http://foo.bar/api',
+    tactic: 'ad',
+    marketing_channel: 'social',
+    referring_domain: 'http://foo.bar',
+    is_automation: false,
+    use_external_editor: false,
+    preview_data: {
+      types: [
+        {
+          label: 'mobile',
+          value: 'http://foo.bar/preview',
+        },
+      ],
+    },
+    fields: [
+      {
+        id: '123',
+        ui_type: 'text-single-line',
+        name: 'test_field',
+        label: 'test field',
+        help_text: 'help text',
+        required: false,
+        min_length: 1,
+        max_length: 50,
+        placeholder: 'placeholder',
+      },
+    ],
+  }
+
+  test('validates a configuration with valid fields', async () => {
+    // When
+    const {success} = MarketingActivityExtensionSchema.safeParse(config)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  describe('fields', () => {
+    test('throws an error if a field is not an object', async () => {
+      // When/Then
+      expect(() =>
+        MarketingActivityExtensionSchema.parse({
+          ...config,
+          fields: ['not an object'],
+        }),
+      ).toThrowError(
+        new zod.ZodError([
+          {
+            message: 'Field must be an object',
+            code: zod.ZodIssueCode.custom,
+            path: ['fields', 0],
+          },
+        ]),
+      )
+    })
+
+    test('throws an error if no fields are defined', async () => {
+      // When/Then
+      expect(() =>
+        MarketingActivityExtensionSchema.parse({
+          ...config,
+          fields: [],
+        }),
+      ).toThrowError(
+        new zod.ZodError([
+          {
+            code: zod.ZodIssueCode.too_small,
+            minimum: 1,
+            type: 'array',
+            inclusive: true,
+            exact: false,
+            message: 'Array must contain at least 1 element(s)',
+            path: ['fields'],
+          },
+        ]),
+      )
+    })
+
+    test('throws an error if field does not have ui_type', async () => {
+      // When/Then
+      expect(() =>
+        MarketingActivityExtensionSchema.parse({
+          ...config,
+          fields: [
+            {
+              ...config.fields[0],
+              ui_type: undefined,
+            },
+          ],
+        }),
+      ).toThrowError(
+        new zod.ZodError([
+          {
+            message: 'Field must have a ui_type',
+            code: zod.ZodIssueCode.custom,
+            path: ['fields', 0],
+          },
+        ]),
+      )
+    })
+
+    test('throws an error if ui_type is not supported', async () => {
+      // When/Then
+      expect(() =>
+        MarketingActivityExtensionSchema.parse({
+          ...config,
+          fields: [
+            {
+              ...config.fields[0],
+              ui_type: 'not_a_ui_type',
+            },
+          ],
+        }),
+      ).toThrowError(
+        new zod.ZodError([
+          {
+            message: 'Unknown ui_type for Field: not_a_ui_type',
+            code: zod.ZodIssueCode.custom,
+            path: ['fields', 0],
+          },
+        ]),
+      )
+    })
+
+    test('throws an error if the schema for the ui_type is invalid', async () => {
+      // When/Then
+      expect(() =>
+        MarketingActivityExtensionSchema.parse({
+          ...config,
+          fields: [
+            {
+              ...config.fields[0],
+              min_length: false,
+            },
+          ],
+        }),
+      ).toThrowError(
+        new zod.ZodError([
+          {
+            message:
+              'Error found on Field "test_field": [\n  {\n    "code": "invalid_type",\n    "expected": "number",\n    "received": "boolean",\n    "path": [\n      "min_length"\n    ],\n    "message": "Expected number, received boolean"\n  }\n]',
+            code: zod.ZodIssueCode.custom,
+            path: ['fields', 0],
+          },
+        ]),
+      )
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/marketing_activity_extension_schemas/marketing_activity_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/marketing_activity_extension_schemas/marketing_activity_extension_schema.ts
@@ -1,0 +1,187 @@
+import {BaseSchema} from '../../schemas.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const BaseFieldSchema = zod.object({
+  id: zod.string(),
+  ui_type: zod.string(),
+})
+
+const CommonFieldSchema = BaseFieldSchema.extend({
+  name: zod.string(),
+  label: zod.string(),
+  help_text: zod.string().optional(),
+  required: zod.boolean(),
+})
+
+const BudgetScheduleFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.literal('budget-schedule'),
+  use_scheduling: zod.boolean(),
+  use_end_date: zod.boolean(),
+  use_daily_budget: zod.boolean(),
+  use_lifetime_budget: zod.boolean(),
+})
+
+const DiscountPickerFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.literal('discount-picker'),
+  min_resources: zod.number().nullable(),
+  max_resources: zod.number().nullable(),
+})
+
+const ScheduleFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.literal('schedule'),
+  use_end_date: zod.boolean(),
+})
+
+const ProductPickerFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.literal('product-picker'),
+  allow_product_image_selection: zod.boolean(),
+  allow_uploaded_image_as_product_image: zod.boolean(),
+  allow_free_image_as_product_image: zod.boolean(),
+  min_resources: zod.number().optional(),
+  max_resources: zod.number().optional(),
+  min_image_select_per_product: zod.number().optional(),
+  max_image_select_per_product: zod.number().optional(),
+})
+
+const SingleLineTextFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.enum(['text-single-line', 'text-email', 'text-tel', 'text-url']),
+  placeholder: zod.string().optional(),
+  min_length: zod.number(),
+  max_length: zod.number(),
+})
+
+const TextMultiLineFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.literal('text-multi-line'),
+  placeholder: zod.string(),
+  min_length: zod.number(),
+  max_length: zod.number(),
+})
+
+const DividerFieldSchema = BaseFieldSchema.extend({
+  ui_type: zod.literal('divider'),
+  title: zod.string(),
+  name: zod.string(),
+})
+
+const SelectFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.enum(['select-single', 'select-multiple']),
+  choices: zod.array(
+    zod.object({
+      label: zod.string(),
+      value: zod.string(),
+    }),
+  ),
+})
+
+const ParagraphFieldSchema = BaseFieldSchema.extend({
+  ui_type: zod.literal('paragraph'),
+  heading: zod.string().optional(),
+  body: zod.string().optional(),
+})
+
+const TypeAheadFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.literal('type-ahead'),
+  placeholder: zod.string(),
+})
+
+const NumberFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.enum(['number-float', 'number-integer']),
+  min: zod.number(),
+  max: zod.number(),
+  step: zod.number(),
+})
+
+const ImagePickerFieldSchema = CommonFieldSchema.extend({
+  ui_type: zod.literal('image-picker'),
+  min_resources: zod.number(),
+  max_resources: zod.number(),
+  allow_free_images: zod.boolean(),
+  alt_text_required: zod.boolean(),
+})
+
+const UISchemaMapping: {[key: string]: zod.Schema} = {
+  'budget-schedule': BudgetScheduleFieldSchema,
+  'discount-picker': DiscountPickerFieldSchema,
+  schedule: ScheduleFieldSchema,
+  'product-picker': ProductPickerFieldSchema,
+  'text-single-line': SingleLineTextFieldSchema,
+  'text-email': SingleLineTextFieldSchema,
+  'text-tel': SingleLineTextFieldSchema,
+  'text-url': SingleLineTextFieldSchema,
+  'text-multi-line': TextMultiLineFieldSchema,
+  'select-single': SelectFieldSchema,
+  'select-multiple': SelectFieldSchema,
+  paragraph: ParagraphFieldSchema,
+  'type-ahead': TypeAheadFieldSchema,
+  'number-float': NumberFieldSchema,
+  'number-integer': NumberFieldSchema,
+  'image-picker': ImagePickerFieldSchema,
+  divider: DividerFieldSchema,
+}
+
+export const MarketingActivityExtensionSchema = BaseSchema.extend({
+  title: zod.string().min(1),
+  description: zod.string().min(1),
+  app_api_url: zod.string(),
+  tactic: zod.enum([
+    'ad',
+    'retargeting',
+    'post',
+    'message',
+    'transactional',
+    'newsletter',
+    'abandoned_cart',
+    'affililate',
+    'loyalty',
+    'link',
+    'storefront_app',
+  ]),
+  marketing_channel: zod.enum(['social', 'search', 'email', 'sms', 'display', 'marketplace']),
+  referring_domain: zod.string().optional(),
+  is_automation: zod.boolean().optional(),
+  use_external_editor: zod.boolean().optional(),
+  preview_data: zod.object({
+    types: zod
+      .array(
+        zod.object({
+          label: zod.string(),
+          value: zod.string(),
+        }),
+      )
+      .max(3)
+      .min(1),
+  }),
+  fields: zod
+    .array(
+      zod.any().superRefine((val, ctx) => {
+        if (typeof val !== 'object') {
+          return ctx.addIssue({
+            message: 'Field must be an object',
+            code: zod.ZodIssueCode.custom,
+          })
+        }
+        if (val.ui_type === undefined) {
+          return ctx.addIssue({
+            message: 'Field must have a ui_type',
+            code: zod.ZodIssueCode.custom,
+          })
+        }
+        const schema = UISchemaMapping[val.ui_type]
+        if (schema === undefined) {
+          return ctx.addIssue({
+            message: `Unknown ui_type for Field: ${val.ui_type}`,
+            code: zod.ZodIssueCode.custom,
+          })
+        }
+
+        const result = schema.safeParse(val)
+        if (!result.success) {
+          return ctx.addIssue({
+            message: `Error found on Field "${val.name}": ${result.error.message}`,
+            code: zod.ZodIssueCode.custom,
+          })
+        }
+      }),
+    )
+    .min(1),
+})

--- a/packages/app/src/cli/services/import-extensions.test.ts
+++ b/packages/app/src/cli/services/import-extensions.test.ts
@@ -45,6 +45,16 @@ const flowExtensionB: ExtensionRegistration = {
   },
 }
 
+const marketingActivityExtension: ExtensionRegistration = {
+  id: 'idC',
+  title: 'titleC',
+  uuid: 'uuidC',
+  type: 'marketing_activity_extension',
+  activeVersion: {
+    config: '{}',
+  },
+}
+
 describe('import-extensions', () => {
   beforeEach(() => {
     // eslint-disable-next-line @shopify/cli/no-vi-manual-mock-clear
@@ -54,7 +64,7 @@ describe('import-extensions', () => {
   test('importing an extension creates a folder and toml file', async () => {
     // Given
     vi.mocked(fetchAppAndIdentifiers).mockResolvedValue([organizationApp, {}])
-    vi.mocked(getExtensions).mockResolvedValue([flowExtensionA, flowExtensionB])
+    vi.mocked(getExtensions).mockResolvedValue([flowExtensionA, flowExtensionB, marketingActivityExtension])
     vi.mocked(renderSelectPrompt).mockResolvedValue('uuidA')
 
     // When
@@ -64,7 +74,7 @@ describe('import-extensions', () => {
       await importExtensions({
         app,
         developerPlatformClient: testDeveloperPlatformClient(),
-        extensionTypes: ['flow_action_definition', 'flow_trigger_definition'],
+        extensionTypes: ['flow_action_definition', 'flow_trigger_definition', 'marketing_activity_extension'],
         buildTomlObject,
       })
 
@@ -79,13 +89,16 @@ describe('import-extensions', () => {
 
       const tomlPathB = joinPath(tmpDir, 'extensions', 'title-b', 'shopify.extension.toml')
       expect(fileExistsSync(tomlPathB)).toBe(false)
+
+      const tomlPathC = joinPath(tmpDir, 'extensions', 'title-c', 'shopify.extension.toml')
+      expect(fileExistsSync(tomlPathC)).toBe(false)
     })
   })
 
   test('selecting All imports all extensions', async () => {
     // Given
     vi.mocked(fetchAppAndIdentifiers).mockResolvedValue([organizationApp, {}])
-    vi.mocked(getExtensions).mockResolvedValue([flowExtensionA, flowExtensionB])
+    vi.mocked(getExtensions).mockResolvedValue([flowExtensionA, flowExtensionB, marketingActivityExtension])
     vi.mocked(renderSelectPrompt).mockResolvedValue('All')
 
     // When
@@ -95,13 +108,13 @@ describe('import-extensions', () => {
       await importExtensions({
         app,
         developerPlatformClient: testDeveloperPlatformClient(),
-        extensionTypes: ['flow_action_definition', 'flow_trigger_definition'],
+        extensionTypes: ['flow_action_definition', 'flow_trigger_definition', 'marketing_activity_extension'],
         buildTomlObject,
       })
 
       expect(renderSuccess).toHaveBeenCalledWith({
         headline: ['Imported the following extensions from the dashboard:'],
-        body: '• "titleA" at: extensions/title-a\n• "titleB" at: extensions/title-b',
+        body: '• "titleA" at: extensions/title-a\n• "titleB" at: extensions/title-b\n• "titleC" at: extensions/title-c',
       })
 
       // Then
@@ -110,6 +123,9 @@ describe('import-extensions', () => {
 
       const tomlPathB = joinPath(tmpDir, 'extensions', 'title-b', 'shopify.extension.toml')
       expect(fileExistsSync(tomlPathB)).toBe(true)
+
+      const tomlPathC = joinPath(tmpDir, 'extensions', 'title-c', 'shopify.extension.toml')
+      expect(fileExistsSync(tomlPathC)).toBe(true)
     })
   })
 
@@ -124,7 +140,7 @@ describe('import-extensions', () => {
       await importExtensions({
         app,
         developerPlatformClient: testDeveloperPlatformClient(),
-        extensionTypes: ['flow_action_definition', 'flow_trigger_definition'],
+        extensionTypes: ['flow_action_definition', 'flow_trigger_definition', 'marketing_activity_extension'],
         buildTomlObject,
       })
 
@@ -140,6 +156,9 @@ describe('import-extensions', () => {
 
       const tomlPathB = joinPath(tmpDir, 'extensions', 'title-b', 'shopify.extension.toml')
       expect(fileExistsSync(tomlPathB)).toBe(false)
+
+      const tomlPathC = joinPath(tmpDir, 'extensions', 'title-c', 'shopify.extension.toml')
+      expect(fileExistsSync(tomlPathC)).toBe(false)
     })
   })
 })

--- a/packages/app/src/cli/services/marketing_activity/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/marketing_activity/extension-to-toml.test.ts
@@ -1,0 +1,162 @@
+import {buildTomlObject, MarketingActivityDashboardConfig} from './extension-to-toml.js'
+import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
+import {describe, expect, test} from 'vitest'
+
+const defaultDashboardConfig: MarketingActivityDashboardConfig = {
+  title: 'test mae',
+  description: 'test mae description',
+  app_api_url: 'https://google.es',
+  tactic: 'ad',
+  platform: 'facebook',
+  is_automation: false,
+  preview_data: [{label: 'test label', value: 'test value'}],
+  fields: [
+    {
+      id: '123',
+      ui_type: 'text-single-line',
+      name: 'test_field',
+      label: 'test field',
+      help_text: 'help text',
+      required: false,
+      min_length: 1,
+      max_length: 50,
+      placeholder: 'placeholder',
+    },
+  ],
+}
+describe('extension-to-toml', () => {
+  test('correctly builds a toml string for a marketing_activity_extension', () => {
+    // Given
+    const extension: ExtensionRegistration = {
+      id: '26237698049',
+      uuid: 'ad9947a9-bc0b-4855-82da-008aefbc1c71',
+      title: 'mae @ test! 123',
+      type: 'marketing_activity_extension',
+      draftVersion: {
+        config: JSON.stringify(defaultDashboardConfig),
+      },
+    }
+
+    // When
+    const got = buildTomlObject(extension)
+
+    // Then
+    expect(got).toEqual(`[[extensions]]
+type = "marketing_activity_extension_cli"
+name = "test mae"
+handle = "mae-test-123"
+title = "test mae"
+description = "test mae description"
+app_api_url = "https://google.es"
+tactic = "ad"
+marketing_channel = "social"
+referring_domain = "facebook.com"
+is_automation = false
+
+  [[extensions.preview_data]]
+  label = "test label"
+  value = "test value"
+
+  [[extensions.fields]]
+  id = "123"
+  ui_type = "text-single-line"
+  name = "test_field"
+  label = "test field"
+  help_text = "help text"
+  required = false
+  min_length = 1
+  max_length = 50
+  placeholder = "placeholder"
+`)
+  })
+
+  test('truncates the handle if the title has >30 characters', () => {
+    // Given
+    const extension: ExtensionRegistration = {
+      id: '26237698049',
+      uuid: 'ad9947a9-bc0b-4855-82da-008aefbc1c71',
+      title: 'mae @ test! 12345555555554444447777778888888',
+      type: 'marketing_activity_extension',
+      draftVersion: {
+        config: JSON.stringify(defaultDashboardConfig),
+      },
+    }
+
+    // When
+    const got = buildTomlObject(extension)
+
+    // Then
+    expect(got).toEqual(`[[extensions]]
+type = "marketing_activity_extension_cli"
+name = "test mae"
+handle = "mae-test-123455555555544444"
+title = "test mae"
+description = "test mae description"
+app_api_url = "https://google.es"
+tactic = "ad"
+marketing_channel = "social"
+referring_domain = "facebook.com"
+is_automation = false
+
+  [[extensions.preview_data]]
+  label = "test label"
+  value = "test value"
+
+  [[extensions.fields]]
+  id = "123"
+  ui_type = "text-single-line"
+  name = "test_field"
+  label = "test field"
+  help_text = "help text"
+  required = false
+  min_length = 1
+  max_length = 50
+  placeholder = "placeholder"
+`)
+  })
+
+  test('sets the channel and referring domain to empty string if no platform mapping is found', () => {
+    // Given
+    const extension: ExtensionRegistration = {
+      id: '26237698049',
+      uuid: 'ad9947a9-bc0b-4855-82da-008aefbc1c71',
+      title: 'mae @ test! 123',
+      type: 'marketing_activity_extension',
+      draftVersion: {
+        config: JSON.stringify({...defaultDashboardConfig, platform: 'not-a-platform'}),
+      },
+    }
+
+    // When
+    const got = buildTomlObject(extension)
+
+    // Then
+    expect(got).toEqual(`[[extensions]]
+type = "marketing_activity_extension_cli"
+name = "test mae"
+handle = "mae-test-123"
+title = "test mae"
+description = "test mae description"
+app_api_url = "https://google.es"
+tactic = "ad"
+marketing_channel = ""
+referring_domain = ""
+is_automation = false
+
+  [[extensions.preview_data]]
+  label = "test label"
+  value = "test value"
+
+  [[extensions.fields]]
+  id = "123"
+  ui_type = "text-single-line"
+  name = "test_field"
+  label = "test field"
+  help_text = "help text"
+  required = false
+  min_length = 1
+  max_length = 50
+  placeholder = "placeholder"
+`)
+  })
+})

--- a/packages/app/src/cli/services/marketing_activity/extension-to-toml.ts
+++ b/packages/app/src/cli/services/marketing_activity/extension-to-toml.ts
@@ -1,0 +1,187 @@
+import {MAX_EXTENSION_HANDLE_LENGTH} from '../../models/extensions/schemas.js'
+import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
+import {encodeToml} from '@shopify/cli-kit/node/toml'
+import {slugify} from '@shopify/cli-kit/common/string'
+
+interface BaseField {
+  id: string
+  ui_type: string
+}
+
+interface CommonField extends BaseField {
+  name: string
+  label: string
+  help_text: string
+  required: boolean
+}
+
+type BudgetScheduleField = CommonField & {
+  ui_type: 'budget-schedule'
+  use_scheduling: boolean
+  use_end_date: boolean
+  use_daily_budget: boolean
+  use_lifetime_budget: boolean
+}
+
+type DiscountPickerField = CommonField & {
+  ui_type: 'discount-picker'
+  min_resources: number | null
+  max_resources: number | null
+}
+
+type ScheduleField = CommonField & {
+  ui_type: 'schedule'
+  use_end_date: boolean
+}
+
+type ProductPickerField = CommonField & {
+  ui_type: 'product-picker'
+  allow_product_image_selection: boolean
+  allow_uploaded_image_as_product_image: boolean
+  allow_free_image_as_product_image: boolean
+  min_resources: number | null
+  max_resources: number | null
+  min_image_select_per_product: number | null
+  max_image_select_per_product: number | null
+}
+
+type SingleLineTextField = CommonField & {
+  ui_type: 'text-single-line' | 'text-email' | 'text-tel' | 'text-url'
+  placeholder: string
+  min_length: number
+  max_length: number
+}
+
+type TextMultiLineField = CommonField & {
+  ui_type: 'text-multi-line'
+  placeholder: string
+  min_length: number
+  max_length: number
+}
+
+type DividerField = BaseField & {
+  ui_type: 'divider'
+  title: string
+  name: string
+}
+
+type SelectField = CommonField & {
+  ui_type: 'select-single' | 'select-multiple'
+  choices: {label: string; value: string}[]
+}
+
+type ParagraphField = BaseField & {
+  ui_type: 'paragraph'
+  heading: string
+  body: string
+}
+
+type TypeAheadField = CommonField & {
+  ui_type: 'type-ahead'
+  placeholder: string
+}
+
+type NumberField = CommonField & {
+  ui_type: 'number-float' | 'number-integer'
+  min: number
+  max: number
+  step: number
+}
+
+type ImagePickerField = CommonField & {
+  ui_type: 'image-picker'
+  min_resources: number
+  max_resources: number
+  allow_free_images: boolean
+  alt_text_required: boolean
+}
+
+type Field =
+  | BudgetScheduleField
+  | DiscountPickerField
+  | ScheduleField
+  | ProductPickerField
+  | SingleLineTextField
+  | TextMultiLineField
+  | SelectField
+  | ParagraphField
+  | TypeAheadField
+  | NumberField
+  | ImagePickerField
+  | DividerField
+
+export interface MarketingActivityDashboardConfig {
+  title: string
+  description: string
+  app_api_url: string
+  tactic: string
+  platform: string
+  is_automation: boolean
+  use_external_editor?: boolean
+  preview_data: {
+    label: string
+    value: string
+  }[]
+  fields: Field[]
+}
+
+const PLATFORM_CHANNEL_MAP: {[key: string]: string} = {
+  facebook: 'social',
+  instagram: 'social',
+  google: 'search',
+  pinterest: 'social',
+  bing: 'search',
+  email: 'email',
+  snapchat: 'social',
+  sms: 'sms',
+  verizon_media: 'display',
+  ebay: 'marketplace',
+  tiktok: 'social',
+  flow: 'email',
+}
+
+const PLATFORM_DOMAIN_MAP: {[key: string]: string | null} = {
+  facebook: 'facebook.com',
+  instagram: 'instagram.com',
+  google: 'google.com',
+  pinterest: 'pinterest.com',
+  bing: 'bing.com',
+  snapchat: 'snapchat.com',
+  verizon_media: null,
+  email: null,
+  sms: null,
+  ebay: 'ebay.com',
+  tiktok: 'tiktok.com',
+  flow: null,
+}
+
+/**
+ * Given a dashboard-built marketing activity extension config file, convert it to toml for the CLI extension
+ */
+export function buildTomlObject(extension: ExtensionRegistration): string {
+  const versionConfig = extension.activeVersion?.config ?? extension.draftVersion?.config
+  if (!versionConfig) throw new Error('No config found for extension')
+  const config: MarketingActivityDashboardConfig = JSON.parse(versionConfig)
+
+  const localExtensionRepresentation = {
+    extensions: [
+      {
+        type: 'marketing_activity_extension_cli',
+        name: config.title,
+        handle: slugify(extension.title.substring(0, MAX_EXTENSION_HANDLE_LENGTH)),
+        title: config.title,
+        description: config.description,
+        app_api_url: config.app_api_url,
+        tactic: config.tactic,
+        marketing_channel: PLATFORM_CHANNEL_MAP[config.platform] ?? '',
+        referring_domain: PLATFORM_DOMAIN_MAP[config.platform] ?? '',
+        is_automation: config.is_automation,
+        use_external_editor: config.use_external_editor,
+        preview_data: config.preview_data,
+        fields: config.fields,
+      },
+    ],
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return encodeToml(localExtensionRepresentation as any)
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/marketing-automations/issues/2041

Adding the ability to migrate the existing marketing activity dashboard extension to CLI

### WHAT is this pull request doing?

Adds the logic to convert the dashboard config to the CLI config. Note: We have simplified the schema as documented [here](https://docs.google.com/document/d/1KwE1Q7AzPULXAucOrCd84h5P8ISY1Mc2WT9woW3gKDw/edit?pli=1#heading=h.r7192k3z5luw). 

Currently, this change is only available to Shopifolk. Once we have finished adding the rest of the migration logic and have proper documentation, then we will release this feature to everyone. 

### How to test your changes?

1. `spin up extensions`
2. run `yarn create @shopify/app` in extensions terminal
3. Start your app dev: `cd your-app` and then `yarn shopify app dev`
4. Visit the Partners dashboard ("Partners Organization List" from your spin instance or the spin open dialog)\ and login as partners@shopify.com / password.
5. Open the "Apps" area and select the app you created in Step 2.
6. Select "Extensions" from the sidebar. Select Marketing Activity Extensions and create an extension.
7. `cd` into `cli` and run the following:
 - `SHOPIFY_RUN_AS_USER=1 pnpm shopify app import-extensions --path <path to app>`.  This sets the `isShopify` check to false, you should not see the option to import the marketing activity. 
 - `pnpm shopify app import-extensions --path <path to app>` This will import the existing config of the extension you created in  Step 6.

<img width="865" alt="image" src="https://github.com/Shopify/cli/assets/97915490/431eaf8b-d336-40b4-906b-f34844f61647">

<img width="801" alt="image" src="https://github.com/Shopify/cli/assets/97915490/ef4b5e61-1c9c-408b-a514-bf2c34a292f6">


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
