### PR TITLE
Add stdout check to isTTY

### DIFF
--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -722,7 +722,7 @@ function throwInNonTTY(
 
 ${outputContent`${outputToken.cyan(promptText)}`.value}
 
-This usually happens when running a command non-interactively, for example in a CI environment, or when piping input from another process.`
+This usually happens when running a command non-interactively, for example in a CI environment, or when piping to or from another process.`
   throw new AbortError(
     errorMessage,
     'To resolve this, specify the option in the command, or run the command in an interactive environment such as your local terminal.',


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/shopify-functions/issues/363

When piping the output of a commands such as `shopify app dev` or `shopify app logs`, we can sometimes encounter a react infinite render error. This happens when a prompt is supposed to be displayed to the user, but since we've piped the output, it's no longer interactable.

The react error doesn't really explain what's going on, and doesn't leverage the existing error we have in our [throwInNonTTY](https://github.com/Shopify/cli/blob/6c4ac20c3f430e496de7becd9898242c2768222e/packages/cli-kit/src/public/node/ui.tsx#L713-L718).

![](https://screenshot.click/19-52-mmaaz-zjbl9.png)

### WHAT is this pull request doing?

Modifies the existing `throwInNonTTY` and `isTTY` functions to also verify that `stdout` is also TTY.

### How to test your changes?

1. Cause the `ensureDevContext` check to trigger by editing 
  `/Users/<user>/Library/Preferences/shopify-cli-app-nodejs/config.json` 
  and remove the entry for your app path
2. Run `shopify app logs | more`

You should see an error explaining that things need to be run in interactive mode

```
╭─ error ──────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Failed to prompt:                                                           │
│                                                                              │
│  Which organization is this work for?                                        │
│                                                                              │
│  This usually happens when running a command non-interactively, for example  │
│   in a CI environment, or when piping to or from another process.            │
│                                                                              │
│  To resolve this, specify the option in the command, or run the command in   │
│  an interactive environment such as your local terminal.                     │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```
### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
