### PR TITLE
Enable multiple asset handling

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -219,8 +219,30 @@ export async function testUIExtension(
       },
     },
     extension_points: [
-      {target: 'target1', module: 'module1'},
-      {target: 'target2', module: 'module2'},
+      {
+        target: 'target1',
+        module: 'module1',
+        build_manifest: {
+          assets: {
+            main: {
+              module: 'module1',
+              filepath: uiExtension?.handle ? `/${uiExtension.handle}.js` : '/test-ui-extension.js',
+            },
+          },
+        },
+      },
+      {
+        target: 'target2',
+        module: 'module2',
+        build_manifest: {
+          assets: {
+            main: {
+              module: 'module2',
+              filepath: uiExtension?.handle ? `/${uiExtension.handle}.js` : '/test-ui-extension.js',
+            },
+          },
+        },
+      },
     ],
   }
   const configurationPath = uiExtension?.configurationPath ?? `${directory}/shopify.ui.extension.toml`

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -255,7 +255,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
       return this.specification.getBundleExtensionStdinContent(this.configuration)
     }
     const relativeImportPath = this.entrySourceFilePath.replace(this.directory, '')
-    return `import '.${relativeImportPath}';`
+    return {main: `import '.${relativeImportPath}';`}
   }
 
   shouldFetchCartUrl(): boolean {

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -36,9 +36,14 @@ const TargetCapabilitiesSchema = zod.object({
   allow_direct_linking: zod.boolean().optional(),
 })
 
+const ShouldRenderSchema = zod.object({
+  module: zod.string(),
+})
+
 const NewExtensionPointSchema = zod.object({
   target: zod.string(),
   module: zod.string(),
+  should_render: ShouldRenderSchema.optional(),
   metafields: zod.array(MetafieldSchema).optional(),
   default_placement: zod.string().optional(),
   capabilities: TargetCapabilitiesSchema.optional(),

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -35,6 +35,16 @@ export interface CustomTransformationConfig {
 type ExtensionExperience = 'extension' | 'configuration'
 type UidStrategy = 'single' | 'dynamic' | 'uuid'
 
+export enum AssetIdentifier {
+  ShouldRender = 'should_render',
+  Main = 'main',
+}
+
+export interface Asset {
+  identifier: AssetIdentifier
+  outputFileName: string
+  content: string
+}
 /**
  * Extension specification with all the needed properties and methods to load an extension.
  */
@@ -50,7 +60,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   experience: ExtensionExperience
   dependency?: string
   graphQLType?: string
-  getBundleExtensionStdinContent?: (config: TConfiguration) => string
+  getBundleExtensionStdinContent?: (config: TConfiguration) => {main: string; assets?: Asset[]}
   deployConfig?: (
     config: TConfiguration,
     directory: string,

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -1,4 +1,4 @@
-import {ExtensionFeature, createExtensionSpecification} from '../specification.js'
+import {Asset, AssetIdentifier, ExtensionFeature, createExtensionSpecification} from '../specification.js'
 import {NewExtensionPointSchemaType, NewExtensionPointsSchema, BaseSchema} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {getExtensionPointTargetSurface} from '../../../services/dev/extension/utilities.js'
@@ -14,6 +14,21 @@ const validatePoints = (config: {extension_points?: unknown[]; targeting?: unkno
   return config.extension_points !== undefined || config.targeting !== undefined
 }
 
+export interface BuildManifest {
+  assets: {
+    // Main asset is always required
+    [AssetIdentifier.Main]: {
+      filepath: string
+      module?: string
+    }
+  } & {
+    [key in AssetIdentifier]?: {
+      filepath: string
+      module?: string
+    }
+  }
+}
+
 const missingExtensionPointsMessage = 'No extension targets defined, add a `targeting` field to your configuration'
 
 export type UIExtensionSchemaType = zod.infer<typeof UIExtensionSchema>
@@ -25,6 +40,23 @@ export const UIExtensionSchema = BaseSchema.extend({
   .refine((config) => validatePoints(config), missingExtensionPointsMessage)
   .transform((config) => {
     const extensionPoints = (config.targeting ?? config.extension_points ?? []).map((targeting) => {
+      const buildManifest: BuildManifest = {
+        assets: {
+          [AssetIdentifier.Main]: {
+            filepath: `${config.handle}.js`,
+            module: targeting.module,
+          },
+          ...(targeting.should_render?.module
+            ? {
+                [AssetIdentifier.ShouldRender]: {
+                  filepath: `${config.handle}-conditions.js`,
+                  module: targeting.should_render.module,
+                },
+              }
+            : null),
+        },
+      }
+
       return {
         target: targeting.target,
         module: targeting.module,
@@ -32,6 +64,7 @@ export const UIExtensionSchema = BaseSchema.extend({
         default_placement_reference: targeting.default_placement,
         capabilities: targeting.capabilities,
         preloads: targeting.preloads ?? {},
+        build_manifest: buildManifest,
       }
     })
     return {...config, extension_points: extensionPoints}
@@ -53,9 +86,11 @@ const uiExtensionSpec = createExtensionSpecification({
     return validateUIExtensionPointConfig(directory, config.extension_points, path)
   },
   deployConfig: async (config, directory) => {
+    const transformedExtensionPoints = config.extension_points.map(addDistPathToAssets)
+
     return {
       api_version: config.api_version,
-      extension_points: config.extension_points,
+      extension_points: transformedExtensionPoints,
       capabilities: config.capabilities,
       name: config.name,
       description: config.description,
@@ -64,7 +99,33 @@ const uiExtensionSpec = createExtensionSpecification({
     }
   },
   getBundleExtensionStdinContent: (config) => {
-    return config.extension_points.map(({module}) => `import '${module}';`).join('\n')
+    const main = config.extension_points
+      .map(({module}) => {
+        return `import '${module}'; `
+      })
+      .join('\n')
+
+    const assets: {[key: string]: Asset} = {}
+    config.extension_points.forEach((extensionPoint) => {
+      // Start of Selection
+      Object.entries(extensionPoint.build_manifest.assets).forEach(([identifier, asset]) => {
+        if (identifier === AssetIdentifier.Main) {
+          return
+        }
+
+        assets[identifier] = {
+          identifier: identifier as AssetIdentifier,
+          outputFileName: asset.filepath,
+          content: `import '${asset.module}'`,
+        }
+      })
+    })
+
+    const assetsArray = Object.values(assets)
+    return {
+      main,
+      ...(assetsArray.length ? {assets: assetsArray} : {}),
+    }
   },
   hasExtensionPointTarget: (config, requestedTarget) => {
     return (
@@ -74,6 +135,24 @@ const uiExtensionSpec = createExtensionSpecification({
     )
   },
 })
+
+function addDistPathToAssets(extP: NewExtensionPointSchemaType & {build_manifest: BuildManifest}) {
+  return {
+    ...extP,
+    build_manifest: {
+      ...extP.build_manifest,
+      assets: Object.fromEntries(
+        Object.entries(extP.build_manifest.assets).map(([key, value]) => [
+          key as AssetIdentifier,
+          {
+            ...value,
+            filepath: joinPath('dist', value.filepath),
+          },
+        ]),
+      ),
+    },
+  }
+}
 
 async function validateUIExtensionPointConfig(
   directory: string,

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -8,7 +8,7 @@ import {exec} from '@shopify/cli-kit/node/system'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import lockfile from 'proper-lockfile'
-import {joinPath} from '@shopify/cli-kit/node/path'
+import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {readFile, touchFile, writeFile, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {Writable} from 'stream'
@@ -91,12 +91,14 @@ export async function buildUIExtension(extension: ExtensionInstance, options: Ex
     env.APP_URL = options.appURL
   }
 
+  const {main, assets} = extension.getBundleExtensionStdinContent()
+
   try {
     await bundleExtension({
       minify: true,
       outputPath: extension.outputPath,
       stdin: {
-        contents: extension.getBundleExtensionStdinContent(),
+        contents: main,
         resolveDir: extension.directory,
         loader: 'tsx',
       },
@@ -106,6 +108,25 @@ export async function buildUIExtension(extension: ExtensionInstance, options: Ex
       stdout: options.stdout,
       sourceMaps: extension.isSourceMapGeneratingExtension,
     })
+    if (assets) {
+      await Promise.all(
+        assets.map(async (asset) => {
+          await bundleExtension({
+            minify: true,
+            outputPath: joinPath(dirname(extension.outputPath), asset.outputFileName),
+            stdin: {
+              contents: asset.content,
+              resolveDir: extension.directory,
+              loader: 'tsx',
+            },
+            environment: options.environment,
+            env,
+            stderr: options.stderr,
+            stdout: options.stdout,
+          })
+        }),
+      )
+    }
   } catch (extensionBundlingError) {
     // this fails if the app's own source code is broken; wrap such that this isn't flagged as a CLI bug
     throw new AbortError(

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
@@ -406,9 +406,9 @@ describe('app-event-watcher', () => {
 class MockESBuildContextManager extends ESBuildContextManager {
   contexts = {
     // The keys are the extension handles, the values are the ESBuild contexts mocked
-    h1: {rebuild: vi.fn(), watch: vi.fn(), serve: vi.fn(), cancel: vi.fn(), dispose: vi.fn()},
-    h2: {rebuild: vi.fn(), watch: vi.fn(), serve: vi.fn(), cancel: vi.fn(), dispose: vi.fn()},
-    'test-ui-extension': {rebuild: vi.fn(), watch: vi.fn(), serve: vi.fn(), cancel: vi.fn(), dispose: vi.fn()},
+    h1: [{rebuild: vi.fn(), watch: vi.fn(), serve: vi.fn(), cancel: vi.fn(), dispose: vi.fn()}],
+    h2: [{rebuild: vi.fn(), watch: vi.fn(), serve: vi.fn(), cancel: vi.fn(), dispose: vi.fn()}],
+    'test-ui-extension': [{rebuild: vi.fn(), watch: vi.fn(), serve: vi.fn(), cancel: vi.fn(), dispose: vi.fn()}],
   }
 
   constructor() {

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -228,7 +228,7 @@ export class AppEventWatcher extends EventEmitter {
       const ext = extEvent.extension
       return useConcurrentOutputContext({outputPrefix: ext.handle, stripAnsi: false}, async () => {
         try {
-          if (this.esbuildManager.contexts[ext.handle]) {
+          if (this.esbuildManager.contexts?.[ext.handle]?.length) {
             await this.esbuildManager.rebuildContext(ext)
           } else {
             await this.buildExtension(ext)

--- a/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.test.ts
@@ -35,6 +35,50 @@ describe('app-watcher-esbuild', () => {
     expect(manager.contexts).toHaveProperty('test-ui-extension')
   })
 
+  test('creating multiple contexts for the same extension', async () => {
+    // Given
+    const options: DevAppWatcherOptions = {
+      dotEnvVariables: {key: 'value'},
+      url: 'http://localhost:3000',
+      outputPath: '/path/to/output',
+    }
+    const manager = new ESBuildContextManager(options)
+    const extension = await testUIExtension({
+      configuration: {
+        ...extension2.configuration,
+        handle: 'conditional-extension',
+        extension_points: [
+          {
+            target: 'target1',
+            module: 'module1',
+            should_render: {
+              module: 'shouldRenderModule1',
+            },
+            build_manifest: {
+              assets: {
+                main: {
+                  module: 'module1',
+                  filepath: '/conditional-extension.js',
+                },
+                should_render: {
+                  module: 'shouldRenderModule1',
+                  filepath: '/conditional-extension-conditions.js',
+                },
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    // When
+    await manager.createContexts([extension])
+
+    // Then
+    expect(manager.contexts).toHaveProperty('conditional-extension')
+    expect(manager.contexts['conditional-extension']).toHaveLength(2)
+  })
+
   test('deleting contexts', async () => {
     // Given
     const manager = new ESBuildContextManager(options)
@@ -76,7 +120,7 @@ describe('app-watcher-esbuild', () => {
     // Given
     const manager = new ESBuildContextManager(options)
     await manager.createContexts([extension1])
-    const spyContext = vi.spyOn(manager.contexts.h1!, 'rebuild').mockResolvedValue({} as any)
+    const spyContext = vi.spyOn(manager.contexts.h1![0]!, 'rebuild').mockResolvedValue({} as any)
     const spyCopy = vi.spyOn(fs, 'copyFile').mockResolvedValue()
 
     // When

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -120,6 +120,151 @@ describe('getUIExtensionPayload', () => {
     })
   })
 
+  test('returns the right payload for UI Extensions with build_manifest', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const outputPath = joinPath(tmpDir, 'test-ui-extension.js')
+      await touchFile(outputPath)
+      const signal: any = vi.fn()
+      const stdout: any = vi.fn()
+      const stderr: any = vi.fn()
+      vi.spyOn(appModel, 'getUIExtensionRendererVersion').mockResolvedValue({
+        name: 'extension-renderer',
+        version: '1.2.3',
+      })
+
+      const buildManifest = {
+        assets: {
+          main: {identifier: 'main', module: './src/ExtensionPointA.js', filepath: '/test-ui-extension.js'},
+          should_render: {
+            identifier: 'should_render',
+            module: './src/ShouldRender.js',
+            filepath: '/test-ui-extension-conditions.js',
+          },
+        },
+      }
+
+      const uiExtension = await testUIExtension({
+        outputPath,
+        directory: tmpDir,
+        configuration: {
+          name: 'test-ui-extension',
+          type: 'ui_extension',
+          metafields: [],
+          capabilities: {
+            network_access: true,
+            api_access: true,
+            block_progress: false,
+            collect_buyer_consent: {
+              sms_marketing: false,
+              customer_privacy: false,
+            },
+            iframe: {
+              sources: ['https://my-iframe.com'],
+            },
+          },
+          extension_points: [
+            {
+              target: 'CUSTOM_EXTENSION_POINT',
+              build_manifest: buildManifest,
+            },
+          ],
+        },
+        devUUID: 'devUUID',
+      })
+
+      const options: Omit<ExtensionDevOptions, 'appWatcher'> = {
+        signal,
+        stdout,
+        stderr,
+        apiKey: 'api-key',
+        appName: 'foobar',
+        appDirectory: '/tmp',
+        extensions: [uiExtension],
+        grantedScopes: ['scope-a'],
+        port: 123,
+        url: 'http://tunnel-url.com',
+        storeFqdn: 'my-domain.com',
+        storeId: '123456789',
+        buildDirectory: tmpDir,
+        checkoutCartUrl: 'https://my-domain.com/cart',
+        subscriptionProductUrl: 'https://my-domain.com/subscription',
+        manifestVersion: '3',
+      }
+      const development: Partial<UIExtensionPayload['development']> = {
+        hidden: true,
+        status: 'success',
+      }
+
+      // When
+      const got = await getUIExtensionPayload(uiExtension, 'mock-bundle-path', {
+        ...options,
+        currentDevelopmentPayload: development,
+      })
+
+      // Then
+      expect(got).toMatchObject({
+        assets: {
+          main: {
+            lastUpdated: expect.any(Number),
+            name: 'main',
+            url: 'http://tunnel-url.com/extensions/devUUID/assets/test-ui-extension.js',
+          },
+        },
+        capabilities: {
+          blockProgress: false,
+          networkAccess: true,
+          apiAccess: true,
+          collectBuyerConsent: {
+            smsMarketing: false,
+          },
+          iframe: {
+            sources: ['https://my-iframe.com'],
+          },
+        },
+        development: {
+          hidden: true,
+          localizationStatus: '',
+          resource: {
+            url: '',
+          },
+          root: {
+            url: 'http://tunnel-url.com/extensions/devUUID',
+          },
+          status: 'success',
+        },
+        extensionPoints: [
+          {
+            target: 'CUSTOM_EXTENSION_POINT',
+            build_manifest: buildManifest,
+            assets: {
+              main: {
+                lastUpdated: expect.any(Number),
+                name: 'main',
+                url: 'http://tunnel-url.com/extensions/devUUID/assets/test-ui-extension.js',
+              },
+              should_render: {
+                lastUpdated: expect.any(Number),
+                name: 'should_render',
+                url: 'http://tunnel-url.com/extensions/devUUID/assets/test-ui-extension-conditions.js',
+              },
+            },
+          },
+        ],
+        externalType: 'ui_extension_external',
+        localization: null,
+        metafields: null,
+        // as surfaces come from remote specs, we dont' have real values here
+        surface: 'test-surface',
+        title: 'test-ui-extension',
+        type: 'ui_extension',
+        uuid: 'devUUID',
+        version: '1.2.3',
+        approvalScopes: ['scope-a'],
+      })
+    })
+  })
+
   test('default values', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -1,12 +1,14 @@
 import {getLocalization} from './localization.js'
-import {DevNewExtensionPointSchema, UIExtensionPayload} from './payload/models.js'
+import {Asset, DevNewExtensionPointSchema, UIExtensionPayload} from './payload/models.js'
 import {getExtensionPointTargetSurface} from './utilities.js'
 import {getUIExtensionResourceURL} from '../../../utilities/extensions/configuration.js'
 import {ExtensionDevOptions} from '../extension.js'
 import {getUIExtensionRendererVersion} from '../../../models/app/app.js'
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
+import {BuildManifest} from '../../../models/extensions/specifications/ui_extension.js'
 import {fileLastUpdatedTimestamp} from '@shopify/cli-kit/node/fs'
 import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
+import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 
 export type GetUIExtensionPayloadOptions = Omit<ExtensionDevOptions, 'appWatcher'> & {
   currentDevelopmentPayload?: Partial<UIExtensionPayload['development']>
@@ -24,6 +26,9 @@ export async function getUIExtensionPayload(
     const {localization, status: localizationStatus} = await getLocalization(extension, options)
 
     const renderer = await getUIExtensionRendererVersion(extension)
+
+    const extensionPoints = await getExtensionPoints(extension, url)
+
     const defaultConfig = {
       assets: {
         main: {
@@ -55,7 +60,7 @@ export async function getUIExtensionPayload(
         status: options.currentDevelopmentPayload?.status || 'success',
         ...(options.currentDevelopmentPayload || {status: 'success'}),
       },
-      extensionPoints: getExtensionPoints(extension.configuration.extension_points, url),
+      extensionPoints,
       localization: localization ?? null,
       metafields: extension.configuration.metafields.length === 0 ? null : extension.configuration.metafields,
       type: extension.configuration.type,
@@ -80,23 +85,46 @@ export async function getUIExtensionPayload(
   })
 }
 
-function getExtensionPoints(extensionPoints: ExtensionInstance['configuration']['extension_points'], url: string) {
-  if (isNewExtensionPointsSchema(extensionPoints)) {
-    return extensionPoints.map((extensionPoint) => {
-      const {target, resource} = extensionPoint
+async function getExtensionPoints(extension: ExtensionInstance, url: string) {
+  const extensionPoints = extension.configuration.extension_points as DevNewExtensionPointSchema[]
 
-      return {
-        ...extensionPoint,
-        surface: getExtensionPointTargetSurface(target),
-        root: {
-          url: `${url}/${target}`,
-        },
-        resource: resource || {url: ''},
-      }
-    })
+  if (isNewExtensionPointsSchema(extensionPoints)) {
+    return Promise.all(
+      extensionPoints.map(async (extensionPoint) => {
+        const {target, resource} = extensionPoint
+
+        return {
+          ...extensionPoint,
+          ...(extensionPoint.build_manifest
+            ? {assets: await extractAssetsFromBuildManifest(extensionPoint.build_manifest, url, extension)}
+            : {}),
+          surface: getExtensionPointTargetSurface(target),
+          root: {
+            url: `${url}/${target}`,
+          },
+          resource: resource || {url: ''},
+        }
+      }),
+    )
   }
 
   return extensionPoints
+}
+
+async function extractAssetsFromBuildManifest(buildManifest: BuildManifest, url: string, extension: ExtensionInstance) {
+  if (!buildManifest?.assets) return {}
+  const assets: {[key: string]: Asset} = {}
+
+  for (const [name, asset] of Object.entries(buildManifest.assets)) {
+    assets[name] = {
+      name,
+      url: `${url}${joinPath('/assets/', asset.filepath)}`,
+      // eslint-disable-next-line no-await-in-loop
+      lastUpdated: (await fileLastUpdatedTimestamp(joinPath(dirname(extension.outputPath), asset.filepath))) ?? 0,
+    }
+  }
+
+  return assets
 }
 
 export function isNewExtensionPointsSchema(extensionPoints: unknown): extensionPoints is DevNewExtensionPointSchema[] {

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -1,4 +1,5 @@
 import {Localization} from '../localization.js'
+import {BuildManifest} from '../../../../models/extensions/specifications/ui_extension.js'
 import type {NewExtensionPointSchemaType, ApiVersionSchemaType} from '../../../../models/extensions/schemas.js'
 
 interface ExtensionsPayloadInterface {
@@ -25,8 +26,17 @@ export interface ExtensionsEndpointPayload extends ExtensionsPayloadInterface {
     url: string
   }
 }
+export interface Asset {
+  name: string
+  url: string
+  lastUpdated: number
+}
 
 export interface DevNewExtensionPointSchema extends NewExtensionPointSchemaType {
+  build_manifest: BuildManifest
+  assets: {
+    [name: string]: Asset
+  }
   root: {
     url: string
   }
@@ -37,10 +47,7 @@ export interface DevNewExtensionPointSchema extends NewExtensionPointSchemaType 
 
 export interface UIExtensionPayload {
   assets: {
-    main: {
-      url: string
-      lastUpdated: number
-    }
+    main: Asset
   }
   capabilities?: Capabilities
   development: {

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -94,7 +94,7 @@ export interface ExtensionPoint {
   localization?: FlattenedLocalization | Localization | null
   name: string
   description?: string
-  shouldRender?: {scriptUrl?: string}
+  assets?: {[name: string]: Asset}
 }
 
 export type ExtensionPoints = string[] | ExtensionPoint[] | null


### PR DESCRIPTION
### WHY are these changes introduced?

Part of [conditional rendering project](https://docs.google.com/document/d/1X1NhQMxz6GnTU49rDplMd1yVmX3rsj2obIfHUFQ7WkM/edit?tab=t.0).

This PR enables the processing of a `should_render` asset, as well as other assets.

### WHAT is this pull request doing?

- Maps `should_render` field from TOML to extension config
- Bundles all `should_render` modules into one file (for both `dev` and `deploy` actions)
- Sends `buildManifest` to `shopify` in order centralize file path information in one place

### How to test your changes?

[Testing instructions](https://gist.github.com/elanalynn/bff3bda620cb5d0284d0cf892e713e90)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
