### PR TITLE
[Themes] Add `push`, `pull`, and `fetchStoreThemes` to Themes Package Public Exports

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ export {default as TunnelStartHook} from '@shopify/plugin-cloudflare/hooks/tunne
 export {default as TunnelProviderHook} from '@shopify/plugin-cloudflare/hooks/provider'
 export {hooks as PluginHook} from '@oclif/plugin-plugins'
 export {AppSensitiveMetadataHook, AppInitHook, AppPublicMetadataHook} from '@shopify/app'
+export {push, pull, fetchStoreThemes} from '@shopify/theme'
 
 export const HydrogenInitHook = HydrogenHooks.init
 

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -14,9 +14,6 @@ import Push from './cli/commands/theme/push.js'
 import Rename from './cli/commands/theme/rename.js'
 import Serve from './cli/commands/theme/serve.js'
 import Share from './cli/commands/theme/share.js'
-import {pull} from './cli/services/pull.js'
-import {push} from './cli/services/push.js'
-import {publicFetchStoreThemes} from './cli/utilities/theme-selector/fetch.js'
 
 const COMMANDS = {
   'theme:init': Init,
@@ -37,14 +34,6 @@ const COMMANDS = {
   'theme:share': Share,
 }
 
-const PUBLIC_COMMANDS = {
-  pull,
-  push,
-  publicFetchStoreThemes,
-}
-
-export {PUBLIC_COMMANDS}
-
 export default COMMANDS
 
 /** Development server for theme extensions */
@@ -53,3 +42,8 @@ export * from './cli/utilities/theme-ext-environment/theme-ext-server.js'
 /** Storefront authentication support for running the development server on password-protected stores */
 export {isStorefrontPasswordProtected} from './cli/utilities/theme-environment/storefront-session.js'
 export {ensureValidPassword} from './cli/utilities/theme-environment/storefront-password-prompt.js'
+
+// Public Theme Commands
+export {pull} from './cli/services/pull.js'
+export {push} from './cli/services/push.js'
+export {publicFetchStoreThemes as fetchStoreThemes} from './cli/utilities/theme-selector/fetch.js'

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -43,7 +43,7 @@ export * from './cli/utilities/theme-ext-environment/theme-ext-server.js'
 export {isStorefrontPasswordProtected} from './cli/utilities/theme-environment/storefront-session.js'
 export {ensureValidPassword} from './cli/utilities/theme-environment/storefront-password-prompt.js'
 
-// Public Theme Commands
+// Expose core utilities for developers to build and expand on the CLI
 export {pull} from './cli/services/pull.js'
 export {push} from './cli/services/push.js'
 export {publicFetchStoreThemes as fetchStoreThemes} from './cli/utilities/theme-selector/fetch.js'


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/develop-advanced-edits/issues/346

### WHAT is this pull request doing?
- Exports the `push, `pull`, and `fetchStoreThemes` commands via the CLI package

### How to test your changes?
1) Checkout and build this branch
2) Create a file in a package that includes `@shopify/theme`, such as `packages/app/src/cli/test.ts`
3) Import `push`, `pull`, and `fetchStoreThemes`
4) Hover over the function definition to see the JSDoc
5) Hover over the args inside of `push` and `pull` to see the JSDoc for the args inside flags
6) Test the autocomplete for flags args

https://github.com/user-attachments/assets/20e127fb-f411-4d34-93a9-95330254364a

<details><summary>Template</summary>

```ts
import {fetchStoreThemes, pull, push} from '@shopify/theme'

await pull({
  development: true,
})
await push({
  development: true,
  only: ['asdf'],
})
await fetchStoreThemes('fqdn', 'asdf')
```

</details> 



### Post-release steps
- [ ] Partner comms

### Measuring impact

How do we know this change was effective? Please choose one
- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact
- [x] Following up on this separately - https://github.com/Shopify/develop-advanced-edits/issues/348

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
