### PR TITLE
Use oclif multiple flag on source

### DIFF
--- a/packages/app/src/cli/commands/app/logs.ts
+++ b/packages/app/src/cli/commands/app/logs.ts
@@ -34,6 +34,7 @@ export default class Logs extends Command {
     source: Flags.string({
       description: 'Filters output to the specified log source.',
       env: 'SHOPIFY_FLAG_SOURCE',
+      multiple: true,
     }),
     status: Flags.string({
       description: 'Filters output to the specified status (success or failure).',
@@ -52,7 +53,7 @@ export default class Logs extends Command {
 
     const apiKey = flags['client-id'] || flags['api-key']
 
-    const sources = flags.source?.split(',')
+    const sources = flags.source
 
     await checkFolderIsValidApp(flags.path)
     const logOptions = {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -557,7 +557,7 @@ FLAGS
       --no-color           Disable color output.
       --path=<value>       The path to your app directory.
       --reset              Reset all your settings.
-      --source=<value>     Filters output to the specified log source.
+      --source=<value>...  Filters output to the specified log source.
       --status=<option>    Filters output to the specified status (success or failure).
                            <options: success|failure>
       --verbose            Increase the verbosity of the output.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1662,7 +1662,7 @@
           "description": "Filters output to the specified log source.",
           "env": "SHOPIFY_FLAG_SOURCE",
           "hasDynamicHelp": false,
-          "multiple": false,
+          "multiple": true,
           "name": "source",
           "type": "option"
         },


### PR DESCRIPTION
### WHY are these changes introduced?

Our current CSV formatting doesn't follow OCLIF standards, which instead has the user enter the flag multiple times.

### WHAT is this pull request doing?

Using the `multiple: true` setting in OCLIF to opt into OCLIF standard behaviour.

### How to test your changes?

Run `shopify app logs --sources extensions.something --sources extensions.something-else`, replacing the sources with real functions from your app.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
