### PR TITLE
Fix running Javy and function-runner on Windows

### DIFF
--- a/.changeset/smart-mugs-love.md
+++ b/.changeset/smart-mugs-love.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix Javy and function-runner downloads on Windows

--- a/packages/app/src/cli/services/function/binaries.test.ts
+++ b/packages/app/src/cli/services/function/binaries.test.ts
@@ -1,4 +1,5 @@
-import {javyBinary, functionRunnerBinary} from './binaries.js'
+import {javyBinary, functionRunnerBinary, installBinary} from './binaries.js'
+import {exec} from '@shopify/cli-kit/node/system'
 import {describe, expect, test} from 'vitest'
 
 const javy = javyBinary()
@@ -8,7 +9,11 @@ describe('javy', () => {
   test('properties are set correctly', () => {
     expect(javy.name).toBe('javy')
     expect(javy.version).match(/^v\d\.\d\.\d$/)
-    expect(javy.path).toMatch(/(\/|\\)javy$/)
+    if (process.platform === 'win32') {
+      expect(javy.path).toMatch(/(\/|\\)javy.exe$/)
+    } else {
+      expect(javy.path).toMatch(/(\/|\\)javy$/)
+    }
   })
 
   describe('downloadUrl returns the correct URL', () => {
@@ -101,13 +106,22 @@ describe('javy', () => {
       )
     })
   })
+
+  test('Javy installs and runs', async () => {
+    await installBinary(javy)
+    await exec(javy.path, ['--help'])
+  })
 })
 
 describe('functionRunner', () => {
   test('properties are set correctly', () => {
     expect(functionRunner.name).toBe('function-runner')
     expect(functionRunner.version).match(/^v\d\.\d\.\d$/)
-    expect(functionRunner.path).toMatch(/(\/|\\)function-runner$/)
+    if (process.platform === 'win32') {
+      expect(functionRunner.path).toMatch(/(\/|\\)function-runner.exe$/)
+    } else {
+      expect(functionRunner.path).toMatch(/(\/|\\)function-runner$/)
+    }
   })
 
   describe('downloadUrl returns the correct URL', () => {
@@ -199,5 +213,10 @@ describe('functionRunner', () => {
         'Unsupported platform/architecture combination win32/arm',
       )
     })
+  })
+
+  test('function-runner installs and runs', async () => {
+    await installBinary(functionRunner)
+    await exec(functionRunner.path, ['--help'])
   })
 })

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -22,7 +22,8 @@ class DownloadableBinary {
   constructor(name: string, version: string, gitHubRepo: string) {
     this.name = name
     this.version = version
-    this.path = joinPath(dirname(fileURLToPath(import.meta.url)), '..', 'bin', `${this.name}`)
+    const filename = process.platform === 'win32' ? `${name}.exe` : name
+    this.path = joinPath(dirname(fileURLToPath(import.meta.url)), '..', 'bin', filename)
     this.gitHubRepo = gitHubRepo
   }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->
Fixes bug on Windows where Javy and function-runner binaries are not executing because the file names do not end with `.exe`. Also adds installing and executing both binaries to the test suite.

### WHY are these changes introduced?

Javy was not was not running on Windows because the executable did not end in `.exe`.

### WHAT is this pull request doing?

Adds `.exe` to the Javy and function-runner binary names on Windows.

### How to test your changes?

If you're on Windows, using cmd:

1. Create a Shopify app containing at least one JS Function extension if you do not already have one.
2. `pnpm shopify app build --path <path_to_app>` will perform the initial download of Javy.
3. Verify there are no errors reported.
4. `pnpm shopify app build --path <path_to_app>` will test that it uses the downloaded version of Javy.
5. Verify there are no errors reported.
6. `echo {} | pnpm shopify app function run --path <path_to_js_function_extension>` will test the initial download of function-runner.
7. Verify there are no errors reported.
8. `echo {} | pnpm shopify app function run --path <path_to_js_function_extension>` will it uses the downloaded version of function-runner.
9. Verify there are no errors reported.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
