### PR TITLE
Add buyer label translations to custom cc schema

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
@@ -93,6 +93,26 @@ describe('CustomCreditCardPaymentsAppExtensionSchema', () => {
     )
   })
 
+  test('returns an error if buyer_label_translations has invalid format', async () => {
+    // When/Then
+    expect(() =>
+      CustomCreditCardPaymentsAppExtensionSchema.parse({
+        ...config,
+        buyer_label_translations: [{label: 'Translation without locale key'}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'string',
+          received: 'undefined',
+          path: ['buyer_label_translations', 0, 'locale'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+
   test('returns an error if encryption certificate fingerprint is not present', async () => {
     // When/Then
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -157,6 +177,8 @@ describe('customCreditCardPaymentsAppExtensionDeployConfig', () => {
       supported_buyer_contexts: config.supported_buyer_contexts,
       encryption_certificate_fingerprint: config.encryption_certificate_fingerprint,
       test_mode_available: config.test_mode_available,
+      default_buyer_label: config.buyer_label,
+      buyer_label_to_locale: config.buyer_label_translations,
       multiple_capture: config.multiple_capture,
       checkout_payment_method_fields: config.checkout_payment_method_fields,
       checkout_hosted_fields: config.checkout_hosted_fields,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
@@ -1,5 +1,6 @@
 import {
   BasePaymentsAppExtensionSchema,
+  BuyerLabelSchema,
   BasePaymentsAppExtensionDeployConfigType,
   ConfirmationSchema,
   SupportedBuyerContextsSchema,
@@ -15,7 +16,8 @@ export type CustomCreditCardPaymentsAppExtensionConfigType = zod.infer<
 export const CUSTOM_CREDIT_CARD_TARGET = 'payments.custom-credit-card.render'
 export const MAX_CHECKOUT_PAYMENT_METHOD_FIELDS = 7
 
-export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(ConfirmationSchema)
+export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(BuyerLabelSchema)
+  .merge(ConfirmationSchema)
   .merge(SupportedBuyerContextsSchema)
   .required({
     refund_session_url: true,
@@ -47,7 +49,10 @@ export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensi
   })
 
 export interface CustomCreditCardPaymentsAppExtensionDeployConfigType extends BasePaymentsAppExtensionDeployConfigType {
-  // Following are overwritten as they are required for custom credit card extensions
+  // BuyerLabelSchema
+  default_buyer_label?: string
+  buyer_label_to_locale?: {locale: string; label: string}[]
+
   start_refund_session_url: string
   start_capture_session_url: string
   start_void_session_url: string
@@ -89,6 +94,8 @@ export function customCreditCardDeployConfigToCLIConfig(
     supported_countries: config.supported_countries,
     supported_payment_methods: config.supported_payment_methods,
     supported_buyer_contexts: config.supported_buyer_contexts,
+    buyer_label: config.default_buyer_label,
+    buyer_label_translations: config.buyer_label_to_locale,
     encryption_certificate_fingerprint: config.encryption_certificate.fingerprint,
     test_mode_available: config.test_mode_available,
     multiple_capture: config.multiple_capture,
@@ -112,6 +119,8 @@ export async function customCreditCardPaymentsAppExtensionDeployConfig(
     supports_3ds: config.supports_3ds,
     supported_countries: config.supported_countries,
     supported_buyer_contexts: config.supported_buyer_contexts,
+    default_buyer_label: config.buyer_label,
+    buyer_label_to_locale: config.buyer_label_translations,
     encryption_certificate_fingerprint: config.encryption_certificate_fingerprint,
     supported_payment_methods: config.supported_payment_methods,
     test_mode_available: config.test_mode_available,


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds `buyer_label` and `buyer_label_translations` to the custom credit card payment extension CLI schema which was not included prior to this PR. 

This is required as part of the custom credit card extension config: https://github.com/Shopify/shopify/blob/main/components/payment_processing/payments_partners/app/models/payments_partners/payments_app_extensions/custom_credit_card_payments_app_extension.rb#L72

Issue: https://github.com/Shopify/payments-platform/issues/6160

🌀 : https://partners.payment-apps-with-cli-nx4r.mark-levidayyan.us.spin.dev/1/apps/905743398575/versions/533

### WHAT is this pull request doing?

Add both fields to the CLI schema

### How to test your changes?

**Payments extension creation:**

<img width="761" alt="Screenshot 2024-09-12 at 14 41 58" src="https://github.com/user-attachments/assets/64bfcb47-11a2-4bc8-ba8b-f8f86348e451">

[
<img width="899" alt="Screenshot 2024-09-12 at 14 41 11" src="https://github.com/user-attachments/assets/908828f9-b7bc-43ed-915f-557140dcfd84">
](url)

**Importing payments extension:**

<img width="870" alt="Screenshot 2024-09-12 at 14 44 26" src="https://github.com/user-attachments/assets/18a9cbef-d050-427d-b53c-c5c0d9ed1157">

<img width="680" alt="Screenshot 2024-09-12 at 14 49 48" src="https://github.com/user-attachments/assets/ed1cc7e4-6928-44e2-8e2a-08c0f5bfb880">

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
