### PR TITLE
Support Hydrogen monorepo on CI

### DIFF
--- a/packages/cli-kit/src/public/node/custom-oclif-loader.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.ts
@@ -9,7 +9,8 @@ export class ShopifyConfig extends Config {
     const currentPath = cwd()
 
     let path = sniffForPath() ?? currentPath
-    const currentPathMightBeHydrogenMonorepo = currentPath.toLowerCase().includes('shopify/hydrogen')
+    // Hydrogen CI uses `hydrogen/hydrogen` path, while local dev uses `shopify/hydrogen`.
+    const currentPathMightBeHydrogenMonorepo = /(shopify|hydrogen)\/hydrogen/i.test(currentPath)
     const ignoreHydrogenMonorepo = process.env.IGNORE_HYDROGEN_MONOREPO
     if (currentPathMightBeHydrogenMonorepo && !ignoreHydrogenMonorepo) {
       path = execaSync('npm', ['prefix']).stdout.trim()


### PR DESCRIPTION
Currently, the CLI doesn't detect Hydrogen monorepo on CI because the paths in GitHub actions does not use the organization name, but the repo name twice (`hydrogen/hydrogen`).