### PR TITLE
Remove isShopify checks for marketing activity extension

### DIFF
--- a/packages/app/src/cli/commands/app/import-extensions.ts
+++ b/packages/app/src/cli/commands/app/import-extensions.ts
@@ -10,7 +10,6 @@ import {renderSelectPrompt, renderFatalError} from '@shopify/cli-kit/node/ui'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {isShopify} from '@shopify/cli-kit/node/context/local'
 
 interface MigrationChoice {
   label: string
@@ -19,7 +18,7 @@ interface MigrationChoice {
   buildTomlObject: (ext: ExtensionRegistration, allExtensions: ExtensionRegistration[]) => string
 }
 
-const getMigrationChoices = (isShopifolk: boolean): MigrationChoice[] => [
+const getMigrationChoices = (): MigrationChoice[] => [
   {
     label: 'Payments Extensions',
     value: 'payments',
@@ -39,16 +38,12 @@ const getMigrationChoices = (isShopifolk: boolean): MigrationChoice[] => [
     extensionTypes: ['flow_action_definition', 'flow_trigger_definition'],
     buildTomlObject: buildFlowTomlObject,
   },
-  ...(isShopifolk
-    ? [
-        {
-          label: 'Marketing Activity Extensions',
-          value: 'marketing activity',
-          extensionTypes: ['marketing_activity_extension'],
-          buildTomlObject: buildMarketingActivityTomlObject,
-        },
-      ]
-    : []),
+  {
+    label: 'Marketing Activity Extensions',
+    value: 'marketing activity',
+    extensionTypes: ['marketing_activity_extension'],
+    buildTomlObject: buildMarketingActivityTomlObject,
+  },
 ]
 
 export default class ImportExtensions extends AppCommand {
@@ -74,8 +69,7 @@ export default class ImportExtensions extends AppCommand {
       userProvidedConfigName: flags.config,
     })
 
-    const isShopifolk = await isShopify()
-    const migrationChoices = getMigrationChoices(isShopifolk)
+    const migrationChoices = getMigrationChoices()
     const choices = migrationChoices.map((choice) => {
       return {label: choice.label, value: choice.value}
     })

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -16,7 +16,6 @@ import {SingleWebhookSubscriptionType} from '../../models/extensions/specificati
 import {outputCompleted} from '@shopify/cli-kit/node/output'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
 import {groupBy} from '@shopify/cli-kit/common/collection'
-import {isShopify} from '@shopify/cli-kit/node/context/local'
 
 interface AppWithExtensions {
   extensionRegistrations: RemoteSource[]
@@ -30,16 +29,17 @@ export async function ensureExtensionsIds(
     dashboardManagedExtensionRegistrations: dashboardOnlyExtensions,
   }: AppWithExtensions,
 ) {
-  const isShopifolk = await isShopify()
   let remoteExtensions = initialRemoteExtensions
   const validIdentifiers = options.envIdentifiers.extensions ?? {}
   const localExtensions = options.app.allExtensions.filter((ext) => ext.isUUIDStrategyExtension)
 
   const uiExtensionsToMigrate = getUIExtensionsToMigrate(localExtensions, remoteExtensions, validIdentifiers)
   const flowExtensionsToMigrate = getFlowExtensionsToMigrate(localExtensions, dashboardOnlyExtensions, validIdentifiers)
-  const marketingActivityExtensionsToMigrate = isShopifolk
-    ? getMarketingActivtyExtensionsToMigrate(localExtensions, dashboardOnlyExtensions, validIdentifiers)
-    : []
+  const marketingActivityExtensionsToMigrate = getMarketingActivtyExtensionsToMigrate(
+    localExtensions,
+    dashboardOnlyExtensions,
+    validIdentifiers,
+  )
   const paymentsExtensionsToMigrate = getPaymentsExtensionsToMigrate(
     localExtensions,
     dashboardOnlyExtensions,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Removing the `isShopify` check for marketing activity extensions as we are ready for rollout


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
