### PR TITLE
[Themes] Fix empty files in host themes during `app dev`

### DIFF
--- a/.changeset/great-zoos-punch.md
+++ b/.changeset/great-zoos-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix an issue in `app dev` where host themes would have empty files

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -104,14 +104,14 @@ describe('fetchChecksums', () => {
 })
 
 describe('createTheme', () => {
+  const id = 123
+  const name = 'new theme'
+  const role = 'unpublished'
+  const processing = false
+  const params: ThemeParams = {name, role}
+
   test('creates a theme', async () => {
     // Given
-    const id = 123
-    const name = 'new theme'
-    const role = 'unpublished'
-    const processing = false
-    const params: ThemeParams = {name, role}
-
     vi.mocked(restRequest)
       .mockResolvedValueOnce({
         json: {theme: {id, name, role, processing}},
@@ -136,6 +136,36 @@ describe('createTheme', () => {
     expect(theme!.name).toEqual(name)
     expect(theme!.role).toEqual(role)
     expect(theme!.processing).toBeFalsy()
+  })
+
+  test('does not upload minimum theme assets when src is provided', async () => {
+    // Given
+    vi.mocked(restRequest)
+      .mockResolvedValueOnce({
+        json: {theme: {id, name, role, processing}},
+        status: 200,
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        json: {
+          results: [],
+        },
+        status: 207,
+        headers: {},
+      })
+
+    // When
+    const theme = await createTheme({...params, src: 'https://example.com/theme.zip'}, session)
+
+    // Then
+    expect(restRequest).toHaveBeenCalledWith(
+      'POST',
+      '/themes',
+      session,
+      {theme: {...params, src: 'https://example.com/theme.zip'}},
+      {},
+    )
+    expect(restRequest).not.toHaveBeenCalledWith('PUT', `/themes/${id}/assets/bulk`, session, undefined, {})
   })
 })
 

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -31,13 +31,16 @@ export async function fetchThemes(session: AdminSession): Promise<Theme[]> {
 
 export async function createTheme(params: ThemeParams, session: AdminSession): Promise<Theme | undefined> {
   const response = await request('POST', '/themes', session, {theme: {...params}})
-  const minimumThemeAssets = [
-    {key: 'config/settings_schema.json', value: '[]'},
-    {key: 'layout/password.liquid', value: '{{ content_for_header }}{{ content_for_layout }}'},
-    {key: 'layout/theme.liquid', value: '{{ content_for_header }}{{ content_for_layout }}'},
-  ]
 
-  await bulkUploadThemeAssets(response.json.theme.id, minimumThemeAssets, session)
+  if (!params.src) {
+    const minimumThemeAssets = [
+      {key: 'config/settings_schema.json', value: '[]'},
+      {key: 'layout/password.liquid', value: '{{ content_for_header }}{{ content_for_layout }}'},
+      {key: 'layout/theme.liquid', value: '{{ content_for_header }}{{ content_for_layout }}'},
+    ]
+
+    await bulkUploadThemeAssets(response.json.theme.id, minimumThemeAssets, session)
+  }
 
   return buildTheme({...response.json.theme, createdAtRuntime: true})
 }


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/cli/issues/4793

When using `app dev`, host themes were getting overwritten due to a race condition between the `minimum asset upload` and the core job that handles theme installation when the `src` param`, causing potential issues during development.

### WHAT is this pull request doing?

Prevents the upload of of minimum theme assets when a source URL is provided during theme creation. 

### How to test your changes?

1. Run `app dev` with a theme extension
2. Verify that the host theme is created with proper content
3. Ensure no empty files are present in the theme 

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes