### PR TITLE
Use TOML configuration for function build path

### DIFF
--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -143,7 +143,11 @@ export async function buildFunctionExtension(
 
   try {
     const bundlePath = extension.outputPath
-    extension.outputPath = joinPath(extension.directory, joinPath('dist', 'function.wasm'))
+    const relativeBuildPath =
+      (extension as ExtensionInstance<FunctionConfigType>).configuration.build.path ?? joinPath('dist', 'index.wasm')
+
+    extension.outputPath = joinPath(extension.directory, relativeBuildPath)
+
     if (extension.isJavaScript) {
       await runCommandOrBuildJSFunction(extension, options)
     } else {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-functions/issues/445

### WHAT is this pull request doing?

Function developers have the option of specifying a custom build path for their Wasm file. This PR updates the CLI code to read from that path if it's specified, otherwise use the default path of `dist/index.wasm` (described [here](https://shopify.dev/docs/api/functions/configuration#properties)).

### How to test your changes?

1. Create a Rust function with a specific build path (e.g. `target/wasm32-wasi/release/my-function.wasm`)
2. Run `shopify app deploy`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
