### PR TITLE
Add codegen for admin schema

### DIFF
--- a/bin/get-graphql-schemas.js
+++ b/bin/get-graphql-schemas.js
@@ -27,6 +27,11 @@ const schemas = [
     repo: 'shopify',
     pathToFile: 'db/graphql/app_dev_schema_unstable_public.graphql',
     localPath: './packages/app/src/cli/api/graphql/app-dev/app_dev_schema.graphql',
+  },
+  {
+    repo: 'shopify',
+    pathToFile: 'db/graphql/admin_schema_unstable_public.graphql',
+    localPath: './packages/cli-kit/src/cli/api/graphql/admin/admin_schema.graphql',
   }
 ]
 
@@ -70,14 +75,14 @@ async function fetchFileForSchema(schema, octokit) {
   try {
     // Fetch the file content from the repository
     const {data} = await octokit.repos.getContent({
+      mediaType: { format: "raw" },
       owner: OWNER,
       repo: schema.repo,
       path: schema.pathToFile,
       ref: BRANCH,
     })
 
-    // Decode the base64 content
-    const content = Buffer.from(data.content, 'base64').toString('utf-8')
+    const content = Buffer.from(data).toString('utf-8')
 
     // Define the local path where the file will be saved
     const localFilePath = schema.localPath

--- a/graphql.config.ts
+++ b/graphql.config.ts
@@ -1,11 +1,11 @@
-function projectFactory(name: string, schemaName: string) {
+function projectFactory(name: string, schemaName: string, project: string = "app") {
   return {
-    schema: `./packages/app/src/cli/api/graphql/${name}/${schemaName}`,
-    documents: [`./packages/app/src/cli/api/graphql/${name}/queries/**/*.graphql`],
+    schema: `./packages/${project}/src/cli/api/graphql/${name}/${schemaName}`,
+    documents: [`./packages/${project}/src/cli/api/graphql/${name}/queries/**/*.graphql`],
     extensions: {
       codegen: {
         generates: {
-          [`./packages/app/src/cli/api/graphql/${name}/generated/types.d.ts`]: {
+          [`./packages/${project}/src/cli/api/graphql/${name}/generated/types.d.ts`]: {
             plugins: [
               {'graphql-codegen-typescript-operation-types': {enumsAsTypes: true, useTypeImports: true}},
               {
@@ -24,7 +24,7 @@ function projectFactory(name: string, schemaName: string) {
               },
             },
           },
-          [`./packages/app/src/cli/api/graphql/${name}/generated/`]: {
+          [`./packages/${project}/src/cli/api/graphql/${name}/generated/`]: {
             preset: 'near-operation-file',
             plugins: [
               {
@@ -73,5 +73,6 @@ export default {
     businessPlatformDestinations: projectFactory('business-platform-destinations', 'destinations_schema.graphql'),
     businessPlatformOrganizations: projectFactory('business-platform-organizations', 'organizations_schema.graphql'),
     appDev: projectFactory('app-dev', 'app_dev_schema.graphql'),
+    admin: projectFactory('admin', 'admin_schema.graphql', 'cli-kit'),
   },
 }

--- a/package.json
+++ b/package.json
@@ -256,6 +256,9 @@
           "**/{commands,hooks}/**/*.ts!",
           "**/public/**/*.{ts,tsx}!"
         ],
+        "ignore": [
+          "**/graphql/**/generated/*.ts"
+        ],
         "project": "**/*.{ts,tsx}!",
         "ignoreBinaries": [
           "bundle",

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -3,7 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/cli-kit/src",
   "projectType": "library",
-  "tags": ["scope:foundation"],
+  "tags": [
+    "scope:foundation"
+  ],
   "targets": {
     "clean": {
       "executor": "nx:run-commands",
@@ -14,8 +16,12 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
-      "inputs": ["{projectRoot}/src/**/*"],
+      "outputs": [
+        "{workspaceRoot}/dist"
+      ],
+      "inputs": [
+        "{projectRoot}/src/**/*"
+      ],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",
         "cwd": "packages/cli-kit"
@@ -23,7 +29,9 @@
     },
     "docs:generate": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/docs"],
+      "outputs": [
+        "{workspaceRoot}/docs"
+      ],
       "options": {
         "command": "node ./scripts/generate-docs.js",
         "cwd": "packages/cli-kit"
@@ -31,7 +39,9 @@
     },
     "docs:open": {
       "executor": "nx:run-commands",
-      "dependsOn": ["docs:generate"],
+      "dependsOn": [
+        "docs:generate"
+      ],
       "options": {
         "command": "open ../../docs/api/cli-kit/index.html",
         "cwd": "packages/cli-kit"
@@ -39,7 +49,9 @@
     },
     "lint": {
       "executor": "nx:run-commands",
-      "dependsOn": ["lint:js"],
+      "dependsOn": [
+        "lint:js"
+      ],
       "options": {
         "cwd": "packages/cli-kit",
         "commands": []
@@ -61,7 +73,9 @@
     },
     "lint:fix": {
       "executor": "nx:run-commands",
-      "dependsOn": ["lint:js:fix"],
+      "dependsOn": [
+        "lint:js:fix"
+      ],
       "options": {
         "cwd": "packages/cli-kit",
         "commands": []
@@ -83,7 +97,9 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": ["test:js"],
+      "dependsOn": [
+        "test:js"
+      ],
       "options": {
         "commands": [],
         "cwd": "packages/cli-kit"
@@ -106,7 +122,9 @@
     },
     "test:coverage": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
+      "dependsOn": [
+        "build"
+      ],
       "options": {
         "command": "pnpm vitest run --reporter json --coverage --outputFile ./coverage/report.json",
         "cwd": "packages/cli-kit"
@@ -131,6 +149,68 @@
       "options": {
         "command": "FORCE_HYPERLINK=0 node --loader ts-node/esm ./bin/refresh-documentation.ts",
         "cwd": "packages/cli-kit"
+      }
+    },
+    "graphql-codegen": {
+      "executor": "nx:noop",
+      "dependsOn": [
+        "graphql-codegen:formatting"
+      ]
+    },
+    "graphql-codegen:formatting": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        "graphql-codegen:postfix"
+      ],
+      "inputs": [
+        {
+          "dependentTasksOutputFiles": "**/*.ts"
+        }
+      ],
+      "outputs": [
+        "{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"
+      ],
+      "options": {
+        "commands": [
+          "pnpm eslint 'src/cli/api/graphql/admin/generated/**/*.{ts,tsx}' --fix"
+        ],
+        "cwd": "packages/cli-kit"
+      }
+    },
+    "graphql-codegen:generate:admin": {
+      "executor": "nx:run-commands",
+      "inputs": [
+        "{workspaceRoot}/graphql.config.ts",
+        "{projectRoot}/src/cli/api/graphql/admin/**/*.graphql"
+      ],
+      "outputs": [
+        "{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"
+      ],
+      "options": {
+        "commands": [
+          "pnpm exec graphql-codegen --project=admin"
+        ],
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "graphql-codegen:postfix": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        "graphql-codegen:generate:admin"
+      ],
+      "inputs": [
+        {
+          "dependentTasksOutputFiles": "**/*.ts"
+        }
+      ],
+      "outputs": [
+        "{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"
+      ],
+      "options": {
+        "commands": [
+          "find ./packages/cli-kit/src/cli/api/graphql/admin/generated/ -type f -name '*.ts' -exec sh -c 'sed -i \"\" \"s|import \\* as Types from '\\''./types'\\'';|import \\* as Types from '\\''./types.js'\\'';|g; s|export const \\([A-Za-z0-9_]*\\)Document =|export const \\1 =|g\" \"$0\"' {} \\;"
+        ],
+        "cwd": "{workspaceRoot}"
       }
     }
   }

--- a/packages/cli-kit/src/cli/api/graphql/.gitignore
+++ b/packages/cli-kit/src/cli/api/graphql/.gitignore
@@ -1,0 +1,1 @@
+*_schema.graphql

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/public_api_versions.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/public_api_versions.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type PublicApiVersionsQueryVariables = Types.Exact<{[key: string]: never}>
+
+export type PublicApiVersionsQuery = {publicApiVersions: {handle: string; supported: boolean}[]}
+
+export const PublicApiVersions = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: {kind: 'Name', value: 'publicApiVersions'},
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'publicApiVersions'},
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'supported'}},
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<PublicApiVersionsQuery, PublicApiVersionsQueryVariables>

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/no-explicit-any, tsdoc/syntax  */
+export type Maybe<T> = T | null
+export type InputMaybe<T> = Maybe<T>
+export type Exact<T extends {[key: string]: unknown}> = {[K in keyof T]: T[K]}
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {[SubKey in K]?: Maybe<T[SubKey]>}
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {[SubKey in K]: Maybe<T[SubKey]>}
+export type MakeEmpty<T extends {[key: string]: unknown}, K extends keyof T> = {[_ in K]?: never}
+export type Incremental<T> = T | {[P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never}
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: {input: string; output: string}
+  String: {input: string; output: string}
+  Boolean: {input: boolean; output: boolean}
+  Int: {input: number; output: number}
+  Float: {input: number; output: number}
+  /**
+   * An Amazon Web Services Amazon Resource Name (ARN), including the Region and account ID.
+   * For more information, refer to [Amazon Resource Names](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
+   */
+  ARN: {input: any; output: any}
+  /**
+   * Represents non-fractional signed whole numeric values. Since the value may
+   * exceed the size of a 32-bit integer, it's encoded as a string.
+   */
+  BigInt: {input: any; output: any}
+  /**
+   * A string containing a hexadecimal representation of a color.
+   *
+   * For example, "#6A8D48".
+   */
+  Color: {input: any; output: any}
+  /**
+   * Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date string.
+   * For example, September 7, 2019 is represented as `"2019-07-16"`.
+   */
+  Date: {input: any; output: any}
+  /**
+   * Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date and time string.
+   * For example, 3:50 pm on September 7, 2019 in the time zone of UTC (Coordinated Universal Time) is
+   * represented as `"2019-09-07T15:50:00Z`".
+   */
+  DateTime: {input: any; output: any}
+  /**
+   * A signed decimal number, which supports arbitrary precision and is serialized as a string.
+   *
+   * Example values: `"29.99"`, `"29.999"`.
+   */
+  Decimal: {input: any; output: any}
+  /**
+   * A string containing a strict subset of HTML code. Non-allowed tags will be stripped out.
+   * Allowed tags:
+   * * `a` (allowed attributes: `href`, `target`)
+   * * `b`
+   * * `br`
+   * * `em`
+   * * `i`
+   * * `strong`
+   * * `u`
+   * Use [HTML](https://shopify.dev/api/admin-graphql/latest/scalars/HTML) instead if you need to
+   * include other HTML tags.
+   *
+   * Example value: `"Your current domain is <strong>example.myshopify.com</strong>."`
+   */
+  FormattedString: {input: any; output: any}
+  /**
+   * A string containing HTML code. Refer to the [HTML spec](https://html.spec.whatwg.org/#elements-3) for a
+   * complete list of HTML elements.
+   *
+   * Example value: `"<p>Grey cotton knit sweater.</p>"`
+   */
+  HTML: {input: any; output: any}
+  /**
+   * A [JSON](https://www.json.org/json-en.html) object.
+   *
+   * Example value:
+   * `{
+   *   "product": {
+   *     "id": "gid://shopify/Product/1346443542550",
+   *     "title": "White T-shirt",
+   *     "options": [{
+   *       "name": "Size",
+   *       "values": ["M", "L"]
+   *     }]
+   *   }
+   * }`
+   */
+  JSON: {input: any; output: any}
+  /** A monetary value string without a currency symbol or code. Example value: `"100.57"`. */
+  Money: {input: any; output: any}
+  /** A scalar value. */
+  Scalar: {input: any; output: any}
+  /**
+   * Represents a unique identifier in the Storefront API. A `StorefrontID` value can
+   * be used wherever an ID is expected in the Storefront API.
+   *
+   * Example value: `"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEwMDc5Nzg1MTAw"`.
+   */
+  StorefrontID: {input: any; output: any}
+  /**
+   * Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
+   * [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
+   *
+   * For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+   * (`example.myshopify.com`).
+   */
+  URL: {input: any; output: any}
+  /**
+   * An unsigned 64-bit integer. Represents whole numeric values between 0 and 2^64 - 1 encoded as a string of base-10 digits.
+   *
+   * Example value: `"50"`.
+   */
+  UnsignedInt64: {input: any; output: any}
+  /**
+   * Time between UTC time and a location's observed time, in the format `"+HH:MM"` or `"-HH:MM"`.
+   *
+   * Example value: `"-07:00"`.
+   */
+  UtcOffset: {input: any; output: any}
+}

--- a/packages/cli-kit/src/cli/api/graphql/admin/queries/public_api_versions.graphql
+++ b/packages/cli-kit/src/cli/api/graphql/admin/queries/public_api_versions.graphql
@@ -1,0 +1,6 @@
+query publicApiVersions {
+  publicApiVersions {
+    handle
+    supported
+  }
+}

--- a/packages/cli-kit/src/public/node/api/admin.test.ts
+++ b/packages/cli-kit/src/public/node/api/admin.test.ts
@@ -1,5 +1,5 @@
 import * as admin from './admin.js'
-import {graphqlRequest} from './graphql.js'
+import {graphqlRequest, graphqlRequestDoc} from './graphql.js'
 import {AdminSession} from '../session.js'
 import {buildHeaders} from '../../../private/node/api/headers.js'
 import * as http from '../../../public/node/http.js'
@@ -34,17 +34,20 @@ describe('admin-graphql-api', () => {
   test('calls the graphql client twice: get api version and then execute the request', async () => {
     // Given
     vi.mocked(graphqlRequest).mockResolvedValue(mockedResult)
+    vi.mocked(graphqlRequestDoc).mockResolvedValue(mockedResult)
 
     // When
     await admin.adminRequest('query', Session, {})
 
     // Then
-    expect(graphqlRequest).toHaveBeenCalledTimes(2)
+    expect(graphqlRequest).toHaveBeenCalledTimes(1)
+    expect(graphqlRequestDoc).toHaveBeenCalledTimes(1)
   })
 
   test('request is called with correct parameters', async () => {
     // Given
     vi.mocked(graphqlRequest).mockResolvedValue(mockedResult)
+    vi.mocked(graphqlRequestDoc).mockResolvedValue(mockedResult)
 
     // When
     await admin.adminRequest('query', Session, {variables: 'variables'})

--- a/packages/cli-kit/src/public/node/api/admin.ts
+++ b/packages/cli-kit/src/public/node/api/admin.ts
@@ -1,10 +1,12 @@
-import {graphqlRequest, GraphQLVariables} from './graphql.js'
+import {graphqlRequest, graphqlRequestDoc, GraphQLResponseOptions, GraphQLVariables} from './graphql.js'
 import {AdminSession} from '../session.js'
 import {outputContent, outputToken} from '../../../public/node/output.js'
 import {BugError, AbortError} from '../error.js'
 import {restRequestBody, restRequestHeaders, restRequestUrl} from '../../../private/node/api/rest.js'
 import {fetch} from '../http.js'
-import {ClientError, gql} from 'graphql-request'
+import {PublicApiVersions} from '../../../cli/api/graphql/admin/generated/public_api_versions.js'
+import {ClientError, Variables} from 'graphql-request'
+import {TypedDocumentNode} from '@graphql-typed-document-node/core'
 
 /**
  * Executes a GraphQL query against the Admin API.
@@ -19,6 +21,36 @@ export async function adminRequest<T>(query: string, session: AdminSession, vari
   const version = await fetchLatestSupportedApiVersion(session)
   const url = adminUrl(session.storeFqdn, version)
   return graphqlRequest({query, api, url, token: session.token, variables})
+}
+
+/**
+ * Executes a GraphQL query against the Admin API. Uses typed documents.
+ *
+ * @param query - GraphQL query to execute.
+ * @param session - Shopify admin session including token and Store FQDN.
+ * @param variables - GraphQL variables to pass to the query.
+ * @param version - API version.
+ * @param responseOptions - Control how API responses will be handled.
+ * @returns The response of the query of generic type <TResult>.
+ */
+export async function adminRequestDoc<TResult, TVariables extends Variables>(
+  query: TypedDocumentNode<TResult, TVariables>,
+  session: AdminSession,
+  variables?: TVariables,
+  version?: string,
+  responseOptions?: GraphQLResponseOptions<TResult>,
+): Promise<TResult> {
+  let apiVersion = version
+  if (!version) {
+    apiVersion = await fetchLatestSupportedApiVersion(session)
+  }
+  const opts = {
+    url: adminUrl(session.storeFqdn, apiVersion),
+    api: 'Admin',
+    token: session.token,
+  }
+  const result = graphqlRequestDoc<TResult, TVariables>({...opts, query, variables, responseOptions})
+  return result
 }
 
 /**
@@ -53,19 +85,9 @@ export async function supportedApiVersions(session: AdminSession): Promise<strin
  * @returns - An array of supported and unsupported API versions.
  */
 async function fetchApiVersions(session: AdminSession): Promise<ApiVersion[]> {
-  const url = adminUrl(session.storeFqdn, 'unstable')
-  const query = apiVersionQuery()
   try {
-    const data: ApiVersionResponse = await graphqlRequest({
-      query,
-      api: 'Admin',
-      url,
-      token: session.token,
-      variables: {},
-      responseOptions: {handleErrors: false},
-    })
-
-    return data.publicApiVersions
+    const response = await adminRequestDoc(PublicApiVersions, session, {}, 'unstable', {handleErrors: false})
+    return response.publicApiVersions
   } catch (error) {
     if (error instanceof ClientError && error.response.status === 403) {
       const storeName = session.storeFqdn.replace('.myshopify.com', '')
@@ -96,26 +118,6 @@ export function adminUrl(store: string, version: string | undefined): string {
 interface ApiVersion {
   handle: string
   supported: boolean
-}
-
-interface ApiVersionResponse {
-  publicApiVersions: ApiVersion[]
-}
-
-/**
- * GraphQL query string to retrieve the latest supported API version.
- *
- * @returns - A query string.
- */
-function apiVersionQuery(): string {
-  return gql`
-    query {
-      publicApiVersions {
-        handle
-        supported
-      }
-    }
-  `
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Add codegen for admin schema required by cli-kit to integrate with the [new theme graphQL APIs](https://shopify.dev/changelog/introducing-theme-and-theme-file-management-in-the-admin-graphql-api)