### PR TITLE
[Functions] Bump @shopify/function_javascript to v `1.0.0`

### DIFF
--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -521,7 +521,6 @@ describe('getFunctionRuntimeDependencies', () => {
 
     // Then
     expect(got.find((dep) => dep.name === '@shopify/shopify_function')).toBeTruthy()
-    expect(got.find((dep) => dep.name === 'javy')).toBeTruthy()
   })
 
   test('no-ops for non-JS functions', async () => {
@@ -533,6 +532,5 @@ describe('getFunctionRuntimeDependencies', () => {
 
     // Then
     expect(got.find((dep) => dep.name === '@shopify/shopify_function')).toBeFalsy()
-    expect(got.find((dep) => dep.name === 'javy')).toBeFalsy()
   })
 })

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -254,7 +254,7 @@ function getSrcFileExtension(extensionFlavor: ExtensionFlavorValue): SrcFileExte
 export function getFunctionRuntimeDependencies(templateLanguage: string): DependencyVersion[] {
   const dependencies: DependencyVersion[] = []
   if (templateLanguage === 'javascript') {
-    dependencies.push({name: '@shopify/shopify_function', version: '0.1.0'}, {name: 'javy', version: '0.1.1'})
+    dependencies.push({name: '@shopify/shopify_function', version: '1.0.0'})
   }
   return dependencies
 }


### PR DESCRIPTION
This commit ensures that new functions are bootstrapped with version 1.0.0 of the `@shopify/function_javascript` package, which includes the
  changes in https://github.com/Shopify/shopify-function-javascript/pull/16


<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->


### How to test your changes?

To :tophat:

* Create a new app and JavaScript extension.
* Build the app
* Run the app


<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
