### PR TITLE
[Feature] Add shortcut keys to theme dev

### DIFF
--- a/.changeset/swift-frogs-fail.md
+++ b/.changeset/swift-frogs-fail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Add shortcut keys to theme dev commands


### PR DESCRIPTION
Do you suffer from long logs? Do you accidentally close your browser window and have to scroll all the way up in your terminal to find the theme dev links? Look no further than the addition of shortcut keys!

### WHY are these changes introduced?

Closes https://github.com/Shopify/cli/issues/4713
Closes https://github.com/Shopify/develop-advanced-edits/issues/427

With the amount of logs `theme dev` generates, it can be difficult to find the original store links such as previewing your theme, or opening the theme editor. Having shortcut keys is a simple way to open the links without needing to physically click on them in the terminal.

### WHAT is this pull request doing?

Add shortcut keys to the `theme dev` command
We look for keypresses, specifically:
`t` - opens the theme locally
`e` - opens the theme editor
`p` - opens the share preview
`g` - opens the gift cards preview
we also look for `ctrl` + `c` to exit the process (current behaviour)

<img width="1270" alt="Screenshot 2024-11-21 at 4 51 40 PM" src="https://github.com/user-attachments/assets/9bfc88b6-0494-41fa-a0f8-186595cc210b">


### How to test your changes?

Pull down the branch
Build the branch
Run the `theme dev` command
Try out the shortcut keys. Click some links, save some files, and see that it does not affect anything else running, `ctrl+c` out to confirm you can exit the same as before.

### Post-release steps


### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
