### PR TITLE
Fix duplicated slashes when deploying privacy compliance webhooks with relative URIs

### DIFF
--- a/.changeset/metal-plants-chew.md
+++ b/.changeset/metal-plants-chew.md
@@ -1,5 +1,0 @@
----
-'@shopify/app': patch
----
-
-Remove duplicated slashes when deploying privacy compliance webhooks with relative URIs

--- a/.changeset/metal-plants-chew.md
+++ b/.changeset/metal-plants-chew.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Remove duplicated slashes when deploying privacy compliance webhooks with relative URIs

--- a/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.test.ts
@@ -81,6 +81,38 @@ describe('privacy_compliance_webhooks', () => {
       // Then
       expect(isEmpty(result)).toBeTruthy()
     })
+
+    test('should transform with relative URIs', () => {
+      // Given
+      const object = {
+        webhooks: {
+          api_version: '2024-07',
+          subscriptions: [
+            {
+              compliance_topics: ['customers/redact', 'customers/data_request'],
+              uri: '/customers_webhooks',
+            },
+            {
+              compliance_topics: ['shop/redact'],
+              uri: '/shop_webhooks',
+            },
+          ],
+        },
+      }
+      const privacyComplianceSpec = spec
+      const appConfiguration = {application_url: 'https://example.com/', scopes: ''}
+
+      // When
+      const result = privacyComplianceSpec.transformLocalToRemote!(object, appConfiguration)
+
+      // Then
+      expect(result).toMatchObject({
+        api_version: '2024-07',
+        customers_redact_url: 'https://example.com/customers_webhooks',
+        customers_data_request_url: 'https://example.com/customers_webhooks',
+        shop_redact_url: 'https://example.com/shop_webhooks',
+      })
+    })
   })
 
   describe('reverseTransform with declarative_webhooks flag', () => {

--- a/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_privacy_compliance_webhooks.ts
@@ -2,6 +2,7 @@ import {WebhookSubscription, WebhooksConfig} from './types/app_config_webhook.js
 import {WebhooksSchema} from './app_config_webhook_schemas/webhooks_schema.js'
 import {ComplianceTopic} from './app_config_webhook_schemas/webhook_subscription_schema.js'
 import {mergeAllWebhooks} from './transform/app_config_webhook.js'
+import {removeTrailingSlash} from './validation/common.js'
 import {CustomTransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {Flag} from '../../../utilities/developer-platform-client.js'
 import {AppConfigurationWithoutPath, CurrentAppConfiguration} from '../../app/app.js'
@@ -89,7 +90,7 @@ function getComplianceUri(webhooks: WebhooksConfig, complianceTopic: string): st
 }
 
 function relativeUri(uri?: string, appUrl?: string) {
-  return appUrl && uri?.startsWith('/') ? `${appUrl}${uri}` : uri
+  return appUrl && uri?.startsWith('/') ? `${removeTrailingSlash(appUrl)}${uri}` : uri
 }
 
 function getCustomersDeletionUri(webhooks: WebhooksConfig) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/4511

When you deploy an app with:

- Application URL including a final slash (default value in the template), like `https://example.com/`
- Privacy compliance webhook with a relative URI, like `/webhooks`

Then the webhook is registered with a duplicated slash in Partners: https://example.com//webhooks

### WHAT is this pull request doing?

The same as https://github.com/Shopify/cli/pull/4357, but for privacy compliance webhooks.

Removes the ending slash from the application URL when generating the final URL to deploy.

### How to test your changes?

- Create an app and set the application URL to `https://whatever.com/`
- Add a privacy compliance webhook with a relative URL: `/webhooks`
- `p shopify app deploy`
- Check in Partners that the webhook URL is `https://whatever.com/webhooks`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
