### PR TITLE
Restore style.css for GraphiQL

### DIFF
--- a/bin/bundling/esbuild-plugin-graphiql-imports.js
+++ b/bin/bundling/esbuild-plugin-graphiql-imports.js
@@ -10,7 +10,7 @@ const GraphiQLImportsPlugin = {
       return {
         contents: contents
           .replace('@shopify/app/assets/graphiql/favicon.ico', './assets/graphiql/favicon.ico')
-          .replace('@shopify/cli-kit/assets/style.css', './assets/style.css'),
+          .replace('@shopify/app/assets/graphiql/style.css', './assets/graphiql/style.css'),
       }
     })
   },

--- a/packages/app/assets/graphiql/style.css
+++ b/packages/app/assets/graphiql/style.css
@@ -1,0 +1,58 @@
+html {
+  font-family: -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, sans-serif;
+  text-size-adjust: 100%;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-size: 26px;
+  line-height: normal;
+  margin: 0;
+  padding: 0;
+}
+
+button, input, optgroup, select, textarea {
+  font-family: inherit;
+}
+
+h1 {
+  font-weight: 600;
+  font-size: 1em;
+}
+
+p {
+  font-weight: 400;
+}
+
+.body-success {
+  color: #F6F6F7;
+}
+
+.body-error {
+  color: #202223;
+}
+
+.app-success {
+  width: 100vw;
+  height: 100vh;
+  background-color: #054A49;
+  display: flex;
+}
+
+.app-error {
+  width: 100vw;
+  height: 100vh;
+  background-color: #F6F6F7;
+  display: flex;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-left: 7.5em;
+}

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -143,6 +143,7 @@ export function setupGraphiQLServer({
       throw err
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const apiVersion = apiVersions.sort().reverse()[0]!
 
     const query = req.query.query ? decodeURIComponent(req.query.query as string).replace(/\n/g, '\\n') : undefined

--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -102,7 +102,7 @@ export function setupGraphiQLServer({
     res.sendFile(faviconPath)
   })
 
-  const stylePath = require.resolve('@shopify/cli-kit/assets/style.css')
+  const stylePath = require.resolve('@shopify/app/assets/graphiql/style.css')
   app.get('/graphiql/simple.css', (_req, res) => {
     res.sendFile(stylePath)
   })
@@ -143,7 +143,6 @@ export function setupGraphiQLServer({
       throw err
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const apiVersion = apiVersions.sort().reverse()[0]!
 
     const query = req.query.query ? decodeURIComponent(req.query.query as string).replace(/\n/g, '\\n') : undefined


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We accidentally deleted the `style.css` file that was used for both legacy auth and graphiQL while removing the legacy auth flow.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Restore the `style.css` file, but add it to `app` this time since it is only used by GraphiQL.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
