### PR TITLE
Bump function-runner to 6.2.1

### DIFF
--- a/.changeset/gold-berries-prove.md
+++ b/.changeset/gold-berries-prove.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Updates the function-runner version to 6.2.1

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs'
 import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
-const FUNCTION_RUNNER_VERSION = 'v6.2.0'
+const FUNCTION_RUNNER_VERSION = 'v6.2.1'
 const JAVY_VERSION = 'v3.1.0'
 
 // The logic for determining the download URL and what to do with the response stream is _coincidentally_ the same for


### PR DESCRIPTION
### WHY are these changes introduced?

Related issue: https://github.com/Shopify/shopify-functions/issues/394

We released a small update to the `function-runner`.

### WHAT is this pull request doing?

This PR bumps the `function-runner` version so that it is using the latest version.

### How to test your changes?

1. Run a function with the `app function run --verbose` command. Verify that the debug log line states version 6.2.1.
2. Run the downloaded binary with the `--version` flag and verify it's 6.2.1.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
