### PR TITLE
Make sure the dev-session starts after the app-watcher is ready

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -89,6 +89,7 @@ export class AppEventWatcher extends EventEmitter {
   private readonly options: OutputContextOptions
   private readonly appURL?: string
   private readonly esbuildManager: ESBuildContextManager
+  private started = false
 
   constructor(app: AppLinkedInterface, appURL?: string, options?: OutputContextOptions, buildOutputPath?: string) {
     super()
@@ -105,6 +106,8 @@ export class AppEventWatcher extends EventEmitter {
   }
 
   async start() {
+    if (this.started) return
+    this.started = true
     // If there is a previous build folder, delete it
     if (await fileExists(this.buildOutputPath)) await rmdir(this.buildOutputPath, {force: true})
     await mkdir(this.buildOutputPath)
@@ -145,6 +148,8 @@ export class AppEventWatcher extends EventEmitter {
           this.options.stderr.write(`Error handling event: ${error.message}`)
         })
     })
+
+    this.emit('ready')
   }
 
   /**
@@ -156,6 +161,20 @@ export class AppEventWatcher extends EventEmitter {
   onEvent(listener: (appEvent: AppEvent) => Promise<void> | void) {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.addListener('all', listener)
+    return this
+  }
+
+  /**
+   * Register as a listener for the start event.
+   * This event is emitted when the watcher is ready to start processing events. (after the initial extension build)
+   *
+   * @param listener - The listener function to add
+   * @returns The AppEventWatcher instance
+   */
+  onStart(listener: () => Promise<void> | void) {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    this.addListener('ready', listener)
+    if (this.started) this.emit('ready')
     return this
   }
 

--- a/packages/app/src/cli/services/dev/processes/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session.ts
@@ -9,9 +9,10 @@ import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {zip} from '@shopify/cli-kit/node/archiver'
 import {formData, fetch} from '@shopify/cli-kit/node/http'
-import {outputDebug, outputWarn} from '@shopify/cli-kit/node/output'
+import {outputContent, outputDebug, outputToken} from '@shopify/cli-kit/node/output'
 import {endHRTimeInMs, startHRTime} from '@shopify/cli-kit/node/hrtime'
 import {performActionWithRetryAfterRecovery} from '@shopify/cli-kit/common/retry'
+import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
 import {Writable} from 'stream'
 
 interface DevSessionOptions {
@@ -57,7 +58,7 @@ export async function setupDevSessionProcess({
   }
 }
 
-export const pushUpdatesForDevSession: DevProcessFunction<DevSessionOptions> = async (
+const pushUpdatesForDevSession: DevProcessFunction<DevSessionOptions> = async (
   {stderr, stdout, abortSignal: signal},
   options,
 ) => {
@@ -74,49 +75,50 @@ export const pushUpdatesForDevSession: DevProcessFunction<DevSessionOptions> = a
 
   const processOptions = {...options, stderr, stdout, signal, bundlePath: appWatcher.buildOutputPath}
 
-  outputWarn('-----> Using DEV SESSIONS <-----')
-  processOptions.stdout.write('Preparing dev session...')
+  await printWarning('[BETA] Starting Dev Session', processOptions.stdout)
 
-  await bundleExtensionsAndUpload(processOptions, false)
+  appWatcher
+    .onEvent(async (event) => {
+      // Cancel any ongoing bundle and upload process
+      bundleControllers.forEach((controller) => controller.abort())
+      // Remove aborted controllers from array:
+      bundleControllers = bundleControllers.filter((controller) => !controller.signal.aborted)
 
-  appWatcher.onEvent(async (event) => {
-    // Cancel any ongoing bundle and upload process
-    bundleControllers.forEach((controller) => controller.abort())
-    // Remove aborted controllers from array:
-    bundleControllers = bundleControllers.filter((controller) => !controller.signal.aborted)
+      event.extensionEvents.map((eve) => {
+        switch (eve.type) {
+          case EventType.Created:
+            processOptions.stdout.write(`✅ Extension created ->> ${eve.extension.handle}`)
+            break
+          case EventType.Deleted:
+            processOptions.stdout.write(`❌ Extension deleted ->> ${eve.extension.handle}`)
+            break
+          case EventType.Updated:
+            processOptions.stdout.write(`🔄 Extension Updated ->> ${eve.extension.handle}`)
+            break
+        }
+      })
 
-    event.extensionEvents.map((eve) => {
-      switch (eve.type) {
-        case EventType.Created:
-          processOptions.stdout.write(`✅ Extension created ->> ${eve.extension.handle}`)
-          break
-        case EventType.Deleted:
-          processOptions.stdout.write(`❌ Extension deleted ->> ${eve.extension.handle}`)
-          break
-        case EventType.Updated:
-          processOptions.stdout.write(`🔄 Extension Updated ->> ${eve.extension.handle}`)
-          break
-      }
+      const networkStartTime = startHRTime()
+      await performActionWithRetryAfterRecovery(async () => {
+        const result = await bundleExtensionsAndUpload({...processOptions, app: event.app}, true)
+        const endTime = endHRTimeInMs(event.startTime)
+        const endNetworkTime = endHRTimeInMs(networkStartTime)
+        if (result) {
+          processOptions.stdout.write(`✅ Session updated [Network: ${endNetworkTime}ms -- Total: ${endTime}ms]`)
+        } else {
+          processOptions.stdout.write(
+            `❌ Session update aborted (new change detected) [Network: ${endNetworkTime}ms -- Total: ${endTime}ms]`,
+          )
+        }
+      }, refreshToken)
     })
-
-    const networkStartTime = startHRTime()
-    await performActionWithRetryAfterRecovery(async () => {
-      const result = await bundleExtensionsAndUpload({...processOptions, app: event.app}, true)
-      const endTime = endHRTimeInMs(event.startTime)
-      const endNetworkTime = endHRTimeInMs(networkStartTime)
-      if (result) {
-        processOptions.stdout.write(`✅ Session updated [Network: ${endNetworkTime}ms -- Total: ${endTime}ms]`)
-      } else {
-        processOptions.stdout.write(
-          `❌ Session update aborted (new change detected) [Network: ${endNetworkTime}ms -- Total: ${endTime}ms]`,
-        )
-      }
-    }, refreshToken)
-  })
+    .onStart(async () => {
+      await bundleExtensionsAndUpload(processOptions, false)
+      await printWarning('[BETA] Dev session ready, watching for changes in your app', processOptions.stdout)
+    })
 
   // Start watching for changes in the app
   await appWatcher.start()
-  processOptions.stdout.write(`Dev session ready, watching for changes in your app`)
 }
 
 /**
@@ -184,4 +186,14 @@ async function bundleExtensionsAndUpload(options: DevSessionProcessOptions, upda
     options.stderr.write(error.message)
   }
   return true
+}
+
+async function printWarning(message: string, stdout: Writable) {
+  await printLogMessage(outputContent`${outputToken.yellow(message)}`.value, stdout)
+}
+
+async function printLogMessage(message: string, stdout: Writable) {
+  await useConcurrentOutputContext({outputPrefix: 'extensions', stripAnsi: false}, () => {
+    stdout.write(message)
+  })
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Recent changes to the app watcher were causing a race condition where the dev-session would start before the app watcher was ready and the bundle folder didn't exist.

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2294

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Add a new `start` event to the app watcher, so that the dev-session will start AFTER the watcher is completely initialized and the extensions built.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
In an app without a `.shopify/bundle` folder, run `dev` using the app management api
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
