### PR TITLE
Only reset errors if there are errors

### DIFF
--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
@@ -52,7 +52,7 @@ export function usePollAppLogs({initialJwt, filters, resubscribeCallback}: UsePo
         }
         retryIntervalMs = result.retryIntervalMs
       } else {
-        setErrors([])
+        setErrors((errors) => (errors.length ? [] : errors))
       }
 
       const {cursor: nextCursor, appLogs} = response as SuccessResponse


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-functions/issues/364

### WHAT is this pull request doing?

Because React re-renders when a state changes (by reference), every time we received a successful request, we were setting the errors array. We poll roughly twice a second, which meant that we are performing a ton of unnecessary re-renders, causing flickering.

### How to test your changes?

1. Run `app logs`
2. Trigger enough function runs so that your terminal has to scroll

With this change, there should be no flickering and it should be easy to copy your function run output.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
