### PR TITLE
Throttle analytics to 300 daily events per dev machine

### DIFF
--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -6,6 +6,7 @@ import {
   removeSession,
   setSession,
   runAtMinimumInterval,
+  runWithRateLimit,
 } from './conf-store.js'
 import {LocalStorage} from '../../public/node/local-storage.js'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -242,6 +243,147 @@ describe('runAtMinimumInterval', () => {
         timeout,
         async () => {
           taskRan = true
+        },
+        config,
+      )
+
+      // Then
+      expect(taskRan).toBe(true)
+    })
+  })
+})
+
+describe('runWithRateLimit', () => {
+  const key = 'TASK'
+  const timeout = {seconds: 1}
+  const limit = 2
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('runs the task as usual when the cache is not populated', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<any>({cwd})
+
+      // When
+      let taskRan = false
+      await runWithRateLimit(
+        {
+          key,
+          timeout,
+          limit,
+          task: async () => {
+            taskRan = true
+          },
+        },
+        config,
+      )
+
+      // Then
+      expect(taskRan).toBe(true)
+    })
+  })
+
+  test('throttles the task when the cache is populated recently', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<any>({cwd})
+      for (let i = 0; i < limit; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        await runWithRateLimit(
+          {
+            key,
+            timeout,
+            limit,
+            task: async () => {},
+          },
+          config,
+        )
+      }
+
+      // When
+      let taskRan = false
+      await runWithRateLimit(
+        {
+          key,
+          limit,
+          timeout,
+          task: async () => {
+            taskRan = true
+          },
+        },
+        config,
+      )
+
+      // Then
+      expect(taskRan).toBe(false)
+    })
+  })
+
+  test("runs the task as usual when the cache is populated recently but the rate limit isn't used up", async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<any>({cwd})
+      // Run the task once, but the rate limit is 2
+      await runWithRateLimit(
+        {
+          key,
+          timeout,
+          limit,
+          task: async () => {},
+        },
+        config,
+      )
+
+      // When
+      let taskRan = false
+      await runWithRateLimit(
+        {
+          key,
+          limit,
+          timeout,
+          task: async () => {
+            taskRan = true
+          },
+        },
+        config,
+      )
+
+      // Then
+      expect(taskRan).toBe(true)
+    })
+  })
+
+  test('runs the task as usual when the cache is populated but outdated', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<any>({cwd})
+      for (let i = 0; i < limit; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        await runWithRateLimit(
+          {
+            key,
+            timeout,
+            limit,
+            task: async () => {},
+          },
+          config,
+        )
+      }
+
+      // When
+      let taskRan = false
+      vi.setSystemTime(vi.getRealSystemTime() + 1000)
+      await runWithRateLimit(
+        {
+          key,
+          limit,
+          timeout,
+          task: async () => {
+            taskRan = true
+          },
         },
         config,
       )

--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -193,7 +193,7 @@ describe('runAtMinimumInterval', () => {
 
       // When
       let taskRan = false
-      await runAtMinimumInterval(
+      const got = await runAtMinimumInterval(
         key,
         timeout,
         async () => {
@@ -203,6 +203,7 @@ describe('runAtMinimumInterval', () => {
       )
 
       // Then
+      expect(got).toBe(true)
       expect(taskRan).toBe(true)
     })
   })
@@ -215,7 +216,7 @@ describe('runAtMinimumInterval', () => {
 
       // When
       let taskRan = false
-      await runAtMinimumInterval(
+      const got = await runAtMinimumInterval(
         key,
         timeout,
         async () => {
@@ -225,6 +226,7 @@ describe('runAtMinimumInterval', () => {
       )
 
       // Then
+      expect(got).toBe(false)
       expect(taskRan).toBe(false)
     })
   })
@@ -238,7 +240,7 @@ describe('runAtMinimumInterval', () => {
       // When
       let taskRan = false
       vi.setSystemTime(vi.getRealSystemTime() + 1000)
-      await runAtMinimumInterval(
+      const got = await runAtMinimumInterval(
         key,
         timeout,
         async () => {
@@ -248,6 +250,7 @@ describe('runAtMinimumInterval', () => {
       )
 
       // Then
+      expect(got).toBe(true)
       expect(taskRan).toBe(true)
     })
   })
@@ -269,7 +272,7 @@ describe('runWithRateLimit', () => {
 
       // When
       let taskRan = false
-      await runWithRateLimit(
+      const got = await runWithRateLimit(
         {
           key,
           timeout,
@@ -282,6 +285,7 @@ describe('runWithRateLimit', () => {
       )
 
       // Then
+      expect(got).toBe(true)
       expect(taskRan).toBe(true)
     })
   })
@@ -305,7 +309,7 @@ describe('runWithRateLimit', () => {
 
       // When
       let taskRan = false
-      await runWithRateLimit(
+      const got = await runWithRateLimit(
         {
           key,
           limit,
@@ -318,6 +322,7 @@ describe('runWithRateLimit', () => {
       )
 
       // Then
+      expect(got).toBe(false)
       expect(taskRan).toBe(false)
     })
   })
@@ -339,7 +344,7 @@ describe('runWithRateLimit', () => {
 
       // When
       let taskRan = false
-      await runWithRateLimit(
+      const got = await runWithRateLimit(
         {
           key,
           limit,
@@ -352,6 +357,7 @@ describe('runWithRateLimit', () => {
       )
 
       // Then
+      expect(got).toBe(true)
       expect(taskRan).toBe(true)
     })
   })
@@ -376,7 +382,7 @@ describe('runWithRateLimit', () => {
       // When
       let taskRan = false
       vi.setSystemTime(vi.getRealSystemTime() + 1000)
-      await runWithRateLimit(
+      const got = await runWithRateLimit(
         {
           key,
           limit,
@@ -389,6 +395,7 @@ describe('runWithRateLimit', () => {
       )
 
       // Then
+      expect(got).toBe(true)
       expect(taskRan).toBe(true)
     })
   })

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -10,13 +10,15 @@ interface CacheValue<T> {
 export type IntrospectionUrlKey = `identity-introspection-url-${string}`
 export type PackageVersionKey = `npm-package-${string}`
 type MostRecentOccurrenceKey = `most-recent-occurrence-${string}`
+type RateLimitKey = `rate-limited-occurrences-${string}`
 
 type ExportedKey = IntrospectionUrlKey | PackageVersionKey
 
 interface Cache {
   [introspectionUrlKey: IntrospectionUrlKey]: CacheValue<string>
   [packageVersionKey: PackageVersionKey]: CacheValue<string>
-  [MostRecentOccurrenceKey: MostRecentOccurrenceKey]: CacheValue<boolean>
+  [mostRecentOccurrenceKey: MostRecentOccurrenceKey]: CacheValue<boolean>
+  [rateLimitKey: RateLimitKey]: CacheValue<number[]>
 }
 
 export interface ConfSchema {
@@ -129,14 +131,14 @@ function timeIntervalToMilliseconds({days = 0, hours = 0, minutes = 0, seconds =
  * days, hours, minutes, and seconds properties.
  * If the most recent occurrence is older than this, the task will be executed.
  * @param task - The task to run if the most recent occurrence is older than the timeout.
- * @returns The result of the task, or undefined if the task was not run.
+ * @returns true, or undefined if the task was not run.
  */
 export async function runAtMinimumInterval(
   key: string,
   timeout: TimeInterval,
   task: () => Promise<void>,
   config = cliKitStore(),
-): Promise<boolean | undefined> {
+): Promise<true | undefined> {
   const cache: Cache = config.get('cache') || {}
   const cacheKey: MostRecentOccurrenceKey = `most-recent-occurrence-${key}`
   const cached = cache[cacheKey]
@@ -148,5 +150,75 @@ export async function runAtMinimumInterval(
   await task()
   cache[cacheKey] = {value: true, timestamp: Date.now()}
   config.set('cache', cache)
+  return true
+}
+
+interface RunWithRateLimitOptions {
+  /**
+   * The key to use for the cache.
+   */
+  key: string
+
+  /**
+   * The number of times the task can be run within the limit
+   */
+  limit: number
+
+  /**
+   * The window of time after which the rate limit is refreshed,
+   * expressed as an object with days, hours, minutes, and seconds properties.
+   * If the most recent occurrence is older than this, the task will be executed.
+   */
+  timeout: TimeInterval
+
+  /**
+   * The task to run if the most recent occurrence is older than the timeout.
+   */
+  task: () => Promise<void>
+}
+
+/**
+ * Execute a task with a time-based rate limit. The rate limit is enforced by
+ * checking how many times that task has been executed in a window of time ending
+ * at the current time. If the task has been executed more than the allowed number
+ * of times in that window, the task will not be executed.
+ *
+ * Note that this function has side effects, as it will also remove events prior
+ * to the window of time that is being checked.
+ * @param options - The options for the rate limiting.
+ * @returns true, or undefined if the task was not run.
+ */
+export async function runWithRateLimit(
+  options: RunWithRateLimitOptions,
+  config = cliKitStore(),
+): Promise<true | undefined> {
+  const {key, limit, timeout, task} = options
+  const cache: Cache = config.get('cache') || {}
+  const cacheKey: RateLimitKey = `rate-limited-occurrences-${key}`
+  const cached = cache[cacheKey]
+  const now = Date.now()
+
+  if (cached?.value) {
+    // First sweep through the cache and eliminate old events
+    const windowStart = now - timeIntervalToMilliseconds(timeout)
+    const occurrences = cached.value.filter((occurrence) => occurrence >= windowStart)
+
+    // Now check that the number of occurrences within the interval is below the limit
+    if (occurrences.length >= limit) {
+      // First remove the old occurrences from the cache
+      cache[cacheKey] = {value: occurrences, timestamp: Date.now()}
+      config.set('cache', cache)
+
+      return undefined
+    }
+
+    await task()
+    cache[cacheKey] = {value: [...occurrences, now], timestamp: now}
+  } else {
+    await task()
+    cache[cacheKey] = {value: [now], timestamp: now}
+  }
+  config.set('cache', cache)
+
   return true
 }

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -79,3 +79,5 @@ export const sessionConstants = {
 }
 
 export const bugsnagApiKey = '9e1e6889176fd0c795d5c659225e0fae'
+
+export const reportingRateLimit = {limit: 300, timeout: {days: 1}}

--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -12,9 +12,10 @@ import {
 } from './error.js'
 import {getEnvironmentData} from '../../private/node/analytics.js'
 import {outputDebug, outputInfo} from '../../public/node/output.js'
-import {bugsnagApiKey} from '../../private/node/constants.js'
+import {bugsnagApiKey, reportingRateLimit} from '../../private/node/constants.js'
 import {printEventsJson} from '../../private/node/demo-recorder.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
+import {runWithRateLimit} from '../../private/node/conf-store.js'
 import {settings, Interfaces} from '@oclif/core'
 import StackTracey from 'stacktracey'
 import Bugsnag, {Event} from '@bugsnag/js'
@@ -104,6 +105,19 @@ export async function sendErrorToBugsnag(
     })
     .join('\n')
   reportableError.stack = `Error: ${reportableError.message}\n${formattedStacktrace}`
+
+  let withinRateLimit = false
+  await runWithRateLimit({
+    key: 'send-error-to-bugsnag',
+    ...reportingRateLimit,
+    task: async () => {
+      withinRateLimit = true
+    },
+  })
+  if (!withinRateLimit) {
+    outputDebug(`Skipping Bugsnag report due to rate limiting`)
+    report = false
+  }
 
   if (report) {
     initializeBugsnag()


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Some users are experiencing errors thousands of times daily, with minimal value added by analytics from those reports. We are throttling analytics (including bugsnag, monorail, and open analytics) to 300 events daily, to balance the need for continuous visibility into error conditions with the need to make those problems more visible by clearing out much of the noise from individual users with e.g. a background process retrying continuously thousands of times daily.

This isn't a perfect solution, we still are getting up to hundreds of reports daily from noisy users. But it's a quick and easy solution that gets us started down the path and eliminates the vast majority of noise immediately.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Adds a rate limiter around the reporting functions. At the moment, there is no granularity for specific errors, though it would be great to add that in the future.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Run an invalid command in verbose mode, e.g. `pnpm shopify app dev --path /path/to/your/app --config nonexistent --verbose`
2. Note that you see output like `Skipping command analytics` with a payload
3. Edit your local copy in `packages/cli-kit/src/private/node` to have an absurdly low rate limit (e.g. once daily)
4. Now run it again, and you should see `Skipping command analytics due to rate limiting` with a payload

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
