### PR TITLE
Use new parameters for app management create mutations

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -28,7 +28,7 @@ import {
   DevSessionOptions,
 } from '../../utilities/developer-platform-client.js'
 import {AllAppExtensionRegistrationsQuerySchema} from '../../api/graphql/all_app_extension_registrations.js'
-import {AppDeploySchema, AppDeployVariables} from '../../api/graphql/app_deploy.js'
+import {AppDeploySchema, AppDeployVariables, AppModuleSettings} from '../../api/graphql/app_deploy.js'
 import {ExtensionCreateSchema, ExtensionCreateVariables} from '../../api/graphql/extension_create.js'
 import {ConvertDevToTransferDisabledStoreVariables} from '../../api/graphql/convert_dev_to_transfer_disabled_store.js'
 import {
@@ -149,6 +149,17 @@ export function testAppWithConfig(options?: TestAppWithConfigOptions): AppInterf
   } as CurrentAppConfiguration
 
   return app as AppInterface<CurrentAppConfiguration>
+}
+
+export function testAppModuleSettings(settings?: Partial<AppModuleSettings>): AppModuleSettings {
+  const defaultSettings = {
+    uid: 'uid',
+    specificationIdentifier: 'spec',
+    config: '{"key": "value"}',
+    context: 'context',
+    handle: 'handle',
+  }
+  return {...defaultSettings, ...settings}
 }
 
 export function getWebhookConfig(webhookConfigOverrides?: WebhooksConfig): CurrentAppConfiguration {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -206,6 +206,28 @@ describe('deploy', () => {
   const session = {token, accountInfo: userAccountInfo}
   const client = new AppManagementClient(session)
 
+  const mockedVersionResponse: CreateAppVersionMutationSchema = {
+    appVersionCreate: {
+      version: {
+        id: versionId,
+        appModules: [],
+        metadata: {message: '', versionTag},
+      },
+      userErrors: [],
+    },
+  }
+  const mockedReleaseResponse: ReleaseVersionMutationSchema = {
+    appReleaseCreate: {
+      release: {
+        version: {
+          id: versionId,
+          metadata: {message: '', versionTag},
+        },
+      },
+      userErrors: [],
+    },
+  }
+
   test('creates an app version from a bundle URL', async () => {
     // Given
     const bundleUrl = 'https://example.com/mybundle'
@@ -245,8 +267,6 @@ describe('deploy', () => {
         metadata: {versionTag},
       }),
     )
-    expect(got.appDeploy.appVersion.versionTag).toEqual(versionTag)
-    expect(got.appDeploy.appVersion.uuid).toEqual(versionId)
   })
 
   test('creates an app version directly', async () => {
@@ -267,21 +287,6 @@ describe('deploy', () => {
       handle: 'handle2',
     }
     const appModules = [module1, module2]
-    const mockedVersionResponse: CreateAppVersionMutationSchema = {
-      appVersionCreate: {
-        version: {
-          id: versionId,
-          appModules: appModules.map((mod) => ({
-            uuid: mod.uid,
-            handle: mod.handle,
-            config: JSON.parse(mod.config),
-            specification: {name: mod.specificationIdentifier, identifier: mod.specificationIdentifier},
-          })),
-          metadata: {message: '', versionTag},
-        },
-        userErrors: [],
-      },
-    }
 
     vi.mocked(appManagementRequest).mockResolvedValueOnce(mockedVersionResponse)
 
@@ -318,36 +323,12 @@ describe('deploy', () => {
         metadata: {versionTag},
       }),
     )
-    expect(got.appDeploy.appVersion.versionTag).toEqual(versionTag)
-    expect(got.appDeploy.appVersion.uuid).toEqual(versionId)
   })
 
   test('creates an app version and a release', async () => {
     // Given
     const name = 'my-app-name'
-    const mockedVersionResponse: CreateAppVersionMutationSchema = {
-      appVersionCreate: {
-        version: {
-          id: versionId,
-          appModules: [],
-          metadata: {message: '', versionTag},
-        },
-        userErrors: [],
-      },
-    }
     vi.mocked(appManagementRequest).mockResolvedValueOnce(mockedVersionResponse)
-
-    const mockedReleaseResponse: ReleaseVersionMutationSchema = {
-      appReleaseCreate: {
-        release: {
-          version: {
-            id: versionId,
-            metadata: {message: '', versionTag},
-          },
-        },
-        userErrors: [],
-      },
-    }
     vi.mocked(appManagementRequest).mockResolvedValueOnce(mockedReleaseResponse)
 
     // When
@@ -386,7 +367,5 @@ describe('deploy', () => {
         versionId,
       }),
     )
-    expect(got.appDeploy.appVersion.versionTag).toEqual(versionTag)
-    expect(got.appDeploy.appVersion.uuid).toEqual(versionId)
   })
 })

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -236,16 +236,6 @@ describe('deploy', () => {
   test('creates an app version from a bundle URL', async () => {
     // Given
     const bundleUrl = 'https://example.com/mybundle'
-    const mockedVersionResponse: CreateAppVersionMutationSchema = {
-      appVersionCreate: {
-        version: {
-          id: versionId,
-          appModules: [],
-          metadata: {message: '', versionTag},
-        },
-        userErrors: [],
-      },
-    }
 
     vi.mocked(appManagementRequest).mockResolvedValueOnce(mockedVersionResponse)
 
@@ -274,7 +264,7 @@ describe('deploy', () => {
     )
   })
 
-  test('creates an app version directly', async () => {
+  test('creates an app version directly from a manifest', async () => {
     // Given
     const name = 'my-app-name'
     const module1 = testAppModuleSettings()
@@ -318,7 +308,7 @@ describe('deploy', () => {
     )
   })
 
-  test('creates an app version and a release', async () => {
+  test('creates an app version and a release when skipPublish is not true', async () => {
     // Given
     const name = 'my-app-name'
     vi.mocked(appManagementRequest).mockResolvedValueOnce(mockedVersionResponse)

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -10,7 +10,12 @@ import {AppModule} from './app-management-client/graphql/app-version-by-id.js'
 import {OrganizationBetaFlagsQuerySchema} from './app-management-client/graphql/organization_beta_flags.js'
 import {CreateAppVersionMutationSchema} from './app-management-client/graphql/create-app-version.js'
 import {ReleaseVersionMutationSchema} from './app-management-client/graphql/release-version.js'
-import {testUIExtension, testRemoteExtensionTemplates, testOrganizationApp} from '../../models/app/app.test-data.js'
+import {
+  testUIExtension,
+  testRemoteExtensionTemplates,
+  testOrganizationApp,
+  testAppModuleSettings,
+} from '../../models/app/app.test-data.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {AccountInfo} from '../../services/context/partner-account-info.js'
 import {describe, expect, test, vi} from 'vitest'
@@ -203,7 +208,7 @@ describe('deploy', () => {
   const token = 'business-platform-token'
 
   const userAccountInfo: AccountInfo = {type: 'UnknownAccount'}
-  const session = {token, accountInfo: userAccountInfo}
+  const session = {token, accountInfo: userAccountInfo, userId: 'user'}
   const client = new AppManagementClient(session)
 
   const mockedVersionResponse: CreateAppVersionMutationSchema = {
@@ -272,20 +277,8 @@ describe('deploy', () => {
   test('creates an app version directly', async () => {
     // Given
     const name = 'my-app-name'
-    const module1 = {
-      uid: 'uid',
-      specificationIdentifier: 'spec',
-      config: '{"key": "value"}',
-      context: 'context',
-      handle: 'handle',
-    }
-    const module2 = {
-      uid: 'uid2',
-      specificationIdentifier: 'spec2',
-      config: '{"key2": "value2"}',
-      context: 'context2',
-      handle: 'handle2',
-    }
+    const module1 = testAppModuleSettings()
+    const module2 = testAppModuleSettings({uid: 'uid2', specificationIdentifier: 'spec2'})
     const appModules = [module1, module2]
 
     vi.mocked(appManagementRequest).mockResolvedValueOnce(mockedVersionResponse)
@@ -312,10 +305,10 @@ describe('deploy', () => {
         version: {
           source: {
             name,
-            appModules: appModules.map((mod) => ({
+            modules: appModules.map((mod) => ({
               uid: mod.uid,
               handle: mod.handle,
-              specificationIdentifier: mod.specificationIdentifier,
+              type: mod.specificationIdentifier,
               config: JSON.parse(mod.config),
             })),
           },
@@ -352,7 +345,7 @@ describe('deploy', () => {
         version: {
           source: {
             name,
-            appModules: [],
+            modules: [],
           },
         },
         metadata: {versionTag},

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -643,13 +643,14 @@ export class AppManagementClient implements DeveloperPlatformClient {
       if (brandingModule) {
         updatedName = JSON.parse(brandingModule.config).name
       }
+
       versionInput = {
         source: {
           name: updatedName,
-          appModules: (appModules ?? []).map((mod) => {
+          modules: (appModules ?? []).map((mod) => {
             return {
+              type: mod.specificationIdentifier,
               uid: mod.uid ?? mod.uuid ?? mod.handle,
-              specificationIdentifier: mod.specificationIdentifier,
               handle: mod.handle,
               config: JSON.parse(mod.config),
             }
@@ -921,11 +922,11 @@ function createAppVars(name: string, isLaunchable = true, scopesArray?: string[]
     initialVersion: {
       source: {
         name,
-        appModules: [
+        modules: [
           {
             // Change the uid to AppHomeSpecIdentifier
             uid: 'app_home',
-            specificationIdentifier: AppHomeSpecIdentifier,
+            type: AppHomeSpecIdentifier,
             config: {
               app_url: isLaunchable ? 'https://example.com' : MAGIC_URL,
               embedded: isLaunchable,
@@ -934,19 +935,19 @@ function createAppVars(name: string, isLaunchable = true, scopesArray?: string[]
           {
             // Change the uid to BrandingSpecIdentifier
             uid: 'branding',
-            specificationIdentifier: BrandingSpecIdentifier,
+            type: BrandingSpecIdentifier,
             config: {name},
           },
           {
             // Change the uid to WebhooksSpecIdentifier
             uid: 'webhooks',
-            specificationIdentifier: WebhooksSpecIdentifier,
+            type: WebhooksSpecIdentifier,
             config: {api_version: '2024-01'},
           },
           {
             // Change the uid to AppAccessSpecIdentifier
             uid: 'app_access',
-            specificationIdentifier: AppAccessSpecIdentifier,
+            type: AppAccessSpecIdentifier,
             config: {
               redirect_url_allowlist: isLaunchable ? ['https://example.com/api/auth'] : [MAGIC_REDIRECT_URL],
               ...(scopesArray && {scopes: scopesArray.map((scope) => scope.trim()).join(',')}),

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app-version.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app-version.ts
@@ -1,9 +1,10 @@
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 import {gql} from 'graphql-request'
 
+// eslint-disable-next-line @shopify/cli/no-inline-graphql
 export const CreateAppVersionMutation = gql`
-  mutation CreateAppVersion($appId: ID!, $appSource: AppSourceInput!, $name: String!, $metadata: VersionMetadataInput) {
-    appVersionCreate(appId: $appId, appSource: $appSource, name: $name, metadata: $metadata) {
+  mutation CreateAppVersion($appId: ID!, $version: AppVersionInput!, $metadata: VersionMetadataInput) {
+    appVersionCreate(appId: $appId, version: $version, metadata: $metadata) {
       version {
         id
         appModules {
@@ -32,14 +33,17 @@ export const CreateAppVersionMutation = gql`
 
 export interface CreateAppVersionMutationVariables {
   appId: string
-  name?: string
-  appSource: {
-    assetsUrl?: string
-    appModules: {
-      uid: string
-      specificationIdentifier?: string
-      config: JsonMapType
-    }[]
+  version: {
+    sourceUrl?: string
+    source?: {
+      name: string
+      handle?: string
+      appModules: {
+        uid: string
+        specificationIdentifier?: string
+        config: JsonMapType
+      }[]
+    }
   }
   metadata?: {
     message?: string

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app-version.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app-version.ts
@@ -33,18 +33,7 @@ export const CreateAppVersionMutation = gql`
 
 export interface CreateAppVersionMutationVariables {
   appId: string
-  version: {
-    sourceUrl?: string
-    source?: {
-      name: string
-      handle?: string
-      appModules: {
-        uid: string
-        specificationIdentifier?: string
-        config: JsonMapType
-      }[]
-    }
-  }
+  version: {sourceUrl: string} | {source: JsonMapType}
   metadata?: {
     message?: string
     sourceControlUrl?: string

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app.ts
@@ -1,9 +1,10 @@
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 import {gql} from 'graphql-request'
 
+// eslint-disable-next-line @shopify/cli/no-inline-graphql
 export const CreateAppMutation = gql`
-  mutation CreateApp($appSource: AppSourceInput!, $name: String!) {
-    appCreate(appSource: $appSource, name: $name) {
+  mutation CreateApp($initialVersion: AppVersionInput!) {
+    appCreate(initialVersion: $initialVersion) {
       app {
         id
         key
@@ -18,15 +19,18 @@ export const CreateAppMutation = gql`
 `
 
 export interface CreateAppMutationVariables {
-  appSource: {
-    appModules: {
-      uid: string
-      specificationIdentifier: string
-      config: JsonMapType
-    }[]
-    assetsUrl?: string
+  initialVersion: {
+    source?: {
+      name: string
+      handle?: string
+      appModules: {
+        uid: string
+        specificationIdentifier: string
+        config: JsonMapType
+      }[]
+    }
+    sourceUrl?: string
   }
-  name: string
 }
 
 export interface CreateAppMutationSchema {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app.ts
@@ -19,18 +19,7 @@ export const CreateAppMutation = gql`
 `
 
 export interface CreateAppMutationVariables {
-  initialVersion: {
-    source?: {
-      name: string
-      handle?: string
-      appModules: {
-        uid: string
-        specificationIdentifier: string
-        config: JsonMapType
-      }[]
-    }
-    sourceUrl?: string
-  }
+  initialVersion: {sourceUrl: string} | {source: JsonMapType}
 }
 
 export interface CreateAppMutationSchema {


### PR DESCRIPTION
### WHY are these changes introduced?

Part 2 of https://github.com/Shopify/develop-app-foundations/issues/1050

This PR adapts to changes in the. App Management API introduced in [part 1](https://github.com/Shopify/shopify/pull/532987) of the sequence of PRs.

### WHAT is this pull request doing?

The new `AppVersionInput` graphql type is used in the App Management client as a variable for in the app/version create mutations. 

On deploy, if a bundle has been uploaded, only that bundle URL is specified as `sourceUrl` in `AppVersionInput`. That means that the bundle's manifest is the sole source of app module information like config, etc.

If no bundle has been uploaded, then name and app module information is passed in the `source` field of `AppVersionInput`, similar to existing (now-deprecated) API.

It doesn't appear that there are existing tests to cover the `deploy` logic in the app management client, so I added a few new ones to test deploys and this PR in particular. 
 
### How to test your changes?

Running `app deploy` for a new app will exercise all of the changes in this PR. Note that there is currently an unrelated [issue](https://github.com/Shopify/develop-app-inner-loop/issues/2072) where an app's initial deploy will fail at the CLI level because of a switch to using the partners client for some reason. In this case, the app and initial version are still created correctly.

Testing can be run against production once [part 1](https://github.com/Shopify/shopify/pull/532987) has deployed, or against a spin instance running that PR's branch.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
