### PR TITLE
Bump Javy to 3.1.1

### DIFF
--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -10,7 +10,7 @@ import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
 const FUNCTION_RUNNER_VERSION = 'v6.2.1'
-const JAVY_VERSION = 'v3.1.0'
+const JAVY_VERSION = 'v3.1.1'
 
 // The logic for determining the download URL and what to do with the response stream is _coincidentally_ the same for
 // Javy and function-runner for now. Those methods may not continue to have the same logic in the future. If they


### PR DESCRIPTION
### WHY are these changes introduced?

Javy 3.1.1 contains a fix for `source-compression`, which ensures that the JS source gets compressed correctly.

### WHAT is this pull request doing?

This PR bumps the Javy version to 3.1.1

### How to test your changes?

1. Clean all artifacts locally: `p clean`
2. Validate there's no Javy binary at `packages/app/dist/cli/services/bin/javy`
3. Build a JS function: `p run shopify app function build --path {pathToFunction} --verbose`

Ensure:
- Build was successful
- `packages/app/dist/cli/services/bin/javy --version` outputs 3.1.1
- Running the function works

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
