### PR TITLE
Show an error when the `config/settings_schema.json` file can't be parsed

### DIFF
--- a/.changeset/small-goats-cough.md
+++ b/.changeset/small-goats-cough.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Show an error when the `config/settings_schema.json` file cannot be parsed.

--- a/packages/theme/src/cli/services/package.test.ts
+++ b/packages/theme/src/cli/services/package.test.ts
@@ -150,6 +150,28 @@ describe('packageTheme', () => {
       expect(renderSuccess).not.toBeCalled()
     })
   })
+
+  test('abort when the config/settings_schema.json file is broken', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const inputDirectory = joinPath(tmpDir, 'theme')
+      await mkdir(inputDirectory)
+      const themeRelativePaths = ['config/settings_schema.json']
+      await createFiles(themeRelativePaths, inputDirectory)
+      await createSettingsSchema('[{"name":', inputDirectory)
+
+      await expect(async () => {
+        // When
+        await packageTheme(inputDirectory)
+
+        // Then
+      }).rejects.toThrowError(
+        /The file config\/settings_schema.json contains an error. Please check if the file is valid JSON and includes the theme_info.theme_name configuration./,
+      )
+
+      expect(renderSuccess).not.toBeCalled()
+    })
+  })
 })
 
 async function createFiles(structure: string[], directory: string) {


### PR DESCRIPTION
### WHY are these changes introduced?

When `config/settings_schema.json` has an error, the `shopify theme package` command was presenting an unactionable error message. Now, it shows a friendly error.

### WHAT is this pull request doing?

Updates the `shopify theme package` to handle that error and also to use `parseJSON` instead of `JSON.parse` to support comments.

### How to test your changes?

- Run `shopify theme package`

Before:
![Screenshot 2024-10-25 at 09 56 46](https://github.com/user-attachments/assets/4dd3633c-c2e2-4c4e-b791-73a35730aad1)

After:
![Screenshot 2024-10-25 at 09 57 03](https://github.com/user-attachments/assets/217f9b3a-c126-4235-a9a6-fb94a9f6cfbb)

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
