### PR TITLE
[Themes] Verify existence of required theme files before initializing storefront session

### DIFF
--- a/.changeset/brown-dots-clap.md
+++ b/.changeset/brown-dots-clap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Added a warning to help users troubleshoot when a development theme is missing required files

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
@@ -1,0 +1,70 @@
+import {verifyRequiredFilesExist} from './dev-server-session.js'
+import {fetchThemeAssets, themeDelete} from '@shopify/cli-kit/node/themes/api'
+import {describe, expect, test, vi} from 'vitest'
+import {AdminSession} from '@shopify/cli-kit/node/session'
+import {ThemeAsset} from '@shopify/cli-kit/node/themes/types'
+
+vi.mock('@shopify/cli-kit/node/themes/api')
+vi.mock('timers', () => ({
+  setTimeout: () => Promise.resolve(),
+}))
+
+const mockAdminSession: AdminSession = {token: 'token', storeFqdn: 'store.myshopify.com'}
+const themeId = '1234'
+
+const mockLayoutAsset: ThemeAsset = {
+  key: 'layout/theme.liquid',
+  value: 'content',
+  attachment: undefined,
+  checksum: 'asdf',
+}
+
+const mockConfigAsset: ThemeAsset = {
+  key: 'config/settings_schema.json',
+  value: '[]',
+  attachment: undefined,
+  checksum: 'fdsa',
+}
+
+describe('verifyRequiredFilesExist', () => {
+  test('succeeds when both required files exist', async () => {
+    // Given
+    vi.mocked(fetchThemeAssets).mockResolvedValue([mockLayoutAsset, mockConfigAsset])
+
+    // When
+    await expect(verifyRequiredFilesExist(themeId, mockAdminSession)).resolves.not.toThrow()
+
+    // Then
+    expect(themeDelete).not.toHaveBeenCalled()
+  })
+
+  test('retries once and succeeds if files exist on second attempt', async () => {
+    // Given
+    vi.mocked(fetchThemeAssets).mockResolvedValueOnce([]).mockResolvedValue([mockLayoutAsset, mockConfigAsset])
+
+    // When
+    const promise = verifyRequiredFilesExist(themeId, mockAdminSession)
+    vi.runAllTimers()
+    await expect(promise).resolves.not.toThrow()
+
+    // Then
+    expect(fetchThemeAssets).toHaveBeenCalledTimes(2)
+    expect(themeDelete).not.toHaveBeenCalled()
+  })
+
+  test('deletes theme and throws if any file is missing after retry', async () => {
+    // Given
+    vi.mocked(fetchThemeAssets).mockResolvedValue([mockLayoutAsset])
+    vi.mocked(themeDelete).mockResolvedValue(true)
+
+    // When
+    const promise = verifyRequiredFilesExist(themeId, mockAdminSession)
+    vi.runAllTimers()
+    await expect(promise).rejects.toThrow(
+      'Invalid theme removed from storefront. Please try deleting the theme and recreating it.',
+    )
+
+    // Then
+    expect(themeDelete).toHaveBeenCalledWith(1234, mockAdminSession)
+  })
+})

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
@@ -5,6 +5,7 @@ import {fetchThemeAssets, themeDelete} from '@shopify/cli-kit/node/themes/api'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 import {ThemeAsset} from '@shopify/cli-kit/node/themes/types'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 
 vi.mock('@shopify/cli-kit/node/themes/api')
 vi.mock('@shopify/cli-kit/node/session')
