### PR TITLE
[Theme] Fix Liquid asset hot reload

### DIFF
--- a/.changeset/empty-hats-own.md
+++ b/.changeset/empty-hats-own.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix hot reloading of `.css.liquid` assets.

--- a/.changeset/empty-hats-own.md
+++ b/.changeset/empty-hats-own.md
@@ -2,4 +2,4 @@
 '@shopify/theme': patch
 ---
 
-Fix hot reloading of `.css.liquid` assets.
+Fix hot reloading of `.css.liquid` and `.js.liquid` assets.

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/client.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/client.ts
@@ -64,8 +64,10 @@ function hotReloadScript() {
 
   const refreshHTMLLinkElements = (elements: HTMLLinkElement[]) => {
     for (const element of elements) {
-      // The `href` property prepends the host to the pathname. Use attributes instead:
-      element.setAttribute('href', element.getAttribute('href')!.replace(/v=\d+$/, `v=${Date.now()}`))
+      // The `href` property prepends the host to the pathname. Use attributes instead.
+      // Note: when a .liquid asset is requested but not found in SFR, it will be rendered as
+      // `.../assets/file.css?1234` instead of `.../assets/file.css?v=1234`. Ensure we target both.
+      element.setAttribute('href', element.getAttribute('href')!.replace(/(\?|&)(?:v=)?\d+$/, `$1v=${Date.now()}`))
     }
   }
 

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
@@ -165,7 +165,8 @@ describe('hot-reload server', () => {
     // Emits a CSS HotReload event after syncing:
     expect(cssLiquidSyncSpy).toHaveBeenCalled()
     await nextTick()
-    expect(hotReloadEvents.at(-1)).toMatch(`data: {"type":"full","key":"${cssLiquidFileKey}"}`)
+    // Removes the `.liquid` extension before sending it to the browser:
+    expect(hotReloadEvents.at(-1)).toMatch(`data: {"type":"css","key":"${cssLiquidFileKey.replace('.liquid', '')}"}`)
 
     // -- Updates other files:
     const jsFileKey = 'assets/something.js'

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
@@ -98,7 +98,7 @@ export function setupInMemoryTemplateWatcher(ctx: DevServerContext) {
     if (isAsset) {
       if (extension === '.liquid') {
         // If the asset is a .css.liquid or similar, we wait until it's been synced:
-        onSync(() => triggerHotReload(fileKey, ctx))
+        onSync(() => triggerHotReload(fileKey.replace(extension, ''), ctx))
       } else {
         // Otherwise, just full refresh directly:
         triggerHotReload(fileKey, ctx)

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -233,6 +233,15 @@ function proxyStorefrontRequest(event: H3Event, ctx: DevServerContext) {
   const path = event.path.replaceAll(EXTENSION_CDN_PREFIX, '/')
   const host = event.path.startsWith(EXTENSION_CDN_PREFIX) ? 'cdn.shopify.com' : ctx.session.storeFqdn
   const url = new URL(path, `https://${host}`)
+
+  // When a .css.liquid or .js.liquid file is requested but it doesn't exist in SFR,
+  // it will be rendered with a query string like `assets/file.css?1234`.
+  // For some reason, after refreshing, this rendered URL keeps the wrong `?1234`
+  // query string for a while. We replace it with a proper timestamp here to fix it.
+  if (/\/assets\/[^/]+\.(css|js)$/.test(url.pathname) && /\?\d+$/.test(url.search)) {
+    url.search = `?v=${Date.now()}`
+  }
+
   url.searchParams.set('_fd', '0')
   url.searchParams.set('pb', '0')
   const headers = getProxyStorefrontHeaders(event)

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -347,5 +347,22 @@ describe('setupDevServer', () => {
       const {body} = await eventPromise
       expect(body).toMatch(`src: url(/cdn/shop/t/img/assets/font.woff2)`)
     })
+
+    test('proxies .js.liquid assets replacing the error query string', async () => {
+      const fetchStub = vi.fn(() => new Response())
+      vi.stubGlobal('fetch', fetchStub)
+      vi.useFakeTimers()
+      const now = Date.now()
+
+      const pathname = '/cdn/shop/t/img/assets/file4.js'
+      const eventPromise = dispatchEvent(`${pathname}?1234`)
+      await expect(eventPromise).resolves.not.toThrow()
+      expect(vi.mocked(render)).not.toHaveBeenCalled()
+
+      expect(fetchStub).toHaveBeenCalledWith(
+        `https://${defaultServerContext.session.storeFqdn}${pathname}?v=${now}&_fd=0&pb=0`,
+        expect.any(Object),
+      )
+    })
   })
 })


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #2614 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

When a missing .liquid asset that is referenced in the app is created anew, the server will try to hot reload it and fail.
Pairing with @jamesmengo , we found out during the first rendering, SFR renders `?1234` for the file querystring, which returns a 404.

The problem is that even after creating the file and uploading it, SFR still renders the wrong `?1234` instead of `?v=timestamp`. This makes the request fail again with 404 even though the file already exists. This might be related to caching at the SFR level, I'm not sure about it.

This PR makes 3 changes:
1. Use HotReload for CSS instead of full page reload.
2. During CSS HotReload, it replaces the wrong `?1234` with a new `?v=` timestamp.
3. The same approach doesn't work for JS assets because we only do a full refresh. Therefore, the fix here is to use our proxy to rewrite `?1234` queries to `?v=` timestamp queries. This fix would probably also work for CSS assets, but I'm keeping the previous one since it's cleaner for CSS.

### How to test your changes?

1. Reference a missing `.liquid.css` file from your theme.
2. Load the page, see it provokes a 404
3. Create the new file (or move it from another folder). It should now hot reload accordingly.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
