### PR TITLE
Revert "1676/add data extension spec"

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -621,23 +621,6 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     },
   },
   {
-    name: 'Data Extension',
-    externalName: 'Data Extension',
-    identifier: 'data_extension',
-    externalIdentifier: 'data_extension_external',
-    gated: false,
-    experience: 'extension',
-    options: {
-      managementExperience: 'cli',
-      registrationLimit: 50,
-    },
-    features: {
-      argo: {
-        surface: 'admin',
-      },
-    },
-  },
-  {
     name: 'UI Extension',
     externalName: 'UI Extension',
     identifier: 'ui_extension',


### PR DESCRIPTION
### WHY are these changes introduced?

Based on the update for app modules using `contracts`, adding a local specification to the CLI is NOT required anymore. 

### WHAT is this pull request doing?

Reverts the last piece of Shopify/cli#4636

Another [PR](https://github.com/Shopify/cli/pull/4699) shipped today to remove the `data_extension` files. This PR just removes a block in the test data.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
