### PR TITLE
Fix syntax for theme command documentation

### DIFF
--- a/.changeset/thick-poets-brake.md
+++ b/.changeset/thick-poets-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Fix syntax for theme command documentation

--- a/docs-shopify.dev/commands/examples/theme-console.example.sh
+++ b/docs-shopify.dev/commands/examples/theme-console.example.sh
@@ -1,3 +1,3 @@
-theme:console
+theme console
 
-theme:console --url /products/classic-leather-jacket
+theme console --url /products/classic-leather-jacket

--- a/docs-shopify.dev/commands/examples/theme-init.example.sh
+++ b/docs-shopify.dev/commands/examples/theme-init.example.sh
@@ -1,1 +1,1 @@
-theme:init [name]
+theme init [name]

--- a/docs-shopify.dev/commands/examples/theme-push.example.sh
+++ b/docs-shopify.dev/commands/examples/theme-push.example.sh
@@ -1,3 +1,3 @@
-theme:push
+theme push
 
-theme:push --unpublished --json
+theme push --unpublished --json

--- a/docs-shopify.dev/generated/generated_docs_data.json
+++ b/docs-shopify.dev/generated/generated_docs_data.json
@@ -4564,7 +4564,7 @@
         "tabs": [
           {
             "title": "theme console",
-            "code": "theme:console\n\ntheme:console --url /products/classic-leather-jacket",
+            "code": "theme console\n\ntheme console --url /products/classic-leather-jacket",
             "language": "bash"
           }
         ],
@@ -5085,7 +5085,7 @@
         "tabs": [
           {
             "title": "theme init",
-            "code": "theme:init [name]",
+            "code": "theme init [name]",
             "language": "bash"
           }
         ],
@@ -5774,7 +5774,7 @@
         "tabs": [
           {
             "title": "theme push",
-            "code": "theme:push\n\ntheme:push --unpublished --json",
+            "code": "theme push\n\ntheme push --unpublished --json",
             "language": "bash"
           }
         ],

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -63,18 +63,18 @@
 * [`shopify plugins update`](#shopify-plugins-update)
 * [`shopify search [QUERY]`](#shopify-search-query)
 * [`shopify theme check`](#shopify-theme-check)
-* [`shopify theme:console`](#shopify-themeconsole)
+* [`shopify theme console`](#shopify-theme-console)
 * [`shopify theme delete`](#shopify-theme-delete)
 * [`shopify theme dev`](#shopify-theme-dev)
 * [`shopify theme info`](#shopify-theme-info)
-* [`shopify theme:init [name]`](#shopify-themeinit-name)
+* [`shopify theme init [name]`](#shopify-theme-init-name)
 * [`shopify theme language-server`](#shopify-theme-language-server)
 * [`shopify theme list`](#shopify-theme-list)
 * [`shopify theme open`](#shopify-theme-open)
 * [`shopify theme package`](#shopify-theme-package)
 * [`shopify theme publish`](#shopify-theme-publish)
 * [`shopify theme pull`](#shopify-theme-pull)
-* [`shopify theme:push`](#shopify-themepush)
+* [`shopify theme push`](#shopify-theme-push)
 * [`shopify theme rename`](#shopify-theme-rename)
 * [`shopify theme share`](#shopify-theme-share)
 * [`shopify upgrade`](#shopify-upgrade)
@@ -1702,7 +1702,7 @@ DESCRIPTION
   (https://shopify.dev/docs/themes/tools/theme-check/checks)
 ```
 
-## `shopify theme:console`
+## `shopify theme console`
 
 Shopify Liquid REPL (read-eval-print loop) tool
 
@@ -1892,7 +1892,7 @@ DESCRIPTION
   specific theme.
 ```
 
-## `shopify theme:init [name]`
+## `shopify theme init [name]`
 
 Clones a Git repository to use as a starting point for building a new theme.
 
@@ -2095,7 +2095,7 @@ DESCRIPTION
   If no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.
 ```
 
-## `shopify theme:push`
+## `shopify theme push`
 
 Uploads your local theme files to the connected store, overwriting the remote version if specified.
 

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4816,8 +4816,8 @@
       "strict": true,
       "summary": "Shopify Liquid REPL (read-eval-print loop) tool",
       "usage": [
-        "theme:console",
-        "theme:console --url /products/classic-leather-jacket"
+        "theme console",
+        "theme console --url /products/classic-leather-jacket"
       ]
     },
     "theme:delete": {
@@ -5271,7 +5271,7 @@
       "pluginType": "core",
       "strict": true,
       "summary": "Clones a Git repository to use as a starting point for building a new theme.",
-      "usage": "theme:init [name]"
+      "usage": "theme init [name]"
     },
     "theme:language-server": {
       "aliases": [
@@ -5918,8 +5918,8 @@
       "strict": true,
       "summary": "Uploads your local theme files to the connected store, overwriting the remote version if specified.",
       "usage": [
-        "theme:push",
-        "theme:push --unpublished --json"
+        "theme push",
+        "theme push --unpublished --json"
       ]
     },
     "theme:rename": {

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -9,7 +9,7 @@ import {Flags} from '@oclif/core'
 export default class Console extends ThemeCommand {
   static summary = 'Shopify Liquid REPL (read-eval-print loop) tool'
 
-  static usage = ['theme:console', 'theme:console --url /products/classic-leather-jacket']
+  static usage = ['theme console', 'theme console --url /products/classic-leather-jacket']
 
   static descriptionWithMarkdown = `Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.
 

--- a/packages/theme/src/cli/commands/theme/init.ts
+++ b/packages/theme/src/cli/commands/theme/init.ts
@@ -10,7 +10,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 export default class Init extends ThemeCommand {
   static summary = 'Clones a Git repository to use as a starting point for building a new theme.'
 
-  static usage = 'theme:init [name]'
+  static usage = 'theme init [name]'
 
   static descriptionWithMarkdown = `Clones a Git repository to your local machine to use as the starting point for building a theme.
 

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -7,7 +7,7 @@ import {globalFlags} from '@shopify/cli-kit/node/cli'
 export default class Push extends ThemeCommand {
   static summary = 'Uploads your local theme files to the connected store, overwriting the remote version if specified.'
 
-  static usage = ['theme:push', 'theme:push --unpublished --json']
+  static usage = ['theme push', 'theme push --unpublished --json']
 
   static descriptionWithMarkdown = `Uploads your local theme files to Shopify, overwriting the remote version if specified.
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-advanced-edits/issues/369

There are some leftover theme commands that show a different pattern on how to call them in our dev docs. They show up as `theme: command` where the majority of examples refer to the commands as `theme command`

### WHAT is this pull request doing?
Updated examples for `console`, `push` and `init` to use a space instead of `:`

### How to test your changes?
You can see the updated auto-generated documents showing the changes, (`README.md`, `oclif.manifest.json`, and example scripts (`.sh`))
You can double check by pulling down the branch, and running `npm run refresh:manifests`. There should be no other changes to the generated docs.

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
