### PR TITLE
Bump Javy to 3.1.1

### DIFF
--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -10,7 +10,7 @@ import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
 const FUNCTION_RUNNER_VERSION = 'v6.2.1'
-const JAVY_VERSION = 'v3.1.0'
+const JAVY_VERSION = 'v3.1.1'
 
 // The logic for determining the download URL and what to do with the response stream is _coincidentally_ the same for
 // Javy and function-runner for now. Those methods may not continue to have the same logic in the future. If they


### PR DESCRIPTION
This is a patch release PR for https://github.com/Shopify/cli/pull/4481