### PR TITLE
Fix Flow action extension CLI import

### DIFF
--- a/packages/app/src/cli/services/flow/serialize-fields.ts
+++ b/packages/app/src/cli/services/flow/serialize-fields.ts
@@ -64,6 +64,9 @@ export const serializeCommerceObjectField = (field: ConfigField, type: FlowExten
     uiType: type === 'flow_action' ? 'commerce-object-id' : commerceObject,
     description: field.description,
   }
+  if (commerceObject === 'marketing_activity') {
+    serializedField.uiType = 'marketing-activity-id'
+  }
 
   if (type === 'flow_action') {
     serializedField.label = `${pascalize(commerceObject)} ID`

--- a/packages/app/src/cli/services/flow/serialize-partners-fields.test.ts
+++ b/packages/app/src/cli/services/flow/serialize-partners-fields.test.ts
@@ -20,6 +20,12 @@ describe('serialize-fields', () => {
         uiType: 'commerce-object-id',
       },
       {
+        name: 'marketing_activity_id',
+        label: 'MarketingActivity ID',
+        required: false,
+        uiType: 'marketing-activity-id',
+      },
+      {
         name: 'email field',
         label: 'email label',
         description: 'email help',

--- a/packages/app/src/cli/services/flow/serialize-partners-fields.ts
+++ b/packages/app/src/cli/services/flow/serialize-partners-fields.ts
@@ -37,6 +37,11 @@ const serializeCommerceObjectField = (field: SerializedField, type: FlowPartners
     serializedField.required = field.required
   }
 
+  if (field.uiType === 'marketing-activity-id') {
+    serializedField.marketingActivityCreateUrl = field.marketingActivityCreateUrl
+    serializedField.marketingActivityDeleteUrl = field.marketingActivityDeleteUrl
+  }
+
   return serializedField
 }
 
@@ -44,7 +49,11 @@ export const configFromSerializedFields = (type: FlowPartnersExtensionTypes, fie
   if (!fields) return []
 
   const serializedFields = fields.map((field) => {
-    if (field.uiType === 'commerce-object-id' || PARTNERS_COMMERCE_OBJECTS.includes(field.uiType)) {
+    if (
+      field.uiType === 'commerce-object-id' ||
+      field.uiType === 'marketing-activity-id' ||
+      PARTNERS_COMMERCE_OBJECTS.includes(field.uiType)
+    ) {
       return serializeCommerceObjectField(field, type)
     }
 

--- a/packages/app/src/cli/services/flow/types.ts
+++ b/packages/app/src/cli/services/flow/types.ts
@@ -4,6 +4,8 @@ export interface ConfigField {
   key?: string
   name?: string
   description?: string
+  marketingActivityCreateUrl?: string
+  marketingActivityDeleteUrl?: string
 }
 
 export interface SerializedField {
@@ -13,6 +15,8 @@ export interface SerializedField {
   required?: boolean
   uiType: string
   typeRefName?: string
+  marketingActivityCreateUrl?: string
+  marketingActivityDeleteUrl?: string
 }
 
 export type FlowExtensionTypes = 'flow_action' | 'flow_trigger'


### PR DESCRIPTION
### WHY are these changes introduced?
Flow action extension needs to support marketing activity config field.
https://github.com/Shopify/marketing-automations/issues/2118#issuecomment-2430000954

### WHAT is this pull request doing?
Adding the needed logic to support `shopify app import-extensions` for Flow action extensions with marketing activity config field.

### How to test your changes?
#### Instructions
* spin up `extensions`
* run `yarn create @shopify/app` in extensions terminal
* Start your app by running `dev cd your-app` and then `yarn shopify app dev`. It'll ask you to login, make sure you pick the partners account not regular dev account
* Go the partners dashboard and create a Flow action extension with multiple config fields including marketing activity config
* In CLI shell, run `pnpm shopify app import-extensions --path ../extensions/your-app`, choose `Flow Extensions` when asked "Extension type to migrate", and then select the extension you just created in the partners dash
* It should import the extension and create a TOML file with the right fields.
* In core, check that the config is persisted successfully by opening the shopify console and run `Apps::Models::Extensions::Version.find(id).config` where id is the id of the marketing activity extension entry in the `app_static_extension_configs` table (master shard).

#### Results
##### Before: import fails due to 
<img width="579" alt="image" src="https://github.com/user-attachments/assets/240c8626-ebd2-474d-9b76-1761f473018a">


##### After: TOML file gets created successfully and config is persisted in `app_static_extension_configs`
<details>
  <summary>Partner dash</summary>
 
<img width="1505" alt="image" src="https://github.com/user-attachments/assets/65accfd0-38a6-433a-b217-223fb653c3db">
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/6fbfeb6b-de6e-493c-bc04-87f94a34520e">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/aa692463-c76d-4c08-aa2b-fce2ac8043de">
</details>

**Importing extension succeeds and creates toml file with the activity URLs**
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/e31dae67-cc87-4dda-858e-6d4205aa75ff">
<img width="579" alt="image" src="https://github.com/user-attachments/assets/1fbf3e97-d077-4506-95ca-d3bf238e62be">

**config is persisted in app_static_extension_configs table and the content looks correct**
<img width="706" alt="image" src="https://github.com/user-attachments/assets/479a5c00-b217-4510-98c0-6115420fa43e">
<img width="802" alt="image" src="https://github.com/user-attachments/assets/758871f8-7cba-47f4-a8c0-77a4cbdd5986">
Note: Label is empty as defined [here](https://github.com/Shopify/partners-web-platform/blob/main/packages/partners-dashboard/src/sections/Apps/pages/AppExtensions/extensions/flow_action_definition/constants.ts#L84)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
