### PR TITLE
Migrate theme delete/update/publish to GraphQL 

### DIFF
--- a/graphql.config.ts
+++ b/graphql.config.ts
@@ -1,7 +1,7 @@
 function projectFactory(name: string, schemaName: string, project: string = 'app') {
   return {
     schema: `./packages/${project}/src/cli/api/graphql/${name}/${schemaName}`,
-    documents: [`./packages/${project}/src/cli/api/graphql/${name}/queries/**/*.graphql`],
+    documents: [`./packages/${project}/src/cli/api/graphql/${name}/queries/**/*.graphql`,`./packages/${project}/src/cli/api/graphql/${name}/mutations/**/*.graphql`],
     extensions: {
       codegen: {
         generates: {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_delete.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_delete.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type ThemeDeleteMutationVariables = Types.Exact<{
+  id: Types.Scalars['ID']['input']
+}>
+
+export type ThemeDeleteMutation = {
+  themeDelete?: {
+    deletedThemeId?: string | null
+    userErrors: {field?: string[] | null; message: string}[]
+  } | null
+}
+
+export const ThemeDelete = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'themeDelete'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'themeDelete'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'id'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {kind: 'Field', name: {kind: 'Name', value: 'deletedThemeId'}},
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'userErrors'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'field'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ThemeDeleteMutation, ThemeDeleteMutationVariables>

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_publish.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_publish.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type ThemePublishMutationVariables = Types.Exact<{
+  id: Types.Scalars['ID']['input']
+}>
+
+export type ThemePublishMutation = {
+  themePublish?: {
+    theme?: {id: string; name: string; role: Types.ThemeRole} | null
+    userErrors: {field?: string[] | null; message: string}[]
+  } | null
+}
+
+export const ThemePublish = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'themePublish'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'themePublish'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'id'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'theme'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'id'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'role'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'userErrors'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'field'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ThemePublishMutation, ThemePublishMutationVariables>

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_update.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_update.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type ThemeUpdateMutationVariables = Types.Exact<{
+  id: Types.Scalars['ID']['input']
+  input: Types.OnlineStoreThemeInput
+}>
+
+export type ThemeUpdateMutation = {
+  themeUpdate?: {
+    theme?: {id: string; name: string; role: Types.ThemeRole} | null
+    userErrors: {field?: string[] | null; message: string}[]
+  } | null
+}
+
+export const ThemeUpdate = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'themeUpdate'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}}},
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'input'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'OnlineStoreThemeInput'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'themeUpdate'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'id'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+              },
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'input'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'input'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'theme'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'id'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'role'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'userErrors'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'field'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ThemeUpdateMutation, ThemeUpdateMutationVariables>

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
@@ -119,3 +119,37 @@ export type Scalars = {
    */
   UtcOffset: {input: any; output: any}
 }
+
+/** The input fields for Theme attributes to update. */
+export type OnlineStoreThemeInput = {
+  /** The new name of the theme. */
+  name?: InputMaybe<Scalars['String']['input']>
+}
+
+/** The role of the theme. */
+export type ThemeRole =
+  /**
+   * The theme is archived if a merchant changes their plan and exceeds the maximum
+   * number of themes allowed. Archived themes can be downloaded by merchant, but
+   * can not be customized or published until the plan is upgraded.
+   */
+  | 'ARCHIVED'
+  /**
+   * The theme is installed as a trial from the Shopify Theme Store. It can be
+   * customized using the theme editor, but access to the code editor and the
+   * ability to publish the theme are restricted until it is purchased.
+   */
+  | 'DEMO'
+  /** The theme is automatically created by the CLI for previewing purposes when in a development session. */
+  | 'DEVELOPMENT'
+  /**
+   * The theme is locked if it is identified as unlicensed. Customization and
+   * publishing are restricted until the merchant resolves the licensing issue.
+   */
+  | 'LOCKED'
+  /** TThe currently published theme. There can only be one main theme at any time. */
+  | 'MAIN'
+  /** The currently published theme that is only accessible to a mobile client. */
+  | 'MOBILE'
+  /** The theme is currently not published. It can be transitioned to the main role if it is published by the merchant. */
+  | 'UNPUBLISHED'

--- a/packages/cli-kit/src/cli/api/graphql/admin/mutations/theme_delete.graphql
+++ b/packages/cli-kit/src/cli/api/graphql/admin/mutations/theme_delete.graphql
@@ -1,0 +1,9 @@
+mutation themeDelete($id: ID!) {
+  themeDelete(id: $id) {
+    deletedThemeId
+    userErrors {
+      field
+      message
+    }
+  }
+}

--- a/packages/cli-kit/src/cli/api/graphql/admin/mutations/theme_publish.graphql
+++ b/packages/cli-kit/src/cli/api/graphql/admin/mutations/theme_publish.graphql
@@ -1,0 +1,13 @@
+mutation themePublish($id: ID!) {
+  themePublish(id: $id) {
+    theme {
+      id
+      name
+      role
+    }
+    userErrors{
+      field
+      message
+    }
+  }
+}

--- a/packages/cli-kit/src/cli/api/graphql/admin/mutations/theme_update.graphql
+++ b/packages/cli-kit/src/cli/api/graphql/admin/mutations/theme_update.graphql
@@ -1,0 +1,13 @@
+mutation themeUpdate($id: ID!, $input: OnlineStoreThemeInput!) {
+  themeUpdate(id: $id, input: $input ) {
+    theme {
+      id
+      name
+      role
+    }
+    userErrors{
+      field
+      message
+    }
+  }
+}

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -1,25 +1,29 @@
 import {
   createTheme,
-  deleteTheme,
+  themeDelete,
   fetchThemes,
   ThemeParams,
-  updateTheme,
-  publishTheme,
-  upgradeTheme,
+  themeUpdate,
+  themePublish,
   fetchChecksums,
   bulkUploadThemeAssets,
   AssetParams,
   deleteThemeAsset,
 } from './api.js'
 import {RemoteBulkUploadResponse} from './factories.js'
+import {ThemeDelete} from '../../../cli/api/graphql/admin/generated/theme_delete.js'
+import {ThemeUpdate} from '../../../cli/api/graphql/admin/generated/theme_update.js'
+import {ThemePublish} from '../../../cli/api/graphql/admin/generated/theme_publish.js'
 import {test, vi, expect, describe} from 'vitest'
-import {restRequest} from '@shopify/cli-kit/node/api/admin'
+import {adminRequestDoc, restRequest} from '@shopify/cli-kit/node/api/admin'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
 vi.mock('@shopify/cli-kit/node/api/admin')
 vi.mock('@shopify/cli-kit/node/system')
 
 const session = {token: 'token', storeFqdn: 'my-shop.myshopify.com'}
+const themeAccessSession = {...session, token: 'shptka_token'}
+const sessions = {CLI: session, 'Theme Access': themeAccessSession}
 
 describe('fetchThemes', () => {
   test('returns store themes', async () => {
@@ -132,58 +136,66 @@ describe('createTheme', () => {
   })
 })
 
-describe('upgradeTheme', () => {
-  test('upgrades a theme with a script', async () => {
+describe('themeUpdate', () => {
+  for (const [sessionType, session] of Object.entries(sessions)) {
+    test(`updates a theme with graphql with a ${sessionType} session`, async () => {
+      // Given
+      const id = 123
+      const name = 'updated theme'
+      const role = 'unpublished'
+      const params: ThemeParams = {name, role}
+
+      vi.mocked(adminRequestDoc).mockResolvedValue({
+        themeUpdate: {
+          theme: {
+            id: `gid://shopify/OnlineStoreTheme/${id}`,
+            name,
+            role,
+          },
+          userErrors: [],
+        },
+      })
+
+      // When
+      const theme = await themeUpdate(id, params, session)
+
+      // Then
+      expect(adminRequestDoc).toHaveBeenCalledWith(ThemeUpdate, session, {
+        id: `gid://shopify/OnlineStoreTheme/${id}`,
+        input: {name},
+      })
+      expect(theme).not.toBeNull()
+      expect(theme!.id).toEqual(id)
+      expect(theme!.name).toEqual(name)
+      expect(theme!.role).toEqual(role)
+    })
+  }
+
+  test('no-ops when input hash is empty', async () => {
     // Given
-    const fromTheme = 123
-    const toTheme = 456
-    const id = 789
-    const name = 'updated-theme'
+    const id = 123
+    const name = 'theme'
     const role = 'unpublished'
 
-    vi.mocked(restRequest).mockResolvedValue({
-      json: {theme: {id, name, role}},
-      status: 200,
-      headers: {},
+    vi.mocked(adminRequestDoc).mockResolvedValue({
+      themeUpdate: {
+        theme: {
+          id: `gid://shopify/OnlineStoreTheme/${id}`,
+          name,
+          role,
+        },
+        userErrors: [],
+      },
     })
 
     // When
-    const theme = await upgradeTheme({fromTheme, toTheme, session})
+    const theme = await themeUpdate(id, {}, session)
 
     // Then
-    expect(restRequest).toHaveBeenCalledWith('POST', `/themes`, session, {from_theme: fromTheme, to_theme: toTheme}, {})
-    expect(theme).not.toBeNull()
-    expect(theme!.id).toEqual(id)
-    expect(theme!.name).toEqual(name)
-    expect(theme!.role).toEqual(role)
-  })
-
-  test('upgrades a theme without a script', async () => {
-    // Given
-    const fromTheme = 123
-    const toTheme = 456
-    const script = 'update_extension.json contents'
-    const id = 789
-    const name = 'updated-theme'
-    const role = 'unpublished'
-
-    vi.mocked(restRequest).mockResolvedValue({
-      json: {theme: {id, name, role}},
-      status: 200,
-      headers: {},
+    expect(adminRequestDoc).toHaveBeenCalledWith(ThemeUpdate, session, {
+      id: `gid://shopify/OnlineStoreTheme/${id}`,
+      input: {},
     })
-
-    // When
-    const theme = await upgradeTheme({fromTheme, toTheme, script, session})
-
-    // Then
-    expect(restRequest).toHaveBeenCalledWith(
-      'POST',
-      `/themes`,
-      session,
-      {from_theme: fromTheme, to_theme: toTheme, script},
-      {},
-    )
     expect(theme).not.toBeNull()
     expect(theme!.id).toEqual(id)
     expect(theme!.name).toEqual(name)
@@ -191,55 +203,36 @@ describe('upgradeTheme', () => {
   })
 })
 
-describe('updateTheme', () => {
-  test('updates a theme', async () => {
-    // Given
-    const id = 123
-    const name = 'updated theme'
-    const role = 'unpublished'
-    const params: ThemeParams = {name, role}
+describe('themePublish', () => {
+  for (const [sessionType, session] of Object.entries(sessions)) {
+    test(`publish a theme with graphql with a ${sessionType} session`, async () => {
+      // Given
+      const id = 123
+      const name = 'updated theme'
+      const role = 'live'
 
-    vi.mocked(restRequest).mockResolvedValue({
-      json: {theme: {id, name, role}},
-      status: 200,
-      headers: {},
+      vi.mocked(adminRequestDoc).mockResolvedValue({
+        themePublish: {
+          theme: {
+            id: `gid://shopify/OnlineStoreTheme/${id}`,
+            name,
+            role,
+          },
+          userErrors: [],
+        },
+      })
+
+      // When
+      const theme = await themePublish(id, session)
+
+      // Then
+      expect(adminRequestDoc).toHaveBeenCalledWith(ThemePublish, session, {id: `gid://shopify/OnlineStoreTheme/${id}`})
+      expect(theme).not.toBeNull()
+      expect(theme!.id).toEqual(id)
+      expect(theme!.name).toEqual(name)
+      expect(theme!.role).toEqual(role)
     })
-
-    // When
-    const theme = await updateTheme(id, params, session)
-
-    // Then
-    expect(restRequest).toHaveBeenCalledWith('PUT', `/themes/${id}`, session, {theme: {id, ...params}}, {})
-    expect(theme).not.toBeNull()
-    expect(theme!.id).toEqual(id)
-    expect(theme!.name).toEqual(name)
-    expect(theme!.role).toEqual(role)
-  })
-})
-
-describe('publishTheme', () => {
-  test('publish a theme', async () => {
-    // Given
-    const id = 123
-    const name = 'updated theme'
-    const role = 'live'
-
-    vi.mocked(restRequest).mockResolvedValue({
-      json: {theme: {id, name, role}},
-      status: 200,
-      headers: {},
-    })
-
-    // When
-    const theme = await publishTheme(id, session)
-
-    // Then
-    expect(restRequest).toHaveBeenCalledWith('PUT', `/themes/${id}`, session, {theme: {id, role: 'main'}}, {})
-    expect(theme).not.toBeNull()
-    expect(theme!.id).toEqual(id)
-    expect(theme!.name).toEqual(name)
-    expect(theme!.role).toEqual(role)
-  })
+  }
 })
 
 describe('deleteThemeAsset', () => {
@@ -302,53 +295,47 @@ describe('deleteThemeAsset', () => {
   })
 })
 
-describe('deleteTheme', () => {
-  test('deletes a theme', async () => {
-    // Given
-    const id = 123
-    const name = 'store theme'
-
-    vi.mocked(restRequest).mockResolvedValue({
-      json: {theme: {id, name}},
-      status: 200,
-      headers: {},
-    })
-
-    // When
-    const theme = await deleteTheme(id, session)
-
-    // Then
-    expect(restRequest).toHaveBeenCalledWith('DELETE', `/themes/${id}`, session, undefined, {})
-    expect(theme).not.toBeNull()
-    expect(theme!.id).toEqual(id)
-    expect(theme!.name).toEqual('store theme')
-  })
-})
-
-describe('request errors', () => {
-  const httpResponses = [
-    {httpError: 401, expectedRetries: 3},
-    {httpError: 403, expectedRetries: 1},
-    {httpError: 500, expectedRetries: 3},
-    {httpError: 999, expectedRetries: 1},
-  ]
-
-  httpResponses.forEach(({httpError, expectedRetries}) => {
-    test(`${httpError} errors`, async () => {
+describe('themeDelete', () => {
+  for (const [sessionType, session] of Object.entries(sessions)) {
+    test(`deletes a theme with graphql with a ${sessionType} session`, async () => {
       // Given
-      vi.mocked(restRequest).mockResolvedValue({
-        json: {},
-        status: httpError,
-        headers: {},
+      const id = 123
+      const name = 'store theme'
+
+      vi.mocked(adminRequestDoc).mockResolvedValue({
+        themeDelete: {
+          deletedThemeId: 'gid://shopify/OnlineStoreTheme/123',
+          userErrors: [],
+        },
       })
 
       // When
-      const deletePromise = async () => deleteTheme(1, session)
+      const response = await themeDelete(id, session)
 
       // Then
-      await expect(deletePromise).rejects.toThrowError(AbortError)
-      expect(restRequest).toBeCalledTimes(expectedRetries)
+      expect(adminRequestDoc).toHaveBeenCalledWith(ThemeDelete, session, {id: `gid://shopify/OnlineStoreTheme/${id}`})
+      expect(response).toBe(true)
     })
+  }
+})
+
+describe('request errors', () => {
+  test(`returns AbortError when graphql returns user error`, async () => {
+    // Given
+
+    vi.mocked(adminRequestDoc).mockResolvedValue({
+      themeDelete: {
+        deletedThemeId: null,
+        userErrors: [{message: 'Could not delete theme'}],
+      },
+    })
+
+    await expect(async () => {
+      // When
+      return themeDelete(1, session)
+
+      // Then
+    }).rejects.toThrowError(AbortError)
   })
 })
 

--- a/packages/cli-kit/src/public/node/themes/utils.ts
+++ b/packages/cli-kit/src/public/node/themes/utils.ts
@@ -2,6 +2,8 @@ import {renderTextPrompt} from '../ui.js'
 import {getRandomName} from '@shopify/cli-kit/common/string'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 
+const GID_REGEXP = /gid:\/\/shopify\/\w*\/(\d+)/
+
 export const DEVELOPMENT_THEME_ROLE = 'development'
 export const LIVE_THEME_ROLE = 'live'
 export const UNPUBLISHED_THEME_ROLE = 'unpublished'
@@ -18,4 +20,16 @@ export async function promptThemeName(message: string) {
     message,
     defaultValue: defaultName,
   })
+}
+
+export function composeThemeGid(id: number): string {
+  return `gid://shopify/OnlineStoreTheme/${id}`
+}
+
+export function parseGid(gid: string): number {
+  const matches = GID_REGEXP.exec(gid)
+  if (matches && matches[1] !== undefined) {
+    return parseInt(matches[1], 10)
+  }
+  throw new Error(`Invalid GID: ${gid}`)
 }

--- a/packages/theme/src/cli/commands/theme/delete.ts
+++ b/packages/theme/src/cli/commands/theme/delete.ts
@@ -1,7 +1,7 @@
 import {ensureThemeStore} from '../../utilities/theme-store.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {themeFlags} from '../../flags.js'
-import {deleteThemes, renderDeprecatedArgsWarning} from '../../services/delete.js'
+import {themesDelete, renderDeprecatedArgsWarning} from '../../services/delete.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
@@ -61,7 +61,7 @@ export default class Delete extends ThemeCommand {
       renderDeprecatedArgsWarning(argv)
     }
 
-    await deleteThemes(adminSession, {
+    await themesDelete(adminSession, {
       selectTheme: flags['show-all'],
       development,
       themes,

--- a/packages/theme/src/cli/services/delete.test.ts
+++ b/packages/theme/src/cli/services/delete.test.ts
@@ -1,6 +1,6 @@
-import {deleteThemes, renderDeprecatedArgsWarning} from './delete.js'
+import {themesDelete, renderDeprecatedArgsWarning} from './delete.js'
 import {findOrSelectTheme, findThemes} from '../utilities/theme-selector.js'
-import {deleteTheme} from '@shopify/cli-kit/node/themes/api'
+import {themeDelete} from '@shopify/cli-kit/node/themes/api'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 import {test, describe, expect, vi} from 'vitest'
 import {renderConfirmationPrompt, renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
@@ -36,7 +36,7 @@ const options = {
   themes: [],
 }
 
-describe('deleteThemes', () => {
+describe('themesDelete', () => {
   test('deletes the development theme', async () => {
     // Given
     const confirmed = true
@@ -45,10 +45,10 @@ describe('deleteThemes', () => {
     vi.mocked(findThemes).mockResolvedValue([theme1])
 
     // When
-    await deleteThemes(session, {...options, development: true})
+    await themesDelete(session, {...options, development: true})
 
     // Then
-    expect(deleteTheme).toBeCalledWith(theme1.id, session)
+    expect(themeDelete).toBeCalledWith(theme1.id, session)
     expect(renderSuccess).toBeCalledWith({
       body: ['The theme', "'my theme'", {subdued: '(#1)'}, 'was deleted from my-shop.myshopify.com.'],
     })
@@ -62,10 +62,10 @@ describe('deleteThemes', () => {
     vi.mocked(findOrSelectTheme).mockResolvedValue(theme1)
 
     // When
-    await deleteThemes(session, options)
+    await themesDelete(session, options)
 
     // Then
-    expect(deleteTheme).toBeCalledWith(theme1.id, session)
+    expect(themeDelete).toBeCalledWith(theme1.id, session)
     expect(renderSuccess).toBeCalledWith({
       body: ['The theme', "'my theme'", {subdued: '(#1)'}, 'was deleted from my-shop.myshopify.com.'],
     })
@@ -79,11 +79,11 @@ describe('deleteThemes', () => {
     vi.mocked(findThemes).mockResolvedValue([theme1, theme2])
 
     // When
-    await deleteThemes(session, {...options, themes: ['my theme', '2']})
+    await themesDelete(session, {...options, themes: ['my theme', '2']})
 
     // Then
-    expect(deleteTheme).toBeCalledWith(theme1.id, session)
-    expect(deleteTheme).toBeCalledWith(theme2.id, session)
+    expect(themeDelete).toBeCalledWith(theme1.id, session)
+    expect(themeDelete).toBeCalledWith(theme2.id, session)
     expect(renderSuccess).toBeCalledWith({
       body: [
         'The following themes were deleted from my-shop.myshopify.com:',
@@ -107,11 +107,11 @@ describe('deleteThemes', () => {
     vi.mocked(findThemes).mockResolvedValue([theme1, theme2])
 
     // When
-    await deleteThemes(session, {...options, force: true, themes: ['my theme', '2']})
+    await themesDelete(session, {...options, force: true, themes: ['my theme', '2']})
 
     // Then
-    expect(deleteTheme).toBeCalledWith(theme1.id, session)
-    expect(deleteTheme).toBeCalledWith(theme2.id, session)
+    expect(themeDelete).toBeCalledWith(theme1.id, session)
+    expect(themeDelete).toBeCalledWith(theme2.id, session)
     expect(renderSuccess).toBeCalledWith({
       body: [
         'The following themes were deleted from my-shop.myshopify.com:',
@@ -135,10 +135,10 @@ describe('deleteThemes', () => {
     vi.mocked(findThemes).mockResolvedValue([theme1, theme2])
 
     // When
-    await deleteThemes(session, {...options, themes: ['my theme', '2']})
+    await themesDelete(session, {...options, themes: ['my theme', '2']})
 
     // Then
-    expect(deleteTheme).not.toBeCalled()
+    expect(themeDelete).not.toBeCalled()
     expect(renderSuccess).not.toBeCalled()
   })
 })

--- a/packages/theme/src/cli/services/delete.ts
+++ b/packages/theme/src/cli/services/delete.ts
@@ -2,7 +2,7 @@ import {removeDevelopmentTheme} from './local-storage.js'
 import {findOrSelectTheme, findThemes} from '../utilities/theme-selector.js'
 import {themeComponent, themesComponent} from '../utilities/theme-ui.js'
 import {DevelopmentThemeManager} from '../utilities/development-theme-manager.js'
-import {deleteTheme} from '@shopify/cli-kit/node/themes/api'
+import {themeDelete} from '@shopify/cli-kit/node/themes/api'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {
   renderConfirmationPrompt,
@@ -23,7 +23,7 @@ interface DeleteOptions {
   themes: string[]
 }
 
-export async function deleteThemes(adminSession: AdminSession, options: DeleteOptions) {
+export async function themesDelete(adminSession: AdminSession, options: DeleteOptions) {
   let themeIds = options.themes
   if (options.development) {
     const theme = await new DevelopmentThemeManager(adminSession).find()
@@ -42,7 +42,7 @@ export async function deleteThemes(adminSession: AdminSession, options: DeleteOp
       if (isDevelopmentTheme(theme)) {
         removeDevelopmentTheme()
       }
-      return deleteTheme(theme.id, adminSession)
+      return themeDelete(theme.id, adminSession)
     }),
   )
 

--- a/packages/theme/src/cli/services/publish.test.ts
+++ b/packages/theme/src/cli/services/publish.test.ts
@@ -3,7 +3,7 @@ import {findOrSelectTheme} from '../utilities/theme-selector.js'
 import {renderSuccess, renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
 import {test, describe, expect, vi} from 'vitest'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
-import {publishTheme} from '@shopify/cli-kit/node/themes/api'
+import {themePublish} from '@shopify/cli-kit/node/themes/api'
 
 vi.mock('@shopify/cli-kit/node/system')
 vi.mock('@shopify/cli-kit/node/ui')
@@ -29,7 +29,7 @@ describe('publish', () => {
   test('prompts for confirmation, publishes the theme and renders the theme link', async () => {
     // Given
     vi.mocked(findOrSelectTheme).mockResolvedValue(theme)
-    vi.mocked(publishTheme).mockResolvedValue(theme)
+    vi.mocked(themePublish).mockResolvedValue(theme)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
     // When
@@ -62,7 +62,7 @@ describe('publish', () => {
   test('prompts for confirmation, does not publish when cancelled', async () => {
     // Given
     vi.mocked(findOrSelectTheme).mockResolvedValue(theme)
-    vi.mocked(publishTheme).mockResolvedValue(theme)
+    vi.mocked(themePublish).mockResolvedValue(theme)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
 
     // When
@@ -80,7 +80,7 @@ describe('publish', () => {
   test('when using --force, does not prompt for confirmation and publishes', async () => {
     // Given
     vi.mocked(findOrSelectTheme).mockResolvedValue(theme)
-    vi.mocked(publishTheme).mockResolvedValue(theme)
+    vi.mocked(themePublish).mockResolvedValue(theme)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
 
     // When

--- a/packages/theme/src/cli/services/publish.ts
+++ b/packages/theme/src/cli/services/publish.ts
@@ -1,6 +1,6 @@
 import {findOrSelectTheme} from '../utilities/theme-selector.js'
 import {themeComponent} from '../utilities/theme-ui.js'
-import {publishTheme} from '@shopify/cli-kit/node/themes/api'
+import {themePublish} from '@shopify/cli-kit/node/themes/api'
 import {themePreviewUrl} from '@shopify/cli-kit/node/themes/urls'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 import {renderConfirmationPrompt, renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
@@ -39,7 +39,7 @@ export async function publish(adminSession: AdminSession, themeId: string | unde
     if (!accept) return
   }
 
-  await publishTheme(theme.id, adminSession)
+  await themePublish(theme.id, adminSession)
 
   renderSuccess({
     body: [

--- a/packages/theme/src/cli/services/push.test.ts
+++ b/packages/theme/src/cli/services/push.test.ts
@@ -6,7 +6,7 @@ import {ensureThemeStore} from '../utilities/theme-store.js'
 import {findOrSelectTheme} from '../utilities/theme-selector.js'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {test, describe, vi, expect, beforeEach} from 'vitest'
-import {createTheme, fetchTheme, publishTheme} from '@shopify/cli-kit/node/themes/api'
+import {createTheme, fetchTheme, themePublish} from '@shopify/cli-kit/node/themes/api'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {
   DEVELOPMENT_THEME_ROLE,
@@ -48,7 +48,7 @@ describe('push', () => {
     vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(adminSession)
   })
 
-  test('should call publishTheme if publish flag is provided', async () => {
+  test('should call themePublish if publish flag is provided', async () => {
     // Given
     const theme = buildTheme({id: 1, name: 'Theme', role: 'development'})!
     vi.mocked(findOrSelectTheme).mockResolvedValue(theme)
@@ -57,7 +57,7 @@ describe('push', () => {
     await push({...defaultFlags, publish: true})
 
     // Then
-    expect(publishTheme).toHaveBeenCalledWith(theme.id, adminSession)
+    expect(themePublish).toHaveBeenCalledWith(theme.id, adminSession)
   })
 })
 

--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -8,7 +8,7 @@ import {findOrSelectTheme} from '../utilities/theme-selector.js'
 import {Role} from '../utilities/theme-selector/fetch.js'
 import {configureCLIEnvironment} from '../utilities/cli-config.js'
 import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
-import {createTheme, fetchChecksums, publishTheme} from '@shopify/cli-kit/node/themes/api'
+import {createTheme, fetchChecksums, themePublish} from '@shopify/cli-kit/node/themes/api'
 import {Result, Theme} from '@shopify/cli-kit/node/themes/types'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 import {
@@ -157,7 +157,7 @@ async function executePush(theme: Theme, session: AdminSession, options: PushOpt
   await renderThemeSyncProgress()
 
   if (options.publish) {
-    await publishTheme(theme.id, session)
+    await themePublish(theme.id, session)
   }
 
   await handlePushOutput(uploadResults, theme, session, options)

--- a/packages/theme/src/cli/services/rename.test.ts
+++ b/packages/theme/src/cli/services/rename.test.ts
@@ -3,7 +3,7 @@ import {findOrSelectTheme} from '../utilities/theme-selector.js'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 import {test, describe, expect, vi} from 'vitest'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
-import {updateTheme} from '@shopify/cli-kit/node/themes/api'
+import {themeUpdate} from '@shopify/cli-kit/node/themes/api'
 
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('@shopify/cli-kit/node/themes/api')
@@ -28,7 +28,7 @@ const options: RenameOptions = {
 }
 
 describe('renameTheme', () => {
-  test('calls updateTheme with the development flag', async () => {
+  test('calls themeUpdate with the development flag', async () => {
     // Given
     vi.mocked(findOrSelectTheme).mockResolvedValue(developmentTheme)
 
@@ -36,13 +36,13 @@ describe('renameTheme', () => {
     await renameTheme(adminSession, {...options, development: true})
 
     // Then
-    expect(updateTheme).toBeCalledWith(developmentTheme.id, {name: options.newName}, adminSession)
+    expect(themeUpdate).toBeCalledWith(developmentTheme.id, {name: options.newName}, adminSession)
     expect(renderSuccess).toBeCalledWith({
       body: ['The theme', "'my development theme'", {subdued: '(#1)'}, 'was renamed to', "'Renamed Theme'"],
     })
   })
 
-  test('calls updateTheme with a theme ID', async () => {
+  test('calls themeUpdate with a theme ID', async () => {
     // Given
     const theme1 = {
       id: 2,
@@ -55,13 +55,13 @@ describe('renameTheme', () => {
     await renameTheme(adminSession, {...options, theme: '2'})
 
     // Then
-    expect(updateTheme).toBeCalledWith(theme1.id, {name: options.newName}, adminSession)
+    expect(themeUpdate).toBeCalledWith(theme1.id, {name: options.newName}, adminSession)
     expect(renderSuccess).toBeCalledWith({
       body: ['The theme', "'my theme'", {subdued: '(#2)'}, 'was renamed to', "'Renamed Theme'"],
     })
   })
 
-  test('calls updateTheme with the live flag', async () => {
+  test('calls themeUpdate with the live flag', async () => {
     // Given
     const theme1 = {
       id: 2,
@@ -74,7 +74,7 @@ describe('renameTheme', () => {
     await renameTheme(adminSession, {...options, live: true})
 
     // Then
-    expect(updateTheme).toBeCalledWith(theme1.id, {name: options.newName}, adminSession)
+    expect(themeUpdate).toBeCalledWith(theme1.id, {name: options.newName}, adminSession)
     expect(renderSuccess).toBeCalledWith({
       body: ['The theme', "'live theme'", {subdued: '(#2)'}, 'was renamed to', "'Renamed Theme'"],
     })

--- a/packages/theme/src/cli/services/rename.ts
+++ b/packages/theme/src/cli/services/rename.ts
@@ -1,6 +1,6 @@
 import {findOrSelectTheme} from '../utilities/theme-selector.js'
 import {themeComponent} from '../utilities/theme-ui.js'
-import {updateTheme} from '@shopify/cli-kit/node/themes/api'
+import {themeUpdate} from '@shopify/cli-kit/node/themes/api'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 
@@ -20,7 +20,7 @@ export async function renameTheme(adminSession: AdminSession, options: RenameOpt
       live: options.live,
     },
   })
-  await updateTheme(theme.id, {name: options.newName}, adminSession)
+  await themeUpdate(theme.id, {name: options.newName}, adminSession)
   renderSuccess({
     body: ['The theme', ...themeComponent(theme), 'was renamed to', `'${options.newName}'`],
   })


### PR DESCRIPTION
### WHY are these changes introduced?

Following the introduction of theme admin GraphQL endpoints, port the CLI to use GraphQL.

Extending what @catlee started here https://github.com/Shopify/cli/pull/4541

### WHAT is this pull request doing?

Migrate `themeDelete`, `themeUpdate`, and` themePublish` to use the admin graphql for both regular sessions and theme access sessions. Renamed uses of `delete/update/publishTheme` to `themeDelete/Update/Publish` for consistency.

Change themeDelete to return boolean (true on success, false on failure) instead of a theme.

To ship after Chris' code gen PR (shipped).

### How to test your changes?

`shopify theme delete`
<img width="1042" alt="Screenshot 2024-10-16 at 15 51 19" src="https://github.com/user-attachments/assets/4a9b3cdb-0690-4b6d-8d03-fa91d12f87cb">

`shopify theme publish`
<img width="1067" alt="Screenshot 2024-10-16 at 15 50 52" src="https://github.com/user-attachments/assets/7dc14ea6-da83-4e10-842b-553f176c1f6f">

 `shopify theme rename`
<img width="1043" alt="Screenshot 2024-10-16 at 15 50 32" src="https://github.com/user-attachments/assets/49add904-6b16-4301-b99e-9ba1938c7f22">



### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
