### PR TITLE
[Themes] Console - Make storefront password storage sticky

### DIFF
--- a/packages/theme/src/cli/services/local-storage.ts
+++ b/packages/theme/src/cli/services/local-storage.ts
@@ -11,9 +11,14 @@ interface DevelopmentThemeLocalStorageSchema {
   [themeStore: string]: DevelopmentThemeId
 }
 
+interface ThemeStorePasswordSchema {
+  [themeStore: string]: string
+}
+
 let _themeLocalStorageInstance: LocalStorage<ThemeLocalStorageSchema> | undefined
 let _developmentThemeLocalStorageInstance: LocalStorage<DevelopmentThemeLocalStorageSchema> | undefined
 let _replThemeLocalStorageInstance: LocalStorage<DevelopmentThemeLocalStorageSchema> | undefined
+let _themeStoreLocalStorageInstance: LocalStorage<ThemeStorePasswordSchema> | undefined
 
 function themeLocalStorage() {
   if (!_themeLocalStorageInstance) {
@@ -38,6 +43,15 @@ function replThemeLocalStorage() {
     })
   }
   return _replThemeLocalStorageInstance
+}
+
+function themeStoreLocalStorage() {
+  if (!_themeStoreLocalStorageInstance) {
+    _themeStoreLocalStorageInstance = new LocalStorage<ThemeStorePasswordSchema>({
+      projectName: 'shopify-cli-theme-store-password',
+    })
+  }
+  return _themeStoreLocalStorageInstance
 }
 
 export function getThemeStore() {
@@ -76,4 +90,22 @@ export function setREPLTheme(theme: string): void {
 export function removeREPLTheme(): void {
   outputDebug(outputContent`Removing REPL theme...`)
   replThemeLocalStorage().delete(getThemeStore())
+}
+
+export function getStorefrontPassword(): string | undefined {
+  const themeStore = getThemeStore()
+  outputDebug(outputContent`Getting storefront password for shop ${themeStore}...`)
+  return themeStoreLocalStorage().get(getThemeStore())
+}
+
+export function setStorefrontPassword(password: string): void {
+  const themeStore = getThemeStore()
+  outputDebug(outputContent`Setting storefront password for shop ${themeStore}...`)
+  themeStoreLocalStorage().set(themeStore, password)
+}
+
+export function removeStorefrontPassword(): void {
+  const themeStore = getThemeStore()
+  outputDebug(outputContent`Removing storefront password for ${themeStore}...`)
+  themeStoreLocalStorage().delete(themeStore)
 }

--- a/packages/theme/src/cli/utilities/repl/storefront-password-prompt.test.ts
+++ b/packages/theme/src/cli/utilities/repl/storefront-password-prompt.test.ts
@@ -1,6 +1,6 @@
 import {ensureValidPassword} from './storefront-password-prompt.js'
 import {isStorefrontPasswordProtected, isStorefrontPasswordCorrect} from '../theme-environment/storefront-session.js'
-import {getStorefrontPassword, setStorefrontPassword} from '../../services/local-storage.js'
+import {getStorefrontPassword, removeStorefrontPassword, setStorefrontPassword} from '../../services/local-storage.js'
 import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 import {describe, beforeEach, vi, test, expect} from 'vitest'
 
@@ -64,7 +64,6 @@ describe('ensureValidPassword', () => {
     expect(isStorefrontPasswordCorrect).toHaveBeenCalledWith('testPassword', 'test-store')
   })
 
-  // should set the password in local storage when a password is provided
   test('should set the password in local storage when a password is validated', async () => {
     // Given
     vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
@@ -77,7 +76,6 @@ describe('ensureValidPassword', () => {
     expect(setStorefrontPassword).toHaveBeenCalledWith('testPassword')
   })
 
-  // should prompt user for password if local storage password is no longer correct
   test('should prompt user for password if local storage password is no longer correct', async () => {
     // Given
     vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
@@ -91,5 +89,6 @@ describe('ensureValidPassword', () => {
     // Then
     expect(renderTextPrompt).toHaveBeenCalled()
     expect(setStorefrontPassword).toHaveBeenCalledWith('correctPassword')
+    expect(removeStorefrontPassword).toHaveBeenCalled()
   })
 })

--- a/packages/theme/src/cli/utilities/repl/storefront-password-prompt.test.ts
+++ b/packages/theme/src/cli/utilities/repl/storefront-password-prompt.test.ts
@@ -1,10 +1,12 @@
 import {ensureValidPassword} from './storefront-password-prompt.js'
 import {isStorefrontPasswordProtected, isStorefrontPasswordCorrect} from '../theme-environment/storefront-session.js'
+import {getStorefrontPassword, setStorefrontPassword} from '../../services/local-storage.js'
 import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 import {describe, beforeEach, vi, test, expect} from 'vitest'
 
-vi.mock('../theme-environment/storefront-session.js')
 vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('../theme-environment/storefront-session.js')
+vi.mock('../../services/local-storage.js')
 vi.mock('../utilities/repl-theme-manager.js', () => {
   const REPLThemeManager = vi.fn()
   REPLThemeManager.prototype.findOrCreate = () => ({
@@ -47,5 +49,47 @@ describe('ensureValidPassword', () => {
 
     // Then
     expect(renderTextPrompt).toHaveBeenCalledTimes(2)
+  })
+
+  test('should read the password from local storage when no password is provided', async () => {
+    // Given
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
+    vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)
+    vi.mocked(getStorefrontPassword).mockReturnValue('testPassword')
+
+    // When
+    await ensureValidPassword(undefined, 'test-store')
+
+    // Then
+    expect(isStorefrontPasswordCorrect).toHaveBeenCalledWith('testPassword', 'test-store')
+  })
+
+  // should set the password in local storage when a password is provided
+  test('should set the password in local storage when a password is validated', async () => {
+    // Given
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
+    vi.mocked(isStorefrontPasswordCorrect).mockResolvedValue(true)
+
+    // When
+    await ensureValidPassword('testPassword', 'test-store')
+
+    // Then
+    expect(setStorefrontPassword).toHaveBeenCalledWith('testPassword')
+  })
+
+  // should prompt user for password if local storage password is no longer correct
+  test('should prompt user for password if local storage password is no longer correct', async () => {
+    // Given
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
+    vi.mocked(isStorefrontPasswordCorrect).mockResolvedValueOnce(false).mockResolvedValue(true)
+    vi.mocked(getStorefrontPassword).mockReturnValue('incorrectPassword')
+    vi.mocked(renderTextPrompt).mockResolvedValue('correctPassword')
+
+    // When
+    await ensureValidPassword(undefined, 'test-store')
+
+    // Then
+    expect(renderTextPrompt).toHaveBeenCalled()
+    expect(setStorefrontPassword).toHaveBeenCalledWith('correctPassword')
   })
 })

--- a/packages/theme/src/cli/utilities/repl/storefront-password-prompt.ts
+++ b/packages/theme/src/cli/utilities/repl/storefront-password-prompt.ts
@@ -1,12 +1,17 @@
-import {getStorefrontPassword, setStorefrontPassword} from '../../services/local-storage.js'
+import {getStorefrontPassword, removeStorefrontPassword, setStorefrontPassword} from '../../services/local-storage.js'
 import {isStorefrontPasswordCorrect} from '../theme-environment/storefront-session.js'
 import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 export async function ensureValidPassword(password: string | undefined, store: string) {
   let finalPassword = password || getStorefrontPassword() || (await promptPassword('Enter your theme password'))
+  let isPasswordRemoved = false
 
   // eslint-disable-next-line no-await-in-loop
   while (!(await isStorefrontPasswordCorrect(finalPassword, store))) {
+    if (!isPasswordRemoved) {
+      removeStorefrontPassword()
+      isPasswordRemoved = true
+    }
     // eslint-disable-next-line no-await-in-loop
     finalPassword = await promptPassword('Incorrect password provided. Please try again')
   }

--- a/packages/theme/src/cli/utilities/repl/storefront-password-prompt.ts
+++ b/packages/theme/src/cli/utilities/repl/storefront-password-prompt.ts
@@ -1,14 +1,17 @@
+import {getStorefrontPassword, setStorefrontPassword} from '../../services/local-storage.js'
 import {isStorefrontPasswordCorrect} from '../theme-environment/storefront-session.js'
 import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 
 export async function ensureValidPassword(password: string | undefined, store: string) {
-  let finalPassword = password || (await promptPassword('Enter your theme password'))
+  let finalPassword = password || getStorefrontPassword() || (await promptPassword('Enter your theme password'))
 
   // eslint-disable-next-line no-await-in-loop
   while (!(await isStorefrontPasswordCorrect(finalPassword, store))) {
     // eslint-disable-next-line no-await-in-loop
     finalPassword = await promptPassword('Incorrect password provided. Please try again')
   }
+
+  setStorefrontPassword(finalPassword)
   return finalPassword
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?
- https://github.com/Shopify/develop-advanced-edits/issues/276

### WHAT is this pull request doing?
- Stores the storefront password in local storage so that users don't have to continually provide the password via a flag or text input
- Passwords are stored separately for **each store**

This includes
- Basic storage of valid passwords
- Ability to override the stored value with the `--store-password flag`
- Removal of incorrect or outdated passwords

https://github.com/user-attachments/assets/1ad8752a-a788-40b2-ab1a-de887a51cfdc

### How to test your changes?

**Basic Usage:**
1) Run the command with a correct password
2) Run the command again without providing a password - it should work

**Override Capability:**
3) Override the stored password by using the  `--store-password` flag with an incorrect value
4) You should be prompted to input another password again

**Incorrect Password Handling:**
5) Provide incorrect password
6) Terminate the session `ctrl + c`
7) Run the command again and verify that you're prompted to provide the password

**Notes**
- _A hacky way to "flush" local storage is to modify the project name [here](https://github.com/Shopify/cli/pull/4295/files#diff-13a6338bd5d9fcd9084551b529c16494db56a6c46e67aed35702c309998f133aR48-R56) and run `p build`_
- You can also test changing the password via the admin panel to invalidate the stored password

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
