### PR TITLE
Upgrade Cloudflared and use the new release for ARM64

### DIFF
--- a/.changeset/khaki-shirts-taste.md
+++ b/.changeset/khaki-shirts-taste.md
@@ -1,0 +1,5 @@
+---
+'@shopify/plugin-cloudflare': patch
+---
+
+Upgrade cloudflared to 2024.8.2 and use the arm64 release

--- a/packages/plugin-cloudflare/src/install-cloudflared.test.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.test.ts
@@ -36,7 +36,7 @@ describe('install-cloudflare', () => {
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
-  test('install works when system is mac', async () => {
+  test('install works when system is mac and x64', async () => {
     // Given
     const env = {}
 
@@ -46,7 +46,22 @@ describe('install-cloudflare', () => {
     // Then
     // expect(global.fetch).not.toHaveBeenCalled()
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://github.com/cloudflare/cloudflared/releases/download/2024.6.1/cloudflared-darwin-amd64.tgz',
+      'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-darwin-amd64.tgz',
+      expect.anything(),
+    )
+  })
+
+  test('install works when system is mac and arm64', async () => {
+    // Given
+    const env = {}
+
+    // When
+    await install(env, 'darwin', 'arm64')
+
+    // Then
+    // expect(global.fetch).not.toHaveBeenCalled()
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-darwin-arm64.tgz',
       expect.anything(),
     )
   })
@@ -61,7 +76,7 @@ describe('install-cloudflare', () => {
     // Then
     // expect(global.fetch).not.toHaveBeenCalled()
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://github.com/cloudflare/cloudflared/releases/download/2024.6.1/cloudflared-linux-amd64',
+      'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-linux-amd64',
       expect.anything(),
     )
   })
@@ -75,7 +90,7 @@ describe('install-cloudflare', () => {
 
     // Then
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://github.com/cloudflare/cloudflared/releases/download/2024.6.1/cloudflared-windows-amd64.exe',
+      'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-windows-amd64.exe',
       expect.anything(),
     )
   })

--- a/packages/plugin-cloudflare/src/install-cloudflared.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.ts
@@ -15,7 +15,7 @@ import {pipeline} from 'stream'
 // eslint-disable-next-line no-restricted-imports
 import {execSync, execFileSync} from 'child_process'
 
-export const CURRENT_CLOUDFLARE_VERSION = '2024.6.1'
+export const CURRENT_CLOUDFLARE_VERSION = '2024.8.2'
 const CLOUDFLARE_REPO = `https://github.com/cloudflare/cloudflared/releases/download/${CURRENT_CLOUDFLARE_VERSION}/`
 
 const LINUX_URL: {[key: string]: string} = {
@@ -26,7 +26,7 @@ const LINUX_URL: {[key: string]: string} = {
 }
 
 const MACOS_URL: {[key: string]: string} = {
-  arm64: 'cloudflared-darwin-amd64.tgz',
+  arm64: 'cloudflared-darwin-arm64.tgz',
   x64: 'cloudflared-darwin-amd64.tgz',
 }
 

--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -134,15 +134,6 @@ class TunnelClientInstance implements TunnelClient {
       signal: this.abortController.signal,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       externalErrorHandler: async (error: any) => {
-        if (error.message.includes('Unknown system error -86')) {
-          // Cloudflare crashed because Rosetta 2 is not installed
-          this.currentStatus = {
-            status: 'error',
-            message: `Could not start Cloudflare tunnel: Missing Rosetta 2.`,
-            tryMessage: "Install it by running 'softwareupdate --install-rosetta' and try again",
-          }
-          return
-        }
         // If already resolved, means that the CLI already received the tunnel URL.
         // Can't retry because the CLI is running with an invalid URL
         if (resolved) {


### PR DESCRIPTION
### WHY are these changes introduced?

The [latest release from cloudflared](https://github.com/cloudflare/cloudflared/releases/tag/2024.8.2) finally includes the ARM64 version, so we can use it and not require Rosetta anymore.

### WHAT is this pull request doing?

- Upgrades cloudflared
- Uses the new release for the ARM64 platform
- Removes an error related to Rosetta

### How to test your changes?

 - `p shopify app dev`
 - `./packages/plugin-cloudflare/bin/cloudflared version` => 2024.8.2
 - [Ensure Rosetta is not used](https://thenextweb.com/news/how-to-check-app-running-m1-native-version-on-mac): 
   - `./packages/plugin-cloudflare/bin/cloudflared tunnel --url localhost:8080`
   - Open the Activity Monitor
   - Filter by `cloudflared`
   - Check that it shows `Apple` in the `Kind` column

Tested in Mac/Linux/Windows

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
