### PR TITLE
Add debug logging for loading .env files

### DIFF
--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -249,6 +249,7 @@ export async function loadDotEnv(appDirectory: string, configurationPath: string
   let dotEnvFile: DotEnvFile | undefined
   const dotEnvPath = joinPath(appDirectory, getDotEnvFileName(configurationPath))
   if (await fileExists(dotEnvPath)) {
+    outputDebug('Loading contents of .env file found at ' + dotEnvPath)
     dotEnvFile = await readAndParseDotEnv(dotEnvPath)
   }
   return dotEnvFile


### PR DESCRIPTION
### WHY are these changes introduced?

I just spent 2+ hours trying to debug why I was receiving a 401 when running `shopify theme dev`. I understood from the debug logging that my Admin API session was invalid and `https://theme-kit-access.shopifyapps.com/cli/admin/api/unstable/themes.json` was failing, but even after running `shopify auth logout` I was not being prompted to login via browser (as I normally do).

Finally after adding some additional logging, I found that $SHOPIFY_CLI_THEME_TOKEN was being set. I had forgotten that I had created a .env file several weeks ago and it was setting the `--password` flag in this case

### WHAT is this pull request doing?

Just knowing that a .env file is being loaded would have probably saved me a few hours of debugging. One-liner log to let people know that an .env file was found and being loaded.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
