### PR TITLE
[Themes] Remove legacy message in the `theme dev` command

### DIFF
--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -6,7 +6,7 @@ import {isStorefrontPasswordProtected} from '../utilities/theme-environment/stor
 import {ensureValidPassword} from '../utilities/theme-environment/storefront-password-prompt.js'
 import {emptyThemeExtFileSystem} from '../utilities/theme-fs-empty.js'
 import {initializeDevServerSession} from '../utilities/theme-environment/dev-server-session.js'
-import {renderInfo, renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
+import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {AdminSession, ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
 import {outputDebug} from '@shopify/cli-kit/node/output'
@@ -49,8 +49,6 @@ export async function dev(options: DevOptions) {
     await legacyDev(options)
     return
   }
-
-  showNewVersionInfo()
 
   if (!(await hasRequiredThemeDirectories(options.directory)) && !(await currentDirectoryConfirmed(options.force))) {
     return
@@ -227,11 +225,4 @@ export async function refreshTokens(store: string, password: string | undefined,
   }
 
   return {adminSession, storefrontToken}
-}
-
-function showNewVersionInfo() {
-  renderInfo({
-    headline: [`You're using the new version of`, {command: 'shopify theme dev'}, {char: '.'}],
-    body: ['Run', {command: 'shopify theme dev --legacy'}, 'to switch back to the previous version.'],
-  })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-advanced-edits/issues/361

### WHAT is this pull request doing?

Removes `--legacy` message when users run the new `theme dev` command

### How to test your changes?
`pnpm shopify theme dev` should not render a message matching the screenshot in the issue

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
