### PR TITLE
[Theme] Fix hot reload for section groups

### DIFF
--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
@@ -131,6 +131,23 @@ describe('hot-reload server', () => {
     expect(hotReloadEvents).toHaveLength(hotReloadEventsLengthBeforeUnlink)
     await nextTick()
 
+    // -- Updates section groups:
+    const sectionGroupFileKey = testSectionFileKey.replace('.liquid', '.json')
+    const sectionGroupContent = JSON.stringify({
+      sections: {first: {type: testSectionType}, second: {type: testSectionType}},
+    })
+    const {contentSpy: addSectionGroupContentSpy} = await triggerFileEvent(
+      'add',
+      sectionGroupFileKey,
+      sectionGroupContent,
+    )
+    expect(addSectionGroupContentSpy).toHaveBeenCalled()
+    expect(getInMemoryTemplates(ctx)).toEqual({[sectionGroupFileKey]: sectionGroupContent})
+    // Finds section names based on the existing JSON file:
+    expect(hotReloadEvents.at(-1)).toMatch(
+      `data: {"type":"section","key":"${sectionGroupFileKey}","names":["first","second"]}`,
+    )
+
     // -- Updates CSS files:
     const cssFileKey = 'assets/style.css'
     const {syncSpy: cssSyncSpy} = await triggerFileEvent('add', cssFileKey)

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
@@ -23,12 +23,15 @@ import type {DevServerContext} from '../types.js'
 
 /** Store existing section names and types read from JSON files in the project */
 const sectionNamesByFile = new Map<string, [string, string][]>()
+interface SectionGroup {
+  [key: string]: {type: string}
+}
 
 function saveSectionsFromJson(fileKey: string, content: string) {
   const maybeJson = parseJSON(content, null)
   if (!maybeJson) return
 
-  const sections: undefined | {[key: string]: {type: string}} = maybeJson?.sections
+  const sections: SectionGroup | undefined = maybeJson?.sections
 
   if (sections) {
     sectionNamesByFile.set(
@@ -255,10 +258,10 @@ function triggerHotReload(key: string, ctx: DevServerContext) {
     return emitHotReloadEvent({type: 'full', key})
   }
 
-  const type = key.split('/')[0]
+  const [type] = key.split('/')
 
   if (type === 'sections') {
-    hotReloadSections(key)
+    hotReloadSections(key, ctx)
   } else if (type === 'assets' && key.endsWith('.css')) {
     emitHotReloadEvent({type: 'css', key})
   } else {
@@ -266,15 +269,28 @@ function triggerHotReload(key: string, ctx: DevServerContext) {
   }
 }
 
-function hotReloadSections(key: string) {
-  const sectionId = key.match(/^sections\/(.+)\.liquid$/)?.[1]
-  if (!sectionId) return
-
+function hotReloadSections(key: string, ctx: DevServerContext) {
   const sectionsToUpdate = new Set<string>()
-  for (const [_fileKey, sections] of sectionNamesByFile) {
-    for (const [type, name] of sections) {
-      if (type === sectionId) {
-        sectionsToUpdate.add(name)
+
+  if (key.endsWith('.json')) {
+    // Update section groups by reading the section names from the group JSON file.
+    const content = ctx.localThemeFileSystem.files.get(key)?.value
+    if (content) {
+      const sections: SectionGroup | undefined = parseJSON(content, null)?.sections
+      for (const sectionName of Object.keys(sections || {})) {
+        sectionsToUpdate.add(sectionName)
+      }
+    }
+  } else {
+    // Update specific sections by reading the section names from the in-memory map.
+    const sectionId = key.match(/^sections\/(.+)\.liquid$/)?.[1]
+    if (sectionId) {
+      for (const [_fileKey, sections] of sectionNamesByFile) {
+        for (const [type, name] of sections) {
+          if (type === sectionId) {
+            sectionsToUpdate.add(name)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/develop-advanced-edits/issues/302

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Grab the section names from the section group JSON file and sends them to the browser to request new versions of the sections.

### How to test your changes?

Follow the video in the linked issue.

cc @Shopify/advanced-edits 