### PR TITLE
Restore gift card preview URL

### DIFF
--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -105,7 +105,7 @@ export async function dev(options: DevOptions) {
   }
 }
 
-function renderLinks(store: string, themeId: string, host = DEFAULT_HOST, port = DEFAULT_PORT) {
+export function renderLinks(store: string, themeId: string, host = DEFAULT_HOST, port = DEFAULT_PORT) {
   const remoteUrl = `https://${store}`
   const localUrl = `http://${host}:${port}`
   renderSuccess({
@@ -124,6 +124,14 @@ function renderLinks(store: string, themeId: string, host = DEFAULT_HOST, port =
       },
     ],
     nextSteps: [
+      [
+        {
+          link: {
+            label: 'Preview your gift cards',
+            url: `${localUrl}/gift_cards/[store_id]/preview`,
+          },
+        },
+      ],
       [
         {
           link: {


### PR DESCRIPTION
### WHY are these changes introduced?

It seems like we accidentally removed the gift card preview [here](https://github.com/Shopify/cli/pull/4560/files#diff-6aa5bcfd28a39726943182f60e3836a310541225dab8a218aa25bc9982488536L182-L189). This PR brings it back.

### WHAT is this pull request doing?

It brings the gift card link back and adds a test to avoid a similar scenario in the future.

I'm not adding a changeset because the PR that removed the gift card preview was merged recently, so this is not a user-facing thing.

### How to test your changes?

- Run `shopify theme dev`

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
