### PR TITLE
[Themes] Add support for the `--notify` flag in the theme dev command

### DIFF
--- a/packages/cli-kit/src/public/node/themes/types.ts
+++ b/packages/cli-kit/src/public/node/themes/types.ts
@@ -25,6 +25,7 @@ export type ThemeFSEventPayload<T extends ThemeFSEventName = 'add'> = (ThemeFSEv
 
 export interface ThemeFileSystemOptions {
   filters?: {ignore?: string[]; only?: string[]}
+  notify?: string
 }
 
 /**

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -186,6 +186,7 @@ You can run this command only in a directory that matches the [default Shopify t
       noDelete: flags.nodelete,
       ignore,
       only,
+      notify: flags.notify,
     })
   }
 }

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -41,6 +41,7 @@ export interface DevOptions {
   noDelete: boolean
   ignore: string[]
   only: string[]
+  notify?: string
 }
 
 export async function dev(options: DevOptions) {
@@ -65,7 +66,10 @@ export async function dev(options: DevOptions) {
   }
 
   const localThemeExtensionFileSystem = emptyThemeExtFileSystem()
-  const localThemeFileSystem = mountThemeFileSystem(options.directory, {filters: options})
+  const localThemeFileSystem = mountThemeFileSystem(options.directory, {
+    filters: options,
+    notify: options.notify,
+  })
 
   const host = options.host || DEFAULT_HOST
   if (options.port && !(await checkPortAvailability(Number(options.port)))) {

--- a/packages/theme/src/cli/utilities/notifier.test.ts
+++ b/packages/theme/src/cli/utilities/notifier.test.ts
@@ -13,13 +13,13 @@ describe('Notifier', () => {
     const mockFetch = vi.spyOn(global, 'fetch').mockResolvedValue(new Response())
     const url = 'https://example.com/notify'
     notifier = new Notifier(url)
-    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+    const fileName = 'announcement.liquid'
 
-    await notifier.notify(fileInfo)
+    await notifier.notify(fileName)
 
     expect(mockFetch).toHaveBeenCalledWith(url, {
       method: 'POST',
-      body: JSON.stringify({files: [fileInfo]}),
+      body: JSON.stringify({files: [fileName]}),
       headers: {'Content-Type': 'application/json'},
     })
   })
@@ -27,19 +27,19 @@ describe('Notifier', () => {
   test('updates file atime and mtime when path is not a URL', async () => {
     const path = 'theme.update'
     notifier = new Notifier(path)
-    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+    const fileName = 'announcement.liquid'
 
-    await notifier.notify(fileInfo)
+    await notifier.notify(fileName)
 
-    expect(fs.appendFile).toHaveBeenCalledWith(path, expect.any(String))
+    expect(fs.writeFile).toHaveBeenCalledWith(path, fileName)
   })
 
   test('does not update if path is empty', async () => {
     const fetchSpy = vi.spyOn(global, 'fetch')
     notifier = new Notifier('')
-    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+    const fileName = 'announcement.liquid'
 
-    await notifier.notify(fileInfo)
+    await notifier.notify(fileName)
 
     expect(fetchSpy).not.toHaveBeenCalled()
     expect(fs.appendFile).not.toHaveBeenCalled()
@@ -49,9 +49,9 @@ describe('Notifier', () => {
     const url = 'https://example.com/notify'
     const mockFetch = vi.spyOn(global, 'fetch').mockResolvedValue(new Response())
     notifier = new Notifier(url)
-    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+    const fileName = 'announcement.liquid'
 
-    await notifier.notify(fileInfo)
+    await notifier.notify(fileName)
 
     expect(mockFetch).toHaveBeenCalled()
     expect(fs.appendFile).not.toHaveBeenCalled()
@@ -61,9 +61,9 @@ describe('Notifier', () => {
     const url = 'https://example.com/notify'
     vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, {status: 500, statusText: 'Internal Server Error'}))
     notifier = new Notifier(url)
-    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+    const fileName = 'announcement.liquid'
 
-    await notifier.notify(fileInfo)
+    await notifier.notify(fileName)
 
     expect(outputWarn).toHaveBeenCalledWith(
       'Failed to notify filechange listener at https://example.com/notify: Internal Server Error',
@@ -74,9 +74,9 @@ describe('Notifier', () => {
     const url = 'https://example.com/notify'
     vi.spyOn(global, 'fetch').mockRejectedValue(new URIError('Network error'))
     notifier = new Notifier(url)
-    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+    const fileName = 'announcement.liquid'
 
-    await notifier.notify(fileInfo)
+    await notifier.notify(fileName)
 
     expect(outputWarn).toHaveBeenCalledWith(
       'Failed to notify filechange listener at https://example.com/notify: Network error',
@@ -85,11 +85,11 @@ describe('Notifier', () => {
 
   test('outputs error if file update fails', async () => {
     const invalidPath = 'dir/file:theme.update'
-    vi.spyOn(fs, 'appendFile').mockRejectedValue(new Error('No such file or directory'))
+    vi.spyOn(fs, 'writeFile').mockRejectedValue(new Error('No such file or directory'))
     notifier = new Notifier(invalidPath)
-    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+    const fileName = 'announcement.liquid'
 
-    await notifier.notify(fileInfo)
+    await notifier.notify(fileName)
 
     expect(outputWarn).toHaveBeenCalledWith(
       `Failed to notify filechange listener at ${invalidPath}: No such file or directory`,

--- a/packages/theme/src/cli/utilities/notifier.test.ts
+++ b/packages/theme/src/cli/utilities/notifier.test.ts
@@ -1,0 +1,98 @@
+import {Notifier} from './notifier.js'
+import {vi, describe, expect, test} from 'vitest'
+import {outputWarn} from '@shopify/cli-kit/node/output'
+import fs from 'fs/promises'
+
+vi.mock('fs/promises')
+vi.mock('@shopify/cli-kit/node/output')
+
+describe('Notifier', () => {
+  let notifier: Notifier
+
+  test('updates notifyPath via POST request when path is a URL', async () => {
+    const mockFetch = vi.spyOn(global, 'fetch').mockResolvedValue(new Response())
+    const url = 'https://example.com/notify'
+    notifier = new Notifier(url)
+    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+
+    await notifier.notify(fileInfo)
+
+    expect(mockFetch).toHaveBeenCalledWith(url, {
+      method: 'POST',
+      body: JSON.stringify({files: [fileInfo]}),
+      headers: {'Content-Type': 'application/json'},
+    })
+  })
+
+  test('updates file atime and mtime when path is not a URL', async () => {
+    const path = 'theme.update'
+    notifier = new Notifier(path)
+    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+
+    await notifier.notify(fileInfo)
+
+    expect(fs.appendFile).toHaveBeenCalledWith(path, expect.any(String))
+  })
+
+  test('does not update if path is empty', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch')
+    notifier = new Notifier('')
+    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+
+    await notifier.notify(fileInfo)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(fs.appendFile).not.toHaveBeenCalled()
+  })
+
+  test('does not notify file when path is URL', async () => {
+    const url = 'https://example.com/notify'
+    const mockFetch = vi.spyOn(global, 'fetch').mockResolvedValue(new Response())
+    notifier = new Notifier(url)
+    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+
+    await notifier.notify(fileInfo)
+
+    expect(mockFetch).toHaveBeenCalled()
+    expect(fs.appendFile).not.toHaveBeenCalled()
+  })
+
+  test('prints error if response is not successful', async () => {
+    const url = 'https://example.com/notify'
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, {status: 500, statusText: 'Internal Server Error'}))
+    notifier = new Notifier(url)
+    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+
+    await notifier.notify(fileInfo)
+
+    expect(outputWarn).toHaveBeenCalledWith(
+      'Failed to notify filechange listener at https://example.com/notify: Internal Server Error',
+    )
+  })
+
+  test('outputs error if request fails', async () => {
+    const url = 'https://example.com/notify'
+    vi.spyOn(global, 'fetch').mockRejectedValue(new URIError('Network error'))
+    notifier = new Notifier(url)
+    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+
+    await notifier.notify(fileInfo)
+
+    expect(outputWarn).toHaveBeenCalledWith(
+      'Failed to notify filechange listener at https://example.com/notify: Network error',
+    )
+  })
+
+  test('outputs error if file update fails', async () => {
+    const invalidPath = 'dir/file:theme.update'
+    vi.spyOn(fs, 'appendFile').mockRejectedValue(new Error('No such file or directory'))
+    notifier = new Notifier(invalidPath)
+    const fileInfo = {name: 'announcement.liquid', accessedAt: new Date(), modifiedAt: new Date()}
+
+    await notifier.notify(fileInfo)
+
+    expect(outputWarn).toHaveBeenCalledWith(
+      `Failed to notify filechange listener at ${invalidPath}: No such file or directory`,
+    )
+  })
+})

--- a/packages/theme/src/cli/utilities/notifier.ts
+++ b/packages/theme/src/cli/utilities/notifier.ts
@@ -11,11 +11,13 @@ export class Notifier {
   constructor(notifyPath: string) {
     this.notifyPath = notifyPath
     this.isValidUrl = this.validateUrl(notifyPath)
+    if (this.notifyPath === '') {
+      outputWarn('Notification skipped: notifyPath is an empty string')
+    }
   }
 
   async notify(fileName: string): Promise<void> {
     if (this.notifyPath === '') {
-      outputDebug('Notification skipped: notifyPath is an empty string')
       return
     }
 

--- a/packages/theme/src/cli/utilities/notifier.ts
+++ b/packages/theme/src/cli/utilities/notifier.ts
@@ -10,23 +10,28 @@ interface FileChangeInfo {
 export class Notifier {
   private notifyPath: string
   private initialized: boolean
+  private isValidUrl: boolean
+
   constructor(notifyPath: string) {
     this.notifyPath = notifyPath
     this.initialized = false
+    this.isValidUrl = this.validateUrl(notifyPath)
   }
 
   async notify(fileInfo: FileChangeInfo): Promise<void> {
-    if (!this.initialized) {
-      await this.init()
-    }
     try {
+      if (!this.initialized && !this.isValidUrl) {
+        await this.initFile()
+      }
+
       outputDebug(`Notifying filechange listener at ${this.notifyPath}...`)
-      if (!this.notifyPath) return
+      const content = JSON.stringify({files: [fileInfo]})
 
-      const content = JSON.stringify(fileInfo, null, 2)
-
-      if (this.isValidUrl(this.notifyPath)) {
-        await this.notifyUrl(content)
+      if (this.isValidUrl) {
+        const response = await this.notifyUrl(content)
+        if (!response.ok) {
+          outputWarn(`Failed to notify URL: ${response.statusText}`)
+        }
       } else {
         await this.notifyFile(content)
       }
@@ -36,19 +41,25 @@ export class Notifier {
     }
   }
 
-  private async init() {
+  private async initFile() {
     await fs.writeFile(this.notifyPath, '')
     this.initialized = true
   }
 
-  private async notifyUrl(_content: string): Promise<void> {}
+  private async notifyUrl(content: string): Promise<Response> {
+    return fetch(this.notifyPath, {
+      method: 'POST',
+      body: content,
+      headers: {'Content-Type': 'application/json'},
+    })
+  }
 
   private async notifyFile(content: string): Promise<void> {
     outputDebug(`Updating file timestamps at ${this.notifyPath}...`)
     await fs.appendFile(this.notifyPath, content)
   }
 
-  private isValidUrl(url: string): boolean {
+  private validateUrl(url: string): boolean {
     try {
       const parsedUrl = new URL(url)
       return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:'

--- a/packages/theme/src/cli/utilities/notifier.ts
+++ b/packages/theme/src/cli/utilities/notifier.ts
@@ -1,0 +1,60 @@
+import {outputDebug, outputWarn} from '@shopify/cli-kit/node/output'
+import fs from 'fs/promises'
+
+interface FileChangeInfo {
+  name: string
+  accessedAt: Date
+  modifiedAt: Date
+}
+
+export class Notifier {
+  private notifyPath: string
+  private initialized: boolean
+  constructor(notifyPath: string) {
+    this.notifyPath = notifyPath
+    this.initialized = false
+  }
+
+  async notify(fileInfo: FileChangeInfo): Promise<void> {
+    if (!this.initialized) {
+      await this.init()
+    }
+    try {
+      outputDebug(`Notifying filechange listener at ${this.notifyPath}...`)
+      if (!this.notifyPath) return
+
+      const content = JSON.stringify(fileInfo, null, 2)
+
+      if (this.isValidUrl(this.notifyPath)) {
+        await this.notifyUrl(content)
+      } else {
+        await this.notifyFile(content)
+      }
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      outputWarn(`Failed to notify filechange listener at ${this.notifyPath}: ${error}`)
+    }
+  }
+
+  private async init() {
+    await fs.writeFile(this.notifyPath, '')
+    this.initialized = true
+  }
+
+  private async notifyUrl(_content: string): Promise<void> {}
+
+  private async notifyFile(content: string): Promise<void> {
+    outputDebug(`Updating file timestamps at ${this.notifyPath}...`)
+    await fs.appendFile(this.notifyPath, content)
+  }
+
+  private isValidUrl(url: string): boolean {
+    try {
+      const parsedUrl = new URL(url)
+      return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:'
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      return false
+    }
+  }
+}

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -9,7 +9,7 @@ import {DEFAULT_IGNORE_PATTERNS, timestampDateFormat} from '../constants.js'
 import {glob, readFile, ReadOptions, fileExists, mkdir, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, basename, relativePath} from '@shopify/cli-kit/node/path'
 import {lookupMimeType, setMimeTypes} from '@shopify/cli-kit/node/mimes'
-import {consoleError, outputContent, outputDebug, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
+import {outputContent, outputDebug, outputInfo, outputToken, outputWarn} from '@shopify/cli-kit/node/output'
 import {buildThemeAsset} from '@shopify/cli-kit/node/themes/factories'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {bulkUploadThemeAssets, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
@@ -115,18 +115,12 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
         }
       })
       .catch((error) => {
-        consoleError(`Error handling file event for ${fileKey}: ${error}`)
+        outputWarn(`Error handling file event for ${fileKey}: ${error}`)
       })
   }
 
   function notifyFileChange(fileKey: string): Promise<void> {
-    const fileChange = {
-      name: fileKey,
-      accessedAt: new Date(),
-      modifiedAt: new Date(),
-    }
-
-    return notifier?.notify(fileChange) ?? Promise.resolve()
+    return notifier?.notify(fileKey) ?? Promise.resolve()
   }
 
   const handleFileUpdate = (

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -4,11 +4,12 @@ import {
   raiseWarningForNonExplicitGlobPatterns,
   getPatternsFromShopifyIgnore,
 } from './asset-ignore.js'
+import {Notifier} from './notifier.js'
 import {DEFAULT_IGNORE_PATTERNS, timestampDateFormat} from '../constants.js'
 import {glob, readFile, ReadOptions, fileExists, mkdir, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, basename, relativePath} from '@shopify/cli-kit/node/path'
 import {lookupMimeType, setMimeTypes} from '@shopify/cli-kit/node/mimes'
-import {outputContent, outputDebug, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
+import {consoleError, outputContent, outputDebug, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
 import {buildThemeAsset} from '@shopify/cli-kit/node/themes/factories'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {bulkUploadThemeAssets, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
@@ -58,6 +59,7 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
   const emitEvent = <T extends ThemeFSEventName>(eventName: T, payload: ThemeFSEventPayload<T>) => {
     eventEmitter.emit(eventName, payload)
   }
+  const notifier = options?.notify ? new Notifier(options.notify) : undefined
 
   const read = async (fileKey: string) => {
     const fileContent = await readThemeFile(root, fileKey)
@@ -94,18 +96,50 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
   const getKey = (filePath: string) => relativePath(root, filePath)
   const isFileIgnored = (fileKey: string) => applyIgnoreFilters([{key: fileKey}], filterPatterns).length === 0
 
+  function handleFsEvent(
+    eventName: 'add' | 'change' | 'unlink',
+    themeId: string,
+    adminSession: AdminSession,
+    filePath: string,
+  ) {
+    const fileKey = getKey(filePath)
+
+    notifyFileChange(fileKey)
+      .then(() => {
+        switch (eventName) {
+          case 'add':
+          case 'change':
+            return handleFileUpdate(eventName, themeId, adminSession, fileKey)
+          case 'unlink':
+            return handleFileDelete(themeId, adminSession, fileKey)
+        }
+      })
+      .catch((error) => {
+        consoleError(`Error handling file event for ${fileKey}: ${error}`)
+      })
+  }
+
+  function notifyFileChange(fileKey: string): Promise<void> {
+    const fileChange = {
+      name: fileKey,
+      accessedAt: new Date(),
+      modifiedAt: new Date(),
+    }
+
+    return notifier?.notify(fileChange) ?? Promise.resolve()
+  }
+
   const handleFileUpdate = (
     eventName: 'add' | 'change',
     themeId: string,
     adminSession: AdminSession,
-    filePath: string,
+    fileKey: string,
   ) => {
-    const fileKey = getKey(filePath)
     if (isFileIgnored(fileKey)) return
 
     const previousChecksum = files.get(fileKey)?.checksum
 
-    const contentPromise = read(fileKey).then(() => {
+    const contentPromise = read(fileKey).then(async () => {
       const file = files.get(fileKey)!
 
       if (file.checksum === previousChecksum) {
@@ -159,8 +193,7 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
     })
   }
 
-  const handleFileDelete = (themeId: string, adminSession: AdminSession, filePath: string) => {
-    const fileKey = getKey(filePath)
+  const handleFileDelete = (themeId: string, adminSession: AdminSession, fileKey: string) => {
     if (isFileIgnored(fileKey)) return
 
     unsyncedFileKeys.delete(fileKey)
@@ -168,7 +201,7 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
     emitEvent('unlink', {fileKey})
 
     deleteThemeAsset(Number(themeId), fileKey, adminSession)
-      .then((success) => {
+      .then(async (success) => {
         if (!success) throw new Error('Unknown issue.')
         outputSyncResult('delete', fileKey)
       })
@@ -209,9 +242,9 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
       })
 
       watcher
-        .on('add', handleFileUpdate.bind(null, 'add', themeId, adminSession))
-        .on('change', handleFileUpdate.bind(null, 'change', themeId, adminSession))
-        .on('unlink', handleFileDelete.bind(null, themeId, adminSession))
+        .on('add', handleFsEvent.bind(null, 'add', themeId, adminSession))
+        .on('change', handleFsEvent.bind(null, 'change', themeId, adminSession))
+        .on('unlink', handleFsEvent.bind(null, 'unlink', themeId, adminSession))
     },
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

- Closes https://github.com/Shopify/develop-advanced-edits/issues/297

### WHAT is this pull request doing?
Adds a `Notifier` module that accepts a URL or a filepath
- If a valid `URL` is provided, we will send a `POST` request with the shape `{"files":["<FILE_KEY>"]}
- Otherwise, we will attempt to write the `filename` to the file located at the path specified
  - `notifyPath` can be a `relative` **or** `absolute` path

I considered adding support for specifying numerous `notifiers` - I want to gather alignment before building this, as I'm unsure of how much value lies in that change. I _believe_ it should be pretty straightforward to do so!

### How to test your changes?
- Run `shopify-dev theme dev --dev-preview --notify <PATH>` with a couple of the following cases:
  - a relative path e.g. (`./output` or `output`)
  - absolute path e.g. (`/Users/<YOUR_USER>/src/github.com/Shopify/Dawn/templates/gift_card.liquid`)
  - **URL** -> create a URL via [RequestBin](https://public.requestbin.com/r)
  - **invalid path** (`/this-path:invalid` or `./non-existent/directory`)

https://github.com/user-attachments/assets/7a4f36ec-64b0-46e6-982c-368700dc08e3

### Measuring impact

How do we know this change was effective? Please choose one:
- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
