### PR TITLE
Small replay output improvements

### DIFF
--- a/packages/app/src/cli/services/function/ui/components/Replay/Replay.tsx
+++ b/packages/app/src/cli/services/function/ui/components/Replay/Replay.tsx
@@ -143,7 +143,8 @@ function StatsDisplay({recentFunctionRuns}: {recentFunctionRuns: [FunctionRunFro
   return (
     <Box flexDirection="column">
       <Text>
-        {figures.pointerSmall} Instruction count change: {delta>0 ? '+' : ''}{delta}
+        {figures.pointerSmall} Instruction count change: {delta > 0 ? '+' : ''}
+        {delta}
       </Text>
     </Box>
   )
@@ -158,6 +159,7 @@ function ReplayLog({log}: {log: ReplayLog}) {
           <LogDisplay logs={log.logs} />
           <OutputDisplay output={log.output} />
           <BenchmarkDisplay functionRun={log} />
+          <Text>&nbsp;</Text>
         </Box>
       )
     case 'systemMessage':

--- a/packages/app/src/cli/services/function/ui/components/Replay/__snapshots__/Replay.test.tsx.snap
+++ b/packages/app/src/cli/services/function/ui/components/Replay/__snapshots__/Replay.test.tsx.snap
@@ -34,6 +34,7 @@ Instructions: 532.633K
 Size: 1KB
 
 
+
             Input            
 
 {
@@ -63,6 +64,7 @@ Name: product-discount
 Linear Memory Usage: 0KB
 Instructions: 532.632K
 Size: 0KB
+
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
 
@@ -106,6 +108,7 @@ Instructions: 532.633K
 Size: 1KB
 
 
+
             Input            
 
 {
@@ -135,6 +138,7 @@ Name: product-discount
 Linear Memory Usage: 0KB
 Instructions: 532.632K
 Size: 0KB
+
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
### WHY are these changes introduced?

Small improvements to replay output based on slack conversation.

### WHAT is this pull request doing?

- Adds a leading `+` when the instruction count difference is >0.
- Adds an empty line after a replay output to make it easier to tell when the rebuild from watch is happening.

### How to test your changes?

Run replay with watch i.e.
```bash
pnpm shopify app function replay --path /Users/lopert/code/log-streaming/app/log-streamer/extensions/product-discount
```
and change the function to see it rebuild / display stats

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
