### PR TITLE
force cli minor version 3.68.0

### DIFF
--- a/.changeset/fresh-mice-travel.md
+++ b/.changeset/fresh-mice-travel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': minor
+---
+
+force a minor CLI 3.68.0 release from patch changes


### PR DESCRIPTION
- we need to manually trigger a minor release to stay with our cadence
- CLI version `3.68.0`
- there were no minor labelled changes, so we'll manually add one to trigger the automated changeset process