### PR TITLE
Dunk.source

### DIFF
--- a/packages/app/src/cli/commands/app/logs.ts
+++ b/packages/app/src/cli/commands/app/logs.ts
@@ -49,12 +49,14 @@ export default class Logs extends Command {
 
     const apiKey = flags['client-id'] || flags['api-key']
 
+    const sources = flags.source?.split(',')
+
     await checkFolderIsValidApp(flags.path)
     const logOptions = {
       apiKey,
       directory: flags.path,
       storeFqdn: flags.store,
-      source: flags.source,
+      sources,
       status: flags.status,
       configName: flags.config,
       reset: flags.reset,

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -455,7 +455,7 @@ export async function testFlowActionExtension(directory = './my-extension'): Pro
   return extension
 }
 
-function defaultFunctionConfiguration(): FunctionConfigType {
+export function defaultFunctionConfiguration(): FunctionConfigType {
   return {
     name: 'test function extension',
     description: 'description',

--- a/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.test.ts
@@ -37,7 +37,7 @@ const RESPONSE_DATA_SUCCESS = {
   cursor: RETURNED_CURSOR,
 }
 
-const EMPTY_FILTERS = {status: undefined, source: undefined}
+const EMPTY_FILTERS = {status: undefined, sources: undefined}
 
 // Custom mock response with .json method to mock response from poll
 const createMockResponse = (data: any, status = 200, statusText = 'OK') => {
@@ -78,7 +78,7 @@ describe('pollProcess', () => {
     const result = await pollAppLogs({
       jwtToken: MOCKED_JWT_TOKEN,
       cursor: MOCKED_CURSOR,
-      filters: {status: 'failure', source: 'my-function'},
+      filters: {status: 'failure', sources: ['extensions.my-function', 'extensions.my-other-function']},
     })
 
     expect(result).toEqual({

--- a/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.ts
@@ -1,4 +1,4 @@
-import {PollOptions, AppLogData, PollResponse} from '../types.js'
+import {PollOptions, AppLogData, PollResponse, PollFilters} from '../types.js'
 import {fetchAppLogs} from '../utils.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
@@ -32,13 +32,14 @@ export const pollAppLogs = async ({jwtToken, cursor, filters}: PollOptions): Pro
   }
 }
 
-function filterLogs(appLogs: AppLogData[], filters: {status: string | undefined; source: string | undefined}) {
+function filterLogs(appLogs: AppLogData[], filters: PollFilters) {
   let filterLogs: AppLogData[] = appLogs
 
-  if (filters.status !== undefined || filters.source !== undefined) {
+  if (filters.status !== undefined || filters.sources !== undefined) {
     filterLogs = filterLogs.filter((log) => {
       const statusMatch = filters.status === undefined ? true : log.status === filters.status
-      const sourceMatch = filters.source === undefined ? true : log.source === filters.source
+      const sourceMatch =
+        filters.sources === undefined ? true : filters.sources.includes(`${log.source_namespace}.${log.source}`)
       return statusMatch && sourceMatch
     })
   }

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
@@ -34,7 +34,7 @@ describe('renderJsonLogs', () => {
     vi.mocked(pollAppLogs).mockImplementation(pollAppLogsMock)
 
     await renderJsonLogs({
-      pollOptions: {cursor: 'cursor', filters: {status: undefined, source: undefined}, jwtToken: 'jwtToken'},
+      pollOptions: {cursor: 'cursor', filters: {status: undefined, sources: undefined}, jwtToken: 'jwtToken'},
       options: {
         variables: {shopIds: ['1'], apiKey: 'key', token: 'token'},
         developerPlatformClient: testDeveloperPlatformClient(),
@@ -63,7 +63,7 @@ describe('renderJsonLogs', () => {
     vi.mocked(handleFetchAppLogsError).mockImplementation(handleFetchAppLogsErrorMock)
 
     await renderJsonLogs({
-      pollOptions: {cursor: 'cursor', filters: {status: undefined, source: undefined}, jwtToken: 'jwtToken'},
+      pollOptions: {cursor: 'cursor', filters: {status: undefined, sources: undefined}, jwtToken: 'jwtToken'},
       options: {
         variables: {shopIds: [], apiKey: '', token: ''},
         developerPlatformClient: testDeveloperPlatformClient(),

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
@@ -152,7 +152,7 @@ const USE_POLL_APP_LOGS_ERRORS_RETURN_VALUE = {
   appLogOutputs: [],
 }
 
-const EMPTY_FILTERS = {status: undefined, source: undefined}
+const EMPTY_FILTERS = {status: undefined, sources: undefined}
 
 describe('Logs', () => {
   test('renders prefix and applogs', async () => {

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
@@ -177,7 +177,7 @@ const POLL_APP_LOGS_FOR_LOGS_UNKNOWN_RESPONSE = {
   errors: [{status: 422, message: 'Unprocessable'}],
 }
 
-const EMPTY_FILTERS = {status: undefined, source: undefined}
+const EMPTY_FILTERS = {status: undefined, sources: undefined}
 
 describe('usePollAppLogs', () => {
   beforeEach(() => {

--- a/packages/app/src/cli/services/app-logs/types.ts
+++ b/packages/app/src/cli/services/app-logs/types.ts
@@ -169,7 +169,7 @@ export interface PollOptions {
 
 export interface PollFilters {
   status: string | undefined
-  source: string | undefined
+  sources: string[] | undefined
 }
 export interface AppLogPrefix {
   status: string

--- a/packages/app/src/cli/services/logs.test.ts
+++ b/packages/app/src/cli/services/logs.test.ts
@@ -4,8 +4,15 @@ import {ensureDevContext} from './context.js'
 import * as renderLogs from './app-logs/logs-command/ui.js'
 import * as renderJsonLogs from './app-logs/logs-command/render-json-logs.js'
 import {loadAppConfiguration} from '../models/app/loader.js'
-import {buildVersionedAppSchema, testApp, testOrganizationApp} from '../models/app/app.test-data.js'
+import {
+  buildVersionedAppSchema,
+  testApp,
+  testOrganizationApp,
+  testFunctionExtension,
+  defaultFunctionConfiguration,
+} from '../models/app/app.test-data.js'
 import {consoleLog} from '@shopify/cli-kit/node/output'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {describe, test, vi, expect} from 'vitest'
 
 vi.mock('../models/app/loader.js')
@@ -28,7 +35,7 @@ describe('logs', () => {
       directory: 'directory',
       apiKey: 'api-key',
       storeFqdn: 'store-fqdn',
-      source: 'source',
+      sources: ['extensions.source'],
       status: 'status',
       configName: 'config-name',
       userProvidedConfigName: 'user-provided-config-name',
@@ -51,7 +58,7 @@ describe('logs', () => {
       apiKey: 'api-key',
       directory: 'directory',
       storeFqdn: 'store-fqdn',
-      source: 'source',
+      sources: ['extensions.source'],
       status: 'status',
       configName: 'config-name',
       userProvidedConfigName: 'user-provided-config-name',
@@ -61,9 +68,59 @@ describe('logs', () => {
     expect(consoleLog).toHaveBeenCalledWith('Waiting for app logs...\n')
     expect(spy).toHaveBeenCalled()
   })
+
+  test('should raise error when app has no valid sources', async () => {
+    // Given
+    await setupDevContext([])
+    const spy = vi.spyOn(renderLogs, 'renderLogs')
+
+    // When
+    await expect(() => {
+      return logs({
+        reset: false,
+        format: 'text',
+        apiKey: 'api-key',
+        directory: 'directory',
+        storeFqdn: 'store-fqdn',
+        sources: ['extensions.source'],
+        status: 'status',
+        configName: 'config-name',
+        userProvidedConfigName: 'user-provided-config-name',
+      })
+    }).rejects.toThrowError(
+      new AbortError(
+        'This app has no log sources. Learn more about app logs at https://shopify.dev/docs/api/shopify-cli/app/app-logs',
+      ),
+    )
+  })
+
+  test('should raise error when sources in filter do not match valid sources', async () => {
+    // Given
+    await setupDevContext(['realSource', 'anotherSource'])
+    const spy = vi.spyOn(renderLogs, 'renderLogs')
+
+    // When
+    await expect(() => {
+      return logs({
+        reset: false,
+        format: 'text',
+        apiKey: 'api-key',
+        directory: 'directory',
+        storeFqdn: 'store-fqdn',
+        sources: ['extensions.realSource', 'extensions.invalidSource'],
+        status: 'status',
+        configName: 'config-name',
+        userProvidedConfigName: 'user-provided-config-name',
+      })
+    }).rejects.toThrowError(
+      new AbortError(
+        'Invalid sources: extensions.invalidSource. Valid sources are: extensions.realSource, extensions.anotherSource',
+      ),
+    )
+  })
 })
 
-async function setupDevContext() {
+async function setupDevContext(handles: string[] = ['source']) {
   const {schema: configSchema} = await buildVersionedAppSchema()
   vi.mocked(loadAppConfiguration).mockResolvedValue({
     directory: '/app',
@@ -75,8 +132,16 @@ async function setupDevContext() {
     specifications: [],
     remoteFlags: [],
   })
+
+  const app = testApp()
+  app.realExtensions = await Promise.all(
+    handles.map(async (handle) => {
+      return testFunctionExtension({config: {handle, ...defaultFunctionConfiguration()}})
+    }),
+  )
+
   vi.mocked(ensureDevContext).mockResolvedValue({
-    localApp: testApp(),
+    localApp: app,
     remoteApp: testOrganizationApp(),
     remoteAppUpdated: false,
     updateURLs: false,

--- a/packages/app/src/cli/services/logs.ts
+++ b/packages/app/src/cli/services/logs.ts
@@ -5,6 +5,7 @@ import {renderJsonLogs} from './app-logs/logs-command/render-json-logs.js'
 import {AppInterface} from '../models/app/app.js'
 import {loadAppConfiguration} from '../models/app/loader.js'
 import {selectDeveloperPlatformClient, DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {consoleLog} from '@shopify/cli-kit/node/output'
 
 export type Format = 'json' | 'text'
@@ -14,7 +15,7 @@ interface LogsOptions {
   reset: boolean
   apiKey?: string
   storeFqdn?: string
-  source?: string
+  sources?: string[]
   status?: string
   configName?: string
   userProvidedConfigName?: string
@@ -23,6 +24,25 @@ interface LogsOptions {
 
 export async function logs(commandOptions: LogsOptions) {
   const logsConfig = await prepareForLogs(commandOptions)
+
+  const validSources = logsConfig.localApp.allExtensions.flatMap((extension) => {
+    return extension.isFunctionExtension ? [`extensions.${extension.configuration.handle}`] : []
+  })
+
+  if (validSources.length === 0) {
+    throw new AbortError(
+      `This app has no log sources. Learn more about app logs at https://shopify.dev/docs/api/shopify-cli/app/app-logs`,
+    )
+  }
+
+  if (commandOptions.sources) {
+    const invalidSources = commandOptions.sources.filter((source) => !validSources.includes(source))
+    if (invalidSources.length) {
+      throw new AbortError(
+        `Invalid sources: ${invalidSources.join(', ')}. Valid sources are: ${validSources.join(', ')}`,
+      )
+    }
+  }
 
   const variables = {
     shopIds: [logsConfig.storeId],
@@ -34,7 +54,7 @@ export async function logs(commandOptions: LogsOptions) {
 
   const filters = {
     status: commandOptions.status,
-    source: commandOptions.source,
+    sources: commandOptions.sources,
   }
 
   const pollOptions = {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes: https://github.com/Shopify/shopify-functions/issues/371

As per the issue, sources weren't using namespaces, didn't accept comma separated lists, and didn't validate against existing sources.

### WHAT is this pull request doing?

I've updated the command to split the source flag into a `sources` list, validated them against existing functions extensions (the only supported extension type ATM), and added an additional error when an app has no extensions that will receive logs. Also added in the namespace everywhere.

### How to test your changes?

Tophat:
- Create an app with no functions. Try to run app logs- it should fail with an error message
- Add a function. Try to run `shopify app logs --source=junk`, it should fail with a message indicating what the valid sources are
- Run `shopify app logs --source=extensions.your-function-name`, replacing the source with the function name
- Ensure that logs are received when the function runs
- Add an additional function, but don't configure it to run
- Run `shopify app logs --source=extensions.your-second-function-name`, replacing the source with the new function's name
- Trigger the function, ensure that the logs are filtered out and do not appear
- 
### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
