### PR TITLE
Fix `app init` with custom templates.

### DIFF
--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -199,8 +199,7 @@ async function init(options: InitOptions) {
   let app: OrganizationApp
   if (options.selectedAppOrNameResult.result === 'new') {
     // Load the local app to get the creation options.
-    // NOTE: We need the specs just to load the scopes, if we ever remove the local scopes, we need to find a way to
-    // do this without them.
+    // NOTE: need the specs to load the scopes, if we ever remove the local specs, we need to find a way to do this without them.
     const specifications = await loadLocalExtensionsSpecifications()
     const localApp = await loadApp({specifications, directory: outputDirectory, userProvidedConfigName: undefined})
     const org = options.selectedAppOrNameResult.org


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
`app init` automatically reads the scopes from the template toml to use them to create the app. This doesn't work when the template has a toml with `access_scopes`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Use the local specifications to load the app used to get the `creationDefaultOptions`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
