### PR TITLE
Fix assets in deploy manifest

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -350,7 +350,7 @@ export class App<
           type: module.externalType,
           handle: module.handle,
           uid: module.uid,
-          assets: module.handle,
+          assets: module.uid,
           target: module.contextValue,
           config: (config ?? {}) as JsonMapType,
         }

--- a/packages/app/src/cli/services/deploy/bundle.test.ts
+++ b/packages/app/src/cli/services/deploy/bundle.test.ts
@@ -40,7 +40,7 @@ describe('bundleAndBuildExtensions', () => {
             type: 'web_pixel_extension_external',
             handle: 'test-ui-extension',
             uid: 'test-ui-extension-uid',
-            assets: 'test-ui-extension',
+            assets: 'test-ui-extension-uid',
             target: '',
             config: {},
           },
@@ -48,7 +48,7 @@ describe('bundleAndBuildExtensions', () => {
             type: 'theme_external',
             handle: 'theme-extension-name',
             uid: themeExtension.uid,
-            assets: 'theme-extension-name',
+            assets: themeExtension.uid,
             target: '',
             config: {
               theme_extension: {

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -230,8 +230,9 @@ export function deploymentErrorsToCustomSections(
 function generalErrorsSection(errors: AppDeploySchema['appDeploy']['userErrors'], flags: {version?: string} = {}) {
   if (errors.length > 0) {
     if (
-      errors.filter((error) => error.field.includes('version_tag') && error.message === 'has already been taken')
-        .length > 0 &&
+      errors.filter(
+        (error) => error.field && error.field.includes('version_tag') && error.message === 'has already been taken',
+      ).length > 0 &&
       flags.version
     ) {
       return [


### PR DESCRIPTION
### WHY are these changes introduced?

As @pt2pham discovered, we were incorrectly setting the `assets` field in the deploy manifest file that we added in https://github.com/Shopify/cli/pull/4194. We were saving the `handle` there, but we actually use the `uid` as the folder name to store the extension stuff.

### WHAT is this pull request doing?

- Fixes the assets field in the manifest file
- Fixes an unrelated issue with error handling on deploy

### How to test your changes?

- Replace the tmpDir [here](https://github.com/Shopify/cli/blob/eb5c103914a39f98625e9fe11bfd016c4bb85f32/packages/app/src/cli/services/deploy/bundle.ts#L20) to `/tmp` to be able to check generated the bundle
- Generate an extension and run `USE_APP_MANAGEMENT_API=1 bin/spin p shopify app deploy`
- `cat /tmp/bundle/manifest.json`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
