### PR TITLE
The development server no longer forces a session refresh when creating the development server session

### DIFF
--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
@@ -24,7 +24,7 @@ export async function initializeDevServerSession(
   adminPassword?: string,
   storefrontPassword?: string,
 ) {
-  const session = await fetchDevServerSession(themeId, adminSession, adminPassword, storefrontPassword, true)
+  const session = await fetchDevServerSession(themeId, adminSession, adminPassword, storefrontPassword)
 
   setInterval(() => {
     fetchDevServerSession(themeId, adminSession, adminPassword, storefrontPassword)
@@ -45,13 +45,12 @@ async function fetchDevServerSession(
   adminSession: AdminSession,
   adminPassword?: string,
   storefrontPassword?: string,
-  forceRefresh = false,
 ): Promise<DevServerSession> {
   const baseUrl = buildBaseStorefrontUrl(adminSession)
 
   const [session, storefrontToken] = await Promise.all([
-    ensureAuthenticatedThemes(adminSession.storeFqdn, adminPassword, [], forceRefresh),
-    ensureAuthenticatedStorefront([], adminPassword, forceRefresh),
+    ensureAuthenticatedThemes(adminSession.storeFqdn, adminPassword, []),
+    ensureAuthenticatedStorefront([], adminPassword),
   ])
 
   const sessionCookies = await getStorefrontSessionCookies(baseUrl, themeId, storefrontPassword, {})


### PR DESCRIPTION
### WHY are these changes introduced?

This PR avoids forcing a session refresh during the creation of the development server session, which triggers unnecessary prompts when users are initializing the `shopify app dev` command.

### WHAT is this pull request doing?

This command defers to the `ensureAuthenticated*` family of methods to decide when to refresh tokens. Specifically, in the `shopify app dev` command, when multiple modules require authentication, forcing the refresh logic is not ideal and it's also unnecessary in the context of theme development.

### How to test your changes?

- Run `shopify auth logout`
- Run `shopify app dev`, press <kbd>Ctrl</kbd> + <kbd>C</kbd>, re-run `shopify app dev` multiple times
- Notice you're no longer prompted to authenticate after the startup

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
