### PR TITLE
[Themes] Improve storefront password protection redirect handling

### DIFF
--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -53,6 +53,17 @@ describe('Storefront API', () => {
       // Then
       await expect(isProtected).rejects.toThrow(AbortError)
     })
+
+    test('returns false when store redirects via 301 to a non-password page / different domain', async () => {
+      // Given
+      vi.mocked(fetch).mockResolvedValue(response({status: 301, headers: {location: 'https://store.myshopify.se'}}))
+
+      // When
+      const isProtected = isStorefrontPasswordProtected('store.myshopify.com')
+
+      // Then
+      await expect(isProtected).rejects.toThrow(AbortError)
+    })
   })
 
   describe('getStorefrontSessionCookies', () => {

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -5,12 +5,14 @@ import {
 } from './storefront-session.js'
 import {describe, expect, test, vi} from 'vitest'
 import {fetch} from '@shopify/cli-kit/node/http'
+import {renderWarning} from '@shopify/cli-kit/node/ui'
 
 vi.mock('@shopify/cli-kit/node/http')
+vi.mock('@shopify/cli-kit/node/ui')
 
 describe('Storefront API', () => {
   describe('isStorefrontPasswordProtected', () => {
-    test('returns true when the store is password protected', async () => {
+    test('returns true when the request is redirected to the password page', async () => {
       // Given
       vi.mocked(fetch).mockResolvedValue(
         response({status: 302, headers: {location: 'https://store.myshopify.com/password'}}),
@@ -27,9 +29,9 @@ describe('Storefront API', () => {
       })
     })
 
-    test('returns false when the store is not password protected', async () => {
+    test('returns false when request is not redirected', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValue(response({status: 302, headers: {location: 'https://store.myshopify.com/'}}))
+      vi.mocked(fetch).mockResolvedValue(response({status: 200}))
 
       // When
       const isProtected = await isStorefrontPasswordProtected('store.myshopify.com')
@@ -42,8 +44,7 @@ describe('Storefront API', () => {
       })
     })
 
-    // returns false when store redirects to a non-password page
-    test('returns false when store redirects to a non-password page', async () => {
+    test('returns false when store redirects to a non-password page / different domain', async () => {
       // Given
       vi.mocked(fetch).mockResolvedValue(response({status: 302, headers: {location: 'https://store.myshopify.se'}}))
 
@@ -52,6 +53,7 @@ describe('Storefront API', () => {
 
       // Then
       expect(isProtected).toBe(false)
+      expect(renderWarning).toHaveBeenCalled()
     })
   })
 

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -65,6 +65,19 @@ describe('Storefront API', () => {
       // Then
       expect(isProtected).toBe(false)
     })
+
+    test('return true when store redirects to /<locale>/password', async () => {
+      // Given
+      vi.mocked(fetch).mockResolvedValue(
+        response({status: 302, headers: {location: 'https://store.myshopify.com/fr-CA/password'}}),
+      )
+
+      // When
+      const isProtected = await isStorefrontPasswordProtected('store.myshopify.com')
+
+      // Then
+      expect(isProtected).toBe(true)
+    })
   })
 
   describe('getStorefrontSessionCookies', () => {

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -78,6 +78,19 @@ describe('Storefront API', () => {
       // Then
       expect(isProtected).toBe(true)
     })
+
+    test('returns false if response is not a 302', async () => {
+      // Given
+      vi.mocked(fetch).mockResolvedValue(
+        response({status: 301, headers: {location: 'https://store.myshopify.com/random'}}),
+      )
+
+      // When
+      const isProtected = await isStorefrontPasswordProtected('store.myshopify.com')
+
+      // Then
+      expect(isProtected).toBe(false)
+    })
   })
 
   describe('getStorefrontSessionCookies', () => {

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -5,10 +5,9 @@ import {
 } from './storefront-session.js'
 import {describe, expect, test, vi} from 'vitest'
 import {fetch} from '@shopify/cli-kit/node/http'
-import {renderWarning} from '@shopify/cli-kit/node/ui'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 vi.mock('@shopify/cli-kit/node/http')
-vi.mock('@shopify/cli-kit/node/ui')
 
 describe('Storefront API', () => {
   describe('isStorefrontPasswordProtected', () => {
@@ -49,11 +48,10 @@ describe('Storefront API', () => {
       vi.mocked(fetch).mockResolvedValue(response({status: 302, headers: {location: 'https://store.myshopify.se'}}))
 
       // When
-      const isProtected = await isStorefrontPasswordProtected('store.myshopify.com')
+      const isProtected = isStorefrontPasswordProtected('store.myshopify.com')
 
       // Then
-      expect(isProtected).toBe(false)
-      expect(renderWarning).toHaveBeenCalled()
+      await expect(isProtected).rejects.toThrow(AbortError)
     })
   })
 

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -12,14 +12,16 @@ describe('Storefront API', () => {
   describe('isStorefrontPasswordProtected', () => {
     test('returns true when the store is password protected', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValue(response({status: 200}))
+      vi.mocked(fetch).mockResolvedValue(
+        response({status: 302, headers: {location: 'https://store.myshopify.com/password'}}),
+      )
 
       // When
       const isProtected = await isStorefrontPasswordProtected('store.myshopify.com')
 
       // Then
       expect(isProtected).toBe(true)
-      expect(fetch).toBeCalledWith('https://store.myshopify.com/password', {
+      expect(fetch).toBeCalledWith('https://store.myshopify.com', {
         method: 'GET',
         redirect: 'manual',
       })
@@ -27,17 +29,29 @@ describe('Storefront API', () => {
 
     test('returns false when the store is not password protected', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValue(response({status: 302}))
+      vi.mocked(fetch).mockResolvedValue(response({status: 302, headers: {location: 'https://store.myshopify.com/'}}))
 
       // When
       const isProtected = await isStorefrontPasswordProtected('store.myshopify.com')
 
       // Then
       expect(isProtected).toBe(false)
-      expect(fetch).toBeCalledWith('https://store.myshopify.com/password', {
+      expect(fetch).toBeCalledWith('https://store.myshopify.com', {
         method: 'GET',
         redirect: 'manual',
       })
+    })
+
+    // returns false when store redirects to a non-password page
+    test('returns false when store redirects to a non-password page', async () => {
+      // Given
+      vi.mocked(fetch).mockResolvedValue(response({status: 302, headers: {location: 'https://store.myshopify.se'}}))
+
+      // When
+      const isProtected = await isStorefrontPasswordProtected('store.myshopify.com')
+
+      // Then
+      expect(isProtected).toBe(false)
     })
   })
 

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -12,24 +12,32 @@ describe('Storefront API', () => {
   describe('isStorefrontPasswordProtected', () => {
     test('returns true when the store is password protected', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValue(response({status: 302}))
+      vi.mocked(fetch).mockResolvedValue(response({status: 200}))
 
       // When
-      const isProtected = await isStorefrontPasswordProtected('https://store.myshopify.com')
+      const isProtected = await isStorefrontPasswordProtected('store.myshopify.com')
 
       // Then
       expect(isProtected).toBe(true)
+      expect(fetch).toBeCalledWith('https://store.myshopify.com/password', {
+        method: 'GET',
+        redirect: 'manual',
+      })
     })
 
     test('returns false when the store is not password protected', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValue(response({status: 200}))
+      vi.mocked(fetch).mockResolvedValue(response({status: 302}))
 
       // When
-      const isProtected = await isStorefrontPasswordProtected('https://store.myshopify.com')
+      const isProtected = await isStorefrontPasswordProtected('store.myshopify.com')
 
       // Then
       expect(isProtected).toBe(false)
+      expect(fetch).toBeCalledWith('https://store.myshopify.com/password', {
+        method: 'GET',
+        redirect: 'manual',
+      })
     })
   })
 

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -4,14 +4,23 @@ import {fetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 
+// !!! ding ding ding I think it's here but like honestly not sure
 export async function isStorefrontPasswordProtected(storeURL: string): Promise<boolean> {
-  const response = await fetch(`${prependHttps(storeURL)}/password`, {
+  const response = await fetch(prependHttps(storeURL), {
     method: 'GET',
     redirect: 'manual',
   })
-  const passwordPageRedirects = response.status === 302
 
-  return !passwordPageRedirects
+  const redirectsToPasswordPage =
+    response.status === 302 && response.headers.get('location') === `${prependHttps(storeURL)}/password`
+
+  outputDebug(
+    `checking if store is password protected: ${redirectsToPasswordPage}\n
+    - status: ${response.status}\n
+    - location: ${response.headers.get('location')}`,
+  )
+
+  return redirectsToPasswordPage
 }
 
 /**

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -5,12 +5,13 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 
 export async function isStorefrontPasswordProtected(storeURL: string): Promise<boolean> {
-  const response = await fetch(prependHttps(storeURL), {
+  const response = await fetch(`${prependHttps(storeURL)}/password`, {
     method: 'GET',
     redirect: 'manual',
   })
+  const passwordPageRedirects = response.status === 302
 
-  return response.status === 302
+  return !passwordPageRedirects
 }
 
 /**

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -3,7 +3,6 @@ import {defaultHeaders} from './storefront-utils.js'
 import {fetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputDebug} from '@shopify/cli-kit/node/output'
-import {renderWarning} from '@shopify/cli-kit/node/ui'
 
 export async function isStorefrontPasswordProtected(storeURL: string): Promise<boolean> {
   const response = await fetch(prependHttps(storeURL), {
@@ -16,9 +15,9 @@ export async function isStorefrontPasswordProtected(storeURL: string): Promise<b
     if (redirectLocation === `${prependHttps(storeURL)}/password`) {
       return true
     } else if (redirectLocation) {
-      renderWarning({
-        body: `${storeURL} redirected to ${redirectLocation}. Please update the --store flag as this may cause issues.`,
-      })
+      throw new AbortError(
+        `${storeURL} redirected to ${redirectLocation}. Please update the --store flag as this may cause issues.`,
+      )
     }
   }
 

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -10,6 +10,8 @@ export async function isStorefrontPasswordProtected(storeURL: string): Promise<b
     redirect: 'manual',
   })
 
+  if (response.status !== 302) return false
+
   return response.headers.get('location')?.endsWith('/password') ?? false
 }
 

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -10,18 +10,7 @@ export async function isStorefrontPasswordProtected(storeURL: string): Promise<b
     redirect: 'manual',
   })
 
-  if (response.status !== 302 && response.status !== 301) {
-    return false
-  }
-
-  const redirectLocation = response.headers.get('location')
-  if (redirectLocation === `${prependHttps(storeURL)}/password`) {
-    return true
-  } else {
-    throw new AbortError(
-      `${storeURL} redirected to ${redirectLocation}. Please update the --store flag as this may cause issues.`,
-    )
-  }
+  return response.headers.get('location') === `${prependHttps(storeURL)}/password`
 }
 
 /**

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -10,7 +10,7 @@ export async function isStorefrontPasswordProtected(storeURL: string): Promise<b
     redirect: 'manual',
   })
 
-  return response.headers.get('location') === `${prependHttps(storeURL)}/password`
+  return response.headers.get('location')?.endsWith('/password') ?? false
 }
 
 /**

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -10,18 +10,18 @@ export async function isStorefrontPasswordProtected(storeURL: string): Promise<b
     redirect: 'manual',
   })
 
-  if (response.status === 302) {
-    const redirectLocation = response.headers.get('location')
-    if (redirectLocation === `${prependHttps(storeURL)}/password`) {
-      return true
-    } else if (redirectLocation) {
-      throw new AbortError(
-        `${storeURL} redirected to ${redirectLocation}. Please update the --store flag as this may cause issues.`,
-      )
-    }
+  if (response.status !== 302 && response.status !== 301) {
+    return false
   }
 
-  return false
+  const redirectLocation = response.headers.get('location')
+  if (redirectLocation === `${prependHttps(storeURL)}/password`) {
+    return true
+  } else {
+    throw new AbortError(
+      `${storeURL} redirected to ${redirectLocation}. Please update the --store flag as this may cause issues.`,
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/cli/issues/4737

Fixes a bug in the storefront password protection detection logic where redirects on the provided URL (e.g. `.com` -> `.se`) cause us to detect the storefront as password protected.

### WHAT is this pull request doing?

- Specifically check for redirects to the `/password` path, rather than assuming any `302` redirect indicates password protection
- Improving debug output for password protection status

### How to test your changes?
**Replicate**
1. Disable password protection on your store
2. Add a domain to your store, and set that as your default domain
3. Provide the original (now secondary) domain in the `--store` flag value
4. Run `pnpm shopify theme dev` with this branch and verify the appropriate error message is shown

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JdHLnhebSbtZTZO01I1e/f4c0979d-bf37-4e2b-a1c9-9bd94f33e88f.png)

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes