### PR TITLE
[Themes] Theme Dev - Do not display warnings when file deletion fails

### DIFF
--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -13,7 +13,7 @@ import {outputContent, outputDebug, outputInfo, outputToken, outputWarn} from '@
 import {buildThemeAsset} from '@shopify/cli-kit/node/themes/factories'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {bulkUploadThemeAssets, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
-import {renderError, renderWarning} from '@shopify/cli-kit/node/ui'
+import {renderError} from '@shopify/cli-kit/node/ui'
 import EventEmitter from 'node:events'
 import type {
   ThemeFileSystem,
@@ -196,12 +196,12 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
 
     deleteThemeAsset(Number(themeId), fileKey, adminSession)
       .then(async (success) => {
-        if (!success) throw new Error('Unknown issue.')
+        if (!success) throw new Error(`Failed to delete file "${fileKey}" from remote theme.`)
         unsyncedFileKeys.delete(fileKey)
         outputSyncResult('delete', fileKey)
       })
       .catch((error) => {
-        renderWarning({headline: `Failed to delete file "${fileKey}".`, body: error.message})
+        outputDebug(error.message)
       })
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/develop-advanced-edits/issues/310

>The goals of this task are:
Update the logic so the file system module doesn't attempt to delete a non-existent file.
Change the logging approach from renderWarning to outputDebug since users cannot take any action on this issue.

### WHAT is this pull request doing?
~~- Prevents the watcher from attempting to delete files that don't exist on the local theme~~
- `outputDebug` when the file deletion fails (either due to server error or because the file already doesn't exist)

### How to test your changes?
Setup:
1) Create a theme with missing files -> `shopify theme push -d` -> delete files from the code editor
2) Execute `shopify-dev theme dev --dev-preview --theme-editor-sync --verbose` 
3) Select 'delete files from local theme'
4) Check for `verbose` logs. You should see logs like: `Failed to delete file "${fileKey}" from remote theme.`

BEFORE
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/7c4c43a9-5b0a-4ff5-bddb-7c6aa8975d84">

AFTER

https://github.com/user-attachments/assets/3fe26e8a-7a97-43c5-bbdd-970b2842ba90

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes