### PR TITLE
[ShopifyVM] Update-function runner to use dynamic scaling

### DIFF
--- a/.changeset/sixty-mangos-beam.md
+++ b/.changeset/sixty-mangos-beam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Bumps function-runner version to include details on dynamic resource limits.

--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -1,4 +1,4 @@
-import {functionFlags, inFunctionContext} from '../../../services/function/common.js'
+import {functionFlags, inFunctionContext, getOrGenerateSchemaPath} from '../../../services/function/common.js'
 import {runFunction} from '../../../services/function/runner.js'
 import {appFlags} from '../../../flags.js'
 import Command from '@shopify/cli-kit/node/base-command'
@@ -44,7 +44,7 @@ export default class FunctionRun extends Command {
     await inFunctionContext({
       path: flags.path,
       userProvidedConfigName: flags.config,
-      callback: async (_app, ourFunction) => {
+      callback: async (app, ourFunction) => {
         let functionExport = DEFAULT_FUNCTION_EXPORT
 
         if (flags.export !== undefined) {
@@ -78,12 +78,18 @@ export default class FunctionRun extends Command {
           )
         }
 
+        const inputQueryPath = ourFunction?.configuration.targeting?.[0]?.input_query
+        const queryPath = inputQueryPath && `${ourFunction?.directory}/${inputQueryPath}`
+        const schemaPath = await getOrGenerateSchemaPath(ourFunction, app)
+
         await runFunction({
           functionExtension: ourFunction,
           json: flags.json,
           inputPath: flags.input,
           export: functionExport,
           stdin: 'inherit',
+          schemaPath,
+          queryPath,
         })
       },
     })

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -8,7 +8,7 @@ import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
 const JAVY_VERSION = 'v3.0.1'
-const FUNCTION_RUNNER_VERSION = 'v6.0.0'
+const FUNCTION_RUNNER_VERSION = 'v6.2.0'
 
 // The logic for determining the download URL and what to do with the response stream is _coincidentally_ the same for
 // Javy and function-runner for now. Those methods may not continue to have the same logic in the future. If they

--- a/packages/app/src/cli/services/function/common.test.ts
+++ b/packages/app/src/cli/services/function/common.test.ts
@@ -1,16 +1,21 @@
-import {inFunctionContext} from './common.js'
+import {getOrGenerateSchemaPath, inFunctionContext} from './common.js'
 import {loadApp} from '../../models/app/loader.js'
 import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {AppInterface} from '../../models/app/app.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
+import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
+import {generateSchemaService} from '../generate-schema.js'
 import {describe, vi, expect, beforeEach, test} from 'vitest'
 import {renderAutocompletePrompt, renderFatalError} from '@shopify/cli-kit/node/ui'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {isTerminalInteractive} from '@shopify/cli-kit/node/context/local'
+import {fileExists} from '@shopify/cli-kit/node/fs'
 
 vi.mock('../../models/app/loader.js')
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('@shopify/cli-kit/node/context/local')
+vi.mock('@shopify/cli-kit/node/fs')
+vi.mock('../generate-schema.js')
 
 let app: AppInterface
 let ourFunction: ExtensionInstance
@@ -73,6 +78,49 @@ describe('ensure we are within a function context', () => {
       }),
     ).rejects.toThrowError()
 
+    // Then
     expect(ranCallback).toBe(false)
+  })
+})
+
+describe('getOrGenerateSchemaPath', () => {
+  let extension: ExtensionInstance<FunctionConfigType>
+  let app: AppInterface
+
+  beforeEach(() => {
+    extension = {
+      directory: '/path/to/function',
+      configuration: {},
+    } as ExtensionInstance<FunctionConfigType>
+
+    app = {} as AppInterface
+  })
+
+  test('returns the path if the schema file exists', async () => {
+    // Given
+    const expectedPath = joinPath(extension.directory, 'schema.graphql')
+    vi.mocked(fileExists).mockResolvedValue(true)
+
+    // When
+    const result = await getOrGenerateSchemaPath(extension, app)
+
+    // Then
+    expect(result).toBe(expectedPath)
+    expect(fileExists).toHaveBeenCalledWith(expectedPath)
+  })
+
+  test('generates the schema file if it does not exist', async () => {
+    // Given
+    const expectedPath = joinPath(extension.directory, 'schema.graphql')
+    vi.mocked(fileExists).mockResolvedValue(false)
+    vi.mocked(generateSchemaService).mockResolvedValueOnce()
+    vi.mocked(fileExists).mockResolvedValueOnce(true)
+
+    // When
+    const result = await getOrGenerateSchemaPath(extension, app)
+
+    // Then
+    expect(result).toBe(expectedPath)
+    expect(fileExists).toHaveBeenCalledWith(expectedPath)
   })
 })

