### PR TITLE
Add root test element to ensure proper word wrapping

### DIFF
--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.tsx
@@ -50,10 +50,12 @@ const Logs: FunctionComponent<LogsProps> = ({pollOptions: {jwtToken, filters}, r
           <Box flexDirection="column" key={index}>
             {/* update: use invocationId after https://github.com/Shopify/shopify-functions/issues/235 */}
             <Box flexDirection="row" gap={1}>
-              <Text color="green">{prefix.logTimestamp}</Text>
-              <Text color="blueBright">{`${prefix.source}`}</Text>
-              <Text color={prefix.status === 'Success' ? 'green' : 'red'}>{prefix.status}</Text>
-              <Text>{prefix.description}</Text>
+              <Text>
+                <Text color="green">{prefix.logTimestamp} </Text>
+                <Text color="blueBright">{`${prefix.source}`} </Text>
+                <Text color={prefix.status === 'Success' ? 'green' : 'red'}>{prefix.status} </Text>
+                <Text>{prefix.description}</Text>
+              </Text>
             </Box>
             <Box flexDirection="column" marginLeft={4}>
               {appLog instanceof FunctionRunLog && (


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-functions/issues/292

Text was being wrapped columnwise in the metadata line of the log, rather than as a unit. 

E.G. it was doing:

```
this is my fu your command ran in 
nction name 9 million instructions
```

Instead of:
```
this is my function name your com
mand ran in 9 million instructions
```

### WHAT is this pull request doing?

Following the pattern in [this PR](https://github.com/Shopify/cli/pull/3959/files), I added a root text element to instruct ink to wrap these as a single unit.

### How to test your changes?

- Shrink your window, increase your function handle length, or increase text size until the metadata log line does not fit in one line in the terminal
- Run `shopify app logs` and run the function
- The metadata line should wrap as a row, e.g.
```
2024-08-12T18:31:16.747589Z cv Success export "run" executed in 0.4034M
instructions
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
