### PR TITLE
Remove reference to package.json

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -89,7 +89,7 @@ body:
   - type: input
     id: cli_version
     attributes:
-      label: Shopify CLI version (check your project's `package.json` if you're not sure)
+      label: Shopify CLI version (`shopify --version`)
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Since the Shopify CLI is now installed globally by default, the instruction in the issue template to check `package.json` to find the version is outdated.