### PR TITLE
Use function runner binary in replay

### DIFF
--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -1,5 +1,5 @@
 import {functionFlags, inFunctionContext} from '../../../services/function/common.js'
-import {runFunctionRunner} from '../../../services/function/build.js'
+import {runFunction} from '../../../services/function/runner.js'
 import {appFlags} from '../../../flags.js'
 import Command from '@shopify/cli-kit/node/base-command'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -78,10 +78,12 @@ export default class FunctionRun extends Command {
           )
         }
 
-        await runFunctionRunner(ourFunction, {
+        await runFunction({
+          functionExtension: ourFunction,
           json: flags.json,
-          input: flags.input,
+          inputPath: flags.input,
           export: functionExport,
+          stdin: 'inherit',
         })
       },
     })

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -8,7 +8,7 @@ import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
 const JAVY_VERSION = 'v3.0.1'
-const FUNCTION_RUNNER_VERSION = 'v5.1.3'
+const FUNCTION_RUNNER_VERSION = 'v5.1.4'
 
 // The logic for determining the download URL and what to do with the response stream is _coincidentally_ the same for
 // Javy and function-runner for now. Those methods may not continue to have the same logic in the future. If they

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -1,5 +1,5 @@
-import {buildGraphqlTypes, bundleExtension, runFunctionRunner, runJavy, ExportJavyBuilder, jsExports} from './build.js'
-import {javyBinary, functionRunnerBinary} from './binaries.js'
+import {buildGraphqlTypes, bundleExtension, runJavy, ExportJavyBuilder, jsExports} from './build.js'
+import {javyBinary} from './binaries.js'
 import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
