### PR TITLE
Add vendored DevServer library

### DIFF
--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -63,7 +63,8 @@
       "../../.eslintrc.cjs"
     ],
     "ignorePatterns": [
-      "**/vendor/otel-js/**/*.ts"
+      "**/vendor/otel-js/**/*.ts",
+      "**/vendor/dev_server/**/*.ts"
     ],
     "overrides": [
       {
@@ -144,6 +145,7 @@
     "macaddress": "0.5.3",
     "minimatch": "9.0.3",
     "mrmime": "1.0.1",
+    "network-interfaces": "1.1.0",
     "node-abort-controller": "3.1.1",
     "node-fetch": "3.3.2",
     "open": "8.4.2",

--- a/packages/cli-kit/src/public/node/context/fqdn.test.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.test.ts
@@ -6,6 +6,22 @@ import {expect, describe, test, vi} from 'vitest'
 vi.mock('../context/spin.js')
 vi.mock('../../../private/node/context/service.js')
 
+vi.mock('../vendor/dev_server/DevServer.js', () => {
+  return {
+    DevServerCore: class {
+      host(serviceName: string) {
+        return `${serviceName}.myshopify.io`
+      }
+    },
+    DevServer: class {
+      constructor(private readonly serviceName: string) {}
+      host() {
+        return `${this.serviceName}.myshopify.io`
+      }
+    },
+  }
+})
+
 describe('partners', () => {
   test('returns the local fqdn when the environment is local', async () => {
     // Given
@@ -51,7 +67,7 @@ describe('appManagementFqdn', () => {
     const got = await appManagementFqdn()
 
     // Then
-    expect(got).toEqual('app.shopify.myshopify.io')
+    expect(got).toEqual('app.myshopify.io')
   })
 
   test('returns the production fqdn when the environment is production', async () => {

--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -1,6 +1,7 @@
 import {spinFqdn} from './spin.js'
 import {AbortError} from '../error.js'
 import {serviceEnvironment} from '../../../private/node/context/service.js'
+import {DevServer, DevServerCore} from '../vendor/dev_server/DevServer.js'
 
 export const CouldntObtainPartnersSpinFQDNError = new AbortError(
   "Couldn't obtain the Spin FQDN for Partners when the CLI is not running from a Spin environment.",
@@ -25,7 +26,7 @@ export async function partnersFqdn(): Promise<string> {
   const productionFqdn = 'partners.shopify.com'
   switch (environment) {
     case 'local':
-      return 'partners.myshopify.io'
+      return new DevServer('partners').host()
     case 'spin':
       return `partners.${await spinFqdn()}`
     default:
@@ -43,7 +44,7 @@ export async function appManagementFqdn(): Promise<string> {
   const productionFqdn = 'app.shopify.com'
   switch (environment) {
     case 'local':
-      return 'app.shopify.myshopify.io'
+      return new DevServerCore().host('app')
     case 'spin':
       return `app.shopify.${await spinFqdn()}`
     default:
@@ -61,7 +62,7 @@ export async function developerDashboardFqdn(): Promise<string> {
   const productionFqdn = 'dev.shopify.com'
   switch (environment) {
     case 'local':
-      return 'dev.shopify.myshopify.io'
+      return new DevServerCore().host('dev')
     case 'spin':
       return `dev.shopify.${await spinFqdn()}`
     default:
@@ -79,7 +80,7 @@ export async function businessPlatformFqdn(): Promise<string> {
   const productionFqdn = 'destinations.shopifysvc.com'
   switch (environment) {
     case 'local':
-      return 'business-platform.myshopify.io'
+      return new DevServer('business-platform').host()
     case 'spin':
       return `business-platform.${await spinFqdn()}`
     default:
@@ -97,7 +98,7 @@ export async function identityFqdn(): Promise<string> {
   const productionFqdn = 'accounts.shopify.com'
   switch (environment) {
     case 'local':
-      return 'identity.myshopify.io'
+      return new DevServer('identity').host()
     case 'spin':
       return `identity.${await spinFqdn()}`
     default:
@@ -118,7 +119,7 @@ export async function normalizeStoreFqdn(store: string): Promise<string> {
   const addDomain = async (storeFqdn: string) => {
     switch (serviceEnvironment()) {
       case 'local':
-        return `${storeFqdn}.myshopify.io`
+        return new DevServerCore().host(storeFqdn)
       case 'spin':
         return `${storeFqdn}.shopify.${await spinFqdn()}`
       default:
@@ -126,6 +127,9 @@ export async function normalizeStoreFqdn(store: string): Promise<string> {
     }
   }
   const containDomain = (storeFqdn: string) =>
-    storeFqdn.includes('.myshopify.com') || storeFqdn.includes('spin.dev') || storeFqdn.includes('shopify.io')
+    storeFqdn.includes('.myshopify.com') ||
+    storeFqdn.includes('spin.dev') ||
+    storeFqdn.includes('shopify.io') ||
+    storeFqdn.includes('.shop.dev')
   return containDomain(storeFqdn) ? storeFqdn : addDomain(storeFqdn)
 }

--- a/packages/cli-kit/src/public/node/vendor/dev_server/DevServer.ts
+++ b/packages/cli-kit/src/public/node/vendor/dev_server/DevServer.ts
@@ -1,0 +1,199 @@
+import fs from 'fs';
+import * as os from 'os';
+import * as ni from 'network-interfaces';
+import { execSync } from 'child_process';
+
+class DevServerUtils {
+  static readonly INFERENCE_MODE_SENTINEL =
+    '/opt/dev/misc/dev-server-inference-mode';
+  static readonly BACKEND_PORT = 8080;
+  static readonly CONNECT_TIMEOUT = 100; // 100ms
+  static readonly HOSTS_FILE = '/etc/hosts';
+
+  static assertConnectable(name: string, addr: string, port: number): void {
+    try {
+      execSync(`nc -z -v -w 1 ${addr} ${port}`, {
+        timeout: DevServerUtils.CONNECT_TIMEOUT,
+        stdio: 'ignore',
+      });
+    } catch (err) {
+      throw new Error(
+        `NET FAILED DevServer for '${name}' is not running on ${port} / ${addr}: \`dev up ${name}\` to start it.`
+      );
+    }
+  }
+
+  static inferenceModeAndProjectIsEdition2016(name: string): boolean {
+    try {
+      fs.accessSync(DevServerUtils.INFERENCE_MODE_SENTINEL);
+      try {
+        fs.accessSync(`/opt/nginx/etc/manifest/${name}/current/edition-2024`);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  static getIpFromHosts(hostname: string): string {
+    try {
+      const hostsContent = fs.readFileSync(DevServerUtils.HOSTS_FILE, 'utf8');
+      const lines = hostsContent.split(/\r?\n/);
+      for (const line of lines) {
+        const matches = /^\s*?([^#]+?)\s+([^#]+?)$/.exec(line);
+        if (matches && matches.length === 3 && matches[2] === hostname) {
+          return matches[1]!; // Return the IP address
+        }
+      }
+    } catch (error) {
+      console.error('Error reading hosts file:', error);
+    }
+
+    throw new Error(`No IP found for hostname: ${hostname}`);
+  }
+
+  static getAddrPort2024(name: string): [string, number] {
+    try {
+      const backendIp = DevServerUtils.resolveBackendHost(name);
+      const interfaceName = ni.fromIp(backendIp, {
+        internal: true,
+        ipVersion: 4,
+      });
+      return [backendIp, DevServerUtils.BACKEND_PORT];
+    } catch (error) {
+      throw new Error(
+        `DevServer for '${name}' is not running: \`dev up ${name}\` to start it.`
+      );
+    }
+  }
+
+  static getAddrPort2016(name: string): [string, number] {
+    try {
+      const portContent = fs.readFileSync(
+        `${os.homedir()}/.local/run/services/${name}/server/port`,
+        'utf-8'
+      );
+      return ['localhost', parseInt(portContent, 10)];
+    } catch (error) {
+      throw new Error(
+        `DevServer for '${name}' is not running: \`dev up ${name}\` to start it.`
+      );
+    }
+  }
+
+  static resolveBackendHost(name: string): string {
+    let host: string;
+    try {
+      host = fs.readlinkSync(`/opt/nginx/etc/manifest/${name}/current`);
+    } catch (error) {
+      host = `${name}.root.shopify.dev.internal`;
+    }
+
+    try {
+      return DevServerUtils.getIpFromHosts(host);
+    } catch {
+      return host;
+    }
+  }
+}
+
+export class DevServer {
+  protected name: string;
+
+  constructor(name: string) {
+    if (!process.env.SPIN && !process.env.USING_DEV) {
+      throw new Error('DevServer is not supported in this environment');
+    }
+
+    if (name === 'shopify') {
+      throw new Error('Use DevServer.core for the \'shopify\' project');
+    }
+    this.name = name;
+  }
+
+  url({
+    nonstandardHostPrefix,
+  }: { nonstandardHostPrefix?: string } = {}): string {
+    return `https://${this.host({nonstandardHostPrefix})}`;
+  }
+
+  host({
+    nonstandardHostPrefix,
+  }: { nonstandardHostPrefix?: string } = {}): string {
+    const prefix = nonstandardHostPrefix || this.name;
+
+    if (process.env.SPIN === '1') {
+      const services = fs.readdirSync('/run/ports2')
+        .filter(file => file.endsWith(`--${this.name}`));
+
+      if (services.length === 0) {
+        throw new Error(
+          `DevServer for '${this.name}' not present in this spin environment`
+        );
+      }
+
+      const match = new RegExp(`^(.+)${this.name}$`).exec(services[0]!);
+      const organization = match ? match[1] : '';
+      const spinPrefix = organization !== 'shopify--' ? `${organization}` : '';
+
+      return `${spinPrefix}${this.name}.${process.env.SPIN_FQDN}`;
+    } else if (DevServerUtils.inferenceModeAndProjectIsEdition2016(this.name)) {
+      this.assertRunningLocally2016();
+      return `${prefix}.myshopify.io`;
+    } else {
+      this.assertRunningLocally2024();
+      return `${prefix}.shop.dev`;
+    }
+  }
+
+  protected assertRunningLocally2024(): void {
+    const [addr, port] = DevServerUtils.getAddrPort2024(this.name);
+    DevServerUtils.assertConnectable(this.name, addr, port);
+  }
+
+  protected assertRunningLocally2016(): void {
+    const [addr, port] = DevServerUtils.getAddrPort2016(this.name);
+    DevServerUtils.assertConnectable(this.name, addr, port);
+  }
+}
+
+export class DevServerCore {
+  private readonly name = 'shopify';
+
+  url(prefix: string): string {
+    return `https://${this.host(prefix)}`;
+  }
+
+  host(prefix: string): string {
+    if (process.env.SPIN === '1') {
+      const projectPortRoot = fs
+        .readdirSync('/run/ports2')
+        .find((file) => file.endsWith(`--${this.name}`));
+      if (!projectPortRoot) {
+        throw new Error(
+          `DevServer for '${this.name}' not present in this spin environment`
+        );
+      }
+      // Spin mostly doesn't do alternative hostname prefixing.
+      return `${prefix}.${this.name}.${process.env.SPIN_FQDN}`;
+    } else if (DevServerUtils.inferenceModeAndProjectIsEdition2016('shopify')) {
+      this.assertRunningLocally2016();
+      return `${prefix}.myshopify.io`;
+    } else {
+      this.assertRunningLocally2024();
+      return `${prefix}.my.shop.dev`;
+    }
+  }
+
+  private assertRunningLocally2024(): void {
+    const [addr, port] = DevServerUtils.getAddrPort2024('shopify');
+    DevServerUtils.assertConnectable('shopify', addr, port);
+  }
+
+  private assertRunningLocally2016(): void {
+    const [addr, port] = DevServerUtils.getAddrPort2016('shopify');
+    DevServerUtils.assertConnectable('shopify', addr, port);
+  }
+}

--- a/packages/cli-kit/src/public/node/vendor/dev_server/network-interfaces.d.ts
+++ b/packages/cli-kit/src/public/node/vendor/dev_server/network-interfaces.d.ts
@@ -1,0 +1,5 @@
+declare module 'network-interfaces' {
+    export function fromIp(ip: string, options?: { internal?: boolean, ipVersion?: number }): string;
+    export function toIp(interfaceName: string, options?: { internal?: boolean, ipVersion?: number }): string;
+    export function getInterface(options?: { internal?: boolean, ipVersion?: number }): string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,9 @@ importers:
       mrmime:
         specifier: 1.0.1
         version: 1.0.1
+      network-interfaces:
+        specifier: 1.1.0
+        version: 1.1.0
       node-abort-controller:
         specifier: 3.1.1
         version: 3.1.1
@@ -12709,6 +12712,10 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /network-interfaces@1.1.0:
+    resolution: {integrity: sha512-fBk/Cm/RminFKhyUYKolI5nWI2de1m0pHlikz1mnTDbbe/1d2+ti+x/pWlOYuK8o/9p9vyK912+66h2NXGNUwQ==}
     dev: false
 
   /no-case@3.0.4:


### PR DESCRIPTION
### WHY are these changes introduced?

Internal to Shopify, the CLI needs to support the new dev server infrastructure and hostnames for local development environments.

For any non-Shopifolk: there's no difference, it's an internal adjustment.

### WHAT is this pull request doing?

Adds a copy of the DevServer library (with permission) and use it for FQDNs during local dev.

### How to test your changes?

Run ` SHOPIFY_SERVICE_ENV="local" p shopify app info --path=<path to an app> --verbose`

You'll see the CLI exit, because the first thing it wanted to connect locally to wasn't there (probably `identity`). Confirm the error message and the URL it was trying to connect to.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix