### PR TITLE
Add GQL support for theme access tokens

### DIFF
--- a/packages/cli-kit/src/private/node/api.ts
+++ b/packages/cli-kit/src/private/node/api.ts
@@ -125,7 +125,8 @@ function errorsIncludeStatus429(error: ClientError): boolean {
     return true
   }
 
-  // More so checking if type of error.response.errors is not GraphQLError[]
+  // GraphQL returns a 401 with a string error message when auth fails
+  // Therefore error.response.errros can be a string or GraphQLError[]
   if (typeof error.response.errors === 'string') {
     return false
   }

--- a/packages/cli-kit/src/private/node/api/graphql.ts
+++ b/packages/cli-kit/src/private/node/api/graphql.ts
@@ -1,12 +1,12 @@
-/* eslint-disable @typescript-eslint/no-base-to-string */
 import {GraphQLClientError, sanitizedHeadersOutput} from './headers.js'
 import {stringifyMessage, outputContent, outputToken, outputDebug} from '../../../public/node/output.js'
 import {AbortError} from '../../../public/node/error.js'
-import {ClientError, RequestDocument, Variables} from 'graphql-request'
+import {ClientError, Variables} from 'graphql-request'
 
 export function debugLogRequestInfo(
   api: string,
-  query: RequestDocument,
+  query: string,
+  url: string,
   variables?: Variables,
   headers: {[key: string]: string} = {},
 ) {
@@ -14,8 +14,8 @@ export function debugLogRequestInfo(
   ${outputToken.raw(query.toString().trim())}
 ${variables ? `\nWith variables:\n${sanitizeVariables(variables)}\n` : ''}
 With request headers:
-${sanitizedHeadersOutput(headers)}
-`)
+${sanitizedHeadersOutput(headers)}\n
+to ${url}`)
 }
 
 function sanitizeVariables(variables: Variables): string {

--- a/packages/cli-kit/src/private/node/api/graphql.ts
+++ b/packages/cli-kit/src/private/node/api/graphql.ts
@@ -1,4 +1,5 @@
 import {GraphQLClientError, sanitizedHeadersOutput} from './headers.js'
+import {sanitizeURL} from './urls.js'
 import {stringifyMessage, outputContent, outputToken, outputDebug} from '../../../public/node/output.js'
 import {AbortError} from '../../../public/node/error.js'
 import {ClientError, Variables} from 'graphql-request'
@@ -15,7 +16,7 @@ export function debugLogRequestInfo(
 ${variables ? `\nWith variables:\n${sanitizeVariables(variables)}\n` : ''}
 With request headers:
 ${sanitizedHeadersOutput(headers)}\n
-to ${url}`)
+to ${sanitizeURL(url)}`)
 }
 
 function sanitizeVariables(variables: Variables): string {

--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -52,25 +52,28 @@ describe('common API methods', () => {
     })
   })
 
