### PR TITLE
Functions_370 Adding local time to cli logs

### DIFF
--- a/packages/app/src/cli/services/app-logs/dev/write-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/write-app-logs.test.ts
@@ -4,6 +4,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 import {writeLog} from '@shopify/cli-kit/node/logs'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 import camelcaseKeys from 'camelcase-keys'
+import {formatDate} from '@shopify/cli-kit/common/string'
 
 vi.mock('@shopify/cli-kit/node/logs')
 
@@ -33,6 +34,17 @@ const NEW_APP_LOG: AppLogData = {
 
 const FUNCTION_RUN_PAYLOAD = new FunctionRunLog(camelcaseKeys(JSON.parse(APP_LOG.payload)))
 const API_KEY = 'apiKey'
+const utcTime = new Date(APP_LOG.log_timestamp)
+const localTime = new Date(
+  Date.UTC(
+    utcTime.getFullYear(),
+    utcTime.getMonth(),
+    utcTime.getDate(),
+    utcTime.getHours(),
+    utcTime.getMinutes(),
+    utcTime.getSeconds(),
+  ),
+)
 
 describe('writeAppLogsToFile', () => {
   let stdout: any
@@ -67,6 +79,7 @@ describe('writeAppLogsToFile', () => {
       source: APP_LOG.source,
       sourceNamespace: APP_LOG.source_namespace,
       logTimestamp: APP_LOG.log_timestamp,
+      localTime: formatDate(localTime),
     }
     const expectedLogData = JSON.stringify(expectedSaveData, null, 2)
 
@@ -104,6 +117,7 @@ function expectedLogDataFromAppEvent(event: AppLogData, payload: AppLogPayload |
     {
       ...eventWithoutCursor,
       payload,
+      localTime: formatDate(localTime),
     },
     {deep: true},
   )

--- a/packages/app/src/cli/services/app-logs/dev/write-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/write-app-logs.test.ts
@@ -4,7 +4,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 import {writeLog} from '@shopify/cli-kit/node/logs'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 import camelcaseKeys from 'camelcase-keys'
-import {formatDate} from '@shopify/cli-kit/common/string'
+import {formatLocalDate} from '@shopify/cli-kit/common/string'
 
 vi.mock('@shopify/cli-kit/node/logs')
 
@@ -34,17 +34,6 @@ const NEW_APP_LOG: AppLogData = {
 
 const FUNCTION_RUN_PAYLOAD = new FunctionRunLog(camelcaseKeys(JSON.parse(APP_LOG.payload)))
 const API_KEY = 'apiKey'
-const utcTime = new Date(APP_LOG.log_timestamp)
-const localTime = new Date(
-  Date.UTC(
-    utcTime.getFullYear(),
-    utcTime.getMonth(),
-    utcTime.getDate(),
-    utcTime.getHours(),
-    utcTime.getMinutes(),
-    utcTime.getSeconds(),
-  ),
-)
 
 describe('writeAppLogsToFile', () => {
   let stdout: any
@@ -79,7 +68,7 @@ describe('writeAppLogsToFile', () => {
       source: APP_LOG.source,
       sourceNamespace: APP_LOG.source_namespace,
       logTimestamp: APP_LOG.log_timestamp,
-      localTime: formatDate(localTime),
+      localTime: formatLocalDate(APP_LOG.log_timestamp),
     }
     const expectedLogData = JSON.stringify(expectedSaveData, null, 2)
 
@@ -117,7 +106,7 @@ function expectedLogDataFromAppEvent(event: AppLogData, payload: AppLogPayload |
     {
       ...eventWithoutCursor,
       payload,
-      localTime: formatDate(localTime),
+      localTime: formatLocalDate(APP_LOG.log_timestamp),
     },
     {deep: true},
   )

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
@@ -4,7 +4,7 @@ import {handleFetchAppLogsError} from '../utils.js'
 import {testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 import {describe, expect, vi, test, beforeEach, afterEach} from 'vitest'
-import {formatDate} from '@shopify/cli-kit/common/string'
+import {formatLocalDate} from '@shopify/cli-kit/common/string'
 
 vi.mock('./poll-app-logs')
 vi.mock('../utils', async (importOriginal) => {
@@ -27,19 +27,8 @@ describe('renderJsonLogs', () => {
   })
 
   test('should handle success response correctly', async () => {
-    const utcTime = new Date(2024, 8, 14)
-    const localTime = formatDate(
-      new Date(
-        Date.UTC(
-          utcTime.getFullYear(),
-          utcTime.getMonth(),
-          utcTime.getDate(),
-          utcTime.getHours(),
-          utcTime.getMinutes(),
-          utcTime.getSeconds(),
-        ),
-      ),
-    )
+    const utcTime = '2024-09-14T05:00:00.000Z'
+    const localTime = formatLocalDate(utcTime)
 
     const mockSuccessResponse = {
       cursor: 'next-cursor',
@@ -61,11 +50,11 @@ describe('renderJsonLogs', () => {
 
     expect(outputInfo).toHaveBeenNthCalledWith(
       1,
-      JSON.stringify({payload: {message: 'Log 1'}, logTimestamp: '2024-09-14T05:00:00.000Z', localTime}),
+      JSON.stringify({payload: {message: 'Log 1'}, logTimestamp: utcTime, localTime}),
     )
     expect(outputInfo).toHaveBeenNthCalledWith(
       2,
-      JSON.stringify({payload: {message: 'Log 2'}, logTimestamp: '2024-09-14T05:00:00.000Z', localTime}),
+      JSON.stringify({payload: {message: 'Log 2'}, logTimestamp: utcTime, localTime}),
     )
     expect(pollAppLogs).toHaveBeenCalled()
     expect(vi.getTimerCount()).toEqual(1)

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
@@ -4,6 +4,7 @@ import {handleFetchAppLogsError} from '../utils.js'
 import {testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 import {describe, expect, vi, test, beforeEach, afterEach} from 'vitest'
+import {formatDate} from '@shopify/cli-kit/common/string'
 
 vi.mock('./poll-app-logs')
 vi.mock('../utils', async (importOriginal) => {
@@ -26,9 +27,26 @@ describe('renderJsonLogs', () => {
   })
 
   test('should handle success response correctly', async () => {
+    const utcTime = new Date(2024, 8, 14)
+    const localTime = formatDate(
+      new Date(
+        Date.UTC(
+          utcTime.getFullYear(),
+          utcTime.getMonth(),
+          utcTime.getDate(),
+          utcTime.getHours(),
+          utcTime.getMinutes(),
+          utcTime.getSeconds(),
+        ),
+      ),
+    )
+
     const mockSuccessResponse = {
       cursor: 'next-cursor',
-      appLogs: [{payload: JSON.stringify({message: 'Log 1'})}, {payload: JSON.stringify({message: 'Log 2'})}],
+      appLogs: [
+        {payload: JSON.stringify({message: 'Log 1'}), log_timestamp: utcTime},
+        {payload: JSON.stringify({message: 'Log 2'}), log_timestamp: utcTime},
+      ],
     }
     const pollAppLogsMock = vi.fn().mockResolvedValue(mockSuccessResponse)
     vi.mocked(pollAppLogs).mockImplementation(pollAppLogsMock)
@@ -41,8 +59,14 @@ describe('renderJsonLogs', () => {
       },
     })
 
-    expect(outputInfo).toHaveBeenNthCalledWith(1, JSON.stringify({payload: {message: 'Log 1'}}))
-    expect(outputInfo).toHaveBeenNthCalledWith(2, JSON.stringify({payload: {message: 'Log 2'}}))
+    expect(outputInfo).toHaveBeenNthCalledWith(
+      1,
+      JSON.stringify({payload: {message: 'Log 1'}, logTimestamp: '2024-09-14T05:00:00.000Z', localTime}),
+    )
+    expect(outputInfo).toHaveBeenNthCalledWith(
+      2,
+      JSON.stringify({payload: {message: 'Log 2'}, logTimestamp: '2024-09-14T05:00:00.000Z', localTime}),
+    )
     expect(pollAppLogs).toHaveBeenCalled()
     expect(vi.getTimerCount()).toEqual(1)
   })

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
@@ -26,7 +26,7 @@ const NEW_JWT_TOKEN = 'newJwt'
 const RETURNED_CURSOR = '2024-05-23T19:17:02.321773Z'
 const FUNCTION_ID = 'e57b4d31-2038-49ff-a0a1-1eea532414f7'
 const FUEL_CONSUMED = 512436
-const TIME = '2024-06-18 16:02:04.868'
+const TIME = '2024-06-18 16:02:04'
 
 const LOG_TYPE = 'function_run'
 const STATUS = 'success'

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
@@ -14,6 +14,7 @@ import {
 import {ErrorResponse, SuccessResponse, AppLogOutput, PollFilters, AppLogPayload} from '../../../../types.js'
 import {pollAppLogs} from '../../../poll-app-logs.js'
 import {useState, useEffect} from 'react'
+import {formatDate} from '@shopify/cli-kit/common/string'
 
 interface UsePollAppLogsOptions {
   initialJwt: string
@@ -88,11 +89,23 @@ export function usePollAppLogs({initialJwt, filters, resubscribeCallback}: UsePo
               return
           }
 
+          const utcDateTime = new Date(log.log_timestamp)
+          const localDateTime = new Date(
+            Date.UTC(
+              utcDateTime.getFullYear(),
+              utcDateTime.getMonth(),
+              utcDateTime.getDate(),
+              utcDateTime.getHours(),
+              utcDateTime.getMinutes(),
+              utcDateTime.getSeconds(),
+            ),
+          )
+
           const prefix = {
             status: log.status === 'success' ? 'Success' : 'Failure',
             source: log.source,
             description,
-            logTimestamp: log.log_timestamp,
+            logTimestamp: formatDate(localDateTime),
           }
 
           setAppLogOutputs((prev) => [...prev, {appLog, prefix}])

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
@@ -14,7 +14,7 @@ import {
 import {ErrorResponse, SuccessResponse, AppLogOutput, PollFilters, AppLogPayload} from '../../../../types.js'
 import {pollAppLogs} from '../../../poll-app-logs.js'
 import {useState, useEffect} from 'react'
-import {formatDate} from '@shopify/cli-kit/common/string'
+import {formatLocalDate} from '@shopify/cli-kit/common/string'
 
 interface UsePollAppLogsOptions {
   initialJwt: string
@@ -89,23 +89,11 @@ export function usePollAppLogs({initialJwt, filters, resubscribeCallback}: UsePo
               return
           }
 
-          const utcDateTime = new Date(log.log_timestamp)
-          const localDateTime = new Date(
-            Date.UTC(
-              utcDateTime.getFullYear(),
-              utcDateTime.getMonth(),
-              utcDateTime.getDate(),
-              utcDateTime.getHours(),
-              utcDateTime.getMinutes(),
-              utcDateTime.getSeconds(),
-            ),
-          )
-
           const prefix = {
             status: log.status === 'success' ? 'Success' : 'Failure',
             source: log.source,
             description,
-            logTimestamp: formatDate(localDateTime),
+            logTimestamp: formatLocalDate(log.log_timestamp),
           }
 
           setAppLogOutputs((prev) => [...prev, {appLog, prefix}])

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -18,7 +18,7 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import camelcaseKeys from 'camelcase-keys'
-import {formatDate} from '@shopify/cli-kit/common/string'
+import {formatLocalDate} from '@shopify/cli-kit/common/string'
 
 export const POLLING_INTERVAL_MS = 450
 export const POLLING_ERROR_RETRY_INTERVAL_MS = 5 * 1000
@@ -171,24 +171,12 @@ export const toFormattedAppLogJson = (
   prettyPrint = true,
 ): string => {
   const {cursor: _, ...appLogWithoutCursor} = appLog
-  const utcDateTime = new Date(appLog.log_timestamp)
-  const localDateTime = new Date(
-    Date.UTC(
-      utcDateTime.getFullYear(),
-      utcDateTime.getMonth(),
-      utcDateTime.getDate(),
-      utcDateTime.getHours(),
-      utcDateTime.getMinutes(),
-      utcDateTime.getSeconds(),
-    ),
-  )
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const toSaveData: any = camelcaseKeys(
     {
       ...appLogWithoutCursor,
       payload: appLogPayload,
-      localTime: formatDate(localDateTime),
+      localTime: formatLocalDate(appLog.log_timestamp),
     },
     {deep: true},
   )

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -18,6 +18,7 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import camelcaseKeys from 'camelcase-keys'
+import {formatDate} from '@shopify/cli-kit/common/string'
 
 export const POLLING_INTERVAL_MS = 450
 export const POLLING_ERROR_RETRY_INTERVAL_MS = 5 * 1000
@@ -170,11 +171,24 @@ export const toFormattedAppLogJson = (
   prettyPrint = true,
 ): string => {
   const {cursor: _, ...appLogWithoutCursor} = appLog
+  const utcDateTime = new Date(appLog.log_timestamp)
+  const localDateTime = new Date(
+    Date.UTC(
+      utcDateTime.getFullYear(),
+      utcDateTime.getMonth(),
+      utcDateTime.getDate(),
+      utcDateTime.getHours(),
+      utcDateTime.getMinutes(),
+      utcDateTime.getSeconds(),
+    ),
+  )
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const toSaveData: any = camelcaseKeys(
     {
       ...appLogWithoutCursor,
       payload: appLogPayload,
+      localTime: formatDate(localDateTime),
     },
     {deep: true},
   )

--- a/packages/cli-kit/src/public/common/string.test.ts
+++ b/packages/cli-kit/src/public/common/string.test.ts
@@ -1,5 +1,6 @@
 import {
   formatDate,
+  formatLocalDate,
   getRandomName,
   joinWithAnd,
   linesToColumns,
@@ -103,6 +104,19 @@ describe('formatDate', () => {
 
     // Then
     expect(str).toBe('2020-01-01 00:00:00')
+  })
+})
+
+describe('formatLocalDate', () => {
+  test('formats an ISO date string to local date string', () => {
+    // Given
+    const ISODateString = '2020-01-01T00:00:00.000Z'
+
+    // When
+    const str = formatLocalDate(ISODateString)
+
+    // Then
+    expect(str).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)
   })
 })
 

--- a/packages/cli-kit/src/public/common/string.ts
+++ b/packages/cli-kit/src/public/common/string.ts
@@ -349,6 +349,27 @@ export function formatDate(date: Date): string {
 }
 
 /**
+ * Given a date in UTC ISO String format, return a formatted string in local time like "2021-01-01 12:00:00".
+ *
+ * @param dateString - UTC ISO Date String.
+ * @returns The transformed string in local system time.
+ */
+export function formatLocalDate(dateString: string): string {
+  const dateObj = new Date(dateString)
+  const localDate = new Date(
+    Date.UTC(
+      dateObj.getFullYear(),
+      dateObj.getMonth(),
+      dateObj.getDate(),
+      dateObj.getHours(),
+      dateObj.getMinutes(),
+      dateObj.getSeconds(),
+    ),
+  )
+  return formatDate(localDate)
+}
+
+/**
  * Given a list of items, it returns a string with the items joined by commas and the last item joined by "and".
  * All items are wrapped in double quotes.
  * For example: ["a", "b", "c"] returns "a", "b" and "c".


### PR DESCRIPTION
[Ticket](https://github.com/orgs/Shopify/projects/2117/views/75?pane=issue&itemId=73912552)
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

For ease of reading logs we want to have the function run logs in the developer's local timezone. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

1. Changing the log timezone in regular text app logs to be in local time.

<img width="1194" alt="Screenshot 2024-08-13 at 2 10 27 PM" src="https://github.com/user-attachments/assets/545f8086-5497-4475-a6da-a9d240d9b552">

2. Adding local timezone for JSON app logs. 

<img width="1265" alt="Screenshot 2024-08-13 at 2 09 56 PM" src="https://github.com/user-attachments/assets/a756540b-78ab-4f9b-80bf-94f437f80a64">

### How to test your changes?

1. Checkout my branch in your local machine.
2. Have an app with a function ready. 
3. From cli repo run `pnpm run shopify app logs --path <path to functions app>`
4. Trigger function run. 

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
