### PR TITLE
Enforce that all commands load an app

### DIFF
--- a/packages/app/src/cli/commands/app/app-logs/sources.ts
+++ b/packages/app/src/cli/commands/app/app-logs/sources.ts
@@ -1,12 +1,12 @@
 import {appFlags} from '../../../flags.js'
 import {AppInterface} from '../../../models/app/app.js'
 import {loadApp} from '../../../models/app/loader.js'
-import Command from '../../../utilities/app-command.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {sources} from '../../../services/app-logs/sources.js'
+import AppCommand from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
-export default class Sources extends Command {
+export default class Sources extends AppCommand {
   static summary = 'Print out a list of sources that may be used with the logs command.'
 
   static descriptionWithMarkdown = `The output source names can be used with the \`--source\` argument of \`shopify app logs\` to filter log output. Currently only function extensions are supported as sources.`

--- a/packages/app/src/cli/commands/app/app-logs/sources.ts
+++ b/packages/app/src/cli/commands/app/app-logs/sources.ts
@@ -3,7 +3,7 @@ import {AppInterface} from '../../../models/app/app.js'
 import {loadApp} from '../../../models/app/loader.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {sources} from '../../../services/app-logs/sources.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
 export default class Sources extends AppCommand {
@@ -18,7 +18,7 @@ export default class Sources extends AppCommand {
     ...appFlags,
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(Sources)
     const specifications = await loadLocalExtensionsSpecifications()
     const app: AppInterface = await loadApp({
@@ -33,5 +33,6 @@ export default class Sources extends AppCommand {
     } else {
       sources(app)
     }
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/build.ts
+++ b/packages/app/src/cli/commands/app/build.ts
@@ -2,14 +2,14 @@ import {appFlags} from '../../flags.js'
 import {AppInterface} from '../../models/app/app.js'
 import {loadApp} from '../../models/app/loader.js'
 import build from '../../services/build.js'
-import Command from '../../utilities/app-command.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import AppCommand from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
-export default class Build extends Command {
+export default class Build extends AppCommand {
   static summary = 'Build the app, including extensions.'
 
   static descriptionWithMarkdown = `This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration).

--- a/packages/app/src/cli/commands/app/build.ts
+++ b/packages/app/src/cli/commands/app/build.ts
@@ -4,7 +4,7 @@ import {loadApp} from '../../models/app/loader.js'
 import build from '../../services/build.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
-import AppCommand from '../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
@@ -41,7 +41,7 @@ export default class Build extends AppCommand {
     }),
   }
 
-  async run(): Promise<void> {
+  async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(Build)
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
@@ -59,5 +59,7 @@ export default class Build extends AppCommand {
       userProvidedConfigName: flags.config,
     })
     await build({app, skipDependenciesInstallation: flags['skip-dependencies-installation'], apiKey})
+
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/config/link.ts
+++ b/packages/app/src/cli/commands/app/config/link.ts
@@ -1,10 +1,10 @@
 import {appFlags} from '../../../flags.js'
 import link, {LinkOptions} from '../../../services/app/config/link.js'
-import Command from '../../../utilities/app-command.js'
+import AppCommand from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
-export default class ConfigLink extends Command {
+export default class ConfigLink extends AppCommand {
   static summary = 'Fetch your app configuration from the Partner Dashboard.'
 
   static descriptionWithMarkdown = `Pulls app configuration from the Partner Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.

--- a/packages/app/src/cli/commands/app/config/link.ts
+++ b/packages/app/src/cli/commands/app/config/link.ts
@@ -1,6 +1,8 @@
 import {appFlags} from '../../../flags.js'
+import {loadApp} from '../../../models/app/loader.js'
+import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import link, {LinkOptions} from '../../../services/app/config/link.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
@@ -24,7 +26,7 @@ export default class ConfigLink extends AppCommand {
     }),
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(ConfigLink)
 
     const options: LinkOptions = {
@@ -33,5 +35,15 @@ export default class ConfigLink extends AppCommand {
     }
 
     await link(options)
+
+    const specifications = await loadLocalExtensionsSpecifications()
+
+    const app = await loadApp({
+      specifications,
+      directory: flags.path,
+      userProvidedConfigName: undefined,
+    })
+
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/config/use.ts
+++ b/packages/app/src/cli/commands/app/config/use.ts
@@ -1,7 +1,8 @@
 import {appFlags} from '../../../flags.js'
-import {checkFolderIsValidApp} from '../../../models/app/loader.js'
+import {checkFolderIsValidApp, loadApp} from '../../../models/app/loader.js'
+import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import use from '../../../services/app/config/use.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {Args, Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
@@ -35,10 +36,20 @@ export default class ConfigUse extends AppCommand {
     }),
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags, args} = await this.parse(ConfigUse)
 
     await checkFolderIsValidApp(flags.path)
     await use({directory: flags.path, configName: args.config, reset: flags.reset})
+
+    const specifications = await loadLocalExtensionsSpecifications()
+
+    const app = await loadApp({
+      specifications,
+      directory: flags.path,
+      userProvidedConfigName: undefined,
+    })
+
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/config/use.ts
+++ b/packages/app/src/cli/commands/app/config/use.ts
@@ -1,7 +1,7 @@
 import {appFlags} from '../../../flags.js'
 import {checkFolderIsValidApp} from '../../../models/app/loader.js'
 import use from '../../../services/app/config/use.js'
-import Command from '../../../utilities/app-command.js'
+import AppCommand from '../../../utilities/app-command.js'
 import {Args, Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
@@ -9,7 +9,7 @@ import {globalFlags} from '@shopify/cli-kit/node/cli'
 // `--config` flag, because we're passing it as an argument.
 const {config, ...appFlagsWithoutConfig} = appFlags
 
-export default class ConfigUse extends Command {
+export default class ConfigUse extends AppCommand {
   static summary = 'Activate an app configuration.'
 
   static descriptionWithMarkdown = `Sets default configuration when you run app-related CLI commands. If you omit the \`config-name\` parameter, then you'll be prompted to choose from the configuration files in your project.`

--- a/packages/app/src/cli/commands/app/demo/watcher.ts
+++ b/packages/app/src/cli/commands/app/demo/watcher.ts
@@ -3,7 +3,7 @@ import {AppInterface} from '../../../models/app/app.js'
 import {loadApp} from '../../../models/app/loader.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {AppEventWatcher, EventType} from '../../../services/dev/app-events/app-event-watcher.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import colors from '@shopify/cli-kit/node/colors'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
@@ -18,7 +18,7 @@ export default class DemoWatcher extends AppCommand {
     ...appFlags,
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(DemoWatcher)
     const specifications = await loadLocalExtensionsSpecifications()
     const app: AppInterface = await loadApp({
@@ -55,5 +55,6 @@ export default class DemoWatcher extends AppCommand {
 
     // Just to keep the process running
     setInterval(() => {}, 1 << 30)
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/demo/watcher.ts
+++ b/packages/app/src/cli/commands/app/demo/watcher.ts
@@ -1,15 +1,15 @@
 import {appFlags} from '../../../flags.js'
 import {AppInterface} from '../../../models/app/app.js'
 import {loadApp} from '../../../models/app/loader.js'
-import Command from '../../../utilities/app-command.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {AppEventWatcher, EventType} from '../../../services/dev/app-events/app-event-watcher.js'
+import AppCommand from '../../../utilities/app-command.js'
 import colors from '@shopify/cli-kit/node/colors'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 import {endHRTimeInMs} from '@shopify/cli-kit/node/hrtime'
 
-export default class DemoWatcher extends Command {
+export default class DemoWatcher extends AppCommand {
   static summary = 'Watch and prints out changes to an app.'
   static hidden = true
 

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -7,7 +7,7 @@ import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.j
 import {validateMessage} from '../../validations/message.js'
 import metadata from '../../metadata.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
-import AppCommand from '../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
@@ -77,7 +77,7 @@ export default class Deploy extends AppCommand {
     }),
   }
 
-  async run(): Promise<void> {
+  async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(Deploy)
 
     await metadata.addPublicMetadata(() => ({
@@ -110,7 +110,7 @@ export default class Deploy extends AppCommand {
     if (!apiKey && !app.configuration.client_id) requiredNonTTYFlags.push('client-id')
     this.failMissingNonTTYFlags(flags, requiredNonTTYFlags)
 
-    await deploy({
+    const result = await deploy({
       app,
       apiKey,
       reset: flags.reset,
@@ -120,5 +120,7 @@ export default class Deploy extends AppCommand {
       version: flags.version,
       commitReference: flags['source-control-url'],
     })
+
+    return {app: result.app}
   }
 }

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -3,16 +3,16 @@ import {deploy} from '../../services/deploy.js'
 import {AppInterface} from '../../models/app/app.js'
 import {loadApp} from '../../models/app/loader.js'
 import {validateVersion} from '../../validations/version-name.js'
-import Command from '../../utilities/app-command.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {validateMessage} from '../../validations/message.js'
 import metadata from '../../metadata.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import AppCommand from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
-export default class Deploy extends Command {
+export default class Deploy extends AppCommand {
   static summary = 'Deploy your Shopify app.'
 
   static descriptionWithMarkdown = `[Builds the app](https://shopify.dev/docs/api/shopify-cli/app/app-build), then deploys your app configuration and extensions.

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -2,7 +2,7 @@ import {appFlags} from '../../flags.js'
 import {dev, DevOptions} from '../../services/dev.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {checkFolderIsValidApp} from '../../models/app/loader.js'
-import AppCommand from '../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -142,7 +142,7 @@ If you're using the PHP or Ruby app template, then you need to complete the foll
     return 'app dev stop'
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(Dev)
 
     if (!flags['api-key']) {
@@ -186,6 +186,7 @@ If you're using the PHP or Ruby app template, then you need to complete the foll
       devPreview: !flags.legacy,
     }
 
-    await dev(devOptions)
+    const result = await dev(devOptions)
+    return {app: result.app}
   }
 }

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -1,14 +1,14 @@
 import {appFlags} from '../../flags.js'
 import {dev, DevOptions} from '../../services/dev.js'
-import Command from '../../utilities/app-command.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {checkFolderIsValidApp} from '../../models/app/loader.js'
+import AppCommand from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
-export default class Dev extends Command {
+export default class Dev extends AppCommand {
   static summary = 'Run the app.'
 
   static descriptionWithMarkdown = `[Builds the app](https://shopify.dev/docs/api/shopify-cli/app/app-build) and lets you preview it on a [development store](https://shopify.dev/docs/apps/tools/development-stores) or [Plus sandbox store](https://help.shopify.com/partners/dashboard/managing-stores/plus-sandbox-store).

--- a/packages/app/src/cli/commands/app/env/pull.ts
+++ b/packages/app/src/cli/commands/app/env/pull.ts
@@ -2,14 +2,14 @@ import {appFlags} from '../../../flags.js'
 import {AppInterface} from '../../../models/app/app.js'
 import {getDotEnvFileName, loadApp} from '../../../models/app/loader.js'
 import {pullEnv} from '../../../services/app/env/pull.js'
-import Command from '../../../utilities/app-command.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
+import AppCommand from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
-export default class EnvPull extends Command {
+export default class EnvPull extends AppCommand {
   static summary = 'Pull app and extensions environment variables.'
 
   static descriptionWithMarkdown = `Creates or updates an \`.env\` files that contains app and app extension environment variables.

--- a/packages/app/src/cli/commands/app/env/pull.ts
+++ b/packages/app/src/cli/commands/app/env/pull.ts
@@ -3,7 +3,7 @@ import {AppInterface} from '../../../models/app/app.js'
 import {getDotEnvFileName, loadApp} from '../../../models/app/loader.js'
 import {pullEnv} from '../../../services/app/env/pull.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
@@ -28,7 +28,7 @@ export default class EnvPull extends AppCommand {
     }),
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(EnvPull)
     const specifications = await loadLocalExtensionsSpecifications()
     const app: AppInterface = await loadApp({
@@ -39,5 +39,6 @@ export default class EnvPull extends AppCommand {
     })
     const envFile = joinPath(app.directory, flags['env-file'] ?? getDotEnvFileName(app.configuration.path))
     outputInfo(await pullEnv(app, {envFile}))
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/env/show.ts
+++ b/packages/app/src/cli/commands/app/env/show.ts
@@ -3,11 +3,11 @@ import {AppInterface} from '../../../models/app/app.js'
 import {loadApp} from '../../../models/app/loader.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {showEnv} from '../../../services/app/env/show.js'
-import Command from '../../../utilities/app-command.js'
+import AppCommand from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 
-export default class EnvShow extends Command {
+export default class EnvShow extends AppCommand {
   static summary = 'Display app and extensions environment variables.'
 
   static descriptionWithMarkdown = `Displays environment variables that can be used to deploy apps and app extensions.`

--- a/packages/app/src/cli/commands/app/env/show.ts
+++ b/packages/app/src/cli/commands/app/env/show.ts
@@ -3,7 +3,7 @@ import {AppInterface} from '../../../models/app/app.js'
 import {loadApp} from '../../../models/app/loader.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {showEnv} from '../../../services/app/env/show.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 
@@ -19,7 +19,7 @@ export default class EnvShow extends AppCommand {
     ...appFlags,
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(EnvShow)
     const specifications = await loadLocalExtensionsSpecifications()
     const app: AppInterface = await loadApp({
@@ -29,5 +29,6 @@ export default class EnvShow extends AppCommand {
       mode: 'report',
     })
     outputInfo(await showEnv(app))
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/function/build.ts
+++ b/packages/app/src/cli/commands/app/function/build.ts
@@ -1,7 +1,7 @@
 import {inFunctionContext, functionFlags} from '../../../services/function/common.js'
 import {buildFunctionExtension} from '../../../services/build/extension.js'
 import {appFlags} from '../../../flags.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 
@@ -18,9 +18,9 @@ export default class FunctionBuild extends AppCommand {
     ...functionFlags,
   }
 
-  public async run() {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(FunctionBuild)
-    await inFunctionContext({
+    const app = await inFunctionContext({
       path: flags.path,
       userProvidedConfigName: flags.config,
       callback: async (app, ourFunction) => {
@@ -32,7 +32,9 @@ export default class FunctionBuild extends AppCommand {
           environment: 'production',
         })
         renderSuccess({headline: 'Function built successfully.'})
+        return app
       },
     })
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/function/build.ts
+++ b/packages/app/src/cli/commands/app/function/build.ts
@@ -1,11 +1,11 @@
 import {inFunctionContext, functionFlags} from '../../../services/function/common.js'
 import {buildFunctionExtension} from '../../../services/build/extension.js'
 import {appFlags} from '../../../flags.js'
-import Command from '@shopify/cli-kit/node/base-command'
+import AppCommand from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 
-export default class FunctionBuild extends Command {
+export default class FunctionBuild extends AppCommand {
   static summary = 'Compile a function to wasm.'
 
   static descriptionWithMarkdown = `Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.`

--- a/packages/app/src/cli/commands/app/function/replay.ts
+++ b/packages/app/src/cli/commands/app/function/replay.ts
@@ -2,7 +2,7 @@ import {functionFlags, inFunctionContext} from '../../../services/function/commo
 import {replay} from '../../../services/function/replay.js'
 import {appFlags} from '../../../flags.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 
@@ -51,14 +51,14 @@ export default class FunctionReplay extends AppCommand {
     }),
   }
 
-  public async run() {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(FunctionReplay)
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
     }
     const apiKey = flags['client-id'] || flags['api-key']
 
-    await inFunctionContext({
+    const app = await inFunctionContext({
       path: flags.path,
       userProvidedConfigName: flags.config,
       callback: async (app, ourFunction) => {
@@ -71,7 +71,9 @@ export default class FunctionReplay extends AppCommand {
           json: flags.json,
           watch: flags.watch,
         })
+        return app
       },
     })
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/function/replay.ts
+++ b/packages/app/src/cli/commands/app/function/replay.ts
@@ -2,11 +2,11 @@ import {functionFlags, inFunctionContext} from '../../../services/function/commo
 import {replay} from '../../../services/function/replay.js'
 import {appFlags} from '../../../flags.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
-import Command from '@shopify/cli-kit/node/base-command'
+import AppCommand from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 
-export default class FunctionReplay extends Command {
+export default class FunctionReplay extends AppCommand {
   static summary = 'Replays a function run from an app log.'
 
   static descriptionWithMarkdown = `Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).`

--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -1,7 +1,7 @@
 import {functionFlags, inFunctionContext, getOrGenerateSchemaPath} from '../../../services/function/common.js'
 import {runFunction} from '../../../services/function/runner.js'
 import {appFlags} from '../../../flags.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 import {renderAutocompletePrompt, isTTY} from '@shopify/cli-kit/node/ui'
@@ -39,9 +39,9 @@ export default class FunctionRun extends AppCommand {
     }),
   }
 
-  public async run() {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(FunctionRun)
-    await inFunctionContext({
+    const app = await inFunctionContext({
       path: flags.path,
       userProvidedConfigName: flags.config,
       callback: async (app, ourFunction) => {
@@ -91,7 +91,10 @@ export default class FunctionRun extends AppCommand {
           schemaPath,
           queryPath,
         })
+        return app
       },
     })
+
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -1,7 +1,7 @@
 import {functionFlags, inFunctionContext, getOrGenerateSchemaPath} from '../../../services/function/common.js'
 import {runFunction} from '../../../services/function/runner.js'
 import {appFlags} from '../../../flags.js'
-import Command from '@shopify/cli-kit/node/base-command'
+import AppCommand from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 import {renderAutocompletePrompt, isTTY} from '@shopify/cli-kit/node/ui'
@@ -9,7 +9,7 @@ import {outputDebug} from '@shopify/cli-kit/node/output'
 
 const DEFAULT_FUNCTION_EXPORT = '_start'
 
-export default class FunctionRun extends Command {
+export default class FunctionRun extends AppCommand {
   static summary = 'Run a function locally for testing.'
 
   static descriptionWithMarkdown = `Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).`

--- a/packages/app/src/cli/commands/app/function/schema.ts
+++ b/packages/app/src/cli/commands/app/function/schema.ts
@@ -2,7 +2,7 @@ import {generateSchemaService} from '../../../services/generate-schema.js'
 import {functionFlags, inFunctionContext} from '../../../services/function/common.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
 import {appFlags} from '../../../flags.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
@@ -40,14 +40,14 @@ export default class FetchSchema extends AppCommand {
     }),
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(FetchSchema)
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
     }
     const apiKey = flags['client-id'] || flags['api-key']
 
-    await inFunctionContext({
+    const app = await inFunctionContext({
       path: flags.path,
       userProvidedConfigName: flags.config,
       callback: async (app, ourFunction) => {
@@ -58,7 +58,10 @@ export default class FetchSchema extends AppCommand {
           stdout: flags.stdout,
           path: flags.path,
         })
+        return app
       },
     })
+
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/function/schema.ts
+++ b/packages/app/src/cli/commands/app/function/schema.ts
@@ -2,11 +2,11 @@ import {generateSchemaService} from '../../../services/generate-schema.js'
 import {functionFlags, inFunctionContext} from '../../../services/function/common.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
 import {appFlags} from '../../../flags.js'
+import AppCommand from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import Command from '@shopify/cli-kit/node/base-command'
 
-export default class FetchSchema extends Command {
+export default class FetchSchema extends AppCommand {
   static summary = 'Fetch the latest GraphQL schema for a function.'
 
   static descriptionWithMarkdown = `Generates the latest [GraphQL schema](https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.

--- a/packages/app/src/cli/commands/app/function/typegen.ts
+++ b/packages/app/src/cli/commands/app/function/typegen.ts
@@ -1,11 +1,11 @@
 import {functionFlags, inFunctionContext} from '../../../services/function/common.js'
 import {buildGraphqlTypes} from '../../../services/function/build.js'
 import {appFlags} from '../../../flags.js'
-import Command from '@shopify/cli-kit/node/base-command'
+import AppCommand from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 
-export default class FunctionTypegen extends Command {
+export default class FunctionTypegen extends AppCommand {
   static summary = 'Generate GraphQL types for a JavaScript function.'
 
   static descriptionWithMarkdown = `Creates GraphQL types based on your [input query](https://shopify.dev/docs/apps/functions/input-output#input) for a function written in JavaScript.`

--- a/packages/app/src/cli/commands/app/function/typegen.ts
+++ b/packages/app/src/cli/commands/app/function/typegen.ts
@@ -20,13 +20,15 @@ export default class FunctionTypegen extends AppCommand {
 
   public async run() {
     const {flags} = await this.parse(FunctionTypegen)
-    await inFunctionContext({
+    const app = await inFunctionContext({
       path: flags.path,
       userProvidedConfigName: flags.config,
       callback: async (app, ourFunction) => {
         await buildGraphqlTypes(ourFunction, {stdout: process.stdout, stderr: process.stderr, app})
         renderSuccess({headline: 'GraphQL types generated successfully.'})
+        return app
       },
     })
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -1,14 +1,14 @@
 import {appFlags} from '../../../flags.js'
 import metadata from '../../../metadata.js'
-import Command from '../../../utilities/app-command.js'
 import generate from '../../../services/generate.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
 import {checkFolderIsValidApp} from '../../../models/app/loader.js'
+import AppCommand from '../../../utilities/app-command.js'
 import {Args, Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
 
-export default class AppGenerateExtension extends Command {
+export default class AppGenerateExtension extends AppCommand {
   static summary = 'Generate a new app Extension.'
   static examples = ['<%= config.bin %> <%= command.id %>']
 

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -3,7 +3,7 @@ import metadata from '../../../metadata.js'
 import generate from '../../../services/generate.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
 import {checkFolderIsValidApp} from '../../../models/app/loader.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {Args, Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
@@ -82,7 +82,7 @@ export default class AppGenerateExtension extends AppCommand {
     return 'app scaffold extension'
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(AppGenerateExtension)
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
@@ -100,12 +100,12 @@ export default class AppGenerateExtension extends AppCommand {
         headline: ['The flag --type has been deprecated in favor of --template.'],
         body: ['Please use --template instead.'],
       })
-      return
+      process.exit(2)
     }
 
     await checkFolderIsValidApp(flags.path)
 
-    await generate({
+    const result = await generate({
       directory: flags.path,
       reset: flags.reset,
       apiKey,
@@ -115,5 +115,7 @@ export default class AppGenerateExtension extends AppCommand {
       flavor: flags.flavor,
       configName: flags.config,
     })
+
+    return {app: result.app}
   }
 }

--- a/packages/app/src/cli/commands/app/generate/schema.ts
+++ b/packages/app/src/cli/commands/app/generate/schema.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @shopify/cli/app-commands-requirements */
 import FetchSchema from '../function/schema.js'
 
 export default class GenerateSchema extends FetchSchema {

--- a/packages/app/src/cli/commands/app/import-extensions.ts
+++ b/packages/app/src/cli/commands/app/import-extensions.ts
@@ -7,7 +7,7 @@ import {loadApp} from '../../models/app/loader.js'
 import {AppInterface} from '../../models/app/app.js'
 import {importExtensions} from '../../services/import-extensions.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
-import AppCommand from '../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {renderSelectPrompt, renderFatalError} from '@shopify/cli-kit/node/ui'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -67,7 +67,7 @@ export default class ImportExtensions extends AppCommand {
     }),
   }
 
-  async run(): Promise<void> {
+  async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(ImportExtensions)
     const specifications = await loadLocalExtensionsSpecifications()
     const app: AppInterface = await loadApp({
@@ -84,7 +84,7 @@ export default class ImportExtensions extends AppCommand {
     const migrationChoice = migrationChoices.find((choice) => choice.value === promptAnswer)
     if (migrationChoice === undefined) {
       renderFatalError(new AbortError('Invalid migration choice'))
-      return
+      return {app}
     }
     await importExtensions({
       app,
@@ -92,5 +92,7 @@ export default class ImportExtensions extends AppCommand {
       extensionTypes: migrationChoice.extensionTypes,
       buildTomlObject: migrationChoice.buildTomlObject,
     })
+
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/import-extensions.ts
+++ b/packages/app/src/cli/commands/app/import-extensions.ts
@@ -6,8 +6,8 @@ import {appFlags} from '../../flags.js'
 import {loadApp} from '../../models/app/loader.js'
 import {AppInterface} from '../../models/app/app.js'
 import {importExtensions} from '../../services/import-extensions.js'
-import Command from '../../utilities/app-command.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import AppCommand from '../../utilities/app-command.js'
 import {renderSelectPrompt, renderFatalError} from '@shopify/cli-kit/node/ui'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -53,7 +53,7 @@ const getMigrationChoices = (isShopifolk: boolean): MigrationChoice[] => [
     : []),
 ]
 
-export default class ImportExtensions extends Command {
+export default class ImportExtensions extends AppCommand {
   static description = 'Import dashboard-managed extensions into your app.'
 
   static flags = {

--- a/packages/app/src/cli/commands/app/info.ts
+++ b/packages/app/src/cli/commands/app/info.ts
@@ -3,7 +3,7 @@ import {AppInterface} from '../../models/app/app.js'
 import {Format, info} from '../../services/info.js'
 import {loadApp} from '../../models/app/loader.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
-import AppCommand from '../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
@@ -36,7 +36,7 @@ export default class AppInfo extends AppCommand {
     }),
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(AppInfo)
     const specifications = await loadLocalExtensionsSpecifications()
     const app: AppInterface = await loadApp({
@@ -53,5 +53,6 @@ export default class AppInfo extends AppCommand {
       }),
     )
     if (app.errors) process.exit(2)
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/info.ts
+++ b/packages/app/src/cli/commands/app/info.ts
@@ -2,13 +2,13 @@ import {appFlags} from '../../flags.js'
 import {AppInterface} from '../../models/app/app.js'
 import {Format, info} from '../../services/info.js'
 import {loadApp} from '../../models/app/loader.js'
-import Command from '../../utilities/app-command.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import AppCommand from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 
-export default class AppInfo extends Command {
+export default class AppInfo extends AppCommand {
   static summary = 'Print basic information about your app and extensions.'
 
   static descriptionWithMarkdown = `The information returned includes the following:

--- a/packages/app/src/cli/commands/app/init.ts
+++ b/packages/app/src/cli/commands/app/init.ts
@@ -6,8 +6,8 @@ import {selectOrCreateApp} from '../../services/dev/select-app.js'
 import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {validateFlavorValue, validateTemplateValue} from '../../services/init/validate.js'
 import {OrganizationApp} from '../../models/organization.js'
-import {fetchSpecifications} from '../../services/generate/fetch-extension-specifications.js'
 import {loadApp} from '../../models/app/loader.js'
+import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
@@ -118,10 +118,7 @@ export default class Init extends AppCommand {
       },
     })
 
-    const specifications = await fetchSpecifications({
-      developerPlatformClient: platformClient,
-      app: selectedApp,
-    })
+    const specifications = await loadLocalExtensionsSpecifications()
 
     const app = await loadApp({
       specifications,

--- a/packages/app/src/cli/commands/app/logs.ts
+++ b/packages/app/src/cli/commands/app/logs.ts
@@ -1,13 +1,13 @@
 import Dev from './dev.js'
-import Command from '../../utilities/app-command.js'
 import {checkFolderIsValidApp} from '../../models/app/loader.js'
 import {logs, Format} from '../../services/logs.js'
 import {appFlags} from '../../flags.js'
+import AppCommand from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
-export default class Logs extends Command {
+export default class Logs extends AppCommand {
   static summary = 'Stream detailed logs for your Shopify app.'
 
   static descriptionWithMarkdown = `

--- a/packages/app/src/cli/commands/app/logs.ts
+++ b/packages/app/src/cli/commands/app/logs.ts
@@ -2,7 +2,7 @@ import Dev from './dev.js'
 import {checkFolderIsValidApp} from '../../models/app/loader.js'
 import {logs, Format} from '../../services/logs.js'
 import {appFlags} from '../../flags.js'
-import AppCommand from '../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -51,7 +51,7 @@ export default class Logs extends AppCommand {
     }),
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(Logs)
 
     const apiKey = flags['client-id'] || flags['api-key']
@@ -68,6 +68,7 @@ export default class Logs extends AppCommand {
       format: (flags.json ? 'json' : 'text') as Format,
     }
 
-    await logs(logOptions)
+    const app = await logs(logOptions)
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -4,7 +4,7 @@ import {loadApp} from '../../models/app/loader.js'
 import {release} from '../../services/release.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
-import AppCommand from '../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
@@ -53,7 +53,7 @@ export default class Release extends AppCommand {
     }),
   }
 
-  async run(): Promise<void> {
+  async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(Release)
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
@@ -82,5 +82,7 @@ export default class Release extends AppCommand {
       force: flags.force,
       version: flags.version,
     })
+
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -1,15 +1,15 @@
 import {appFlags} from '../../flags.js'
 import {AppInterface} from '../../models/app/app.js'
 import {loadApp} from '../../models/app/loader.js'
-import Command from '../../utilities/app-command.js'
 import {release} from '../../services/release.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import AppCommand from '../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
-export default class Release extends Command {
+export default class Release extends AppCommand {
   static summary = 'Release an app version.'
 
   static usage = `app:release --version <version>`

--- a/packages/app/src/cli/commands/app/scaffold/extension.ts
+++ b/packages/app/src/cli/commands/app/scaffold/extension.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @shopify/cli/app-commands-requirements */
 import AppGenerateExtension from '../generate/extension.js'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
 

--- a/packages/app/src/cli/commands/app/scaffold/extension.ts
+++ b/packages/app/src/cli/commands/app/scaffold/extension.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @shopify/cli/app-commands-requirements */
+import {AppCommandOutput} from '../../../utilities/app-command.js'
 import AppGenerateExtension from '../generate/extension.js'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
 
 class AppScaffoldExtension extends AppGenerateExtension {
   static description = 'Scaffold an Extension.'
   static hidden = true
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     renderWarning({
       headline: [
         'The command',
@@ -18,7 +19,7 @@ class AppScaffoldExtension extends AppGenerateExtension {
         "script in the project's package.json.",
       ],
     })
-    await super.run()
+    return super.run()
   }
 }
 

--- a/packages/app/src/cli/commands/app/versions/list.ts
+++ b/packages/app/src/cli/commands/app/versions/list.ts
@@ -4,7 +4,7 @@ import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load
 import {AppInterface} from '../../../models/app/app.js'
 import {loadApp} from '../../../models/app/loader.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Args, Flags} from '@oclif/core'
 
@@ -43,7 +43,7 @@ export default class VersionsList extends AppCommand {
     file: Args.string(),
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(VersionsList)
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
@@ -62,5 +62,7 @@ export default class VersionsList extends AppCommand {
       reset: false,
       json: flags.json,
     })
+
+    return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/versions/list.ts
+++ b/packages/app/src/cli/commands/app/versions/list.ts
@@ -1,14 +1,14 @@
 import {appFlags} from '../../../flags.js'
-import Command from '../../../utilities/app-command.js'
 import versionList from '../../../services/versions-list.js'
 import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load-specifications.js'
 import {AppInterface} from '../../../models/app/app.js'
 import {loadApp} from '../../../models/app/loader.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
+import AppCommand from '../../../utilities/app-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Args, Flags} from '@oclif/core'
 
-export default class VersionsList extends Command {
+export default class VersionsList extends AppCommand {
   static summary = 'List deployed versions of your app.'
 
   static descriptionWithMarkdown = `Lists the deployed app versions. An app version is a snapshot of your app extensions.`

--- a/packages/app/src/cli/commands/app/webhook/trigger.ts
+++ b/packages/app/src/cli/commands/app/webhook/trigger.ts
@@ -2,11 +2,11 @@ import {DELIVERY_METHOD, WebhookTriggerFlags} from '../../../services/webhook/tr
 import {webhookTriggerService} from '../../../services/webhook/trigger.js'
 import {deliveryMethodInstructionsAsString} from '../../../prompts/webhook/trigger.js'
 import {appFlags} from '../../../flags.js'
+import AppCommand from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
-import Command from '@shopify/cli-kit/node/base-command'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
 
-export default class WebhookTrigger extends Command {
+export default class WebhookTrigger extends AppCommand {
   static summary = 'Trigger delivery of a sample webhook topic payload to a designated address.'
 
   static descriptionWithMarkdown = `

--- a/packages/app/src/cli/commands/app/webhook/trigger.ts
+++ b/packages/app/src/cli/commands/app/webhook/trigger.ts
@@ -2,7 +2,7 @@ import {DELIVERY_METHOD, WebhookTriggerFlags} from '../../../services/webhook/tr
 import {webhookTriggerService} from '../../../services/webhook/trigger.js'
 import {deliveryMethodInstructionsAsString} from '../../../prompts/webhook/trigger.js'
 import {appFlags} from '../../../flags.js'
-import AppCommand from '../../../utilities/app-command.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {Flags} from '@oclif/core'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
 
@@ -85,7 +85,7 @@ export default class WebhookTrigger extends AppCommand {
     }),
   }
 
-  public async run() {
+  public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(WebhookTrigger)
 
     const usedFlags: WebhookTriggerFlags = {
@@ -107,6 +107,7 @@ export default class WebhookTrigger extends AppCommand {
       })
     }
 
-    await webhookTriggerService(usedFlags)
+    const result = await webhookTriggerService(usedFlags)
+    return {app: result.app}
   }
 }

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -145,6 +145,8 @@ export async function deploy(options: DeployOptions) {
       throw error
     }
   })
+
+  return {app}
 }
 
 async function outputCompletionMessage({

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -73,6 +73,7 @@ export async function dev(commandOptions: DevOptions) {
   const {processes, graphiqlUrl, previewUrl} = await setupDevProcesses(config)
   await actionsBeforeLaunchingDevProcesses(config)
   await launchDevProcesses({processes, previewUrl, graphiqlUrl, config})
+  return {app: config.localApp}
 }
 
 async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {

--- a/packages/app/src/cli/services/function/common.ts
+++ b/packages/app/src/cli/services/function/common.ts
@@ -29,7 +29,7 @@ export async function inFunctionContext({
 }: {
   path: string
   userProvidedConfigName?: string
-  callback: (app: AppInterface, ourFunction: ExtensionInstance<FunctionConfigType>) => Promise<void>
+  callback: (app: AppInterface, ourFunction: ExtensionInstance<FunctionConfigType>) => Promise<AppInterface>
 }) {
   const specifications = await loadLocalExtensionsSpecifications()
   const app: AppInterface = await loadApp({specifications, directory: path, userProvidedConfigName})

--- a/packages/app/src/cli/services/generate.ts
+++ b/packages/app/src/cli/services/generate.ts
@@ -62,6 +62,7 @@ async function generate(options: GenerateOptions) {
   const generatedExtension = await generateExtensionTemplate(generateExtensionOptions)
 
   renderSuccessMessage(generatedExtension, app.packageManager)
+  return {app}
 }
 
 async function buildPromptOptions(

--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -219,6 +219,8 @@ async function init(options: InitOptions) {
       ],
     ],
   })
+
+  return {outputDirectory}
 }
 
 async function ensureAppDirectoryIsAvailable(directory: string, name: string): Promise<void> {

--- a/packages/app/src/cli/services/logs.ts
+++ b/packages/app/src/cli/services/logs.ts
@@ -83,6 +83,8 @@ export async function logs(commandOptions: LogsOptions) {
       storeNameById: logsConfig.storeNameById,
     })
   }
+
+  return logsConfig.localApp
 }
 
 async function prepareForLogs(commandOptions: LogsOptions): Promise<{

--- a/packages/app/src/cli/services/webhook/trigger.ts
+++ b/packages/app/src/cli/services/webhook/trigger.ts
@@ -36,6 +36,7 @@ export async function webhookTriggerService(flags: WebhookTriggerFlags) {
   const options: WebhookTriggerOptions = await validateAndCollectFlags(flags, developerPlatformClient, app)
 
   await sendSample(options)
+  return {app}
 }
 
 async function validateAndCollectFlags(

--- a/packages/app/src/cli/utilities/app-command.ts
+++ b/packages/app/src/cli/utilities/app-command.ts
@@ -1,8 +1,23 @@
 import {configurationFileNames} from '../constants.js'
+import {AppInterface} from '../models/app/app.js'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import BaseCommand from '@shopify/cli-kit/node/base-command'
+
+/**
+ * By forcing all commands to return `AppCommandOutput` we can be sure that during the run of each command we:
+ * - Authenticate the user
+ * - Load an app
+ */
+export interface AppCommandOutput {
+  app: AppInterface
+}
 
 export default abstract class AppCommand extends BaseCommand {
   environmentsFilename(): string {
     return configurationFileNames.appEnvironments
+  }
+
+  public async run(): Promise<AppCommandOutput> {
+    throw new AbortError('You should not call this method directly, implement it in a subclass')
   }
 }

--- a/packages/app/src/cli/utilities/app-command.ts
+++ b/packages/app/src/cli/utilities/app-command.ts
@@ -1,7 +1,7 @@
 import {configurationFileNames} from '../constants.js'
-import Command from '@shopify/cli-kit/node/base-command'
+import BaseCommand from '@shopify/cli-kit/node/base-command'
 
-export default abstract class AppCommand extends Command {
+export default abstract class AppCommand extends BaseCommand {
   environmentsFilename(): string {
     return configurationFileNames.appEnvironments
   }

--- a/packages/app/src/cli/utilities/app-command.ts
+++ b/packages/app/src/cli/utilities/app-command.ts
@@ -5,10 +5,11 @@ import BaseCommand from '@shopify/cli-kit/node/base-command'
 
 /**
  * By forcing all commands to return `AppCommandOutput` we can be sure that during the run of each command we:
- * - Authenticate the user
+ * - Authenticate the user (PENDING)
  * - Load an app
  */
 export interface AppCommandOutput {
+  // session: PartnersSession (PENDING)
   app: AppInterface
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -83,7 +83,7 @@ PluginPluginsCommands['plugins:install'].description = ''
 const appCommands = Object.keys(AppCommands) as (keyof typeof AppCommands)[]
 appCommands.forEach((command) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(AppCommands[command] as any).customPluginName = '@shopify/app'
+  ;(AppCommands[command] as unknown as any).customPluginName = '@shopify/app'
 })
 
 const themeCommands = Object.keys(ThemeCommands) as (keyof typeof ThemeCommands)[]

--- a/packages/eslint-plugin-cli/config.js
+++ b/packages/eslint-plugin-cli/config.js
@@ -123,6 +123,7 @@ module.exports = {
     '@shopify/cli/banner-headline-format': 'warn',
     '@shopify/cli/required-fields-when-loading-app': 'error',
     '@shopify/cli/no-inline-graphql': 'error',
+    '@shopify/cli/app-commands-requirements': 'error',
     'no-restricted-syntax': [
       'error',
       {

--- a/packages/eslint-plugin-cli/index.js
+++ b/packages/eslint-plugin-cli/index.js
@@ -13,6 +13,7 @@ module.exports = {
     'banner-headline-format': require('./rules/banner-headline-format'),
     'required-fields-when-loading-app': require('./rules/required-fields-when-loading-app'),
     'no-inline-graphql': require('./rules/no-inline-graphql'),
+    'app-commands-requirements': require('./rules/app-commands-requirements'),
   },
 
   configs: {

--- a/packages/eslint-plugin-cli/rules/app-commands-requirements.js
+++ b/packages/eslint-plugin-cli/rules/app-commands-requirements.js
@@ -1,0 +1,53 @@
+const path = require('path')
+
+/**
+ * Every App Command should have a default export that extends `AppCommand`
+ *
+ * This way we control that all commands are contrained by what's defined in the `AppCommand` abstract class.
+ * Such as the return type for the run() function.
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce that files in app/commands have a default export extending AppCommand',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+  },
+  create(context) {
+    const filename = context.getFilename()
+
+    // Applies to every file with `commands/app` in the path
+    const isInAppCommandsFolder = filename.includes(path.join('commands', 'app'))
+    if (!isInAppCommandsFolder) {
+      return {}
+    }
+
+    return {
+      Program(node) {
+        let hasDefaultExport = false
+        let extendsAppCommand = false
+
+        node.body.forEach((statement) => {
+          if (statement.type === 'ExportDefaultDeclaration') {
+            hasDefaultExport = true
+            if (statement.declaration.type === 'ClassDeclaration') {
+              const superClass = statement.declaration.superClass
+              if (superClass && superClass.type === 'Identifier' && superClass.name === 'AppCommand') {
+                extendsAppCommand = true
+              }
+            }
+          }
+        })
+
+        if (!hasDefaultExport || !extendsAppCommand) {
+          context.report({
+            node,
+            message: 'Files in app/commands must have a default export that extends AppCommand',
+          })
+        }
+      },
+    }
+  },
+}

--- a/packages/eslint-plugin-cli/rules/app-commands-requirements.js
+++ b/packages/eslint-plugin-cli/rules/app-commands-requirements.js
@@ -44,7 +44,7 @@ module.exports = {
         if (!hasDefaultExport || !extendsAppCommand) {
           context.report({
             node,
-            message: 'Files in app/commands must have a default export that extends AppCommand',
+            message: 'Files in commands/app must have a default export that extends AppCommand',
           })
         }
       },

--- a/packages/eslint-plugin-cli/rules/app-commands-requirements.js
+++ b/packages/eslint-plugin-cli/rules/app-commands-requirements.js
@@ -3,7 +3,7 @@ const path = require('path')
 /**
  * Every App Command should have a default export that extends `AppCommand`
  *
- * This way we control that all commands are contrained by what's defined in the `AppCommand` abstract class.
+ * This way we control that all commands are constrained by what's defined in the `AppCommand` abstract class.
  * Such as the return type for the run() function.
  */
 module.exports = {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
All commands should track all app-related details.
To enforce that, we make every app command return an `AppInterface`, which means that an app was loaded at some point.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add a new ESLint rule to make all commands in `app/commands` extend `AppCommand`
- In `AppCommand` define the `run` function to return an object with an `AppInterface`, TS will force all child classes to use the same return type.
- Solve all the issues created by the two rules above: all commands extend `AppCommand`, all return an `AppInterface` now.

IN A FUTURE PR:
- All app commands should return a Session, to force authentication in all of them.
- Since all commands have auth + app loading -> extract that logic to a single place: `loadAppContext`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Nothing to test in the CLI itself, you can try to modify the code of a command and see that the rules are being applied.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
