### PR TITLE
Fix cart requests in the local proxy to avoid 401-Unauthorized errors

### DIFF
--- a/.changeset/six-bugs-design.md
+++ b/.changeset/six-bugs-design.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix cart requests in the local proxy to avoid 401-Unauthorized errors

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -21,6 +21,7 @@ import type {Theme} from '@shopify/cli-kit/node/themes/types'
 import type {Response as NodeResponse} from '@shopify/cli-kit/node/http'
 import type {DevServerContext} from './types.js'
 
+const CART_PREFIX = '/cart/'
 const VANITY_CDN_PREFIX = '/cdn/'
 const EXTENSION_CDN_PREFIX = '/ext/cdn/'
 const IGNORED_ENDPOINTS = [
@@ -62,13 +63,15 @@ export function getProxyHandler(_theme: Theme, ctx: DevServerContext) {
  * | /cdn/...          |                    | Proxy    |
  * | /ext/cdn/...      |                    | Proxy    |
  * | /.../file.js      |                    | Proxy    |
+ * | /cart/...         |                    | Proxy    |
  * | /payments/config  | application/json   | Proxy    |
  * | /search/suggest   | * / *              | No proxy |
  * | /.../index.html   |                    | No Proxy |
  *
  */
-function canProxyRequest(event: H3Event) {
+export function canProxyRequest(event: H3Event) {
   if (event.method !== 'GET') return true
+  if (event.path.startsWith(CART_PREFIX)) return true
   if (event.path.startsWith(VANITY_CDN_PREFIX)) return true
   if (event.path.startsWith(EXTENSION_CDN_PREFIX)) return true
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes:
- https://github.com/Shopify/cli/issues/4488
- https://github.com/Shopify/cli/issues/4510

### WHAT is this pull request doing?

This PR fixes the 401-Unauthorized errors involving cart requests by proxying them instead of relying on the SFR-remote-renderer client. The code is very declarative, but I've added some tests to document the intention.


### How to test your changes?

- Run `shopify theme init`
- Add a regular `HTMLAnchorElement` to remove a cart item `<a href="{{ item.url_to_remove }}">Remove</a>` (as described by [#4488](https://github.com/Shopify/cli/issues/4488))
- Remove an element from the cart
- Notice it works as expected

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
