### PR TITLE
Use Shopify CDN URL instead of GitHub CDN

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -305,7 +305,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
           'Failed to fetch extension templates from',
           {link: {url: TEMPLATE_JSON_URL}},
           {char: '.'},
-          'This likely means a problem with GitHub.',
+          'This likely means a problem with your internet connection.',
         ],
         [
           {link: {url: 'https://www.githubstatus.com', label: 'Check if GitHub is experiencing downtime'}},

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -115,7 +115,7 @@ import {versionSatisfies} from '@shopify/cli-kit/node/node-package-manager'
 import {outputWarn} from '@shopify/cli-kit/node/output'
 import {developerDashboardFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
-const TEMPLATE_JSON_URL = 'https://raw.githubusercontent.com/Shopify/extensions-templates/main/templates.json'
+const TEMPLATE_JSON_URL = 'https://cdn.shopify.com/static/cli/extensions/templates.json'
 
 type OrgType = NonNullable<ListAppDevStoresQuery['organization']>
 type Properties = NonNullable<OrgType['properties']>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2265 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Switches to Shopify CDN hosted templates JSON, so we're not relying directly on GitHub's CDN infrastructure for moment-to-moment CLI operations.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

```sh
$ USE_APP_MANAGEMENT_API=1 pnpm app generate extension --path /path/to/your/app
```

You should see the prompt as usual.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
