### PR TITLE
Remove legacy customer account target

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -143,10 +143,10 @@ describe('getExtensionPointRedirectUrl()', () => {
       id: 123,
     } as unknown as ExtensionDevOptions
 
-    const result = getExtensionPointRedirectUrl('CustomerAccount::FullPage::RenderWithin', extension, options)
+    const result = getExtensionPointRedirectUrl('customer-account.page.render', extension, options)
 
     expect(result).toBe(
-      'https://shopify.com/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&appId=123&target=CustomerAccount%3A%3AFullPage%3A%3ARenderWithin',
+      'https://shopify.com/123456789/account/extensions-development?origin=https%3A%2F%2Flocalhost%3A8081%2Fextensions&extensionId=123abc&source=CUSTOMER_ACCOUNT_EXTENSION&appId=123&target=customer-account.page.render',
     )
   })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Relates to: https://github.com/Shopify/core-issues/issues/70673

The `CustomerAccount::FullPage::RenderWithin` is a legacy target which is no longer supported. The correct name for the target is `customer-account.page.render`

### WHAT is this pull request doing?

Replaces the legacy target with the correct target

### How to test your changes?

Let CI run.

### Post-release steps

N/A

### Measuring impact

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
