### PR TITLE
[Themes] - Add tests to local storage functions that call `requireThemeStore`

### DIFF
--- a/packages/theme/src/cli/services/local-storage.test.ts
+++ b/packages/theme/src/cli/services/local-storage.test.ts
@@ -38,7 +38,7 @@ describe('local-storage', () => {
   ]
 
   testCases.forEach(({name, func}) => {
-    describe(func.name, () => {
+    describe(name, () => {
       test('throws error when theme store is not set', async () => {
         await inTemporaryDirectory(async (cwd) => {
           const storage = new LocalStorage<ThemeLocalStorageSchema>({cwd})

--- a/packages/theme/src/cli/services/local-storage.test.ts
+++ b/packages/theme/src/cli/services/local-storage.test.ts
@@ -1,0 +1,31 @@
+import {requireThemeStore, setThemeStore, ThemeLocalStorageSchema} from './local-storage.js'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
+import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
+import {describe, expect, test} from 'vitest'
+
+describe('requireThemeStore', async () => {
+  await inTemporaryDirectory(async (cwd) => {
+    test('throws an error if the theme store is not set', async () => {
+      // Given
+      const storage = new LocalStorage<ThemeLocalStorageSchema>({cwd})
+
+      // When
+      // Then
+      await expect(() => requireThemeStore(storage)).toThrowError(AbortError)
+      await expect(() => requireThemeStore(storage)).toThrowError('Theme store is not set')
+    })
+
+    test('returns the theme store if it is set', async () => {
+      // Given
+      const storage = new LocalStorage<ThemeLocalStorageSchema>({cwd})
+      setThemeStore('my-theme-store.myshopify.com', storage)
+
+      // When
+      const result = requireThemeStore(storage)
+
+      // Then
+      expect(result).toBe('my-theme-store.myshopify.com')
+    })
+  })
+})

--- a/packages/theme/src/cli/services/local-storage.ts
+++ b/packages/theme/src/cli/services/local-storage.ts
@@ -4,7 +4,7 @@ import {outputDebug, outputContent} from '@shopify/cli-kit/node/output'
 
 type DevelopmentThemeId = string
 
-interface ThemeLocalStorageSchema {
+export interface ThemeLocalStorageSchema {
   themeStore: string
 }
 
@@ -55,12 +55,12 @@ function themeStorePasswordStorage() {
   return _themeStorePasswordStorageInstance
 }
 
-export function getThemeStore() {
-  return themeLocalStorage().get('themeStore')
+export function getThemeStore(storage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage()) {
+  return storage.get('themeStore')
 }
 
-export function setThemeStore(store: string) {
-  themeLocalStorage().set('themeStore', store)
+export function setThemeStore(store: string, storage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage()) {
+  storage.set('themeStore', store)
 }
 
 export function getDevelopmentTheme(): string | undefined {
@@ -111,8 +111,8 @@ export function removeStorefrontPassword(): void {
   themeStorePasswordStorage().delete(themeStore)
 }
 
-function requireThemeStore(): string {
-  const themeStore = getThemeStore()
+export function requireThemeStore(storage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage()): string {
+  const themeStore = getThemeStore(storage)
   if (!themeStore) {
     throw new BugError(
       'Theme store is not set. This indicates an unexpected issue with the CLI. Please report this to the Shopify CLI team.',

--- a/packages/theme/src/cli/services/local-storage.ts
+++ b/packages/theme/src/cli/services/local-storage.ts
@@ -67,7 +67,7 @@ export function getDevelopmentTheme(
   themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
 ): string | undefined {
   outputDebug(outputContent`Getting development theme...`)
-  return developmentThemeLocalStorage().get(requireThemeStore(themeStorage))
+  return developmentThemeLocalStorage().get(assertThemeStoreExists(themeStorage))
 }
 
 export function setDevelopmentTheme(
@@ -75,21 +75,21 @@ export function setDevelopmentTheme(
   themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
 ): void {
   outputDebug(outputContent`Setting development theme...`)
-  developmentThemeLocalStorage().set(requireThemeStore(themeStorage), theme)
+  developmentThemeLocalStorage().set(assertThemeStoreExists(themeStorage), theme)
 }
 
 export function removeDevelopmentTheme(
   themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
 ): void {
   outputDebug(outputContent`Removing development theme...`)
-  developmentThemeLocalStorage().delete(requireThemeStore(themeStorage))
+  developmentThemeLocalStorage().delete(assertThemeStoreExists(themeStorage))
 }
 
 export function getREPLTheme(
   themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
 ): string | undefined {
   outputDebug(outputContent`Getting REPL theme...`)
-  return replThemeLocalStorage().get(requireThemeStore(themeStorage))
+  return replThemeLocalStorage().get(assertThemeStoreExists(themeStorage))
 }
 
 export function setREPLTheme(
@@ -97,18 +97,18 @@ export function setREPLTheme(
   themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
 ): void {
   outputDebug(outputContent`Setting REPL theme to ${theme}...`)
-  replThemeLocalStorage().set(requireThemeStore(themeStorage), theme)
+  replThemeLocalStorage().set(assertThemeStoreExists(themeStorage), theme)
 }
 
 export function removeREPLTheme(themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage()): void {
   outputDebug(outputContent`Removing REPL theme...`)
-  replThemeLocalStorage().delete(requireThemeStore(themeStorage))
+  replThemeLocalStorage().delete(assertThemeStoreExists(themeStorage))
 }
 
 export function getStorefrontPassword(
   themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
 ): string | undefined {
-  const themeStore = requireThemeStore(themeStorage)
+  const themeStore = assertThemeStoreExists(themeStorage)
   outputDebug(outputContent`Getting storefront password for shop ${themeStore}...`)
   return themeStorePasswordStorage().get(themeStore)
 }
@@ -117,7 +117,7 @@ export function setStorefrontPassword(
   password: string,
   themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
 ): void {
-  const themeStore = requireThemeStore(themeStorage)
+  const themeStore = assertThemeStoreExists(themeStorage)
   outputDebug(outputContent`Setting storefront password for shop ${themeStore}...`)
   themeStorePasswordStorage().set(themeStore, password)
 }
@@ -125,12 +125,12 @@ export function setStorefrontPassword(
 export function removeStorefrontPassword(
   themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
 ): void {
-  const themeStore = requireThemeStore(themeStorage)
+  const themeStore = assertThemeStoreExists(themeStorage)
   outputDebug(outputContent`Removing storefront password for ${themeStore}...`)
   themeStorePasswordStorage().delete(themeStore)
 }
 
-function requireThemeStore(storage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage()): string {
+function assertThemeStoreExists(storage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage()): string {
   const themeStore = getThemeStore(storage)
   if (!themeStore) {
     throw new BugError(

--- a/packages/theme/src/cli/services/local-storage.ts
+++ b/packages/theme/src/cli/services/local-storage.ts
@@ -63,55 +63,74 @@ export function setThemeStore(store: string, storage: LocalStorage<ThemeLocalSto
   storage.set('themeStore', store)
 }
 
-export function getDevelopmentTheme(): string | undefined {
+export function getDevelopmentTheme(
+  themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
+): string | undefined {
   outputDebug(outputContent`Getting development theme...`)
-  return developmentThemeLocalStorage().get(requireThemeStore())
+  return developmentThemeLocalStorage().get(requireThemeStore(themeStorage))
 }
 
-export function setDevelopmentTheme(theme: string): void {
+export function setDevelopmentTheme(
+  theme: string,
+  themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
+): void {
   outputDebug(outputContent`Setting development theme...`)
-  developmentThemeLocalStorage().set(requireThemeStore(), theme)
+  developmentThemeLocalStorage().set(requireThemeStore(themeStorage), theme)
 }
 
-export function removeDevelopmentTheme(): void {
+export function removeDevelopmentTheme(
+  themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
+): void {
   outputDebug(outputContent`Removing development theme...`)
-  developmentThemeLocalStorage().delete(requireThemeStore())
+  developmentThemeLocalStorage().delete(requireThemeStore(themeStorage))
 }
 
-export function getREPLTheme(): string | undefined {
+export function getREPLTheme(
+  themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
+): string | undefined {
   outputDebug(outputContent`Getting REPL theme...`)
-  return replThemeLocalStorage().get(requireThemeStore())
+  return replThemeLocalStorage().get(requireThemeStore(themeStorage))
 }
 
-export function setREPLTheme(theme: string): void {
+export function setREPLTheme(
+  theme: string,
+  themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
+): void {
   outputDebug(outputContent`Setting REPL theme to ${theme}...`)
-  replThemeLocalStorage().set(requireThemeStore(), theme)
+  replThemeLocalStorage().set(requireThemeStore(themeStorage), theme)
 }
 
-export function removeREPLTheme(): void {
+export function removeREPLTheme(themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage()): void {
   outputDebug(outputContent`Removing REPL theme...`)
-  replThemeLocalStorage().delete(requireThemeStore())
+  replThemeLocalStorage().delete(requireThemeStore(themeStorage))
 }
 
-export function getStorefrontPassword(): string | undefined {
-  const themeStore = requireThemeStore()
+export function getStorefrontPassword(
+  themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
+): string | undefined {
+  const themeStore = requireThemeStore(themeStorage)
   outputDebug(outputContent`Getting storefront password for shop ${themeStore}...`)
   return themeStorePasswordStorage().get(themeStore)
 }
 
-export function setStorefrontPassword(password: string): void {
-  const themeStore = requireThemeStore()
+export function setStorefrontPassword(
+  password: string,
+  themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
+): void {
+  const themeStore = requireThemeStore(themeStorage)
   outputDebug(outputContent`Setting storefront password for shop ${themeStore}...`)
   themeStorePasswordStorage().set(themeStore, password)
 }
 
-export function removeStorefrontPassword(): void {
-  const themeStore = requireThemeStore()
+export function removeStorefrontPassword(
+  themeStorage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage(),
+): void {
+  const themeStore = requireThemeStore(themeStorage)
   outputDebug(outputContent`Removing storefront password for ${themeStore}...`)
   themeStorePasswordStorage().delete(themeStore)
 }
 
-export function requireThemeStore(storage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage()): string {
+function requireThemeStore(storage: LocalStorage<ThemeLocalStorageSchema> = themeLocalStorage()): string {
   const themeStore = getThemeStore(storage)
   if (!themeStore) {
     throw new BugError(


### PR DESCRIPTION
### WHY are these changes introduced?
Adds tests for the changes introduced [Force dealing with config get returning undefined](https://github.com/Shopify/cli/pull/4517)

Closes https://github.com/Shopify/cli/issues/4528

### WHAT is this pull request doing?
- Test that the functions in `local-storage` throw an Error when `getThemeStore()` returns `undefined`
- Allow for a `LocalStorage<ThemeLocalStorageSchema>` instance to be injected into the functions in `local-storage`, which will be used to check in `requireThemeStore` (_this enables the testing, which was unfortunately not as straightforward as I would have liked_)

### How to test your changes?
`pnpm test`

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes

cc: @Shopify/advanced-edits 