### PR TITLE
Ruby dependencies should only be invoked when the legacy flag is passed

### DIFF
--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -143,7 +143,7 @@ You can run this command only in a directory that matches the [default Shopify t
     const store = ensureThemeStore(flags)
     const {ignore = [], only = []} = flags
 
-    const {adminSession, storefrontToken} = await refreshTokens(store, flags.password, flags.legacy)
+    const {adminSession, storefrontToken} = await refreshTokens(store, flags.password, Boolean(flags.legacy))
 
     let theme: Theme
 


### PR DESCRIPTION
### WHY are these changes introduced?

Ruby dependencies should only be invoked when the legacy flag is passed. However, users receive the following message when they try to invoke `shopify theme dev`.

### WHAT is this pull request doing?

When the `--legacy` flag is not passed, it defaults to `undefined`, and then the mechanism that refreshes the session is invoked. This regression was introduced after the dev preview when we [inverted](https://github.com/Shopify/cli/pull/4439) the logic from `--dev-preview` to `--legacy`.

### How to test your changes?

- Run `shopify theme dev`

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
