### PR TITLE
Clarify v8 of pnpm is required, as v9 is not supported yet

### DIFF
--- a/docs/cli/get-started.md
+++ b/docs/cli/get-started.md
@@ -8,7 +8,7 @@ This wiki contains documentation that's useful for contributors of the project.
 If you'd like to contribute to this project, the following system dependencies need to be present in the environment.
 
 - [Node](https://nodejs.org/en/) (v14 or higher)
-- [PNPM](https://pnpm.io/)
+- [PNPM](https://pnpm.io/) (v8)
 
 ### Set up
 


### PR DESCRIPTION
As per https://github.com/Shopify/cli/issues/4467#issuecomment-2360936979, v8 is required.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
https://github.com/Shopify/cli/issues/4467#issuecomment-2360936979 says that v8 of pnpm is required. I struggled with this bug until accidentally stumbling across the issue. The clarification would be helpful.

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Clarifying the docs for getting started locally.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Follow the instructions, with pnpm v9 installed. Confirm you get the error in the linked issue. 

Downgrade to v8, confirm `pnpm install` works.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
