### PR TITLE
Add default_value to Settings FieldSchema

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -49,6 +49,7 @@ export const FieldSchema = zod.object({
   name: zod.string().optional(),
   description: zod.string().optional(),
   required: zod.boolean().optional(),
+  default_value: zod.any().optional(),
   type: zod.string(),
   validations: zod.array(zod.any()).optional(),
 })


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

closes https://github.com/Shopify/checkout-web/issues/36347
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
TL;DR - UiExtensions have the ability to parse fields marked as `required`  so long as they have a "default_value`. But only `required` exists on the schema. This would have gone unnoticed as the CheckoutUiExtension CLI settings schema allowed any key to be passed: https://github.com/Shopify/cli/blob/a3dd9e5eb2a91b7fdf255feb33deac777fb76ee0/packages/app/src/cli/models/extensions/extension-specifications/checkout_ui_extension.ts#L10-L14

However in core we validate this, so including `required` necessitates including `default_value`. These keys were not explicitly defined, and the feature has [not rolled out](https://app.shopify.com/services/internal/app_betas/checkout_ui_extensions_settings_expanded_definitions) , so my guess is this is simply an understandable oversight. 

Because the default value can be any type of allowed metafield type (bool, string, date, etc) the type is set to `any`.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Either roll the `checkout_ui_extensions_settings_expanded_definitions` flag to 100% or apply it to your app from the partners internal.

Deploy a ui_extension with a settings such as
```
[extensions.settings]
[[extensions.settings.fields]]
key = "banner_title"
type = "single_line_text_field"
name = "banner_title"
required = true
default_value = "Whatever"
```

It's probably best to have core on sb/jk/cleanup-configuration-definitions-rebased but the current main should behave the same. Currently `default_value` is removed from the config as it's uploaded to core, and the following message appears:
<img width="663" alt="Screenshot 2024-07-26 at 2 02 39 PM" src="https://github.com/user-attachments/assets/4ac2fad0-654c-4ea7-8fe8-0d07cb1bf620">


On this branch the extension should deploy fine, as the default value is provided alongside the required key. Removing the the default value should throw the core invalidation again.

A default value can be added without it being required.
