### PR TITLE
[Theme] Handle async errors

### DIFF
--- a/.changeset/polite-suits-remain.md
+++ b/.changeset/polite-suits-remain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Handle background async errors and avoid process exit in some scenarios.

--- a/packages/theme/src/cli/utilities/errors.ts
+++ b/packages/theme/src/cli/utilities/errors.ts
@@ -3,12 +3,27 @@ import {outputDebug} from '@shopify/cli-kit/node/output'
 import {renderError, renderFatalError} from '@shopify/cli-kit/node/ui'
 
 /**
- * Renders an error banner for a failed syncing operation without interrupting the process.
+ * Renders an error banner for a thrown error with a headline.
+ * @param headline - The headline for the error.
+ * @param error - The error to render.
+ */
+export function renderThrownError(headline: string, error: Error | AbortError) {
+  if (error instanceof AbortError) {
+    error.message = `${headline}\n${error.message}`
+    renderFatalError(error)
+  } else {
+    renderError({headline, body: error.message})
+    outputDebug(`${headline}\n${error.stack ?? error.message}`)
+  }
+}
+
+/**
+ * Creates a function that renders a failed syncing operation without interrupting the process.
  * @param resource - The file that was being operated on, or a headline for the error.
  * @param preset - The type of operation that failed.
  * @returns A function that accepts an error and renders it.
  */
