### PR TITLE
Generate local sourcemap files for UI extensions

### DIFF
--- a/.changeset/two-laws-hammer.md
+++ b/.changeset/two-laws-hammer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Enable local file systen sourcemap generation for UI extensions

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -27,10 +27,11 @@ import {ok} from '@shopify/cli-kit/node/result'
 import {constantize, slugify} from '@shopify/cli-kit/common/string'
 import {hashString, randomUUID} from '@shopify/cli-kit/node/crypto'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {joinPath} from '@shopify/cli-kit/node/path'
-import {fileExists, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
+import {joinPath, basename} from '@shopify/cli-kit/node/path'
+import {fileExists, touchFile, moveFile, writeFile, glob} from '@shopify/cli-kit/node/fs'
 import {getPathValue} from '@shopify/cli-kit/common/object'
 import {useThemebundling} from '@shopify/cli-kit/node/context/local'
+import {outputDebug} from '@shopify/cli-kit/node/output'
 
 export const CONFIG_EXTENSION_IDS = [
   AppAccessSpecIdentifier,
@@ -110,6 +111,10 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
   get isESBuildExtension() {
     return this.features.includes('esbuild')
+  }
+
+  get isSourceMapGeneratingExtension() {
+    return this.features.includes('generates_source_maps')
   }
 
   get isAppConfigExtension() {
@@ -219,6 +224,25 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     return this.specification.buildValidation(this)
   }
 
+  async keepBuiltSourcemapsLocally(bundleDirectory: string, extensionId: string): Promise<void> {
+    if (!this.isSourceMapGeneratingExtension) return Promise.resolve()
+
+    const inputPath = joinPath(bundleDirectory, extensionId)
+
+    const pathsToMove = await glob(`**/${this.handle}.js.map`, {
+      cwd: inputPath,
+      absolute: true,
+      followSymbolicLinks: false,
+    })
+
+    const pathToMove = pathsToMove[0]
+    if (pathToMove === undefined) return Promise.resolve()
+
+    const outputPath = joinPath(this.directory, 'dist', basename(pathToMove))
+    await moveFile(pathToMove, outputPath, {overwrite: true})
+    outputDebug(`Source map for ${this.localIdentifier} created: ${outputPath}`)
+  }
+
   async publishURL(options: {orgId: string; appId: string; extensionId?: string}) {
     const fqdn = await partnersFqdn()
     const parnersPath = this.specification.partnersWebIdentifier
@@ -230,7 +254,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     if (this.specification.getBundleExtensionStdinContent) {
       return this.specification.getBundleExtensionStdinContent(this.configuration)
     }
-    const relativeImportPath = this.entrySourceFilePath?.replace(this.directory, '')
+    const relativeImportPath = this.entrySourceFilePath.replace(this.directory, '')
     return `import '.${relativeImportPath}';`
   }
 
@@ -291,7 +315,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   get isJavaScript() {
-    return Boolean(this.entrySourceFilePath?.endsWith('.js') || this.entrySourceFilePath?.endsWith('.ts'))
+    return Boolean(this.entrySourceFilePath.endsWith('.js') || this.entrySourceFilePath.endsWith('.ts'))
   }
 
   async build(options: ExtensionBuildOptions): Promise<void> {
@@ -325,6 +349,8 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     if (this.isThemeExtension && useThemebundling()) {
       await bundleThemeExtension(this, options)
     }
+
+    await this.keepBuiltSourcemapsLocally(bundleDirectory, extensionId)
   }
 
   get singleTarget() {

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -21,6 +21,7 @@ export type ExtensionFeature =
   | 'esbuild'
   | 'single_js_entry_path'
   | 'localization'
+  | 'generates_source_maps'
 
 export interface TransformationConfig {
   [key: string]: string

--- a/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
@@ -18,7 +18,14 @@ const checkoutSpec = createExtensionSpecification({
   identifier: 'checkout_ui_extension',
   dependency,
   schema: CheckoutSchema,
-  appModuleFeatures: (_) => ['ui_preview', 'bundling', 'cart_url', 'esbuild', 'single_js_entry_path'],
+  appModuleFeatures: (_) => [
+    'ui_preview',
+    'bundling',
+    'cart_url',
+    'esbuild',
+    'single_js_entry_path',
+    'generates_source_maps',
+  ],
   deployConfig: async (config, directory) => {
     return {
       extension_points: config.extension_points,

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -42,7 +42,7 @@ const uiExtensionSpec = createExtensionSpecification({
   dependency,
   schema: UIExtensionSchema,
   appModuleFeatures: (config) => {
-    const basic: ExtensionFeature[] = ['ui_preview', 'bundling', 'esbuild']
+    const basic: ExtensionFeature[] = ['ui_preview', 'bundling', 'esbuild', 'generates_source_maps']
     const needsCart =
       config?.extension_points?.find((extensionPoint) => {
         return getExtensionPointTargetSurface(extensionPoint.target) === 'checkout'

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -104,6 +104,7 @@ export async function buildUIExtension(extension: ExtensionInstance, options: Ex
       env,
       stderr: options.stderr,
       stdout: options.stdout,
+      sourceMaps: extension.isSourceMapGeneratingExtension,
     })
   } catch (extensionBundlingError) {
     // this fails if the app's own source code is broken; wrap such that this isn't flagged as a CLI bug


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [UI extension source map generation issue](https://github.com/Shopify/shopify/issues/548438) <!-- link to issue if one exists -->

Extension developers will be able to use generated source map files for e.g. troubleshooting a live extension in a production store by loading the file in Chrome dev tools while interacting with a checkout where their extension is present.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
- Adds `generates_source_maps` ExtensionFeature value
- Adds `generates_source_maps` feature to `ui_extension` and `checkout_ui_extension` specifications
- For these extensions, generate the sourcemap on `shopify app deploy` and move it into a `/dist` subdirectory of the extension project that was used to produce it
- Output the source map file paths when in `--verbose` mode

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Spin up `checkout-ui-extension-dev:developer-dashboard`

From the `CLI` project, call the deploy command like so:
`pnpm shopify app deploy --path ../checkout-ui-extension-dev` (optionally: `--verbose`)

This will upload scripts for two extension projects:
- checkout-ui
- validation-settings

You will then be able to find the source map files for each of these in their respective project folders, under `/dist`.

<img width="1361" alt="Screenshot 2024-10-21 at 2 52 55 PM" src="https://github.com/user-attachments/assets/bf828277-c6a3-4f1d-bbb5-eec2098482dd">

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
