### PR TITLE
remove [object Object] from theme push --json warning message

### DIFF
--- a/.changeset/quiet-gorillas-tie.md
+++ b/.changeset/quiet-gorillas-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Improved warning message on shopify theme push --json by removing reference to [object Object]

--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -224,7 +224,7 @@ function handleJsonOutput(theme: Theme, hasErrors: boolean, session: AdminSessio
   }
 
   if (hasErrors) {
-    const message = `The theme ${themeComponent(theme).join(' ')} was pushed with errors`
+    const message = `The theme '${theme.name}' was pushed with errors`
     output.theme.warning = message
   }
   outputInfo(JSON.stringify(output))


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-advanced-edits/issues/357

When using the `--json` flag on `shopify theme push`, if there is an error, we are getting [object Object] as part of the output.

### WHAT is this pull request doing?
Making a small change to only output the `theme.name` since it's all that's required for the warning message.

Before:
![image](https://github.com/user-attachments/assets/d3944730-9ae0-423c-81ee-68b80ece7249)

After:
![image](https://github.com/user-attachments/assets/e9e5dd7e-26bd-46c6-9b2f-fbf1a54044d6)

### How to test your changes?

pull down the branch `fix-issue-357`
build the branch
break any `.json` file
run `theme push --json`


### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
