### PR TITLE
Access GraphiQL on remote URL

### DIFF
--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -125,6 +125,9 @@ export function setupGraphiQLServer({
     outputDebug('Handling /graphiql request', stdout)
     if (failIfUnmatchedKey(req.query.key as string, res)) return
 
+    const usesHttps = req.protocol === 'https' || req.headers['x-forwarded-proto'] === 'https'
+    const url = `http${usesHttps ? 's' : ''}://${req.get('host')}`
+
     let apiVersions: string[]
     try {
       apiVersions = await fetchApiVersionsWithTokenRefresh()
@@ -133,7 +136,7 @@ export function setupGraphiQLServer({
         return res.send(
           await renderLiquidTemplate(unauthorizedTemplate, {
             previewUrl: appUrl,
-            url: `${req.protocol}://${req.get('host')}`,
+            url,
           }),
         )
       }
@@ -155,7 +158,7 @@ export function setupGraphiQLServer({
           storeFqdn,
         }),
         {
-          url: `${req.protocol}://${req.get('host')}`,
+          url,
           defaultQueries: [{query: defaultQuery}],
           query,
         },

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -54,8 +54,6 @@ export function setupGraphiQLServer({
   storeFqdn,
 }: SetupGraphiQLServerOptions): Server {
   outputDebug(`Setting up GraphiQL HTTP server on port ${port}...`, stdout)
-  const localhostUrl = `http://localhost:${port}`
-
   const app = express()
 
   function failIfUnmatchedKey(str: string, res: express.Response): boolean {
@@ -135,7 +133,7 @@ export function setupGraphiQLServer({
         return res.send(
           await renderLiquidTemplate(unauthorizedTemplate, {
             previewUrl: appUrl,
-            url: localhostUrl,
+            url: `${req.protocol}://${req.get('host')}`,
           }),
         )
       }
@@ -157,7 +155,7 @@ export function setupGraphiQLServer({
           storeFqdn,
         }),
         {
-          url: localhostUrl,
+          url: `${req.protocol}://${req.get('host')}`,
           defaultQueries: [{query: defaultQuery}],
           query,
         },


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4223

We aren't able to access GraphiQL on a remote environment because the localhost URL is hardcoded.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Pulls the URL from the request context, so even if it's behind a tunnel or proxy, the URLs will be correctly formed from the perspective of the browser.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Run an HTTPS tunnel to `localhost:3457`
2. `p shopify app dev --path /path/to/your/app --graphiql-key=abcdef`
3. Hit `g` to open up GraphiQL. It will give an error page. Add `?key=abcdef` to your URL and then it should work.
4. Replace `localhost:3457` with your tunnel URL on https. Everything should still work properly, including firing a GraphQL query.
5. Try uninstalling your app and going through the install flow from GraphiQL. Things should work as normal.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
