### PR TITLE
Remove Ruby dependency from the Homebrew formula

### DIFF
--- a/packaging/3/src/shopify-cli.rb.liquid
+++ b/packaging/3/src/shopify-cli.rb.liquid
@@ -11,7 +11,6 @@ class ShopifyCli{% if formulaVersion %}{% if formulaVersion == '3' %}AT3{% else 
   sha256 "{{ cliSha }}"
   license "MIT"
   depends_on "node"
-  depends_on "ruby"
   depends_on "git"
 
   livecheck do
@@ -38,7 +37,6 @@ class ShopifyCli{% if formulaVersion %}{% if formulaVersion == '3' %}AT3{% else 
     executable_content = <<~SCRIPT
       #!/usr/bin/env #{Formula["node"].opt_bin}/node
 
-      process.env.SHOPIFY_RUBY_BINDIR = "#{Formula["ruby"].opt_bin}"
       process.env.SHOPIFY_HOMEBREW_FORMULA = "shopify-cli{% if formulaVersion %}{% if formulaVersion == '3' %}@{% else %}-{% endif %}{{formulaVersion}}{% endif %}"
 
       import("#{new_original_executable_path}")


### PR DESCRIPTION
### WHY are these changes introduced?

Ruby is not required anymore

### WHAT is this pull request doing?

Removes the Ruby dependency from the Homebrew formula

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
