### PR TITLE
add userAgent header to fetchAppLogs

### DIFF
--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
@@ -7,6 +7,7 @@ import {fetch} from '@shopify/cli-kit/node/http'
 import * as components from '@shopify/cli-kit/node/ui/components'
 import * as output from '@shopify/cli-kit/node/output'
 import camelcaseKeys from 'camelcase-keys'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 
 const JWT_TOKEN = 'jwtToken'
 const API_KEY = 'apiKey'
@@ -257,6 +258,7 @@ describe('pollAppLogs', () => {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${JWT_TOKEN}`,
+        'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
       },
     })
 
@@ -264,6 +266,7 @@ describe('pollAppLogs', () => {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${JWT_TOKEN}`,
+        'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
       },
     })
 

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -17,6 +17,7 @@ import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import camelcaseKeys from 'camelcase-keys'
 import {formatLocalDate} from '@shopify/cli-kit/common/string'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 
 export const POLLING_INTERVAL_MS = 450
 export const POLLING_ERROR_RETRY_INTERVAL_MS = 5 * 1000
@@ -118,11 +119,14 @@ export const fetchAppLogs = async (
   },
 ): Promise<Response> => {
   const url = await generateFetchAppLogUrl(cursor, filters)
+  const userAgent = `Shopify CLI; v=${CLI_KIT_VERSION}`
+  const headers = {
+    Authorization: `Bearer ${jwtToken}`,
+    'User-Agent': userAgent,
+  }
   return fetch(url, {
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${jwtToken}`,
-    },
+    headers,
   })
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Part of: https://github.com/Shopify/shopify-functions/issues/295
Required for: https://github.com/Shopify/partners/pull/56100

### WHAT is this pull request doing?

Adds the CLI version in the `User-Agent` header.
Required to know which version of the CLI is invoking the endpoint, which we want for metrics.

### How to test your changes?
I have tophatted this in my spin instance, and can catch the new user-header in partners with `request.user_header`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
