### PR TITLE
Prefer @typescript-eslint/no-unused-expressions to base rule

### DIFF
--- a/packages/eslint-plugin-cli/config.js
+++ b/packages/eslint-plugin-cli/config.js
@@ -180,6 +180,9 @@ module.exports = {
     '@typescript-eslint/prefer-optional-chain': 'off',
     '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/non-nullable-type-assertion-style': 'off',
+    '@babel/no-unused-expressions': 'off',
+    'no-unused-expressions': 'off',
+    '@typescript-eslint/no-unused-expressions': ['error', {allowTernary: true}],
   },
   overrides: [
     {

--- a/packages/ui-extensions-dev-console/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/packages/ui-extensions-dev-console/src/components/Modal/components/Dialog/Dialog.tsx
@@ -22,7 +22,7 @@ export function Dialog({labelledBy, children, onClose, setClosing, width, ...css
   const containerNode = useRef<HTMLDivElement>(null)
 
   const ensureFocusInsideModal = useCallback(() => {
-    // eslint-disable-next-line @babel/no-unused-expressions
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     containerNode.current &&
       !containerNode.current.contains(document.activeElement) &&
       focusFirstFocusableNode(containerNode.current)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We were getting a confusing message about `@babel/no-unused-expressions` when we really only work with `@typescript-eslint` lint rules.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Deactivate base rules, enable the TS based one. Ternary expressions are allowed.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
