### PR TITLE
Fix --nodelete behaviour on dev command

### DIFF
--- a/.changeset/strong-guests-worry.md
+++ b/.changeset/strong-guests-worry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Fix theme dev command deleting remote files even if using --nodelete flag

--- a/packages/cli-kit/src/public/node/themes/types.ts
+++ b/packages/cli-kit/src/public/node/themes/types.ts
@@ -26,6 +26,7 @@ export type ThemeFSEventPayload<T extends ThemeFSEventName = 'add'> = (ThemeFSEv
 export interface ThemeFileSystemOptions {
   filters?: {ignore?: string[]; only?: string[]}
   notify?: string
+  noDelete?: boolean
 }
 
 /**

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -49,6 +49,7 @@ export async function dev(options: DevOptions) {
   const localThemeFileSystem = mountThemeFileSystem(options.directory, {
     filters: options,
     notify: options.notify,
+    noDelete: options.noDelete,
   })
 
   const host = options.host ?? DEFAULT_HOST

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -189,17 +189,19 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
     files.delete(fileKey)
     unsyncedFileKeys.add(fileKey)
 
-    const syncPromise = deleteThemeAsset(Number(themeId), fileKey, adminSession)
-      .then(async (success) => {
-        if (!success) throw new Error(`Failed to delete file "${fileKey}" from remote theme.`)
-        unsyncedFileKeys.delete(fileKey)
-        outputSyncResult('delete', fileKey)
-        return true
-      })
-      .catch((error) => {
-        createSyncingCatchError(fileKey, 'delete')(error)
-        return false
-      })
+    const syncPromise = options?.noDelete
+      ? Promise.resolve()
+      : deleteThemeAsset(Number(themeId), fileKey, adminSession)
+          .then(async (success) => {
+            if (!success) throw new Error(`Failed to delete file "${fileKey}" from remote theme.`)
+            unsyncedFileKeys.delete(fileKey)
+            outputSyncResult('delete', fileKey)
+            return true
+          })
+          .catch((error) => {
+            createSyncingCatchError(fileKey, 'delete')(error)
+            return false
+          })
 
     emitEvent('unlink', {
       fileKey,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes: https://github.com/Shopify/develop-advanced-edits/issues/370
While fixing up some of the documentation relating to using the `--nodelete` flag, I noticed that files were still being deleted remotely when using `theme dev --nodelete`. 

### WHAT is this pull request doing?

The `mountThemeFileSystem` was not receiving the `--nodelete` flag if it was being used. I added it to the `ThemeFileSystemOptions` type and now we check if it present in the `handleFileDelete` method. If it is, we return early.

### How to test your changes?
Run the current build and use the command `theme dev --nodelete`
Make a file.
Delete the file.
You should see it be deleted remotely.

-------------------------------------

Pull down this branch
Build this branch
Run `theme dev --nodelete`
Make a file
Delete the file
You will see it keeps the remote file.

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