--- a/packages/app/src/cli/services/function/runner.test.ts
+++ b/packages/app/src/cli/services/function/runner.test.ts
@@ -39,6 +39,8 @@ describe('runFunction', () => {
       stdin: new Readable(),
       stdout: new Writable(),
       stderr: new Writable(),
+      schemaPath: 'schemaPath',
+      queryPath: 'src/queryPath',
     }
 
     // When
@@ -47,7 +49,19 @@ describe('runFunction', () => {
     // Then
     expect(exec).toHaveBeenCalledWith(
       functionRunnerBinary().path,
-      ['-f', functionExtension.outputPath, '--input', options.inputPath, '--export', options.export, '--json'],
+      [
+        '-f',
+        functionExtension.outputPath,
+        '--input',
+        options.inputPath,
+        '--export',
+        options.export,
+        '--json',
+        '--schema-path',
+        options.schemaPath,
+        '--query-path',
+        options.queryPath,
+      ],
       {
         cwd: functionExtension.directory,
         stdin: options.stdin,

--- a/packages/app/src/cli/services/function/runner.ts
+++ b/packages/app/src/cli/services/function/runner.ts
@@ -10,6 +10,8 @@ interface FunctionRunnerOptions {
   inputPath?: string
   export?: string
   json?: boolean
+  schemaPath?: string
+  queryPath?: string
   stdin?: Readable | 'inherit'
   stdout?: Writable | 'inherit'
   stderr?: Writable | 'inherit'
@@ -28,6 +30,10 @@ export async function runFunction(options: FunctionRunnerOptions) {
   }
   if (options.json) {
     args.push('--json')
+  }
+  if (options.schemaPath && options.queryPath) {
+    args.push('--schema-path', options.schemaPath)
+    args.push('--query-path', options.queryPath)
   }
 
   return exec(functionRunner.path, ['-f', options.functionExtension.outputPath, ...args], {


### PR DESCRIPTION
#gsd:37875

Addresses:
- https://github.com/Shopify/script-service/issues/7502

Pre-requisite:
- https://github.com/Shopify/function-runner/pull/352
- Release new version ✅

### WHY are these changes introduced?

Updates the function-runner version used by CLI. 

The new version will show an update benchmark results sections, including more information on the input and output size. Also, the color of the text in the `Benchmarks` section will be determined by the dynamic scaling limits. 

The new function runner requires two additional parameters to be provided (schema path and query path). 

Note: If incorrect arguments are provided to function for schema path and query path, then function runner will halt execution. If parameters are not passed, then it will use defaults for the limits. 

For Partners DX, there should not be an changes in the DX. They will run the same command (example):

```
npm run shopify app function run -- --input=./js_function_input.json --path=./innovative-shareholder-app   
```

A partners function will have a schema and query file. We can include the paths to those files when we call function runner from the cli.

### WHAT is this pull request doing?

<img width="587" alt="Screenshot 2024-09-11 at 4 31 29 PM" src="https://github.com/user-attachments/assets/1b92a9ad-c6b5-4907-82c9-74b958f31b86">


Uses new version of function runner to provide additional information on benchmark results and a resource limits section.

From CLI we need to provide two additional paths to function-runner, `schema-path` and `query-path`.

The changes in this PR are small, but its important to review how we are determining the query / schema path we are providing. 

1. **Query Path**
- The extensions targeting configuration (specified in the toml) has input query path accessible
- The input query for functions are located in either `src/run.graphql`, or `fetch.grapql`. As per the docs, I dont know if this is a requirement or someting the partner can change. But regardless, we have access to the input query path specified. 
- And in CLI we have access to this value from `functionExtension.configuration.targeting?.[0]?.input_query`

2. **Schema Path**
- Schema gets created with the `generate schema` command, and it creates a `schema.graphql` at the root of the app directory. 
- If there is no schema file, we will call the code to generate one similar to what the `schema` command does with utilizing `generateSchemaService`. 

Making Note: CLI handles cases where query and schema are not at requires paths. 

If Schema or input is not located in the app directory, partners will get errors when deploying the function. 

Schema not located in root - CLI handles these errors on deploy like:
<img width="721" alt="Screenshot 2024-09-11 at 9 13 42 AM" src="https://github.com/user-attachments/assets/baff383c-809d-4583-8fff-913f6316970b">

Query not located in specifed location in cargo toml - CLI handles these errors on deploy like:
<img width="663" alt="Screenshot 2024-09-11 at 9 15 34 AM" src="https://github.com/user-attachments/assets/bdc2cec4-3da7-473e-943d-dbb791d71059">

^ verified partner can update the value of the input query file in the `shopify.extension.toml`

If there is no schema, we will call the code to generate the schema, and output a message when the schema file gets cr

<img width="1164" alt="Screenshot 2024-09-11 at 4 28 26 PM" src="https://github.com/user-attachments/assets/69854687-25d2-493b-b585-c00ccf19598b">

### 🎩 How to test your changes?

Alex showed me and linked his [comment here](https://github.com/Shopify/cli/pull/4404#pullrequestreview-2280436279). But function-runner in the CLI gets run from a binary. So to run the code before we release the new version of function-runner. You will need to replace the binary in your local CLI.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
