### PR TITLE
[Themes] Remove Ruby from `theme dev` command

### DIFF
--- a/.changeset/soft-melons-retire.md
+++ b/.changeset/soft-melons-retire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': major
+---
+
+Removes the Ruby implementation of the `theme push` command

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4912,20 +4912,6 @@
       ],
       "args": {
       },
-      "cli2Flags": [
-        "host",
-        "live-reload",
-        "poll",
-        "theme-editor-sync",
-        "overwrite-json",
-        "port",
-        "theme",
-        "nodelete",
-        "only",
-        "ignore",
-        "force",
-        "notify"
-      ],
       "customPluginName": "@shopify/theme",
       "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
       "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
@@ -6038,20 +6024,6 @@
       ],
       "args": {
       },
-      "cli2Flags": [
-        "host",
-        "live-reload",
-        "poll",
-        "theme-editor-sync",
-        "overwrite-json",
-        "port",
-        "theme",
-        "nodelete",
-        "only",
-        "ignore",
-        "force",
-        "notify"
-      ],
       "customPluginName": "@shopify/theme",
       "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
       "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4965,22 +4965,6 @@
           "name": "ignore",
           "type": "option"
         },
-        "legacy": {
-          "allowNo": false,
-          "description": "Use the legacy Ruby implementation for the `shopify theme dev` command.",
-          "env": "SHOPIFY_FLAG_LEGACY",
-          "hidden": true,
-          "name": "legacy",
-          "type": "boolean"
-        },
-        "legacy-3.66": {
-          "allowNo": false,
-          "description": "Use the legacy Ruby implementation for the `shopify theme dev` command.",
-          "env": "SHOPIFY_FLAG_LEGACY_3_66",
-          "hidden": true,
-          "name": "legacy-3.66",
-          "type": "boolean"
-        },
         "live-reload": {
           "default": "hot-reload",
           "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
@@ -6106,22 +6090,6 @@
           "multiple": true,
           "name": "ignore",
           "type": "option"
-        },
-        "legacy": {
-          "allowNo": false,
-          "description": "Use the legacy Ruby implementation for the `shopify theme dev` command.",
-          "env": "SHOPIFY_FLAG_LEGACY",
-          "hidden": true,
-          "name": "legacy",
-          "type": "boolean"
-        },
-        "legacy-3.66": {
-          "allowNo": false,
-          "description": "Use the legacy Ruby implementation for the `shopify theme dev` command.",
-          "env": "SHOPIFY_FLAG_LEGACY_3_66",
-          "hidden": true,
-          "name": "legacy-3.66",
-          "type": "boolean"
         },
         "live-reload": {
           "default": "hot-reload",

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -1,7 +1,7 @@
 import {themeFlags} from '../../flags.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
 import ThemeCommand, {FlagValues} from '../../utilities/theme-command.js'
-import {dev, showDeprecationWarnings} from '../../services/dev.js'
+import {dev} from '../../services/dev.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
 import {findOrSelectTheme} from '../../utilities/theme-selector.js'
 import {Flags} from '@oclif/core'
@@ -115,8 +115,6 @@ You can run this command only in a directory that matches the [default Shopify t
   }
 
   async run(): Promise<void> {
-    showDeprecationWarnings(this.argv)
-
     const parsed = await this.parse(Dev)
     let flags = parsed.flags as typeof parsed.flags & FlagValues
     const {ignore = [], only = []} = flags

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -1,12 +1,13 @@
 import {themeFlags} from '../../flags.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
 import ThemeCommand, {FlagValues} from '../../utilities/theme-command.js'
-import {dev, refreshTokens, showDeprecationWarnings} from '../../services/dev.js'
+import {dev, showDeprecationWarnings} from '../../services/dev.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
 import {findOrSelectTheme} from '../../utilities/theme-selector.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
+import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import type {LiveReload} from '../../utilities/theme-environment/types.js'
 
 export default class Dev extends ThemeCommand {
@@ -118,10 +119,10 @@ You can run this command only in a directory that matches the [default Shopify t
 
     const parsed = await this.parse(Dev)
     let flags = parsed.flags as typeof parsed.flags & FlagValues
-    const store = ensureThemeStore(flags)
     const {ignore = [], only = []} = flags
 
-    const {adminSession, storefrontToken} = await refreshTokens(store, flags.password)
+    const store = ensureThemeStore(flags)
+    const adminSession = await ensureAuthenticatedThemes(store, flags.password)
 
     let theme: Theme
 
@@ -139,7 +140,6 @@ You can run this command only in a directory that matches the [default Shopify t
 
     await dev({
       adminSession,
-      storefrontToken,
       directory: flags.path,
       store,
       password: flags.password,

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -4,7 +4,6 @@ import ThemeCommand, {FlagValues} from '../../utilities/theme-command.js'
 import {dev, refreshTokens, showDeprecationWarnings} from '../../services/dev.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
 import {findOrSelectTheme} from '../../utilities/theme-selector.js'
-import {showEmbeddedCLIWarning} from '../../utilities/embedded-cli-warning.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
@@ -130,7 +129,6 @@ You can run this command only in a directory that matches the [default Shopify t
   ]
 
   async run(): Promise<void> {
-    showEmbeddedCLIWarning()
     showDeprecationWarnings(this.argv)
 
     const parsed = await this.parse(Dev)

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -90,16 +90,6 @@ You can run this command only in a directory that matches the [default Shopify t
       description: 'Skip hot reloading any files that match the specified pattern.',
       env: 'SHOPIFY_FLAG_IGNORE',
     }),
-    legacy: Flags.boolean({
-      hidden: true,
-      description: 'Use the legacy Ruby implementation for the `shopify theme dev` command.',
-      env: 'SHOPIFY_FLAG_LEGACY',
-    }),
-    'legacy-3.66': Flags.boolean({
-      hidden: true,
-      description: 'Use the legacy Ruby implementation for the `shopify theme dev` command.',
-      env: 'SHOPIFY_FLAG_LEGACY_3_66',
-    }),
     force: Flags.boolean({
       hidden: true,
       char: 'f',
@@ -148,7 +138,7 @@ You can run this command only in a directory that matches the [default Shopify t
     const store = ensureThemeStore(flags)
     const {ignore = [], only = []} = flags
 
-    const {adminSession, storefrontToken} = await refreshTokens(store, flags.password, Boolean(flags.legacy))
+    const {adminSession, storefrontToken} = await refreshTokens(store, flags.password)
 
     let theme: Theme
 
@@ -180,7 +170,6 @@ You can run this command only in a directory that matches the [default Shopify t
       force: flags.force,
       open: flags.open,
       flagsToPass,
-      legacy: flags['legacy-3.66'],
       'theme-editor-sync': flags['theme-editor-sync'],
       noDelete: flags.nodelete,
       ignore,

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -113,21 +113,6 @@ You can run this command only in a directory that matches the [default Shopify t
     }),
   }
 
-  static cli2Flags = [
-    'host',
-    'live-reload',
-    'poll',
-    'theme-editor-sync',
-    'overwrite-json',
-    'port',
-    'theme',
-    'nodelete',
-    'only',
-    'ignore',
-    'force',
-    'notify',
-  ]
-
   async run(): Promise<void> {
     showDeprecationWarnings(this.argv)
 
@@ -152,8 +137,6 @@ You can run this command only in a directory that matches the [default Shopify t
       flags = {...flags, theme: theme.id.toString(), 'overwrite-json': overwriteJson}
     }
 
-    const flagsToPass = this.passThroughFlags(flags, {allowedFlags: Dev.cli2Flags})
-
     await dev({
       adminSession,
       storefrontToken,
@@ -167,7 +150,6 @@ You can run this command only in a directory that matches the [default Shopify t
       'live-reload': flags['live-reload'] as LiveReload,
       force: flags.force,
       open: flags.open,
-      flagsToPass,
       'theme-editor-sync': flags['theme-editor-sync'],
       noDelete: flags.nodelete,
       ignore,

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -1,4 +1,4 @@
-import {showDeprecationWarnings, refreshTokens, dev, DevOptions} from './dev.js'
+import {showDeprecationWarnings, dev, DevOptions} from './dev.js'
 import {setupDevServer} from '../utilities/theme-environment/theme-environment.js'
 import {mountThemeFileSystem} from '../utilities/theme-fs.js'
 import {fakeThemeFileSystem} from '../utilities/theme-fs/theme-fs-mock-factory.js'
@@ -9,7 +9,6 @@ import {initializeDevServerSession} from '../utilities/theme-environment/dev-ser
 import {DevServerSession} from '../utilities/theme-environment/types.js'
 import {describe, expect, test, vi} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
-import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
@@ -27,7 +26,6 @@ describe('dev', () => {
   const adminSession = {storeFqdn: 'my-store.myshopify.com', token: 'my-token'}
   const options: DevOptions = {
     adminSession,
-    storefrontToken: 'my-storefront-token',
     directory: 'my-directory',
     store: 'my-store',
     theme: buildTheme({id: 123, name: 'My Theme', role: DEVELOPMENT_THEME_ROLE})!,
@@ -139,27 +137,5 @@ describe('showDeprecationWarnings', () => {
 
     // Then
     expect(outputMock.output()).toMatch(/The CLI flag --poll is now deprecated/)
-  })
-})
-
-describe('refreshTokens', () => {
-  test('returns the admin session and storefront token', async () => {
-    // When
-    const result = await refreshTokens('my-store', 'my-password')
-
-    // Then
-    expect(result).toEqual({
-      adminSession: {storeFqdn: 'my-store.myshopify.com', token: 'my-password'},
-      storefrontToken: 'my-password',
-    })
-  })
-
-  test('refreshes CLI2 cache with theme token command', async () => {
-    // When
-    await refreshTokens('my-store', 'my-password')
-
-    // Then
-    const expectedParams = ['theme', 'token', '--admin', 'my-password', '--sfr', 'my-password']
-    expect(execCLI2).toHaveBeenCalledWith(expectedParams)
   })
 })

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -1,4 +1,4 @@
-import {showDeprecationWarnings, dev, DevOptions} from './dev.js'
+import {dev, DevOptions} from './dev.js'
 import {setupDevServer} from '../utilities/theme-environment/theme-environment.js'
 import {mountThemeFileSystem} from '../utilities/theme-fs.js'
 import {fakeThemeFileSystem} from '../utilities/theme-fs/theme-fs-mock-factory.js'
@@ -8,7 +8,6 @@ import {emptyThemeExtFileSystem} from '../utilities/theme-fs-empty.js'
 import {initializeDevServerSession} from '../utilities/theme-environment/dev-server-session.js'
 import {DevServerSession} from '../utilities/theme-environment/types.js'
 import {describe, expect, test, vi} from 'vitest'
-import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
@@ -91,51 +90,5 @@ describe('dev', () => {
         },
       })
     })
-  })
-})
-
-describe('showDeprecationWarnings', () => {
-  test('does nothing when the -e flag includes a value', async () => {
-    // Given
-    const outputMock = mockAndCaptureOutput()
-
-    // When
-    showDeprecationWarnings(['-e', 'whatever'])
-
-    // Then
-    expect(outputMock.output()).toMatch('')
-  })
-
-  test('shows a warning message when the -e flag does not include a value', async () => {
-    // Given
-    const outputMock = mockAndCaptureOutput()
-
-    // When
-    showDeprecationWarnings(['-e'])
-
-    // Then
-    expect(outputMock.output()).toMatch(/reserved for environments/)
-  })
-
-  test('shows a warning message when the -e flag is followed by another flag', async () => {
-    // Given
-    const outputMock = mockAndCaptureOutput()
-
-    // When
-    showDeprecationWarnings(['-e', '--verbose'])
-
-    // Then
-    expect(outputMock.output()).toMatch(/reserved for environments/)
-  })
-
-  test('shows a warning message when the --poll flag is used', () => {
-    // Given
-    const outputMock = mockAndCaptureOutput()
-
-    // When
-    showDeprecationWarnings(['--poll'])
-
-    // Then
-    expect(outputMock.output()).toMatch(/The CLI flag --poll is now deprecated/)
   })
 })

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -36,7 +36,6 @@ describe('dev', () => {
     flagsToPass: [],
     password: 'my-token',
     'theme-editor-sync': false,
-    legacy: true,
     'live-reload': 'hot-reload',
     noDelete: false,
     ignore: [],
@@ -93,72 +92,6 @@ describe('dev', () => {
           noDelete: false,
           only: [],
         },
-      })
-    })
-  })
-
-  describe('Ruby implementation', async () => {
-    test('runs theme serve on CLI2 without passing a token when no password is used', async () => {
-      // Given
-      const devOptions = {...options, password: undefined}
-
-      // When
-      await dev(devOptions)
-
-      // Then
-      const expectedParams = ['theme', 'serve', 'my-directory']
-      expect(execCLI2).toHaveBeenCalledWith(expectedParams, {
-        store: 'my-store',
-        adminToken: undefined,
-        storefrontToken: undefined,
-      })
-    })
-
-    test('runs theme serve on CLI2 passing a token when a password is used', async () => {
-      // Given
-      const devOptions = {...options, password: 'my-token'}
-
-      // When
-      await dev(devOptions)
-
-      // Then
-      const expectedParams = ['theme', 'serve', 'my-directory']
-      expect(execCLI2).toHaveBeenCalledWith(expectedParams, {
-        store: 'my-store',
-        adminToken: 'my-token',
-        storefrontToken: 'my-storefront-token',
-      })
-    })
-
-    test("runs theme serve on CLI2 passing '--open' flag when it's true", async () => {
-      // Given
-      const devOptions = {...options, open: true}
-
-      // When
-      await dev(devOptions)
-
-      // Then
-      const expectedParams = ['theme', 'serve', 'my-directory', '--open']
-      expect(execCLI2).toHaveBeenCalledWith(expectedParams, {
-        store: 'my-store',
-        adminToken: 'my-token',
-        storefrontToken: 'my-storefront-token',
-      })
-    })
-
-    test("runs theme serve on CLI2 passing '--open' flag when it's false", async () => {
-      // Given
-      const devOptions = {...options, open: false}
-
-      // When
-      await dev(devOptions)
-
-      // Then
-      const expectedParams = ['theme', 'serve', 'my-directory']
-      expect(execCLI2).toHaveBeenCalledWith(expectedParams, {
-        store: 'my-store',
-        adminToken: 'my-token',
-        storefrontToken: 'my-storefront-token',
       })
     })
   })

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -33,7 +33,6 @@ describe('dev', () => {
     theme: buildTheme({id: 123, name: 'My Theme', role: DEVELOPMENT_THEME_ROLE})!,
     force: false,
     open: false,
-    flagsToPass: [],
     password: 'my-token',
     'theme-editor-sync': false,
     'live-reload': 'hot-reload',
@@ -129,6 +128,17 @@ describe('showDeprecationWarnings', () => {
 
     // Then
     expect(outputMock.output()).toMatch(/reserved for environments/)
+  })
+
+  test('shows a warning message when the --poll flag is used', () => {
+    // Given
+    const outputMock = mockAndCaptureOutput()
+
+    // When
+    showDeprecationWarnings(['--poll'])
+
+    // Then
+    expect(outputMock.output()).toMatch(/The CLI flag --poll is now deprecated/)
   })
 })
 

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -106,6 +106,8 @@ export async function dev(options: DevOptions) {
 }
 
 function renderLinks(store: string, themeId: string, host = DEFAULT_HOST, port = DEFAULT_PORT) {
+  const remoteUrl = `https://${store}`
+  const localUrl = `http://${host}:${port}`
   renderSuccess({
     body: [
       {
@@ -114,7 +116,7 @@ function renderLinks(store: string, themeId: string, host = DEFAULT_HOST, port =
           items: [
             {
               link: {
-                url: `http://${host}:${port}`,
+                url: localUrl,
               },
             },
           ],
@@ -126,7 +128,7 @@ function renderLinks(store: string, themeId: string, host = DEFAULT_HOST, port =
         {
           link: {
             label: 'Customize your theme at the theme editor',
-            url: `https://${store}/admin/themes/${themeId}/editor`,
+            url: `${remoteUrl}/admin/themes/${themeId}/editor`,
           },
         },
       ],
@@ -134,11 +136,11 @@ function renderLinks(store: string, themeId: string, host = DEFAULT_HOST, port =
         {
           link: {
             label: 'Share your theme preview',
-            url: `https://${store}/?preview_theme_id=${themeId}`,
+            url: `${remoteUrl}/?preview_theme_id=${themeId}`,
           },
         },
         {
-          subdued: `(https://${store}/?preview_theme_id=${themeId})`,
+          subdued: `(${remoteUrl}/?preview_theme_id=${themeId})`,
         },
       ],
     ],

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -6,7 +6,7 @@ import {isStorefrontPasswordProtected} from '../utilities/theme-environment/stor
 import {ensureValidPassword} from '../utilities/theme-environment/storefront-password-prompt.js'
 import {emptyThemeExtFileSystem} from '../utilities/theme-fs-empty.js'
 import {initializeDevServerSession} from '../utilities/theme-environment/dev-server-session.js'
-import {renderInfo, renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
+import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 import {checkPortAvailability, getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
@@ -36,8 +36,6 @@ export interface DevOptions {
 }
 
 export async function dev(options: DevOptions) {
-  showNewVersionInfo()
-
   if (!(await hasRequiredThemeDirectories(options.directory)) && !(await currentDirectoryConfirmed(options.force))) {
     return
   }
@@ -171,11 +169,4 @@ export function showDeprecationWarnings(args: string[]) {
       body: 'The CLI flag --poll is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
     })
   }
-}
-
-function showNewVersionInfo() {
-  renderInfo({
-    headline: [`You're using the new version of`, {command: 'shopify theme dev'}, {char: '.'}],
-    body: ['Run', {command: 'shopify theme dev --legacy'}, 'to switch back to the previous version.'],
-  })
 }

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -99,7 +99,6 @@ export async function dev(options: DevOptions) {
 
   renderLinks(options.store, String(options.theme.id), host, port)
   if (options.open) {
-    // eslint-disable-next-line @typescript-eslint/use-unknown-in-catch-callback-variable
     openURL(`http://${host}:${port}`).catch((error: Error) => {
       renderWarning({headline: 'Failed to open the development server.', body: error.stack ?? error.message})
     })

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -145,28 +145,3 @@ function renderLinks(store: string, themeId: string, host = DEFAULT_HOST, port =
     ],
   })
 }
-
-export function showDeprecationWarnings(args: string[]) {
-  const eFlagIndex = args.findIndex((arg) => arg === '-e')
-
-  const wrongEnvFlag = eFlagIndex >= 0 && (!args[eFlagIndex + 1] || args[eFlagIndex + 1]?.startsWith('-'))
-  if (wrongEnvFlag) {
-    renderWarning({
-      body: [
-        'If you want to enable synchronization with Theme Editor, please use',
-        {command: '--theme-editor-sync'},
-        {char: '.'},
-        'The shortcut',
-        {command: '-e'},
-        'is now reserved for environments.',
-      ],
-    })
-  }
-
-  const pollFlagPresent = args.find((arg) => arg === '--poll')
-  if (pollFlagPresent) {
-    renderWarning({
-      body: 'The CLI flag --poll is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
-    })
-  }
-}

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -30,7 +30,6 @@ export interface DevOptions {
   host?: string
   port?: string
   force: boolean
-  flagsToPass: string[]
   'theme-editor-sync': boolean
   'live-reload': LiveReload
   noDelete: boolean
@@ -50,12 +49,6 @@ export async function dev(options: DevOptions) {
     (needsPassword) =>
       needsPassword ? ensureValidPassword(options.storePassword, options.adminSession.storeFqdn) : undefined,
   )
-
-  if (options.flagsToPass.includes('--poll')) {
-    renderWarning({
-      body: 'The CLI flag --pull is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
-    })
-  }
 
   const localThemeExtensionFileSystem = emptyThemeExtFileSystem()
   const localThemeFileSystem = mountThemeFileSystem(options.directory, {
@@ -171,6 +164,7 @@ function renderLinks(store: string, themeId: string, host = DEFAULT_HOST, port =
 
 export function showDeprecationWarnings(args: string[]) {
   const eFlagIndex = args.findIndex((arg) => arg === '-e')
+
   const wrongEnvFlag = eFlagIndex >= 0 && (!args[eFlagIndex + 1] || args[eFlagIndex + 1]?.startsWith('-'))
   if (wrongEnvFlag) {
     renderWarning({
@@ -185,24 +179,10 @@ export function showDeprecationWarnings(args: string[]) {
     })
   }
 
-  const legacyFlagPresent = args.find((arg) => arg === '--legacy')
-
-  if (legacyFlagPresent) {
+  const pollFlagPresent = args.find((arg) => arg === '--poll')
+  if (pollFlagPresent) {
     renderWarning({
-      headline: ['The', {command: '--legacy'}, 'flag is deprecated.'],
-      body: [
-        'The',
-        {command: '--legacy'},
-        'flag has been deprecated. If this variable is essential to your workflow, please report an issue at',
-        {
-          link: {
-            url: 'https://github.com/Shopify/cli/issues',
-          },
-        },
-        {
-          char: '.',
-        },
-      ],
+      body: 'The CLI flag --poll is now deprecated and will be removed in future releases. It is no longer necessary with the new implementation. Please update your usage accordingly.',
     })
   }
 }

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -119,6 +119,7 @@ export async function dev(options: DevOptions) {
 
   renderLinks(options.store, String(options.theme.id), host, port)
   if (options.open) {
+    // eslint-disable-next-line @typescript-eslint/use-unknown-in-catch-callback-variable
     openURL(`http://${host}:${port}`).catch((error: Error) => {
       renderWarning({headline: 'Failed to open the development server.', body: error.stack ?? error.message})
     })


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-advanced-edits/issues/354

### WHAT is this pull request doing?
- Remove `legacy` and `legacy-3.66` flag from `theme dev` command
- Remove Ruby code path in `theme dev` command
  - Remove call to `execCLI2`
  - Remove `CLI2 flags` and related functionality
- Remove `refreshTokens` and related code
- Remove `deprecationWarnings` for `poll` and `-e` flags

### How to test your changes?
- Run `shopify theme dev` with the follow options:
  - `--legacy` and `--legacy-3.66` flag is not supported
  - `--poll` and `-e` flag will no longer render warnings

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes