### PR TITLE
Fix the theme ID mismatch error, where the live theme ID is returned instead of the development theme ID

### DIFF
--- a/.changeset/fresh-ears-search.md
+++ b/.changeset/fresh-ears-search.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix the theme ID mismatch error, where the live theme ID is returned instead of the development theme ID

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
@@ -227,47 +227,57 @@ describe('dev proxy', () => {
   describe('canProxyRequest', () => {
     test('should proxy non-GET requests', () => {
       const event = createH3Event('POST', '/some-path.html')
-      expect(canProxyRequest(event)).toBe(true)
+      expect(canProxyRequest(event)).toBeTruthy()
     })
 
     test('should proxy Cart requests as they are not supported by the SFR client', () => {
       const event = createH3Event('GET', '/cart/some-path')
-      expect(canProxyRequest(event)).toBe(true)
+      expect(canProxyRequest(event)).toBeTruthy()
     })
 
     test('should proxy CDN requests', () => {
       const event = createH3Event('GET', '/cdn/some-path')
-      expect(canProxyRequest(event)).toBe(true)
+      expect(canProxyRequest(event)).toBeTruthy()
     })
 
     test('should proxy CDN requests for extensions', () => {
       const event = createH3Event('GET', '/ext/cdn/some-path')
-      expect(canProxyRequest(event)).toBe(true)
+      expect(canProxyRequest(event)).toBeTruthy()
     })
 
     test('should proxy requests with file extensions', () => {
       const event = createH3Event('GET', '/some-path.js')
-      expect(canProxyRequest(event)).toBe(true)
+      expect(canProxyRequest(event)).toBeTruthy()
     })
 
     test('should proxy requests with a non-default accept header', () => {
       const event = createH3Event('GET', '/some-path', {accept: 'application/json'})
-      expect(canProxyRequest(event)).toBe(true)
+      expect(canProxyRequest(event)).toBeTruthy()
     })
 
     test('should not proxy requests with a default accept header and no extension, allowing them to be rendered by the SFR client', () => {
       const event = createH3Event('GET', '/some-path', {accept: '*/*'})
-      expect(canProxyRequest(event)).toBe(false)
+      expect(canProxyRequest(event)).toBeFalsy()
     })
 
     test('should not proxy HTML requests (based on the extension), allowing them to be rendered by the SFR client', () => {
       const event = createH3Event('GET', '/some-path.html')
-      expect(canProxyRequest(event)).toBe(false)
+      expect(canProxyRequest(event)).toBeFalsy()
     })
 
     test('should not proxy HTML requests (based on the "accept" header), allowing them to be rendered by the SFR client', () => {
       const event = createH3Event('GET', '/some-path', {accept: 'text/html'})
-      expect(canProxyRequest(event)).toBe(false)
+      expect(canProxyRequest(event)).toBeFalsy()
+    })
+
+    test('should proxy the /account requests as it may result on 302 (for users with "Sign in with Shop"), and rendering via the the SFR API would result in a broken 200', () => {
+      const event = createH3Event('GET', '/account')
+      expect(canProxyRequest(event)).toBeTruthy()
+    })
+
+    test('should not proxy the /account/login requests', () => {
+      const event = createH3Event('GET', '/account/login')
+      expect(canProxyRequest(event)).toBeFalsy()
     })
   })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
@@ -270,7 +270,11 @@ describe('dev proxy', () => {
       expect(canProxyRequest(event)).toBeFalsy()
     })
 
-    test('should proxy the /account requests as it may result on 302 (for users with "Sign in with Shop"), and rendering via the the SFR API would result in a broken 200', () => {
+    /*
+     * "Sign in with Shop" users face an error if the rendering happens via the
+     * SFR API (as it results in a broken 200, instead of a 302)
+     */
+    test('should proxy the /account requests as it may result on a 302 that must be followd', () => {
       const event = createH3Event('GET', '/account')
       expect(canProxyRequest(event)).toBeTruthy()
     })

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -25,9 +25,14 @@ import type {Theme} from '@shopify/cli-kit/node/themes/types'
 import type {Response as NodeResponse} from '@shopify/cli-kit/node/http'
 import type {DevServerContext} from './types.js'
 
-const CART_PREFIX = '/cart/'
 export const VANITY_CDN_PREFIX = '/cdn/'
 export const EXTENSION_CDN_PREFIX = '/ext/cdn/'
+
+const CART_PATTERN = /^\/cart\//
+const ACCOUNT_PATTERN = /^\/account\/?$/
+const VANITY_CDN_PATTERN = new RegExp(`^${VANITY_CDN_PREFIX}`)
+const EXTENSION_CDN_PATTERN = new RegExp(`^${EXTENSION_CDN_PREFIX}`)
+
 const IGNORED_ENDPOINTS = [
   '/.well-known',
   '/shopify/monorail',
@@ -75,9 +80,10 @@ export function getProxyHandler(_theme: Theme, ctx: DevServerContext) {
  */
 export function canProxyRequest(event: H3Event) {
   if (event.method !== 'GET') return true
-  if (event.path.startsWith(CART_PREFIX)) return true
-  if (event.path.startsWith(VANITY_CDN_PREFIX)) return true
-  if (event.path.startsWith(EXTENSION_CDN_PREFIX)) return true
+  if (event.path.match(CART_PATTERN)) return true
+  if (event.path.match(ACCOUNT_PATTERN)) return true
+  if (event.path.match(VANITY_CDN_PATTERN)) return true
+  if (event.path.match(EXTENSION_CDN_PATTERN)) return true
 
   const [pathname] = event.path.split('?') as [string]
   const extension = extname(pathname)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shopify/cli/issues/4634

When the "Sign in with Shop" is activated, the `/account` endpoint behaves differently (returning the live theme ID in the body) impacting the proxy. However, following the redirect maintains the expected theme ID in the session.

It's important to note that stores without that feature were not being affected by this, and are not affected by this change as well.

### WHAT is this pull request doing?

This PR updates the proxy logic to proxy `/account` requests and avoid the remote-render of the `/account` endpoint.

This PR also refactors the logic in the proxy to rely on regular expressions to evaluate patterns to centralize the logic for each case on the regular expressions and prevent conditions from growing like `p.startsWith(..) && p.endsWith(..)`.

### How to test your changes?

- Run `shopify theme dev` in a store with "Sign in with Shop" is activated
- Open http://127.0.0.1:9292/account in the browser
- Notice the mismatch error no longer happens

**Before**
![before](https://github.com/user-attachments/assets/a8c4f0e4-4a8a-4bc8-b236-fca55cac27ed)

**After**
![after](https://github.com/user-attachments/assets/37e5b951-19be-416c-8887-a96863e952cf)


### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
