### PR TITLE
[Functions] Bump `javy`

### DIFF
--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -7,8 +7,8 @@ import fs from 'node:fs'
 import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
-const JAVY_VERSION = 'v3.0.1'
 const FUNCTION_RUNNER_VERSION = 'v6.2.0'
+const JAVY_VERSION = 'v3.1.0'
 
 // The logic for determining the download URL and what to do with the response stream is _coincidentally_ the same for
 // Javy and function-runner for now. Those methods may not continue to have the same logic in the future. If they

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -143,7 +143,7 @@ describe('runJavy', () => {
     await expect(got).resolves.toBeUndefined()
     expect(exec).toHaveBeenCalledWith(
       javyBinary().path,
-      ['compile', '-d', '-o', joinPath(ourFunction.directory, 'dist/index.wasm'), 'dist/function.js'],
+      ['build', '-C', 'dynamic', '-o', joinPath(ourFunction.directory, 'dist/index.wasm'), 'dist/function.js'],
       {
         cwd: ourFunction.directory,
         stderr: 'inherit',
@@ -222,18 +222,20 @@ describe('ExportJavyBuilder', () => {
 
         // Then
         await expect(got).resolves.toBeUndefined()
+
         expect(exec).toHaveBeenCalledWith(
           javyBinary().path,
           [
-            'compile',
-            '-d',
+            'build',
+            '-C',
+            'dynamic',
+            '-C',
+            expect.stringContaining('wit='),
+            '-C',
+            'wit-world=shopify-function',
             '-o',
             joinPath(ourFunction.directory, 'dist/index.wasm'),
             'dist/function.js',
-            '--wit',
-            expect.stringContaining('javy-world.wit'),
-            '-n',
-            'shopify-function',
           ],
           {
             cwd: ourFunction.directory,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -169,7 +169,10 @@ export async function runJavy(
   const javy = javyBinary()
   await installBinary(javy)
 
-  const args = ['compile', '-d', '-o', fun.outputPath, 'dist/function.js', ...extra]
+  // Using the `build` command we want to emit:
+  //
+  //    `javy build -C dynamic -C wit=<path> -C wit-world=val -o <path> <function.js>`
+  const args = ['build', '-C', 'dynamic', ...extra, '-o', fun.outputPath, 'dist/function.js']
 
   return exec(javy.path, args, {
     cwd: fun.directory,
@@ -242,7 +245,7 @@ export class ExportJavyBuilder implements JavyBuilder {
       const witPath = joinPath(dir, 'javy-world.wit')
       await writeFile(witPath, witContent)
 
-      return runJavy(fun, options, ['--wit', witPath, '-n', JAVY_WORLD])
+      return runJavy(fun, options, ['-C', `wit=${witPath}`, '-C', `wit-world=${JAVY_WORLD}`])
     })
   }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This commit updates the following versions:

* `javy`: 3.0.1 -> 3.1.0

The only functional change introduced as part of this PR is changing the invocation of `javy`, which includes the new option groups, introduced in version 3.1.0. 

<!--
  Context about the problem that’s being addressed.
-->


### How to test your changes?

- Create a new JavaScript extension
- Build it
- Test it with function runner
- Inspect the generated Wasm binary, it should include exports under the namespace: `javy_quickjs_provider_v3`

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
