### PR TITLE
Allow specific error messages to be flagged as environmental and not bugs

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -6,7 +6,7 @@ import {
   AbortSilentError,
   CancelExecution,
   errorMapper,
-  shouldReportError,
+  shouldReportErrorAsUnexpected,
   handler,
   cleanSingleStackTracePath,
 } from './error.js'
@@ -46,7 +46,7 @@ export async function errorHandler(
 const reportError = async (error: unknown, config?: Interfaces.Config): Promise<void> => {
   // categorise the error first
   let exitMode: CommandExitMode = 'expected_error'
-  if (shouldReportError(error)) exitMode = 'unexpected_error'
+  if (shouldReportErrorAsUnexpected(error)) exitMode = 'unexpected_error'
 
   if (config !== undefined) {
     // Log an analytics event when there's an error

--- a/packages/cli-kit/src/public/node/error.test.ts
+++ b/packages/cli-kit/src/public/node/error.test.ts
@@ -1,4 +1,4 @@
-import {AbortError, BugError, handler, cleanSingleStackTracePath} from './error.js'
+import {AbortError, BugError, handler, cleanSingleStackTracePath, shouldReportErrorAsUnexpected} from './error.js'
 import {renderFatalError} from './ui.js'
 import {describe, expect, test, vi} from 'vitest'
 
@@ -51,5 +51,23 @@ describe('stack file path helpers', () => {
     ['windows no file', 'D:\\something\\there.js'],
   ])('%s', (_, path) => {
     expect(cleanSingleStackTracePath(path)).toEqual('/something/there.js')
+  })
+})
+
+describe('shouldReportErrorAsUnexpected helper', () => {
+  test('returns true for normal errors', () => {
+    expect(shouldReportErrorAsUnexpected(new Error('test'))).toBe(true)
+  })
+
+  test('returns false for AbortError', () => {
+    expect(shouldReportErrorAsUnexpected(new AbortError('test'))).toBe(false)
+  })
+
+  test('returns true for BugError', () => {
+    expect(shouldReportErrorAsUnexpected(new BugError('test'))).toBe(true)
+  })
+
+  test('returns false for errors that imply environment issues', () => {
+    expect(shouldReportErrorAsUnexpected(new Error('EPERM: operation not permitted, scandir'))).toBe(false)
   })
 })


### PR DESCRIPTION
…bugs

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

There are a category of errors that are not CLI bugs, and are environmental issues -- e.g. a disk becomes readonly in use. These come up a lot, as this is code that runs on a multitude of environments. Let's flag them as non-bugs as they make it hard to track real issues.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Adds an allow-list of "not bugs" messages.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
