### PR TITLE
[Theme] Avoid process exit when failing to delete a file from the remote theme

### DIFF
--- a/.changeset/rotten-worms-rush.md
+++ b/.changeset/rotten-worms-rush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Avoid process exit when failing to delete a file from the remote theme.

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -4,7 +4,7 @@ import {renderTasksToStdErr} from './theme-ui.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Result, Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {AssetParams, bulkUploadThemeAssets, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
-import {renderWarning, Task} from '@shopify/cli-kit/node/ui'
+import {renderError, renderWarning, Task} from '@shopify/cli-kit/node/ui'
 import {outputDebug, outputInfo, outputNewline, outputWarn} from '@shopify/cli-kit/node/output'
 
 interface UploadOptions {
@@ -127,9 +127,13 @@ function buildDeleteJob(
   const progress = {current: 0, total: orderedFiles.length}
   const promise = Promise.all(
     orderedFiles.map((file) =>
-      deleteThemeAsset(theme.id, file.key, session).then(() => {
-        progress.current++
-      }),
+      deleteThemeAsset(theme.id, file.key, session)
+        .catch((error) => {
+          renderError({headline: `Failed to delete file "${file.key}" from remote theme.`, body: error.message})
+        })
+        .finally(() => {
+          progress.current++
+        }),
     ),
   ).then(() => {
     progress.current = progress.total


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

I found that this promise rejection was causing process exit:
<img width="583" alt="image" src="https://github.com/user-attachments/assets/19d5e39f-a917-454a-9b80-ed4919eda65e">

Turning it here into an error message instead:

<img width="789" alt="image" src="https://github.com/user-attachments/assets/03be3a7d-750b-461f-8e18-f33d8925764a">

(Note in the above image I was using `renderWarning` but I've changed it to `renderError` since that's more accurate, I think)

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
