### PR TITLE
fix extension name when migrating marketing activity extension

### DIFF
--- a/packages/app/src/cli/services/marketing_activity/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/marketing_activity/extension-to-toml.test.ts
@@ -43,7 +43,7 @@ describe('extension-to-toml', () => {
     // Then
     expect(got).toEqual(`[[extensions]]
 type = "marketing_activity"
-name = "test mae"
+name = "mae @ test! 123"
 handle = "mae-test-123"
 title = "test mae"
 description = "test mae description"

--- a/packages/app/src/cli/services/marketing_activity/extension-to-toml.ts
+++ b/packages/app/src/cli/services/marketing_activity/extension-to-toml.ts
@@ -172,7 +172,7 @@ export function buildTomlObject(extension: ExtensionRegistration): string {
     extensions: [
       {
         type: 'marketing_activity',
-        name: config.title,
+        name: extension.title,
         handle: slugify(extension.title.substring(0, MAX_EXTENSION_HANDLE_LENGTH)),
         title: config.title,
         description: config.description,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We were using the wrong field for the extension name

### WHAT is this pull request doing?
Updates the logic to use the `extension.title` instead

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
