### PR TITLE
[3.67] - Account for empty assets when calculating theme asset size

### DIFF
--- a/.changeset/nervous-sloths-wash.md
+++ b/.changeset/nervous-sloths-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix a bug when building empty theme assets

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -12,7 +12,8 @@ interface RemoteThemeResponse {
 interface RemoteAssetResponse {
   key: string
   checksum: string
-  attachment: string
+  attachment: string | undefined
+  // value is an empty string ('') when the file is empty
   value: string
 }
 
@@ -52,10 +53,7 @@ export function buildThemeAsset(asset?: RemoteAssetResponse): ThemeAsset | undef
 
   const {key, checksum, attachment, value} = asset
   // Note: for attachments, this is the size of the base64 string, not the real length of the file
-  const valueOrAttachment = value || attachment
-  const size = valueOrAttachment ? valueOrAttachment.length : 0
-  const stats = {size, mtime: Date.now()}
-
+  const stats = {size: (value || attachment || '').length, mtime: Date.now()}
   return {key, checksum, attachment, value, stats}
 }
 

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -45,14 +45,14 @@ export function buildChecksum(asset?: RemoteAssetResponse): Checksum | undefined
   return {key, checksum}
 }
 
-export function buildThemeAsset(asset: undefined): undefined
-export function buildThemeAsset(asset: RemoteAssetResponse): ThemeAsset
 export function buildThemeAsset(asset?: RemoteAssetResponse): ThemeAsset | undefined {
   if (!asset) return
 
   const {key, checksum, attachment, value} = asset
   // Note: for attachments, this is the size of the base64 string, not the real length of the file
-  const stats = {size: (value || attachment).length, mtime: Date.now()}
+  const valueOrAttachment = value || attachment
+  const size = valueOrAttachment ? valueOrAttachment.length : 0
+  const stats = {size, mtime: Date.now()}
 
   return {key, checksum, attachment, value, stats}
 }

--- a/packages/cli-kit/src/public/node/themes/factories.ts
+++ b/packages/cli-kit/src/public/node/themes/factories.ts
@@ -45,6 +45,8 @@ export function buildChecksum(asset?: RemoteAssetResponse): Checksum | undefined
   return {key, checksum}
 }
 
+export function buildThemeAsset(asset: undefined): undefined
+export function buildThemeAsset(asset: RemoteAssetResponse): ThemeAsset
 export function buildThemeAsset(asset?: RemoteAssetResponse): ThemeAsset | undefined {
   if (!asset) return
 


### PR DESCRIPTION
Backport [[Themes] Account for empty assets when calculating theme asset size by jamesmengo · Pull Request #4475 · Shopify/cli](https://github.com/Shopify/cli/pull/4475/commits) which fixes #4470