### PR TITLE
Change CLI auth pages

### DIFF
--- a/packages/cli-kit/assets/auth-error.html
+++ b/packages/cli-kit/assets/auth-error.html
@@ -4,20 +4,18 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Shopify CLI</title>
+    <title>Shopify CLI - Authentication Error</title>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.svg" sizes="any" type="image/svg+xml">
 </head>
-
-<body class="body-error">
-    <div class="app-error">
-        <div class="container">
+<body>
+    <main>
+        <div class="card">
             <h1>Something went wrong!</h1>
             <p>There was an issue while trying to authenticate.</p>
-            <br />
-            <br />
             <p>Return to your terminal and try running the previous command again.</p>
         </div>
-    </div>
+    </main>
+    <div class="background-elements"></div>
 </body>
 </html>

--- a/packages/cli-kit/assets/empty-url.html
+++ b/packages/cli-kit/assets/empty-url.html
@@ -4,20 +4,18 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Shopify CLI</title>
+    <title>Shopify CLI - Empty URL</title>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.svg" sizes="any" type="image/svg+xml">
 </head>
-
-<body class="body-error">
-    <div class="app-error">
-        <div class="container">
+<body>
+    <main>
+        <div class="card">
             <h1>Something went wrong!</h1>
             <p>We received the authentication redirect but the URL is empty.</p>
-            <br />
-            <br />
             <p>Return to your terminal and try running the previous command again.</p>
         </div>
-    </div>
+    </main>
+    <div class="background-elements"></div>
 </body>
 </html>

--- a/packages/cli-kit/assets/missing-code.html
+++ b/packages/cli-kit/assets/missing-code.html
@@ -4,20 +4,18 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Shopify CLI</title>
+    <title>Shopify CLI - Missing Code</title>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.svg" sizes="any" type="image/svg+xml">
 </head>
-
-<body class="body-error">
-    <div class="app-error">
-        <div class="container">
+<body>
+    <main>
+        <div class="card">
             <h1>Something went wrong!</h1>
             <p>The authentication can't continue because the redirect doesn't include the code.</p>
-            <br />
-            <br />
             <p>Return to your terminal and try running the previous command again.</p>
         </div>
-    </div>
+    </main>
+    <div class="background-elements"></div>
 </body>
 </html>

--- a/packages/cli-kit/assets/missing-state.html
+++ b/packages/cli-kit/assets/missing-state.html
@@ -4,20 +4,18 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Shopify CLI</title>
+    <title>Shopify CLI - Missing State</title>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.svg" sizes="any" type="image/svg+xml">
 </head>
-
-<body class="body-error">
-    <div class="app-error">
-        <div class="container">
+<body>
+    <main>
+        <div class="card">
             <h1>Something went wrong!</h1>
             <p>The authentication can't continue because the redirect doesn't include the state.</p>
-            <br />
-            <br />
             <p>Return to your terminal and try running the previous command again.</p>
         </div>
-    </div>
+    </main>
+    <div class="background-elements"></div>
 </body>
 </html>

--- a/packages/cli-kit/assets/style.css
+++ b/packages/cli-kit/assets/style.css
@@ -1,58 +1,90 @@
+:root {
+
+    --shopify-navy: #00234b;
+    --shopify-light: #f3f3f3;
+}
+
 html {
     font-family: -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, sans-serif;
-    text-size-adjust: 100%;
-    text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+    font-size: 16px;
+    line-height: 1.5;
+    color: var(--shopify-navy);
+    background-color: var(--shopify-light);
+    height: 100%;
 }
 
 body {
-    font-size: 26px;
-    line-height: normal;
     margin: 0;
     padding: 0;
-}
-
-button, input, optgroup, select, textarea {
-    font-family: inherit;
-}
-
-h1 {
-    font-weight: 600;
-    font-size: 1em;
-}
-
-p {
-    font-weight: 400;
-}
-
-.body-success {
-    color: #F6F6F7;
-}
-
-.body-error {
-    color: #202223;
-}
-
-.app-success {
-    width: 100vw;
-    height: 100vh;
-    background-color: #054A49;
-    display: flex;
-}
-
-.app-error {
-    width: 100vw;
-    height: 100vh;
-    background-color: #F6F6F7;
-    display: flex;
-}
-
-.container {
+    min-height: 100%;
     display: flex;
     flex-direction: column;
     justify-content: center;
+    align-items: center;
+    position: relative;
+    overflow-x: hidden;
+}
+
+main {
+    z-index: 1;
+    padding: 2rem;
+    max-width: 600px;
     width: 100%;
-    height: 100%;
-    padding-left: 7.5em;
+    box-sizing: border-box;
+}
+
+.card {
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    padding: 2rem;
+    text-align: center;
+}
+
+h1 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    color: var(--shopify-navy);
+}
+
+p {
+    font-size: 1rem;
+    color: #637381;
+}
+
+.background-elements {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 0;
+    overflow: hidden;
+}
+
+.background-elements::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    opacity: 0.1;
+    width: 200px;
+    height: 200px;
+    background-color: var(--shopify-light-green);
+    bottom: -50px;
+    right: -50px;
+}
+
+@media (max-width: 600px) {
+    html {
+        font-size: 14px;
+    }
+
+    main {
+        padding: 1rem;
+    }
+
+    .card {
+        padding: 1.5rem;
+    }
 }

--- a/packages/cli-kit/assets/success.html
+++ b/packages/cli-kit/assets/success.html
@@ -8,13 +8,13 @@
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.svg" sizes="any" type="image/svg+xml">
 </head>
-
-<body class="body-success">
-    <div class="app-success">
-        <div class="container">
-            <h1>You've successfully logged into the Shopify CLI!</h1>
+<body>
+    <main>
+        <div class="card">
+            <h1>You've successfully logged into the <br/>Shopify CLI!</h1>
             <p>You can close this tab and return to your terminal.</p>
         </div>
-    </div>
+    </main>
+    <div class="background-elements"></div>
 </body>
 </html>


### PR DESCRIPTION
### WHY are these changes introduced?

The current CLI auth pages are a green full screen with simple test. This doesn't match any of the colours we currently use so I wanted to just make it a card.

### WHAT is this pull request doing?
| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/4bc5a96a-b4ec-4149-98e5-074e4c0aea43) |  ![image](https://github.com/user-attachments/assets/0023e90c-64c3-4f18-84ea-0cd7eade0502) |


### How to test your changes?

Open the files up on your local machine, they are static

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
