### PR TITLE
Track env_auth_method

### DIFF
--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -1,3 +1,4 @@
+import {getLastSeenAuthMethod} from './session.js'
 import {hashString} from '../../public/node/crypto.js'
 import {getPackageManager, packageManagerFromUserAgent} from '../../public/node/node-package-manager.js'
 import BaseCommand from '../../public/node/base-command.js'
@@ -61,6 +62,7 @@ interface EnvironmentData {
   env_cloud: string
   env_package_manager: string
   env_is_global: boolean
+  env_auth_method: string
 }
 
 export async function getEnvironmentData(config: Interfaces.Config): Promise<EnvironmentData> {
@@ -83,6 +85,7 @@ export async function getEnvironmentData(config: Interfaces.Config): Promise<Env
     env_cloud: cloudEnvironment().platform,
     env_package_manager: await getPackageManager(cwd()),
     env_is_global: currentProcessIsGlobal(),
+    env_auth_method: getLastSeenAuthMethod(),
   }
 }
 

--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -85,7 +85,7 @@ export async function getEnvironmentData(config: Interfaces.Config): Promise<Env
     env_cloud: cloudEnvironment().platform,
     env_package_manager: await getPackageManager(cwd()),
     env_is_global: currentProcessIsGlobal(),
-    env_auth_method: getLastSeenAuthMethod(),
+    env_auth_method: await getLastSeenAuthMethod(),
   }
 }
 

--- a/packages/cli-kit/src/private/node/api/rest.ts
+++ b/packages/cli-kit/src/private/node/api/rest.ts
@@ -40,6 +40,6 @@ export function restRequestHeaders(session: AdminSession) {
   return headers
 }
 
