### PR TITLE
Allow advanced-edits to review docs updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,5 @@ packages/theme/** @shopify/advanced-edits @shopify/app-inner-loop
 .changeset/* @shopify/advanced-edits @shopify/app-inner-loop
 .github/CODEOWNERS @shopify/advanced-edits @shopify/app-inner-loop
 packages/cli/oclif.manifest.json @shopify/advanced-edits @shopify/app-inner-loop
+docs-shopify.dev/*  @shopify/advanced-edits @shopify/app-inner-loop
 


### PR DESCRIPTION
### WHY are these changes introduced?

Unblock auto-generated documentation change reviews

### WHAT is this pull request doing?
- Adds `@advanced-edits` and @`app-inner-loop` as code owners in the `docs-shopify.dev` directory