### PR TITLE
Remove unneeded changeset

### DIFF
--- a/.changeset/seven-starfishes-jump.md
+++ b/.changeset/seven-starfishes-jump.md
@@ -1,5 +1,0 @@
----
-'@shopify/app': patch
----
-
-Do not link on deploy when there is a current config


### PR DESCRIPTION
I added a changeset by mistake in https://github.com/Shopify/cli/pull/4387, because it will be already included in the patch release: https://github.com/Shopify/cli/pull/4388
