### PR TITLE
Fix `shopify theme pull --only <value>` so it does not delete ignored files

### DIFF
--- a/.changeset/witty-insects-study.md
+++ b/.changeset/witty-insects-study.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `shopify theme pull --only <value>` so it does not delete ignored files

--- a/packages/theme/src/cli/utilities/theme-downloader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-downloader.test.ts
@@ -32,6 +32,26 @@ describe('theme-downloader', () => {
       expect(spy).toHaveBeenCalledWith('assets/deleteme.css')
     })
 
+    test('does not delete files when filters are passed', async () => {
+      // Given
+      const remote: Checksum[] = []
+      const files = new Map<string, ThemeAsset>([
+        ['assets/keepme.css', {key: 'assets/keepme.css', checksum: '1', value: 'content'}],
+      ])
+      const fileSystem = fakeThemeFileSystem(root, files, {
+        filters: {
+          only: ['templates/*'],
+        },
+      })
+      const spy = vi.spyOn(fileSystem, 'delete')
+
+      // When
+      await downloadTheme(remoteTheme, adminSession, remote, fileSystem, downloadOptions)
+
+      // Then
+      expect(spy).not.toHaveBeenCalled()
+    })
+
     test('does not delete files when nodelete is set', async () => {
       // Given
       const downloadOptions = {nodelete: true}

--- a/packages/theme/src/cli/utilities/theme-downloader.ts
+++ b/packages/theme/src/cli/utilities/theme-downloader.ts
@@ -29,7 +29,7 @@ function buildDeleteTasks(remoteChecksums: Checksum[], themeFileSystem: ThemeFil
 
   const remoteKeys = new Set(remoteChecksums.map((checksum) => checksum.key))
 
-  const localKeys = Array.from(themeFileSystem.files.keys())
+  const localKeys = themeFileSystem.applyIgnoreFilters([...themeFileSystem.files.values()]).map(({key}) => key)
   const localFilesToBeDeleted = localKeys.filter((key) => !remoteKeys.has(key))
 
   return localFilesToBeDeleted.map((key) => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/4472

### WHAT is this pull request doing?

This updates the `shopify theme pull` command to ignore files as expected by applying the ignore filters in the local keys.

### How to test your changes?

- Run `shopify theme init test`
- Run `cd test`
- Run `rm locales/es*`
- Run `shopify theme push -d`
- Run `git checkout locales/`
- Run `shopify theme pull -d --only config`
- Notice that `locales/es.json` and `locales/es.schema.json` are no longer deleted

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
