### PR TITLE
update function-runner to v6.0.0

### DIFF
--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -8,7 +8,7 @@ import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
 const JAVY_VERSION = 'v3.0.1'
-const FUNCTION_RUNNER_VERSION = 'v5.1.4'
+const FUNCTION_RUNNER_VERSION = 'v6.0.0'
 
 // The logic for determining the download URL and what to do with the response stream is _coincidentally_ the same for
 // Javy and function-runner for now. Those methods may not continue to have the same logic in the future. If they


### PR DESCRIPTION
### WHY are these changes introduced?
I fixed the output in function-runner and released a new version.

### WHAT is this pull request doing?
Updates the binaries to use the latest function-runner.

### How to test your changes?
Run a replay
```
pnpm shopify app function replay --path /Users/lopert/code/log-streaming/app/log-streamer/extensions/product-discount
```
Ensure that the output of the replay command no longer contains the wrapping `JsonOutput`.

cd to the binary's directory
```
cd /Users/lopert/src/github.com/Shopify/cli/packages/app/dist/cli/services/bin
```

check the version
```
./function-runner --version
function-runner 6.0.0
```



### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
