### PR TITLE
Update Javy and function-runner versions

### DIFF
--- a/.changeset/eight-dragons-grab.md
+++ b/.changeset/eight-dragons-grab.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update Javy to 3.2.0 and function-runner to 6.3.0

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -9,8 +9,8 @@ import fs from 'node:fs'
 import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
-const FUNCTION_RUNNER_VERSION = 'v6.2.1'
-const JAVY_VERSION = 'v3.1.2'
+const FUNCTION_RUNNER_VERSION = 'v6.3.0'
+const JAVY_VERSION = 'v3.2.0'
 
 // The logic for determining the download URL and what to do with the response stream is _coincidentally_ the same for
 // Javy and function-runner for now. Those methods may not continue to have the same logic in the future. If they


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The function-runner version has an Javy QuickJS provider that matches what's being used in production. I'm already in here so may as well update Javy as well. This should also slightly de-risk future updates to Javy because there will be fewer changes (compared to updating across multiple versions at the same time).

### WHAT is this pull request doing?

Updates the versions the CLI will download to the latest versions of Javy and the function-runner.

### How to test your changes?

- `rm -r packages/app/dist/cli/services/bin/` (clear out any cached downloaded binaries)
- `pnpm shopify app function build --path <path_to_function_extension>` (downloads and runs Javy)
- `echo "{}" | pnpm shopify app function run --path <path_to_function_extension>` (downloads and runs function-runner)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
