### PR TITLE
fix Flow action extension CLI deploy to work with marketing activity config field

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -62,6 +62,8 @@ export const FieldSchema = zod.object({
   default_value: zod.any().optional(),
   type: zod.string(),
   validations: zod.array(zod.any()).optional(),
+  marketingActivityCreateUrl: zod.string().optional(),
+  marketingActivityDeleteUrl: zod.string().optional(),
 })
 
 const SettingsSchema = zod.object({

--- a/packages/app/src/cli/services/flow/serialize-fields.ts
+++ b/packages/app/src/cli/services/flow/serialize-fields.ts
@@ -66,6 +66,8 @@ export const serializeCommerceObjectField = (field: ConfigField, type: FlowExten
   }
   if (commerceObject === 'marketing_activity') {
     serializedField.uiType = 'marketing-activity-id'
+    serializedField.marketingActivityCreateUrl = field.marketingActivityCreateUrl
+    serializedField.marketingActivityDeleteUrl = field.marketingActivityDeleteUrl
   }
 
   if (type === 'flow_action') {

--- a/packages/app/src/cli/services/flow/validation.ts
+++ b/packages/app/src/cli/services/flow/validation.ts
@@ -44,6 +44,8 @@ export const validateFieldShape = (
     return baseFieldSchema
       .extend({
         required: zod.boolean().optional(),
+        marketingActivityCreateUrl: zod.string().optional(),
+        marketingActivityDeleteUrl: zod.string().optional(),
       })
       .parse(configField)
   }


### PR DESCRIPTION
### WHY are these changes introduced?
Flow action extension needs to support marketing activity config field.
https://github.com/Shopify/marketing-automations/issues/2118#issuecomment-2430000954

### WHAT is this pull request doing?
Adding the needed logic to support `shopify app deploy` for Flow action extensions with marketing activity config field. The marketing activity config field should get persisted in the `app_static_extension_configs` table in core with the right URL's.

### How to test your changes?
#### Instructions
* spin up `extensions`
* run `yarn create @shopify/app` in extensions terminal
* Start your app by running `dev cd your-app` and then `yarn shopify app dev`. It'll ask you to login, make sure you pick the partners account not regular dev account
* In CLI shell,  run `pnpm shopify app generate extension --path ../extensions/your-app` to generate a Flow action extension, modify the `your-app/extensions/extension-name/shopify.extension.toml` file to include the marketing activity config field.
    ```
    [[settings.fields]]
    type = "marketing_activity_reference"
    marketingActivityCreateUrl = "https://create"
    marketingActivityDeleteUrl = "https://delete"
    ```
* Run `pnpm shopify app deploy --path ../extensions/your-app`, and it should be successful
* In core, check that the config is persisted correctly with the URLs by opening the shopify console and run `Apps::Models::Extensions::Version.find(id).config` where id is the id of the marketing activity extension entry in the `app_static_extension_configs` table (master shard).

#### Results

**config is persisted in app_static_extension_configs table and the content looks correct**
<img width="921" alt="image" src="https://github.com/user-attachments/assets/a9dfba27-97ff-4aa9-a7df-4ababd4fa0f0">

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
