### PR TITLE
Remove ruby version from theme info command

### DIFF
--- a/.changeset/great-timers-explode.md
+++ b/.changeset/great-timers-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Remove ruby version from theme info command

--- a/packages/theme/src/cli/services/info.ts
+++ b/packages/theme/src/cli/services/info.ts
@@ -2,7 +2,6 @@ import {getDevelopmentTheme, getThemeStore} from './local-storage.js'
 import {findOrSelectTheme} from '../utilities/theme-selector.js'
 import {DevelopmentThemeManager} from '../utilities/development-theme-manager.js'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
-import {version as rubyVersion} from '@shopify/cli-kit/node/ruby'
 import {checkForNewVersion} from '@shopify/cli-kit/node/node-package-manager'
 import {themeEditorUrl, themePreviewUrl} from '@shopify/cli-kit/node/themes/urls'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
@@ -80,13 +79,11 @@ function devConfigSection(): [string, string] {
 async function systemInfoSection(config: {cliVersion: string}): Promise<[string, string]> {
   const title = 'Tooling and System'
   const {platform, arch} = platformAndArch()
-  const ruby = (await rubyVersion()) || 'Not installed'
   const lines: string[][] = [
     ['Shopify CLI', await cliVersionInfo(config)],
     ['OS', `${platform}-${arch}`],
     ['Shell', process.env.SHELL || 'unknown'],
     ['Node version', process.version],
-    ['Ruby version', ruby],
   ]
   return [title, linesToColumns(lines)]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-advanced-edits/issues/377

Now that we are no longer keeping the legacy ruby commands, we can remove the need to check for a ruby version in `theme info`

### WHAT is this pull request doing?

Remove the ruby version check from the command.

Before:
![image](https://github.com/user-attachments/assets/3c7fce54-ab30-4e16-b876-62570d447203)

After
![image](https://github.com/user-attachments/assets/66989af8-96f9-4c41-b058-05e5c9aeacde)

### How to test your changes?

Pull down the branch
Build the branch
Run `theme info`

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
