### PR TITLE
[Theme] Delay watcher events until file is fully written

### DIFF
--- a/.changeset/chatty-months-sit.md
+++ b/.changeset/chatty-months-sit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Increase file watcher stability threshold to handle uploading of large files.

--- a/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-fs.ts
@@ -117,6 +117,13 @@ export function mountThemeExtensionFileSystem(root: string): ThemeExtensionFileS
         ignored: DEFAULT_IGNORE_PATTERNS,
         persistent: !process.env.SHOPIFY_UNIT_TEST,
         ignoreInitial: true,
+        // Big files (e.g. Tailwind output) can take a while to write.
+        // Delaying the event until the file size doesn't change for a
+        // short period ensures that we get the fully written file:
+        awaitWriteFinish: {
+          stabilityThreshold: 400,
+          pollInterval: 100,
+        },
       })
 
       watcher

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -252,6 +252,13 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
         ignored: DEFAULT_IGNORE_PATTERNS,
         persistent: !process.env.SHOPIFY_UNIT_TEST,
         ignoreInitial: true,
+        // Big files (e.g. Tailwind output) can take a while to write.
+        // Delaying the event until the file size doesn't change for a
+        // short period ensures that we get the fully written file:
+        awaitWriteFinish: {
+          stabilityThreshold: 400,
+          pollInterval: 100,
+        },
       })
 
       watcher


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

A bit of a shot in the dark but might help in #4764

Tailwind seems to be clearing the output file first, then building its CSS, then writing the actual output content. In this scenario, we'd be emitting an event for the empty file first, then another one every time the file is written (could be in multiple chunks, unsure). Perhaps the latter events are lost or throttled down the line.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This delays the watcher events until a safe period of time passes without file size changes. It delays all events, but it's a short period that might not be very noticeable.

The alternative would be adding some sort of debouncing logic before calling `bulkUploadThemeAssets`, or canceling in-flight fetch calls and sending new again as they come. These approaches seemed more complex that delaying the watcher events directly.

If the current solutions works in #4764, we might want to set a sensible default (e.g. 400ms) or introduce a flag / env variable to customize this for situations where there are big files.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
