### PR TITLE
[Themes] Theme Dev - Editor Sync - Fix Hanging Theme Reconciliation Progress Bar and User Inputs

### DIFF
--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -95,10 +95,15 @@ export async function dev(options: DevOptions) {
     },
   }
 
+  if (options['theme-editor-sync']) {
+    session.storefrontPassword = await storefrontPasswordPromise
+  }
+
   const {serverStart, renderDevSetupProgress} = setupDevServer(options.theme, ctx)
 
-  const storefrontPassword = await storefrontPasswordPromise
-  session.storefrontPassword = storefrontPassword
+  if (!options['theme-editor-sync']) {
+    session.storefrontPassword = await storefrontPasswordPromise
+  }
 
   await renderDevSetupProgress()
   await serverStart()

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
@@ -6,7 +6,7 @@ import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 vi.mock('@shopify/cli-kit/node/themes/api')
 vi.mock('./theme-reconciliation.js')
@@ -17,20 +17,22 @@ describe('reconcileAndPollThemeEditorChanges', async () => {
   const developmentTheme = buildTheme({id: 1, name: 'Theme', role: DEVELOPMENT_THEME_ROLE})!
   const adminSession = {token: '', storeFqdn: ''}
 
+  beforeEach(() => {
+    vi.mocked(reconcileJsonFiles).mockResolvedValue({
+      workPromise: Promise.resolve(),
+    })
+  })
+
   test('should call pollThemeEditorChanges with updated checksums if the remote theme was been updated during reconciliation', async () => {
     // Given
     const files = new Map<string, ThemeAsset>([])
     const defaultThemeFileSystem = fakeThemeFileSystem('tmp', files)
     const initialRemoteChecksums = [{checksum: '1', key: 'templates/asset.json'}]
 
-    vi.mocked(reconcileJsonFiles).mockResolvedValue({
-      reconciliationFinishedPromise: Promise.resolve(),
-      readyForReconciliationPromise: Promise.resolve(),
-    })
     vi.mocked(fetchChecksums).mockResolvedValue([{checksum: '2', key: 'templates/asset.json'}])
 
     // When
-    await reconcileAndPollThemeEditorChanges(
+    const {workPromise, updatedRemoteChecksumsPromise} = await reconcileAndPollThemeEditorChanges(
       developmentTheme,
       adminSession,
       initialRemoteChecksums,
@@ -41,6 +43,8 @@ describe('reconcileAndPollThemeEditorChanges', async () => {
         only: [],
       },
     )
+    await workPromise
+    await updatedRemoteChecksumsPromise
 
     // Then
     expect(pollThemeEditorChanges).toHaveBeenCalledWith(
@@ -54,34 +58,6 @@ describe('reconcileAndPollThemeEditorChanges', async () => {
         only: [],
       },
     )
-  })
-
-  test('should not call reconcileJsonFiles when remote theme contains no files', async () => {
-    // Given
-    const files = new Map<string, ThemeAsset>([])
-    const defaultThemeFileSystem = fakeThemeFileSystem('tmp', files)
-    const emptyRemoteChecksums: [] = []
-    const newFileSystem = fakeThemeFileSystem('tmp', new Map<string, ThemeAsset>([]))
-
-    vi.mocked(fetchChecksums).mockResolvedValue([])
-    const readySpy = vi.spyOn(defaultThemeFileSystem, 'ready').mockResolvedValue()
-
-    // When
-    await reconcileAndPollThemeEditorChanges(
-      developmentTheme,
-      adminSession,
-      emptyRemoteChecksums,
-      defaultThemeFileSystem,
-      {
-        noDelete: false,
-        ignore: [],
-        only: [],
-      },
-    )
-
-    // Then
-    expect(reconcileJsonFiles).not.toHaveBeenCalled()
-    expect(pollThemeEditorChanges).toHaveBeenCalled()
   })
 
   test('should wait for the local theme file system to be ready before reconciling', async () => {

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.test.ts
@@ -23,7 +23,10 @@ describe('reconcileAndPollThemeEditorChanges', async () => {
     const defaultThemeFileSystem = fakeThemeFileSystem('tmp', files)
     const initialRemoteChecksums = [{checksum: '1', key: 'templates/asset.json'}]
 
-    vi.mocked(reconcileJsonFiles).mockResolvedValue(undefined)
+    vi.mocked(reconcileJsonFiles).mockResolvedValue({
+      reconciliationFinishedPromise: Promise.resolve(),
+      readyForReconciliationPromise: Promise.resolve(),
+    })
     vi.mocked(fetchChecksums).mockResolvedValue([{checksum: '2', key: 'templates/asset.json'}])
 
     // When

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
@@ -29,7 +29,7 @@ export async function reconcileAndPollThemeEditorChanges(
   outputDebug('Initiating theme asset reconciliation process')
   await localThemeFileSystem.ready()
 
-  const {workPromise} = await reconcileJsonFiles(remoteChecksums, localThemeFileSystem, targetTheme, session, options)
+  const {workPromise} = await reconcileJsonFiles(targetTheme, session, remoteChecksums, localThemeFileSystem, options)
 
   const updatedRemoteChecksumsPromise = workPromise.then(async () => {
     const updatedRemoteChecksums = await fetchChecksums(targetTheme.id, session)

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
@@ -1,5 +1,6 @@
 import {pollThemeEditorChanges} from './theme-polling.js'
 import {reconcileJsonFiles} from './theme-reconciliation.js'
+import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
@@ -23,23 +24,26 @@ export async function reconcileAndPollThemeEditorChanges(
     only: string[]
   },
 ): Promise<{
-  updatedRemoteChecksums: Checksum[]
-  reconciliationFinishedPromise: Promise<void>
-  readyForReconciliationPromise: Promise<void>
+  updatedRemoteChecksumsPromise: Promise<Checksum[]>
+  userInputPromise: Promise<unknown>
+  workPromise: Promise<void>
 }> {
   outputDebug('Initiating theme asset reconciliation process')
   await localThemeFileSystem.ready()
 
-  const {reconciliationFinishedPromise, readyForReconciliationPromise} = await reconcileJsonFiles(
-    targetTheme,
-    session,
+  const {userInputPromise, workPromise} = await reconcileJsonFiles(
     remoteChecksums,
     localThemeFileSystem,
+    targetTheme,
+    session,
     options,
   )
 
-  const updatedRemoteChecksums = await fetchChecksums(targetTheme.id, session)
-  pollThemeEditorChanges(targetTheme, session, updatedRemoteChecksums, localThemeFileSystem, options)
+  const updatedRemoteChecksumsPromise = workPromise.then(async () => {
+    const updatedRemoteChecksums = await fetchChecksums(targetTheme.id, session)
+    pollThemeEditorChanges(targetTheme, session, updatedRemoteChecksums, localThemeFileSystem, options)
+    return updatedRemoteChecksums
+  })
 
-  return {updatedRemoteChecksums, reconciliationFinishedPromise, readyForReconciliationPromise}
+  return {updatedRemoteChecksumsPromise, userInputPromise, workPromise}
 }

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
@@ -22,16 +22,24 @@ export async function reconcileAndPollThemeEditorChanges(
     ignore: string[]
     only: string[]
   },
-) {
+): Promise<{
+  updatedRemoteChecksums: Checksum[]
+  reconciliationFinishedPromise: Promise<void>
+  readyForReconciliationPromise: Promise<void>
+}> {
   outputDebug('Initiating theme asset reconciliation process')
   await localThemeFileSystem.ready()
 
-  if (remoteChecksums.length !== 0) {
-    await reconcileJsonFiles(targetTheme, session, remoteChecksums, localThemeFileSystem, options)
-  }
+  const {reconciliationFinishedPromise, readyForReconciliationPromise} = await reconcileJsonFiles(
+    targetTheme,
+    session,
+    remoteChecksums,
+    localThemeFileSystem,
+    options,
+  )
 
   const updatedRemoteChecksums = await fetchChecksums(targetTheme.id, session)
   pollThemeEditorChanges(targetTheme, session, updatedRemoteChecksums, localThemeFileSystem, options)
 
-  return updatedRemoteChecksums
+  return {updatedRemoteChecksums, reconciliationFinishedPromise, readyForReconciliationPromise}
 }

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
@@ -25,19 +25,12 @@ export async function reconcileAndPollThemeEditorChanges(
   },
 ): Promise<{
   updatedRemoteChecksumsPromise: Promise<Checksum[]>
-  userInputPromise: Promise<unknown>
   workPromise: Promise<void>
 }> {
   outputDebug('Initiating theme asset reconciliation process')
   await localThemeFileSystem.ready()
 
-  const {userInputPromise, workPromise} = await reconcileJsonFiles(
-    remoteChecksums,
-    localThemeFileSystem,
-    targetTheme,
-    session,
-    options,
-  )
+  const {workPromise} = await reconcileJsonFiles(remoteChecksums, localThemeFileSystem, targetTheme, session, options)
 
   const updatedRemoteChecksumsPromise = workPromise.then(async () => {
     const updatedRemoteChecksums = await fetchChecksums(targetTheme.id, session)
@@ -45,5 +38,5 @@ export async function reconcileAndPollThemeEditorChanges(
     return updatedRemoteChecksums
   })
 
-  return {updatedRemoteChecksumsPromise, userInputPromise, workPromise}
+  return {updatedRemoteChecksumsPromise, workPromise}
 }

--- a/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/remote-theme-watcher.ts
@@ -4,7 +4,6 @@ import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
-import {outputDebug} from '@shopify/cli-kit/node/output'
 
 export const LOCAL_STRATEGY = 'local'
 export const REMOTE_STRATEGY = 'remote'

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -105,9 +105,8 @@ describe('setupDevServer', () => {
       },
     }
     vi.mocked(reconcileAndPollThemeEditorChanges).mockResolvedValue({
-      updatedRemoteChecksums: [],
-      readyForReconciliationPromise: Promise.resolve(),
-      reconciliationFinishedPromise: Promise.resolve(),
+      updatedRemoteChecksumsPromise: Promise.resolve([]),
+      workPromise: Promise.resolve(),
     })
 
     // When

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -104,6 +104,11 @@ describe('setupDevServer', () => {
         ...filters,
       },
     }
+    vi.mocked(reconcileAndPollThemeEditorChanges).mockResolvedValue({
+      updatedRemoteChecksums: [],
+      readyForReconciliationPromise: Promise.resolve(),
+      reconciliationFinishedPromise: Promise.resolve(),
+    })
 
     // When
     await setupDevServer(developmentTheme, context).workPromise

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -44,8 +44,7 @@ function ensureThemeEnvironmentSetup(theme: Theme, ctx: DevServerContext) {
     workPromise: uploadPromise.then((result) => result.workPromise),
     renderProgress: async () => {
       if (ctx.options.themeEditorSync) {
-        const {userInputPromise, workPromise} = await reconcilePromise
-        await userInputPromise
+        const {workPromise} = await reconcilePromise
         await renderTasksToStdErr([
           {
             title: 'Performing file synchronization. This may take a while...',
@@ -63,7 +62,14 @@ function ensureThemeEnvironmentSetup(theme: Theme, ctx: DevServerContext) {
   }
 }
 
-function handleThemeEditorSync(theme: Theme, ctx: DevServerContext, remoteChecksums: Checksum[]) {
+function handleThemeEditorSync(
+  theme: Theme,
+  ctx: DevServerContext,
+  remoteChecksums: Checksum[],
+): Promise<{
+  updatedRemoteChecksumsPromise: Promise<Checksum[]>
+  workPromise: Promise<void>
+}> {
   if (ctx.options.themeEditorSync) {
     return reconcileAndPollThemeEditorChanges(theme, ctx.session, remoteChecksums, ctx.localThemeFileSystem, {
       noDelete: ctx.options.noDelete,
@@ -71,11 +77,10 @@ function handleThemeEditorSync(theme: Theme, ctx: DevServerContext, remoteChecks
       only: ctx.options.only,
     })
   } else {
-    return {
+    return Promise.resolve({
       updatedRemoteChecksumsPromise: Promise.resolve(remoteChecksums),
-      userInputPromise: Promise.resolve(),
       workPromise: Promise.resolve(),
-    }
+    })
   }
 }
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -1,8 +1,8 @@
-import {reconcileAndPollThemeEditorChanges} from './remote-theme-watcher.js'
 import {getHotReloadHandler, setupInMemoryTemplateWatcher} from './hot-reload/server.js'
 import {getHtmlHandler} from './html.js'
 import {getAssetsHandler} from './local-assets.js'
 import {getProxyHandler} from './proxy.js'
+import {reconcileAndPollThemeEditorChanges} from './remote-theme-watcher.js'
 import {uploadTheme} from '../theme-uploader.js'
 import {renderTasksToStdErr} from '../theme-ui.js'
 import {createApp, defineEventHandler, defineLazyEventHandler, toNodeListener} from 'h3'
@@ -28,58 +28,42 @@ export function setupDevServer(theme: Theme, ctx: DevServerContext) {
 function ensureThemeEnvironmentSetup(theme: Theme, ctx: DevServerContext) {
   const remoteChecksumsPromise = fetchChecksums(theme.id, ctx.session)
 
-  const editorSyncPromise = remoteChecksumsPromise.then((remoteChecksums) =>
+  const reconcilePromise = remoteChecksumsPromise.then((remoteChecksums) =>
     handleThemeEditorSync(theme, ctx, remoteChecksums),
   )
 
-  const themeSetupPromise = editorSyncPromise.then(
-    ({updatedRemoteChecksums, reconciliationFinishedPromise, readyForReconciliationPromise}) => {
-      const uploadPromise = reconciliationFinishedPromise.then(() =>
-        uploadTheme(theme, ctx.session, updatedRemoteChecksums, ctx.localThemeFileSystem, {
-          nodelete: ctx.options.noDelete,
-          ignore: ctx.options.ignore,
-          only: ctx.options.only,
-          deferPartialWork: true,
-        }),
-      )
-
-      return {uploadPromise, reconciliationFinishedPromise, readyForReconciliationPromise}
-    },
-  )
+  const uploadPromise = reconcilePromise.then(async ({updatedRemoteChecksumsPromise}) => {
+    const updatedRemoteChecksums = await updatedRemoteChecksumsPromise
+    return uploadTheme(theme, ctx.session, updatedRemoteChecksums, ctx.localThemeFileSystem, {
+      nodelete: ctx.options.noDelete,
+      deferPartialWork: true,
+    })
+  })
 
   return {
-    workPromise: themeSetupPromise.then(async ({uploadPromise}) => (await uploadPromise).workPromise),
+    workPromise: uploadPromise.then((result) => result.workPromise),
     renderProgress: async () => {
       if (ctx.options.themeEditorSync) {
-        await themeSetupPromise.then(({readyForReconciliationPromise}) => readyForReconciliationPromise)
+        const {userInputPromise, workPromise} = await reconcilePromise
+        await userInputPromise
         await renderTasksToStdErr([
           {
             title: 'Performing file synchronization. This may take a while...',
             task: async () => {
-              await themeSetupPromise.then(async ({reconciliationFinishedPromise}) => {
-                await reconciliationFinishedPromise
-              })
+              await workPromise
             },
           },
         ])
       }
 
-      const {renderThemeSyncProgress} = await themeSetupPromise.then(({uploadPromise}) => uploadPromise)
+      const {renderThemeSyncProgress} = await uploadPromise
 
       await renderThemeSyncProgress()
     },
   }
 }
 
-function handleThemeEditorSync(
-  theme: Theme,
-  ctx: DevServerContext,
-  remoteChecksums: Checksum[],
-): Promise<{
-  updatedRemoteChecksums: Checksum[]
-  reconciliationFinishedPromise: Promise<void>
-  readyForReconciliationPromise: Promise<void>
-}> {
+function handleThemeEditorSync(theme: Theme, ctx: DevServerContext, remoteChecksums: Checksum[]) {
   if (ctx.options.themeEditorSync) {
     return reconcileAndPollThemeEditorChanges(theme, ctx.session, remoteChecksums, ctx.localThemeFileSystem, {
       noDelete: ctx.options.noDelete,
@@ -87,11 +71,11 @@ function handleThemeEditorSync(
       only: ctx.options.only,
     })
   } else {
-    return Promise.resolve({
-      updatedRemoteChecksums: remoteChecksums,
-      reconciliationFinishedPromise: Promise.resolve(),
-      readyForReconciliationPromise: Promise.resolve(),
-    })
+    return {
+      updatedRemoteChecksumsPromise: Promise.resolve(remoteChecksums),
+      userInputPromise: Promise.resolve(),
+      workPromise: Promise.resolve(),
+    }
   }
 }
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.test.ts
@@ -33,7 +33,13 @@ describe('reconcileThemeFiles', () => {
       ]
 
       // When
-      await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, defaultThemeFileSystem, defaultOptions)
+      await reconcileAndWaitForReconciliationFinish(
+        developmentTheme,
+        adminSession,
+        remoteChecksums,
+        defaultThemeFileSystem,
+        defaultOptions,
+      )
 
       // Then
       expect(fetchThemeAsset).toHaveBeenCalledTimes(1)
@@ -51,10 +57,16 @@ describe('reconcileThemeFiles', () => {
       ]
 
       // When
-      await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, defaultThemeFileSystem, {
-        ...defaultOptions,
-        only: ['templates/*'],
-      })
+      await reconcileAndWaitForReconciliationFinish(
+        developmentTheme,
+        adminSession,
+        remoteChecksums,
+        defaultThemeFileSystem,
+        {
+          ...defaultOptions,
+          only: ['templates/*'],
+        },
+      )
 
       // Then
       expect(fetchThemeAsset).toHaveBeenCalledTimes(1)
@@ -93,7 +105,13 @@ describe('reconcileThemeFiles', () => {
 
       // When
       expect(defaultThemeFileSystem.files.get('templates/asset.json')).toBeUndefined()
-      await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, defaultThemeFileSystem, defaultOptions)
+      await reconcileAndWaitForReconciliationFinish(
+        developmentTheme,
+        adminSession,
+        remoteChecksums,
+        defaultThemeFileSystem,
+        defaultOptions,
+      )
 
       // Then
       expect(fetchThemeAsset).toHaveBeenCalledWith(developmentTheme.id, assetToBeDownloaded.key, adminSession)
@@ -107,7 +125,13 @@ describe('reconcileThemeFiles', () => {
       const remoteChecksums = [assetToBeDeleted]
 
       // When
-      await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, defaultThemeFileSystem, defaultOptions)
+      await reconcileAndWaitForReconciliationFinish(
+        developmentTheme,
+        adminSession,
+        remoteChecksums,
+        defaultThemeFileSystem,
+        defaultOptions,
+      )
 
       // Then
       expect(deleteThemeAsset).toHaveBeenCalledWith(developmentTheme.id, assetToBeDeleted.key, adminSession)
@@ -124,7 +148,13 @@ describe('reconcileThemeFiles', () => {
       const spy = vi.spyOn(localThemeFileSystem, 'delete')
 
       // When
-      await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, localThemeFileSystem, defaultOptions)
+      await reconcileAndWaitForReconciliationFinish(
+        developmentTheme,
+        adminSession,
+        remoteChecksums,
+        localThemeFileSystem,
+        defaultOptions,
+      )
 
       // Then
       expect(spy).toHaveBeenCalledWith('templates/asset.json')
@@ -138,7 +168,13 @@ describe('reconcileThemeFiles', () => {
       const spy = vi.spyOn(localThemeFileSystem, 'delete')
 
       // When
-      await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, localThemeFileSystem, defaultOptions)
+      await reconcileAndWaitForReconciliationFinish(
+        developmentTheme,
+        adminSession,
+        remoteChecksums,
+        localThemeFileSystem,
+        defaultOptions,
+      )
 
       // Then
       expect(spy).not.toHaveBeenCalled()
@@ -151,10 +187,16 @@ describe('reconcileThemeFiles', () => {
       const spy = vi.spyOn(localThemeFileSystem, 'delete')
 
       // When
-      await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, localThemeFileSystem, {
-        ...defaultOptions,
-        noDelete: true,
-      })
+      await reconcileAndWaitForReconciliationFinish(
+        developmentTheme,
+        adminSession,
+        remoteChecksums,
+        localThemeFileSystem,
+        {
+          ...defaultOptions,
+          noDelete: true,
+        },
+      )
 
       // Then
       expect(renderSelectPrompt).not.toHaveBeenCalled()
@@ -171,7 +213,13 @@ describe('reconcileThemeFiles', () => {
       const remoteChecksums = [{checksum: '2', key: 'templates/asset.json'}]
 
       // When
-      await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, localThemeFileSystem, defaultOptions)
+      await reconcileAndWaitForReconciliationFinish(
+        developmentTheme,
+        adminSession,
+        remoteChecksums,
+        localThemeFileSystem,
+        defaultOptions,
+      )
 
       // Then
       expect(fetchThemeAsset).toHaveBeenCalled()
@@ -185,10 +233,21 @@ describe('reconcileThemeFiles', () => {
       const remoteChecksums = [{checksum: '2', key: 'templates/asset.json'}]
 
       // When
-      await reconcileJsonFiles(developmentTheme, adminSession, remoteChecksums, localThemeFileSystem, defaultOptions)
+      await reconcileAndWaitForReconciliationFinish(
+        developmentTheme,
+        adminSession,
+        remoteChecksums,
+        localThemeFileSystem,
+        defaultOptions,
+      )
 
       // Then
       expect(fetchThemeAsset).not.toHaveBeenCalled()
     })
   })
 })
+
+async function reconcileAndWaitForReconciliationFinish(...args: Parameters<typeof reconcileJsonFiles>) {
+  const {reconciliationFinishedPromise} = await reconcileJsonFiles(...args)
+  return reconciliationFinishedPromise
+}

--- a/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.ts
@@ -19,6 +19,10 @@ interface ReconciliationOptions {
   ignore: string[]
 }
 
+const noWorkPromise = {
+  workPromise: Promise.resolve(),
+}
+
 export async function reconcileJsonFiles(
   targetTheme: Theme,
   session: AdminSession,
@@ -26,15 +30,16 @@ export async function reconcileJsonFiles(
   localThemeFileSystem: ThemeFileSystem,
   options: ReconciliationOptions,
 ): Promise<{
-  readyForReconciliationPromise: Promise<void>
-  reconciliationFinishedPromise: Promise<void>
+  workPromise: Promise<void>
 }> {
+  if (remoteChecksums.length === 0) {
+    return noWorkPromise
+  }
+
   outputDebug('Initiating theme asset reconciliation process')
 
-  const {filesOnlyPresentLocally, filesOnlyPresentOnRemote, filesWithConflictingChecksums} = identifyFilesToReconcile(
-    remoteChecksums,
-    localThemeFileSystem,
-  )
+  const {filesOnlyPresentLocally, filesOnlyPresentOnRemote, filesWithConflictingChecksums} =
+    await identifyFilesToReconcile(remoteChecksums, localThemeFileSystem)
 
   if (
     filesOnlyPresentLocally.length === 0 &&
@@ -42,13 +47,10 @@ export async function reconcileJsonFiles(
     filesWithConflictingChecksums.length === 0
   ) {
     outputDebug('Local and remote checksums match - no need to reconcile theme assets')
-    return {
-      readyForReconciliationPromise: Promise.resolve(),
-      reconciliationFinishedPromise: Promise.resolve(),
-    }
+    return noWorkPromise
   }
 
-  const readyForReconciliationPromise = partitionFilesByReconciliationStrategy(
+  const partitionedFiles = await partitionFilesByReconciliationStrategy(
     {
       filesOnlyPresentLocally,
       filesOnlyPresentOnRemote,
@@ -57,14 +59,14 @@ export async function reconcileJsonFiles(
     options,
   )
 
-  const reconciliationFinishedPromise = readyForReconciliationPromise.then((partitionedFiles) =>
-    performFileReconciliation(targetTheme, session, localThemeFileSystem, partitionedFiles),
+  const fileReconciliationPromise = performFileReconciliation(
+    targetTheme,
+    session,
+    localThemeFileSystem,
+    partitionedFiles,
   )
 
-  return {
-    readyForReconciliationPromise: readyForReconciliationPromise.then(() => {}),
-    reconciliationFinishedPromise,
-  }
+  return {workPromise: fileReconciliationPromise}
 }
 
 function identifyFilesToReconcile(


### PR DESCRIPTION
### WHY are these changes introduced?
- https://github.com/Shopify/develop-advanced-edits/issues/300

### WHAT is this pull request doing?
- Adds the `theme reconciliation` progress bar back 
  - Fixes an issue where the progress bar would render before the user has a chance to provide input - rendering the CLI in a "stuck" state where input there is no way to provide the input needed to resolve the progress bar
- Fixes an async conflict with the `store-password` input which prevented users from selecting a `reconciliation option`

### How to test your changes?
1) **Checkout the latest version of Dawn**
2) **Upload this version of Dawn** to your shop using `shopify theme push -d`.
This will trigger a job on core which adds `settings` keys in your `JSON` assets
3) **Run `shopify-dev theme dev --dev-preview --theme-editor-sync --store-password=<INCORRECT_PASSWORD>`**.
You should see a large number of JSON files listed.
4) **Select 'Keep the remote version`.** 
5) Verify the following:
  - you were able to select an option for reconciliation
  - the progress bar should only render AFTER that
  - progress bar should terminate once your reconciliation is completed

![Code - Dawn](https://github.com/user-attachments/assets/587c5c06-7325-466a-ac95-ff2620c5f062)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
