### PR TITLE
Add `advanced edits` to CODEOWNERS for `cli-kit` themes changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,6 @@ packages/theme/** @shopify/advanced-edits @shopify/app-inner-loop
 .changeset/* @shopify/advanced-edits @shopify/app-inner-loop
 .github/CODEOWNERS @shopify/advanced-edits @shopify/app-inner-loop
 packages/cli/oclif.manifest.json @shopify/advanced-edits @shopify/app-inner-loop
+packages/cli-kit/src/{private,public}/themes/* @shopify/advanced-edits @shopify/app-inner-loop
 docs-shopify.dev/*  @shopify/advanced-edits @shopify/app-inner-loop
 


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up on this comment: https://github.com/Shopify/cli/pull/4674#issuecomment-2437678202

### WHAT is this pull request doing?
- Adds `advanced-edits` as a code owner for
  - `packages/cli-kit/src/private/themes/*`
  - `packages/cli-kit/src/public/themes/*`

