### PR TITLE
[Theme] Fix querystring after localization redirect

### DIFF
--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -180,7 +180,12 @@ function patchProxiedResponseHeaders(ctx: DevServerContext, event: H3Event, resp
 
   // Location header might contain the store domain, proxy it:
   const locationHeader = response.headers.get('Location')
-  if (locationHeader) setResponseHeader(event, 'Location', locationHeader.replace(/^https?:\/\/[^/]+/, ''))
+  if (locationHeader) {
+    const url = new URL(locationHeader, 'https://shopify.dev')
+    url.searchParams.delete('_fd')
+    url.searchParams.delete('pb')
+    setResponseHeader(event, 'Location', url.href.replace(url.origin, ''))
+  }
 
   // Cookies are set for the vanity domain, fix it for localhost:
   const setCookieHeader =


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/develop-advanced-edits/issues/328
Closes https://github.com/Shopify/develop-advanced-edits/issues/303 (already fixed in https://github.com/Shopify/cli/pull/4447)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

The localization form/links are adding `return_to: /?_fd=0&pb=0` to its FormData.

<img width="413" alt="image" src="https://github.com/user-attachments/assets/c0f29b7d-e776-4414-95ac-19f820e263e3">

This change removes these query params from the Location header before forwarding it to the browser.

cc @Shopify/advanced-edits 