@@ -38,8 +39,11 @@ describe('fetchDevServerSession', () => {
     // When/Then
     await expect(fetchDevServerSession(themeId, mockAdminSession)).rejects.toThrow(
       new AbortError(
-        `The theme with id ${themeId} is missing required files.
-        Please try deleting by running \`shopify theme delete -t ${themeId}\` and recreating it.`,
+        outputContent`The theme with id ${outputToken.cyan(
+          themeId,
+        )} is missing required files. Please try deleting by running ${outputToken.cyan(
+          `shopify theme delete -t ${themeId}`,
+        )} and recreating it.`.value,
       ),
     )
   })

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
@@ -1,4 +1,4 @@
-import {fetchDevServerSession, verifyRequiredFilesExist} from './dev-server-session.js'
+import {fetchDevServerSession, abortOnMissingRequiredFile} from './dev-server-session.js'
 import {getStorefrontSessionCookies, ShopifyEssentialError} from './storefront-session.js'
 import {AdminSession, ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {fetchThemeAssets, themeDelete} from '@shopify/cli-kit/node/themes/api'
@@ -39,11 +39,9 @@ describe('fetchDevServerSession', () => {
     // When/Then
     await expect(fetchDevServerSession(themeId, mockAdminSession)).rejects.toThrow(
       new AbortError(
-        outputContent`The theme with id ${outputToken.cyan(
-          themeId,
-        )} is missing required files. Please try deleting by running ${outputToken.cyan(
+        outputContent`Theme ${outputToken.cyan(themeId)} is missing required files. Run ${outputToken.cyan(
           `shopify theme delete -t ${themeId}`,
-        )} and recreating it.`.value,
+        )} to delete it, then try your command again.`.value,
       ),
     )
   })
@@ -60,7 +58,7 @@ describe('verifyRequiredFilesExist', () => {
 
     // When
     // Then
-    await expect(verifyRequiredFilesExist(themeId, mockAdminSession)).resolves.not.toThrow()
+    await expect(abortOnMissingRequiredFile(themeId, mockAdminSession)).resolves.not.toThrow()
   })
 
   //   throws an AbortError if any file is missing
@@ -70,6 +68,6 @@ describe('verifyRequiredFilesExist', () => {
 
     // When
     // Then
-    await expect(verifyRequiredFilesExist(themeId, mockAdminSession)).rejects.toThrow()
+    await expect(abortOnMissingRequiredFile(themeId, mockAdminSession)).rejects.toThrow()
   })
 })

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
@@ -46,7 +46,11 @@ export async function initializeDevServerSession(
   return session
 }
 
