### PR TITLE
Fix the URL output to add a new product

### DIFF
--- a/packages/app/src/cli/utilities/extensions/fetch-product-variant.ts
+++ b/packages/app/src/cli/utilities/extensions/fetch-product-variant.ts
@@ -16,7 +16,7 @@ export async function fetchProductVariant(store: string) {
     throw new AbortError(
       'Could not find a product variant',
       `Your store needs to have at least one product to test a 'checkout_ui' extension\n
-You can add a new product here: https://${store}/admin/products/new`,
+You can add a new product here: ${store}/admin/products/new`,
     )
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const variantURL = result.products.edges[0]!.node.variants.edges[0]!.node.id


### PR DESCRIPTION
### WHY are these changes introduced?

Currently the URL output by this Checkout UI extensions error message during `shopify app dev` has an extra `https://`.

```
╭─ error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                               │
│  Could not find a product variant                                                                                             │
│                                                                                                                               │
│  Your store needs to have at least one product to test a 'checkout_ui' extension                                              │
│                                                                                                                               │
│  You can add a new product here: https://https://nw-dd-dev-1.myshopify.com/admin/products/new                                 │
│                                                                                                                               │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

I assume that we expect the Store FQDN here to already have a protocol.