### PR TITLE
Fix secretKey missing in app dev

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -253,13 +253,13 @@ async function handleUpdatingOfPartnerUrls(
   },
   localApp: AppLinkedInterface,
   cachedUpdateURLs: boolean | undefined,
-  remoteApp: Omit<OrganizationApp, 'apiSecretKeys'> & {apiSecret?: string | undefined},
+  remoteApp: OrganizationApp,
   apiKey: string,
   developerPlatformClient: DeveloperPlatformClient,
 ) {
   const {backendConfig, frontendConfig} = frontAndBackendConfig(webs)
   let shouldUpdateURLs = false
-  if (frontendConfig || backendConfig) {
+  if (frontendConfig ?? backendConfig) {
     if (commandSpecifiedToUpdate) {
       const newURLs = generatePartnersURLs(
         network.proxyUrl,

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -127,7 +127,7 @@ describe('setup-dev-processes', () => {
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',
-      apiSecret: 'api-secret',
+      apiSecretKeys: [{secret: 'api-secret'}],
       id: '1234',
       title: 'App',
       organizationId: '5678',
@@ -300,7 +300,7 @@ describe('setup-dev-processes', () => {
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',
-      apiSecret: 'api-secret',
+      apiSecretKeys: [{secret: 'api-secret'}],
       id: '1234',
       title: 'App',
       organizationId: '5678',
@@ -393,7 +393,7 @@ describe('setup-dev-processes', () => {
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',
-      apiSecret: 'api-secret',
+      apiSecretKeys: [{secret: 'api-secret'}],
       id: '1234',
       title: 'App',
       organizationId: '5678',
@@ -487,7 +487,7 @@ describe('setup-dev-processes', () => {
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',
-      apiSecret: 'api-secret',
+      apiSecretKeys: [{secret: 'api-secret'}],
       id: '1234',
       title: 'App',
       organizationId: '5678',
@@ -580,7 +580,7 @@ describe('setup-dev-processes', () => {
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',
-      apiSecret: 'api-secret',
+      apiSecretKeys: [{secret: 'api-secret'}],
       id: '1234',
       title: 'App',
       organizationId: '5678',

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -48,9 +48,7 @@ interface DevNetworkOptions {
 export interface DevConfig {
   localApp: AppInterface
   remoteAppUpdated: boolean
-  remoteApp: Omit<OrganizationApp, 'apiSecretKeys'> & {
-    apiSecret?: string | undefined
-  }
+  remoteApp: OrganizationApp
   developerPlatformClient: DeveloperPlatformClient
   storeFqdn: string
   storeId: string
@@ -78,7 +76,7 @@ export async function setupDevProcesses({
   graphiqlUrl: string | undefined
 }> {
   const apiKey = remoteApp.apiKey
-  const apiSecret = (remoteApp.apiSecret as string) ?? ''
+  const apiSecret = remoteApp.apiSecretKeys[0]?.secret ?? ''
   const appPreviewUrl = await buildAppURLForWeb(storeFqdn, apiKey)
   const env = getEnvironmentVariables()
   const shouldRenderGraphiQL = !isTruthy(env[environmentVariableNames.disableGraphiQLExplorer])

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -20,7 +20,7 @@ interface ThemeAppExtensionServerOptions {
 }
 
 interface HostThemeSetupOptions {
-  remoteApp: Omit<OrganizationApp, 'apiSecretKeys'>
+  remoteApp: OrganizationApp
   localApp: AppInterface
   storeFqdn: string
   theme?: string
@@ -145,7 +145,7 @@ export async function findOrCreateHostTheme(adminSession: AdminSession, theme?: 
   return hostTheme
 }
 
-async function buildAppUrl(remoteApp: Omit<OrganizationApp, 'apiSecretKeys'>) {
+async function buildAppUrl(remoteApp: OrganizationApp) {
   const fqdn = await partnersFqdn()
 
   return `https://${fqdn}/${remoteApp.organizationId}/apps/${remoteApp.id}/test`

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -15,7 +15,7 @@ import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 export async function outputUpdateURLsResult(
   updated: boolean,
   urls: PartnersURLs,
-  remoteApp: Omit<OrganizationApp, 'apiSecretKeys' | 'apiKey'> & {apiSecret?: string},
+  remoteApp: OrganizationApp,
   localApp: AppInterface,
 ) {
   const dashboardURL = await partnersURL(remoteApp.organizationId, remoteApp.id)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
With recent changes to dev we forgot to properly parse the apiSecretKeys that's passed to the local app.

This is because the type wasn't strict enough, so it wasn't noticed before. 
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Stop using `Omit<OrganizationApp, 'apiSecretKeys'> & {apiSecret: string | undefined}`, it doesn't add any value and is not a strong type.
- Use `OrganizationApp` everywhere and access the secret keys like `app.apiSecretKeys[0].secret`.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
`app dev` should pass the api secret key to the local app
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
