### PR TITLE
Add import admin link extensions to CLI and migration on deployment

### DIFF
--- a/packages/app/src/cli/commands/app/import-extensions.ts
+++ b/packages/app/src/cli/commands/app/import-extensions.ts
@@ -1,5 +1,6 @@
 import {buildTomlObject as buildPaymentsTomlObject} from '../../services/payments/extension-to-toml.js'
 import {buildTomlObject as buildFlowTomlObject} from '../../services/flow/extension-to-toml.js'
+import {buildTomlObject as buildAdminLinkTomlObject} from '../../services/admin-link/extension-to-toml.js'
 import {buildTomlObject as buildMarketingActivityTomlObject} from '../../services/marketing_activity/extension-to-toml.js'
 import {buildTomlObject as buildSubscriptionLinkTomlObject} from '../../services/subscription_link/extension-to-toml.js'
 import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
@@ -50,6 +51,12 @@ const getMigrationChoices = (): MigrationChoice[] => [
     value: 'subscription link',
     extensionTypes: ['subscription_link'],
     buildTomlObject: buildSubscriptionLinkTomlObject,
+  },
+  {
+    label: 'Admin Link extensions',
+    value: 'link extension',
+    extensionTypes: ['app_link', 'bulk_action'],
+    buildTomlObject: buildAdminLinkTomlObject,
   },
 ]
 

--- a/packages/app/src/cli/services/admin-link/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/admin-link/extension-to-toml.test.ts
@@ -1,0 +1,63 @@
+import {buildTomlObject} from './extension-to-toml.js'
+import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
+import {describe, expect, test} from 'vitest'
+
+describe('extension-to-toml', () => {
+  test('correctly builds a toml string for a app_link', () => {
+    // Given
+    const extension1: ExtensionRegistration = {
+      id: '26237698049',
+      uuid: 'ad9947a9-bc0b-4855-82da-008aefbc1c71',
+      title: 'Admin link title',
+      type: 'app_link',
+      draftVersion: {
+        context: 'COLLECTIONS#SHOW',
+        config: '{"text":"admin link label","url":"https://google.es"}',
+      },
+    }
+
+    // When
+    const got = buildTomlObject(extension1)
+
+    // Then
+    expect(got).toEqual(`[[extensions]]
+type = "admin_link"
+name = "Admin link title"
+handle = "admin-link-title"
+
+  [[extensions.targeting]]
+  text = "admin link label"
+  url = "https://google.es"
+  target = "admin.collection.item.link"
+`)
+  })
+
+  test('correctly builds a toml string for a bulk_action', () => {
+    // Given
+    const extension1: ExtensionRegistration = {
+      id: '26237698049',
+      uuid: 'ad9947a9-bc0b-4855-82da-008aefbc1c71',
+      title: 'Bulk action title',
+      type: 'bulk_action',
+      draftVersion: {
+        context: 'PRODUCTS#ACTION',
+        config: '{"text":"bulk action label","url":"https://google.es"}',
+      },
+    }
+
+    // When
+    const got = buildTomlObject(extension1)
+
+    // Then
+    expect(got).toEqual(`[[extensions]]
+type = "admin_link"
+name = "Bulk action title"
+handle = "bulk-action-title"
+
+  [[extensions.targeting]]
+  text = "bulk action label"
+  url = "https://google.es"
+  target = "admin.product.selection.link"
+`)
+  })
+})

