### PR TITLE
Introduce support to HTTP methods in the remote renderer

### DIFF
--- a/packages/theme/src/cli/utilities/repl/evaluator.ts
+++ b/packages/theme/src/cli/utilities/repl/evaluator.ts
@@ -105,6 +105,7 @@ function printSyntaxError(snippet: string, error: string) {
 async function makeRequest(config: EvaluationConfig): Promise<Response> {
   const requestBody = buildRequestBody(config)
   const response = await render(config.themeSession, {
+    method: 'GET',
     path: config.url,
     query: [],
     themeId: config.themeId,

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
@@ -188,6 +188,7 @@ export function getHotReloadHandler(theme: Theme, ctx: DevServerContext) {
       }
 
       return render(ctx.session, {
+        method: event.method,
         path: browserPathname ?? '/',
         query: [...new URLSearchParams(browserSearch).entries()],
         themeId: String(theme.id),

--- a/packages/theme/src/cli/utilities/theme-environment/html.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/html.ts
@@ -14,6 +14,7 @@ export function getHtmlHandler(theme: Theme, ctx: DevServerContext) {
     const [browserPathname = '/', browserSearch = ''] = event.path.split('?')
 
     return render(ctx.session, {
+      method: event.method,
       path: browserPathname,
       query: [...new URLSearchParams(browserSearch)],
       themeId: String(theme.id),

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.test.ts
@@ -1,5 +1,6 @@
 import {render} from './storefront-renderer.js'
 import {getStorefrontSessionCookies} from './storefront-session.js'
+import {DevServerRenderContext} from './types.js'
 import {describe, expect, test, vi} from 'vitest'
 import {fetch} from '@shopify/cli-kit/node/http'
 import {ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
@@ -28,7 +29,8 @@ const session = {
   expiresAt: new Date(),
 }
 
-const context = {
+const context: DevServerRenderContext = {
+  method: 'GET',
   path: '/products/1',
   themeId: '123',
   query: [],

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
@@ -12,7 +12,7 @@ export async function render(session: DevServerSession, context: DevServerRender
 
   outputDebug(`→ Rendering ${url} (with ${Object.keys(context.replaceTemplates)})...`)
 
-  const bodyParams = storefrontReplaceTemplatesParams(context.replaceTemplates)
+  const bodyParams = storefrontReplaceTemplatesParams(context)
   const headers = await buildHeaders(session, context)
 
   const response = await fetch(url, {

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-utils.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-utils.test.ts
@@ -1,15 +1,34 @@
 import {storefrontReplaceTemplatesParams} from './storefront-utils.js'
+import {DevServerRenderContext} from './types.js'
 import {describe, test, expect} from 'vitest'
+
+const context: DevServerRenderContext = {
+  method: 'GET',
+  path: '/products/1',
+  themeId: '123',
+  query: [],
+  headers: {
+    'Content-Length': '100',
+    'X-Special-Header': '200',
+    cookie: 'theme_cookie=abc;',
+    Cookie: 'theme_cookie=def;',
+  },
+  replaceTemplates: {},
+  sectionId: '',
+}
 
 describe('storefrontFormData', () => {
   test("returns the params string with correct mappings for section's content", () => {
     // Given
-    const sections = {
-      'sections/announcement-bar.liquid': '<h1>Content</h1>',
+    const ctx: DevServerRenderContext = {
+      ...context,
+      replaceTemplates: {
+        'sections/announcement-bar.liquid': '<h1>Content</h1>',
+      },
     }
 
     // When
-    const formData = storefrontReplaceTemplatesParams(sections)
+    const formData = storefrontReplaceTemplatesParams(ctx)
 
     // Then
     const formDataContent = formData.toString()
@@ -20,13 +39,31 @@ describe('storefrontFormData', () => {
 
   test('handles empty sections record as expected', () => {
     // Given
-    const sectionsContent = {}
+    const ctx: DevServerRenderContext = {
+      ...context,
+      replaceTemplates: {},
+    }
 
     // When
-    const formData = storefrontReplaceTemplatesParams(sectionsContent)
+    const formData = storefrontReplaceTemplatesParams(ctx)
 
     // Then
     const formDataContent = formData.toString()
     expect(formDataContent).toEqual('_method=GET')
+  })
+
+  test('handles different HTTP method as expected', () => {
+    // Given
+    const ctx: DevServerRenderContext = {
+      ...context,
+      method: 'POST',
+    }
+
+    // When
+    const formData = storefrontReplaceTemplatesParams(ctx)
+
+    // Then
+    const formDataContent = formData.toString()
+    expect(formDataContent).toEqual('_method=POST')
   })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-utils.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-utils.ts
@@ -1,16 +1,18 @@
+import {DevServerRenderContext} from './types.js'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 
-export function storefrontReplaceTemplatesParams(replaceTemplates: {[key: string]: string}): URLSearchParams {
+export function storefrontReplaceTemplatesParams(context: DevServerRenderContext): URLSearchParams {
   /**
    * Theme access proxy doesn't support FormData encoding.
    */
   const params = new URLSearchParams()
+  const {method, replaceTemplates} = context
 
   for (const [path, content] of Object.entries(replaceTemplates)) {
     params.append(`replace_templates[${path}]`, content)
   }
 
-  params.append('_method', 'GET')
+  params.append('_method', method)
 
   return params
 }

--- a/packages/theme/src/cli/utilities/theme-environment/types.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/types.ts
@@ -112,6 +112,11 @@ export interface DevServerRenderContext {
   path: string
 
   /**
+   * HTTP method to be used during the rendering.
+   */
+  method: 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE'
+
+  /**
    * Theme identifier for rendering.
    */
   themeId: string


### PR DESCRIPTION
### WHY are these changes introduced?

This PR introduces support for multiple HTTP methods in the remote renderer. Currently, the proxy does not support multiple HTTP verbs, which could be an issue in future renderings or during our upcoming bug hunt investigations.

### WHAT is this pull request doing?

This PR enhances the flexibility of the remote renderer without impacting any current features.

### How to test your changes?

N/A

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
