### PR TITLE
Port fetchThemeAssets / fetchChecksums to graphQL

### DIFF
--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme_file_bodies.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme_file_bodies.ts
@@ -1,0 +1,193 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type GetThemeFileBodiesQueryVariables = Types.Exact<{
+  id: Types.Scalars['ID']['input']
+  after?: Types.InputMaybe<Types.Scalars['String']['input']>
+  filenames?: Types.InputMaybe<Types.Scalars['String']['input'][] | Types.Scalars['String']['input']>
+}>
+
+export type GetThemeFileBodiesQuery = {
+  theme?: {
+    files?: {
+      nodes: {
+        filename: string
+        size: unknown
+        checksumMd5?: string | null
+        body:
+          | {__typename: 'OnlineStoreThemeFileBodyBase64'; contentBase64: string}
+          | {__typename: 'OnlineStoreThemeFileBodyText'; content: string}
+          | {__typename: 'OnlineStoreThemeFileBodyUrl'; url: string}
+      }[]
+      userErrors: {filename: string; code: Types.OnlineStoreThemeFileResultType}[]
+      pageInfo: {hasNextPage: boolean; endCursor?: string | null}
+    } | null
+  } | null
+}
+
+export const GetThemeFileBodies = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: {kind: 'Name', value: 'getThemeFileBodies'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}}},
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'after'}},
+          type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}},
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'filenames'}},
+          type: {
+            kind: 'ListType',
+            type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'theme'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'id'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'files'},
+                  arguments: [
+                    {kind: 'Argument', name: {kind: 'Name', value: 'first'}, value: {kind: 'IntValue', value: '250'}},
+                    {
+                      kind: 'Argument',
+                      name: {kind: 'Name', value: 'after'},
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'after'}},
+                    },
+                    {
+                      kind: 'Argument',
+                      name: {kind: 'Name', value: 'filenames'},
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'filenames'}},
+                    },
+                  ],
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'nodes'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'filename'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'size'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'checksumMd5'}},
+                            {
+                              kind: 'Field',
+                              name: {kind: 'Name', value: 'body'},
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                                  {
+                                    kind: 'InlineFragment',
+                                    typeCondition: {
+                                      kind: 'NamedType',
+                                      name: {kind: 'Name', value: 'OnlineStoreThemeFileBodyText'},
+                                    },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {kind: 'Field', name: {kind: 'Name', value: 'content'}},
+                                        {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    kind: 'InlineFragment',
+                                    typeCondition: {
+                                      kind: 'NamedType',
+                                      name: {kind: 'Name', value: 'OnlineStoreThemeFileBodyBase64'},
+                                    },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {kind: 'Field', name: {kind: 'Name', value: 'contentBase64'}},
+                                        {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    kind: 'InlineFragment',
+                                    typeCondition: {
+                                      kind: 'NamedType',
+                                      name: {kind: 'Name', value: 'OnlineStoreThemeFileBodyUrl'},
+                                    },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {kind: 'Field', name: {kind: 'Name', value: 'url'}},
+                                        {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'userErrors'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'filename'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'code'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'pageInfo'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'hasNextPage'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'endCursor'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetThemeFileBodiesQuery, GetThemeFileBodiesQueryVariables>

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme_file_checksums.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme_file_checksums.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type GetThemeFileChecksumsQueryVariables = Types.Exact<{
+  id: Types.Scalars['ID']['input']
+  after?: Types.InputMaybe<Types.Scalars['String']['input']>
+}>
+
+export type GetThemeFileChecksumsQuery = {
+  theme?: {
+    files?: {
+      nodes: {filename: string; size: unknown; checksumMd5?: string | null}[]
+      userErrors: {filename: string; code: Types.OnlineStoreThemeFileResultType}[]
+      pageInfo: {hasNextPage: boolean; endCursor?: string | null}
+    } | null
+  } | null
+}
+
+export const GetThemeFileChecksums = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: {kind: 'Name', value: 'getThemeFileChecksums'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}}},
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'after'}},
+          type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'theme'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'id'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'files'},
+                  arguments: [
+                    {kind: 'Argument', name: {kind: 'Name', value: 'first'}, value: {kind: 'IntValue', value: '250'}},
+                    {
+                      kind: 'Argument',
+                      name: {kind: 'Name', value: 'after'},
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'after'}},
+                    },
+                  ],
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'nodes'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'filename'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'size'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'checksumMd5'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'userErrors'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'filename'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'code'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'pageInfo'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'hasNextPage'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'endCursor'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetThemeFileChecksumsQuery, GetThemeFileChecksumsQueryVariables>

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
@@ -120,6 +120,23 @@ export type Scalars = {
   UtcOffset: {input: any; output: any}
 }
 
