### PR TITLE
Coverage analysis shouldn't include vendored libraries

### DIFF
--- a/configurations/vite.config.ts
+++ b/configurations/vite.config.ts
@@ -44,6 +44,7 @@ export default function config(packagePath: string) {
         include: ['**/src/**'],
         all: true,
         reporter: ['text', 'json', 'lcov'],
+        exclude: ['**/src/**/vendor/**'],
       },
       snapshotFormat: {
         escapeString: true,


### PR DESCRIPTION
### WHY are these changes introduced?

Excludes vendor directories from code coverage reporting to ensure more accurate test coverage metrics that focus on our own codebase.

### WHAT is this pull request doing?

Adds an exclude pattern `**/src/**/vendor/**` to the code coverage configuration in Vite to prevent vendor code from being included in coverage reports.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes