### PR TITLE
Remove the warning message from the ignore-module because some files can only be ignored using backward-compatible patterns

### DIFF
--- a/.changeset/hungry-grapes-mate.md
+++ b/.changeset/hungry-grapes-mate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Remove the warning message from the ignore-module because some files can only be ignored using backward-compatible patterns

--- a/packages/theme/src/cli/utilities/asset-ignore.test.ts
+++ b/packages/theme/src/cli/utilities/asset-ignore.test.ts
@@ -1,6 +1,5 @@
 import {applyIgnoreFilters, getPatternsFromShopifyIgnore} from './asset-ignore.js'
 import {ReadOptions, fileExists, readFile} from '@shopify/cli-kit/node/fs'
-import {outputWarn} from '@shopify/cli-kit/node/output'
 import {test, describe, beforeEach, vi, expect} from 'vitest'
 
 vi.mock('@shopify/cli-kit/node/fs', async () => {
@@ -74,7 +73,7 @@ describe('asset-ignore', () => {
   describe('applyIgnoreFilters', () => {
     test(`returns entire list of checksums when there's no filter to apply`, async () => {
       // Given/When
-      const actualChecksums = await applyIgnoreFilters(checksums, {})
+      const actualChecksums = applyIgnoreFilters(checksums, {})
 
       // Then
       expect(actualChecksums).toEqual(checksums)
@@ -94,7 +93,7 @@ describe('asset-ignore', () => {
       }
 
       // When
-      const actualChecksums = await applyIgnoreFilters(checksums, options)
+      const actualChecksums = applyIgnoreFilters(checksums, options)
 
       // Then
       expect(actualChecksums).toEqual([{key: 'assets/basic.css', checksum: '00000000000000000000000000000000'}])
@@ -105,7 +104,7 @@ describe('asset-ignore', () => {
       const options = {ignore: ['config/*', 'templates/*', 'assets/image.png']}
 
       // When
-      const actualChecksums = await applyIgnoreFilters(checksums, options)
+      const actualChecksums = applyIgnoreFilters(checksums, options)
 
       // Then
       expect(actualChecksums).toEqual([
@@ -120,7 +119,7 @@ describe('asset-ignore', () => {
       const options = {only: ['config/*', 'assets/image.png']}
 
       // When
-      const actualChecksums = await applyIgnoreFilters(checksums, options)
+      const actualChecksums = applyIgnoreFilters(checksums, options)
 
       // Then
       expect(actualChecksums).toEqual([
@@ -135,7 +134,7 @@ describe('asset-ignore', () => {
       const options = {ignore: ['*.css']}
 
       // When
-      const actualChecksums = await applyIgnoreFilters(checksums, options)
+      const actualChecksums = applyIgnoreFilters(checksums, options)
 
       // Then
       expect(actualChecksums).toEqual([
@@ -153,7 +152,7 @@ describe('asset-ignore', () => {
       const options = {only: ['templates/*.json']}
 
       // When
-      const actualChecksums = await applyIgnoreFilters(checksums, options)
+      const actualChecksums = applyIgnoreFilters(checksums, options)
 
       // Then
       expect(actualChecksums).toEqual([
@@ -167,43 +166,12 @@ describe('asset-ignore', () => {
       const options = {only: ['templates/**/*.json']}
 
       // When
-      const actualChecksums = await applyIgnoreFilters(checksums, options)
+      const actualChecksums = applyIgnoreFilters(checksums, options)
 
       // Then
       expect(actualChecksums).toEqual([
         {key: 'templates/customers/account.json', checksum: '7777777777777777777777777777777'},
       ])
-    })
-
-    test(`only outputs glob pattern subdirectory warnings for the templates folder`, async () => {
-      // Given
-      const options = {only: ['assets/*.json', 'config/*.json', 'sections/*.json']}
-      // When
-      await applyIgnoreFilters(checksums, options)
-      // Then
-      expect(vi.mocked(outputWarn)).not.toHaveBeenCalled()
-    })
-
-    test(`outputs warnings when there are glob pattern modifications required for subdirectories`, async () => {
-      // Given
-      const options = {only: ['templates/*.json']}
-
-      // When
-      await applyIgnoreFilters(checksums, options)
-
-      // Then
-      expect(vi.mocked(outputWarn)).toHaveBeenCalledTimes(1)
-    })
-
-    test('only outputs a single warning for duplicated glob patterns', async () => {
-      // Given
-      const options = {only: ['templates/*.json'], ignore: ['templates/*.json']}
-
-      // When
-      await applyIgnoreFilters(checksums, options)
-
-      // Then
-      expect(vi.mocked(outputWarn)).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/theme/src/cli/utilities/asset-ignore.ts
+++ b/packages/theme/src/cli/utilities/asset-ignore.ts
@@ -1,5 +1,5 @@
 import {fileExists, readFile, matchGlob as originalMatchGlob} from '@shopify/cli-kit/node/fs'
-import {outputDebug, outputWarn} from '@shopify/cli-kit/node/output'
+import {outputDebug} from '@shopify/cli-kit/node/output'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
 const SHOPIFY_IGNORE = '.shopifyignore'
@@ -12,8 +12,6 @@ export function applyIgnoreFilters<T extends {key: string}>(
   const shopifyIgnore = options.ignoreFromFile ?? []
   const ignoreOptions = options.ignore ?? []
   const onlyOptions = options.only ?? []
-
-  raiseWarningForNonExplicitGlobPatterns([...shopifyIgnore, ...ignoreOptions, ...onlyOptions])
 
   return files
     .filter(filterBy(shopifyIgnore, '.shopifyignore'))
@@ -71,20 +69,6 @@ function matchGlob(key: string, pattern: string) {
   }
 
   return false
-}
-
-export function raiseWarningForNonExplicitGlobPatterns(patterns: string[]) {
-  const allPatterns = new Set(patterns)
-  allPatterns.forEach((pattern) => {
-    if (shouldReplaceGlobPattern(pattern)) {
-      outputWarn(
-        `Warning: The pattern '${pattern}' does not include subdirectories. To maintain backwards compatibility, we have modified your pattern to ${pattern.replace(
-          templatesRegex,
-          'templates/**/*$1',
-        )} to explicitly include subdirectories.`,
-      )
-    }
-  })
 }
 
 function shouldReplaceGlobPattern(pattern: string): boolean {

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -7,11 +7,7 @@ import {
   partitionThemeFiles,
   readThemeFile,
 } from './theme-fs.js'
-import {
-  getPatternsFromShopifyIgnore,
-  applyIgnoreFilters,
-  raiseWarningForNonExplicitGlobPatterns,
-} from './asset-ignore.js'
+import {getPatternsFromShopifyIgnore, applyIgnoreFilters} from './asset-ignore.js'
 import {removeFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {test, describe, expect, vi, beforeEach} from 'vitest'
 import chokidar from 'chokidar'
@@ -279,7 +275,6 @@ describe('theme-fs', () => {
       const themeFileSystem = mountThemeFileSystem(root, options)
       await themeFileSystem.ready()
 
-      expect(raiseWarningForNonExplicitGlobPatterns).toHaveBeenCalledOnce()
       expect(getPatternsFromShopifyIgnore).toHaveBeenCalledWith(root)
       expect(themeFileSystem.applyIgnoreFilters(files)).toEqual([{key: 'assets/file.json'}])
       expect(applyIgnoreFilters).toHaveBeenCalledWith(files, {

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -1,9 +1,5 @@
 import {calculateChecksum} from './asset-checksum.js'
-import {
-  applyIgnoreFilters,
-  raiseWarningForNonExplicitGlobPatterns,
-  getPatternsFromShopifyIgnore,
-} from './asset-ignore.js'
+import {applyIgnoreFilters, getPatternsFromShopifyIgnore} from './asset-ignore.js'
 import {Notifier} from './notifier.js'
 import {createSyncingCatchError} from './errors.js'
 import {DEFAULT_IGNORE_PATTERNS, timestampDateFormat} from '../constants.js'
@@ -86,11 +82,6 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
     .then((filesPaths) => Promise.all([getPatternsFromShopifyIgnore(root), ...filesPaths.map(read)]))
     .then(([ignoredPatterns]) => {
       filterPatterns.ignoreFromFile.push(...ignoredPatterns)
-      raiseWarningForNonExplicitGlobPatterns([
-        ...filterPatterns.ignoreFromFile,
-        ...filterPatterns.ignore,
-        ...filterPatterns.only,
-      ])
     })
 
   const getKey = (filePath: string) => relativePath(root, filePath)


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/issues/4644

Remove the warning message from the ignore-module because some files can only be ignored using backward-compatible patterns otherwise users need to resort to regexes (you may double-check patterns in action and compare the recent version with the legacy one on [this gist](https://gist.github.com/karreiro/bc2ea3de24e8de577ef6bd54efb1cb21)).

### WHAT is this pull request doing?

Removes the warning message.

### How to test your changes?

- Run `shopify theme dev --legacy --ignore "templates/*.json"`
- Notice the warning no longer appears

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
