### PR TITLE
[Themes] Remove Ruby from `theme console` command

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4755,14 +4755,6 @@
           "name": "environment",
           "type": "option"
         },
-        "legacy": {
-          "allowNo": false,
-          "description": "Use the legacy Ruby implementation for the `shopify theme console` command.",
-          "env": "SHOPIFY_FLAG_LEGACY",
-          "hidden": true,
-          "name": "legacy",
-          "type": "boolean"
-        },
         "no-color": {
           "allowNo": false,
           "description": "Disable color output.",
@@ -4777,15 +4769,6 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "name": "password",
-          "type": "option"
-        },
-        "port": {
-          "description": "Local port to serve authentication service.",
-          "env": "SHOPIFY_FLAG_PORT",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "port",
           "type": "option"
         },
         "store": {

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -3,11 +3,8 @@ import ThemeCommand from '../../utilities/theme-command.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
 import {ensureReplEnv, initializeRepl} from '../../services/console.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
-import {execCLI2} from '@shopify/cli-kit/node/ruby'
-import {renderInfo, renderWarning} from '@shopify/cli-kit/node/ui'
+import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {Flags} from '@oclif/core'
-import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 
 export default class Console extends ThemeCommand {
   static summary = 'Shopify Liquid REPL (read-eval-print loop) tool'
@@ -30,66 +27,20 @@ export default class Console extends ThemeCommand {
       env: 'SHOPIFY_FLAG_URL',
       default: '/',
     }),
-    port: Flags.string({
-      hidden: true,
-      description: 'Local port to serve authentication service.',
-      env: 'SHOPIFY_FLAG_PORT',
-    }),
     'store-password': Flags.string({
       description: 'The password for storefronts with password protection.',
       env: 'SHOPIFY_FLAG_STORE_PASSWORD',
-    }),
-    legacy: Flags.boolean({
-      hidden: true,
-      description: 'Use the legacy Ruby implementation for the `shopify theme console` command.',
-      env: 'SHOPIFY_FLAG_LEGACY',
     }),
   }
 
   async run() {
     const {flags} = await this.parse(Console)
     const store = ensureThemeStore(flags)
-    const {url, port, password: themeAccessPassword} = flags
-    const cliVersion = CLI_KIT_VERSION
-    const theme = `liquid-console-repl-${cliVersion}`
+    const {url, password: themeAccessPassword} = flags
 
     const adminSession = await ensureAuthenticatedThemes(store, themeAccessPassword, [], true)
-    const authUrl = `http://localhost:${port ?? '9293'}/password`
 
-    if (!flags.legacy) {
-      if (flags.port) {
-        renderPortDeprecationWarning()
-      }
-      const {themeId, storePassword} = await ensureReplEnv(adminSession, flags['store-password'])
-      await initializeRepl(adminSession, themeId, url, themeAccessPassword, storePassword)
-      return
-    }
-
-    renderInfo({
-      body: [
-        'Activate the Shopify Liquid console in',
-        {link: {label: 'your browser', url: authUrl}},
-        'and enter your store password if prompted.',
-      ],
-    })
-
-    const storefrontToken = await ensureAuthenticatedStorefront([], themeAccessPassword)
-
-    return execCLI2(['theme', 'console', '--url', url, '--port', port ?? '9293', '--theme', theme], {
-      store,
-      adminToken: adminSession.token,
-      storefrontToken,
-    })
+    const {themeId, storePassword} = await ensureReplEnv(adminSession, flags['store-password'])
+    await initializeRepl(adminSession, themeId, url, themeAccessPassword, storePassword)
   }
-}
-function renderPortDeprecationWarning() {
-  renderWarning({
-    headline: ['The', {command: '--port'}, 'flag has been deprecated.'],
-    body: [
-      {command: 'shopify theme console'},
-      'no longer requires a port to run. The',
-      {command: '--port'},
-      'flag is in the process of being deprecated and will be removed soon.',
-    ],
-  })
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/develop-advanced-edits/issues/350

### WHAT is this pull request doing?

This pull request focuses on cleaning up and simplifying the `Console` class in the `theme` package by removing deprecated and unused code. The most important changes include removing unnecessary imports, flags, and methods related to legacy implementations and port handling.

### Code Cleanup and Simplification:
- Removes Ruby CLI2 invocations from the `theme console` command
- Removes `legacy` and `port` flags

### How to test your changes?
- Run the command with the `legacy` or `port` flags

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes

cc: @Shopify/advanced-edits 
