### PR TITLE
Report GraphQL system errors as expected

### DIFF
--- a/packages/cli-kit/src/private/node/api/graphql.ts
+++ b/packages/cli-kit/src/private/node/api/graphql.ts
@@ -1,7 +1,6 @@
 import {GraphQLClientError, sanitizedHeadersOutput} from './headers.js'
 import {sanitizeURL} from './urls.js'
 import {stringifyMessage, outputContent, outputToken, outputDebug} from '../../../public/node/output.js'
-import {AbortError} from '../../../public/node/error.js'
 import {ClientError, Variables} from 'graphql-request'
 
 export function debugLogRequestInfo(
@@ -43,12 +42,7 @@ ${outputToken.json(error.response.errors)}
 Request ID: ${requestId}
 `
       }
-      let mappedError: Error
-      if (status < 500) {
-        mappedError = new GraphQLClientError(errorMessage, status, error.response.errors)
-      } else {
-        mappedError = new AbortError(errorMessage)
-      }
+      const mappedError: Error = new GraphQLClientError(errorMessage, status, error.response.errors)
       mappedError.stack = error.stack
       return mappedError
     } else {


### PR DESCRIPTION
### WHY are these changes introduced?

Improve accuracy of the CLI error count SLOs by marking GraphQL failures due to internal server errors as `expected`.

Internal server errors are recorded as unexpected events by the back-end that generates them. From the point of view of the  CLI, we expect such errors will occur and we communicate the failure to the user. That's all we can do, so they should not count against the error count SLOs

### WHAT is this pull request doing?

Uses a common type to identify all GraphQL. Interrogates the error response info to determine if the error is internal, and reports the error as expected if it is internal. 

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
