### PR TITLE
Config state after linking should include the real app directory

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -106,8 +106,8 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
   const state: AppConfigurationStateLinked = {
     state: 'connected-app',
     basicConfiguration: mergedAppConfiguration,
-    appDirectory: options.directory,
-    configurationPath: joinPath(options.directory, configFileName),
+    appDirectory,
+    configurationPath: joinPath(appDirectory, configFileName),
     configSource: options.configName ? 'flag' : 'cached',
     configurationFileName: configFileName,
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
A bug was introduced the other day when, to support app-context, we made `link` return a config state.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Config state returned from link now returns the actual directory of the app, and not the one passed by the user (which might or might not be the app directory!)

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
- Have an app with an empty toml (just `scopes = ""`)
- Add a function
- Make sure that the toml is still empty, if it's not, force it.
- run 
```
pnpm shopify app function schema --stdout --path <path_to_function> --client-id <a_client_id>
```
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