+/** Type of a theme file operation result. */
+export type OnlineStoreThemeFileResultType =
+  /** Operation was malformed or invalid. */
+  | 'BAD_REQUEST'
+  /** Operation faced a conflict with the current state of the file. */
+  | 'CONFLICT'
+  /** Operation encountered an error. */
+  | 'ERROR'
+  /** Operation file could not be found. */
+  | 'NOT_FOUND'
+  /** Operation was successful. */
+  | 'SUCCESS'
+  /** Operation timed out. */
+  | 'TIMEOUT'
+  /** Operation could not be processed due to issues with input data. */
+  | 'UNPROCESSABLE_ENTITY'
+
 /** The input fields for Theme attributes to update. */
 export type OnlineStoreThemeInput = {
   /** The new name of the theme. */

--- a/packages/cli-kit/src/cli/api/graphql/admin/queries/get_theme_file_bodies.graphql
+++ b/packages/cli-kit/src/cli/api/graphql/admin/queries/get_theme_file_bodies.graphql
@@ -1,0 +1,25 @@
+query getThemeFileBodies($id: ID!, $after: String, $filenames: [String!]) {
+  theme(id: $id) {
+    files(first: 250, after: $after, filenames: $filenames) {
+      nodes {
+      filename
+        size
+        checksumMd5
+        body {
+          __typename
+          ... on OnlineStoreThemeFileBodyText { content }
+          ... on OnlineStoreThemeFileBodyBase64 { contentBase64 }
+          ... on OnlineStoreThemeFileBodyUrl { url }
+        }
+      }
+      userErrors {
+        filename
+        code
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}

--- a/packages/cli-kit/src/cli/api/graphql/admin/queries/get_theme_file_checksums.graphql
+++ b/packages/cli-kit/src/cli/api/graphql/admin/queries/get_theme_file_checksums.graphql
@@ -1,0 +1,19 @@
+query getThemeFileChecksums($id: ID!, $after: String) {
+  theme(id: $id) {
+    files(first: 250, after: $after) {
+      nodes {
+        filename
+        size
+        checksumMd5
+      }
+      userErrors {
+        filename
+        code
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -4,15 +4,12 @@ import * as throttler from '../api/rest-api-throttler.js'
 import {ThemeUpdate} from '../../../cli/api/graphql/admin/generated/theme_update.js'
 import {ThemeDelete} from '../../../cli/api/graphql/admin/generated/theme_delete.js'
 import {ThemePublish} from '../../../cli/api/graphql/admin/generated/theme_publish.js'
+import {GetThemeFileBodies} from '../../../cli/api/graphql/admin/generated/get_theme_file_bodies.js'
+import {GetThemeFileChecksums} from '../../../cli/api/graphql/admin/generated/get_theme_file_checksums.js'
 import {restRequest, RestResponse, adminRequestDoc} from '@shopify/cli-kit/node/api/admin'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {
-  buildBulkUploadResults,
-  buildChecksum,
-  buildTheme,
-  buildThemeAsset,
-} from '@shopify/cli-kit/node/themes/factories'
+import {buildBulkUploadResults, buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {Result, Checksum, Key, Theme, ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {sleep} from '@shopify/cli-kit/node/system'
@@ -45,12 +42,45 @@ export async function createTheme(params: ThemeParams, session: AdminSession): P
   return buildTheme({...response.json.theme, createdAtRuntime: true})
 }
 
-export async function fetchThemeAsset(id: number, key: Key, session: AdminSession): Promise<ThemeAsset | undefined> {
-  const response = await request('GET', `/themes/${id}/assets`, session, undefined, {
-    'asset[key]': key,
-  })
+export async function fetchThemeAssets(id: number, filenames: Key[], session: AdminSession): Promise<ThemeAsset[]> {
+  const assets: ThemeAsset[] = []
+  let after: string | null = null
 
-  return buildThemeAsset(response.json.asset)
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop
+    const response = await adminRequestDoc(GetThemeFileBodies, session, {
+      id: themeGid(id),
+      filenames,
+      after,
+    })
+
+    if (!response.theme?.files?.nodes || !response.theme?.files?.pageInfo) {
+      const userErrors = response.theme?.files?.userErrors.map((error) => error.filename).join(', ')
+      throw new AbortError(`Error fetching assets: ${userErrors}`)
+    }
+
+    const {nodes, pageInfo} = response.theme.files
+
+    assets.push(
+      // eslint-disable-next-line no-await-in-loop
+      ...(await Promise.all(
+        nodes.map(async (file) => {
+          const content = await parseThemeFileContent(file.body)
+          return {
+            key: file.filename,
+            checksum: file.checksumMd5 as string,
+            value: content,
+          }
+        }),
+      )),
+    )
+
+    if (!pageInfo.hasNextPage) {
+      return assets
+    }
+
+    after = pageInfo.endCursor as string
+  }
 }
 
 export async function deleteThemeAsset(id: number, key: Key, session: AdminSession): Promise<boolean> {
@@ -73,12 +103,33 @@ export async function bulkUploadThemeAssets(
 }
 
 export async function fetchChecksums(id: number, session: AdminSession): Promise<Checksum[]> {
-  const response = await request('GET', `/themes/${id}/assets`, session, undefined, {fields: 'key,checksum'})
-  const assets = response.json.assets
+  const checksums: Checksum[] = []
+  let after: string | null = null
 
-  if (assets?.length > 0) return assets.map(buildChecksum)
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop
+    const response = await adminRequestDoc(GetThemeFileChecksums, session, {id: themeGid(id), after})
 
-  return []
+    if (!response?.theme?.files?.nodes || !response?.theme?.files?.pageInfo) {
+      const userErrors = response.theme?.files?.userErrors.map((error) => error.filename).join(', ')
+      throw new AbortError(`Failed to fetch checksums for: ${userErrors}`)
+    }
+
+    const {nodes, pageInfo} = response.theme.files
+
+    checksums.push(
+      ...nodes.map((file) => ({
+        key: file.filename,
+        checksum: file.checksumMd5 as string,
+      })),
+    )
+
+    if (!pageInfo.hasNextPage) {
+      return checksums
+    }
+
+    after = pageInfo.endCursor as string
+  }
 }
 
 export async function themeUpdate(id: number, params: ThemeParams, session: AdminSession): Promise<Theme | undefined> {
@@ -273,4 +324,32 @@ async function handleRetriableError({path, retries, retry, fail}: RetriableError
 
   await sleep(0.2)
   return retry()
+}
+
+function themeGid(id: number): string {
+  return `gid://shopify/OnlineStoreTheme/${id}`
+}
+
+type OnlineStoreThemeFileBody =
+  | {__typename: 'OnlineStoreThemeFileBodyBase64'; contentBase64: string}
+  | {__typename: 'OnlineStoreThemeFileBodyText'; content: string}
+  | {__typename: 'OnlineStoreThemeFileBodyUrl'; url: string}
+
+async function parseThemeFileContent(body: OnlineStoreThemeFileBody): Promise<string> {
+  switch (body.__typename) {
+    case 'OnlineStoreThemeFileBodyText':
+      return body.content
+      break
+    case 'OnlineStoreThemeFileBodyBase64':
+      return Buffer.from(body.contentBase64, 'base64').toString()
+      break
+    case 'OnlineStoreThemeFileBodyUrl':
+      try {
+        const response = await fetch(body.url)
+        return await response.text()
+      } catch (error) {
+        // Raise error if we can't download the file
+        throw new AbortError(`Error downloading content from URL: ${body.url}`)
+      }
+  }
 }

--- a/packages/theme/src/cli/constants.ts
+++ b/packages/theme/src/cli/constants.ts
@@ -32,3 +32,5 @@ export const DEFAULT_IGNORE_PATTERNS = [
   '**/node_modules/',
   '.prettierrc.json',
 ]
+
+export const MAX_GRAPHQL_THEME_FILES = 50

--- a/packages/theme/src/cli/utilities/batching.ts
+++ b/packages/theme/src/cli/utilities/batching.ts
@@ -1,0 +1,32 @@
+export function batchedRequests<TItem>(
+  items: TItem[],
+  batchSize: number,
+  fn: (batch: TItem[]) => Promise<unknown>,
+): Promise<unknown>[] {
+  const requests = []
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize)
+    requests.push(fn(batch))
+  }
+  return requests
+}
+
+export interface Task {
+  title: string
+  task: () => Promise<void>
+}
+
+export function batchedTasks<TItem>(
+  items: TItem[],
+  batchSize: number,
+  fn: (batch: TItem[], start: number) => Task,
+): Task[] {
+  const tasks: Task[] = []
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize)
+    tasks.push(fn(batch, i))
+  }
+
+  return tasks
+}

--- a/packages/theme/src/cli/utilities/theme-downloader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-downloader.test.ts
@@ -1,6 +1,6 @@
 import {downloadTheme} from './theme-downloader.js'
 import {fakeThemeFileSystem} from './theme-fs/theme-fs-mock-factory.js'
-import {fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
+import {fetchThemeAssets} from '@shopify/cli-kit/node/themes/api'
 import {Checksum, ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 import {test, describe, expect, vi} from 'vitest'
 
@@ -85,7 +85,7 @@ describe('theme-downloader', () => {
       ]
       const spy = vi.spyOn(fileSystem, 'write')
 
-      vi.mocked(fetchThemeAsset).mockResolvedValue(fileToDownload)
+      vi.mocked(fetchThemeAssets).mockResolvedValue([fileToDownload])
 
       // When
       await downloadTheme(remoteTheme, adminSession, remote, fileSystem, downloadOptions)

--- a/packages/theme/src/cli/utilities/theme-downloader.ts
+++ b/packages/theme/src/cli/utilities/theme-downloader.ts
@@ -1,6 +1,8 @@
+import {batchedTasks, Task} from './batching.js'
+import {MAX_GRAPHQL_THEME_FILES} from '../constants.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
-import {fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
-import {ThemeFileSystem, Theme, Checksum} from '@shopify/cli-kit/node/themes/types'
+import {fetchThemeAssets} from '@shopify/cli-kit/node/themes/api'
+import {ThemeFileSystem, Theme, Checksum, ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
 
 interface DownloadOptions {
@@ -45,44 +47,39 @@ function buildDownloadTasks(
   theme: Theme,
   themeFileSystem: ThemeFileSystem,
   session: AdminSession,
-) {
-  const checksums = themeFileSystem.applyIgnoreFilters(remoteChecksums)
+): Task[] {
+  let checksums = themeFileSystem.applyIgnoreFilters(remoteChecksums)
 
-  return checksums
-    .map((checksum) => {
-      const remoteChecksumValue = checksum.checksum
-      const localAsset = themeFileSystem.files.get(checksum.key)
+  // Filter out files we already have
+  checksums = checksums.filter((checksum) => {
+    const remoteChecksumValue = checksum.checksum
+    const localAsset = themeFileSystem.files.get(checksum.key)
 
-      if (localAsset?.checksum === remoteChecksumValue) {
-        return
-      }
+    if (localAsset?.checksum === remoteChecksumValue) {
+      return false
+    } else {
+      return true
+    }
+  })
 
-      const progress = progressPct(remoteChecksums, checksum)
-      const title = `Pulling theme "${theme.name}" (#${theme.id}) from ${session.storeFqdn} [${progress}%]`
+  const filenames = checksums.map((checksum) => checksum.key)
 
-      return {
-        title,
-        task: async () => downloadFile(theme, themeFileSystem, checksum, session),
-      }
-    })
-    .filter(notNull)
+  const batches = batchedTasks(filenames, MAX_GRAPHQL_THEME_FILES, (batchedFilenames, i) => {
+    const title = `Downloading files ${i}..${i + batchedFilenames.length} / ${filenames.length} files`
+    return {
+      title,
+      task: async () => downloadFiles(theme, themeFileSystem, batchedFilenames, session),
+    }
+  })
+  return batches
 }
 
-async function downloadFile(theme: Theme, fileSystem: ThemeFileSystem, checksum: Checksum, session: AdminSession) {
-  const themeAsset = await fetchThemeAsset(theme.id, checksum.key, session)
+async function downloadFiles(theme: Theme, fileSystem: ThemeFileSystem, filenames: string[], session: AdminSession) {
+  const assets = await fetchThemeAssets(theme.id, filenames, session)
+  if (!assets) return
 
-  if (!themeAsset) return
-
-  await fileSystem.write(themeAsset)
-}
-
-function progressPct(themeChecksums: Checksum[], checksum: Checksum): number {
-  const current = themeChecksums.indexOf(checksum) + 1
-  const total = themeChecksums.length
-
-  return Math.round((current / total) * 100)
-}
-
-function notNull<T>(value: T | null | undefined): value is T {
-  return value !== null && value !== undefined
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  assets.forEach(async (asset: ThemeAsset) => {
+    await fileSystem.write(asset)
+  })
 }

--- a/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-reconciliation.ts
@@ -1,7 +1,9 @@
 import {REMOTE_STRATEGY, LOCAL_STRATEGY} from './remote-theme-watcher.js'
+import {batchedRequests} from '../batching.js'
+import {MAX_GRAPHQL_THEME_FILES} from '../../constants.js'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
-import {fetchThemeAsset, deleteThemeAsset} from '@shopify/cli-kit/node/themes/api'
+import {deleteThemeAsset, fetchThemeAssets} from '@shopify/cli-kit/node/themes/api'
 import {Checksum, ThemeFileSystem, ThemeAsset, Theme} from '@shopify/cli-kit/node/themes/types'
 import {renderInfo, renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 
@@ -38,8 +40,10 @@ export async function reconcileJsonFiles(
 
   outputDebug('Initiating theme asset reconciliation process')
 
-  const {filesOnlyPresentLocally, filesOnlyPresentOnRemote, filesWithConflictingChecksums} =
-    await identifyFilesToReconcile(remoteChecksums, localThemeFileSystem)
+  const {filesOnlyPresentLocally, filesOnlyPresentOnRemote, filesWithConflictingChecksums} = identifyFilesToReconcile(
+    remoteChecksums,
+    localThemeFileSystem,
+  )
 
   if (
     filesOnlyPresentLocally.length === 0 &&
@@ -159,12 +163,22 @@ async function performFileReconciliation(
   const {localFilesToDelete, filesToDownload, remoteFilesToDelete} = partitionedFiles
 
   const deleteLocalFiles = localFilesToDelete.map((file) => localThemeFileSystem.delete(file.key))
-  const downloadRemoteFiles = filesToDownload.map(async (file) => {
-    const asset = await fetchThemeAsset(targetTheme.id, file.key, session)
-    if (asset) {
-      return localThemeFileSystem.write(asset)
-    }
+
+  const downloadRemoteFiles = batchedRequests(filesToDownload, MAX_GRAPHQL_THEME_FILES, async (chunk) => {
+    const assets = await fetchThemeAssets(
+      targetTheme.id,
+      chunk.map((file) => file.key),
+      session,
+    )
+    return Promise.all(
+      assets.map((asset) => {
+        if (asset) {
+          return localThemeFileSystem.write(asset)
+        }
+      }),
+    )
   })
+
   const deleteRemoteFiles = remoteFilesToDelete.map((file) => deleteThemeAsset(targetTheme.id, file.key, session))
 
   await Promise.all([...deleteLocalFiles, ...downloadRemoteFiles, ...deleteRemoteFiles])

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -11,7 +11,7 @@ import {getPatternsFromShopifyIgnore, applyIgnoreFilters} from './asset-ignore.j
 import {removeFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {test, describe, expect, vi, beforeEach} from 'vitest'
 import chokidar from 'chokidar'
-import {deleteThemeAsset, fetchThemeAsset} from '@shopify/cli-kit/node/themes/api'
+import {deleteThemeAsset, fetchThemeAssets} from '@shopify/cli-kit/node/themes/api'
 import {renderError} from '@shopify/cli-kit/node/ui'
 import EventEmitter from 'events'
 import type {Checksum, ThemeAsset} from '@shopify/cli-kit/node/themes/types'
@@ -499,13 +499,15 @@ describe('theme-fs', () => {
 
     test('deletes file from remote theme', async () => {
       // Given
-      vi.mocked(fetchThemeAsset).mockResolvedValue({
-        key: 'assets/base.css',
-        checksum: '1',
-        value: 'content',
-        attachment: '',
-        stats: {size: 100, mtime: 100},
-      })
+      vi.mocked(fetchThemeAssets).mockResolvedValue([
+        {
+          key: 'assets/base.css',
+          checksum: '1',
+          value: 'content',
+          attachment: '',
+          stats: {size: 100, mtime: 100},
+        },
+      ])
       vi.mocked(deleteThemeAsset).mockResolvedValue(true)
 
       // When
@@ -532,13 +534,15 @@ describe('theme-fs', () => {
 
     test('does not delete file from remote when options.noDelete is true', async () => {
       // Given
-      vi.mocked(fetchThemeAsset).mockResolvedValue({
-        key: 'assets/base.css',
-        checksum: '1',
-        value: 'content',
-        attachment: '',
-        stats: {size: 100, mtime: 100},
-      })
+      vi.mocked(fetchThemeAssets).mockResolvedValue([
+        {
+          key: 'assets/base.css',
+          checksum: '1',
+          value: 'content',
+          attachment: '',
+          stats: {size: 100, mtime: 100},
+        },
+      ])
       vi.mocked(deleteThemeAsset).mockResolvedValue(true)
 
       // When
@@ -565,12 +569,14 @@ describe('theme-fs', () => {
 
     test('renders a warning to debug if the file deletion fails', async () => {
       // Given
-      vi.mocked(fetchThemeAsset).mockResolvedValue({
-        key: 'assets/base.css',
-        value: 'file content',
-        checksum: '1',
-        stats: {size: 100, mtime: 100},
-      })
+      vi.mocked(fetchThemeAssets).mockResolvedValue([
+        {
+          key: 'assets/base.css',
+          value: 'file content',
+          checksum: '1',
+          stats: {size: 100, mtime: 100},
+        },
+      ])
       vi.mocked(deleteThemeAsset).mockResolvedValue(false)
 
       // When


### PR DESCRIPTION
### WHY are these changes introduced?

Migrate off the REST Assets API and use graphQL instead.

### WHAT is this pull request doing?

This PR adjusts the `fetchThemeAsset` and `fetchChecksums` method to use the [`OnlineStoreTheme.files` field](https://shopify.dev/docs/api/admin-graphql/unstable/objects/OnlineStoreTheme#connection-files).

Where appropriate I've also updated callers to fetch multiple assets at once with `fetchThemeAssets`.

### How to test your changes?

`p shopify theme pull ...` should fetch all the files from your theme to a local directory.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
