### PR TITLE
Use extension only verbage to match shopify.dev docs

### DIFF
--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -33,6 +33,8 @@ export type Scalars = {
   PropertyPublicID: {input: string; output: string}
   /** The ID for a Role. */
   RoleID: {input: any; output: any}
+  /** The ID for a Shop. */
+  ShopID: {input: any; output: any}
   /** The ID for a ShopifyShop. */
   ShopifyShopID: {input: any; output: any}
   /** The ID for a StoreAdditionRequest. */

--- a/packages/create-app/src/prompts/init.test.ts
+++ b/packages/create-app/src/prompts/init.test.ts
@@ -71,7 +71,7 @@ describe('init', () => {
     expect(renderSelectPrompt).toHaveBeenCalledWith({
       choices: [
         {label: 'Build a Remix app (recommended)', value: 'remix'},
-        {label: 'Build an extension only app', value: 'none'},
+        {label: 'Build an extension-only app', value: 'none'},
       ],
       message: 'Get started building your app:',
       defaultValue: 'remix',
@@ -98,7 +98,7 @@ describe('init', () => {
     expect(renderSelectPrompt).toHaveBeenCalledWith({
       choices: [
         {label: 'Build a Remix app (recommended)', value: 'remix'},
-        {label: 'Build an extension only app', value: 'none'},
+        {label: 'Build an extension-only app', value: 'none'},
       ],
       message: 'Get started building your app:',
       defaultValue: 'remix',

--- a/packages/create-app/src/prompts/init.test.ts
+++ b/packages/create-app/src/prompts/init.test.ts
@@ -70,8 +70,8 @@ describe('init', () => {
     // Then
     expect(renderSelectPrompt).toHaveBeenCalledWith({
       choices: [
-        {label: 'Start with Remix (recommended)', value: 'remix'},
-        {label: 'Start by adding your first extension', value: 'none'},
+        {label: 'Build a Remix app (recommended)', value: 'remix'},
+        {label: 'Build an extension only app', value: 'none'},
       ],
       message: 'Get started building your app:',
       defaultValue: 'remix',
@@ -97,8 +97,8 @@ describe('init', () => {
     // Then
     expect(renderSelectPrompt).toHaveBeenCalledWith({
       choices: [
-        {label: 'Start with Remix (recommended)', value: 'remix'},
-        {label: 'Start by adding your first extension', value: 'none'},
+        {label: 'Build a Remix app (recommended)', value: 'remix'},
+        {label: 'Build an extension only app', value: 'none'},
       ],
       message: 'Get started building your app:',
       defaultValue: 'remix',

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -48,7 +48,7 @@ export const templates = {
   } as Template,
   none: {
     url: 'https://github.com/Shopify/shopify-app-template-none',
-    label: 'Build an extension only app',
+    label: 'Build an extension-only app',
     visible: true,
   } as Template,
   node: {

--- a/packages/create-app/src/prompts/init.ts
+++ b/packages/create-app/src/prompts/init.ts
@@ -36,7 +36,7 @@ interface Template {
 export const templates = {
   remix: {
     url: 'https://github.com/Shopify/shopify-app-template-remix',
-    label: 'Start with Remix (recommended)',
+    label: 'Build a Remix app (recommended)',
     visible: true,
     branches: {
       prompt: 'For your Remix template, which language do you want?',
@@ -48,7 +48,7 @@ export const templates = {
   } as Template,
   none: {
     url: 'https://github.com/Shopify/shopify-app-template-none',
-    label: 'Start by adding your first extension',
+    label: 'Build an extension only app',
     visible: true,
   } as Template,
   node: {


### PR DESCRIPTION
### WHY are these changes introduced?

The shopify.dev docs use "[extension only app](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app)" nomenclature. When creating a new app in the CLI we use "start by adding your first extension".  This inconsistency is confusing.

### WHAT is this pull request doing?

* "Start by adding your first extension" becomes "Build an extension only app".
* For consistency, "Start with Remix (recommended)" becomes "Build a Remix app (recommended)".

### How to test your changes?

Run through the create a new app process.

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