-  test.each(['shpat', 'shpua', 'shpca'])(`when custom app token starts with %s, do not prepend 'Bearer'`, (prefix) => {
-    // Given
-    vi.mocked(randomUUID).mockReturnValue('random-uuid')
-    vi.mocked(firstPartyDev).mockReturnValue(false)
-    const token = `${prefix}_my_token`
-    // When
-    const headers = buildHeaders(token)
+  test.each(['shpat', 'shpua', 'shpca', 'shptka'])(
+    `when custom app token starts with %s, do not prepend 'Bearer'`,
+    (prefix) => {
+      // Given
+      vi.mocked(randomUUID).mockReturnValue('random-uuid')
+      vi.mocked(firstPartyDev).mockReturnValue(false)
+      const token = `${prefix}_my_token`
+      // When
+      const headers = buildHeaders(token)
 
-    // Then
-    const version = CLI_KIT_VERSION
-    expect(headers).toEqual({
-      'Content-Type': 'application/json',
-      'Keep-Alive': 'timeout=30',
-      'X-Shopify-Access-Token': token,
-      'User-Agent': `Shopify CLI; v=${version}`,
-      authorization: token,
-      'Sec-CH-UA-PLATFORM': process.platform,
-    })
-  })
+      // Then
+      const version = CLI_KIT_VERSION
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+        'Keep-Alive': 'timeout=30',
+        'X-Shopify-Access-Token': token,
+        'User-Agent': `Shopify CLI; v=${version}`,
+        authorization: token,
+        'Sec-CH-UA-PLATFORM': process.platform,
+      })
+    },
+  )
 
   test('sanitizedHeadersOutput removes the headers that include the token', () => {
     // Given

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -56,7 +56,7 @@ export function buildHeaders(token?: string): {[key: string]: string} {
     ...(firstPartyDev() && {'X-Shopify-Cli-Employee': '1'}),
   }
   if (token) {
-    const authString = token.match(/^shp(at|ua|ca)/) ? token : `Bearer ${token}`
+    const authString = token.match(/^shp(at|ua|ca|tka)/) ? token : `Bearer ${token}`
 
     headers.authorization = authString
     headers['X-Shopify-Access-Token'] = authString

--- a/packages/cli-kit/src/private/node/api/rest.ts
+++ b/packages/cli-kit/src/private/node/api/rest.ts
@@ -1,5 +1,5 @@
 import {buildHeaders} from './headers.js'
-import {defaultThemeKitAccessDomain, environmentVariables} from '../constants.js'
+import {themeKitAccessDomain} from '../constants.js'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 
 export function restRequestBody<T>(requestBody?: T) {
@@ -14,9 +14,7 @@ export function restRequestUrl(
   apiVersion: string,
   path: string,
   searchParams: {[name: string]: string} = {},
-  env = process.env,
 ) {
-  const themeKitAccessDomain = env[environmentVariables.themeKitAccessDomain] || defaultThemeKitAccessDomain
   const url = new URL(
     isThemeAccessSession(session)
       ? `https://${themeKitAccessDomain}/cli/admin/api/${apiVersion}${path}.json`

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -80,3 +80,6 @@ export const sessionConstants = {
 export const bugsnagApiKey = '9e1e6889176fd0c795d5c659225e0fae'
 
 export const reportingRateLimit = {limit: 300, timeout: {days: 1}}
+
+export const themeKitAccessDomain =
+  process.env[environmentVariables.themeKitAccessDomain] ?? defaultThemeKitAccessDomain

--- a/packages/cli-kit/src/public/node/api/admin.test.ts
+++ b/packages/cli-kit/src/public/node/api/admin.test.ts
@@ -57,7 +57,36 @@ describe('admin-graphql-api', () => {
       query: 'query',
       api: 'Admin',
       url: 'https://store.myshopify.com/admin/api/2022-01/graphql.json',
+      addedHeaders: {},
       token,
+      variables: {variables: 'variables'},
+    })
+  })
+
+  test('request is called with correct parameters when it is a theme access session', async () => {
+    // Given
+    const themeAccessToken = 'shptka_token'
+    const themeAccessSession = {
+      ...Session,
+      token: themeAccessToken,
+    }
+
+    vi.mocked(graphqlRequest).mockResolvedValue(mockedResult)
+    vi.mocked(graphqlRequestDoc).mockResolvedValue(mockedResult)
+
+    // When
+    await admin.adminRequest('query', themeAccessSession, {variables: 'variables'})
+
+    // Then
+    expect(graphqlRequest).toHaveBeenLastCalledWith({
+      query: 'query',
+      api: 'Admin',
+      addedHeaders: {
+        'X-Shopify-Access-Token': 'shptka_token',
+        'X-Shopify-Shop': 'store',
+      },
+      url: `https://${defaultThemeKitAccessDomain}/cli/admin/api/2022-01/graphql.json`,
+      token: themeAccessToken,
       variables: {variables: 'variables'},
     })
   })

--- a/packages/cli-kit/src/public/node/api/graphql.test.ts
+++ b/packages/cli-kit/src/public/node/api/graphql.test.ts
@@ -101,6 +101,7 @@ describe('graphqlRequestDoc', () => {
       `query QueryName {
   example
 }`,
+      'mockedAddress',
       mockVariables,
       expect.anything(),
     )

--- a/packages/cli-kit/src/public/node/api/graphql.ts
+++ b/packages/cli-kit/src/public/node/api/graphql.ts
@@ -55,7 +55,7 @@ async function performGraphQLRequest<TResult>(options: PerformGraphQLRequestOpti
     ...buildHeaders(token),
   }
 
-  debugLogRequestInfo(api, queryAsString, variables, headers)
+  debugLogRequestInfo(api, queryAsString, url, variables, headers)
   const clientOptions = {agent: await httpsAgent(), headers}
   const client = new GraphQLClient(url, clientOptions)
 


### PR DESCRIPTION
### WHY are these changes introduced?
Along with https://github.com/Shopify/themekit-access/pull/3703, add support for theme access tokens for GraphQL in the CLI. Will unblocking CLI GraphQL migration effort.

### WHAT is this pull request doing?

Add theme access logic for GraphQL requests (proxy to theme access app with appropriate headers).

In follow up, would like to clean up theme access logic by creating a file for it, rather than implementing it in REST and GraphQL 

### How to test your changes?
See https://github.com/Shopify/themekit-access/pull/3703 for tophatting instructions

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
