### PR TITLE
[Themes][Feature] Dev Server - Handle theme editor sync conflicts between local and remote themes

### DIFF
--- a/packages/theme/src/cli/constants.ts
+++ b/packages/theme/src/cli/constants.ts
@@ -1,1 +1,11 @@
 export const configurationFileName = 'shopify.theme.toml'
+
+// This is a more performant date time format that allows us to circumvent the locale looku p
+// performed in toLocaleTimeString
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
+export const timestampDateFormat = new Intl.DateTimeFormat(undefined, {
+  hour12: false,
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+})

--- a/packages/theme/src/cli/constants.ts
+++ b/packages/theme/src/cli/constants.ts
@@ -1,6 +1,6 @@
 export const configurationFileName = 'shopify.theme.toml'
 
-// This is a more performant date time format that allows us to circumvent the locale looku p
+// This is a more performant date time format that allows us to circumvent the locale lookup
 // performed in toLocaleTimeString
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 export const timestampDateFormat = new Intl.DateTimeFormat(undefined, {

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
@@ -2,7 +2,6 @@ import {reconcileJsonFiles} from './theme-reconciliation.js'
 import {reconcileAndPollThemeEditorChanges} from './remote-theme-watcher.js'
 import {pollThemeEditorChanges} from './theme-polling.js'
 import {fakeThemeFileSystem} from '../theme-fs/theme-fs-mock-factory.js'
-import {mountThemeFileSystem} from '../theme-fs.js'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {ThemeAsset} from '@shopify/cli-kit/node/themes/types'
@@ -23,11 +22,9 @@ describe('reconcileAndPollThemeEditorChanges', async () => {
     const files = new Map<string, ThemeAsset>([])
     const defaultThemeFileSystem = fakeThemeFileSystem('tmp', files)
     const initialRemoteChecksums = [{checksum: '1', key: 'templates/asset.json'}]
-    const newFileSystem = fakeThemeFileSystem('tmp', new Map<string, ThemeAsset>([]))
 
     vi.mocked(reconcileJsonFiles).mockResolvedValue(undefined)
     vi.mocked(fetchChecksums).mockResolvedValue([{checksum: '2', key: 'templates/asset.json'}])
-    vi.mocked(mountThemeFileSystem).mockReturnValue(newFileSystem)
 
     // When
     await reconcileAndPollThemeEditorChanges(
@@ -47,7 +44,7 @@ describe('reconcileAndPollThemeEditorChanges', async () => {
       developmentTheme,
       adminSession,
       [{checksum: '2', key: 'templates/asset.json'}],
-      newFileSystem,
+      defaultThemeFileSystem,
       {
         noDelete: false,
         ignore: [],

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
@@ -61,6 +61,7 @@ describe('reconcileAndPollThemeEditorChanges', async () => {
     const newFileSystem = fakeThemeFileSystem('tmp', new Map<string, ThemeAsset>([]))
 
     vi.mocked(fetchChecksums).mockResolvedValue([])
+    const readySpy = vi.spyOn(defaultThemeFileSystem, 'ready').mockResolvedValue()
 
     // When
     await reconcileAndPollThemeEditorChanges(
@@ -77,11 +78,7 @@ describe('reconcileAndPollThemeEditorChanges', async () => {
 
     // Then
     expect(reconcileJsonFiles).not.toHaveBeenCalled()
-    expect(pollThemeEditorChanges).toHaveBeenCalledWith(developmentTheme, adminSession, [], newFileSystem, {
-      noDelete: false,
-      ignore: [],
-      only: [],
-    })
+    expect(pollThemeEditorChanges).toHaveBeenCalled()
   })
 
   test('should wait for the local theme file system to be ready before reconciling', async () => {

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
@@ -1,9 +1,9 @@
 import {pollThemeEditorChanges} from './theme-polling.js'
 import {reconcileJsonFiles} from './theme-reconciliation.js'
-import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
+import {outputDebug} from '@shopify/cli-kit/node/output'
 
 export const LOCAL_STRATEGY = 'local'
 export const REMOTE_STRATEGY = 'remote'
@@ -24,6 +24,7 @@ export async function reconcileAndPollThemeEditorChanges(
   },
 ) {
   outputDebug('Initiating theme asset reconciliation process')
+  await localThemeFileSystem.ready()
 
   if (remoteChecksums.length !== 0) {
     await reconcileJsonFiles(targetTheme, session, remoteChecksums, localThemeFileSystem, options)

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
@@ -1,6 +1,5 @@
 import {pollThemeEditorChanges} from './theme-polling.js'
 import {reconcileJsonFiles} from './theme-reconciliation.js'
-import {mountThemeFileSystem} from '../theme-fs.js'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
@@ -31,9 +30,7 @@ export async function reconcileAndPollThemeEditorChanges(
   }
 
   const updatedRemoteChecksums = await fetchChecksums(targetTheme.id, session)
-
-  const themeFileSystem = mountThemeFileSystem(localThemeFileSystem.root, {filters: options})
-  pollThemeEditorChanges(targetTheme, session, updatedRemoteChecksums, themeFileSystem, options)
+  pollThemeEditorChanges(targetTheme, session, updatedRemoteChecksums, localThemeFileSystem, options)
 
   return updatedRemoteChecksums
 }

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -35,7 +35,26 @@ beforeEach(() => {
   })
 })
 
-describe('startDevServer', () => {
+// Vitest is resetting this mock between tests due to a global config `mockReset: true`.
+// For some reason we need to re-mock it here and in beforeEach:
+vi.mock('../theme-uploader.js', async () => {
+  return {
+    uploadTheme: vi.fn(() => {
+      return {
+        workPromise: Promise.resolve(),
+        uploadResults: new Map(),
+        renderThemeSyncProgress: () => Promise.resolve(),
+      }
+    }),
+  }
+})
+beforeEach(() => {
+  vi.mocked(uploadTheme).mockImplementation(() => {
+    return {workPromise: Promise.resolve(), uploadResults: new Map(), renderThemeSyncProgress: () => Promise.resolve()}
+  })
+})
+
+describe('setupDevServer', () => {
   const developmentTheme = buildTheme({id: 1, name: 'Theme', role: DEVELOPMENT_THEME_ROLE})!
   const localFiles = new Map([
     ['templates/asset.json', {checksum: '1', key: 'templates/asset.json'}],

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -35,25 +35,6 @@ beforeEach(() => {
   })
 })
 
-// Vitest is resetting this mock between tests due to a global config `mockReset: true`.
-// For some reason we need to re-mock it here and in beforeEach:
-vi.mock('../theme-uploader.js', async () => {
-  return {
-    uploadTheme: vi.fn(() => {
-      return {
-        workPromise: Promise.resolve(),
-        uploadResults: new Map(),
-        renderThemeSyncProgress: () => Promise.resolve(),
-      }
-    }),
-  }
-})
-beforeEach(() => {
-  vi.mocked(uploadTheme).mockImplementation(() => {
-    return {workPromise: Promise.resolve(), uploadResults: new Map(), renderThemeSyncProgress: () => Promise.resolve()}
-  })
-})
-
 describe('setupDevServer', () => {
   const developmentTheme = buildTheme({id: 1, name: 'Theme', role: DEVELOPMENT_THEME_ROLE})!
   const localFiles = new Map([

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -30,11 +30,13 @@ function ensureThemeEnvironmentSetup(theme: Theme, ctx: DevServerContext) {
 
   const reconcilePromise = remoteChecksumsPromise.then((remoteChecksums) =>
     ctx.options.themeEditorSync
-      ? reconcileAndPollThemeEditorChanges(theme, ctx.session, remoteChecksums, ctx.localThemeFileSystem, {
-          noDelete: ctx.options.noDelete,
-          ignore: ctx.options.ignore,
-          only: ctx.options.only,
-        })
+      ? ctx.localThemeFileSystem.ready().then(() =>
+          reconcileAndPollThemeEditorChanges(theme, ctx.session, remoteChecksums, ctx.localThemeFileSystem, {
+            noDelete: ctx.options.noDelete,
+            ignore: ctx.options.ignore,
+            only: ctx.options.only,
+          }),
+        )
       : remoteChecksums,
   )
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -29,13 +29,11 @@ function ensureThemeEnvironmentSetup(theme: Theme, ctx: DevServerContext) {
 
   const reconcilePromise = remoteChecksumsPromise.then((remoteChecksums) =>
     ctx.options.themeEditorSync
-      ? ctx.localThemeFileSystem.ready().then(() =>
-          reconcileAndPollThemeEditorChanges(theme, ctx.session, remoteChecksums, ctx.localThemeFileSystem, {
-            noDelete: ctx.options.noDelete,
-            ignore: ctx.options.ignore,
-            only: ctx.options.only,
-          }),
-        )
+      ? reconcileAndPollThemeEditorChanges(theme, ctx.session, remoteChecksums, ctx.localThemeFileSystem, {
+          noDelete: ctx.options.noDelete,
+          ignore: ctx.options.ignore,
+          only: ctx.options.only,
+        })
       : remoteChecksums,
   )
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -4,7 +4,6 @@ import {getHtmlHandler} from './html.js'
 import {getAssetsHandler} from './local-assets.js'
 import {getProxyHandler} from './proxy.js'
 import {uploadTheme} from '../theme-uploader.js'
-import {renderTasksToStdErr} from '../theme-ui.js'
 import {createApp, defineEventHandler, defineLazyEventHandler, toNodeListener} from 'h3'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 import {createServer} from 'node:http'
@@ -50,17 +49,6 @@ function ensureThemeEnvironmentSetup(theme: Theme, ctx: DevServerContext) {
   return {
     workPromise: uploadPromise.then((result) => result.workPromise),
     renderProgress: async () => {
-      if (ctx.options.themeEditorSync) {
-        await renderTasksToStdErr([
-          {
-            title: 'Performing file synchronization. This may take a while...',
-            task: async () => {
-              await reconcilePromise
-            },
-          },
-        ])
-      }
-
       const {renderThemeSyncProgress} = await uploadPromise
 
       await renderThemeSyncProgress()

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.test.ts
@@ -1,4 +1,4 @@
-import {PollingOptions, pollRemoteJsonChanges} from './theme-polling.js'
+import {PollingOptions, pollRemoteJsonChanges, deleteRemovedAssets} from './theme-polling.js'
 import {fakeThemeFileSystem} from '../theme-fs/theme-fs-mock-factory.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {fetchChecksums, fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
@@ -223,6 +223,30 @@ describe('pollRemoteJsonChanges', async () => {
         key: 'templates/asset2.json',
         value: 'content',
       })
+    })
+  })
+
+  describe('deleteRemovedAssets', () => {
+    test('does not call delete when assets deleted from remote has already been deleted locally', async () => {
+      // Given
+      const deleteSpy = vi.fn()
+      const files = new Map<string, ThemeAsset>([
+        ['templates/asset.json', {checksum: '1', key: 'templates/asset.json'}],
+      ])
+      const localFileSystem = {
+        ...fakeThemeFileSystem('tmp', files),
+        delete: deleteSpy,
+      }
+
+      // When
+      await deleteRemovedAssets(
+        localFileSystem,
+        [{checksum: '1', key: 'templates/already-deleted.json'}],
+        defaultOptions,
+      )
+
+      // Then
+      expect(deleteSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.test.ts
@@ -245,7 +245,7 @@ describe('pollRemoteJsonChanges', async () => {
       }))
 
       const themeFileSystem = {
-        ...defaultThemeFileSystem,
+        ...fakeThemeFileSystem('tmp', new Map()),
         unsyncedFileKeys: new Set(['templates/asset2.json']),
       }
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
@@ -94,7 +94,7 @@ async function syncChangedAssets(
         await localFileSystem.write(asset)
         outputInfo(
           outputContent`• ${timestampDateFormat.format(new Date())} Synced ${outputToken.raw('»')} ${outputToken.gray(
-            `fetch ${asset.key} from remote theme`,
+            `download ${asset.key} from remote theme`,
           )}`,
         )
       }
@@ -102,22 +102,24 @@ async function syncChangedAssets(
   )
 }
 
-function deleteRemovedAssets(
+export async function deleteRemovedAssets(
   localFileSystem: ThemeFileSystem,
   assetsDeletedFromRemote: Checksum[],
   options: {noDelete: boolean},
 ) {
   if (!options.noDelete) {
     return Promise.all(
-      assetsDeletedFromRemote.map((file) =>
-        localFileSystem.delete(file.key).then(() => {
-          outputInfo(
-            outputContent`• ${timestampDateFormat.format(new Date())} Synced ${outputToken.raw('»')} ${outputToken.gray(
-              `remove ${file.key} from local theme`,
-            )}`,
-          )
-        }),
-      ),
+      assetsDeletedFromRemote.map((file) => {
+        if (localFileSystem.files.get(file.key)) {
+          return localFileSystem.delete(file.key).then(() => {
+            outputInfo(
+              outputContent`• ${timestampDateFormat.format(new Date())} Synced ${outputToken.raw(
+                '»',
+              )} ${outputToken.gray(`remove ${file.key} from local theme`)}`,
+            )
+          })
+        }
+      }),
     )
   }
 }

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
@@ -144,5 +144,7 @@ async function abortIfMultipleSourcesChange(localFileSystem: ThemeFileSystem, as
 
 function applyFileFilters(files: Checksum[], localThemeFileSystem: ThemeFileSystem) {
   const filteredFiles = localThemeFileSystem.applyIgnoreFilters(files)
-  return filteredFiles.filter((file) => file.key.endsWith('.json'))
+  return filteredFiles
+    .filter((file) => file.key.endsWith('.json'))
+    .filter((file) => !localThemeFileSystem.unsyncedFileKeys.has(file.key))
 }

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
@@ -1,3 +1,4 @@
+import {timestampDateFormat} from '../../constants.js'
 import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {fetchChecksums, fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
 import {outputDebug, outputInfo, outputContent, outputToken} from '@shopify/cli-kit/node/output'
@@ -92,12 +93,9 @@ async function syncChangedAssets(
       if (asset) {
         await localFileSystem.write(asset)
         outputInfo(
-          outputContent`• ${new Date().toLocaleTimeString('en-US', {
-            hour12: false,
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-          })} Synced ${outputToken.raw('»')} ${outputToken.gray(`get ${asset.key} from remote theme`)}`,
+          outputContent`• ${timestampDateFormat.format(new Date())} Synced ${outputToken.raw('»')} ${outputToken.gray(
+            `fetch ${asset.key} from remote theme`,
+          )}`,
         )
       }
     }),
@@ -114,12 +112,9 @@ function deleteRemovedAssets(
       assetsDeletedFromRemote.map((file) =>
         localFileSystem.delete(file.key).then(() => {
           outputInfo(
-            outputContent`• ${new Date().toLocaleTimeString('en-US', {
-              hour12: false,
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            })} Synced ${outputToken.raw('»')} ${outputToken.gray(`remove ${file.key} from local theme`)}`,
+            outputContent`• ${timestampDateFormat.format(new Date())} Synced ${outputToken.raw('»')} ${outputToken.gray(
+              `remove ${file.key} from local theme`,
+            )}`,
           )
         }),
       ),

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
@@ -1,8 +1,8 @@
 import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {fetchChecksums, fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
-import {outputDebug} from '@shopify/cli-kit/node/output'
+import {outputDebug, outputInfo, outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
-import {renderError, renderText} from '@shopify/cli-kit/node/ui'
+import {renderError} from '@shopify/cli-kit/node/ui'
 
 const POLLING_INTERVAL = 3000
 class PollingError extends Error {}
@@ -91,7 +91,14 @@ async function syncChangedAssets(
       const asset = await fetchThemeAsset(targetTheme.id, file.key, currentSession)
       if (asset) {
         await localFileSystem.write(asset)
-        renderText({text: `Synced: get '${asset.key}' from remote theme`})
+        outputInfo(
+          outputContent`• ${new Date().toLocaleTimeString('en-US', {
+            hour12: false,
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+          })} Synced ${outputToken.raw('»')} ${outputToken.gray(`get ${asset.key} from remote theme`)}`,
+        )
       }
     }),
   )
@@ -106,7 +113,14 @@ function deleteRemovedAssets(
     return Promise.all(
       assetsDeletedFromRemote.map((file) =>
         localFileSystem.delete(file.key).then(() => {
-          renderText({text: `Synced: remove '${file.key}' from local theme`})
+          outputInfo(
+            outputContent`• ${new Date().toLocaleTimeString('en-US', {
+              hour12: false,
+              hour: '2-digit',
+              minute: '2-digit',
+              second: '2-digit',
+            })} Synced ${outputToken.raw('»')} ${outputToken.gray(`remove ${file.key} from local theme`)}`,
+          )
         }),
       ),
     )

--- a/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.test.ts
@@ -61,7 +61,6 @@ describe('reconcileThemeFiles', () => {
       expect(fetchThemeAsset).toHaveBeenCalledWith(developmentTheme.id, 'templates/template.json', adminSession)
     })
 
-    // should respect the `ignore` option
     test('should not reconcile files that match the `ignore` option', async () => {
       // Given
       const themeFileSystem = fakeThemeFileSystem('tmp', files, {filters: {ignore: ['templates/*']}})
@@ -191,5 +190,19 @@ describe('reconcileThemeFiles', () => {
       // Then
       expect(fetchThemeAsset).not.toHaveBeenCalled()
     })
+  })
+
+  test('should wait for the theme file system to be ready prior to reconciliation', async () => {
+    // Given
+    const themeFileSystem = {
+      ...fakeThemeFileSystem('tmp', files),
+      ready: vi.fn().mockResolvedValue(undefined),
+    }
+
+    // When
+    await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, themeFileSystem, defaultOptions)
+
+    // Then
+    expect(themeFileSystem.ready).toHaveBeenCalled()
   })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.test.ts
@@ -191,18 +191,4 @@ describe('reconcileThemeFiles', () => {
       expect(fetchThemeAsset).not.toHaveBeenCalled()
     })
   })
-
-  test('should wait for the theme file system to be ready prior to reconciliation', async () => {
-    // Given
-    const themeFileSystem = {
-      ...fakeThemeFileSystem('tmp', files),
-      ready: vi.fn().mockResolvedValue(undefined),
-    }
-
-    // When
-    await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, themeFileSystem, defaultOptions)
-
-    // Then
-    expect(themeFileSystem.ready).toHaveBeenCalled()
-  })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.ts
@@ -26,6 +26,8 @@ export async function reconcileJsonFiles(
   localThemeFileSystem: ThemeFileSystem,
   options: ReconciliationOptions,
 ) {
+  await localThemeFileSystem.ready()
+
   const {filesOnlyPresentLocally, filesOnlyPresentOnRemote, filesWithConflictingChecksums} = identifyFilesToReconcile(
     remoteChecksums,
     localThemeFileSystem,

--- a/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.ts
@@ -26,7 +26,7 @@ export async function reconcileJsonFiles(
   localThemeFileSystem: ThemeFileSystem,
   options: ReconciliationOptions,
 ) {
-  await localThemeFileSystem.ready()
+  outputDebug('Initiating theme asset reconciliation process')
 
   const {filesOnlyPresentLocally, filesOnlyPresentOnRemote, filesWithConflictingChecksums} = identifyFilesToReconcile(
     remoteChecksums,

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -63,6 +63,7 @@ describe('theme-fs', () => {
         applyIgnoreFilters: expect.any(Function),
         addEventListener: expect.any(Function),
         startWatcher: expect.any(Function),
+        unsyncedFileKeys: expect.any(Set),
       })
     })
 
@@ -86,6 +87,7 @@ describe('theme-fs', () => {
         applyIgnoreFilters: expect.any(Function),
         addEventListener: expect.any(Function),
         startWatcher: expect.any(Function),
+        unsyncedFileKeys: expect.any(Set),
       })
     })
 

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -63,7 +63,6 @@ describe('theme-fs', () => {
         applyIgnoreFilters: expect.any(Function),
         addEventListener: expect.any(Function),
         startWatcher: expect.any(Function),
-        unsyncedFileKeys: expect.any(Set),
       })
     })
 
@@ -87,7 +86,6 @@ describe('theme-fs', () => {
         applyIgnoreFilters: expect.any(Function),
         addEventListener: expect.any(Function),
         startWatcher: expect.any(Function),
-        unsyncedFileKeys: expect.any(Set),
       })
     })
 

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -135,6 +135,27 @@ describe('theme-fs', () => {
       expect(removeFile).not.toBeCalled()
       expect(themeFileSystem.files.has('assets/nonexistent.css')).toBe(false)
     })
+
+    test('delete updates files map before the async removeFile call', async () => {
+      // Given
+      const fileKey = 'assets/base.css'
+      const root = 'src/cli/utilities/fixtures'
+      const themeFileSystem = await mountThemeFileSystem(root)
+      await themeFileSystem.ready()
+
+      let filesUpdated = false
+      vi.mocked(removeFile).mockImplementationOnce(() => {
+        filesUpdated = !themeFileSystem.files.has(fileKey)
+        return Promise.resolve()
+      })
+
+      // When
+      expect(themeFileSystem.files.has(fileKey)).toBe(true)
+      await themeFileSystem.delete(fileKey)
+
+      // Then
+      expect(filesUpdated).toBe(true)
+    })
   })
 
   describe('themeFileSystem.write', () => {
@@ -178,6 +199,28 @@ describe('theme-fs', () => {
         checksum: '1010',
         attachment,
       })
+    })
+
+    test('write updates files map before the async writeFile call', async () => {
+      // Given
+      const root = 'src/cli/utilities/fixtures'
+      const themeFileSystem = await mountThemeFileSystem(root)
+      await themeFileSystem.ready()
+
+      const newAsset = {key: 'assets/new_file.css', checksum: '1010', value: 'content'}
+
+      let filesUpdated = false
+      vi.mocked(writeFile).mockImplementationOnce(() => {
+        filesUpdated = themeFileSystem.files.get(newAsset.key) === newAsset
+        return Promise.resolve()
+      })
+
+      // When
+      expect(themeFileSystem.files.has(newAsset.key)).toBe(false)
+      await themeFileSystem.write(newAsset)
+
+      // Then
+      expect(filesUpdated).toBe(true)
     })
   })
 

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -120,12 +120,12 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
     const fileKey = getKey(filePath)
     if (isFileIgnored(fileKey)) return
 
-    const lastChecksum = files.get(fileKey)?.checksum
+    const previousChecksum = files.get(fileKey)?.checksum
 
     const contentPromise = read(fileKey).then(() => {
       const file = files.get(fileKey)!
 
-      if (file.checksum === lastChecksum) {
+      if (file.checksum === previousChecksum) {
         // Do not sync if the file has not changed
         return ''
       }

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -4,6 +4,7 @@ import {
   raiseWarningForNonExplicitGlobPatterns,
   getPatternsFromShopifyIgnore,
 } from './asset-ignore.js'
+import {timestampDateFormat} from '../constants.js'
 import {glob, readFile, ReadOptions, fileExists, mkdir, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, basename, relativePath} from '@shopify/cli-kit/node/path'
 import {lookupMimeType, setMimeTypes} from '@shopify/cli-kit/node/mimes'
@@ -378,11 +379,8 @@ function dirPath(filePath: string) {
 
 function outputSyncResult(action: 'update' | 'delete', fileKey: string): void {
   outputInfo(
-    outputContent`• ${new Date().toLocaleTimeString('en-US', {
-      hour12: false,
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    })} Synced ${outputToken.raw('»')} ${outputToken.gray(`${action} ${fileKey}`)}`,
+    outputContent`• ${timestampDateFormat.format(new Date())} Synced ${outputToken.raw('»')} ${outputToken.gray(
+      `${action} ${fileKey}`,
+    )}`,
   )
 }

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -205,12 +205,12 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
     unsyncedFileKeys,
     ready: () => themeSetupPromise,
     delete: async (fileKey: string) => {
-      await removeThemeFile(root, fileKey)
       files.delete(fileKey)
+      await removeThemeFile(root, fileKey)
     },
     write: async (asset: ThemeAsset) => {
-      await writeThemeFile(root, asset)
       files.set(asset.key, asset)
+      await writeThemeFile(root, asset)
     },
     read,
     applyIgnoreFilters: (files) => applyIgnoreFilters(files, filterPatterns),


### PR DESCRIPTION
### WHY are these changes introduced?
Closes
- https://github.com/Shopify/develop-advanced-edits/issues/292
- https://github.com/Shopify/develop-advanced-edits/issues/293

With the introduction of https://github.com/Shopify/cli/pull/4356, the `theme-editor-sync` flag needs to be updated to accommodate the new upload functionality

**Note: there is a known issue where `settings_schema.json` is always detected as a mismatching file. Fixing that is not within the scope of this PR.**

### WHAT is this pull request doing?

#### 1) **Fixes a bug where a conflict gets detected (change on both remote and local) when the `remoteTheme watcher` pulls remote theme changes into the local FS**
  - Shares a single `ThemeFileSystem` instance between the `themeFileSystem watcher` (local FS)  and `remoteTheme watcher`, allowing them to work with a unified version of `files`

#### 2) **Prevents `themeFileSystem watcher`  from re-uploading recently downloaded files from the `remoteThemeWatcher`**
  - When the `remoteThemeWatcher` downloads a file, it updates `localThemeFileSystem.files` with the new value **and checksum** via the `write` function [here](https://github.com/Shopify/cli/blob/ab47b80789e2b08a8a824587df3a3d091d849442/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts#L96)
  - This triggers the `change` or `add` handler in the `themeFileSystem watcher`
  - If the checksum is the same before and after [reading](https://github.com/Shopify/cli/blob/ab47b80789e2b08a8a824587df3a3d091d849442/packages/theme/src/cli/utilities/theme-fs.ts#L99), this means that the checksum was already updated in the `write` call above - indicating that this change event came from a remote change rather than a local FS change. In this case, we skip uploading the file

### How to test your changes?
1) `shopify-dev theme dev --dev-preview --theme-editor-sync`
2) You may be prompted about some file conflicts. Select `keep the remote version`
3) Once the server is up, click on `Customize your theme at the theme editor`
4) Apply some changes to the JSON files in your remote theme
5) Validate that these changes are downloaded locally
6) Validate through console output / logs that we DO NOT upload the changes immediately after downloading

Bonus:
- You can apply some changes to your local theme and validate that we don't pull these changes immediately or raise conflicts that both local and remote contain updates - [example error here](https://github.com/Shopify/develop-advanced-edits/issues/292)


https://github.com/user-attachments/assets/e542133b-ed48-4bec-8db4-7ce2ed1b26a9


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
