### PR TITLE
Apply dev preview development preview improvements

### DIFF
--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -52,7 +52,7 @@ describe('fetchThemes', () => {
   })
 })
 
-describe('fetchChecksums', () => {
+describe('fetwchChecksums', () => {
   test('returns theme checksums', async () => {
     // Given
     vi.mocked(restRequest).mockResolvedValue({
@@ -104,11 +104,19 @@ describe('createTheme', () => {
     const processing = false
     const params: ThemeParams = {name, role}
 
-    vi.mocked(restRequest).mockResolvedValue({
-      json: {theme: {id, name, role, processing}},
-      status: 200,
-      headers: {},
-    })
+    vi.mocked(restRequest)
+      .mockResolvedValueOnce({
+        json: {theme: {id, name, role, processing}},
+        status: 200,
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        json: {
+          results: [],
+        },
+        status: 207,
+        headers: {},
+      })
 
     // When
     const theme = await createTheme(params, session)

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -28,6 +28,14 @@ export async function fetchThemes(session: AdminSession): Promise<Theme[]> {
 
 export async function createTheme(params: ThemeParams, session: AdminSession): Promise<Theme | undefined> {
   const response = await request('POST', '/themes', session, {theme: {...params}})
+  const minimumThemeAssets = [
+    {key: 'config/settings_schema.json', value: '[]'},
+    {key: 'layout/password.liquid', value: '{{ content_for_header }}{{ content_for_layout }}'},
+    {key: 'layout/theme.liquid', value: '{{ content_for_header }}{{ content_for_layout }}'},
+  ]
+
+  await bulkUploadThemeAssets(response.json.theme.id, minimumThemeAssets, session)
+
   return buildTheme({...response.json.theme, createdAtRuntime: true})
 }
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1710,7 +1710,7 @@ FLAGS
                                 (example.myshopify.com, https://example.myshopify.com).
       --no-color                Disable color output.
       --password=<value>        Password generated from the Theme Access app.
-      --port=<value>            [default: 9293] Local port to serve authentication service.
+      --port=<value>            Local port to serve authentication service.
       --store-password=<value>  The password for storefronts with password protection.
       --url=<value>             [default: /] The url to be used as context
       --verbose                 Increase the verbosity of the output.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4808,7 +4808,6 @@
           "type": "option"
         },
         "port": {
-          "default": "9293",
           "description": "Local port to serve authentication service.",
           "env": "SHOPIFY_FLAG_PORT",
           "hasDynamicHelp": false,
@@ -5864,6 +5863,14 @@
           "description": "Allow push to a live theme.",
           "env": "SHOPIFY_FLAG_ALLOW_LIVE",
           "name": "allow-live",
+          "type": "boolean"
+        },
+        "dev-preview": {
+          "allowNo": false,
+          "description": "Enables the developer preview for the upcoming `theme push` implementation.",
+          "env": "SHOPIFY_FLAG_BETA",
+          "hidden": true,
+          "name": "dev-preview",
           "type": "boolean"
         },
         "development": {

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -33,7 +33,6 @@ export default class Console extends ThemeCommand {
     port: Flags.string({
       description: 'Local port to serve authentication service.',
       env: 'SHOPIFY_FLAG_PORT',
-      default: '9293',
     }),
     'store-password': Flags.string({
       description: 'The password for storefronts with password protection.',
@@ -54,7 +53,7 @@ export default class Console extends ThemeCommand {
     const theme = `liquid-console-repl-${cliVersion}`
 
     const adminSession = await ensureAuthenticatedThemes(store, themeAccessPassword, [], true)
-    const authUrl = `http://localhost:${port}/password`
+    const authUrl = `http://localhost:${port ?? '9293'}/password`
 
     if (flags['dev-preview']) {
       if (flags.port) {
@@ -75,7 +74,7 @@ export default class Console extends ThemeCommand {
 
     const storefrontToken = await ensureAuthenticatedStorefront([], themeAccessPassword)
 
-    return execCLI2(['theme', 'console', '--url', url, '--port', port, '--theme', theme], {
+    return execCLI2(['theme', 'console', '--url', url, '--port', port ?? '9293', '--theme', theme], {
       store,
       adminToken: adminSession.token,
       storefrontToken,

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -121,6 +121,11 @@ export default class Push extends ThemeCommand {
       description: 'Proceed without confirmation, if current directory does not seem to be theme directory.',
       env: 'SHOPIFY_FLAG_FORCE',
     }),
+    'dev-preview': Flags.boolean({
+      hidden: true,
+      description: 'Enables the developer preview for the upcoming `theme push` implementation.',
+      env: 'SHOPIFY_FLAG_BETA',
+    }),
   }
 
   static cli2Flags = [
@@ -150,7 +155,7 @@ export default class Push extends ThemeCommand {
       return
     }
 
-    if (!flags.stable && !flags.password) {
+    if (flags['dev-preview'] || (!flags.stable && !flags.password)) {
       const {path, nodelete, publish, json, force, ignore, only} = flags
 
       const selectedTheme: Theme | undefined = await createOrSelectTheme(adminSession, flags)

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -60,7 +60,7 @@ export async function dev(options: DevOptions) {
 
   if (options.flagsToPass.includes('--poll')) {
     renderWarning({
-      body: 'The CLI flag --[flag-name] is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
+      body: 'The CLI flag --pull is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
     })
   }
 

--- a/packages/theme/src/cli/utilities/asset-checksum.test.ts
+++ b/packages/theme/src/cli/utilities/asset-checksum.test.ts
@@ -8,7 +8,7 @@ describe('asset-checksum', () => {
       {file: 'assets/base.css', expectedChecksum: 'b7fbe0ecff2a6c1d6e697a13096e2b17'},
       {file: 'assets/sparkle.gif', expectedChecksum: '7adcd48a3cc215a81fabd9dafb919507'},
       {file: 'config/settings_data.json', expectedChecksum: '22e69af13b7953914563c60035a831bc'},
-      {file: 'config/settings_schema.json', expectedChecksum: '3f6b44e95dbcf0214a0a82627a37cd53'},
+      {file: 'config/settings_schema.json', expectedChecksum: 'cbe979d3fd3b7cdf2041ada9fdb3af57'},
       {file: 'layout/password.liquid', expectedChecksum: '7a92d18f1f58b2396c46f98f9e502c6a'},
       {file: 'layout/theme.liquid', expectedChecksum: '2374357fdadd3b4636405e80e21e87fc'},
       {file: 'locales/en.default.json', expectedChecksum: '94d575574a070397f297a2e9bb32ce7d'},

--- a/packages/theme/src/cli/utilities/asset-checksum.ts
+++ b/packages/theme/src/cli/utilities/asset-checksum.ts
@@ -11,7 +11,7 @@ export function calculateChecksum(fileKey: string, fileContent: string | Buffer 
 
   if (isTextFile(fileKey)) content = content.replace(/\r\n/g, '\n')
 
-  if (isJson(fileKey)) {
+  if (isJson(fileKey) && !isThemeAsset(fileKey) && !isSettingsSchema(fileKey)) {
     content = normalizeJson(content)
 
     /**
@@ -22,9 +22,7 @@ export function calculateChecksum(fileKey: string, fileContent: string | Buffer 
      * approach here (note that already escaped forward slashes are not
      * re-escaped).
      */
-    if (!isThemeAsset(fileKey)) {
-      content = content.replace(/(?<!\\)\//g, '\\/')
-    }
+    content = content.replace(/(?<!\\)\//g, '\\/')
   }
 
   return md5(content)
@@ -92,4 +90,8 @@ export function rejectGeneratedStaticAssets(themeChecksums: Checksum[]) {
  */
 function hasLiquidSource(checksums: Checksum[], key: string) {
   return checksums.some((checksum) => checksum.key === `${key}.liquid`)
+}
+
+function isSettingsSchema(path: string) {
+  return path.endsWith('/settings_schema.json')
 }

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -47,7 +47,7 @@ describe('theme-fs', () => {
           fsEntry({checksum: 'b7fbe0ecff2a6c1d6e697a13096e2b17', key: 'assets/base.css'}),
           fsEntry({checksum: '7adcd48a3cc215a81fabd9dafb919507', key: 'assets/sparkle.gif'}),
           fsEntry({checksum: '22e69af13b7953914563c60035a831bc', key: 'config/settings_data.json'}),
-          fsEntry({checksum: '3f6b44e95dbcf0214a0a82627a37cd53', key: 'config/settings_schema.json'}),
+          fsEntry({checksum: 'cbe979d3fd3b7cdf2041ada9fdb3af57', key: 'config/settings_schema.json'}),
           fsEntry({checksum: '7a92d18f1f58b2396c46f98f9e502c6a', key: 'layout/password.liquid'}),
           fsEntry({checksum: '2374357fdadd3b4636405e80e21e87fc', key: 'layout/theme.liquid'}),
           fsEntry({checksum: '94d575574a070397f297a2e9bb32ce7d', key: 'locales/en.default.json'}),


### PR DESCRIPTION
### WHY are these changes introduced?

During my dev preview tests, I've applied some improvements to fix or polish specific workflows in the dev preview build — this PR syncs the `main` with the dev preview branch.

### WHAT is this pull request doing?

- Fixes the `shopify theme dev` command when a development theme doesn't exist — I've moved the creation of the mini theme to the API that creates a theme to centralize the theme creation. Without this, users can't run `shopify theme dev` because the CLI can't create the session and authenticate on password-protected stores (as the minimum amount of assets is required to conclude that authentication)
- Fixes the `http://localhost:undefined/password` message when users are running the `shopify theme console` without the dev preview flag
- Forces the usage of the new implementation of the `shopify theme push` command in CI/CD workflows when the dev preview flag is passed
- Updates the `--poll` deprecation message to say `The CLI flag --poll is now...` instead of `The CLI flag --[flag-name] is now...`
- No longer normalizes the `config/settings_schema.json` to calculate the checksum as expected

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes



