### PR TITLE
[Themes] Add CLI environment configuration to exported theme pull and push commands

### DIFF
--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -70,6 +70,8 @@ If no theme is specified, then you're prompted to select the theme to pull from 
       only: flags.only,
       ignore: flags.ignore,
       force: flags.force,
+      verbose: flags.verbose,
+      noColor: flags['no-color'],
     }
 
     await pull(pullFlags)

--- a/packages/theme/src/cli/services/pull.ts
+++ b/packages/theme/src/cli/services/pull.ts
@@ -6,6 +6,7 @@ import {showEmbeddedCLIWarning} from '../utilities/embedded-cli-warning.js'
 import {ensureThemeStore} from '../utilities/theme-store.js'
 import {DevelopmentThemeManager} from '../utilities/development-theme-manager.js'
 import {findOrSelectTheme} from '../utilities/theme-selector.js'
+import {configureCLIEnvironment} from '../utilities/cli-config.js'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
@@ -95,6 +96,7 @@ export interface PullFlags {
  * @param flags - All flags are optional.
  */
 export async function pull(flags: PullFlags): Promise<void> {
+  configureCLIEnvironment({verbose: flags.verbose, noColor: flags.noColor})
   showEmbeddedCLIWarning()
 
   const store = ensureThemeStore({store: flags.store})

--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -6,6 +6,7 @@ import {ensureThemeStore} from '../utilities/theme-store.js'
 import {DevelopmentThemeManager} from '../utilities/development-theme-manager.js'
 import {findOrSelectTheme} from '../utilities/theme-selector.js'
 import {Role} from '../utilities/theme-selector/fetch.js'
+import {configureCLIEnvironment} from '../utilities/cli-config.js'
 import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {createTheme, fetchChecksums, publishTheme} from '@shopify/cli-kit/node/themes/api'
 import {Result, Theme} from '@shopify/cli-kit/node/themes/types'
@@ -110,6 +111,12 @@ export interface PushFlags {
  */
 export async function push(flags: PushFlags): Promise<void> {
   const {path} = flags
+
+  configureCLIEnvironment({
+    verbose: flags.verbose,
+    noColor: flags.noColor,
+  })
+
   const force = flags.force ?? false
 
   const store = ensureThemeStore({store: flags.store})

--- a/packages/theme/src/cli/utilities/cli-config.test.ts
+++ b/packages/theme/src/cli/utilities/cli-config.test.ts
@@ -1,4 +1,5 @@
 import {configureCLIEnvironment} from './cli-config.js'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {describe, expect, beforeEach, afterAll, test} from 'vitest'
 
 describe('configureCLIEnvironment', () => {
@@ -13,61 +14,50 @@ describe('configureCLIEnvironment', () => {
   })
 
   describe('verbose', () => {
-    test('sets DEBUG environment variable to * when verbose is true', () => {
+    test('sets verbose environment variable when verbose is true', () => {
       // Given
-      delete process.env.DEBUG
+      delete process.env[globalFlags.verbose.env!]
 
       // When
       configureCLIEnvironment({verbose: true})
 
       // Then
-      expect(process.env.DEBUG).toBe('*')
+      expect(process.env[globalFlags.verbose.env!]).toBe('true')
     })
 
-    test('does not overwrite existing DEBUG value when verbose is true', () => {
+    test('does not set verbose environment variable when verbose is false', () => {
       // Given
-      process.env.DEBUG = 'existing-value'
-
-      // When
-      configureCLIEnvironment({verbose: true})
-
-      // Then
-      expect(process.env.DEBUG).toBe('existing-value')
-    })
-
-    test('does not set DEBUG environment variable when verbose is false', () => {
-      // Given
-      delete process.env.DEBUG
+      delete process.env[globalFlags.verbose.env!]
 
       // When
       configureCLIEnvironment({verbose: false})
 
       // Then
-      expect(process.env.DEBUG).toBeUndefined()
+      expect(process.env[globalFlags.verbose.env!]).toBeUndefined()
     })
   })
 
   describe('noColor', () => {
-    test('sets FORCE_COLOR to 0 when noColor is true', () => {
+    test('sets no-color environment variable when noColor is true', () => {
       // Given
-      delete process.env.FORCE_COLOR
+      delete process.env[globalFlags['no-color'].env!]
 
       // When
       configureCLIEnvironment({noColor: true})
 
       // Then
-      expect(process.env.FORCE_COLOR).toBe('0')
+      expect(process.env[globalFlags['no-color'].env!]).toBe('true')
     })
 
-    test('does not set FORCE_COLOR when noColor is false', () => {
+    test('does not set no-color environment variable when noColor is false', () => {
       // Given
-      delete process.env.FORCE_COLOR
+      delete process.env[globalFlags['no-color'].env!]
 
       // When
       configureCLIEnvironment({noColor: false})
 
       // Then
-      expect(process.env.FORCE_COLOR).toBeUndefined()
+      expect(process.env[globalFlags['no-color'].env!]).toBeUndefined()
     })
   })
 })

--- a/packages/theme/src/cli/utilities/cli-config.test.ts
+++ b/packages/theme/src/cli/utilities/cli-config.test.ts
@@ -1,5 +1,6 @@
 import {configureCLIEnvironment} from './cli-config.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
+import colors from '@shopify/cli-kit/node/colors'
 import {describe, expect, beforeEach, afterAll, test} from 'vitest'
 
 describe('configureCLIEnvironment', () => {
@@ -7,6 +8,7 @@ describe('configureCLIEnvironment', () => {
 
   beforeEach(() => {
     process.env = {...originalEnv}
+    colors.level = 1
   })
 
   afterAll(() => {
@@ -46,7 +48,8 @@ describe('configureCLIEnvironment', () => {
       configureCLIEnvironment({noColor: true})
 
       // Then
-      expect(process.env[globalFlags['no-color'].env!]).toBe('true')
+      expect(colors.level).toBe(0)
+      expect(process.env.FORCE_COLOR).toBe('0')
     })
 
     test('does not set no-color environment variable when noColor is false', () => {
@@ -57,7 +60,8 @@ describe('configureCLIEnvironment', () => {
       configureCLIEnvironment({noColor: false})
 
       // Then
-      expect(process.env[globalFlags['no-color'].env!]).toBeUndefined()
+      expect(colors.level).toBe(1)
+      expect(process.env.FORCE_COLOR).toBe('1')
     })
   })
 })

--- a/packages/theme/src/cli/utilities/cli-config.test.ts
+++ b/packages/theme/src/cli/utilities/cli-config.test.ts
@@ -1,0 +1,73 @@
+import {configureCLIEnvironment} from './cli-config.js'
+import {describe, expect, beforeEach, afterAll, test} from 'vitest'
+
+describe('configureCLIEnvironment', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {...originalEnv}
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  describe('verbose', () => {
+    test('sets DEBUG environment variable to * when verbose is true', () => {
+      // Given
+      delete process.env.DEBUG
+
+      // When
+      configureCLIEnvironment({verbose: true})
+
+      // Then
+      expect(process.env.DEBUG).toBe('*')
+    })
+
+    test('does not overwrite existing DEBUG value when verbose is true', () => {
+      // Given
+      process.env.DEBUG = 'existing-value'
+
+      // When
+      configureCLIEnvironment({verbose: true})
+
+      // Then
+      expect(process.env.DEBUG).toBe('existing-value')
+    })
+
+    test('does not set DEBUG environment variable when verbose is false', () => {
+      // Given
+      delete process.env.DEBUG
+
+      // When
+      configureCLIEnvironment({verbose: false})
+
+      // Then
+      expect(process.env.DEBUG).toBeUndefined()
+    })
+  })
+
+  describe('noColor', () => {
+    test('sets FORCE_COLOR to 0 when noColor is true', () => {
+      // Given
+      delete process.env.FORCE_COLOR
+
+      // When
+      configureCLIEnvironment({noColor: true})
+
+      // Then
+      expect(process.env.FORCE_COLOR).toBe('0')
+    })
+
+    test('does not set FORCE_COLOR when noColor is false', () => {
+      // Given
+      delete process.env.FORCE_COLOR
+
+      // When
+      configureCLIEnvironment({noColor: false})
+
+      // Then
+      expect(process.env.FORCE_COLOR).toBeUndefined()
+    })
+  })
+})

--- a/packages/theme/src/cli/utilities/cli-config.ts
+++ b/packages/theme/src/cli/utilities/cli-config.ts
@@ -1,4 +1,5 @@
 import {globalFlags} from '@shopify/cli-kit/node/cli'
+import colors from '@shopify/cli-kit/node/colors'
 
 interface CLIConfigOptions {
   verbose?: boolean
@@ -17,6 +18,7 @@ export function configureCLIEnvironment(options: CLIConfigOptions): void {
   }
 
   if (options.noColor) {
-    process.env[globalFlags['no-color'].env!] = 'true'
+    colors.level = 0
+    process.env.FORCE_COLOR = '0'
   }
 }

--- a/packages/theme/src/cli/utilities/cli-config.ts
+++ b/packages/theme/src/cli/utilities/cli-config.ts
@@ -1,0 +1,20 @@
+interface CLIConfigOptions {
+  verbose?: boolean
+  noColor?: boolean
+}
+
+/**
+ * Emulates the environment setup that oCLI commands perform when executed theme commands are executed programmatically.
+ * Source: packages/cli-kit/src/public/node/cli.ts
+ *
+ * @param options - Configuration options for the CLI environment
+ */
+export function configureCLIEnvironment(options: CLIConfigOptions): void {
+  if (options.verbose) {
+    process.env.DEBUG = process.env.DEBUG ?? '*'
+  }
+
+  if (options.noColor) {
+    process.env.FORCE_COLOR = '0'
+  }
+}

--- a/packages/theme/src/cli/utilities/cli-config.ts
+++ b/packages/theme/src/cli/utilities/cli-config.ts
@@ -1,3 +1,5 @@
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+
 interface CLIConfigOptions {
   verbose?: boolean
   noColor?: boolean
@@ -11,10 +13,10 @@ interface CLIConfigOptions {
  */
 export function configureCLIEnvironment(options: CLIConfigOptions): void {
   if (options.verbose) {
-    process.env.DEBUG = process.env.DEBUG ?? '*'
+    process.env[globalFlags.verbose.env!] = 'true'
   }
 
   if (options.noColor) {
-    process.env.FORCE_COLOR = '0'
+    process.env[globalFlags['no-color'].env!] = 'true'
   }
 }

--- a/packages/theme/src/cli/utilities/theme-selector.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.ts
@@ -1,6 +1,5 @@
 import {fetchStoreThemes} from './theme-selector/fetch.js'
 import {Filter, FilterProps, filterThemes} from './theme-selector/filter.js'
-import {configureCLIEnvironment} from './cli-config.js'
 import {getDevelopmentTheme} from '../services/local-storage.js'
 import {renderAutocompletePrompt} from '@shopify/cli-kit/node/ui'
 import {AdminSession} from '@shopify/cli-kit/node/session'
@@ -26,15 +25,6 @@ interface FindOrSelectOptions {
    * The filter applied in the list of themes in the store.
    */
   filter: FilterProps
-  /**
-   * Disable color output.
-   */
-  noColor?: boolean
-
-  /**
-   * Increase the verbosity of the output.
-   */
-  verbose?: boolean
 }
 
 /**
@@ -45,7 +35,6 @@ interface FindOrSelectOptions {
  * @returns the selected {@link Theme}
  */
 export async function findOrSelectTheme(session: AdminSession, options: FindOrSelectOptions) {
-  configureCLIEnvironment({verbose: options.verbose, noColor: options.noColor})
   const themes = await fetchStoreThemes(session)
   const filter = new Filter(options.filter)
   const store = session.storeFqdn

--- a/packages/theme/src/cli/utilities/theme-selector.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.ts
@@ -1,5 +1,6 @@
 import {fetchStoreThemes} from './theme-selector/fetch.js'
 import {Filter, FilterProps, filterThemes} from './theme-selector/filter.js'
+import {configureCLIEnvironment} from './cli-config.js'
 import {getDevelopmentTheme} from '../services/local-storage.js'
 import {renderAutocompletePrompt} from '@shopify/cli-kit/node/ui'
 import {AdminSession} from '@shopify/cli-kit/node/session'
@@ -25,6 +26,15 @@ interface FindOrSelectOptions {
    * The filter applied in the list of themes in the store.
    */
   filter: FilterProps
+  /**
+   * Disable color output.
+   */
+  noColor?: boolean
+
+  /**
+   * Increase the verbosity of the output.
+   */
+  verbose?: boolean
 }
 
 /**
@@ -35,6 +45,7 @@ interface FindOrSelectOptions {
  * @returns the selected {@link Theme}
  */
 export async function findOrSelectTheme(session: AdminSession, options: FindOrSelectOptions) {
+  configureCLIEnvironment({verbose: options.verbose, noColor: options.noColor})
   const themes = await fetchStoreThemes(session)
   const filter = new Filter(options.filter)
   const store = session.storeFqdn


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-advanced-edits/issues/356

### WHAT is this pull request doing?

Implements CLI environment configuration for programatic invocation of `theme push`, `theme pull`, and

### How to test your changes?

To test these changes:
- Modify the value of `options.verbose` or `options.noColor` to `true` in the command layer [here](https://github.com/Shopify/cli/blob/48f50c3d3601f3e9c8b16704a9aca01c7d96f093/packages/theme/src/cli/commands/theme/push.ts#L160) and run the command WITHOUT passing the flag

https://github.com/user-attachments/assets/4ffc5965-86bc-4182-9990-dcc391be9cbb

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

No post-release steps are required for this change.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes

cc: @Shopify/advanced-edits 