### PR TITLE
Fix version URL shown after deploy for App Management API

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -4,6 +4,7 @@ import {
   allowedTemplates,
   diffAppModules,
   encodedGidFromId,
+  versionDeepLink,
 } from './app-management-client.js'
 import {AppModule} from './app-management-client/graphql/app-version-by-id.js'
 import {OrganizationBetaFlagsQuerySchema} from './app-management-client/graphql/organization_beta_flags.js'
@@ -170,5 +171,20 @@ describe('allowedTemplates', () => {
     // Then
     expect(got.length).toEqual(2)
     expect(got).toEqual([templateWithoutRules, allowedTemplate])
+  })
+})
+
+describe('versionDeepLink', () => {
+  test('generates the expected URL', async () => {
+    // Given
+    const orgId = '1'
+    const appId = 'gid://shopify/Version/2'
+    const versionId = 'gid://shopify/Version/3'
+
+    // When
+    const got = await versionDeepLink(orgId, appId, versionId)
+
+    // Then
+    expect(got).toEqual('https://dev.shopify.com/dashboard/1/apps/2/versions/3')
   })
 })

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -845,11 +845,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return appDeepLink({id, organizationId})
   }
 
-  async versionDeepLink(organizationId: string, appId: string, versionId: string): Promise<string> {
-    const appLink = await this.appDeepLink({organizationId, id: appId})
-    return `${appLink}/versions/${numberFromGid(versionId)}`
-  }
-
   async devSessionCreate({appId, assetsUrl, shopFqdn}: DevSessionOptions): Promise<DevSessionCreateMutation> {
     const appIdNumber = String(numberFromGid(appId))
     return appDevRequest(DevSessionCreate, shopFqdn, await this.token(), {appId: appIdNumber, assetsUrl})

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -667,7 +667,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
           // Need to deal with ID properly as it's expected to be a number... how do we use it?
           id: parseInt(version.id, 10),
           versionTag: version.metadata.versionTag,
-          location: [await this.appDeepLink({organizationId, id: appId}), `versions/${version.id}`].join('/'),
+          location: await this.versionDeepLink(organizationId, appId, version.id),
           appModuleVersions: version.appModules.map((mod) => {
             return {
               uuid: mod.uuid,
@@ -845,6 +845,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
   async appDeepLink({id, organizationId}: Pick<MinimalAppIdentifiers, 'id' | 'organizationId'>): Promise<string> {
     return `https://${await developerDashboardFqdn()}/dashboard/${organizationId}/apps/${numberFromGid(id)}`
+  }
+
+  async versionDeepLink(organizationId: string, appId: string, versionId: string): Promise<string> {
+    const appLink = await this.appDeepLink({organizationId, id: appId})
+    return `${appLink}/versions/${numberFromGid(versionId)}`
   }
 
   async devSessionCreate({appId, assetsUrl, shopFqdn}: DevSessionOptions): Promise<DevSessionCreateMutation> {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -845,6 +845,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return appDeepLink({id, organizationId})
   }
 
+  async versionDeepLink(organizationId: string, appId: string, versionId: string): Promise<string> {
+    const appLink = await this.appDeepLink({organizationId, id: appId})
+    return `${appLink}/versions/${numberFromGid(versionId)}`
+  }
+
   async devSessionCreate({appId, assetsUrl, shopFqdn}: DevSessionOptions): Promise<DevSessionCreateMutation> {
     const appIdNumber = String(numberFromGid(appId))
     return appDevRequest(DevSessionCreate, shopFqdn, await this.token(), {appId: appIdNumber, assetsUrl})

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -136,10 +136,10 @@ import {
   businessPlatformRequest,
   businessPlatformRequestDoc,
 } from '@shopify/cli-kit/node/api/business-platform'
-import {developerDashboardFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 import {versionSatisfies} from '@shopify/cli-kit/node/node-package-manager'
 import {outputWarn} from '@shopify/cli-kit/node/output'
+import {developerDashboardFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
 const TEMPLATE_JSON_URL = 'https://raw.githubusercontent.com/Shopify/extensions-templates/main/templates.json'
 
@@ -503,11 +503,9 @@ export class AppManagementClient implements DeveloperPlatformClient {
           id: parseInt(versionInfo.id, 10),
           uuid: versionInfo.id,
           versionTag: versionInfo.metadata.versionTag,
-          location: [
-            await this.appDeepLink({organizationId, id: appId}),
-            'versions',
-            numberFromGid(versionInfo.id),
-          ].join('/'),
+          location: [await appDeepLink({organizationId, id: appId}), 'versions', numberFromGid(versionInfo.id)].join(
+            '/',
+          ),
           message: '',
           appModuleVersions: versionInfo.appModules.map((mod: AppModuleReturnType) => {
             return {
@@ -667,7 +665,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
           // Need to deal with ID properly as it's expected to be a number... how do we use it?
           id: parseInt(version.id, 10),
           versionTag: version.metadata.versionTag,
-          location: await this.versionDeepLink(organizationId, appId, version.id),
+          location: await versionDeepLink(organizationId, appId, version.id),
           appModuleVersions: version.appModules.map((mod) => {
             return {
               uuid: mod.uuid,
@@ -718,7 +716,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
           versionTag: releaseResult.appReleaseCreate.release.version.metadata.versionTag,
           message: releaseResult.appReleaseCreate.release.version.metadata.message,
           location: [
-            await this.appDeepLink({organizationId, id: appId}),
+            await appDeepLink({organizationId, id: appId}),
             'versions',
             numberFromGid(releaseResult.appReleaseCreate.release.version.id),
           ].join('/'),
@@ -841,6 +839,10 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
   toExtensionGraphQLType(input: string) {
     return input.toLowerCase()
+  }
+
+  async appDeepLink({id, organizationId}: Pick<MinimalAppIdentifiers, 'id' | 'organizationId'>): Promise<string> {
+    return appDeepLink({id, organizationId})
   }
 
   async devSessionCreate({appId, assetsUrl, shopFqdn}: DevSessionOptions): Promise<DevSessionCreateMutation> {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -843,15 +843,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return input.toLowerCase()
   }
 
-  async appDeepLink({id, organizationId}: Pick<MinimalAppIdentifiers, 'id' | 'organizationId'>): Promise<string> {
-    return `https://${await developerDashboardFqdn()}/dashboard/${organizationId}/apps/${numberFromGid(id)}`
-  }
-
-  async versionDeepLink(organizationId: string, appId: string, versionId: string): Promise<string> {
-    const appLink = await this.appDeepLink({organizationId, id: appId})
-    return `${appLink}/versions/${numberFromGid(versionId)}`
-  }
-
   async devSessionCreate({appId, assetsUrl, shopFqdn}: DevSessionOptions): Promise<DevSessionCreateMutation> {
     const appIdNumber = String(numberFromGid(appId))
     return appDevRequest(DevSessionCreate, shopFqdn, await this.token(), {appId: appIdNumber, assetsUrl})
@@ -968,6 +959,18 @@ function idFromEncodedGid(gid: string): string {
 // gid://organization/Organization/1234 => 1234
 function numberFromGid(gid: string): number {
   return Number(gid.match(/^gid.*\/(\d+)$/)![1])
+}
+
+async function appDeepLink({
+  id,
+  organizationId,
+}: Pick<MinimalAppIdentifiers, 'id' | 'organizationId'>): Promise<string> {
+  return `https://${await developerDashboardFqdn()}/dashboard/${organizationId}/apps/${numberFromGid(id)}`
+}
+
+export async function versionDeepLink(organizationId: string, appId: string, versionId: string): Promise<string> {
+  const appLink = await appDeepLink({organizationId, id: appId})
+  return `${appLink}/versions/${numberFromGid(versionId)}`
 }
 
 interface DiffAppModulesInput {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2005

### WHAT is this pull request doing?

Generates the right URL by extracting the version ID from the global ID returned by the backend

### How to test your changes?

- `USE_APP_MANAGEMENT_API=1 p shopify app deploy` 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
