### PR TITLE
[3.68] Update the ignore module (`--only`/`--ignore`/`.shopifyignore`) to be backward compatible with (Ruby) Shopify CLI 2

### DIFF
--- a/.changeset/unlucky-years-look.md
+++ b/.changeset/unlucky-years-look.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Update the ignore module (`--only`/`--ignore`/`.shopifyignore`) to be backward compatible with (Ruby) Shopify CLI 2

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -522,6 +522,7 @@ export async function findPathUp(
 
 export interface MatchGlobOptions {
   matchBase: boolean
+  noglobstar: boolean
 }
 
 /**
@@ -531,6 +532,6 @@ export interface MatchGlobOptions {
  * @param options - The options to refine the matching approach.
  * @returns true if the key matches the pattern, false otherwise.
  */
-export function matchGlob(key: string, pattern: string, options: MatchGlobOptions = {matchBase: true}): boolean {
+export function matchGlob(key: string, pattern: string, options?: MatchGlobOptions): boolean {
   return minimatch(key, pattern, options)
 }

--- a/packages/theme/src/cli/utilities/asset-ignore.test.ts
+++ b/packages/theme/src/cli/utilities/asset-ignore.test.ts
@@ -148,7 +148,7 @@ describe('asset-ignore', () => {
       ])
     })
 
-    test(`matching is backward compatible with Shopify CLI 2`, async () => {
+    test(`matching is backward compatible with Shopify CLI 2 with the templates/*.json pattern`, async () => {
       // Given
       const options = {only: ['templates/*.json']}
 
@@ -158,6 +158,19 @@ describe('asset-ignore', () => {
       // Then
       expect(actualChecksums).toEqual([
         {key: 'templates/404.json', checksum: '6666666666666666666666666666666'},
+        {key: 'templates/customers/account.json', checksum: '7777777777777777777777777777777'},
+      ])
+    })
+
+    test(`matching is backward compatible with Shopify CLI 2 with the templates/**/*.json pattern`, async () => {
+      // Given
+      const options = {only: ['templates/**/*.json']}
+
+      // When
+      const actualChecksums = await applyIgnoreFilters(checksums, options)
+
+      // Then
+      expect(actualChecksums).toEqual([
         {key: 'templates/customers/account.json', checksum: '7777777777777777777777777777777'},
       ])
     })

--- a/packages/theme/src/cli/utilities/asset-ignore.ts
+++ b/packages/theme/src/cli/utilities/asset-ignore.ts
@@ -51,7 +51,12 @@ export async function getPatternsFromShopifyIgnore(root: string) {
 }
 
 function matchGlob(key: string, pattern: string) {
-  const result = originalMatchGlob(key, pattern)
+  const matchOpts = {
+    matchBase: true,
+    noglobstar: true,
+  }
+
+  const result = originalMatchGlob(key, pattern, matchOpts)
 
   if (result) return true
 
@@ -59,7 +64,7 @@ function matchGlob(key: string, pattern: string) {
   // replace '/*.' with '/**/*.' to emulate Shopify CLI 2.x behavior, as it was
   // based on 'File.fnmatch'.
   if (shouldReplaceGlobPattern(pattern)) {
-    return originalMatchGlob(key, pattern.replace('/*.', '/**/*.'))
+    return originalMatchGlob(key, pattern.replace('/*.', '/**/*.'), matchOpts)
   }
 
   return false


### PR DESCRIPTION
Backport https://github.com/Shopify/cli/pull/4564