-function isThemeAccessSession(session: AdminSession) {
+export function isThemeAccessSession(session: AdminSession) {
   return session.token.startsWith('shptka_')
 }

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -372,7 +372,6 @@ describe('getLastSeenUserIdAfterAuth', () => {
     const userId = await getLastSeenUserIdAfterAuth()
 
     // Then
-    // expect(userId).not.toBe('unknown')
     expect(userId).toBe(nonRandomUUID('theme-token-123'))
   })
 

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -142,7 +142,7 @@ describe('ensureAuthenticated when previous session is invalid', () => {
 
     // The userID is cached in memory and the secureStore is not accessed again
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
-    expect(getLastSeenAuthMethod()).toEqual('device_auth')
+    await expect(getLastSeenAuthMethod()).resolves.toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -161,7 +161,7 @@ The CLI is currently unable to prompt for reauthentication.`,
 
     // Then
     expect(authorize).not.toHaveBeenCalled()
-    expect(getLastSeenAuthMethod()).toEqual('none')
+    await expect(getLastSeenAuthMethod()).resolves.toEqual('none')
 
     // If there never was an auth event, the userId is 'unknown'
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('unknown')
@@ -184,7 +184,7 @@ The CLI is currently unable to prompt for reauthentication.`,
     expect(secureStore).toBeCalledWith(newSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
-    expect(getLastSeenAuthMethod()).toEqual('device_auth')
+    await expect(getLastSeenAuthMethod()).resolves.toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -204,7 +204,7 @@ The CLI is currently unable to prompt for reauthentication.`,
     expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
-    expect(getLastSeenAuthMethod()).toEqual('device_auth')
+    await expect(getLastSeenAuthMethod()).resolves.toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 })
@@ -225,7 +225,7 @@ describe('when existing session is valid', () => {
     expect(refreshAccessToken).not.toBeCalled()
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
-    expect(getLastSeenAuthMethod()).toEqual('device_auth')
+    await expect(getLastSeenAuthMethod()).resolves.toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -246,7 +246,7 @@ describe('when existing session is valid', () => {
     expect(refreshAccessToken).not.toBeCalled()
     expect(got).toEqual(expected)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
-    expect(getLastSeenAuthMethod()).toEqual('partners_token')
+    await expect(getLastSeenAuthMethod()).resolves.toEqual('partners_token')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -266,7 +266,7 @@ describe('when existing session is valid', () => {
     expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
-    expect(getLastSeenAuthMethod()).toEqual('device_auth')
+    await expect(getLastSeenAuthMethod()).resolves.toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 })
@@ -288,7 +288,7 @@ describe('when existing session is expired', () => {
     expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
-    expect(getLastSeenAuthMethod()).toEqual('device_auth')
+    await expect(getLastSeenAuthMethod()).resolves.toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -311,7 +311,7 @@ describe('when existing session is expired', () => {
     expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
-    expect(getLastSeenAuthMethod()).toEqual('device_auth')
+    await expect(getLastSeenAuthMethod()).resolves.toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 })

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -1,8 +1,10 @@
 import {
   ensureAuthenticated,
+  getLastSeenAuthMethod,
   getLastSeenUserIdAfterAuth,
   OAuthApplications,
   OAuthSession,
+  setLastSeenAuthMethod,
   setLastSeenUserIdAfterAuth,
 } from './session.js'
 import {
@@ -117,6 +119,7 @@ beforeEach(() => {
   vi.mocked(partnersRequest).mockResolvedValue(undefined)
   vi.mocked(allDefaultScopes).mockImplementation((scopes) => scopes || [])
   setLastSeenUserIdAfterAuth(undefined as any)
+  setLastSeenAuthMethod('none')
 })
 
 describe('ensureAuthenticated when previous session is invalid', () => {
@@ -138,6 +141,7 @@ describe('ensureAuthenticated when previous session is invalid', () => {
 
     // The userID is cached in memory and the secureStore is not accessed again
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
+    expect(getLastSeenAuthMethod()).toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -156,6 +160,7 @@ The CLI is currently unable to prompt for reauthentication.`,
 
     // Then
     expect(authorize).not.toHaveBeenCalled()
+    expect(getLastSeenAuthMethod()).toEqual('none')
 
     // If there never was an auth event, the userId is 'unknown'
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('unknown')
@@ -178,6 +183,7 @@ The CLI is currently unable to prompt for reauthentication.`,
     expect(secureStore).toBeCalledWith(newSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
+    expect(getLastSeenAuthMethod()).toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -197,6 +203,7 @@ The CLI is currently unable to prompt for reauthentication.`,
     expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
+    expect(getLastSeenAuthMethod()).toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 })
@@ -217,6 +224,7 @@ describe('when existing session is valid', () => {
     expect(refreshAccessToken).not.toBeCalled()
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
+    expect(getLastSeenAuthMethod()).toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -237,6 +245,7 @@ describe('when existing session is valid', () => {
     expect(refreshAccessToken).not.toBeCalled()
     expect(got).toEqual(expected)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
+    expect(getLastSeenAuthMethod()).toEqual('partners_token')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -256,6 +265,7 @@ describe('when existing session is valid', () => {
     expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
+    expect(getLastSeenAuthMethod()).toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 })
@@ -277,6 +287,7 @@ describe('when existing session is expired', () => {
     expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
+    expect(getLastSeenAuthMethod()).toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
@@ -299,6 +310,7 @@ describe('when existing session is expired', () => {
     expect(secureStore).toBeCalledWith(validSession)
     expect(got).toEqual(validTokens)
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
+    expect(getLastSeenAuthMethod()).toEqual('device_auth')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 })

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -433,7 +433,7 @@ describe('getLastSeenAuthMethod', () => {
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
-  test('returns theme_password if there is a theme token in the environment', async () => {
+  test('returns custom_app_token if there is a theme token in the environment and doesnt start with shptka_', async () => {
     // Given
     vi.mocked(themeToken).mockReturnValue('theme-token-123')
 
@@ -441,7 +441,19 @@ describe('getLastSeenAuthMethod', () => {
     const method = await getLastSeenAuthMethod()
 
     // Then
-    expect(method).toBe('theme_password')
+    expect(method).toBe('custom_app_token')
+    expect(secureFetch).toHaveBeenCalledOnce()
+  })
+
+  test('returns theme_access_token if there is a theme token in the environment and starts with shptka_', async () => {
+    // Given
+    vi.mocked(themeToken).mockReturnValue('shptka_theme-token-123')
+
+    // When
+    const method = await getLastSeenAuthMethod()
+
+    // Then
+    expect(method).toBe('theme_access_token')
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -380,13 +380,78 @@ describe('getLastSeenUserIdAfterAuth', () => {
     // Given
     vi.mocked(secureFetch).mockResolvedValue(undefined)
     vi.mocked(getPartnersToken).mockReturnValue('partners-token-456')
-    const env = {}
 
     // When
-    const userId = await getLastSeenUserIdAfterAuth(env)
+    const userId = await getLastSeenUserIdAfterAuth()
 
     // Then
     expect(userId).not.toBe('unknown')
     expect(userId).toBe(nonRandomUUID('partners-token-456'))
+  })
+})
+
+describe('getLastSeenAuthMethod', () => {
+  beforeEach(() => {
+    vi.mocked(secureFetch).mockResolvedValue(undefined)
+    vi.mocked(getPartnersToken).mockReturnValue(undefined)
+    vi.mocked(themeToken).mockReturnValue(undefined)
+    setLastSeenAuthMethod('none')
+  })
+
+  test('returns the existing authMethod if set', async () => {
+    // Given
+    setLastSeenAuthMethod('device_auth')
+
+    // When
+    const method = await getLastSeenAuthMethod()
+
+    // Then
+    expect(method).toBe('device_auth')
+    expect(secureFetch).not.toHaveBeenCalled()
+  })
+
+  test('returns device_auth if there is a cached session', async () => {
+    // Given
+    vi.mocked(secureFetch).mockResolvedValue(validSession)
+
+    // When
+    const method = await getLastSeenAuthMethod()
+
+    // Then
+    expect(method).toBe('device_auth')
+    expect(secureFetch).toHaveBeenCalledOnce()
+  })
+
+  test('returns partners_token if there is a partners token in the environment', async () => {
+    // Given
+    vi.mocked(getPartnersToken).mockReturnValue('partners-token-456')
+
+    // When
+    const method = await getLastSeenAuthMethod()
+
+    // Then
+    expect(method).toBe('partners_token')
+    expect(secureFetch).toHaveBeenCalledOnce()
+  })
+
+  test('returns theme_password if there is a theme token in the environment', async () => {
+    // Given
+    vi.mocked(themeToken).mockReturnValue('theme-token-123')
+
+    // When
+    const method = await getLastSeenAuthMethod()
+
+    // Then
+    expect(method).toBe('theme_password')
+    expect(secureFetch).toHaveBeenCalledOnce()
+  })
+
+  test('returns none if no auth method is detected', async () => {
+    // When
+    const method = await getLastSeenAuthMethod()
+
+    // Then
+    expect(method).toBe('none')
+    expect(secureFetch).toHaveBeenCalledOnce()
   })
 })

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -101,7 +101,7 @@ export interface OAuthSession {
   userId: string
 }
 
-type AuthMethod = 'partners_token' | 'device_auth' | 'none'
+type AuthMethod = 'partners_token' | 'device_auth' | 'theme-password' | 'none'
 
 let userId: undefined | string
 let authMethod: AuthMethod = 'none'

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -17,7 +17,7 @@ import {pollForDeviceAuthorization, requestDeviceAuthorization} from './session/
 import {RequestClientError} from './api/headers.js'
 import {getCachedPartnerAccountStatus, setCachedPartnerAccountStatus} from './conf-store.js'
 import {outputContent, outputToken, outputDebug} from '../../public/node/output.js'
-import {firstPartyDev, themeToken, themeToken, themeToken, useDeviceAuth} from '../../public/node/context/local.js'
+import {firstPartyDev, themeToken, useDeviceAuth} from '../../public/node/context/local.js'
 import {AbortError, BugError} from '../../public/node/error.js'
 import {partnersRequest} from '../../public/node/api/partners.js'
 import {normalizeStoreFqdn, partnersFqdn, identityFqdn} from '../../public/node/context/fqdn.js'

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -101,7 +101,10 @@ export interface OAuthSession {
   userId: string
 }
 
+export type AuthMethod = 'partners_token' | 'device_auth' | 'none'
+
 let userId: undefined | string
+let authMethod: AuthMethod = 'none'
 
 /**
  * Retrieves the user ID from the current session or returns 'unknown' if not found.
@@ -121,6 +124,14 @@ export async function getLastSeenUserIdAfterAuth(): Promise<string> {
 
 export function setLastSeenUserIdAfterAuth(id: string) {
   userId = id
+}
+
+export function getLastSeenAuthMethod() {
+  return authMethod
+}
+
+export function setLastSeenAuthMethod(method: AuthMethod) {
+  authMethod = method
 }
 
 /**
@@ -205,6 +216,7 @@ The CLI is currently unable to prompt for reauthentication.`,
     await ensureUserHasPartnerAccount(tokens.partners, tokens.userId)
   }
 
+  setLastSeenAuthMethod(envToken ? 'partners_token' : 'device_auth')
   setLastSeenUserIdAfterAuth(tokens.userId)
   return tokens
 }

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -101,7 +101,7 @@ export interface OAuthSession {
   userId: string
 }
 
-export type AuthMethod = 'partners_token' | 'device_auth' | 'none'
+type AuthMethod = 'partners_token' | 'device_auth' | 'none'
 
 let userId: undefined | string
 let authMethod: AuthMethod = 'none'

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -101,7 +101,7 @@ export interface OAuthSession {
   userId: string
 }
 
-type AuthMethod = 'partners_token' | 'device_auth' | 'theme-password' | 'none'
+type AuthMethod = 'partners_token' | 'device_auth' | 'theme_password' | 'none'
 
 let userId: undefined | string
 let authMethod: AuthMethod = 'none'

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -16,6 +16,7 @@ import * as secureStore from './session/store.js'
 import {pollForDeviceAuthorization, requestDeviceAuthorization} from './session/device-authorization.js'
 import {RequestClientError} from './api/headers.js'
 import {getCachedPartnerAccountStatus, setCachedPartnerAccountStatus} from './conf-store.js'
+import {isThemeAccessSession} from './api/rest.js'
 import {outputContent, outputToken, outputDebug} from '../../public/node/output.js'
 import {firstPartyDev, themeToken, useDeviceAuth} from '../../public/node/context/local.js'
 import {AbortError, BugError} from '../../public/node/error.js'
@@ -102,7 +103,7 @@ export interface OAuthSession {
   userId: string
 }
 
-type AuthMethod = 'partners_token' | 'device_auth' | 'theme_password' | 'none'
+type AuthMethod = 'partners_token' | 'device_auth' | 'theme_access_token' | 'custom_app_token' | 'none'
 
 let userId: undefined | string
 let authMethod: AuthMethod = 'none'
@@ -159,7 +160,9 @@ export async function getLastSeenAuthMethod(): Promise<AuthMethod> {
   if (partnersToken) return 'partners_token'
 
   const themePassword = themeToken()
-  if (themePassword) return 'theme_password'
+  if (themePassword) {
+    return isThemeAccessSession({token: themePassword, storeFqdn: ''}) ? 'theme_access_token' : 'custom_app_token'
+  }
 
   return 'none'
 }

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -6,7 +6,7 @@ import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {shopifyFetch} from '../../../public/node/http.js'
 import {err, ok, Result} from '../../../public/node/result.js'
 import {AbortError, BugError, ExtendableError} from '../../../public/node/error.js'
-import {setLastSeenUserIdAfterAuth} from '../session.js'
+import {setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../session.js'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import * as jose from 'jose'
 import {nonRandomUUID} from '@shopify/cli-kit/node/crypto'
@@ -103,6 +103,7 @@ export async function exchangeCustomPartnerToken(token: string): Promise<{access
     const accessToken = newToken[appId]!.accessToken
     const userId = nonRandomUUID(token)
     setLastSeenUserIdAfterAuth(userId)
+    setLastSeenAuthMethod('partners_token')
     return {accessToken, userId}
   } catch (error) {
     throw new AbortError('The custom token provided is invalid.', 'Ensure the token is correct and not expired.')

--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -18,7 +18,7 @@ import {addPublicMetadata} from './metadata.js'
 import {startAnalytics} from '../../private/node/analytics.js'
 import {hashString} from '../../public/node/crypto.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
-import {setLastSeenUserIdAfterAuth} from '../../private/node/session.js'
+import {setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../../private/node/session.js'
 import {test, expect, describe, vi, beforeEach, afterEach, MockedFunction} from 'vitest'
 
 vi.mock('./context/local.js')
@@ -67,6 +67,8 @@ describe('event tracking', () => {
       // Given
       const commandContent = {command: 'dev', topic: 'app', alias: 'alias'}
       await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+      setLastSeenAuthMethod('partners_token')
+      setLastSeenUserIdAfterAuth('cached-user-id')
 
       // Log some timings from the command, confirm that submitted timings are always rounded down
       await addPublicMetadata(() => ({
@@ -106,8 +108,8 @@ describe('event tracking', () => {
         cmd_all_timing_active_ms: 49,
         cmd_all_timing_network_ms: 30,
         cmd_all_timing_prompts_ms: 20,
-        user_id: 'unknown',
-        env_auth_method: 'none',
+        user_id: 'cached-user-id',
+        env_auth_method: 'partners_token',
       }
       const expectedPayloadSensitive = {
         args: args.join(' '),

--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -107,6 +107,7 @@ describe('event tracking', () => {
         cmd_all_timing_network_ms: 30,
         cmd_all_timing_prompts_ms: 20,
         user_id: 'unknown',
+        env_auth_method: 'none',
       }
       const expectedPayloadSensitive = {
         args: args.join(' '),

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -193,6 +193,16 @@ export function isCloudEnvironment(env: NodeJS.ProcessEnv = process.env): boolea
 }
 
 /**
+ * The token used to run a theme command with a custom password.
+ *
+ * @param env - Environment variables used when the cli is launched.
+ * @returns A string with the token.
+ */
+export function themeToken(env = process.env): string | undefined {
+  return env[environmentVariables.themeToken]
+}
+
+/**
  * Returns the cloud environment platform name and if the platform support online IDE in case the CLI is run from one of
  * them. Platform name 'localhost' is returned otherwise.
  *

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -10,7 +10,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 type Optional<T> = T | null
 
 // This is the topic name of the main event we log to Monorail, the command tracker
-export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.13'
+export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.14'
 
 export interface Schemas {
   [MONORAIL_COMMAND_TOPIC]: {
@@ -155,6 +155,7 @@ export interface Schemas {
       env_web_ide?: Optional<string>
       env_cloud?: Optional<string>
       env_is_global?: Optional<boolean>
+      env_auth_method?: Optional<string>
     }
   }
   [schemaId: string]: {sensitive: JsonMap; public: JsonMap}

--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -8,7 +8,7 @@ import {
 
 import {getPartnersToken} from './environment.js'
 import {ApplicationToken} from '../../private/node/session/schema.js'
-import {ensureAuthenticated} from '../../private/node/session.js'
+import {ensureAuthenticated, setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../../private/node/session.js'
 import {exchangeCustomPartnerToken} from '../../private/node/session/exchange.js'
 import {vi, describe, expect, test} from 'vitest'
 
@@ -35,6 +35,8 @@ describe('ensureAuthenticatedStorefront', () => {
 
     // Then
     expect(got).toEqual('storefront_token')
+    expect(setLastSeenAuthMethod).not.toBeCalled()
+    expect(setLastSeenUserIdAfterAuth).not.toBeCalled()
   })
 
   test('returns the password if provided', async () => {
@@ -43,6 +45,8 @@ describe('ensureAuthenticatedStorefront', () => {
 
     // Then
     expect(got).toEqual('theme_access_password')
+    expect(setLastSeenAuthMethod).toBeCalledWith('theme-password')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('dd5e7850-e2de-d283-9c5f-79c8190a19d18b52e0ce')
   })
 
   test('throws error if there is no storefront token', async () => {
@@ -137,6 +141,8 @@ describe('ensureAuthenticatedTheme', () => {
 
     // Then
     expect(got).toEqual({token: 'admin_token', storeFqdn: 'mystore.myshopify.com'})
+    expect(setLastSeenAuthMethod).not.toBeCalled()
+    expect(setLastSeenUserIdAfterAuth).not.toBeCalled()
   })
 
   test('throws error if there is no token when no password is provided', async () => {
@@ -156,6 +162,8 @@ describe('ensureAuthenticatedTheme', () => {
 
     // Then
     expect(got).toEqual({token: 'password', storeFqdn: 'mystore.myshopify.com'})
+    expect(setLastSeenAuthMethod).toBeCalledWith('theme-password')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('f5c7086f-320b-3b93-bcdc-a2296adbec02d71eb733')
   })
 })
 

--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -45,7 +45,7 @@ describe('ensureAuthenticatedStorefront', () => {
 
     // Then
     expect(got).toEqual('theme_access_password')
-    expect(setLastSeenAuthMethod).toBeCalledWith('theme-password')
+    expect(setLastSeenAuthMethod).toBeCalledWith('theme_password')
     expect(setLastSeenUserIdAfterAuth).toBeCalledWith('dd5e7850-e2de-d283-9c5f-79c8190a19d18b52e0ce')
   })
 
@@ -162,7 +162,7 @@ describe('ensureAuthenticatedTheme', () => {
 
     // Then
     expect(got).toEqual({token: 'password', storeFqdn: 'mystore.myshopify.com'})
-    expect(setLastSeenAuthMethod).toBeCalledWith('theme-password')
+    expect(setLastSeenAuthMethod).toBeCalledWith('theme_password')
     expect(setLastSeenUserIdAfterAuth).toBeCalledWith('f5c7086f-320b-3b93-bcdc-a2296adbec02d71eb733')
   })
 })

--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -39,14 +39,24 @@ describe('ensureAuthenticatedStorefront', () => {
     expect(setLastSeenUserIdAfterAuth).not.toBeCalled()
   })
 
-  test('returns the password if provided', async () => {
+  test('returns the password if provided, and auth method is custom_app_token', async () => {
     // Given/When
     const got = await ensureAuthenticatedStorefront([], 'theme_access_password')
 
     // Then
     expect(got).toEqual('theme_access_password')
-    expect(setLastSeenAuthMethod).toBeCalledWith('theme_password')
+    expect(setLastSeenAuthMethod).toBeCalledWith('custom_app_token')
     expect(setLastSeenUserIdAfterAuth).toBeCalledWith('dd5e7850-e2de-d283-9c5f-79c8190a19d18b52e0ce')
+  })
+
+  test('returns the password if provided, and auth method is theme_access_token', async () => {
+    // Given/When
+    const got = await ensureAuthenticatedStorefront([], 'shptka_theme_access_password')
+
+    // Then
+    expect(got).toEqual('shptka_theme_access_password')
+    expect(setLastSeenAuthMethod).toBeCalledWith('theme_access_token')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('730a64df-ab2c-3d92-8b11-76a66aadee947aa5c1ce')
   })
 
   test('throws error if there is no storefront token', async () => {
@@ -156,14 +166,24 @@ describe('ensureAuthenticatedTheme', () => {
     await expect(got).rejects.toThrow(`No admin token`)
   })
 
-  test('returns the password when is provided', async () => {
+  test('returns the password when is provided and custom_app_token', async () => {
     // When
     const got = await ensureAuthenticatedThemes('mystore', 'password')
 
     // Then
     expect(got).toEqual({token: 'password', storeFqdn: 'mystore.myshopify.com'})
-    expect(setLastSeenAuthMethod).toBeCalledWith('theme_password')
+    expect(setLastSeenAuthMethod).toBeCalledWith('custom_app_token')
     expect(setLastSeenUserIdAfterAuth).toBeCalledWith('f5c7086f-320b-3b93-bcdc-a2296adbec02d71eb733')
+  })
+
+  test('returns the password when is provided and theme_access_token', async () => {
+    // When
+    const got = await ensureAuthenticatedThemes('mystore', 'shptka_password')
+
+    // Then
+    expect(got).toEqual({token: 'shptka_password', storeFqdn: 'mystore.myshopify.com'})
+    expect(setLastSeenAuthMethod).toBeCalledWith('theme_access_token')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('e3d08cca-4e68-504a-00ec-23e2cea12a6340bb257b')
   })
 })
 

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -86,7 +86,7 @@ export async function ensureAuthenticatedStorefront(
   forceRefresh = false,
 ): Promise<string> {
   if (password) {
-    setLastSeenAuthMethod('theme-password')
+    setLastSeenAuthMethod('theme_password')
     setLastSeenUserIdAfterAuth(nonRandomUUID(password))
     return password
   }
@@ -152,7 +152,7 @@ export async function ensureAuthenticatedThemes(
 ${outputToken.json(scopes)}
 `)
   if (password) {
-    setLastSeenAuthMethod('theme-password')
+    setLastSeenAuthMethod('theme_password')
     setLastSeenUserIdAfterAuth(nonRandomUUID(password))
     return {token: password, storeFqdn: await normalizeStoreFqdn(store)}
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Related to https://github.com/Shopify/monorail/pull/19405

We need to differenciate different auth types.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Adds `env_auth_method` to monorail events, the possible values are `'partners_token' | 'device_auth' | 'theme_access_token' | 'custom_app_token' | 'none'`

Improves `user_id` detection when using custom tokens.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
