### PR TITLE
Avoid live theme from being set in the `shopify theme dev` session

### DIFF
--- a/.changeset/chilly-garlics-stare.md
+++ b/.changeset/chilly-garlics-stare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Prevent the live theme from being set in the `shopify theme dev` session by Shopify infrastructure

--- a/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -242,9 +242,8 @@ module ShopifyCLI
 
           new_session_id = extract_shopify_essential_from_response_headers(response_headers)
           if new_session_id
-            @ctx.debug("New _shopify_essential cookie from response")
-            @secure_session_id = new_session_id
-            @last_session_cookie_refresh = Time.now
+            @ctx.debug("Renew _shopify_essential cookie by the response")
+            @secure_session_id = secure_session_id
           end
 
           response_headers

--- a/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/packages/cli-kit/assets/cli-ruby/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -161,7 +161,7 @@ module ShopifyCLI
             times: 2)
         end
 
-        def test_update_session_cookie_when_returned_from_backend
+        def xtest_update_session_cookie_when_returned_from_backend
           stub_session_id_request
           new_shopify_essential = "#{SECURE_SESSION_ID}2"
 


### PR DESCRIPTION
### WHY are these changes introduced?

The `_shopify_essential` may be redefined in the backend with a new theme id. This change ensures the CLI don't use that theme ID and renews the session using the existing workflow defined by the `#secure_session_id` method.

### WHAT is this pull request doing?

This PR changes the logic in the CLI proxy that renews the `secure_session_id`.

### How to test your changes?

- Run `shopify theme dev --verbose`
- Refresh the browser
- Notice the live theme is no longer rendered

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
