### PR TITLE
Fix handle being too long on flow import

### DIFF
--- a/.changeset/metal-jobs-relax.md
+++ b/.changeset/metal-jobs-relax.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix importing flow extensions with long names

--- a/packages/app/src/cli/services/import-extensions.ts
+++ b/packages/app/src/cli/services/import-extensions.ts
@@ -5,10 +5,12 @@ import {AppInterface} from '../models/app/app.js'
 import {updateAppIdentifiers, IdentifiersExtensions} from '../models/app/identifiers.js'
 import {ExtensionRegistration} from '../api/graphql/all_app_extension_registrations.js'
 import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../utilities/developer-platform-client.js'
+import {MAX_EXTENSION_HANDLE_LENGTH} from '../models/extensions/schemas.js'
 import {renderSelectPrompt, renderSuccess} from '@shopify/cli-kit/node/ui'
 import {basename, joinPath} from '@shopify/cli-kit/node/path'
 import {writeFile} from '@shopify/cli-kit/node/fs'
 import {outputContent} from '@shopify/cli-kit/node/output'
+import {slugify} from '@shopify/cli-kit/common/string'
 
 interface ImportOptions {
   app: AppInterface
@@ -58,7 +60,8 @@ export async function importExtensions(options: ImportOptions) {
     const tomlObject = options.buildTomlObject(ext, extensionRegistrations)
     const path = joinPath(directory, 'shopify.extension.toml')
     await writeFile(path, tomlObject)
-    extensionUuids[ext.title] = ext.uuid
+    const handle = slugify(ext.title.substring(0, MAX_EXTENSION_HANDLE_LENGTH))
+    extensionUuids[handle] = ext.uuid
     return {extension: ext, directory: joinPath('extensions', basename(directory))}
   })
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
- There is currently a limit for handles to be 30 chars long
- The process to import flow extensions (or other importable extensions) was using the name of the extension as identifier in the `.env`
- This is OK when the name is less than 30 chars, as the output would be identical to the handle value.
- If the title is longer, then the id in the `.env` file won't match the `handle` and the deploy will fail.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Adjust the value used to store the key in the `.env` file to match the handle.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
