### PR TITLE
Remove warning union messages from AJV parser 

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/custom_data.ts
+++ b/packages/app/src/cli/models/extensions/specifications/custom_data.ts
@@ -2,6 +2,6 @@ import {createContractBasedConfigModuleSpecification} from '../specification.js'
 
 export const CustomDataSpecIdentifier = 'data'
 
-const customDataSpec = createContractBasedConfigModuleSpecification(CustomDataSpecIdentifier, 'products', 'metaobjects')
+const customDataSpec = createContractBasedConfigModuleSpecification(CustomDataSpecIdentifier, 'product', 'metaobjects')
 
 export default customDataSpec

--- a/packages/cli-kit/src/public/node/json-schema.ts
+++ b/packages/cli-kit/src/public/node/json-schema.ts
@@ -34,7 +34,7 @@ export function jsonSchemaValidate(
   subject: object,
   schema: SchemaObject,
 ): ParseConfigurationResult<unknown> & {rawErrors?: AjvError[]} {
-  const ajv = new Ajv()
+  const ajv = new Ajv({allowUnionTypes: true})
   const validator = ajv.compile(schema)
   validator(subject)
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Closes: https://github.com/Shopify/develop-app-inner-loop/issues/1940

We're getting warning messages from the AJV parser regarding union types. The union is considered valid and we want to  mute the warning messages.

### WHAT is this pull request doing?
Added `{allowUnionTypes: true}` to the AJV object to allow unions.
snuck in: Fixed pluralization on `products`, it should be singular.

### How to test your changes?
Deploy an app and the union warning should be gone.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
