### PR TITLE
Add restriction to only allow one customer account page render per extension

### DIFF
--- a/.changeset/itchy-peas-cheer.md
+++ b/.changeset/itchy-peas-cheer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Add restriction to only allow one customer account page render per extension

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -324,6 +324,39 @@ Please check the configuration in ${uiExtension.configurationPath}`),
         )
       })
     })
+
+    test('returns err(message) when there are both customer-account.order.page.render and customer-account.order.render targets', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        // Given
+        await mkdir(joinPath(tmpDir, 'src'))
+        await touchFile(joinPath(tmpDir, 'src', 'ExtensionPointA.js'))
+        await touchFile(joinPath(tmpDir, 'src', 'ExtensionPointB.js'))
+
+        const uiExtension = await getTestUIExtension({
+          directory: tmpDir,
+          extensionPoints: [
+            {
+              target: 'customer-account.order.page.render',
+              module: './src/ExtensionPointA.js',
+            },
+            {
+              target: 'customer-account.page.render',
+              module: './src/ExtensionPointB.js',
+            },
+          ],
+        })
+
+        // When
+        const result = await uiExtension.validate()
+
+        // Then
+        expect(result).toEqual(
+          err(`An extension can't target both 'customer-account.order.page.render' and 'customer-account.page.render'
+
+Please check the configuration in ${uiExtension.configurationPath}`),
+        )
+      })
+    })
   })
 
   describe('deployConfig()', () => {

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -107,6 +107,14 @@ Please check the module path for ${target}`.value,
     }
   }
 
+  if (
+    uniqueTargets.indexOf('customer-account.order.page.render') >= 0 &&
+    uniqueTargets.indexOf('customer-account.page.render') >= 0
+  ) {
+    errors.push(
+      `An extension can't target both 'customer-account.order.page.render' and 'customer-account.page.render'`,
+    )
+  }
   if (duplicateTargets.length) {
     errors.push(`Duplicate targets found: ${duplicateTargets.join(', ')}\nExtension point targets must be unique`)
   }


### PR DESCRIPTION
### WHY are these changes introduced?


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
