### PR TITLE
Fix deploy after app creation with App Management API

### DIFF
--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -443,9 +443,8 @@ export async function ensureDeployContext(options: DeployContextOptions): Promis
   let developerPlatformClient = options.developerPlatformClient
   const enableLinkingPrompt = !options.apiKey && !isCurrentAppSchema(options.app.configuration)
   const [remoteApp] = await fetchAppAndIdentifiers(options, developerPlatformClient, true, enableLinkingPrompt)
-  const activeAppVersion = await developerPlatformClient.activeAppVersion(remoteApp)
-
   developerPlatformClient = remoteApp.developerPlatformClient ?? developerPlatformClient
+  const activeAppVersion = await developerPlatformClient.activeAppVersion(remoteApp)
 
   const specifications = await fetchSpecifications({developerPlatformClient, app: remoteApp})
   const app: AppInterface = await loadApp({


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2072

Regression introduced in https://github.com/Shopify/cli/pull/4358

### WHAT is this pull request doing?

Ensure we use the right developer platform client before making any request

### How to test your changes?

- `p shopify app init`
- `USE_DEVELOPER_PLATFORM_API=1 p shopify app deploy`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
