### PR TITLE
Show domain for stores list (app management client only)

### DIFF
--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -135,13 +135,13 @@ describe('selectApp', () => {
 })
 
 describe('selectStore', () => {
-  const defaultClientName = 'partners'
+  const defaultShowDomainOnPrompt = false
   test('returns undefined if store list is empty', async () => {
     // Given
     const stores: OrganizationStore[] = []
 
     // When
-    const got = await selectStorePrompt(stores, defaultClientName)
+    const got = await selectStorePrompt(stores, defaultShowDomainOnPrompt)
 
     // Then
     expect(got).toEqual(undefined)
@@ -154,7 +154,7 @@ describe('selectStore', () => {
     const outputMock = mockAndCaptureOutput()
 
     // When
-    const got = await selectStorePrompt(stores, defaultClientName)
+    const got = await selectStorePrompt(stores, defaultShowDomainOnPrompt)
 
     // Then
     expect(got).toEqual(STORE1)
@@ -168,7 +168,7 @@ describe('selectStore', () => {
     vi.mocked(renderAutocompletePrompt).mockResolvedValue('2')
 
     // When
-    const got = await selectStorePrompt(stores, defaultClientName)
+    const got = await selectStorePrompt(stores, defaultShowDomainOnPrompt)
 
     // Then
     expect(got).toEqual(STORE2)
@@ -181,14 +181,13 @@ describe('selectStore', () => {
     })
   })
 
-  test('renders stores list with domain if client is app-management ', async () => {
+  test('renders stores list with domain if showDomainOnPrompt is true ', async () => {
     // Given
-    const clientName = 'app-management'
     const stores: OrganizationStore[] = [STORE1, STORE2]
     vi.mocked(renderAutocompletePrompt).mockResolvedValue('2')
 
     // When
-    const got = await selectStorePrompt(stores, clientName)
+    const got = await selectStorePrompt(stores, true)
 
     // Then
     expect(got).toEqual(STORE2)

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -135,12 +135,13 @@ describe('selectApp', () => {
 })
 
 describe('selectStore', () => {
+  const defaultClientName = 'partners'
   test('returns undefined if store list is empty', async () => {
     // Given
     const stores: OrganizationStore[] = []
 
     // When
-    const got = await selectStorePrompt(stores)
+    const got = await selectStorePrompt(stores, defaultClientName)
 
     // Then
     expect(got).toEqual(undefined)
@@ -153,7 +154,7 @@ describe('selectStore', () => {
     const outputMock = mockAndCaptureOutput()
 
     // When
-    const got = await selectStorePrompt(stores)
+    const got = await selectStorePrompt(stores, defaultClientName)
 
     // Then
     expect(got).toEqual(STORE1)
@@ -167,7 +168,7 @@ describe('selectStore', () => {
     vi.mocked(renderAutocompletePrompt).mockResolvedValue('2')
 
     // When
-    const got = await selectStorePrompt(stores)
+    const got = await selectStorePrompt(stores, defaultClientName)
 
     // Then
     expect(got).toEqual(STORE2)
@@ -176,6 +177,26 @@ describe('selectStore', () => {
       choices: [
         {label: 'store1', value: '1'},
         {label: 'store2', value: '2'},
+      ],
+    })
+  })
+
+  test('renders stores list with domain if client is app-management ', async () => {
+    // Given
+    const clientName = 'app-management'
+    const stores: OrganizationStore[] = [STORE1, STORE2]
+    vi.mocked(renderAutocompletePrompt).mockResolvedValue('2')
+
+    // When
+    const got = await selectStorePrompt(stores, clientName)
+
+    // Then
+    expect(got).toEqual(STORE2)
+    expect(renderAutocompletePrompt).toHaveBeenCalledWith({
+      message: 'Which store would you like to use to view your project?',
+      choices: [
+        {label: 'store1 (domain1)', value: '1'},
+        {label: 'store2 (domain2)', value: '2'},
       ],
     })
   })

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -59,7 +59,7 @@ export async function selectAppPrompt(
 
 export async function selectStorePrompt(
   stores: OrganizationStore[],
-  clientName: string,
+  showDomainOnPrompt: boolean,
 ): Promise<OrganizationStore | undefined> {
   if (stores.length === 0) return undefined
   if (stores.length === 1) {
@@ -69,7 +69,7 @@ export async function selectStorePrompt(
 
   const storeList = stores.map((store) => {
     let label = store.shopName
-    if (clientName === 'app-management') {
+    if (showDomainOnPrompt && store.shopDomain) {
       label = `${store.shopName} (${store.shopDomain})`
     }
     return {label, value: store.shopId}

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -57,13 +57,23 @@ export async function selectAppPrompt(
   return currentAppChoices.find((app) => app.apiKey === apiKey)!
 }
 
-export async function selectStorePrompt(stores: OrganizationStore[]): Promise<OrganizationStore | undefined> {
+export async function selectStorePrompt(
+  stores: OrganizationStore[],
+  clientName: string,
+): Promise<OrganizationStore | undefined> {
   if (stores.length === 0) return undefined
   if (stores.length === 1) {
     outputCompleted(`Using your default dev store, ${stores[0]!.shopName}, to preview your project.`)
     return stores[0]
   }
-  const storeList = stores.map((store) => ({label: store.shopName, value: store.shopId}))
+
+  const storeList = stores.map((store) => {
+    let label = store.shopName
+    if (clientName === 'app-management') {
+      label = `${store.shopName} (${store.shopDomain})`
+    }
+    return {label, value: store.shopId}
+  })
 
   const id = await renderAutocompletePrompt({
     message: 'Which store would you like to use to view your project?',

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -39,9 +39,11 @@ export async function selectStore(
   org: Organization,
   developerPlatformClient: DeveloperPlatformClient,
 ): Promise<OrganizationStore> {
+  const clientName = developerPlatformClient.clientName
+
   // If no stores, guide the developer through creating one
   // Then, with a store selected, make sure its transfer-disabled, prompting to convert if needed
-  let store = await selectStorePrompt(stores)
+  let store = await selectStorePrompt(stores, clientName)
   if (!store) {
     outputInfo(`\n${await CreateStoreLink(org.id)}`)
     await sleep(5)
@@ -63,7 +65,7 @@ export async function selectStore(
   )
   while (!storeIsValid) {
     // eslint-disable-next-line no-await-in-loop
-    store = await selectStorePrompt(stores)
+    store = await selectStorePrompt(stores, clientName)
     if (!store) {
       throw new CancelExecution()
     }

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -8,7 +8,7 @@ import {
   ConvertDevToTransferDisabledSchema,
   ConvertDevToTransferDisabledStoreVariables,
 } from '../../api/graphql/convert_dev_to_transfer_disabled_store.js'
-import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {ClientName, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {sleep} from '@shopify/cli-kit/node/system'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
@@ -39,11 +39,10 @@ export async function selectStore(
   org: Organization,
   developerPlatformClient: DeveloperPlatformClient,
 ): Promise<OrganizationStore> {
-  const clientName = developerPlatformClient.clientName
-
+  const showDomainOnPrompt = developerPlatformClient.clientName === ClientName.AppManagement
   // If no stores, guide the developer through creating one
   // Then, with a store selected, make sure its transfer-disabled, prompting to convert if needed
-  let store = await selectStorePrompt(stores, clientName)
+  let store = await selectStorePrompt(stores, showDomainOnPrompt)
   if (!store) {
     outputInfo(`\n${await CreateStoreLink(org.id)}`)
     await sleep(5)
@@ -65,7 +64,7 @@ export async function selectStore(
   )
   while (!storeIsValid) {
     // eslint-disable-next-line no-await-in-loop
-    store = await selectStorePrompt(stores, clientName)
+    store = await selectStorePrompt(stores, showDomainOnPrompt)
     if (!store) {
       throw new CancelExecution()
     }

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -58,6 +58,11 @@ import {DevSessionDeleteMutation} from '../api/graphql/app-dev/generated/dev-ses
 import {FunctionUploadUrlGenerateResponse} from '@shopify/cli-kit/node/api/partners'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 
+export enum ClientName {
+  AppManagement = 'app-management',
+  Partners = 'partners',
+}
+
 export type Paginateable<T> = T & {
   hasMorePages: boolean
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -48,6 +48,7 @@ import {
   AppVersionIdentifiers,
   DevSessionOptions,
   filterDisabledFlags,
+  ClientName,
 } from '../developer-platform-client.js'
 import {PartnersSession} from '../../services/context/partner-account-info.js'
 import {
@@ -145,7 +146,7 @@ export interface GatedExtensionTemplate extends ExtensionTemplate {
 }
 
 export class AppManagementClient implements DeveloperPlatformClient {
-  public clientName = 'app-management'
+  public clientName = ClientName.AppManagement
   public webUiName = 'Developer Dashboard'
   public requiresOrganization = true
   public supportsAtomicDeployments = true

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -13,6 +13,7 @@ import {
   Paginateable,
   DevSessionOptions,
   filterDisabledFlags,
+  ClientName,
 } from '../developer-platform-client.js'
 import {fetchCurrentAccountInformation, PartnersSession} from '../../../cli/services/context/partner-account-info.js'
 import {
@@ -209,7 +210,7 @@ interface OrgAndAppsResponse {
 }
 
 export class PartnersClient implements DeveloperPlatformClient {
-  public clientName = 'partners'
+  public clientName = ClientName.Partners
   public webUiName = 'Partner Dashboard'
   public supportsAtomicDeployments = false
   public requiresOrganization = false


### PR DESCRIPTION
### WHY are these changes introduced?
Closes https://github.com/Shopify/develop-app-inner-loop/issues/1984

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Basically https://github.com/Shopify/develop-app-inner-loop/issues/1899#issuecomment-2249057719, but use this branch instead for step 1 + in the last step, you should see the domain of the stores instead of just the store names


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
