### PR TITLE
Allow ignoring liquid files using .cli-liquid-bypass

### DIFF
--- a/packages/app/src/cli/services/init/template/cleanup.test.ts
+++ b/packages/app/src/cli/services/init/template/cleanup.test.ts
@@ -9,6 +9,7 @@ describe('cleanup', () => {
     await Promise.all([
       // should keep these
       writeFile(joinPath(tmpDir, 'server.js'), 'console.log()'),
+      writeFile(joinPath(tmpDir, 'cli-liquid-bypass'), '*'),
       mkdir(joinPath(tmpDir, 'node_modules')),
 
       // should delete these
@@ -40,6 +41,7 @@ describe('cleanup', () => {
       await expect(fileExists(joinPath(tmpDir, '.git'))).resolves.toBe(false)
       await expect(fileExists(joinPath(tmpDir, '.github'))).resolves.toBe(false)
       await expect(fileExists(joinPath(tmpDir, '.gitmodules'))).resolves.toBe(false)
+      await expect(fileExists(joinPath(tmpDir, '.cli-liquid-bypass'))).resolves.toBe(false)
       await expect(fileExists(joinPath(tmpDir, 'frontend', '.git'))).resolves.toBe(false)
       await expect(fileExists(joinPath(tmpDir, 'package.json.cli2'))).resolves.toBe(false)
     })

--- a/packages/app/src/cli/services/init/template/cleanup.ts
+++ b/packages/app/src/cli/services/init/template/cleanup.ts
@@ -7,6 +7,7 @@ export default async function cleanup(webOutputDirectory: string) {
       joinPath(webOutputDirectory, '**', '.git'),
       joinPath(webOutputDirectory, '**', '.github'),
       joinPath(webOutputDirectory, '**', '.gitmodules'),
+      joinPath(webOutputDirectory, '**', '.shopifyignore'),
       joinPath(webOutputDirectory, 'LICENSE*'),
       joinPath(webOutputDirectory, '**', 'frontend/LICENSE*'),
       joinPath(webOutputDirectory, 'package.json.cli2'),

--- a/packages/app/src/cli/services/init/template/cleanup.ts
+++ b/packages/app/src/cli/services/init/template/cleanup.ts
@@ -7,7 +7,7 @@ export default async function cleanup(webOutputDirectory: string) {
       joinPath(webOutputDirectory, '**', '.git'),
       joinPath(webOutputDirectory, '**', '.github'),
       joinPath(webOutputDirectory, '**', '.gitmodules'),
-      joinPath(webOutputDirectory, '**', '.shopifyignore'),
+      joinPath(webOutputDirectory, '**', '.cli-liquid-bypass'),
       joinPath(webOutputDirectory, 'LICENSE*'),
       joinPath(webOutputDirectory, '**', 'frontend/LICENSE*'),
       joinPath(webOutputDirectory, 'package.json.cli2'),

--- a/packages/cli-kit/src/public/node/liquid.ts
+++ b/packages/cli-kit/src/public/node/liquid.ts
@@ -1,4 +1,15 @@
-import {mkdir, readFile, copyFile, chmod, isDirectory, writeFile, fileHasExecutablePermissions, glob} from './fs.js'
+import {
+  mkdir,
+  readFile,
+  copyFile,
+  chmod,
+  isDirectory,
+  writeFile,
+  fileHasExecutablePermissions,
+  glob,
+  fileExists,
+  matchGlob,
+} from './fs.js'
 import {joinPath, dirname, relativePath} from './path.js'
 import {outputContent, outputToken, outputDebug} from '../../public/node/output.js'
 import {Liquid} from 'liquidjs'
@@ -29,6 +40,12 @@ export async function recursiveLiquidTemplateCopy(from: string, to: string, data
   outputDebug(outputContent`Copying template from directory ${outputToken.path(from)} to ${outputToken.path(to)}`)
   const templateFiles: string[] = await glob(joinPath(from, '**/*'), {dot: true})
 
+  const ignoreFilePath = joinPath(from, '.shopifyignore')
+  let ignorePatterns: string[] = []
+  if (await fileExists(ignoreFilePath)) {
+    ignorePatterns = (await readFile(ignoreFilePath)).split('\n').filter((line) => line.trim().length > 0)
+  }
+
   const sortedTemplateFiles = templateFiles
     .map((path) => path.split('/'))
     .sort((lhs, rhs) => (lhs.length < rhs.length ? 1 : -1))
@@ -36,9 +53,16 @@ export async function recursiveLiquidTemplateCopy(from: string, to: string, data
   await Promise.all(
     sortedTemplateFiles.map(async (templateItemPath) => {
       const outputPath = await renderLiquidTemplate(joinPath(to, relativePath(from, templateItemPath)), data)
+      const isIgnored = ignorePatterns.some((pattern) => {
+        const path = relativePath(from, templateItemPath)
+        const cleanPattern = pattern.replace(/^\.\//, '')
+
+        return matchGlob(path, cleanPattern) || path.startsWith(cleanPattern)
+      })
+
       if (await isDirectory(templateItemPath)) {
         await mkdir(outputPath)
-      } else if (templateItemPath.endsWith('.liquid')) {
+      } else if (templateItemPath.endsWith('.liquid') && !isIgnored) {
         await mkdir(dirname(outputPath))
         const content = await readFile(templateItemPath)
         const contentOutput = await renderLiquidTemplate(content, data)


### PR DESCRIPTION
### WHY are these changes introduced?

Template repos may come with liquid files in them, and currently the CLI will try to parse them all, which will most likely lead to errors when creating new apps.

### WHAT is this pull request doing?

Adding a file (name TBD) containing a list of files we want the CLI to leave alone when cloning a repo. That way, templates can determine what is off limits for the CLI. Ideally, this file's name should be generic enough that if we add any other sort of pre-processing, we can still use the same file.

### How to test your changes?

Via unit tests, and creating apps with with a private template (slack me for the URL!).

### Post-release steps

None needed!

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition - this would only result in failed app creations

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
  - We probably want to document this file somewhere?
