### PR TITLE
Prevent rendering remote file deletion error when file has already been removed 

### DIFF
--- a/.changeset/little-ladybugs-fix.md
+++ b/.changeset/little-ladybugs-fix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix an issue with `shopify theme dev --theme-editor-sync` to prevent showing a remote file deletion error when the file has already been removed

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -261,7 +261,7 @@ describe('deleteThemeAsset', () => {
     expect(output).toBe(true)
   })
 
-  test('returns empty object when attemping to delete an nonexistent asset', async () => {
+  test('returns true when attemping to delete an nonexistent asset', async () => {
     // Given
     const id = 123
     const key = 'snippets/product-variant-picker.liquid'
@@ -277,7 +277,7 @@ describe('deleteThemeAsset', () => {
 
     // Then
     expect(restRequest).toHaveBeenCalledWith('DELETE', `/themes/${id}/assets`, session, undefined, {'asset[key]': key})
-    expect(output).toBe(false)
+    expect(output).toBe(true)
   })
 })
 

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -51,7 +51,7 @@ export async function deleteThemeAsset(id: number, key: Key, session: AdminSessi
   const response = await request('DELETE', `/themes/${id}/assets`, session, undefined, {
     'asset[key]': key,
   })
-  return Boolean(response.json.message)
+  return response.status === 200
 }
 
 export async function bulkUploadThemeAssets(


### PR DESCRIPTION
### WHY are these changes introduced?
https://github.com/Shopify/develop-advanced-edits/issues/375

### WHAT is this pull request doing?
- Prevents unnecessary warning messages when a file is already absent from the remote theme. This can happen when deleting a file on the remote theme and the `--theme-editor-sync` flag is provided

### How to test your changes?
1) Run `shopify-dev theme dev --theme-editor-sync`
2) Delete a file on the remote theme via the code editor
3) Observe that we don't report the failed deletion

https://github.com/user-attachments/assets/f8016a13-f562-4756-84c4-f19d9e69dfdb


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes