### PR TITLE
Fix URL validation in the app schema

### DIFF
--- a/.changeset/selfish-turkeys-vanish.md
+++ b/.changeset/selfish-turkeys-vanish.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Avoid duplicated error messages for invalid URLs in the TOML

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -185,6 +185,29 @@ automatically_update_urls_on_dev = true
     await expect(loadTestingApp()).rejects.toThrow()
   })
 
+  test('throws an error when the application_url is invalid', async () => {
+    // Given
+    const appConfiguration = `
+name = "for-testing"
+client_id = "1234567890"
+application_url = "wrong"
+embedded = true
+
+[webhooks]
+api_version = "2023-07"
+
+[auth]
+redirect_urls = [ "https://example.com/api/auth" ]
+
+[build]
+automatically_update_urls_on_dev = true
+        `
+    await writeConfig(appConfiguration)
+
+    // When/Then
+    await expect(loadTestingApp()).rejects.toThrow(/\[application_url\]: Invalid URL/)
+  })
+
   test('loads the app when the configuration is valid and has no blocks', async () => {
     // Given
     await writeConfig(appConfiguration)

--- a/packages/app/src/cli/models/app/validation/common.ts
+++ b/packages/app/src/cli/models/app/validation/common.ts
@@ -9,7 +9,7 @@ export function validateUrl(zodType: zod.ZodString, {httpsOnly = false, message 
 function isValidUrl(input: string, httpsOnly: boolean) {
   try {
     const url = new URL(input)
-    return httpsOnly ? url.protocol === 'https:' : url.protocol.startsWith('http')
+    return httpsOnly ? url.protocol === 'https:' : ['http:', 'https:'].includes(url.protocol)
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (TypeError) {
     // new URL() throws a TypeError if the input is not a valid URL

--- a/packages/app/src/cli/models/app/validation/common.ts
+++ b/packages/app/src/cli/models/app/validation/common.ts
@@ -9,9 +9,10 @@ export function validateUrl(zodType: zod.ZodString, {httpsOnly = false, message 
 function isValidUrl(input: string, httpsOnly: boolean) {
   try {
     const url = new URL(input)
-    return httpsOnly ? url.protocol === 'https:' : url.protocol === 'http:' || url.protocol === 'https:'
+    return httpsOnly ? url.protocol === 'https:' : url.protocol.startsWith('http')
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (TypeError) {
+    // new URL() throws a TypeError if the input is not a valid URL
     return false
   }
 }

--- a/packages/app/src/cli/models/app/validation/common.ts
+++ b/packages/app/src/cli/models/app/validation/common.ts
@@ -1,14 +1,21 @@
 import {zod} from '@shopify/cli-kit/node/schema'
 
-// adding http or https presence and absence of new lines to url validation
-export const httpsRegex = /^(https:\/\/)/
-export const validateUrl = (zodType: zod.ZodString, {httpsOnly = false, message = 'Invalid url'} = {}) => {
-  const regex = httpsOnly ? httpsRegex : /^(https?:\/\/)/
+export function validateUrl(zodType: zod.ZodString, {httpsOnly = false, message = 'Invalid URL'} = {}) {
   return zodType
-    .url()
-    .refine((value) => Boolean(value.match(regex)), {message})
+    .refine((value) => isValidUrl(value, httpsOnly), {message})
     .refine((value) => !value.includes('\n'), {message})
 }
 
-export const ensurePathStartsWithSlash = (arg: unknown) =>
-  typeof arg === 'string' && !arg.startsWith('/') ? `/${arg}` : arg
+function isValidUrl(input: string, httpsOnly: boolean) {
+  try {
+    const url = new URL(input)
+    return httpsOnly ? url.protocol === 'https:' : url.protocol === 'http:' || url.protocol === 'https:'
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (TypeError) {
+    return false
+  }
+}
+
+export function ensurePathStartsWithSlash(arg: unknown) {
+  return typeof arg === 'string' && !arg.startsWith('/') ? `/${arg}` : arg
+}

--- a/packages/app/src/cli/models/extensions/specifications/validation/common.ts
+++ b/packages/app/src/cli/models/extensions/specifications/validation/common.ts
@@ -1,6 +1,6 @@
-import {httpsRegex} from '../../../app/validation/common.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
+const httpsRegex = /^(https:\/\/)/
 // example PubSub URI - pubsub://{project}:{topic}
 const pubSubRegex = /^pubsub:\/\/(?<gcp_project_id>[^:]+):(?<gcp_topic>.+)$/
 // example Eventbridge ARN - arn:aws:events:{region}::event-source/aws.partner/shopify.com/{app_id}/{path}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/1959

The [url() validation by Zod](https://github.com/colinhacks/zod/blob/821d45b9ed1f3376f3912de15933c92dc926ccbd/src/types.ts#L818) was adding an error message, and then another one was being added by our custom validation, basically to check for HTTPS.

### WHAT is this pull request doing?

Remove the Zod validation for URL and include that in our custom one, so that we only get one error message.

### How to test your changes?

- Update the `application_url` in the TOML to `wrong`
- `p shopify app deploy`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
