### PR TITLE
Fix App Inner Loop team handle

### DIFF
--- a/.github/workflows/reviewers-reminder.yml
+++ b/.github/workflows/reviewers-reminder.yml
@@ -24,4 +24,4 @@ jobs:
             - UI extensions: @shopify/ui-extensions-cli
               - Checkout UI extensions: @shopify/checkout-ui-extensions-api-stewardship
             - Hydrogen: @shopify/hydrogen
-            - Other: @shopify/app-management
+            - Other: @shopify/app-inner-loop


### PR DESCRIPTION
### WHY are these changes introduced?

This reminder is still showing the old handle of the team (@shopify/app-management):

<img width="947" alt="cli 2024-08-08 09-34-15" src="https://github.com/user-attachments/assets/96520319-d907-4a4b-85e2-9c2219a2f0f7">

### WHAT is this pull request doing?

Update it to @Shopify/app-inner-loop 

### How to test your changes?

See [below](https://github.com/Shopify/cli/pull/4286#issuecomment-2275149043)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