--- a/packages/app/src/cli/services/admin-link/extension-to-toml.ts
+++ b/packages/app/src/cli/services/admin-link/extension-to-toml.ts
@@ -1,0 +1,42 @@
+import {contextToTarget} from './utils.js'
+import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
+import {MAX_EXTENSION_HANDLE_LENGTH} from '../../models/extensions/schemas.js'
+import {encodeToml} from '@shopify/cli-kit/node/toml'
+import {slugify} from '@shopify/cli-kit/common/string'
+
+interface AdminLinkConfig {
+  text: string
+  url: string
+}
+
+/**
+ * Given an app_link or bulk_action extension config file, convert it to toml
+ */
+export function buildTomlObject(extension: ExtensionRegistration): string {
+  const versionConfig = extension.activeVersion?.config ?? extension.draftVersion?.config
+  if (!versionConfig) throw new Error('No config found for extension')
+
+  const context = extension.activeVersion?.context ?? extension.draftVersion?.context
+  if (!context) throw new Error('No context found for link extension')
+
+  const config: AdminLinkConfig = JSON.parse(versionConfig)
+
+  const localExtensionRepresentation = {
+    extensions: [
+      {
+        type: 'admin_link',
+        name: extension.title,
+        handle: slugify(extension.title.substring(0, MAX_EXTENSION_HANDLE_LENGTH)),
+        targeting: [
+          {
+            text: config.text,
+            url: config.url,
+            target: contextToTarget(context),
+          },
+        ],
+      },
+    ],
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return encodeToml(localExtensionRepresentation as any)
+}

--- a/packages/app/src/cli/services/admin-link/utils.test.ts
+++ b/packages/app/src/cli/services/admin-link/utils.test.ts
@@ -1,0 +1,25 @@
+import {contextToTarget} from './utils.js'
+import {describe, expect, test} from 'vitest'
+
+describe('admin link utils', () => {
+  test('correctly parses from context `COLLECTIONS#SHOW` to target', () => {
+    // Given
+    const context = 'COLLECTIONS#SHOW'
+
+    // When
+    const target = contextToTarget(context)
+
+    // Then
+    expect(target).toEqual('admin.collection.item.link')
+  })
+  test('correctly parses from context `ORDERS#INDEX` to target', () => {
+    // Given
+    const context = 'ORDERS#INDEX'
+
+    // When
+    const target = contextToTarget(context)
+
+    // Then
+    expect(target).toEqual('admin.order.index.link')
+  })
+})

--- a/packages/app/src/cli/services/admin-link/utils.ts
+++ b/packages/app/src/cli/services/admin-link/utils.ts
@@ -1,0 +1,30 @@
+export const contextToTarget = (context: string) => {
+  const splitContext = context.split('#')
+  if (splitContext.length !== 2 || splitContext.some((part) => part === '' || part === undefined)) {
+    throw new Error('Invalid context')
+  }
+  const domain = 'admin'
+  const subDomain = typeToSubDomain(splitContext[0] || '')
+  const entity = locationToEntity(splitContext[1] || '')
+  const action = 'link'
+
+  return [domain, subDomain, entity, action].join('.')
+}
+
+const locationToEntity = (location: string) => {
+  switch (location.toLocaleLowerCase()) {
+    case 'show':
+      return 'item'
+    case 'index':
+      return 'index'
+    case 'action':
+      return 'selection'
+    case 'fulfilled_card':
+      return 'fulfilled_card'
+    default:
+      throw new Error(`Invalid context location: ${location}`)
+  }
+}
+const typeToSubDomain = (word: string) => {
+  return word.toLocaleLowerCase().replace(new RegExp(`(s)$`), '')
+}

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -16,6 +16,7 @@ import {
   PaymentModulesMap,
   UIModulesMap,
   SubscriptionModulesMap,
+  AdminLinkModulesMap,
 } from '../dev/migrate-app-module.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
@@ -49,6 +50,12 @@ export async function ensureExtensionsIds(
     dashboardExtensions,
     identifiers,
     SubscriptionModulesMap,
+  )
+  const adminLinkExtensionsToMigrate = getModulesToMigrate(
+    localExtensions,
+    dashboardExtensions,
+    identifiers,
+    AdminLinkModulesMap,
   )
 
   let didMigrateDashboardExtensions = false
@@ -113,6 +120,19 @@ export async function ensureExtensionsIds(
       subscriptionLinksToMigrate,
       options.appId,
       'subscription_link_extension',
+      dashboardExtensions,
+      options.developerPlatformClient,
+    )
+    remoteExtensions = remoteExtensions.concat(newRemoteExtensions)
+  }
+
+  if (adminLinkExtensionsToMigrate.length > 0) {
+    const confirmedMigration = await extensionMigrationPrompt(adminLinkExtensionsToMigrate, false)
+    if (!confirmedMigration) throw new AbortSilentError()
+    const newRemoteExtensions = await migrateAppModules(
+      adminLinkExtensionsToMigrate,
+      options.appId,
+      'admin_link',
       dashboardExtensions,
       options.developerPlatformClient,
     )

--- a/packages/app/src/cli/services/dev/migrate-app-module.ts
+++ b/packages/app/src/cli/services/dev/migrate-app-module.ts
@@ -42,6 +42,10 @@ export const SubscriptionModulesMap = {
   subscription_link_extension: ['subscription_link'],
 }
 
+export const AdminLinkModulesMap = {
+  admin_link: ['app_link', 'bulk_action'],
+}
+
 /**
  * Returns a list of local and remote extensions that need to be migrated.
  *


### PR DESCRIPTION
### WHY are these changes introduced?
With the removal of the Partners Dashboard it is needed to migrate all dashboard managed extensions to be CLI managed. This PR adds support to import existing admin links (`app_link` and `bulk_action) and the call to the appModules migration endpoint on their deployment to update them to a CLI managed specification.

### How to test your changes?

- create a new app or reuse an existing one
- create a new app link extension on partners for the app
- in the CLI repository checkout this branch and run `pnpm shopify app import-extensions --path path/to/your/app`
- select admin links and check that in the extensions folder of your app there is a new extension with the toml file matching this structure and fields:
```
[[extensions]]
type = "admin_link"
name = "bulk action name 1"
handle = "bulk-action-name-1"

  [[extensions.targeting]]
  text = "bulk action label"
  url = "http://example.org"
  target = "admin.order.selection.link"

```


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
