### PR TITLE
Add a new option to create a theme on `shopify theme push`

### DIFF
--- a/.changeset/fifty-items-tan.md
+++ b/.changeset/fifty-items-tan.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Add a new option to create a theme on `shopify theme push`

--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -304,6 +304,7 @@ export async function createOrSelectTheme(
     )
   } else {
     const selectedTheme = await findOrSelectTheme(adminSession, {
+      create: true,
       header: 'Select a theme to push to:',
       filter: {
         live,

--- a/packages/theme/src/cli/utilities/theme-selector.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.ts
@@ -4,19 +4,37 @@ import {getDevelopmentTheme} from '../services/local-storage.js'
 import {renderAutocompletePrompt} from '@shopify/cli-kit/node/ui'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {capitalize} from '@shopify/cli-kit/common/string'
+import {createTheme} from '@shopify/cli-kit/node/themes/api'
+import {promptThemeName, UNPUBLISHED_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {Theme} from '@shopify/cli-kit/node/themes/types'
+
+/**
+ * Options to find or select a theme.
+ */
+interface FindOrSelectOptions {
+  /**
+   * When 'true', the selector renders with an option to create a new theme.
+   */
+  create?: boolean
+  /**
+   * The header presented when users select a theme.
+   */
+  header?: string
+  /**
+   * The filter applied in the list of themes in the store.
+   */
+  filter: FilterProps
+}
 
 /**
  * Finds or selects a theme in the store.
  *
  * @param session - Current Admin session
- * @param options - Options to select a theme:
- *  - header:           the header presented when users select a theme
- *  - filter:           the filter ({@link FilterProps}) applied in the list
- *                      of themes in the store
- *
+ * @param options - Options to select a theme
  * @returns the selected {@link Theme}
  */
-export async function findOrSelectTheme(session: AdminSession, options: {header?: string; filter: FilterProps}) {
+export async function findOrSelectTheme(session: AdminSession, options: FindOrSelectOptions) {
   const themes = await fetchStoreThemes(session)
   const filter = new Filter(options.filter)
   const store = session.storeFqdn
@@ -25,18 +43,27 @@ export async function findOrSelectTheme(session: AdminSession, options: {header?
     return filterThemes(store, themes, filter)[0]!
   }
 
-  return renderAutocompletePrompt({
-    message: options.header ?? '',
-    choices: themes.map((theme) => {
-      const yoursLabel = theme.id.toString() === getDevelopmentTheme() ? ' [yours]' : ''
+  const message = options.header ?? ''
+  const choices = themes.map((theme) => {
+    const yoursLabel = theme.id.toString() === getDevelopmentTheme() ? ' [yours]' : ''
 
-      return {
-        value: theme,
-        label: `${theme.name}${yoursLabel}`,
-        group: capitalize(theme.role),
-      }
-    }),
+    return {
+      value: async () => theme,
+      label: `${theme.name}${yoursLabel}`,
+      group: capitalize(theme.role),
+    }
   })
+
+  if (options.create) {
+    choices.unshift(newThemeOption(session))
+  }
+
+  const themeSupplier = await renderAutocompletePrompt({
+    message,
+    choices,
+  })
+
+  return themeSupplier()
 }
 
 /**
@@ -58,4 +85,26 @@ export async function findThemes(session: AdminSession, filterProps: FilterProps
   }
 
   return []
+}
+
+export function newThemeOption(session: AdminSession): {
+  value: () => Promise<Theme>
+  label: string
+  group: string
+} {
+  return {
+    value: async () => {
+      const role = UNPUBLISHED_THEME_ROLE
+      const name = await promptThemeName('Name of the new theme')
+      const theme = await createTheme({name, role}, session)
+
+      if (!theme) {
+        throw new AbortError('The theme could not be created.')
+      }
+
+      return theme
+    },
+    label: '[Create a new theme]',
+    group: capitalize(UNPUBLISHED_THEME_ROLE),
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-advanced-edits/issues/355

### WHAT is this pull request doing?

This PR adds the `[Create a new theme]` option when users are pushing a new theme to reduce friction during the theme creation.

### How to test your changes?

- Run `shopify theme push`
- Notice we have the option to create a new theme

![image](https://github.com/user-attachments/assets/a9fa2015-5bb9-48d2-8dcf-6d4987bd1ca0)

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
