### PR TITLE
Update the new `shopify theme dev` command so that it does not delete generated assets

### DIFF
--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -390,7 +390,7 @@ describe('bulkUploadThemeAssets', async () => {
     })
   })
 
-  test('throws an error when the server responds a 404', async () => {
+  test('throws an error when the server responds with a 404', async () => {
     const id = 123
     const assets: AssetParams[] = [
       {key: 'snippets/product-variant-picker.liquid', value: 'content'},
@@ -410,7 +410,7 @@ describe('bulkUploadThemeAssets', async () => {
     }).rejects.toThrowError(AbortError)
   })
 
-  test('throws an error when the server responds a 403', async () => {
+  test('throws an error when the server responds with a 403', async () => {
     // Given
     const id = 123
     const assets: AssetParams[] = [

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -390,7 +390,7 @@ describe('bulkUploadThemeAssets', async () => {
     })
   })
 
-  test('throws an error when the server does not respond', async () => {
+  test('throws an error when the server responds a 404', async () => {
     const id = 123
     const assets: AssetParams[] = [
       {key: 'snippets/product-variant-picker.liquid', value: 'content'},
@@ -408,5 +408,30 @@ describe('bulkUploadThemeAssets', async () => {
       return bulkUploadThemeAssets(id, assets, session)
       // Then
     }).rejects.toThrowError(AbortError)
+  })
+
+  test('throws an error when the server responds a 403', async () => {
+    // Given
+    const id = 123
+    const assets: AssetParams[] = [
+      {key: 'snippets/product-variant-picker.liquid', value: 'content'},
+      {key: 'templates/404.json', value: 'to_be_replaced_with_hash'},
+    ]
+    const message = `Cannot delete generated asset 'assets/bla.css'. Delete 'assets/bla.css.liquid' instead.`
+
+    vi.mocked(restRequest).mockResolvedValue({
+      json: {
+        message,
+      },
+      status: 403,
+      headers: {},
+    })
+
+    // When
+    await expect(async () => {
+      return bulkUploadThemeAssets(id, assets, session)
+
+      // Then
+    }).rejects.toThrowError(new AbortError(message))
   })
 })

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -118,7 +118,7 @@ async function request<T>(
       // Retry following the "retry-after" header
       return throttler.delayAwareRetry(response, () => request(method, path, session, params, searchParams))
     case status === 403:
-      return handleForbiddenError(session)
+      return handleForbiddenError(response, session)
     case status === 401:
       throw new AbortError(`[${status}] API request unauthorized error`)
     case status === 422:
@@ -132,9 +132,14 @@ async function request<T>(
   }
 }
 
-function handleForbiddenError(session: AdminSession): never {
+function handleForbiddenError(response: RestResponse, session: AdminSession): never {
   const store = session.storeFqdn
   const adminUrl = storeAdminUrl(session)
+  const error = errorMessage(response)
+
+  if (error.match(/Cannot delete generated asset/) !== null) {
+    throw new AbortError(error)
+  }
 
   throw new AbortError(
     `You are not authorized to edit themes on "${store}".`,
@@ -151,4 +156,14 @@ function handleForbiddenError(session: AdminSession): never {
 
 function errors(response: RestResponse) {
   return JSON.stringify(response.json?.errors)
+}
+
+function errorMessage(response: RestResponse): string {
+  const message = response.json?.message
+
+  if (typeof message === 'string') {
+    return message
+  }
+
+  return ''
 }

--- a/packages/theme/src/cli/services/push.test.ts
+++ b/packages/theme/src/cli/services/push.test.ts
@@ -13,7 +13,6 @@ vi.mock('@shopify/cli-kit/node/themes/api')
 
 describe('push', () => {
   const adminSession = {token: '', storeFqdn: ''}
-  const theme = buildTheme({id: 1, name: 'Theme', role: 'development'})!
 
   beforeEach(() => {
     vi.mocked(uploadTheme).mockResolvedValue(new Map())

--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -1,6 +1,5 @@
 import {mountThemeFileSystem} from '../utilities/theme-fs.js'
 import {uploadTheme} from '../utilities/theme-uploader.js'
-import {rejectGeneratedStaticAssets} from '../utilities/asset-checksum.js'
 import {themeComponent} from '../utilities/theme-ui.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {fetchChecksums, publishTheme} from '@shopify/cli-kit/node/themes/api'
@@ -32,9 +31,8 @@ interface JsonOutput {
 }
 
 export async function push(theme: Theme, session: AdminSession, options: PushOptions) {
-  const remoteChecksums = await fetchChecksums(theme.id, session)
+  const themeChecksums = await fetchChecksums(theme.id, session)
   const themeFileSystem = await mountThemeFileSystem(options.path)
-  const themeChecksums = rejectGeneratedStaticAssets(remoteChecksums)
 
   const results = await uploadTheme(theme, session, themeChecksums, themeFileSystem, options)
 

--- a/packages/theme/src/cli/utilities/theme-uploader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.test.ts
@@ -69,6 +69,26 @@ describe('theme-uploader', () => {
     expect(vi.mocked(deleteThemeAsset)).toHaveBeenCalledWith(remoteTheme.id, 'assets/deleteme.liquid', adminSession)
   })
 
+  test('should not generated assets', async () => {
+    // Given
+    const remote = [
+      {key: 'assets/keepme.liquid', checksum: '1'},
+      {key: 'assets/base.css', checksum: '2'},
+      {key: 'assets/base.css.liquid', checksum: '3'},
+    ]
+    const local = {
+      root: 'tmp',
+      files: new Map([['assets/keepme.liquid', {key: 'assets/keepme.liquid', checksum: '1'}]]),
+    } as ThemeFileSystem
+
+    // When
+    await uploadTheme(remoteTheme, adminSession, remote, local, uploadOptions)
+
+    // Then
+    expect(vi.mocked(deleteThemeAsset)).toHaveBeenCalledOnce()
+    expect(vi.mocked(deleteThemeAsset)).toHaveBeenCalledWith(remoteTheme.id, 'assets/base.css.liquid', adminSession)
+  })
+
   test('should not delete files if nodelete is set', async () => {
     // Given
     const remote = [

--- a/packages/theme/src/cli/utilities/theme-uploader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.test.ts
@@ -69,7 +69,7 @@ describe('theme-uploader', () => {
     expect(vi.mocked(deleteThemeAsset)).toHaveBeenCalledWith(remoteTheme.id, 'assets/deleteme.liquid', adminSession)
   })
 
-  test('should not generated assets', async () => {
+  test('should not delete generated assets', async () => {
     // Given
     const remote = [
       {key: 'assets/keepme.liquid', checksum: '1'},

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -1,6 +1,7 @@
 import {partitionThemeFiles, readThemeFilesFromDisk} from './theme-fs.js'
 import {applyIgnoreFilters} from './asset-ignore.js'
 import {renderTasksToStdErr} from './theme-ui.js'
+import {rejectGeneratedStaticAssets} from './asset-checksum.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Result, Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {AssetParams, bulkUploadThemeAssets, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
@@ -24,10 +25,11 @@ export const MAX_UPLOAD_RETRY_COUNT = 2
 export async function uploadTheme(
   theme: Theme,
   session: AdminSession,
-  remoteChecksums: Checksum[],
+  checksums: Checksum[],
   themeFileSystem: ThemeFileSystem,
   options: UploadOptions = {},
 ) {
+  const remoteChecksums = rejectGeneratedStaticAssets(checksums)
   const uploadResults: Map<string, Result> = new Map()
   const deleteTasks = await buildDeleteTasks(remoteChecksums, themeFileSystem, options, theme, session)
   const uploadTasks = await buildUploadTasks(remoteChecksums, themeFileSystem, options, theme, session, uploadResults)


### PR DESCRIPTION
### WHY are these changes introduced?

The setup of the `shopify theme dev` command was not ignoring static assets, so this PR updates the logic to do that. So, we were facing this message with themes with static assets:

<img src="https://github.com/user-attachments/assets/62e8e011-b23b-4046-be32-af7b74dc1310" width="80%">

(this PR doesn't updates public facing behavior, so I'm not adding a changelog)

### WHAT is this pull request doing?

This PR moves the logic that ignores static assets to the uploader.

Additionally, this PR updates the API layer to show the error proper message. This way, if we face a similar regression in the future or the API will show a friendly message to users:

<img src="https://github.com/user-attachments/assets/50ed536f-8cfc-4fe2-91d9-01c9d6a1ee9b" width="80%">

### How to test your changes?

- Create a file called `assets/bla.css.liquid`
- Run `shopify theme push`
- Run `shopify theme dev --dev-preview`
- Notice we no longer face an error

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
