### PR TITLE
Ensure Javy is always installed before running it

### DIFF
--- a/.changeset/spicy-cheetahs-obey.md
+++ b/.changeset/spicy-cheetahs-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Ensure Javy is always installed before running it

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -132,7 +132,7 @@ describe('bundleExtension', () => {
 })
 
 describe('runJavy', () => {
-  test('runs javy to compile JS into Wasm', async () => {
+  test('runs javy to compile JS into Wasm', {timeout: 20000}, async () => {
     // Given
     const ourFunction = await testFunctionExtension()
 

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -166,9 +166,12 @@ export async function runJavy(
   options: JSFunctionBuildOptions,
   extra: string[] = [],
 ) {
+  const javy = javyBinary()
+  await installBinary(javy)
+
   const args = ['compile', '-d', '-o', fun.outputPath, 'dist/function.js', ...extra]
 
-  return exec(javyBinary().path, args, {
+  return exec(javy.path, args, {
     cwd: fun.directory,
     stdout: 'inherit',
     stderr: 'inherit',


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

If `shopify app function build` is run for a JS Function extension before `shopify app build` is executed, then Javy is not installed before trying to execute it. This used to work when using the `javy-cli` NPM package to execute Javy because that package would implicitly install Javy if it was not already installed. But now that the CLI doesn't use that package, installation needs to be explicitly performed. I've chosen to do it in the `runJavy` function to ensure a check is always performed to see if Javy is installed and install if it isn't.

### WHAT is this pull request doing?

Ensuring Javy is installed before trying to run it. The `installBinary` method performs a check to see if the binary is installed before attempting an install so this won't result in any attempts to redownload the binary if it's already present.

### How to test your changes?

Ensure you don't have the `javy` binary present by running `rm packages/app/dist/cli/services/bin/javy` and `rm packages/app/dist/cli/services/bin/javy`.

Then run:

```
pnpm shopify app function build --path <path-to-js-function-extension>
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
