### PR TITLE
Add log sources command

### DIFF
--- a/packages/app/src/cli/commands/app/app-logs/sources.ts
+++ b/packages/app/src/cli/commands/app/app-logs/sources.ts
@@ -1,0 +1,37 @@
+import {appFlags} from '../../../flags.js'
+import {AppInterface} from '../../../models/app/app.js'
+import {loadApp} from '../../../models/app/loader.js'
+import Command from '../../../utilities/app-command.js'
+import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
+import {sources} from '../../../services/app-logs/sources.js'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+
+export default class Sources extends Command {
+  static summary = 'Print out a list of sources that may be used with the logs command.'
+
+  static descriptionWithMarkdown = `The output source names can be used with the \`--source\` argument of \`shopify app logs\` to filter log output. Currently only function extensions are supported as sources.`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static flags = {
+    ...globalFlags,
+    ...appFlags,
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(Sources)
+    const specifications = await loadLocalExtensionsSpecifications()
+    const app: AppInterface = await loadApp({
+      specifications,
+      directory: flags.path,
+      userProvidedConfigName: flags.config,
+      mode: 'report',
+    })
+
+    if (app.errors) {
+      process.exit(2)
+    } else {
+      sources(app)
+    }
+  }
+}

--- a/packages/app/src/cli/index.ts
+++ b/packages/app/src/cli/index.ts
@@ -5,6 +5,7 @@ import DemoWatcher from './commands/app/demo/watcher.js'
 import Deploy from './commands/app/deploy.js'
 import Dev from './commands/app/dev.js'
 import Logs from './commands/app/logs.js'
+import Sources from './commands/app/app-logs/sources.js'
 import EnvPull from './commands/app/env/pull.js'
 import EnvShow from './commands/app/env/show.js'
 import FunctionBuild from './commands/app/function/build.js'
@@ -30,6 +31,7 @@ export const commands = {
   'app:deploy': Deploy,
   'app:dev': Dev,
   'app:logs': Logs,
+  'app:logs:sources': Sources,
   'app:import-extensions': ImportExtensions,
   'app:info': AppInfo,
   'app:init': Init,

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -455,7 +455,7 @@ export async function testFlowActionExtension(directory = './my-extension'): Pro
   return extension
 }
 
