### PR TITLE
Fix relative webhooks TOML transformation

### DIFF
--- a/.changeset/big-donkeys-wink.md
+++ b/.changeset/big-donkeys-wink.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix webhook URI transformation in TOML to relative path when the app URL ends with a slash

--- a/packages/app/src/cli/services/app/write-app-configuration-file.test.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.test.ts
@@ -12,14 +12,20 @@ const FULL_CONFIGURATION = {
     dev_store_url: 'example.myshopify.com',
   },
   ...DEFAULT_CONFIG,
+  application_url: 'https://myapp.com/',
   auth: {redirect_urls: ['https://example.com/redirect', 'https://example.com/redirect2']},
   webhooks: {
     api_version: '2023-07',
-    privacy_compliance: {
-      customer_deletion_url: 'https://example.com/auth/callback1',
-      customer_data_request_url: 'https://example.com/auth/callback2',
-      shop_deletion_url: 'https://example.com/auth/callback3',
-    },
+    subscriptions: [
+      {
+        topics: ['products/create'],
+        uri: 'https://myapp.com/webhooks',
+      },
+      {
+        compliance_topics: ['customer_deletion_url', 'customer_data_request_url'],
+        uri: 'https://myapp.com/webhooks',
+      },
+    ],
   },
   app_proxy: {
     url: 'https://example.com/auth/prox',
@@ -50,7 +56,7 @@ describe('writeAppConfigurationFile', () => {
 
 client_id = "api-key"
 name = "my app"
-application_url = "https://myapp.com"
+application_url = "https://myapp.com/"
 embedded = true
 
 [build]
@@ -71,10 +77,10 @@ redirect_urls = [
 [webhooks]
 api_version = "2023-07"
 
-  [webhooks.privacy_compliance]
-  customer_deletion_url = "https://example.com/auth/callback1"
-  customer_data_request_url = "https://example.com/auth/callback2"
-  shop_deletion_url = "https://example.com/auth/callback3"
+  [[webhooks.subscriptions]]
+  topics = [ "products/create" ]
+  uri = "/webhooks"
+  compliance_topics = [ "customer_deletion_url", "customer_data_request_url" ]
 
 [app_proxy]
 url = "https://example.com/auth/prox"

--- a/packages/app/src/cli/services/app/write-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.ts
@@ -1,5 +1,6 @@
 import {CurrentAppConfiguration} from '../../models/app/app.js'
 import {reduceWebhooks} from '../../models/extensions/specifications/transform/app_config_webhook.js'
+import {removeTrailingSlash} from '../../models/extensions/specifications/validation/common.js'
 import {writeFileSync} from '@shopify/cli-kit/node/fs'
 import {JsonMapType, encodeToml} from '@shopify/cli-kit/node/toml'
 import {zod} from '@shopify/cli-kit/node/schema'
@@ -97,7 +98,7 @@ export const rewriteConfiguration = <T extends zod.ZodTypeAny>(schema: T, config
 function condenseComplianceAndNonComplianceWebhooks(config: CurrentAppConfiguration) {
   const webhooksConfig = config.webhooks
   if (webhooksConfig?.subscriptions?.length) {
-    const appUrl = config?.application_url as string | undefined
+    const appUrl = removeTrailingSlash(config?.application_url) as string | undefined
     webhooksConfig.subscriptions = reduceWebhooks(webhooksConfig.subscriptions)
     webhooksConfig.subscriptions = webhooksConfig.subscriptions.map(({uri, ...subscription}) => ({
       uri: appUrl && uri.includes(appUrl) ? uri.replace(appUrl, '') : uri,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://shopify.zendesk.com/agent/tickets/49319741
Fixes https://github.com/Shopify/shopify-app-template-remix/issues/776#issuecomment-2259887290

The link process rewrites the TOML to transform webhook URIs like `https://example.com/webhooks` to `/webhooks` when the app URL is `https://example.com`.

But when the app URL ends with a slash, like `https://example.com/`, then we were wrongly updating the webhook URI to `webhooks`, causing the deploy validation to fail.

### WHAT is this pull request doing?

Remove the final slash from the app URL when doing that transformation, so the final result includes the required initial slash.

### How to test your changes?

- Create an app and run link
- Update the `application_url` in the TOML to `https://whatever.com/`
- Add a subscription in the TOML:
```
  [[webhooks.subscriptions]]
  topics = [ "app/uninstalled" ]
  uri = "https://whatever.com/webhooks"
```
- Run deploy
- Run link => it should rewrite the uri to `/webhooks`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
