### PR TITLE
Use <Static /> in app logs command to better support paging

### DIFF
--- a/packages/app/src/cli/services/app-logs/types.ts
+++ b/packages/app/src/cli/services/app-logs/types.ts
@@ -183,3 +183,9 @@ export interface AppLogOutput {
   prefix: AppLogPrefix
   appLog: AppLogPayload
 }
+
+export interface AppLogError {
+  error: string
+}
+
+export type AppLogResult = AppLogOutput | AppLogError


### PR DESCRIPTION
* Moved polling errors inline with logs to support this

This PR will remain draft until Ink merges this and we update our version:
https://github.com/vadimdemedes/ink/pull/669

### WHY are these changes introduced?

With ink [supporting piped output](https://github.com/vadimdemedes/ink/pull/669), the `app logs` command can be used with pagers such as `| less` and `| more`. But we need to use `<Static />` to support live/streaming output when there is no TTY.

### WHAT is this pull request doing?
* Updates the `app logs` UI to use `<Static />`
* Moves polling errors inline with log output, so that they stream together

### How to test your changes?
Use `shopify app logs` on its on and with a pager, e.g. `shoping app logs | more`.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
