### PR TITLE
Fix issue with multipass passwords not working with theme dev

### DIFF
--- a/.changeset/serious-radios-travel.md
+++ b/.changeset/serious-radios-travel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Fix issue where you could not use multipass passwords with theme dev

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
@@ -283,5 +283,17 @@ describe('dev proxy', () => {
       const event = createH3Event('GET', '/account/login')
       expect(canProxyRequest(event)).toBeFalsy()
     })
+
+    test('should proxy /account/login/multipass and /account/login/multipass/ requests', () => {
+      const event = createH3Event('GET', '/account/login/multipass')
+      const event2 = createH3Event('GET', '/account/login/multipass/')
+      expect(canProxyRequest(event)).toBeTruthy()
+      expect(canProxyRequest(event2)).toBeTruthy()
+    })
+
+    test('should proxy /account/login/multipass/<token> requests', () => {
+      const event = createH3Event('GET', '/account/login/multipass/<token>')
+      expect(canProxyRequest(event)).toBeTruthy()
+    })
   })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -29,7 +29,7 @@ export const VANITY_CDN_PREFIX = '/cdn/'
 export const EXTENSION_CDN_PREFIX = '/ext/cdn/'
 
 const CART_PATTERN = /^\/cart\//
-const ACCOUNT_PATTERN = /^\/account\/?$/
+const ACCOUNT_PATTERN = /^\/account(\/login\/multipass(\/[^/]+)?)?\/?$/
 const VANITY_CDN_PATTERN = new RegExp(`^${VANITY_CDN_PREFIX}`)
 const EXTENSION_CDN_PATTERN = new RegExp(`^${EXTENSION_CDN_PREFIX}`)
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/4603

When trying to use a multipass password in theme dev, EX: (/account/login/multipass/<my_token>, we were not redirecting logins and only getting `401`'s.

### WHAT is this pull request doing?

Building on @karreiro's changes to allow the `/account` route to be proxied, amended the regex to allow for the multipass token to be passed in the URL. Now we redirect on a successful login and get a `200`

### How to test your changes?

Pull down the branch
Build the branch
run `theme dev`
Create a multipass token https://shopify.dev/docs/api/multipass
go to `/account/login/multipass/<my_token>

### Post-release steps

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
