### PR TITLE
Fix Theme Access authentication on `shopify theme dev` and `shopify theme console` commands

### DIFF
--- a/.changeset/hip-chefs-dance.md
+++ b/.changeset/hip-chefs-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix Theme Access authentication on `shopify theme dev` and `shopify theme console` commands

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
@@ -50,7 +50,11 @@ async function fetchDevServerSession(
 
   const session = await ensureAuthenticatedThemes(adminSession.storeFqdn, adminPassword, [])
   const storefrontToken = await ensureAuthenticatedStorefront([], adminPassword)
-  const sessionCookies = await getStorefrontSessionCookies(baseUrl, themeId, storefrontPassword, {})
+  const sessionCookies = await getStorefrontSessionCookies(baseUrl, themeId, storefrontPassword, {
+    'X-Shopify-Shop': session.storeFqdn,
+    'X-Shopify-Access-Token': session.token,
+    Authorization: `Bearer ${storefrontToken}`,
+  })
 
   return {
     ...session,

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.test.ts
@@ -12,7 +12,7 @@ vi.mock('@shopify/cli-kit/node/http', async () => {
   }
 })
 
-const successResponse = {ok: true, status: 200, headers: {get: vi.fn()}} as any
+const successResponse = {ok: true, status: 200, headers: {get: vi.fn(), delete: vi.fn()}} as any
 
 const session: DevServerSession = {
   token: 'admin_token_abc123',
@@ -50,6 +50,7 @@ describe('render', () => {
 
     // Then
     expect(response.status).toEqual(200)
+    expect(response.headers.delete).toBeCalled()
     expect(fetch).toHaveBeenCalledWith(
       'https://store.myshopify.com/products/1?_fd=0&pb=0',
       expect.objectContaining({
@@ -74,6 +75,7 @@ describe('render', () => {
 
     // Then
     expect(response.status).toEqual(200)
+    expect(response.headers.delete).toBeCalled()
     expect(fetch).toHaveBeenCalledWith(
       'https://theme-kit-access.shopifyapps.com/cli/sfr/products/1?_fd=0&pb=0',
       expect.objectContaining({
@@ -109,6 +111,7 @@ describe('render', () => {
 
     // Then
     expect(response.status).toEqual(200)
+    expect(response.headers.delete).toBeCalled()
     expect(fetch).toHaveBeenCalledWith(
       'https://store.myshopify.com/products/1?_fd=0&pb=0&section_id=sections--1__announcement-bar',
       expect.objectContaining({
@@ -135,6 +138,7 @@ describe('render', () => {
 
     // Then
     expect(response.status).toEqual(200)
+    expect(response.headers.delete).toBeCalled()
     expect(fetch).toHaveBeenCalledWith(
       'https://store.myshopify.com/products/1?_fd=0&pb=0&app_block_id=00001111222233334444',
       expect.objectContaining({
@@ -162,6 +166,7 @@ describe('render', () => {
 
     // Then
     expect(response.status).toEqual(200)
+    expect(response.headers.delete).toBeCalled()
     expect(fetch).toHaveBeenCalledWith(
       'https://store.myshopify.com/products/1?_fd=0&pb=0&section_id=sections--1__announcement-bar',
       expect.objectContaining({
@@ -191,6 +196,7 @@ describe('render', () => {
 
     // Then
     expect(response.status).toEqual(200)
+    expect(response.headers.delete).toBeCalled()
     expect(fetch).toHaveBeenCalledWith(
       'https://store.myshopify.com/products/1?_fd=0&pb=0&value=A&value=B',
       expect.objectContaining({

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
@@ -34,6 +34,13 @@ export async function render(session: DevServerSession, context: DevServerRender
   const requestId = response.headers.get('x-request-id')
   outputDebug(`← ${response.status} (request_id: ${requestId})`)
 
+  /**
+   * Theme Access app requests return the 'application/json' content type.
+   * However, patched renderings will never patch JSON requests; so we're
+   * consistently discarding the content type.
+   */
+  response.headers.delete('Content-Type')
+
   return response
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/4477

The `shopify theme console` command was failing since [this change](https://github.com/Shopify/cli/pull/4376), because the Theme Access requests need the `Authorization` header.

### WHAT is this pull request doing?

This PR now just passes the `Authorization` header as we already have it at the moment the session is initialized.

This PR also avoids propagating the content-type of the SFR response, because when it's being proxied by the Theme Access app, that content-type is set to `application/json` (we're not introducing any branching code here, to protect the CLI from future changes, and in the end, the content-type should never be `application/json`).

### How to test your changes?

Use the following command passing the Theme Access token:

- Install the Theme Access app in your store
- Generate a  Theme Access app password
- Run `shopify theme dev --password <your_theme_access_password> --store <your_store>`
- Run `shopify theme console --password <your_theme_access_password> --store <your_store>`

**Before:**
![Screenshot 2024-09-20 at 08 11 33](https://github.com/user-attachments/assets/37acc28f-dd8b-4bb4-b538-97aba3185580)

**After:**
![Screenshot 2024-09-20 at 08 11 04](https://github.com/user-attachments/assets/219a88ad-f777-45ed-ba12-c455584d6624)


### Post-release steps

N/a

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
