### PR TITLE
Remove curly expansion from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,13 +2,13 @@
 * @shopify/app-inner-loop
 
 # Theme team and CLI owners should review theme changes
+packages/cli-kit/src/private/themes/* @shopify/advanced-edits @shopify/app-inner-loop
+packages/cli-kit/src/public/themes/* @shopify/advanced-edits @shopify/app-inner-loop
 packages/theme/** @shopify/advanced-edits @shopify/app-inner-loop
 
 # These are metafiles that can be reviewed by anyone
 .changeset/* @shopify/advanced-edits @shopify/app-inner-loop
 .github/CODEOWNERS @shopify/advanced-edits @shopify/app-inner-loop
-packages/cli/oclif.manifest.json @shopify/advanced-edits @shopify/app-inner-loop
-packages/cli-kit/src/private/themes/* @shopify/advanced-edits @shopify/app-inner-loop
-packages/cli-kit/src/public/themes/* @shopify/advanced-edits @shopify/app-inner-loop
 docs-shopify.dev/*  @shopify/advanced-edits @shopify/app-inner-loop
+packages/cli/oclif.manifest.json @shopify/advanced-edits @shopify/app-inner-loop
 


### PR DESCRIPTION
### WHY are these changes introduced?
- Received reports that this is breaking Graphite
- Note for future archaeologists: GH may still [report this file as valid](https://github.com/Shopify/cli/blame/9c870c34ed8dc23a7c798b4b469f8f17576ca60a/.github/CODEOWNERS#L11) even if it's not. The actual behaviour itself was not working, so `advanced-edits` was not tagged in PR's as expected.
- This would normally be caught the next time a PR is opened, but this may be able to [test](https://www.rubydoc.info/gems/codeowners-checker) 

### WHAT is this pull request doing?
- Unrolls curly expansion into their own lines
