### PR TITLE
[Themes] Replace glob with chokidar when mounting the theme file system

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -44,6 +44,7 @@
     "@shopify/cli-kit": "3.65.0",
     "@shopify/theme-check-node": "2.8.0",
     "@shopify/theme-language-server-node": "1.11.4",
+    "chokidar": "3.5.3",
     "yaml": "2.3.2"
   },
   "devDependencies": {

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -108,7 +108,7 @@ async function scanThemeFiles(root: string, directoriesToWatch: string[]): Promi
             outputDebug(`Processed file: ${path}`)
           })
           .catch((error) => {
-            consoleError(`Error processing file ${path}: ${error}`)
+            watcher.emit('error', error)
           })
       })
       .on('ready', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,6 +691,9 @@ importers:
       '@shopify/theme-language-server-node':
         specifier: 1.11.4
         version: 1.11.4
+      chokidar:
+        specifier: 3.5.3
+        version: 3.5.3
       yaml:
         specifier: 2.3.2
         version: 2.3.2


### PR DESCRIPTION
### WHY are these changes introduced?
- Part of https://github.com/Shopify/develop-advanced-edits/issues/281

### WHAT is this pull request doing?
- Refactors the `mountThemeFileSystem` function in `packages/theme/src/cli/utilities/theme-fs.ts` to use Chokidar to mount the themefilesystem initially
- Add some debug and error logging

### How to test your changes?
1. Clone the repository and checkout this branch.
2. `pnpm build`
3. Run tests `p test packages/theme`
4. Test the theme file system mounting process by running a command that utilizes this functionality (e.g., `shopify theme push`, `shopify theme dev`).
  a. _You can compare `theme push` with `theme pull` to verify that these two are consistent - there may be some differences from platform-applied changes_ 
6. Verify that the file scanning process completes successfully and all theme files are properly detected

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
  - I believe `chokidar` behaves slightly differently on different platforms. This is something that we may want to keep in mind if issues arise around this implementation in the future
- [x] I've considered possible [documentation](https://shopify.dev) changes