### PR TITLE
[Theme] Specify charset for HTML responses

### DIFF
--- a/.changeset/short-hornets-compete.md
+++ b/.changeset/short-hornets-compete.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix encoding of certain characters in HTML responses in the new theme dev server.

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -148,6 +148,8 @@ export async function patchRenderingResponse(ctx: DevServerContext, event: H3Eve
   // We are decoding the payload here, remove the header:
   let html = await response.text()
   removeResponseHeader(event, 'content-encoding')
+  // Ensure the content type indicates UTF-8 charset:
+  setResponseHeader(event, 'content-type', 'text/html; charset=utf-8')
 
   html = injectCdnProxy(html, ctx)
   html = patchBaseUrlAttributes(html, ctx)

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -252,7 +252,7 @@ describe('setupDevServer', () => {
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
-      expect(res.getHeader('content-type')).toEqual('text/html')
+      expect(res.getHeader('content-type')).toEqual('text/html; charset=utf-8')
       expect(res.getHeader('link')).toMatch('</cdn/path/to/assets/file1.css>')
       expect(body).toMatch('link href="/cdn/path/to/assets/file1.css"')
     })


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4479 again, after being reopened with a slightly different issue.

I'm unsure why, but it looks like SFR doesn't add the charset encoding when called from development. It seems to be adding it to production sites, however. The legacy CLI was also adding this (not sure if manually or by calling the API in a different way). cc @karreiro do you perhaps have more context on this?

Note: SFR and legacy CLI are not adding the charset encoding to JS / CSS assets so I've not changed that 🤔 

### WHAT is this pull request doing?

For themes that don't specify `<meta charset="utf-8">` in the layout, certain characters are not rendered correctly:

<img width="209" alt="image" src="https://github.com/user-attachments/assets/57577002-0c75-4fde-be6b-00ddef2e271d">


This PR adds the proper charset to the contet-type for HTML responses so things are rendered correctly:

<img width="127" alt="image" src="https://github.com/user-attachments/assets/8a836cbe-ccd1-4134-8404-7dccace4f8e4">




<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

1. Remove `<meta charset="utf-8">` from your layout.
1. Render `××hey××Пи好` in any section.

Without this PR it won't render correctly.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->


cc @Shopify/advanced-edits 
