### PR TITLE
[Theme Dev] - Skip JSON reconciliation when development theme is empty

### DIFF
--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
@@ -55,4 +55,36 @@ describe('reconcileAndPollThemeEditorChanges', async () => {
       },
     )
   })
+
+  test('should not call reconcileJsonFiles when remote theme contains no files', async () => {
+    // Given
+    const files = new Map<string, ThemeAsset>([])
+    const defaultThemeFileSystem = fakeThemeFileSystem('tmp', files)
+    const emptyRemoteChecksums: [] = []
+    const newFileSystem = fakeThemeFileSystem('tmp', new Map<string, ThemeAsset>([]))
+
+    vi.mocked(fetchChecksums).mockResolvedValue([])
+    vi.mocked(mountThemeFileSystem).mockReturnValue(newFileSystem)
+
+    // When
+    await reconcileAndPollThemeEditorChanges(
+      developmentTheme,
+      adminSession,
+      emptyRemoteChecksums,
+      defaultThemeFileSystem,
+      {
+        noDelete: false,
+        ignore: [],
+        only: [],
+      },
+    )
+
+    // Then
+    expect(reconcileJsonFiles).not.toHaveBeenCalled()
+    expect(pollThemeEditorChanges).toHaveBeenCalledWith(developmentTheme, adminSession, [], newFileSystem, {
+      noDelete: false,
+      ignore: [],
+      only: [],
+    })
+  })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
@@ -25,7 +25,10 @@ export async function reconcileAndPollThemeEditorChanges(
   },
 ) {
   outputDebug('Initiating theme asset reconciliation process')
-  await reconcileJsonFiles(targetTheme, session, remoteChecksums, localThemeFileSystem, options)
+
+  if (remoteChecksums.length !== 0) {
+    await reconcileJsonFiles(targetTheme, session, remoteChecksums, localThemeFileSystem, options)
+  }
 
   const updatedRemoteChecksums = await fetchChecksums(targetTheme.id, session)
 


### PR DESCRIPTION
### WHY are these changes introduced?
- https://github.com/Shopify/develop-advanced-edits/issues/298

### WHAT is this pull request doing?
- skips the JSON reconciliation step when the `theme-editor-sync` flag is passed with an empty development theme
  - _The polling will still occur in this case_

### How to test your changes?
1) `shopify theme delete -d`
2) `shopify-dev theme dev --dev-preview --theme-editor-sync`

Validate that you are NOT prompted for JSON reconciliation
https://github.com/user-attachments/assets/821c8761-5bdf-451b-8624-b3cb16ef3a65

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
