### PR TITLE
Fix crash on `dev` when making changes in an extension

### DIFF
--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -7,7 +7,6 @@ import {
 } from '../../models/app/loader.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {ExtensionsArraySchema, UnifiedSchema} from '../../models/extensions/schemas.js'
-import {configWithoutFirstClassFields} from '../../models/extensions/specification.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {themeExtensionConfig} from '../deploy/theme-extension-config.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -111,8 +110,7 @@ export async function reloadExtensionConfig({extension}: UpdateExtensionConfigOp
       )
     }
 
-    const mergedConfig = {...configuration, ...extensionConfig}
-    configObject = configWithoutFirstClassFields(mergedConfig)
+    configObject = {...configuration, ...extensionConfig}
   }
 
   const newConfig = await parseConfigurationObjectAgainstSpecification(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
A recent change introduced a regression in `app dev`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Remove an unnecessary call to `configWithoutFirstClassFields`, that's already done in the `deployConfig` function, no need to do it here.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Run dev in an app with a ui-extension, make a change in the extension while dev is running, everything should work.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
