### PR TITLE
[Themes] Account for empty assets when calculating theme asset size

### DIFF
--- a/.changeset/nervous-sloths-wash.md
+++ b/.changeset/nervous-sloths-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix a bug when building empty theme assets

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -12,7 +12,8 @@ interface RemoteThemeResponse {
 interface RemoteAssetResponse {
   key: string
   checksum: string
-  attachment: string
+  attachment: string | undefined
+  // value is an empty string ('') when the file is empty
   value: string
 }
 
@@ -52,10 +53,7 @@ export function buildThemeAsset(asset?: RemoteAssetResponse): ThemeAsset | undef
 
   const {key, checksum, attachment, value} = asset
   // Note: for attachments, this is the size of the base64 string, not the real length of the file
-  const valueOrAttachment = value || attachment
-  const size = valueOrAttachment ? valueOrAttachment.length : 0
-  const stats = {size, mtime: Date.now()}
-
+  const stats = {size: (value || attachment || '').length, mtime: Date.now()}
   return {key, checksum, attachment, value, stats}
 }
 

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -45,14 +45,14 @@ export function buildChecksum(asset?: RemoteAssetResponse): Checksum | undefined
   return {key, checksum}
 }
 
-export function buildThemeAsset(asset: undefined): undefined
-export function buildThemeAsset(asset: RemoteAssetResponse): ThemeAsset
 export function buildThemeAsset(asset?: RemoteAssetResponse): ThemeAsset | undefined {
   if (!asset) return
 
   const {key, checksum, attachment, value} = asset
   // Note: for attachments, this is the size of the base64 string, not the real length of the file
-  const stats = {size: (value || attachment).length, mtime: Date.now()}
+  const valueOrAttachment = value || attachment
+  const size = valueOrAttachment ? valueOrAttachment.length : 0
+  const stats = {size, mtime: Date.now()}
 
   return {key, checksum, attachment, value, stats}
 }

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -45,6 +45,8 @@ export function buildChecksum(asset?: RemoteAssetResponse): Checksum | undefined
   return {key, checksum}
 }
 
+export function buildThemeAsset(asset: undefined): undefined
+export function buildThemeAsset(asset: RemoteAssetResponse): ThemeAsset
 export function buildThemeAsset(asset?: RemoteAssetResponse): ThemeAsset | undefined {
   if (!asset) return
 


### PR DESCRIPTION
## WHY are these changes introduced?
Fixes https://github.com/Shopify/develop-advanced-edits/issues/339
Fixes https://github.com/Shopify/cli/issues/4470

### WHAT is this pull request doing?
- Add a fallback to calculate size when files are empty

### How to test your changes?
- Add an empty file to your theme via admin
- Run `shopify theme pull -t <THEME>`

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