-export async function verifyRequiredFilesExist(themeId: string, adminSession: AdminSession) {
+export async function verifyRequiredFilesExist(
+  themeId: string,
+  adminSession: AdminSession,
+  retryDelay = RETRY_DELAY_MS,
+) {
   outputDebug(`Verifying required files for theme ${themeId}...`)
 
   const themeIdNumber = Number(themeId)
@@ -58,7 +62,7 @@ export async function verifyRequiredFilesExist(themeId: string, adminSession: Ad
 
   const hasFiles = await areFilesPresent()
   if (!hasFiles) {
-    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
+    await new Promise((resolve) => setTimeout(resolve, retryDelay))
 
     const hasFilesAfterRetry = await areFilesPresent()
     if (!hasFilesAfterRetry) {

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
@@ -43,7 +43,7 @@ export async function initializeDevServerSession(
   return session
 }
 
-export async function fetchDevServerSession(
+async function fetchDevServerSession(
   themeId: string,
   adminSession: AdminSession,
   adminPassword?: string,

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
@@ -3,7 +3,7 @@ import {getStorefrontSessionCookies, ShopifyEssentialError} from './storefront-s
 import {DevServerSession} from './types.js'
 import {fetchThemeAssets} from '@shopify/cli-kit/node/themes/api'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {outputDebug} from '@shopify/cli-kit/node/output'
+import {outputDebug, outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {AdminSession, ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 
 // 30 minutes in miliseconds.
@@ -80,8 +80,11 @@ export async function verifyRequiredFilesExist(themeId: string, adminSession: Ad
 
   if (requiredAssets.length !== REQUIRED_THEME_FILES.length) {
     throw new AbortError(
-      `The theme with id ${themeId} is missing required files.
-      Please try deleting by running \`shopify theme delete -t ${themeId}\` and recreating it.`,
+      outputContent`The theme with id ${outputToken.cyan(
+        themeId,
+      )} is missing required files. Please try deleting by running ${outputToken.cyan(
+        `shopify theme delete -t ${themeId}`,
+      )} and recreating it.`.value,
     )
   }
 

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
@@ -1,15 +1,14 @@
 import {buildBaseStorefrontUrl} from './storefront-renderer.js'
-import {getStorefrontSessionCookies} from './storefront-session.js'
+import {getStorefrontSessionCookies, ShopifyEssentialError} from './storefront-session.js'
 import {DevServerSession} from './types.js'
+import {fetchThemeAssets} from '@shopify/cli-kit/node/themes/api'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AdminSession, ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
-import {AbortError} from '@shopify/cli-kit/node/error'
-import {fetchThemeAssets, themeDelete} from '@shopify/cli-kit/node/themes/api'
 
 // 30 minutes in miliseconds.
 const SESSION_TIMEOUT_IN_MS = 30 * 60 * 1000
 const REQUIRED_THEME_FILES = ['layout/theme.liquid', 'config/settings_schema.json']
-const RETRY_DELAY_MS = 3000
 
 /**
  * Initialize the session object, which is automatically refreshed
@@ -28,8 +27,6 @@ export async function initializeDevServerSession(
   adminPassword?: string,
   storefrontPassword?: string,
 ) {
-  await verifyRequiredFilesExist(themeId, adminSession)
-
   const session = await fetchDevServerSession(themeId, adminSession, adminPassword, storefrontPassword)
 
   setInterval(() => {
@@ -46,51 +43,47 @@ export async function initializeDevServerSession(
   return session
 }
 
-export async function verifyRequiredFilesExist(
-  themeId: string,
-  adminSession: AdminSession,
-  retryDelay = RETRY_DELAY_MS,
-) {
-  outputDebug(`Verifying required files for theme ${themeId}...`)
-
-  const themeIdNumber = Number(themeId)
-
-  const areFilesPresent = async () => {
-    const assets = await fetchThemeAssets(themeIdNumber, REQUIRED_THEME_FILES, adminSession)
-    return assets.length === REQUIRED_THEME_FILES.length
-  }
-
-  const hasFiles = await areFilesPresent()
-  if (!hasFiles) {
-    await new Promise((resolve) => setTimeout(resolve, retryDelay))
-
-    const hasFilesAfterRetry = await areFilesPresent()
-    if (!hasFilesAfterRetry) {
-      await themeDelete(themeIdNumber, adminSession)
-      throw new AbortError('Invalid theme removed from storefront. Please try deleting the theme and recreating it.')
-    }
-  }
-}
-
-async function fetchDevServerSession(
+export async function fetchDevServerSession(
   themeId: string,
   adminSession: AdminSession,
   adminPassword?: string,
   storefrontPassword?: string,
 ): Promise<DevServerSession> {
-  const baseUrl = buildBaseStorefrontUrl(adminSession)
+  try {
+    const baseUrl = buildBaseStorefrontUrl(adminSession)
 
-  const session = await ensureAuthenticatedThemes(adminSession.storeFqdn, adminPassword, [])
-  const storefrontToken = await ensureAuthenticatedStorefront([], adminPassword)
-  const sessionCookies = await getStorefrontSessionCookies(baseUrl, themeId, storefrontPassword, {
-    'X-Shopify-Shop': session.storeFqdn,
-    'X-Shopify-Access-Token': session.token,
-    Authorization: `Bearer ${storefrontToken}`,
-  })
+    const session = await ensureAuthenticatedThemes(adminSession.storeFqdn, adminPassword, [])
+    const storefrontToken = await ensureAuthenticatedStorefront([], adminPassword)
+    const sessionCookies = await getStorefrontSessionCookies(baseUrl, themeId, storefrontPassword, {
+      'X-Shopify-Shop': session.storeFqdn,
+      'X-Shopify-Access-Token': session.token,
+      Authorization: `Bearer ${storefrontToken}`,
+    })
 
-  return {
-    ...session,
-    sessionCookies,
-    storefrontToken,
+    return {
+      ...session,
+      sessionCookies,
+      storefrontToken,
+    }
+  } catch (error) {
+    if (error instanceof ShopifyEssentialError) {
+      await verifyRequiredFilesExist(themeId, adminSession)
+    }
+
+    throw error
   }
+}
+
+export async function verifyRequiredFilesExist(themeId: string, adminSession: AdminSession) {
+  outputDebug(`Verifying if theme with id ${themeId} has required files...`)
+  const requiredAssets = await fetchThemeAssets(Number(themeId), REQUIRED_THEME_FILES, adminSession)
+
+  if (requiredAssets.length !== REQUIRED_THEME_FILES.length) {
+    throw new AbortError(
+      `The theme with id ${themeId} is missing required files.
+      Please try deleting by running \`shopify theme delete -t ${themeId}\` and recreating it.`,
+    )
+  }
+
+  outputDebug(`Theme with id ${themeId} has required files.`)
 }

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -2,9 +2,11 @@ import {
   getStorefrontSessionCookies,
   isStorefrontPasswordCorrect,
   isStorefrontPasswordProtected,
+  ShopifyEssentialError,
 } from './storefront-session.js'
 import {describe, expect, test, vi} from 'vitest'
 import {fetch} from '@shopify/cli-kit/node/http'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 vi.mock('@shopify/cli-kit/node/http')
 
@@ -133,7 +135,7 @@ describe('Storefront API', () => {
       expect(cookies).toEqual({_shopify_essential: ':AABBCCDDEEFFGGHH==123:', storefront_digest: 'digest-value'})
     })
 
-    test(`throws an error when _shopify_essential can't be defined`, async () => {
+    test(`throws an ShopifyEssentialError when _shopify_essential can't be defined`, async () => {
       // Given
       vi.mocked(fetch)
         .mockResolvedValueOnce(
@@ -156,7 +158,9 @@ describe('Storefront API', () => {
 
       // Then
       await expect(cookies).rejects.toThrow(
-        'Your development session could not be created because the "_shopify_essential" could not be defined. Please, check your internet connection.',
+        new ShopifyEssentialError(
+          'Your development session could not be created because the "_shopify_essential" could not be defined. Please, check your internet connection.',
+        ),
       )
     })
 
@@ -182,7 +186,9 @@ describe('Storefront API', () => {
 
       // Then
       await expect(cookies).rejects.toThrow(
-        'Your development session could not be created because the store password is invalid. Please, retry with a different password.',
+        new AbortError(
+          'Your development session could not be created because the store password is invalid. Please, retry with a different password.',
+        ),
       )
     })
   })

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -4,6 +4,8 @@ import {fetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 
+export class ShopifyEssentialError extends Error {}
+
 export async function isStorefrontPasswordProtected(storeURL: string): Promise<boolean> {
   const response = await fetch(prependHttps(storeURL), {
     method: 'GET',
@@ -53,16 +55,6 @@ export async function getStorefrontSessionCookies(
   const cookieRecord: {[key: string]: string} = {}
   const shopifyEssential = await sessionEssentialCookie(storeUrl, themeId, headers)
 
-  if (!shopifyEssential) {
-    /**
-     * SFR should always define a _shopify_essential, so an error at this point
-     * is likely a Shopify error or firewall issue.
-     */
-    throw new AbortError(
-      'Your development session could not be created because the "_shopify_essential" could not be defined. Please, check your internet connection.',
-    )
-  }
-
   cookieRecord._shopify_essential = shopifyEssential
 
   if (!password) {
@@ -74,12 +66,6 @@ export async function getStorefrontSessionCookies(
   }
 
   const storefrontDigest = await enrichSessionWithStorefrontPassword(shopifyEssential, storeUrl, password, headers)
-
-  if (!storefrontDigest) {
-    throw new AbortError(
-      'Your development session could not be created because the store password is invalid. Please, retry with a different password.',
-    )
-  }
 
   cookieRecord.storefront_digest = storefrontDigest
 
@@ -107,11 +93,18 @@ async function sessionEssentialCookie(storeUrl: string, themeId: string, headers
   const setCookies = response.headers.raw()['set-cookie'] ?? []
   const shopifyEssential = getCookie(setCookies, '_shopify_essential')
 
+  /**
+   * SFR should always define a _shopify_essential, so an error at this point
+   * is likely a Shopify error or firewall issue.
+   */
   if (!shopifyEssential) {
     outputDebug(
       `Failed to obtain _shopify_essential cookie.\n
        -Request ID: ${response.headers.get('x-request-id') ?? 'unknown'}\n
        -Body: ${await response.text()}`,
+    )
+    throw new ShopifyEssentialError(
+      'Your development session could not be created because the "_shopify_essential" could not be defined. Please, check your internet connection.',
     )
   }
 
@@ -145,6 +138,9 @@ async function enrichSessionWithStorefrontPassword(
       `Failed to obtain storefront_digest cookie.\n
        -Request ID: ${response.headers.get('x-request-id') ?? 'unknown'}\n
        -Body: ${await response.text()}`,
+    )
+    throw new AbortError(
+      'Your development session could not be created because the store password is invalid. Please, retry with a different password.',
     )
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Adds validation to ensure required theme files exist before initializing the dev server session. This helps catch issues with incomplete or corrupted themes that could cause the dev server to fail when initializing the preview session.

- https://github.com/Shopify/cli/issues/4735
- https://github.com/Shopify/develop-advanced-edits/issues/406

### WHAT is this pull request doing?

- Adds a new `verifyRequiredFilesExist` function that checks for essential theme files (`layout/theme.liquid` and `config/settings_schema.json`)

### How to test your changes?
1. Create a theme missing either `layout/theme.liquid` or `config/settings_schema.json` on your shop (more instructions below if needed)
2. Run the `theme dev` with the theme flag, and specify the `--theme` flag to point at the theme created above. Verify that it fails with appropriate error message

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JdHLnhebSbtZTZO01I1e/b6933ed8-7914-413b-b656-2d072fe45cd0.png)

<details><summary>Creating Theme with Missing Assets</summary>

- [Cherrypick this change](https://github.com/Shopify/cli/commit/ca07b64c49409bdcabcc71eedc7340190367b49e) on top of the PR branch
- `p build`
- Delete your development theme `shopify-dev theme delete -d`
- Run `shopify-dev theme dev`

The above command should create a new development theme with missing files - you should then see the error being rendered.

</details> 

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes