### PR TITLE
Add allow_direct_linking to UIExtension schema

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -32,11 +32,16 @@ export const ExtensionsArraySchema = zod.object({
   extensions: zod.array(zod.any()).optional(),
 })
 
+const TargetCapabilitiesSchema = zod.object({
+  allow_direct_linking: zod.boolean().optional(),
+})
+
 const NewExtensionPointSchema = zod.object({
   target: zod.string(),
   module: zod.string(),
   metafields: zod.array(MetafieldSchema).optional(),
   default_placement: zod.string().optional(),
+  capabilities: TargetCapabilitiesSchema.optional(),
 })
 
 export const NewExtensionPointsSchema = zod.array(NewExtensionPointSchema)

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -122,6 +122,7 @@ describe('ui_extension', async () => {
           module: './src/ExtensionPointA.js',
           metafields: [{namespace: 'test', key: 'test'}],
           default_placement_reference: undefined,
+          capabilities: undefined,
         },
       ])
     })
@@ -171,6 +172,57 @@ describe('ui_extension', async () => {
           module: './src/ExtensionPointA.js',
           metafields: [],
           default_placement_reference: 'PLACEMENT_REFERENCE1',
+          capabilities: undefined,
+        },
+      ])
+    })
+
+    test('targeting object accepts allow_direct_linking for target capabilities', async () => {
+      const allSpecs = await loadLocalExtensionsSpecifications()
+      const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
+      const configuration = {
+        targeting: [
+          {
+            target: 'EXTENSION::POINT::A',
+            module: './src/ExtensionPointA.js',
+            capabilities: {allow_direct_linking: true},
+          },
+        ],
+        api_version: '2023-01' as const,
+        name: 'UI Extension',
+        description: 'This is an ordinary test extension',
+        type: 'ui_extension',
+        capabilities: {
+          block_progress: false,
+          network_access: false,
+          api_access: false,
+          collect_buyer_consent: {
+            customer_privacy: true,
+            sms_marketing: false,
+          },
+          iframe: {
+            sources: [],
+          },
+        },
+        settings: {},
+      }
+
+      // When
+      const parsed = specification.parseConfigurationObject(configuration)
+      if (parsed.state !== 'ok') {
+        throw new Error("Couldn't parse configuration")
+      }
+
+      const got = parsed.data
+
+      // Then
+      expect(got.extension_points).toStrictEqual([
+        {
+          target: 'EXTENSION::POINT::A',
+          module: './src/ExtensionPointA.js',
+          metafields: [],
+          default_placement_reference: undefined,
+          capabilities: {allow_direct_linking: true},
         },
       ])
     })

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -30,6 +30,7 @@ export const UIExtensionSchema = BaseSchema.extend({
         module: targeting.module,
         metafields: targeting.metafields ?? config.metafields ?? [],
         default_placement_reference: targeting.default_placement,
+        capabilities: targeting.capabilities,
       }
     })
     return {...config, extension_points: extensionPoints}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->
Part 2 of https://github.com/Shopify/core-issues/issues/74004
Vault project: https://vault.shopify.io/gsd/projects/39317
### WHY are these changes introduced?

Following the decision on the [tech design](https://docs.google.com/document/d/1DIDgtmb-JicQU9RCmzWfsVYDcV_MNE4KsdxytKRANAI/edit#heading=h.f0wr9ffq0l9g) to introduce a property called `allow_direct_linking` for an extension point's configurable capabilities. This allows app developers to configure whether the app extension can be used inside navigations (do they render a root url)

https://github.com/Shopify/shopify/pull/524406 is for the core side validations and updates the UiExtension API schema to incorporate target-level capabilities. This pull request allows `allow_direct_linking` to be configured for a ui_extension target. 

### WHAT is this pull request doing?

Add an optional capabilities hash which includes an optional `allow_direct_linking` boolean to the `NewExtensionPointSchema`.

### How to test your changes?

Make sure you have a spin instance with partners constellation, can use customer-accounts-dev-ui. Check out https://github.com/Shopify/shopify/pull/524406 there and enable the [api client flag](https://experiments.shopify.com/flags/enable_ui_extension_allow_direct_linking) `bin/rails g verdict:configure_flag enable_ui_extension_allow_direct_linking --subject_type "api_client" --percent 100`
1. Clone the CLI tool `dev clone cli` locally
2. Checkout this branch. From the `cli` directory, install pnpm `pnpm install`, then create an app `SHOPIFY_CLI_1P_DEV=1 SPIN_INSTANCE={spin_name} SHOPIFY_SERVICE_ENV=spin pnpm create @shopify/app` 
3. Create an extension, `SPIN_INSTANCE={spin_name} SHOPIFY_SERVICE_ENV=spin pnpm shopify app generate extension` from the app's directory
4. Install the app to your development store by using the partner dashboard > apps > select your app > test your app > select store
5. Add allow_direct_linking to the `shopify.extension.toml` shopify.extension.toml configuration found inside your extension directory
```
[[extensions.targeting]]
module = "./src/FullPageExtension.tsx"
target = "customer-account.page.render"

  [extensions.targeting.capabilities]
  allow_direct_linking = true
```
6. Change directory back to main cli directory and deploy `SPIN_INSTANCE={spin_name} SHOPIFY_SERVICE_ENV=spin pnpm shopify app deploy --path /Users/path_to_your_app`

### Post-release steps

We will need to have docs updated when [Configure header menu for customer accounts](https://vault.shopify.io/gsd/projects/39317) is released tracked in this issue https://github.com/Shopify/core-issues/issues/75186

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