@@ -149,92 +149,6 @@ describe('runJavy', () => {
         stderr: 'inherit',
         stdout: 'inherit',
         signal,
-      },
-    )
-  })
-})
-
-describe('runFunctionRunner', () => {
-  test('calls function runner to execute function locally', async () => {
-    // Given
-    const ourFunction = await testFunctionExtension()
-
-    // When
-    const got = runFunctionRunner(ourFunction, {json: false})
-
-    // Then
-    await expect(got).resolves.toBeUndefined()
-    expect(exec).toHaveBeenCalledWith(
-      functionRunnerBinary().path,
-      ['-f', joinPath(ourFunction.directory, 'dist/index.wasm')],
-      {
-        cwd: ourFunction.directory,
-        stderr: 'inherit',
-        stdin: 'inherit',
-        stdout: 'inherit',
-      },
-    )
-  })
-
-  test('calls function runner to execute function locally and return json', async () => {
-    // Given
-    const ourFunction = await testFunctionExtension()
-
-    // When
-    const got = runFunctionRunner(ourFunction, {json: true})
-
-    // Then
-    await expect(got).resolves.toBeUndefined()
-    expect(exec).toHaveBeenCalledWith(
-      functionRunnerBinary().path,
-      ['-f', joinPath(ourFunction.directory, 'dist/index.wasm'), '--json'],
-      {
-        cwd: ourFunction.directory,
-        stderr: 'inherit',
-        stdin: 'inherit',
-        stdout: 'inherit',
-      },
-    )
-  })
-
-  test('it supports receiving an input on the command line', async () => {
-    // Given
-    const ourFunction = await testFunctionExtension()
-
-    // When
-    const got = runFunctionRunner(ourFunction, {input: 'input.json', json: false})
-
-    // Then
-    await expect(got).resolves.toBeUndefined()
-    expect(exec).toHaveBeenCalledWith(
-      functionRunnerBinary().path,
-      ['-f', joinPath(ourFunction.directory, 'dist/index.wasm'), '--input', 'input.json'],
-      {
-        cwd: ourFunction.directory,
-        stderr: 'inherit',
-        stdin: 'inherit',
-        stdout: 'inherit',
-      },
-    )
-  })
-
-  test('calls function runner to execute function locally with wasm export name', async () => {
-    // Given
-    const ourFunction = await testFunctionExtension()
-
-    // When
-    const got = runFunctionRunner(ourFunction, {json: false, export: 'foo'})
-
-    // Then
-    await expect(got).resolves.toBeUndefined()
-    expect(exec).toHaveBeenCalledWith(
-      functionRunnerBinary().path,
-      ['-f', joinPath(ourFunction.directory, 'dist/index.wasm'), '--export', 'foo'],
-      {
-        cwd: ourFunction.directory,
-        stderr: 'inherit',
-        stdin: 'inherit',
-        stdout: 'inherit',
       },
     )
   })

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -1,4 +1,4 @@
-import {functionRunnerBinary, installBinary, javyBinary} from './binaries.js'
+import {installBinary, javyBinary} from './binaries.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {AppInterface} from '../../models/app/app.js'
@@ -185,27 +185,6 @@ export async function installJavy(app: AppInterface) {
     const javy = javyBinary()
     await installBinary(javy)
   }
-}
-
-interface FunctionRunnerOptions {
-  input?: string
-  json: boolean
-  export?: string
-}
-
-export async function runFunctionRunner(fun: ExtensionInstance<FunctionConfigType>, options: FunctionRunnerOptions) {
-  const functionRunner = functionRunnerBinary()
-  await installBinary(functionRunner)
-
-  const outputAsJson = options.json ? ['--json'] : []
-  const withInput = options.input ? ['--input', options.input] : []
-  const exportName = options.export ? ['--export', options.export] : []
-  return exec(functionRunner.path, ['-f', fun.outputPath, ...withInput, ...outputAsJson, ...exportName], {
-    cwd: fun.directory,
-    stdin: 'inherit',
-    stdout: 'inherit',
-    stderr: 'inherit',
-  })
 }
 
 export interface JavyBuilder {

--- a/packages/app/src/cli/services/function/replay.test.ts
+++ b/packages/app/src/cli/services/function/replay.test.ts
@@ -1,5 +1,6 @@
 import {FunctionRunData, replay} from './replay.js'
 import {renderReplay} from './ui.js'
+import * as binaries from './binaries.js'
 import {testApp, testDeveloperPlatformClient, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
@@ -47,6 +48,7 @@ describe('replay', () => {
 
   beforeEach(() => {
     vi.mocked(ensureConnectedAppFunctionContext).mockResolvedValue({apiKey, developerPlatformClient})
+    vi.spyOn(binaries, 'installBinary').mockResolvedValue()
   })
 
   test('runs selected function', async () => {
@@ -288,17 +290,8 @@ function createFunctionRunFile(options: FunctionRunFileOptions) {
 
 function expectExecToBeCalledWithInput(input: any) {
   expect(exec).toHaveBeenCalledWith(
-    'npm',
-    [
-      'exec',
-      '--',
-      'function-runner',
-      '-f',
-      '/tmp/project/extensions/my-function/dist/index.wasm',
-      '--json',
-      '--export',
-      'run',
-    ],
+    binaries.functionRunnerBinary().path,
+    ['-f', '/tmp/project/extensions/my-function/dist/index.wasm', '--json', '--export', 'run'],
     {
       cwd: '/tmp/project/extensions/my-function',
       stdout: 'inherit',

--- a/packages/app/src/cli/services/function/replay.ts
+++ b/packages/app/src/cli/services/function/replay.ts
@@ -1,5 +1,5 @@
 import {renderReplay} from './ui.js'
-import {functionRunnerBinary, installBinary} from './binaries.js'
+import {runFunction} from './runner.js'
 import {ensureConnectedAppFunctionContext} from '../generate-schema.js'
 import {AppInterface} from '../../models/app/app.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
@@ -9,7 +9,6 @@ import {selectFunctionRunPrompt} from '../../prompts/function/replay.js'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {readFile} from '@shopify/cli-kit/node/fs'
 import {getLogsDir} from '@shopify/cli-kit/node/logs'
-import {exec} from '@shopify/cli-kit/node/system'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 
@@ -72,30 +71,17 @@ export async function replay(options: ReplayOptions) {
         extension,
       })
     } else {
-      await runFunctionRunnerWithLogInput(extension, options, JSON.stringify(input), runExport)
+      await runFunction({
+        functionExtension: extension,
+        json: options.json,
+        input: JSON.stringify(input),
+        export: runExport,
+      })
     }
   } catch (error) {
     abortController.abort()
     throw error
   }
-}
-
-async function runFunctionRunnerWithLogInput(
-  fun: ExtensionInstance<FunctionConfigType>,
-  options: ReplayOptions,
-  input: string,
-  exportName: string,
-) {
-  const outputAsJson = options.json ? ['--json'] : []
-
-  const functionRunner = functionRunnerBinary()
-  await installBinary(functionRunner)
-  return exec(functionRunner.path, ['-f', fun.outputPath, ...outputAsJson, ...['--export', exportName]], {
-    cwd: fun.directory,
-    input,
-    stdout: 'inherit',
-    stderr: 'inherit',
-  })
 }
 
 async function getRunFromIdentifier(

--- a/packages/app/src/cli/services/function/replay.ts
+++ b/packages/app/src/cli/services/function/replay.ts
@@ -1,4 +1,5 @@
 import {renderReplay} from './ui.js'
+import {functionRunnerBinary, installBinary} from './binaries.js'
 import {ensureConnectedAppFunctionContext} from '../generate-schema.js'
 import {AppInterface} from '../../models/app/app.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
@@ -87,16 +88,14 @@ async function runFunctionRunnerWithLogInput(
 ) {
   const outputAsJson = options.json ? ['--json'] : []
 
-  return exec(
-    'npm',
-    ['exec', '--', 'function-runner', '-f', fun.outputPath, ...outputAsJson, ...['--export', exportName]],
-    {
-      cwd: fun.directory,
-      input,
-      stdout: 'inherit',
-      stderr: 'inherit',
-    },
-  )
+  const functionRunner = functionRunnerBinary()
+  await installBinary(functionRunner)
+  return exec(functionRunner.path, ['-f', fun.outputPath, ...outputAsJson, ...['--export', exportName]], {
+    cwd: fun.directory,
+    input,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
 }
 
 async function getRunFromIdentifier(

--- a/packages/app/src/cli/services/function/runner.test.ts
+++ b/packages/app/src/cli/services/function/runner.test.ts
@@ -1,0 +1,60 @@
+import {runFunction} from './runner.js'
+import {functionRunnerBinary, installBinary} from './binaries.js'
+import {testFunctionExtension} from '../../models/app/app.test-data.js'
+import {describe, test, vi, expect} from 'vitest'
+import {exec} from '@shopify/cli-kit/node/system'
+import {Readable, Writable} from 'stream'
+
+vi.mock('@shopify/cli-kit/node/system')
+vi.mock('./binaries.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./binaries.js')>()
+  return {
+    ...original,
+    installBinary: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+describe('runFunction', () => {
+  test('downloads binary', async () => {
+    // Given
+    const functionExtension = await testFunctionExtension()
+
+    // When
+    await runFunction({functionExtension})
+
+    // Then
+    expect(installBinary).toHaveBeenCalledOnce()
+  })
+
+  test('runs function with options', async () => {
+    // Given
+    vi.mocked(exec).mockResolvedValue()
+    const functionExtension = await testFunctionExtension()
+    const options = {
+      functionExtension,
+      inputPath: 'inputPath',
+      input: 'input',
+      export: 'export',
+      json: true,
+      stdin: new Readable(),
+      stdout: new Writable(),
+      stderr: new Writable(),
+    }
+
+    // When
+    await runFunction(options)
+
+    // Then
+    expect(exec).toHaveBeenCalledWith(
+      functionRunnerBinary().path,
+      ['-f', functionExtension.outputPath, '--input', options.inputPath, '--export', options.export, '--json'],
+      {
+        cwd: functionExtension.directory,
+        stdin: options.stdin,
+        stdout: options.stdout,
+        stderr: options.stderr,
+        input: options.input,
+      },
+    )
+  })
+})

--- a/packages/app/src/cli/services/function/runner.ts
+++ b/packages/app/src/cli/services/function/runner.ts
@@ -1,0 +1,40 @@
+import {functionRunnerBinary, installBinary} from './binaries.js'
+import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
+import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
+import {exec} from '@shopify/cli-kit/node/system'
+import {Readable, Writable} from 'stream'
+
+interface FunctionRunnerOptions {
+  functionExtension: ExtensionInstance<FunctionConfigType>
+  input?: string
+  inputPath?: string
+  export?: string
+  json?: boolean
+  stdin?: Readable | 'inherit'
+  stdout?: Writable | 'inherit'
+  stderr?: Writable | 'inherit'
+}
+
+export async function runFunction(options: FunctionRunnerOptions) {
+  const functionRunner = functionRunnerBinary()
+  await installBinary(functionRunner)
+
+  const args: string[] = []
+  if (options.inputPath) {
+    args.push('--input', options.inputPath)
+  }
+  if (options.export) {
+    args.push('--export', options.export)
+  }
+  if (options.json) {
+    args.push('--json')
+  }
+
+  return exec(functionRunner.path, ['-f', options.functionExtension.outputPath, ...args], {
+    cwd: options.functionExtension.directory,
+    stdin: options.stdin,
+    stdout: options.stdout ?? 'inherit',
+    stderr: options.stderr ?? 'inherit',
+    input: options.input,
+  })
+}

--- a/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.test.tsx
+++ b/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.test.tsx
@@ -8,6 +8,7 @@ import {render} from '@shopify/cli-kit/node/testing/ui'
 import * as system from '@shopify/cli-kit/node/system'
 import {test, describe, vi, beforeEach, afterEach, expect} from 'vitest'
 import React from 'react'
+import * as binaries from '../../../../binaries.js'
 
 vi.mock('../../../../../dev/extension/bundler.js')
 
@@ -64,6 +65,7 @@ const SECOND_EXEC_RESPONSE = {
 describe('useFunctionWatcher', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    vi.spyOn(binaries, 'installBinary').mockResolvedValue()
   })
 
   afterEach(() => {

--- a/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
+++ b/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
@@ -4,8 +4,7 @@ import {FunctionConfigType} from '../../../../../../models/extensions/specificat
 import {ExtensionInstance} from '../../../../../../models/extensions/extension-instance.js'
 import {setupExtensionWatcher} from '../../../../../dev/extension/bundler.js'
 import {FunctionRunFromRunner, ReplayLog} from '../types.js'
-import {functionRunnerBinary, installBinary} from '../../../../binaries.js'
-import {exec} from '@shopify/cli-kit/node/system'
+import {runFunction} from '../../../../runner.js'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import {useEffect, useState} from 'react'
 import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
@@ -130,14 +129,7 @@ async function runFunctionRunnerWithLogInput(
     },
   })
 
-  const functionRunner = functionRunnerBinary()
-  await installBinary(functionRunner)
-  await exec(functionRunner.path, ['--json', '-f', fun.outputPath, '--export', exportName], {
-    cwd: fun.directory,
-    input,
-    stdout: customStdout,
-    stderr: 'inherit',
-  })
+  await runFunction({functionExtension: fun, input, export: exportName, stdout: customStdout, json: true})
 
   const result = JSON.parse(functionRunnerOutput)
   return {...result, type: 'functionRun'}

--- a/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
+++ b/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
@@ -4,6 +4,7 @@ import {FunctionConfigType} from '../../../../../../models/extensions/specificat
 import {ExtensionInstance} from '../../../../../../models/extensions/extension-instance.js'
 import {setupExtensionWatcher} from '../../../../../dev/extension/bundler.js'
 import {FunctionRunFromRunner, ReplayLog} from '../types.js'
+import {functionRunnerBinary, installBinary} from '../../../../binaries.js'
 import {exec} from '@shopify/cli-kit/node/system'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import {useEffect, useState} from 'react'
@@ -129,7 +130,9 @@ async function runFunctionRunnerWithLogInput(
     },
   })
 
-  await exec('npm', ['exec', '--', 'function-runner', '--json', '-f', fun.outputPath, '--export', exportName], {
+  const functionRunner = functionRunnerBinary()
+  await installBinary(functionRunner)
+  await exec(functionRunner.path, ['--json', '-f', fun.outputPath, '--export', exportName], {
     cwd: fun.directory,
     input,
     stdout: customStdout,


### PR DESCRIPTION
### WHY are these changes introduced?

The Function Runner binary to use when running functions was changed recently. However, the `replay` command was not updated, so it was using the old global binary.

### WHAT is this pull request doing?

This PR does two things (in two commits):
1. Updates the replay command to be consistent with how functions should be run.
2. Consolidates the logic for running a function so that it can be used everywhere.

### How to test your changes?

Test:
- `function replay` without watch runs function
- `function replay` with watch runs function on change
- `function run` with piped input runs function
- `function run` with input path runs function

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
