### PR TITLE
Run AppWatcher as a dev process

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher-handler.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher-handler.ts
@@ -4,7 +4,7 @@ import {appDiff} from './app-diffing.js'
 import {AppLinkedInterface} from '../../../models/app/app.js'
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
 import {loadApp} from '../../../models/app/loader.js'
-import {outputDebug, outputWarn} from '@shopify/cli-kit/node/output'
+import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {endHRTimeInMs, startHRTime} from '@shopify/cli-kit/node/hrtime'
 import {basename} from '@shopify/cli-kit/node/path'
@@ -113,8 +113,8 @@ function AppConfigDeletedHandler(_input: HandlerInput): AppEvent {
  * - When the app.toml is updated
  * - When an extension toml is updated
  */
-async function ReloadAppHandler({event, app, options}: HandlerInput): Promise<AppEvent> {
-  const newApp = await reloadApp(app, options)
+async function ReloadAppHandler({event, app}: HandlerInput): Promise<AppEvent> {
+  const newApp = await reloadApp(app)
   const diff = appDiff(app, newApp, true)
   const createdEvents = diff.created.map((ext) => ({type: EventType.Created, extension: ext}))
   const deletedEvents = diff.deleted.map((ext) => ({type: EventType.Deleted, extension: ext}))
@@ -127,7 +127,7 @@ async function ReloadAppHandler({event, app, options}: HandlerInput): Promise<Ap
  * Reload the app and returns it
  * Prints the time to reload the app to stdout
  */
-export async function reloadApp(app: AppLinkedInterface, options: OutputContextOptions): Promise<AppLinkedInterface> {
+export async function reloadApp(app: AppLinkedInterface): Promise<AppLinkedInterface> {
   const start = startHRTime()
   try {
     const newApp = await loadApp({
@@ -136,11 +136,10 @@ export async function reloadApp(app: AppLinkedInterface, options: OutputContextO
       userProvidedConfigName: basename(app.configuration.path),
       remoteFlags: app.remoteFlags,
     })
-    outputDebug(`App reloaded [${endHRTimeInMs(start)}ms]`, options.stdout)
+    outputDebug(`App reloaded [${endHRTimeInMs(start)}ms]`)
     return newApp as AppLinkedInterface
-    // eslint-disable-next-line no-catch-all/no-catch-all, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    outputWarn(`Error reloading app: ${error.message}`, options.stderr)
-    return app
+    throw new Error(`Error reloading app: ${error.message}`)
   }
 }

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -95,19 +95,26 @@ export class AppEventWatcher extends EventEmitter {
   private started = false
   private ready = false
 
-  constructor(app: AppLinkedInterface, appURL?: string, buildOutputPath?: string) {
+  constructor(
+    app: AppLinkedInterface,
+    appURL?: string,
+    buildOutputPath?: string,
+    esbuildManager?: ESBuildContextManager,
+  ) {
     super()
     this.app = app
     this.appURL = appURL
     this.buildOutputPath = buildOutputPath ?? joinPath(app.directory, '.shopify', 'bundle')
     // Default options, to be overwritten by the start method
     this.options = {stdout: process.stdout, stderr: process.stderr, signal: new AbortSignal()}
-    this.esbuildManager = new ESBuildContextManager({
-      outputPath: this.buildOutputPath,
-      dotEnvVariables: this.app.dotenv?.variables ?? {},
-      url: this.appURL ?? '',
-      ...this.options,
-    })
+    this.esbuildManager =
+      esbuildManager ??
+      new ESBuildContextManager({
+        outputPath: this.buildOutputPath,
+        dotEnvVariables: this.app.dotenv?.variables ?? {},
+        url: this.appURL ?? '',
+        ...this.options,
+      })
   }
 
   async start(options?: OutputContextOptions) {

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -125,33 +125,26 @@ export class AppEventWatcher extends EventEmitter {
     await this.esbuildManager.createContexts(this.app.realExtensions.filter((ext) => ext.isESBuildExtension))
 
     // Initial build of all extensions
-    await this.buildExtensions(this.app.realExtensions.map((ext) => ({type: EventType.Created, extension: ext})))
+    await this.buildExtensions(this.app.realExtensions.map((ext) => ({type: EventType.Updated, extension: ext})))
 
     // Start the file system watcher
     await startFileWatcher(this.app, this.options, (events) => {
       handleWatcherEvents(events, this.app, this.options)
         .then(async (appEvent) => {
-          if (!appEvent) return
+          if (appEvent?.extensionEvents.length === 0) outputDebug('Change detected, but no extensions were affected')
+          if (!appEvent || appEvent.extensionEvents.length === 0) return
+
           this.app = appEvent.app
-          if (appEvent.extensionEvents.length === 0) {
-            outputDebug('Change detected, but no extensions were affected', this.options.stdout)
-            return
-          }
           await this.esbuildManager.updateContexts(appEvent)
 
           // Find affected created/updated extensions and build them
-          const createdOrUpdatedExtensionsEvents = appEvent.extensionEvents.filter(
-            (extEvent) => extEvent.type !== EventType.Deleted,
-          )
+          const buildableEvents = appEvent.extensionEvents.filter((extEvent) => extEvent.type !== EventType.Deleted)
 
           // Build the created/updated extensions and update the extension events with the build result
-          await this.buildExtensions(createdOrUpdatedExtensionsEvents)
+          await this.buildExtensions(buildableEvents)
 
           // Find deleted extensions and delete their previous build output
-          const deletedExtensions = appEvent.extensionEvents
-            .filter((extEvent) => extEvent.type === EventType.Deleted)
-            .map((extEvent) => extEvent.extension)
-          await this.deleteExtensionsBuildOutput(deletedExtensions)
+          await this.deleteExtensionsBuildOutput(appEvent)
           this.emit('all', appEvent)
         })
         .catch((error) => {
@@ -197,7 +190,10 @@ export class AppEventWatcher extends EventEmitter {
    *
    * This is just a cleanup function after detecting that an extension has been deleted.
    */
-  private async deleteExtensionsBuildOutput(extensions: ExtensionInstance[]) {
+  private async deleteExtensionsBuildOutput(appEvent: AppEvent) {
+    const extensions = appEvent.extensionEvents
+      .filter((extEvent) => extEvent.type === EventType.Deleted)
+      .map((extEvent) => extEvent.extension)
     const promises = extensions.map(async (ext) => {
       const outputPath = joinPath(this.buildOutputPath, ext.getOutputFolderId())
       return rmdir(outputPath, {force: true})

--- a/packages/app/src/cli/services/dev/processes/app-watcher-process.ts
+++ b/packages/app/src/cli/services/dev/processes/app-watcher-process.ts
@@ -1,0 +1,39 @@
+import {BaseProcess, DevProcessFunction} from './types.js'
+import {AppEventWatcher} from '../app-events/app-event-watcher.js'
+
+interface AppWatcherProcessOptions {
+  appWatcher: AppEventWatcher
+}
+
+export interface AppWatcherProcess extends BaseProcess<AppWatcherProcessOptions> {
+  type: 'app-watcher'
+}
+
+/**
+ * Sets up the app watcher process.
+ *
+ * This process just STARTS the app watcher, the watcher object is created before and shared with all other processes
+ * so they can receive events from it.
+ *
+ * The "start" is done in a process so that it can receive the stdout, stderr and abortSignal of the concurrent output context
+ * that is shared with the other processes.
+ *
+ * @param options - The options for the app watcher process.
+ * @returns The app watcher process.
+ */
+export async function setupAppWatcherProcess(options: AppWatcherProcessOptions): Promise<AppWatcherProcess> {
+  return {
+    type: 'app-watcher',
+    prefix: `dev-session`,
+    options,
+    function: launchAppWatcher,
+  }
+}
+
+export const launchAppWatcher: DevProcessFunction<AppWatcherProcessOptions> = async (
+  {stdout, stderr, abortSignal},
+  options: AppWatcherProcessOptions,
+) => {
+  const {appWatcher} = options
+  await appWatcher.start({stdout, stderr, signal: abortSignal})
+}

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -7,6 +7,7 @@ import {launchGraphiQLServer} from './graphiql.js'
 import {pushUpdatesForDraftableExtensions} from './draftable-extension.js'
 import {pushUpdatesForDevSession} from './dev-session.js'
 import {runThemeAppExtensionsServer} from './theme-app-extension.js'
+import {launchAppWatcher} from './app-watcher-process.js'
 import {
   testAppAccessConfigExtension,
   testAppConfigExtensions,
@@ -26,6 +27,8 @@ import {
 import {WebType} from '../../../models/app/app.js'
 import {ensureDeploymentIdsPresence} from '../../context/identifiers.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {AppEventWatcher} from '../app-events/app-event-watcher.js'
+import {reloadApp} from '../app-events/app-event-watcher-handler.js'
 import {describe, test, expect, beforeEach, vi} from 'vitest'
 import {ensureAuthenticatedAdmin, ensureAuthenticatedStorefront} from '@shopify/cli-kit/node/session'
 import {Config} from '@oclif/core'
@@ -39,6 +42,8 @@ vi.mock('../fetch.js')
 vi.mock('@shopify/cli-kit/node/environment')
 vi.mock('@shopify/theme')
 vi.mock('@shopify/cli-kit/node/themes/api')
+vi.mock('../app-events/app-event-watcher-handler.js')
+
 beforeEach(() => {
   // mocked for draft extensions
   vi.mocked(ensureDeploymentIdsPresence).mockResolvedValue({
@@ -63,6 +68,7 @@ beforeEach(() => {
     role: 'theme',
     processing: false,
   })
+  vi.mocked(reloadApp).mockResolvedValue(testAppLinked())
 })
 
 const appContextResult = {
@@ -124,6 +130,7 @@ describe('setup-dev-processes', () => {
         allExtensions: [previewable, draftable, theme],
       },
     })
+    vi.mocked(reloadApp).mockResolvedValue(localApp)
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',
@@ -251,12 +258,21 @@ describe('setup-dev-processes', () => {
       },
     })
 
+    expect(res.processes[6]).toMatchObject({
+      type: 'app-watcher',
+      prefix: 'dev-session',
+      function: launchAppWatcher,
+      options: {
+        appWatcher: expect.any(AppEventWatcher),
+      },
+    })
+
     // Check the ports & rule mapping
     const webPort = (res.processes[0] as WebProcess).options.port
     const hmrPort = (res.processes[0] as WebProcess).options.hmrServerOptions?.port
     const previewExtensionPort = (res.processes[2] as PreviewableExtensionProcess).options.port
 
-    expect(res.processes[6]).toMatchObject({
+    expect(res.processes[7]).toMatchObject({
       type: 'proxy-server',
       prefix: 'proxy',
       function: startProxyServer,
@@ -390,6 +406,7 @@ describe('setup-dev-processes', () => {
         allExtensions: [previewable, draftable, theme, functionExtension],
       },
     })
+    vi.mocked(reloadApp).mockResolvedValue(localApp)
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',
@@ -577,6 +594,7 @@ describe('setup-dev-processes', () => {
         ],
       },
     })
+    vi.mocked(reloadApp).mockResolvedValue(localApp)
 
     const remoteApp: DevConfig['remoteApp'] = {
       apiKey: 'api-key',

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -7,6 +7,7 @@ import {GraphiQLServerProcess, setupGraphiQLServerProcess} from './graphiql.js'
 import {WebProcess, setupWebProcesses} from './web.js'
 import {DevSessionProcess, setupDevSessionProcess} from './dev-session.js'
 import {AppLogsSubscribeProcess, setupAppLogsPollingProcess} from './app-logs-polling.js'
+import {AppWatcherProcess, setupAppWatcherProcess} from './app-watcher-process.js'
 import {environmentVariableNames} from '../../../constants.js'
 import {AppLinkedInterface, getAppScopes, WebType} from '../../../models/app/app.js'
 
@@ -16,6 +17,8 @@ import {getProxyingWebServer} from '../../../utilities/app/http-reverse-proxy.js
 import {buildAppURLForWeb} from '../../../utilities/app/app-url.js'
 import {PartnersURLs} from '../urls.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {reloadApp} from '../app-events/app-event-watcher-handler.js'
+import {AppEventWatcher} from '../app-events/app-event-watcher.js'
 import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
@@ -34,6 +37,7 @@ type DevProcessDefinition =
   | GraphiQLServerProcess
   | DevSessionProcess
   | AppLogsSubscribeProcess
+  | AppWatcherProcess
 
 export type DevProcesses = DevProcessDefinition[]
 
@@ -82,15 +86,20 @@ export async function setupDevProcesses({
   const shouldRenderGraphiQL = !isTruthy(env[environmentVariableNames.disableGraphiQLExplorer])
   const shouldPerformAppLogPolling = localApp.allExtensions.some((extension) => extension.isFunctionExtension)
 
+  // At this point, the toml file has changed, we need to reload the app before actually starting dev
+  const reloadedApp = await reloadApp(localApp)
+  const appWatcher = new AppEventWatcher(reloadedApp, network.proxyUrl)
+
   const processes = [
+    await setupAppWatcherProcess({appWatcher}),
     ...(await setupWebProcesses({
-      webs: localApp.webs,
+      webs: reloadedApp.webs,
       proxyUrl: network.proxyUrl,
       frontendPort: network.frontendPort,
       backendPort: network.backendPort,
       apiKey,
       apiSecret,
-      scopes: getAppScopes(localApp.configuration),
+      scopes: getAppScopes(reloadedApp.configuration),
     })),
     shouldRenderGraphiQL
       ? await setupGraphiQLServerProcess({
@@ -104,31 +113,32 @@ export async function setupDevProcesses({
         })
       : undefined,
     await setupPreviewableExtensionsProcess({
-      allExtensions: localApp.allExtensions,
+      allExtensions: reloadedApp.allExtensions,
       storeFqdn,
       storeId,
       apiKey,
       subscriptionProductUrl: commandOptions.subscriptionProductUrl,
       checkoutCartUrl: commandOptions.checkoutCartUrl,
       proxyUrl: network.proxyUrl,
-      appName: localApp.name,
-      appDotEnvFile: localApp.dotenv,
+      appName: reloadedApp.name,
+      appDotEnvFile: reloadedApp.dotenv,
       grantedScopes: remoteApp.grantedScopes,
       appId: remoteApp.id,
-      appDirectory: localApp.directory,
+      appDirectory: reloadedApp.directory,
     }),
     developerPlatformClient.supportsDevSessions
       ? await setupDevSessionProcess({
-          app: localApp,
+          app: reloadedApp,
           apiKey,
           developerPlatformClient,
           url: network.proxyUrl,
           appId: remoteApp.id,
           organizationId: remoteApp.organizationId,
           storeFqdn,
+          appWatcher,
         })
       : await setupDraftableExtensionsProcess({
-          localApp,
+          localApp: reloadedApp,
           remoteApp,
           apiKey,
           developerPlatformClient,
@@ -136,13 +146,13 @@ export async function setupDevProcesses({
         }),
     await setupPreviewThemeAppExtensionsProcess({
       remoteApp,
-      localApp,
+      localApp: reloadedApp,
       storeFqdn,
       theme: commandOptions.theme,
       themeExtensionPort: commandOptions.themeExtensionPort,
     }),
     setupSendUninstallWebhookProcess({
-      webs: localApp.webs,
+      webs: reloadedApp.webs,
       backendPort: network.backendPort,
       frontendPort: network.frontendPort,
       developerPlatformClient,

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -91,7 +91,6 @@ export async function setupDevProcesses({
   const appWatcher = new AppEventWatcher(reloadedApp, network.proxyUrl)
 
   const processes = [
-    await setupAppWatcherProcess({appWatcher}),
     ...(await setupWebProcesses({
       webs: reloadedApp.webs,
       proxyUrl: network.proxyUrl,
@@ -170,6 +169,9 @@ export async function setupDevProcesses({
           storeName: storeFqdn,
         })
       : undefined,
+    await setupAppWatcherProcess({
+      appWatcher,
+    }),
   ].filter(stripUndefineds)
 
   // Add http server proxy & configure ports, for processes that need it

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -49,6 +49,11 @@ interface BundleOptions {
    * Whether or not to generate source maps.
    */
   sourceMaps?: boolean
+
+  /**
+   * Whether or not to log messages to the console.
+   */
+  logLevel?: 'silent' | 'error'
 }
 
 /**
@@ -137,6 +142,7 @@ export function getESBuildOptions(options: BundleOptions, processEnv = process.e
     bundle: true,
     define,
     jsx: 'automatic',
+    logLevel: options.logLevel ?? 'error',
     loader: {
       '.esnext': 'ts',
       '.js': 'jsx',


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We want to use the AppWatcher globally by all the other processes, this way any process can subscribe to app changes during dev.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Create a new `AppWatcherProcess` that starts the App Watcher
- Inject the shared AppWatcher to `DevSessionProcess`
- Expose the `BuildResult` in each extension event -> To know if the extension was successfully built after the detected change.
- Do some cleanup and update tests
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Run `app dev` with the app management API.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
