### PR TITLE
Add missing uid to the TOML when generating extensions

### DIFF
--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -125,7 +125,7 @@ async function themeExtensionInit({directory, url, type, name, extensionFlavor, 
   })
 }
 
-async function functionExtensionInit({directory, url, app, name, extensionFlavor}: ExtensionInitOptions) {
+async function functionExtensionInit({directory, url, app, name, extensionFlavor, uid}: ExtensionInitOptions) {
   const templateLanguage = getTemplateLanguage(extensionFlavor?.value)
   const taskList = []
 
@@ -138,6 +138,7 @@ async function functionExtensionInit({directory, url, app, name, extensionFlavor
           name,
           handle: slugify(name),
           flavor: extensionFlavor?.value,
+          uid,
         })
       })
 
@@ -179,7 +180,7 @@ async function functionExtensionInit({directory, url, app, name, extensionFlavor
   await renderTasks(taskList)
 }
 
-async function uiExtensionInit({directory, url, app, name, extensionFlavor}: ExtensionInitOptions) {
+async function uiExtensionInit({directory, url, app, name, extensionFlavor, uid}: ExtensionInitOptions) {
   const templateLanguage = getTemplateLanguage(extensionFlavor?.value)
 
   const tasks = [
@@ -195,6 +196,7 @@ async function uiExtensionInit({directory, url, app, name, extensionFlavor}: Ext
             name,
             handle: slugify(name),
             flavor: extensionFlavor?.value ?? '',
+            uid,
           })
         })
 


### PR DESCRIPTION
### WHY are these changes introduced?

It seems that we forgot to add the `uid` field to the extension TOML when generating functions or UI extensions. It did work for theme extensions.

### WHAT is this pull request doing?

Adds the missing fields

### How to test your changes?

`USE_APP_MANAGEMENT_API=1 p shopify app generate extension`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
