### PR TITLE
[Themes] Replace legacy flag in `Push` command

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5837,6 +5837,14 @@
           "name": "legacy",
           "type": "boolean"
         },
+        "legacy-3.66": {
+          "allowNo": false,
+          "description": "Use the legacy Ruby implementation for the `shopify theme push` command.",
+          "env": "SHOPIFY_FLAG_LEGACY_3_66",
+          "hidden": true,
+          "name": "legacy-3.66",
+          "type": "boolean"
+        },
         "live": {
           "allowNo": false,
           "char": "l",

--- a/packages/theme/src/cli/commands/theme/push.test.ts
+++ b/packages/theme/src/cli/commands/theme/push.test.ts
@@ -77,22 +77,10 @@ describe('Push', () => {
       expect(DevelopmentThemeManager.prototype.fetch).not.toHaveBeenCalled()
       expectCLI2ToHaveBeenCalledWith(`theme push ${path} --theme ${theme.id} --development-theme-id ${theme.id}`)
     })
-
-    test('should run the Ruby implementation if the password flag is provided', async () => {
-      // Given
-      const theme = buildTheme({id: 1, name: 'Theme', role: 'development'})!
-      vi.spyOn(DevelopmentThemeManager.prototype, 'fetch').mockResolvedValue(theme)
-
-      // When
-      await runPushCommand(['--password', '123'], path, adminSession)
-
-      // Then
-      expectCLI2ToHaveBeenCalledWith(`theme push ${path} --development-theme-id ${theme.id}`)
-    })
   })
 
   async function run(argv: string[]) {
-    await runPushCommand(['--legacy', ...argv], path, adminSession)
+    await runPushCommand(['--legacy-3.66', ...argv], path, adminSession)
   }
 
   function expectCLI2ToHaveBeenCalledWith(command: string) {

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -12,6 +12,7 @@ import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {cwd, resolvePath} from '@shopify/cli-kit/node/path'
 import {useEmbeddedThemeCLI} from '@shopify/cli-kit/node/context/local'
 import {execCLI2} from '@shopify/cli-kit/node/ruby'
+import {renderWarning} from '@shopify/cli-kit/node/ui'
 
 export default class Push extends ThemeCommand {
   static summary = 'Uploads your local theme files to the connected store, overwriting the remote version if specified.'
@@ -109,6 +110,11 @@ export default class Push extends ThemeCommand {
       description: 'Use the legacy Ruby implementation for the `shopify theme push` command.',
       env: 'SHOPIFY_FLAG_LEGACY',
     }),
+    'legacy-3.66': Flags.boolean({
+      hidden: true,
+      description: 'Use the legacy Ruby implementation for the `shopify theme push` command.',
+      env: 'SHOPIFY_FLAG_LEGACY_3_66',
+    }),
     force: Flags.boolean({
       hidden: true,
       char: 'f',
@@ -135,7 +141,26 @@ export default class Push extends ThemeCommand {
   async run(): Promise<void> {
     const {flags} = await this.parse(Push)
 
-    if (flags.password || flags.legacy) {
+    if (flags.legacy) {
+      renderWarning({
+        headline: ['The', {command: '--legacy'}, 'flag is deprecated.'],
+        body: [
+          'The',
+          {command: '--legacy'},
+          'flag has been deprecated. If this variable is essential to your workflow, please report an issue at',
+          {
+            link: {
+              url: 'https://github.com/Shopify/cli/issues',
+            },
+          },
+          {
+            char: '.',
+          },
+        ],
+      })
+    }
+
+    if (flags['legacy-3.66']) {
       await this.execLegacyPush()
       return
     }


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/develop-advanced-edits/issues/374

### WHAT is this pull request doing?
1) Remove `password` flag as entrypoint to Legacy implementaiton
2)`legacy` renders a warning and direct users to open an issue
3) Introduces a fallback `legacy` altnerative

### How to test your changes?
1) Run the command with the `legacy` flag 
- Should render a warning and run the TS implementation
2) Run the command with a `password` provided from the theme access app
- Should run the TS implementation
3) Run the command with `legacy-3.66`
- Should run the Ruby implementaiton

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes

cc: @Shopify/advanced-edits 