### PR TITLE
Update checksum calculation to no longer minify assets before calculating

### DIFF
--- a/.changeset/tiny-poems-tie.md
+++ b/.changeset/tiny-poems-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Update checksum calculation to no longer minify assets before calculating

--- a/packages/theme/src/cli/utilities/asset-checksum.test.ts
+++ b/packages/theme/src/cli/utilities/asset-checksum.test.ts
@@ -3,7 +3,7 @@ import {readThemeFile} from './theme-fs.js'
 import {describe, expect, test} from 'vitest'
 
 describe('asset-checksum', () => {
-  describe('normalizeJson', async () => {
+  describe('calculateChecksum', async () => {
     const testCases = [
       {file: 'assets/base.css', expectedChecksum: 'b7fbe0ecff2a6c1d6e697a13096e2b17'},
       {file: 'assets/sparkle.gif', expectedChecksum: '7adcd48a3cc215a81fabd9dafb919507'},
@@ -11,19 +11,19 @@ describe('asset-checksum', () => {
       {file: 'config/settings_schema.json', expectedChecksum: 'cbe979d3fd3b7cdf2041ada9fdb3af57'},
       {file: 'layout/password.liquid', expectedChecksum: '7a92d18f1f58b2396c46f98f9e502c6a'},
       {file: 'layout/theme.liquid', expectedChecksum: '2374357fdadd3b4636405e80e21e87fc'},
-      {file: 'locales/en.default.json', expectedChecksum: '94d575574a070397f297a2e9bb32ce7d'},
+      {file: 'locales/en.default.json', expectedChecksum: '0b2f0aa705a4eb2b4740e2ed68bc043f'},
       {file: 'sections/announcement-bar.liquid', expectedChecksum: '3e8fecc3fb5e886f082e12357beb5d56'},
       {file: 'snippets/language-localization.liquid', expectedChecksum: 'aa0c697b712b22753f73c84ba8a2e35a'},
-      {file: 'templates/404.json', expectedChecksum: 'f14a0bd594f4fee47b13fc09543098ff'},
+      {file: 'templates/404.json', expectedChecksum: '64caf742bd427adcf497bffab63df30c'},
     ]
-
     testCases.forEach(({file, expectedChecksum}) => {
       test(`returns the expected checksum for "${file}"`, async () => {
         // Given
         const root = 'src/cli/utilities/fixtures/theme'
+        const content = await readThemeFile(root, file)
 
         // When
-        const actualChecksum = await calculateChecksum(file, await readThemeFile(root, file))
+        const actualChecksum = await calculateChecksum(file, content)
 
         // Then
         expect(actualChecksum).toEqual(expectedChecksum)

--- a/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-fs.test.ts
@@ -17,7 +17,7 @@ describe('theme-ext-fs', () => {
         root,
         files: new Map([
           fsEntry({checksum: 'd8ceb73ce5faa4ac22713071d2f0a6bd', key: 'blocks/star_rating.liquid'}),
-          fsEntry({checksum: 'dc9c03a6294d7fd8611ddf148e1f7e6e', key: 'locales/en.default.json'}),
+          fsEntry({checksum: '02054e661bbc326a68bf7be83427d7ed', key: 'locales/en.default.json'}),
           fsEntry({checksum: '8a1dd937b2cfe9e669b26e41dc1de5e8', key: 'assets/thumbs-up.png'}),
           fsEntry({checksum: '28fa42561b59f04fc32e98feb3b994ac', key: 'snippets/stars.liquid'}),
         ]),

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -57,10 +57,10 @@ describe('theme-fs', () => {
           fsEntry({checksum: 'cbe979d3fd3b7cdf2041ada9fdb3af57', key: 'config/settings_schema.json'}),
           fsEntry({checksum: '7a92d18f1f58b2396c46f98f9e502c6a', key: 'layout/password.liquid'}),
           fsEntry({checksum: '2374357fdadd3b4636405e80e21e87fc', key: 'layout/theme.liquid'}),
-          fsEntry({checksum: '94d575574a070397f297a2e9bb32ce7d', key: 'locales/en.default.json'}),
+          fsEntry({checksum: '0b2f0aa705a4eb2b4740e2ed68bc043f', key: 'locales/en.default.json'}),
           fsEntry({checksum: '3e8fecc3fb5e886f082e12357beb5d56', key: 'sections/announcement-bar.liquid'}),
           fsEntry({checksum: 'aa0c697b712b22753f73c84ba8a2e35a', key: 'snippets/language-localization.liquid'}),
-          fsEntry({checksum: 'f14a0bd594f4fee47b13fc09543098ff', key: 'templates/404.json'}),
+          fsEntry({checksum: '64caf742bd427adcf497bffab63df30c', key: 'templates/404.json'}),
         ]),
         unsyncedFileKeys: new Set(),
         ready: expect.any(Function),
@@ -240,7 +240,7 @@ describe('theme-fs', () => {
   })
 
   describe('themeFileSystem.read', async () => {
-    test('"read" returns returns the content from the local disk and updates the file map', async () => {
+    test('"read" returns the content from the local disk and updates the file map', async () => {
       // Given
       const root = 'src/cli/utilities/fixtures/theme'
       const key = 'templates/404.json'
@@ -249,7 +249,7 @@ describe('theme-fs', () => {
       const file = themeFileSystem.files.get(key)
       expect(file).toEqual({
         key: 'templates/404.json',
-        checksum: 'f14a0bd594f4fee47b13fc09543098ff',
+        checksum: '64caf742bd427adcf497bffab63df30c',
         value: expect.any(String),
         attachment: '',
         stats: {size: expect.any(Number), mtime: expect.any(Number)},
@@ -262,7 +262,7 @@ describe('theme-fs', () => {
       // Then
       expect(themeFileSystem.files.get(key)).toEqual({
         key: 'templates/404.json',
-        checksum: 'f14a0bd594f4fee47b13fc09543098ff',
+        checksum: '64caf742bd427adcf497bffab63df30c',
         value: content,
         attachment: '',
         stats: {size: content?.length, mtime: expect.any(Number)},


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/4537

### WHAT is this pull request doing?

This PR updates the calculation of checksums to no longer minify assets before calculating the checksum.

### How to test your changes?

- Run `shopify-dev theme init top-hat`
- Run `cd top-hat`
- Run `shopify-dev theme dev --theme-editor-sync` (select **Keep the local version**)
- Notice that translation files no longer keep refreshing (some initial sync does happen with template and section group files due to keys that get auto-added by the platform, but they no longer loop)

**Before**
<img width="80%" src="https://github.com/user-attachments/assets/42482833-1b9b-4842-aaf5-86d71132f939"/>

**After**
<img width="80%" src="https://github.com/user-attachments/assets/17a094c8-a984-4213-a629-dba2678a2c64"/>


### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
