### PR TITLE
Don't pretty print --json output for logs

### DIFF
--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
@@ -1,6 +1,6 @@
 import {renderJsonLogs} from './render-json-logs.js'
 import {pollAppLogs} from './poll-app-logs.js'
-import {handleFetchAppLogsError, outputIsTTY} from '../utils.js'
+import {handleFetchAppLogsError} from '../utils.js'
 import {testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 import {describe, expect, vi, test, beforeEach, afterEach} from 'vitest'
@@ -12,7 +12,6 @@ vi.mock('../utils', async (importOriginal) => {
     ...mod,
     fetchAppLogs: vi.fn(),
     handleFetchAppLogsError: vi.fn(),
-    outputIsTTY: vi.fn(),
   }
 })
 vi.mock('@shopify/cli-kit/node/output')
@@ -33,30 +32,6 @@ describe('renderJsonLogs', () => {
     }
     const pollAppLogsMock = vi.fn().mockResolvedValue(mockSuccessResponse)
     vi.mocked(pollAppLogs).mockImplementation(pollAppLogsMock)
-    vi.mocked(outputIsTTY).mockImplementation(vi.fn().mockReturnValue(true))
-
-    await renderJsonLogs({
-      pollOptions: {cursor: 'cursor', filters: {status: undefined, sources: undefined}, jwtToken: 'jwtToken'},
-      options: {
-        variables: {shopIds: ['1'], apiKey: 'key', token: 'token'},
-        developerPlatformClient: testDeveloperPlatformClient(),
-      },
-    })
-
-    expect(outputInfo).toHaveBeenNthCalledWith(1, JSON.stringify({payload: {message: 'Log 1'}}, null, 2))
-    expect(outputInfo).toHaveBeenNthCalledWith(2, JSON.stringify({payload: {message: 'Log 2'}}, null, 2))
-    expect(pollAppLogs).toHaveBeenCalled()
-    expect(vi.getTimerCount()).toEqual(1)
-  })
-
-  test('should not pretty print logs when stdout is not a tty', async () => {
-    const mockSuccessResponse = {
-      cursor: 'next-cursor',
-      appLogs: [{payload: JSON.stringify({message: 'Log 1'})}, {payload: JSON.stringify({message: 'Log 2'})}],
-    }
-    const pollAppLogsMock = vi.fn().mockResolvedValue(mockSuccessResponse)
-    vi.mocked(pollAppLogs).mockImplementation(pollAppLogsMock)
-    vi.mocked(outputIsTTY).mockImplementation(vi.fn().mockReturnValue(false))
 
     await renderJsonLogs({
       pollOptions: {cursor: 'cursor', filters: {status: undefined, sources: undefined}, jwtToken: 'jwtToken'},

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
@@ -6,7 +6,6 @@ import {
   subscribeToAppLogs,
   toFormattedAppLogJson,
   parseAppLogPayload,
-  outputIsTTY,
 } from '../utils.js'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 
@@ -18,7 +17,6 @@ export async function renderJsonLogs({
   options: SubscribeOptions
 }): Promise<void> {
   const response = await pollAppLogs({cursor, filters, jwtToken})
-  const prettyPrint = outputIsTTY()
   let retryIntervalMs = POLLING_INTERVAL_MS
   let nextJwtToken = jwtToken
 
@@ -48,7 +46,7 @@ export async function renderJsonLogs({
 
   if (appLogs) {
     appLogs.forEach((log) => {
-      outputInfo(toFormattedAppLogJson(log, parseAppLogPayload(log.payload, log.log_type), prettyPrint))
+      outputInfo(toFormattedAppLogJson(log, parseAppLogPayload(log.payload, log.log_type), false))
     })
   }
 

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -164,10 +164,6 @@ export const handleFetchAppLogsError = async (
   return {retryIntervalMs, nextJwtToken}
 }
 
-export function outputIsTTY(): boolean {
-  return Boolean(process.stdout.isTTY)
-}
-
 export const toFormattedAppLogJson = (
   appLog: AppLogData,
   appLogPayload: AppLogPayload | unknown,


### PR DESCRIPTION
### WHY are these changes introduced?

In a prior PR, we started pretty printing JSON for readability, which unintentionally broke the JSONL format interface that we needed for programatic users. This PR fixes that by only pretty printing when the output is a TTY.

### How to test your changes?

Run the command in TTY, it should pretty print:
```
shopify app logs --json
```

Run the command without TTY, it should return JSONL:
```
shopify app logs --json > tmp.txt
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
