### PR TITLE
Use the `--dev-preview` beta flag in the `shopify theme pull` command

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5695,12 +5695,12 @@
       "description": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
       "descriptionWithMarkdown": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
       "flags": {
-        "beta": {
+        "dev-preview": {
           "allowNo": false,
-          "description": "Performs the pull command by relying on the new download implementation.",
+          "description": "Enables the developer preview for the upcoming `theme pull` implementation.",
           "env": "SHOPIFY_FLAG_BETA",
           "hidden": true,
-          "name": "beta",
+          "name": "dev-preview",
           "type": "boolean"
         },
         "development": {

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -8,7 +8,6 @@ import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {renderInfo, renderWarning} from '@shopify/cli-kit/node/ui'
 import {Flags} from '@oclif/core'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
-import {outputInfo} from '@shopify/cli-kit/node/output'
 
 export default class Console extends ThemeCommand {
   static summary = 'Shopify Liquid REPL (read-eval-print loop) tool'
@@ -58,8 +57,6 @@ export default class Console extends ThemeCommand {
     const authUrl = `http://localhost:${port}/password`
 
     if (flags['dev-preview']) {
-      outputInfo('This feature is currently in development and is not ready for use or testing yet.')
-
       if (flags.port) {
         renderPortDeprecationWarning()
       }

--- a/packages/theme/src/cli/commands/theme/pull.test.ts
+++ b/packages/theme/src/cli/commands/theme/pull.test.ts
@@ -30,7 +30,7 @@ describe('Pull', () => {
   describe('run with CLI 3 implementation', () => {
     test('should pass call the CLI 3 command', async () => {
       const theme = buildTheme({id: 1, name: 'Theme', role: 'development'})!
-      const flags = ['--ignore=config', '--only=assets', '--nodelete', '--beta']
+      const flags = ['--ignore=config', '--only=assets', '--nodelete', '--dev-preview']
 
       vi.mocked(useEmbeddedThemeCLI).mockReturnValue(true)
       vi.mocked(findOrSelectTheme).mockResolvedValue(theme)

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -66,9 +66,9 @@ If no theme is specified, then you're prompted to select the theme to pull from 
       description: 'Performs the pull command by relying on the legacy download implementation.',
       env: 'SHOPIFY_FLAG_STABLE',
     }),
-    beta: Flags.boolean({
+    'dev-preview': Flags.boolean({
       hidden: true,
-      description: 'Performs the pull command by relying on the new download implementation.',
+      description: 'Enables the developer preview for the upcoming `theme pull` implementation.',
       env: 'SHOPIFY_FLAG_BETA',
     }),
   }
@@ -87,7 +87,7 @@ If no theme is specified, then you're prompted to select the theme to pull from 
       ? developmentThemeManager.find()
       : developmentThemeManager.fetch())
 
-    if (flags.beta) {
+    if (flags['dev-preview']) {
       const {path, nodelete, live, development, only, ignore, force} = flags
 
       const theme = await findOrSelectTheme(adminSession, {

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -7,7 +7,7 @@ import {ensureValidPassword} from '../utilities/theme-environment/storefront-pas
 import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {AdminSession, ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
-import {outputDebug, outputInfo} from '@shopify/cli-kit/node/output'
+import {outputDebug} from '@shopify/cli-kit/node/output'
 import {useEmbeddedThemeCLI} from '@shopify/cli-kit/node/context/local'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 import {checkPortAvailability, getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
@@ -61,8 +61,6 @@ export async function dev(options: DevOptions) {
       body: 'The CLI flag --[flag-name] is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
     })
   }
-
-  outputInfo('This feature is currently in development and is not ready for use or testing yet.')
 
   const localThemeFileSystem = mountThemeFileSystem(options.directory, {filters: options})
 

--- a/packages/theme/src/cli/services/pull.ts
+++ b/packages/theme/src/cli/services/pull.ts
@@ -34,8 +34,8 @@ export async function pull(theme: Theme, session: AdminSession, options: PullOpt
     return
   }
 
-  const remoteChecksums = await fetchChecksums(theme.id, session)
   const themeFileSystem = mountThemeFileSystem(path, {filters: options})
+  const [remoteChecksums] = await Promise.all([fetchChecksums(theme.id, session), themeFileSystem.ready()])
   const themeChecksums = rejectGeneratedStaticAssets(remoteChecksums)
 
   const store = session.storeFqdn


### PR DESCRIPTION
### WHY are these changes introduced?

Use the `--dev-preview` beta flag in the `shopify theme pull` command instead of `--beta`.

### WHAT is this pull request doing?

Renames the `--beta` to  `--dev-preview`.

### How to test your changes?

- Run `shopify theme pull --dev-preview`

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
