### PR TITLE
[Theme] Fix local asset serve for backward compatibility

### DIFF
--- a/.changeset/wicked-cycles-bake.md
+++ b/.changeset/wicked-cycles-bake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix serving local assets from the root path for backward compatibility.

--- a/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
@@ -80,7 +80,7 @@ function findLocalFile(event: H3Event<EventHandlerRequest>, ctx: DevServerContex
 
   // Try to match theme asset files first and fallback to theme extension asset files
   return (
-    tryGetFile(/^\/cdn\/.*?\/assets\/([^?]+)/, ctx.localThemeFileSystem) ??
+    tryGetFile(/^(?:\/cdn\/.*?)?\/assets\/([^?]+)/, ctx.localThemeFileSystem) ??
     tryGetFile(/^\/ext\/cdn\/extensions\/.*?\/assets\/([^?]+)/, ctx.localThemeExtensionFileSystem) ?? {
       isUnsynced: false,
       fileKey: undefined,

--- a/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
@@ -81,7 +81,7 @@ function findLocalFile(event: H3Event<EventHandlerRequest>, ctx: DevServerContex
   // Try to match theme asset files first and fallback to theme extension asset files
   return (
     tryGetFile(/^(?:\/cdn\/.*?)?\/assets\/([^?]+)/, ctx.localThemeFileSystem) ??
-    tryGetFile(/^\/ext\/cdn\/extensions\/.*?\/assets\/([^?]+)/, ctx.localThemeExtensionFileSystem) ?? {
+    tryGetFile(/^(?:\/ext\/cdn\/extensions\/.*?)?\/assets\/([^?]+)/, ctx.localThemeExtensionFileSystem) ?? {
       isUnsynced: false,
       fileKey: undefined,
       file: undefined,

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -222,6 +222,18 @@ describe('setupDevServer', () => {
       )
     })
 
+    test('serves local assets from the root in a backward compatible way', async () => {
+      // Also serves assets from the root, similar to what the old server did:
+      const eventPromise = dispatchEvent('/assets/file2.css')
+      await expect(eventPromise).resolves.not.toThrow()
+
+      expect(vi.mocked(render)).not.toHaveBeenCalled()
+
+      const {res, body} = await eventPromise
+      expect(res.getHeader('content-type')).toEqual('text/css')
+      expect(body.toString()).toMatchInlineSnapshot(`".another-class {}"`)
+    })
+
     test('gets the right content for assets with non-breaking spaces', async () => {
       const eventPromise = dispatchEvent('/cdn/somepathhere/assets/file-with-nbsp.js')
       await expect(eventPromise).resolves.not.toThrow()


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4607 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Makes the `/cdn/...` pathname prefix optional so that it serves local files from `localhost:1234/assets/...` directly. This is not used by the CLI itself but some users relied on this for custom integrations. I guess we can keep supporting it for backward compatibility? @karreiro @mgmanzella 

**Note:** this only work for local assets. We are not forwarding this type of request to the CDN for files that are only present in the remote version or that need to be rendered remotely (e.g. `assets/file.css.liquid`). Should we do that?

### How to test your changes?

Check that your local theme files can be accesses in the browser from `localhost:1234/assets/...`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
