### PR TITLE
[ShopifyVM] 'app logs' Show input query variables in output for FunctionRunLog

### DIFF
--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
@@ -1,6 +1,8 @@
 import {Logs} from './Logs.js'
 import {usePollAppLogs} from './hooks/usePollAppLogs.js'
 import {
+  AppLogPayload,
+  AppLogPrefix,
   BackgroundExecutionReason,
   FunctionRunLog,
   NetworkAccessRequestExecutedLog,
@@ -45,114 +47,6 @@ const NETWORK_ACCESS_HTTP_RESPONSE = {
   },
 }
 
-const USE_POLL_APP_LOGS_RETURN_VALUE = {
-  appLogOutputs: [
-    {
-      appLog: new FunctionRunLog({
-        export: 'run',
-        input: INPUT,
-        inputBytes: INPUT_BYTES,
-        output: OUTPUT,
-        outputBytes: OUTPUT_BYTES,
-        logs: LOGS,
-        functionId: FUNCTION_ID,
-        fuelConsumed: FUEL_CONSUMED,
-        errorMessage: 'errorMessage',
-        errorType: 'errorType',
-      }),
-      prefix: {
-        functionId: FUNCTION_ID,
-        logTimestamp: TIME,
-        description: `export "run" executed in 0.5124M instructions`,
-        storeName: 'my-store',
-        status: STATUS === 'success' ? 'Success' : 'Failure',
-        source: SOURCE,
-      },
-    },
-    {
-      appLog: new NetworkAccessResponseFromCacheLog({
-        cacheEntryEpochMs: 1683904621000,
-        cacheTtlMs: 300000,
-        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
-        httpResponse: NETWORK_ACCESS_HTTP_RESPONSE,
-      }),
-      prefix: {
-        functionId: FUNCTION_ID,
-        logTimestamp: TIME,
-        description: 'network access response from cache',
-        storeName: 'my-store',
-        status: 'Success',
-        source: SOURCE,
-      },
-    },
-    {
-      appLog: new NetworkAccessRequestExecutedLog({
-        attempt: 1,
-        connectTimeMs: 40,
-        writeReadTimeMs: 40,
-        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
-        httpResponse: NETWORK_ACCESS_HTTP_RESPONSE,
-        error: null,
-      }),
-      prefix: {
-        functionId: FUNCTION_ID,
-        logTimestamp: TIME,
-        description: 'network access request executed in 80 ms',
-        status: 'Success',
-        storeName: 'my-store',
-        source: SOURCE,
-      },
-    },
-    {
-      appLog: new NetworkAccessRequestExecutedLog({
-        attempt: 1,
-        connectTimeMs: null,
-        writeReadTimeMs: null,
-        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
-        httpResponse: null,
-        error: 'Timeout Error',
-      }),
-      prefix: {
-        functionId: FUNCTION_ID,
-        logTimestamp: TIME,
-        description: 'network access request executed',
-        storeName: 'my-store',
-        status: 'Failure',
-        source: SOURCE,
-      },
-    },
-    {
-      appLog: new NetworkAccessRequestExecutionInBackgroundLog({
-        reason: BackgroundExecutionReason.NoCachedResponse,
-        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
-      }),
-      prefix: {
-        functionId: FUNCTION_ID,
-        logTimestamp: TIME,
-        description: 'network access request executing in background',
-        storeName: 'my-store',
-        status: 'Success',
-        source: SOURCE,
-      },
-    },
-    {
-      appLog: new NetworkAccessRequestExecutionInBackgroundLog({
-        reason: BackgroundExecutionReason.CacheAboutToExpire,
-        httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
-      }),
-      prefix: {
-        functionId: FUNCTION_ID,
-        logTimestamp: TIME,
-        description: 'network access request executing in background',
-        storeName: 'my-store',
-        status: 'Success',
-        source: SOURCE,
-      },
-    },
-  ],
-  errors: [],
-}
-
 const USE_POLL_APP_LOGS_ERRORS_RETURN_VALUE = {
   errors: ['Test Error'],
   appLogOutputs: [],
@@ -163,118 +57,448 @@ STORE_NAME_BY_ID.set('1', 'my-store')
 
 const EMPTY_FILTERS = {status: undefined, sources: undefined}
 
+const appLogFunctionRunOutputs = ({
+  prefix = {},
+  appLog = {},
+}: {
+  prefix?: Partial<AppLogPrefix>
+  appLog?: Partial<AppLogPayload>
+} = {}): {appLog: FunctionRunLog; prefix: AppLogPrefix} => {
+  const defaultPrefix = {
+    functionId: FUNCTION_ID,
+    logTimestamp: TIME,
+    description: `export "run" executed in 0.5124M instructions`,
+    storeName: 'my-store',
+    status: STATUS === 'success' ? 'Success' : 'Failure',
+    source: SOURCE,
+  }
+
+  const defaultAppLog = {
+    export: 'run',
+    input: INPUT,
+    inputBytes: INPUT_BYTES,
+    output: OUTPUT,
+    outputBytes: OUTPUT_BYTES,
+    logs: LOGS,
+    functionId: FUNCTION_ID,
+    fuelConsumed: FUEL_CONSUMED,
+    errorMessage: 'errorMessage',
+    errorType: 'errorType',
+    inputQueryVariablesMetafieldValue: '{"key":"value"}',
+    inputQueryVariablesMetafieldNamespace: 'inputQueryVariablesMetafieldNamespace',
+    inputQueryVariablesMetafieldKey: 'inputQueryVariablesMetafieldKey',
+  }
+
+  const resultPrefix = {...defaultPrefix, ...prefix}
+  const resultAppLog = {...defaultAppLog, ...appLog}
+
+  return {
+    appLog: new FunctionRunLog(resultAppLog),
+    prefix: resultPrefix,
+  }
+}
+
 describe('Logs', () => {
-  test('renders prefix and applogs', async () => {
-    // Given
-    const mockedUsePollAppLogs = vi.fn().mockReturnValue(USE_POLL_APP_LOGS_RETURN_VALUE)
-    vi.mocked(usePollAppLogs).mockImplementation(mockedUsePollAppLogs)
-    // When
-    const renderInstance = render(
-      <Logs
-        pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
-        resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
-        storeNameById={new Map()}
-      />,
-    )
+  describe('App Logs', () => {
+    test('renders FunctionRunLog correctly with metafield data', async () => {
+      const appLogOutput = appLogFunctionRunOutputs()
 
-    // Then
-    const lastFrame = renderInstance.lastFrame()
+      const mockedUsePollAppLogs = vi.fn().mockReturnValue({appLogOutputs: [appLogOutput], errors: []})
+      vi.mocked(usePollAppLogs).mockImplementation(mockedUsePollAppLogs)
 
-    expect(unstyled(lastFrame!)).toMatchInlineSnapshot(`
-    "2024-06-18 16:02:04.868 my-store my-function Success export \\"run\\" executed in 0.5124M instructions
-        test logs
-        Input (10 bytes):
-        {
-          \\"test\\": \\"input\\"
-        }
+      const renderInstance = render(
+        <Logs
+          pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
+          resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
+          storeNameById={new Map()}
+        />,
+      )
 
-        Output (10 bytes):
-        {
-          \\"test\\": \\"output\\"
-        }
-    2024-06-18 16:02:04.868 my-store my-function Success network access response from cache
-        Cache write time: 2023-05-12T15:17:01.000Z
-        Cache TTL: 300 s
-        HTTP request:
-        {
-          \\"url\\": \\"https://api.example.com/hello\\",
-          \\"method\\": \\"GET\\",
-          \\"headers\\": {},
-          \\"body\\": null,
-          \\"policy\\": {
-            \\"read_timeout_ms\\": 500
-          }
-        }
-        HTTP response:
-        {
-          \\"status\\": 200,
-          \\"body\\": \\"Success\\",
-          \\"headers\\": {
-            \\"header1\\": \\"value1\\"
-          }
-        }
-    2024-06-18 16:02:04.868 my-store my-function Success network access request executed in 80 ms
-        Attempt: 1
-        Connect time: 40 ms
-        Write read time: 40 ms
-        HTTP request:
-        {
-          \\"url\\": \\"https://api.example.com/hello\\",
-          \\"method\\": \\"GET\\",
-          \\"headers\\": {},
-          \\"body\\": null,
-          \\"policy\\": {
-            \\"read_timeout_ms\\": 500
-          }
-        }
-        HTTP response:
-        {
-          \\"status\\": 200,
-          \\"body\\": \\"Success\\",
-          \\"headers\\": {
-            \\"header1\\": \\"value1\\"
-          }
-        }
-    2024-06-18 16:02:04.868 my-store my-function Failure network access request executed
-        Attempt: 1
-        HTTP request:
-        {
-          \\"url\\": \\"https://api.example.com/hello\\",
-          \\"method\\": \\"GET\\",
-          \\"headers\\": {},
-          \\"body\\": null,
-          \\"policy\\": {
-            \\"read_timeout_ms\\": 500
-          }
-        }
-        Error: Timeout Error
-    2024-06-18 16:02:04.868 my-store my-function Success network access request executing in background
-        Reason: No cached response available
-        HTTP request:
-        {
-          \\"url\\": \\"https://api.example.com/hello\\",
-          \\"method\\": \\"GET\\",
-          \\"headers\\": {},
-          \\"body\\": null,
-          \\"policy\\": {
-            \\"read_timeout_ms\\": 500
-          }
-        }
-    2024-06-18 16:02:04.868 my-store my-function Success network access request executing in background
-        Reason: Cache is about to expire
-        HTTP request:
-        {
-          \\"url\\": \\"https://api.example.com/hello\\",
-          \\"method\\": \\"GET\\",
-          \\"headers\\": {},
-          \\"body\\": null,
-          \\"policy\\": {
-            \\"read_timeout_ms\\": 500
-          }
-        }"
-    `)
+      const lastFrame = renderInstance.lastFrame()
 
-    renderInstance.unmount()
+      expect(unstyled(lastFrame!)).toMatchInlineSnapshot(`
+      "2024-06-18 16:02:04.868 my-store my-function Success export \\"run\\" executed in 0.5124M instructions
+          test logs
+
+          Input Query Variables:
+
+           Namespace: inputQueryVariablesMetafieldNamespace
+           Key: inputQueryVariablesMetafieldKey
+
+           {
+             \\"key\\": \\"value\\"
+           }
+
+          Input (10 bytes):
+
+           {
+             \\"test\\": \\"input\\"
+           }
+
+          Output (10 bytes):
+
+           {
+             \\"test\\": \\"output\\"
+           }"
+      `)
+
+      renderInstance.unmount()
+    })
+
+    test('renders FunctionRunLog correctly with nil metafield value', async () => {
+      const appLogOutput = appLogFunctionRunOutputs({
+        appLog: {
+          inputQueryVariablesMetafieldValue: null,
+        },
+      })
+      const mockedUsePollAppLogs = vi.fn().mockReturnValue({appLogOutputs: [appLogOutput], errors: []})
+      vi.mocked(usePollAppLogs).mockImplementation(mockedUsePollAppLogs)
+
+      const renderInstance = render(
+        <Logs
+          pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
+          resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
+          storeNameById={new Map()}
+        />,
+      )
+
+      const lastFrame = renderInstance.lastFrame()
+
+      expect(unstyled(lastFrame!)).toMatchInlineSnapshot(`
+        "2024-06-18 16:02:04.868 my-store my-function Success export \\"run\\" executed in 0.5124M instructions
+            test logs
+
+            Input Query Variables:
+
+             Namespace: inputQueryVariablesMetafieldNamespace
+             Key: inputQueryVariablesMetafieldKey
+
+             Metafield is not set
+
+            Input (10 bytes):
+
+             {
+               \\"test\\": \\"input\\"
+             }
+
+            Output (10 bytes):
+
+             {
+               \\"test\\": \\"output\\"
+             }"
+        `)
+
+      renderInstance.unmount()
+    })
+
+    test('redners FunctionRunLog without iqv when key and namespace are null', async () => {
+      const appLogOutput = appLogFunctionRunOutputs({
+        appLog: {
+          inputQueryVariablesMetafieldValue: null,
+          inputQueryVariablesMetafieldNamespace: null,
+          inputQueryVariablesMetafieldKey: null,
+        },
+      })
+
+      const mockedUsePollAppLogs = vi.fn().mockReturnValue({appLogOutputs: [appLogOutput], errors: []})
+      vi.mocked(usePollAppLogs).mockImplementation(mockedUsePollAppLogs)
+
+      const renderInstance = render(
+        <Logs
+          pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
+          resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
+          storeNameById={new Map()}
+        />,
+      )
+
+      const lastFrame = renderInstance.lastFrame()
+
+      expect(unstyled(lastFrame!)).toMatchInlineSnapshot(`
+      "2024-06-18 16:02:04.868 my-store my-function Success export \\"run\\" executed in 0.5124M instructions
+          test logs
+
+          Input (10 bytes):
+
+           {
+             \\"test\\": \\"input\\"
+           }
+
+          Output (10 bytes):
+
+           {
+             \\"test\\": \\"output\\"
+           }"
+      `)
+
+      renderInstance.unmount()
+    })
+  })
+
+  describe('Network Access', () => {
+    test('renders NetworkAccessResponseFromCacheLog correctly', async () => {
+      const webhookLogOutput = {
+        appLog: new NetworkAccessResponseFromCacheLog({
+          cacheEntryEpochMs: 1683904621000,
+          cacheTtlMs: 300000,
+          httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+          httpResponse: NETWORK_ACCESS_HTTP_RESPONSE,
+        }),
+        prefix: {
+          functionId: FUNCTION_ID,
+          logTimestamp: TIME,
+          description: 'network access response from cache',
+          storeName: 'my-store',
+          status: 'Success',
+          source: SOURCE,
+        },
+      }
+
+      const mockedUsePollAppLogs = vi.fn().mockReturnValue({appLogOutputs: [webhookLogOutput], errors: []})
+      vi.mocked(usePollAppLogs).mockImplementation(mockedUsePollAppLogs)
+
+      const renderInstance = render(
+        <Logs
+          pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
+          resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
+          storeNameById={new Map()}
+        />,
+      )
+
+      const lastFrame = renderInstance.lastFrame()
+
+      expect(unstyled(lastFrame!)).toMatchInlineSnapshot(`
+      "2024-06-18 16:02:04.868 my-store my-function Success network access response from cache
+          Cache write time: 2023-05-12T15:17:01.000Z
+          Cache TTL: 300 s
+          HTTP request:
+          {
+            \\"url\\": \\"https://api.example.com/hello\\",
+            \\"method\\": \\"GET\\",
+            \\"headers\\": {},
+            \\"body\\": null,
+            \\"policy\\": {
+              \\"read_timeout_ms\\": 500
+            }
+          }
+          HTTP response:
+          {
+            \\"status\\": 200,
+            \\"body\\": \\"Success\\",
+            \\"headers\\": {
+              \\"header1\\": \\"value1\\"
+            }
+          }"
+      `)
+
+      renderInstance.unmount()
+    })
+
+    test('renders NetworkAccessRequestExecutedLog correctly with success', async () => {
+      const webhookLogOutput = {
+        appLog: new NetworkAccessRequestExecutedLog({
+          attempt: 1,
+          connectTimeMs: 40,
+          writeReadTimeMs: 40,
+          httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+          httpResponse: NETWORK_ACCESS_HTTP_RESPONSE,
+          error: null,
+        }),
+        prefix: {
+          functionId: FUNCTION_ID,
+          logTimestamp: TIME,
+          description: 'network access request executed in 80 ms',
+          status: 'Success',
+          storeName: 'my-store',
+          source: SOURCE,
+        },
+      }
+
+      const mockedUsePollAppLogs = vi.fn().mockReturnValue({appLogOutputs: [webhookLogOutput], errors: []})
+      vi.mocked(usePollAppLogs).mockImplementation(mockedUsePollAppLogs)
+
+      const renderInstance = render(
+        <Logs
+          pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
+          resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
+          storeNameById={new Map()}
+        />,
+      )
+
+      const lastFrame = renderInstance.lastFrame()
+
+      expect(unstyled(lastFrame!)).toMatchInlineSnapshot(`
+      "2024-06-18 16:02:04.868 my-store my-function Success network access request executed in 80 ms
+          Attempt: 1
+          Connect time: 40 ms
+          Write read time: 40 ms
+          HTTP request:
+          {
+            \\"url\\": \\"https://api.example.com/hello\\",
+            \\"method\\": \\"GET\\",
+            \\"headers\\": {},
+            \\"body\\": null,
+            \\"policy\\": {
+              \\"read_timeout_ms\\": 500
+            }
+          }
+          HTTP response:
+          {
+            \\"status\\": 200,
+            \\"body\\": \\"Success\\",
+            \\"headers\\": {
+              \\"header1\\": \\"value1\\"
+            }
+          }"
+      `)
+
+      renderInstance.unmount()
+    })
+
+    test('renders NetworkAccessRequestExecutedLog correctly with failure', async () => {
+      const webhookLogOutput = {
+        appLog: new NetworkAccessRequestExecutedLog({
+          attempt: 1,
+          connectTimeMs: null,
+          writeReadTimeMs: null,
+          httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+          httpResponse: null,
+          error: 'Timeout Error',
+        }),
+        prefix: {
+          functionId: FUNCTION_ID,
+          logTimestamp: TIME,
+          description: 'network access request executed',
+          storeName: 'my-store',
+          status: 'Failure',
+          source: SOURCE,
+        },
+      }
+
+      const mockedUsePollAppLogs = vi.fn().mockReturnValue({appLogOutputs: [webhookLogOutput], errors: []})
+      vi.mocked(usePollAppLogs).mockImplementation(mockedUsePollAppLogs)
+
+      const renderInstance = render(
+        <Logs
+          pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
+          resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
+          storeNameById={new Map()}
+        />,
+      )
+
+      const lastFrame = renderInstance.lastFrame()
+
+      expect(unstyled(lastFrame!)).toMatchInlineSnapshot(`
+      "2024-06-18 16:02:04.868 my-store my-function Failure network access request executed
+          Attempt: 1
+          HTTP request:
+          {
+            \\"url\\": \\"https://api.example.com/hello\\",
+            \\"method\\": \\"GET\\",
+            \\"headers\\": {},
+            \\"body\\": null,
+            \\"policy\\": {
+              \\"read_timeout_ms\\": 500
+            }
+          }
+          Error: Timeout Error"
+      `)
+
+      renderInstance.unmount()
+    })
+
+    test('renders NetworkAccessRequestExecutionInBackgroundLog correctly with NoCachedResponse', async () => {
+      const webhookLogOutput = {
+        appLog: new NetworkAccessRequestExecutionInBackgroundLog({
+          reason: BackgroundExecutionReason.NoCachedResponse,
+          httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+        }),
+        prefix: {
+          functionId: FUNCTION_ID,
+          logTimestamp: TIME,
+          description: 'network access request executing in background',
+          storeName: 'my-store',
+          status: 'Success',
+          source: SOURCE,
+        },
+      }
+
+      const mockedUsePollAppLogs = vi.fn().mockReturnValue({appLogOutputs: [webhookLogOutput], errors: []})
+      vi.mocked(usePollAppLogs).mockImplementation(mockedUsePollAppLogs)
+
+      const renderInstance = render(
+        <Logs
+          pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
+          resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
+          storeNameById={new Map()}
+        />,
+      )
+
+      const lastFrame = renderInstance.lastFrame()
+
+      expect(unstyled(lastFrame!)).toMatchInlineSnapshot(`
+      "2024-06-18 16:02:04.868 my-store my-function Success network access request executing in background
+          Reason: No cached response available
+          HTTP request:
+          {
+            \\"url\\": \\"https://api.example.com/hello\\",
+            \\"method\\": \\"GET\\",
+            \\"headers\\": {},
+            \\"body\\": null,
+            \\"policy\\": {
+              \\"read_timeout_ms\\": 500
+            }
+          }"
+      `)
+
+      renderInstance.unmount()
+    })
+
+    test('renders NetworkAccessRequestExecutionInBackgroundLog correctly with CacheAboutToExpire', async () => {
+      const webhookLogOutput = {
+        appLog: new NetworkAccessRequestExecutionInBackgroundLog({
+          reason: BackgroundExecutionReason.CacheAboutToExpire,
+          httpRequest: NETWORK_ACCESS_HTTP_REQUEST,
+        }),
+        prefix: {
+          functionId: FUNCTION_ID,
+          logTimestamp: TIME,
+          description: 'network access request executing in background',
+          storeName: 'my-store',
+          status: 'Success',
+          source: SOURCE,
+        },
+      }
+
+      const mockedUsePollAppLogs = vi.fn().mockReturnValue({appLogOutputs: [webhookLogOutput], errors: []})
+      vi.mocked(usePollAppLogs).mockImplementation(mockedUsePollAppLogs)
+
+      const renderInstance = render(
+        <Logs
+          pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
+          resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
+          storeNameById={new Map()}
+        />,
+      )
+
+      const lastFrame = renderInstance.lastFrame()
+
+      expect(unstyled(lastFrame!)).toMatchInlineSnapshot(`
+      "2024-06-18 16:02:04.868 my-store my-function Success network access request executing in background
+          Reason: Cache is about to expire
+          HTTP request:
+          {
+            \\"url\\": \\"https://api.example.com/hello\\",
+            \\"method\\": \\"GET\\",
+            \\"headers\\": {},
+            \\"body\\": null,
+            \\"policy\\": {
+              \\"read_timeout_ms\\": 500
+            }
+          }"
+      `)
+
+      renderInstance.unmount()
+    })
   })
 
   test('handles errors', async () => {

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.tsx
@@ -63,19 +63,45 @@ const Logs: FunctionComponent<LogsProps> = ({pollOptions: {jwtToken, filters}, r
               {appLog instanceof FunctionRunLog && (
                 <>
                   <Text>{appLog.logs}</Text>
+                  {appLog.inputQueryVariablesMetafieldKey && appLog.inputQueryVariablesMetafieldNamespace && (
+                    <Box flexDirection="column" marginTop={1}>
+                      <Text bold>Input Query Variables:</Text>
+                      <Box flexDirection="row" marginLeft={1} marginTop={1}>
+                        <Text dimColor>Namespace:</Text>
+                        <Text> {appLog.inputQueryVariablesMetafieldNamespace}</Text>
+                      </Box>
+                      <Box flexDirection="row" marginLeft={1}>
+                        <Text dimColor>Key:</Text>
+                        <Text> {appLog.inputQueryVariablesMetafieldKey}</Text>
+                      </Box>
+                      <Box marginLeft={1} marginTop={1}>
+                        <Text>
+                          {prettyPrintJsonIfPossible(appLog.inputQueryVariablesMetafieldValue) || (
+                            <Text color="red">Metafield is not set</Text>
+                          )}
+                        </Text>
+                      </Box>
+                    </Box>
+                  )}
                   {appLog.input && (
-                    <>
-                      <Text>Input ({appLog.inputBytes} bytes): </Text>
-                      <Text>{prettyPrintJsonIfPossible(appLog.input)}</Text>
-                    </>
+                    <Box flexDirection="column" marginTop={1}>
+                      <Text bold>
+                        Input <Text dimColor>({appLog.inputBytes} bytes):</Text>
+                      </Text>
+                      <Box marginLeft={1} marginTop={1}>
+                        <Text>{prettyPrintJsonIfPossible(appLog.input)}</Text>
+                      </Box>
+                    </Box>
                   )}
                   {appLog.output && (
-                    <>
-                      <Text>
-                        {'\n'}Output ({appLog.outputBytes} bytes):
+                    <Box flexDirection="column" marginTop={1}>
+                      <Text bold>
+                        Output <Text dimColor>({appLog.outputBytes} bytes):</Text>
                       </Text>
-                      <Text>{prettyPrintJsonIfPossible(appLog.output)}</Text>
-                    </>
+                      <Box marginLeft={1} marginTop={1}>
+                        <Text>{prettyPrintJsonIfPossible(appLog.output)}</Text>
+                      </Box>
+                    </Box>
                   )}
                 </>
               )}

--- a/packages/app/src/cli/services/app-logs/types.ts
+++ b/packages/app/src/cli/services/app-logs/types.ts
@@ -37,6 +37,9 @@ export class FunctionRunLog {
   fuelConsumed: number
   errorMessage: string | null
   errorType: string | null
+  inputQueryVariablesMetafieldValue: unknown
+  inputQueryVariablesMetafieldNamespace: string | null
+  inputQueryVariablesMetafieldKey: string | null
 
   constructor({
     export: exportValue,
@@ -49,6 +52,9 @@ export class FunctionRunLog {
     fuelConsumed,
     errorMessage,
     errorType,
+    inputQueryVariablesMetafieldValue,
+    inputQueryVariablesMetafieldNamespace,
+    inputQueryVariablesMetafieldKey,
   }: {
     export: string
     input: unknown
@@ -60,6 +66,9 @@ export class FunctionRunLog {
     fuelConsumed: number
     errorMessage: string | null
     errorType: string | null
+    inputQueryVariablesMetafieldValue: unknown
+    inputQueryVariablesMetafieldNamespace: string | null
+    inputQueryVariablesMetafieldKey: string | null
   }) {
     this.export = exportValue
     this.input = input
@@ -71,6 +80,9 @@ export class FunctionRunLog {
     this.fuelConsumed = fuelConsumed
     this.errorMessage = errorMessage
     this.errorType = errorType
+    this.inputQueryVariablesMetafieldValue = inputQueryVariablesMetafieldValue
+    this.inputQueryVariablesMetafieldNamespace = inputQueryVariablesMetafieldNamespace
+    this.inputQueryVariablesMetafieldKey = inputQueryVariablesMetafieldKey
   }
 }
 

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -32,6 +32,11 @@ export const REQUEST_EXECUTION_IN_BACKGROUND_CACHE_ABOUT_TO_EXPIRE_REASON = 'cac
 
 export function parseFunctionRunPayload(payload: string): FunctionRunLog {
   const parsedPayload = JSON.parse(payload)
+
+  const parsedIqvValue =
+    parsedPayload.input_query_variables_metafield_value &&
+    parseJson(parsedPayload.input_query_variables_metafield_value)
+
   return new FunctionRunLog({
     export: parsedPayload.export,
     input: parsedPayload.input,
@@ -43,6 +48,9 @@ export function parseFunctionRunPayload(payload: string): FunctionRunLog {
     fuelConsumed: parsedPayload.fuel_consumed,
     errorMessage: parsedPayload.error_message,
     errorType: parsedPayload.error_type,
+    inputQueryVariablesMetafieldValue: parsedIqvValue,
+    inputQueryVariablesMetafieldNamespace: parsedPayload.input_query_variables_metafield_namespace,
+    inputQueryVariablesMetafieldKey: parsedPayload.input_query_variables_metafield_key,
   })
 }
 
@@ -192,6 +200,12 @@ export const toFormattedAppLogJson = ({
 
   if (appLogPayload instanceof FunctionRunLog) {
     toSaveData.payload.logs = appLogPayload.logs.split('\n').filter(Boolean)
+
+    if (toSaveData.payload.inputQueryVariablesMetafieldValue) {
+      toSaveData.payload.inputQueryVariablesMetafieldValue = parseJson(
+        toSaveData.payload.inputQueryVariablesMetafieldValue,
+      )
+    }
   }
 
   if (prettyPrint) {
@@ -250,5 +264,14 @@ export function prettyPrintJsonIfPossible(json: unknown) {
     }
   } catch (error) {
     throw new Error(`Error parsing JSON: ${error as string}`)
+  }
+}
+
+const parseJson = (json: string): object | string => {
+  try {
+    return JSON.parse(json)
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (error) {
+    return json
   }
 }


### PR DESCRIPTION
Part of: https://github.com/Shopify/script-service/issues/6233

We're enhancing the debugging experience for developers by providing visibility into the input query variables used during a function run.

### WHY are these changes introduced?

This PR will add an input query variables section that will conditionally show based on if input query variables are used. Input query variables will be used when the values are specified in the `toml`.

### WHAT is this pull request doing?

Add input query variables section to the `app logs` command:

I also added some visual improvements to make the output and input sections more clear for partners to view. And updated the ouput and input sections to match.

Changes: **with improved styling**

<img width="768" alt="imrpovestyle-no-color" src="https://github.com/user-attachments/assets/f92a8992-6901-40f3-b63c-30572406d44a">


<details><summary>With coloring (also will need to update other sections - alternate idea)</summary>

<img width="944" alt="new_idea_app_logs" src="https://github.com/user-attachments/assets/3ba996b9-c25b-46b1-8610-3bc685dc7d1f">

</details>

and when no metafield is found:
<img width="780" alt="Screenshot 2024-10-03 at 9 59 41 AM" src="https://github.com/user-attachments/assets/8b0f07d8-5f16-49ac-8a5d-7fcdd49d24e7">

### How to test your changes?

From local cli, to your spin instance:
```
SHOPIFY_CLI_ENABLE_APP_LOG_POLLING=1  NODE_TLS_REJECT_UNAUTHORIZED=0 SPIN=1 SPIN_INSTANCE=68fh pnpm run shopify app logs --path=./efficient-capital-app
```
** replace spin id and app path

### Post-release steps

- part of a CLI release
- potentially add change log indicating that the input query variables are now present in logs and has visual improvements
- use of colouring in text,  I kept everything white in current commit, but use red text when metafield is not found.
- NOTE: might be worth splitting up logic for displaying `FunctionRunLog` and `NetworkAccessResponseFromCacheLog`, `NetworkAccessRequestExecutedLog`  into separate files.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
