### PR TITLE
Avoid link on deploy when there is a current config

### DIFF
--- a/.changeset/seven-starfishes-jump.md
+++ b/.changeset/seven-starfishes-jump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Do not link on deploy when there is a current config


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2048
Fixes https://github.com/Shopify/cli/issues/4264

In v3.65 we included [this refactor](https://github.com/Shopify/cli/pull/4233) that allowed to run link from the deploy command, but there are some situations where we are running link, but we shouldn't because we should use a current configuration. This is affecting especially in CI environments because the link process produces an error as it requires an input by the user.

### WHAT is this pull request doing?

Only run link on deploy when:
- There is no provided api_key or config
- There's no current configuration (cache or TOML) or is legacy
- Reset is passed

### How to test your changes?

- `p shopify app deploy`
- `p shopify app deploy --client-id whatever`
- `p shopify app deploy -c production`
- `p shopify app config use production`
- `p shopify app deploy`
- `p shopify app deploy --reset`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
