### PR TITLE
[Themes] Connect `allowLive` flag to `theme push` execution

### DIFF
--- a/.changeset/giant-icons-exercise.md
+++ b/.changeset/giant-icons-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fixes an issue in the `theme push` command where a confirmation prompt is rendered to users who provide the `--allow-live` flag

--- a/packages/theme/src/cli/services/push.test.ts
+++ b/packages/theme/src/cli/services/push.test.ts
@@ -1,4 +1,4 @@
-import {createOrSelectTheme, push, ThemeSelectionOptions} from './push.js'
+import {createOrSelectTheme, push, PushFlags} from './push.js'
 import {PullFlags} from './pull.js'
 import {setDevelopmentTheme} from './local-storage.js'
 import {uploadTheme} from '../utilities/theme-uploader.js'
@@ -67,7 +67,7 @@ describe('createOrSelectTheme', async () => {
     vi.mocked(createTheme).mockResolvedValue(buildTheme({id: 2, name: 'Theme', role: UNPUBLISHED_THEME_ROLE}))
     vi.mocked(fetchTheme).mockResolvedValue(undefined)
 
-    const flags: ThemeSelectionOptions = {unpublished: true}
+    const flags: PushFlags = {unpublished: true}
 
     // When
     const theme = await createOrSelectTheme(adminSession, flags)
@@ -81,7 +81,7 @@ describe('createOrSelectTheme', async () => {
     // Given
     vi.mocked(createTheme).mockResolvedValue(buildTheme({id: 1, name: 'Theme', role: DEVELOPMENT_THEME_ROLE}))
     vi.mocked(fetchTheme).mockResolvedValue(undefined)
-    const flags: ThemeSelectionOptions = {development: true}
+    const flags: PushFlags = {development: true}
 
     // When
     const theme = await createOrSelectTheme(adminSession, flags)
@@ -95,7 +95,7 @@ describe('createOrSelectTheme', async () => {
     // Given
     vi.mocked(createTheme).mockResolvedValue(buildTheme({id: 1, name: 'Theme', role: DEVELOPMENT_THEME_ROLE}))
     vi.mocked(fetchTheme).mockResolvedValue(undefined)
-    const flags: ThemeSelectionOptions = {development: true, unpublished: true}
+    const flags: PushFlags = {development: true, unpublished: true}
 
     // When
     const theme = await createOrSelectTheme(adminSession, flags)
@@ -107,7 +107,7 @@ describe('createOrSelectTheme', async () => {
   test('returns live theme when live flag is provided', async () => {
     // Given
     vi.mocked(findOrSelectTheme).mockResolvedValue(buildTheme({id: 3, name: 'Live Theme', role: LIVE_THEME_ROLE})!)
-    const flags: ThemeSelectionOptions = {live: true, 'allow-live': true}
+    const flags: PushFlags = {live: true, allowLive: true}
 
     // When
     const theme = await createOrSelectTheme(adminSession, flags)
@@ -116,11 +116,11 @@ describe('createOrSelectTheme', async () => {
     expect(theme).toMatchObject({role: LIVE_THEME_ROLE})
   })
 
-  test("renders confirmation prompt if 'allow-live' flag is not provided and selected theme role is live", async () => {
+  test('renders confirmation prompt if allowLive flag is not provided and selected theme role is live', async () => {
     // Given
     vi.mocked(findOrSelectTheme).mockResolvedValue(buildTheme({id: 3, name: 'Live Theme', role: LIVE_THEME_ROLE})!)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
-    const flags: ThemeSelectionOptions = {live: true}
+    const flags: PushFlags = {live: true}
 
     // When
     const theme = await createOrSelectTheme(adminSession, flags)
@@ -134,7 +134,7 @@ describe('createOrSelectTheme', async () => {
     // Given
     vi.mocked(findOrSelectTheme).mockResolvedValue(buildTheme({id: 3, name: 'Live Theme', role: LIVE_THEME_ROLE})!)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
-    const flags: ThemeSelectionOptions = {theme: '3'}
+    const flags: PushFlags = {theme: '3'}
 
     // When
     const theme = await createOrSelectTheme(adminSession, flags)
@@ -148,7 +148,7 @@ describe('createOrSelectTheme', async () => {
     // Given
     vi.mocked(findOrSelectTheme).mockResolvedValue(buildTheme({id: 3, name: 'Live Theme', role: LIVE_THEME_ROLE})!)
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
-    const flags: ThemeSelectionOptions = {live: true}
+    const flags: PushFlags = {live: true}
 
     // When
     const theme = await createOrSelectTheme(adminSession, flags)

--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -21,14 +21,6 @@ import {themeEditorUrl, themePreviewUrl} from '@shopify/cli-kit/node/themes/urls
 import {cwd, resolvePath} from '@shopify/cli-kit/node/path'
 import {LIVE_THEME_ROLE, promptThemeName, UNPUBLISHED_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
 
-export interface ThemeSelectionOptions {
-  live?: boolean
-  development?: boolean
-  unpublished?: boolean
-  theme?: string
-  'allow-live'?: boolean
-}
-
 interface PushOptions {
   path: string
   nodelete?: boolean
@@ -291,10 +283,7 @@ function handleOutput(theme: Theme, hasErrors: boolean, session: AdminSession) {
   }
 }
 
-export async function createOrSelectTheme(
-  adminSession: AdminSession,
-  flags: ThemeSelectionOptions,
-): Promise<Theme | undefined> {
+export async function createOrSelectTheme(adminSession: AdminSession, flags: PushFlags): Promise<Theme | undefined> {
   const {live, development, unpublished, theme} = flags
 
   if (development) {
@@ -319,7 +308,7 @@ export async function createOrSelectTheme(
       },
     })
 
-    if (await confirmPushToTheme(selectedTheme.role as Role, flags['allow-live'], adminSession.storeFqdn)) {
+    if (await confirmPushToTheme(selectedTheme.role as Role, flags.allowLive, adminSession.storeFqdn)) {
       return selectedTheme
     }
   }

--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -126,12 +126,12 @@ export async function push(flags: PushFlags): Promise<void> {
 
   await executePush(selectedTheme, adminSession, {
     path: workingDirectory,
-    nodelete: flags.nodelete || false,
-    publish: flags.publish || false,
-    json: flags.json || false,
+    nodelete: flags.nodelete ?? false,
+    publish: flags.publish ?? false,
+    json: flags.json ?? false,
     force,
-    ignore: flags.ignore || [],
-    only: flags.only || [],
+    ignore: flags.ignore ?? [],
+    only: flags.only ?? [],
   })
 }
 
@@ -290,7 +290,7 @@ export async function createOrSelectTheme(adminSession: AdminSession, flags: Pus
     const themeManager = new DevelopmentThemeManager(adminSession)
     return themeManager.findOrCreate()
   } else if (unpublished) {
-    const themeName = theme || (await promptThemeName('Name of the new theme'))
+    const themeName = theme ?? (await promptThemeName('Name of the new theme'))
     return createTheme(
       {
         name: themeName,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shopify/cli/issues/4708

### WHAT is this pull request doing?
1) Fixes an issue for users of the `theme push` command where `allowLive` was not being picked up correctly
2) `ESlint` fixes

### How to test your changes?
`pnpm shopify theme push --allow-live --live` should not prompt users

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
