### PR TITLE
Bump cli-hydrogen version [stable branch]

### DIFF
--- a/packages/cli-kit/src/public/node/custom-oclif-loader.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.ts
@@ -9,7 +9,8 @@ export class ShopifyConfig extends Config {
     const currentPath = cwd()
 
     let path = sniffForPath() ?? currentPath
-    const currentPathMightBeHydrogenMonorepo = currentPath.toLowerCase().includes('shopify/hydrogen')
+    // Hydrogen CI uses `hydrogen/hydrogen` path, while local dev uses `shopify/hydrogen`.
+    const currentPathMightBeHydrogenMonorepo = /(shopify|hydrogen)\/hydrogen/i.test(currentPath)
     const ignoreHydrogenMonorepo = process.env.IGNORE_HYDROGEN_MONOREPO
     if (currentPathMightBeHydrogenMonorepo && !ignoreHydrogenMonorepo) {
       path = execaSync('npm', ['prefix']).stdout.trim()

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -109,7 +109,7 @@
     "@shopify/plugin-cloudflare": "3.65.2",
     "@shopify/plugin-did-you-mean": "3.65.2",
     "@shopify/theme": "3.65.2",
-    "@shopify/cli-hydrogen": "8.3.0",
+    "@shopify/cli-hydrogen": "8.4.0",
     "@types/node": "18.19.3",
     "@vitest/coverage-istanbul": "^1.6.0",
     "esbuild-plugin-copy": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,8 +280,8 @@ importers:
         specifier: 3.65.2
         version: link:../app
       '@shopify/cli-hydrogen':
-        specifier: 8.3.0
-        version: 8.3.0(@graphql-codegen/cli@5.0.2)(react-dom@17.0.2)(react@17.0.2)
+        specifier: 8.4.0
+        version: 8.4.0(@graphql-codegen/cli@5.0.2)(react-dom@17.0.2)(react@17.0.2)
       '@shopify/cli-kit':
         specifier: 3.65.2
         version: link:../cli-kit
@@ -6017,8 +6017,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@shopify/cli-hydrogen@8.3.0(@graphql-codegen/cli@5.0.2)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-aQdu1jVgEAhI7fnpOs+9Fpu6/O+0UDkE2fYAdTylwObAo11r/L3QQgBeDByN0yVPtlNyrK8+bcVby87y0u+6eg==}
+  /@shopify/cli-hydrogen@8.4.0(@graphql-codegen/cli@5.0.2)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-Ko8686rkofiE42RL5urDnK9QLZBPl2OCjVfPu7x87dHgmJDHlqsWade3goZjGN8rrsbrCHivfBLF9CY/Ra+hYw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
Mirror of #4299 for the stable branch. I've also cherry-picked [this fix](https://github.com/Shopify/cli/pull/4244) that we need for CI.