### PR TITLE
Report to Bugsnag only in production

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -259,5 +259,6 @@ function initializeBugsnag() {
     appVersion: CLI_KIT_VERSION,
     autoTrackSessions: false,
     autoDetectErrors: false,
+    enabledReleaseStages: ['production'],
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We are getting some errors in Bugnsag from environments like `test`: https://app.bugsnag.com/shopify/cli/errors?filters[error.status]=open&filters[event.since]=all&filters[app.release_stage]=test

It seems that [this check](https://github.com/Shopify/cli/blob/4a22d5b23429771d58c1a3b5748663e76064b938/packages/cli-kit/src/public/node/error-handler.ts#L66) is not working as expected in some cases.

### WHAT is this pull request doing?

Change the Bugsnag settings to only report in production.

Documentation: https://docs.bugsnag.com/platforms/javascript/configuration-options/#enabledreleasestages

### How to test your changes?

One of the PRs that was raising errors from the CI is https://github.com/Shopify/cli/pull/4149. I've checked that [this error](https://app.bugsnag.com/shopify/cli/errors/66a7766ecb88867560472792), coming from that PR, didn't get more events after [updating the configuration there](https://github.com/Shopify/cli/pull/4149/commits/105a64bc5c82b4f494666bbd41d686793dd180df).

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
