### PR TITLE
Avoid errors when trying to output empty variables

### DIFF
--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -153,7 +153,7 @@ export function outputContent(
 
     if (typeof token === 'string') {
       output += token
-    } else {
+    } else if (token) {
       const enumTokenOutput = token.output()
 
       if (Array.isArray(enumTokenOutput)) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://app.bugsnag.com/shopify/cli/errors/64b0013d044bd600081193c1

<img width="594" alt="Monosnap -zsh 2024-09-24 10-37-31" src="https://github.com/user-attachments/assets/30a56635-5de6-473b-bee1-4b0da05eb3df">

### WHAT is this pull request doing?

We don't want verbose output messages to make the command fail when a variable is undefined.

In this case, if the store variable is needed, it will fail later in a more controlled way:

![image](https://github.com/user-attachments/assets/485c0100-85f8-4730-86f9-d072c7460f25)

### How to test your changes?

I couldn't find a real situation when this happens, but it can be reproduced this way:

- Remove theme cache: `rm ~/Library/Preferences/shopify-cli-theme-conf-nodejs/config.json`
- Add this line at the beginning of the theme info command: ``outputDebug(outputContent`Store: ${getThemeStore()}`)``
- `p shopify theme info --verbose`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