-export function defaultFunctionConfiguration(): FunctionConfigType {
+function defaultFunctionConfiguration(): FunctionConfigType {
   return {
     name: 'test function extension',
     description: 'description',

--- a/packages/app/src/cli/services/app-logs/sources.test.ts
+++ b/packages/app/src/cli/services/app-logs/sources.test.ts
@@ -1,0 +1,24 @@
+import {sourcesForApp} from './utils.js'
+import {sources} from './sources.js'
+import {testApp} from '../../models/app/app.test-data.js'
+import {outputInfo, formatSection} from '@shopify/cli-kit/node/output'
+import {describe, test, vi, expect} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/output')
+vi.mock('./utils.js')
+
+describe('sources', () => {
+  test('prints sources by namespace', async () => {
+    // Given
+    vi.mocked(sourcesForApp).mockReturnValue(['extensions.source1', 'extensions.source2', 'arbitrary.text'])
+    vi.mocked(formatSection).mockReturnValue('formatted section')
+
+    // When
+    sources(testApp())
+
+    // Then
+    expect(formatSection).toHaveBeenCalledWith('extensions', 'extensions.source1\nextensions.source2')
+    expect(formatSection).toHaveBeenCalledWith('arbitrary', 'arbitrary.text')
+    expect(outputInfo).toHaveBeenCalledWith('formatted section')
+  })
+})

--- a/packages/app/src/cli/services/app-logs/sources.ts
+++ b/packages/app/src/cli/services/app-logs/sources.ts
@@ -1,0 +1,25 @@
+import {AppInterface} from '../../models/app/app.js'
+import {sourcesForApp} from '../../services/app-logs/utils.js'
+import {formatSection, outputInfo} from '@shopify/cli-kit/node/output'
+
+export function sources(app: AppInterface) {
+  const sources = sourcesForApp(app)
+  const sourcesByNamespace = new Map<string, string[]>()
+  sources.forEach((source) => {
+    const tokens = source.split('.')
+
+    if (tokens.length >= 2) {
+      const sourceNamespace = tokens[0]!
+
+      if (!sourcesByNamespace.has(sourceNamespace)) {
+        sourcesByNamespace.set(sourceNamespace, [])
+      }
+
+      sourcesByNamespace.set(sourceNamespace, [...sourcesByNamespace.get(sourceNamespace)!, source])
+    }
+  })
+
+  for (const [namespace, sources] of sourcesByNamespace) {
+    outputInfo(formatSection(namespace, sources.join('\n')))
+  }
+}

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -11,6 +11,7 @@ import {
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppLogsSubscribeVariables} from '../../api/graphql/subscribe_to_app_logs.js'
 import {environmentVariableNames} from '../../constants.js'
+import {AppInterface} from '../../models/app/app.js'
 import {fetch, Response} from '@shopify/cli-kit/node/http'
 import {outputDebug, outputWarn} from '@shopify/cli-kit/node/output'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
@@ -162,6 +163,12 @@ export const handleFetchAppLogsError = async (
   }
 
   return {retryIntervalMs, nextJwtToken}
+}
+
+export function sourcesForApp(app: AppInterface): string[] {
+  return app.allExtensions.flatMap((extension) => {
+    return extension.isFunctionExtension ? [`extensions.${extension.configuration.handle}`] : []
+  })
 }
 
 export const toFormattedAppLogJson = (

--- a/packages/app/src/cli/services/logs.ts
+++ b/packages/app/src/cli/services/logs.ts
@@ -1,6 +1,6 @@
 import {DevContextOptions, ensureDevContext} from './context.js'
 import {renderLogs} from './app-logs/logs-command/ui.js'
-import {subscribeToAppLogs} from './app-logs/utils.js'
+import {subscribeToAppLogs, sourcesForApp} from './app-logs/utils.js'
 import {renderJsonLogs} from './app-logs/logs-command/render-json-logs.js'
 import {AppInterface} from '../models/app/app.js'
 import {loadAppConfiguration} from '../models/app/loader.js'
@@ -25,9 +25,7 @@ interface LogsOptions {
 export async function logs(commandOptions: LogsOptions) {
   const logsConfig = await prepareForLogs(commandOptions)
 
-  const validSources = logsConfig.localApp.allExtensions.flatMap((extension) => {
-    return extension.isFunctionExtension ? [`extensions.${extension.configuration.handle}`] : []
-  })
+  const validSources = sourcesForApp(logsConfig.localApp)
 
   if (validSources.length === 0) {
     throw new AbortError(

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,6 +15,7 @@
 * [`shopify app import-extensions`](#shopify-app-import-extensions)
 * [`shopify app info`](#shopify-app-info)
 * [`shopify app init`](#shopify-app-init)
+* [`shopify app logs sources`](#shopify-app-logs-sources)
 * [`shopify app:release --version <version>`](#shopify-apprelease---version-version)
 * [`shopify app versions list [FILE]`](#shopify-app-versions-list-file)
 * [`shopify app webhook trigger`](#shopify-app-webhook-trigger)
@@ -507,6 +508,27 @@ FLAGS
                                   - Any GitHub repo with optional branch and subpath, e.g.,
                                   https://github.com/Shopify/<repository>/[subpath]#[branch]
       --verbose                   Increase the verbosity of the output.
+```
+
+## `shopify app logs sources`
+
+Print out a list of sources that may be used with the logs command.
+
+```
+USAGE
+  $ shopify app logs sources [-c <value>] [--no-color] [--path <value>] [--verbose]
+
+FLAGS
+  -c, --config=<value>  The name of the app configuration.
+      --no-color        Disable color output.
+      --path=<value>    The path to your app directory.
+      --verbose         Increase the verbosity of the output.
+
+DESCRIPTION
+  Print out a list of sources that may be used with the logs command.
+
+  The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently
+  only function extensions are supported as sources.
 ```
 
 ## `shopify app:release --version <version>`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1783,6 +1783,61 @@
       "strict": true,
       "summary": "Stream detailed logs for your Shopify app."
     },
+    "app:logs:sources": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "customPluginName": "@shopify/app",
+      "description": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
+      "descriptionWithMarkdown": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
+      "flags": {
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "config",
+          "type": "option"
+        },
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [
+      ],
+      "id": "app:logs:sources",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Print out a list of sources that may be used with the logs command."
+    },
     "app:release": {
       "aliases": [
       ],


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-functions/issues/373

Adds the `shopify app logs sources` command, a listing of the sources that are valid arguments for `shopify app logs --source=[csv list of valid sources]`

Tophat 🎩 

Help Menu:
```
macbook-pro:cli duncanuszkay$ pnpm run shopify help app logs sources
Print out a list of sources to use with the logs command.

USAGE
  $ shopify app logs sources [-c <value>] [--no-color] [--path <value>] [--verbose]

FLAGS
  -c, --config=<value>  The name of the app configuration.
      --no-color        Disable color output.
      --path=<value>    The path to your app directory.
      --verbose         Increase the verbosity of the output.

DESCRIPTION
  Print out a list of sources to use with the logs command.

  Currently only functions are supported as sources.
```

Command output:
```
macbook-pro:cli duncanuszkay$ pnpm run shopify app logs sources --path=cv
╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  You are running a global installation of Shopify CLI                        │
│                                                                              │
│  This project has Shopify CLI as a local dependency in package.json. If you  │
│   prefer to use that version, run the command with your package manager      │
│  (e.g. pnpm run shopify).                                                    │
│                                                                              │
│  For more information, see Shopify CLI documentation                         │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

EXTENSIONS                         
extensions.10-percent-off
extensions.cv
```

### Measuring impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