-export function renderCatchError(resource: string, preset?: 'delete' | 'upload') {
+export function createRenderCatchError(resource: string, preset?: 'delete' | 'upload') {
   let headline = resource
 
   if (preset) {
@@ -18,31 +33,19 @@ export function renderCatchError(resource: string, preset?: 'delete' | 'upload')
         : `Failed to upload file "${resource}" to remote theme.`
   }
 
-  return (error: Error | AbortError) => {
-    if (error instanceof AbortError) {
-      error.message = `${headline}.\n${error.message}`
-      renderFatalError(error)
-    } else {
-      renderError({headline, body: error.message})
-      outputDebug(`${headline}\n${error.stack ?? error.message}`)
-    }
+  return (error: Error) => {
+    renderThrownError(headline, error)
   }
 }
 
 /**
- * Renders a fatal error banner and exits the process without continuing.
+ * Creates a function that renders a failed syncing operation and exits the process.
  * @param headline - The headline for the error.
  * @returns A function that accepts an error and renders it.
  */
-export function abortCatchError(headline: string) {
-  return (error: Error | AbortError): never => {
-    if (error instanceof AbortError) {
-      error.message = `${headline}\n${error.message}`
-      renderFatalError(error)
-    } else {
-      renderError({headline, body: error.message})
-    }
-
+export function createAbortCatchError(headline: string) {
+  return (error: Error): never => {
+    renderThrownError(headline, error)
     process.exit(1)
   }
 }

--- a/packages/theme/src/cli/utilities/errors.ts
+++ b/packages/theme/src/cli/utilities/errors.ts
@@ -1,0 +1,30 @@
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {outputDebug} from '@shopify/cli-kit/node/output'
+import {renderError, renderFatalError} from '@shopify/cli-kit/node/ui'
+
+/**
+ * Renders an error banner for a failed syncing operation without interrupting the process.
+ * @param resource - The file that was being operated on, or a headline for the error.
+ * @param preset - The type of operation that failed.
+ * @returns A function that accepts an error and renders it.
+ */
+export function renderCatchError(resource: string, preset?: 'delete' | 'upload') {
+  let headline = resource
+
+  if (preset) {
+    headline =
+      preset === 'delete'
+        ? `Failed to delete file "${resource}" from remote theme.`
+        : `Failed to upload file "${resource}" to remote theme.`
+  }
+
+  return (error: Error | AbortError) => {
+    if (error instanceof AbortError) {
+      error.message = `${headline}.\n${error.message}`
+      renderFatalError(error)
+    } else {
+      renderError({headline, body: error.message})
+      outputDebug(`${headline}\n${error.stack ?? error.message}`)
+    }
+  }
+}

--- a/packages/theme/src/cli/utilities/errors.ts
+++ b/packages/theme/src/cli/utilities/errors.ts
@@ -28,3 +28,21 @@ export function renderCatchError(resource: string, preset?: 'delete' | 'upload')
     }
   }
 }
+
+/**
+ * Renders a fatal error banner and exits the process without continuing.
+ * @param headline - The headline for the error.
+ * @returns A function that accepts an error and renders it.
+ */
+export function abortCatchError(headline: string) {
+  return (error: Error | AbortError): never => {
+    if (error instanceof AbortError) {
+      error.message = `${headline}\n${error.message}`
+      renderFatalError(error)
+    } else {
+      renderError({headline, body: error.message})
+    }
+
+    process.exit(1)
+  }
+}

--- a/packages/theme/src/cli/utilities/errors.ts
+++ b/packages/theme/src/cli/utilities/errors.ts
@@ -23,15 +23,13 @@ export function renderThrownError(headline: string, error: Error | AbortError) {
  * @param preset - The type of operation that failed.
  * @returns A function that accepts an error and renders it.
  */
-export function createRenderCatchError(resource: string, preset?: 'delete' | 'upload') {
-  let headline = resource
-
-  if (preset) {
-    headline =
-      preset === 'delete'
-        ? `Failed to delete file "${resource}" from remote theme.`
-        : `Failed to upload file "${resource}" to remote theme.`
-  }
+export function createSyncingCatchError(resource: string, preset?: 'delete' | 'upload') {
+  const headline =
+    {
+      delete: `Failed to delete file "${resource}" from remote theme.`,
+      upload: `Failed to upload file "${resource}" to remote theme.`,
+      default: resource,
+    }[preset ?? 'default'] ?? resource
 
   return (error: Error) => {
     renderThrownError(headline, error)

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -112,6 +112,7 @@ describe('setupDevServer', () => {
     expect(uploadTheme).toHaveBeenCalledWith(developmentTheme, context.session, [], context.localThemeFileSystem, {
       nodelete: true,
       deferPartialWork: true,
+      backgroundWorkCatch: expect.any(Function),
     })
   })
 
@@ -161,6 +162,7 @@ describe('setupDevServer', () => {
     expect(uploadTheme).toHaveBeenCalledWith(developmentTheme, context.session, [], context.localThemeFileSystem, {
       nodelete: true,
       deferPartialWork: true,
+      backgroundWorkCatch: expect.any(Function),
     })
   })
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -5,7 +5,7 @@ import {getProxyHandler} from './proxy.js'
 import {reconcileAndPollThemeEditorChanges} from './remote-theme-watcher.js'
 import {uploadTheme} from '../theme-uploader.js'
 import {renderTasksToStdErr} from '../theme-ui.js'
-import {abortCatchError} from '../errors.js'
+import {createAbortCatchError} from '../errors.js'
 import {createApp, defineEventHandler, defineLazyEventHandler, toNodeListener} from 'h3'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 import {createServer} from 'node:http'
@@ -29,7 +29,7 @@ export function setupDevServer(theme: Theme, ctx: DevServerContext) {
 }
 
 function ensureThemeEnvironmentSetup(theme: Theme, ctx: DevServerContext) {
-  const abort = abortCatchError('Failed to perform the initial theme synchronization.')
+  const abort = createAbortCatchError('Failed to perform the initial theme synchronization.')
 
   const remoteChecksumsPromise = fetchChecksums(theme.id, ctx.session).catch(abort)
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
@@ -3,7 +3,8 @@ import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/typ
 import {fetchChecksums, fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
 import {outputDebug, outputInfo, outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
-import {renderError} from '@shopify/cli-kit/node/ui'
+import {renderError, renderFatalError} from '@shopify/cli-kit/node/ui'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 const POLLING_INTERVAL = 3000
 class PollingError extends Error {}
@@ -21,19 +22,46 @@ export function pollThemeEditorChanges(
 ) {
   outputDebug('Listening for changes in the theme editor')
 
-  return setTimeout(() => {
-    pollRemoteJsonChanges(targetTheme, session, remoteChecksum, localFileSystem, options)
-      .then((latestChecksums) => {
-        pollThemeEditorChanges(targetTheme, session, latestChecksums, localFileSystem, options)
+  let failedPollingAttempts = 0
+  let latestChecksums = remoteChecksum
+  const poll = async () => {
+    // Asynchronously wait for the polling interval, similar to a setInterval
+    // but ensure the polling work is done before starting the next interval.
+    await new Promise((resolve) => setTimeout(resolve, POLLING_INTERVAL))
+
+    // eslint-disable-next-line require-atomic-updates
+    latestChecksums = await pollRemoteJsonChanges(targetTheme, session, latestChecksums, localFileSystem, options)
+      .then((checksums) => {
+        failedPollingAttempts = 0
+        return checksums
       })
-      .catch((err) => {
-        if (err instanceof PollingError) {
-          renderError({body: err.message})
+      .catch((err: Error | AbortError) => {
+        failedPollingAttempts++
+        if (err instanceof AbortError) {
+          renderFatalError(err)
         } else {
-          throw err
+          renderError({headline: 'Error while polling for changes.', body: err.stack})
         }
+
+        if (failedPollingAttempts >= 5) {
+          renderFatalError(
+            new AbortError('Too many polling errors...', 'Please check your internet connection and try again.'),
+          )
+
+          process.exit(1)
+        }
+
+        return latestChecksums
       })
-  }, POLLING_INTERVAL)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  setTimeout(async () => {
+    while (true) {
+      // eslint-disable-next-line no-await-in-loop
+      await poll()
+    }
+  })
 }
 
 export async function pollRemoteJsonChanges(

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
@@ -1,5 +1,5 @@
 import {timestampDateFormat} from '../../constants.js'
-import {renderCatchError} from '../errors.js'
+import {renderThrownError} from '../errors.js'
 import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {fetchChecksums, fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
 import {outputDebug, outputInfo, outputContent, outputToken} from '@shopify/cli-kit/node/output'
@@ -46,7 +46,7 @@ export function pollThemeEditorChanges(
 
         if (error.message !== lastError) {
           lastError = error.message
-          renderCatchError('Error while polling for changes.')(error)
+          renderThrownError('Error while polling for changes.', error)
         }
 
         if (failedPollingAttempts >= maxPollingAttempts) {

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
@@ -51,7 +51,10 @@ export function pollThemeEditorChanges(
 
         if (failedPollingAttempts >= maxPollingAttempts) {
           renderFatalError(
-            new AbortError('Too many polling errors...', 'Please check your internet connection and try again.'),
+            new AbortError(
+              'Too many polling errors...',
+              'Please check the errors above and ensure you have a stable internet connection.',
+            ),
           )
 
           process.exit(1)

--- a/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-polling.ts
@@ -1,9 +1,10 @@
 import {timestampDateFormat} from '../../constants.js'
+import {renderCatchError} from '../errors.js'
 import {Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {fetchChecksums, fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
 import {outputDebug, outputInfo, outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
-import {renderError, renderFatalError} from '@shopify/cli-kit/node/ui'
+import {renderFatalError} from '@shopify/cli-kit/node/ui'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
 const POLLING_INTERVAL = 3000
@@ -37,15 +38,15 @@ export function pollThemeEditorChanges(
       .then((checksums) => {
         failedPollingAttempts = 0
         lastError = ''
+
         return checksums
       })
-      .catch((err: Error) => {
+      .catch((error: Error) => {
         failedPollingAttempts++
-        if (err.message !== lastError) {
-          lastError = err.message
-          const headline = 'Error while polling for changes.'
-          renderError({headline, body: err.message})
-          outputDebug(`${headline}\n${err.stack ?? err.message}`)
+
+        if (error.message !== lastError) {
+          lastError = error.message
+          renderCatchError('Error while polling for changes.')(error)
         }
 
         if (failedPollingAttempts >= maxPollingAttempts) {

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -16,7 +16,7 @@ import {removeFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {test, describe, expect, vi, beforeEach} from 'vitest'
 import chokidar from 'chokidar'
 import {deleteThemeAsset, fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
-import {outputDebug} from '@shopify/cli-kit/node/output'
+import {renderError} from '@shopify/cli-kit/node/ui'
 import EventEmitter from 'events'
 import type {Checksum, ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 
@@ -563,7 +563,10 @@ describe('theme-fs', () => {
 
       // Then
       expect(deleteThemeAsset).toHaveBeenCalledWith(Number(themeId), 'assets/base.css', adminSession)
-      expect(outputDebug).toHaveBeenCalledWith('Failed to delete file "assets/base.css" from remote theme.')
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Failed to delete file "assets/base.css" from remote theme.',
+        body: expect.any(String),
+      })
     })
   })
 

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -5,7 +5,7 @@ import {
   getPatternsFromShopifyIgnore,
 } from './asset-ignore.js'
 import {Notifier} from './notifier.js'
-import {renderCatchError} from './errors.js'
+import {createRenderCatchError} from './errors.js'
 import {DEFAULT_IGNORE_PATTERNS, timestampDateFormat} from '../constants.js'
 import {glob, readFile, ReadOptions, fileExists, mkdir, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, basename, relativePath} from '@shopify/cli-kit/node/path'
@@ -163,7 +163,7 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
 
         return true
       })
-      .catch(renderCatchError(fileKey, 'upload'))
+      .catch(createRenderCatchError(fileKey, 'upload'))
 
     emitEvent(eventName, {
       fileKey,
@@ -200,7 +200,7 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
         unsyncedFileKeys.delete(fileKey)
         outputSyncResult('delete', fileKey)
       })
-      .catch(renderCatchError(fileKey, 'delete'))
+      .catch(createRenderCatchError(fileKey, 'delete'))
   }
 
   const directoriesToWatch = new Set(

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -5,7 +5,7 @@ import {
   getPatternsFromShopifyIgnore,
 } from './asset-ignore.js'
 import {Notifier} from './notifier.js'
-import {createRenderCatchError} from './errors.js'
+import {createSyncingCatchError} from './errors.js'
 import {DEFAULT_IGNORE_PATTERNS, timestampDateFormat} from '../constants.js'
 import {glob, readFile, ReadOptions, fileExists, mkdir, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, basename, relativePath} from '@shopify/cli-kit/node/path'
@@ -163,7 +163,7 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
 
         return true
       })
-      .catch(createRenderCatchError(fileKey, 'upload'))
+      .catch(createSyncingCatchError(fileKey, 'upload'))
 
     emitEvent(eventName, {
       fileKey,
@@ -200,7 +200,7 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
         unsyncedFileKeys.delete(fileKey)
         outputSyncResult('delete', fileKey)
       })
-      .catch(createRenderCatchError(fileKey, 'delete'))
+      .catch(createSyncingCatchError(fileKey, 'delete'))
   }
 
   const directoriesToWatch = new Set(

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -1,6 +1,7 @@
 import {partitionThemeFiles} from './theme-fs.js'
 import {rejectGeneratedStaticAssets} from './asset-checksum.js'
 import {renderTasksToStdErr} from './theme-ui.js'
+import {renderCatchError} from './errors.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Result, Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {AssetParams, bulkUploadThemeAssets, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
@@ -132,9 +133,7 @@ function buildDeleteJob(
   const promise = Promise.all(
     orderedFiles.map((file) =>
       deleteThemeAsset(theme.id, file.key, session)
-        .catch((error) => {
-          renderError({headline: `Failed to delete file "${file.key}" from remote theme.`, body: error.stack})
-        })
+        .catch(renderCatchError(file.key, 'delete'))
         .finally(() => {
           progress.current++
         }),

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -1,7 +1,7 @@
 import {partitionThemeFiles} from './theme-fs.js'
 import {rejectGeneratedStaticAssets} from './asset-checksum.js'
 import {renderTasksToStdErr} from './theme-ui.js'
-import {createRenderCatchError} from './errors.js'
+import {createSyncingCatchError} from './errors.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Result, Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {AssetParams, bulkUploadThemeAssets, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
@@ -139,7 +139,7 @@ function buildDeleteJob(
         .catch((error: Error) => {
           failedDeleteAttempts++
           if (failedDeleteAttempts > 3) throw error
-          createRenderCatchError(file.key, 'delete')(error)
+          createSyncingCatchError(file.key, 'delete')(error)
         })
         .finally(() => {
           progress.current++

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -4,7 +4,7 @@ import {renderTasksToStdErr} from './theme-ui.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Result, Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {AssetParams, bulkUploadThemeAssets, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
-import {renderError, renderWarning, Task} from '@shopify/cli-kit/node/ui'
+import {renderError, Task} from '@shopify/cli-kit/node/ui'
 import {outputDebug, outputInfo, outputNewline, outputWarn} from '@shopify/cli-kit/node/output'
 
 interface UploadOptions {
@@ -48,8 +48,12 @@ export function uploadTheme(
     ? themeCreationPromise
     : deleteJobPromise
         .then((result) => result.promise)
-        .catch(() => {
-          renderWarning({headline: 'Failed to delete outdated files from remote theme.'})
+        .catch((error) => {
+          // Do not throw here since the process still works locally.
+          renderError({
+            headline: 'Failed to delete outdated files from remote theme.',
+            body: error.stack,
+          })
         })
 
   return {
@@ -129,7 +133,7 @@ function buildDeleteJob(
     orderedFiles.map((file) =>
       deleteThemeAsset(theme.id, file.key, session)
         .catch((error) => {
-          renderError({headline: `Failed to delete file "${file.key}" from remote theme.`, body: error.message})
+          renderError({headline: `Failed to delete file "${file.key}" from remote theme.`, body: error.stack})
         })
         .finally(() => {
           progress.current++

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -1,7 +1,7 @@
 import {partitionThemeFiles} from './theme-fs.js'
 import {rejectGeneratedStaticAssets} from './asset-checksum.js'
 import {renderTasksToStdErr} from './theme-ui.js'
-import {renderCatchError} from './errors.js'
+import {createRenderCatchError} from './errors.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {Result, Checksum, Theme, ThemeFileSystem} from '@shopify/cli-kit/node/themes/types'
 import {AssetParams, bulkUploadThemeAssets, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
@@ -139,7 +139,7 @@ function buildDeleteJob(
         .catch((error: Error) => {
           failedDeleteAttempts++
           if (failedDeleteAttempts > 3) throw error
-          renderCatchError(file.key, 'delete')(error)
+          createRenderCatchError(file.key, 'delete')(error)
         })
         .finally(() => {
           progress.current++


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Related to #4576 and #4598

A proper request retry + token refresh is still needed but this PR tries to handle async errors more gracefully.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Ensure we print async errors properly with a red banner, and avoid process exit in some situations:
- On file delete / upload error in the remote theme, we show the error but the process continues. This is because the local development can continue working with local files in most cases, and is up to the developer to halt the process after seeing the error.
- On polling errors, wait for 5 errors before exiting the process. This is because it might recover from one or two failed attempts since it still compares local checksums with latest.

For example, when you lose your internet connection while polling:

<img width="687" alt="image" src="https://github.com/user-attachments/assets/b9644c9a-c651-48fb-aae8-73d3e13ce3d0">

During the initial sync, if there are too many delete errors or a single upload error:

<img width="684" alt="image" src="https://github.com/user-attachments/assets/3da56955-66ad-4767-8834-f873acf94c04">


### How to test your changes?

Create fake errors around the modified code or directly disconnect your internet + reconnect it within 15 seconds.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
