### PR TITLE
Make `shopify theme dev` more resilient to HTTP errors with the Admin API

### DIFF
--- a/.changeset/silent-ghosts-hide.md
+++ b/.changeset/silent-ghosts-hide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Make `shopify theme dev` more resilient to HTTP errors with the Admin API

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -10,6 +10,8 @@ import {
   buildThemeAsset,
 } from '@shopify/cli-kit/node/themes/factories'
 import {Result, Checksum, Key, Theme, ThemeAsset} from '@shopify/cli-kit/node/themes/types'
+import {outputDebug} from '@shopify/cli-kit/node/output'
+import {sleep} from '@shopify/cli-kit/node/system'
 
 export type ThemeParams = Partial<Pick<Theme, 'name' | 'role' | 'processing' | 'src'>>
 export type AssetParams = Pick<ThemeAsset, 'key'> & Partial<Pick<ThemeAsset, 'value' | 'attachment'>>
@@ -108,6 +110,7 @@ async function request<T>(
   session: AdminSession,
   params?: T,
   searchParams: {[name: string]: string} = {},
+  retries = 1,
 ): Promise<RestResponse> {
   const response = await throttler.throttle(() => restRequest(method, path, session, params, searchParams))
 
@@ -128,13 +131,33 @@ async function request<T>(
     case status === 403:
       return handleForbiddenError(response, session)
     case status === 401:
-      throw new AbortError(`[${status}] API request unauthorized error`)
+      // Retry 401 errors to be resilient to authentication errors.
+      return handleRetriableError({
+        path,
+        retries,
+        retry: () => {
+          return request(method, path, session, params, searchParams, retries + 1)
+        },
+        fail: () => {
+          throw new AbortError(`[${status}] API request unauthorized error`)
+        },
+      })
     case status === 422:
       throw new AbortError(`[${status}] API request unprocessable content: ${errors(response)}`)
     case status >= 400 && status <= 499:
       throw new AbortError(`[${status}] API request client error`)
     case status >= 500 && status <= 599:
-      throw new AbortError(`[${status}] API request server error`)
+      // Retry 500-family of errors as that may solve the issue (especially in 503 errors)
+      return handleRetriableError({
+        path,
+        retries,
+        retry: () => {
+          return request(method, path, session, params, searchParams, retries + 1)
+        },
+        fail: () => {
+          throw new AbortError(`[${status}] API request server error`)
+        },
+      })
     default:
       throw new AbortError(`[${status}] API request unexpected error`)
   }
@@ -174,4 +197,22 @@ function errorMessage(response: RestResponse): string {
   }
 
   return ''
+}
+
+interface RetriableErrorOptions {
+  path: string
+  retries: number
+  retry: () => Promise<RestResponse>
+  fail: () => never
+}
+
+async function handleRetriableError({path, retries, retry, fail}: RetriableErrorOptions): Promise<RestResponse> {
+  if (retries >= 3) {
+    fail()
+  }
+
+  outputDebug(`[${retries}] Retrying '${path}' request...`)
+
+  await sleep(0.2)
+  return retry()
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/issues/4576, https://github.com/Shopify/cli/issues/4598, and https://github.com/Shopify/cli/pull/4599

Retry requests for some HTTP errors. This PR doesn't propose to refresh the session because we're already refreshing it every [30 minutes](https://github.com/Shopify/cli/blob/main/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts#L8), the Admin session token expires in 2 hours, and we're getting a [fresh](https://github.com/Shopify/cli/blob/74fa66cfdb97b2d2e01c53be7f68409d7bb2710a/packages/theme/src/cli/services/dev.ts#L222) token when we start the session.

### WHAT is this pull request doing?

This PR updates the Admin REST API client to retry requests when they encounter certain HTTP errors. The Ruby CLI was more permissive regarding execution abortion, so we're adopting this approach as a middle-term to: fail when errors really happen but also be resilient and retry in some scenarios.

### How to test your changes?

- Run `shopify theme push -d`
- Cherry-pick this commit `e806941bd7538a0325593da4c02663c599f18e64` in your local CLI (it will trigger an error every time we update a file)
- Update the `layout/theme.liquid` file
- Run `shopify theme push -d --verbose`
- Notice the retries happening in the logs

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
