### PR TITLE
Fix password validation to handle capitalized store names on `shopify theme dev`

### DIFF
--- a/.changeset/wet-rats-applaud.md
+++ b/.changeset/wet-rats-applaud.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix password validation to handle capitalized store names on `shopify theme dev`

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -237,6 +237,33 @@ describe('Storefront API', () => {
       })
     })
 
+    test('returns true when the password is correct and the store name is capitalized', async () => {
+      // Given
+      vi.mocked(fetch).mockResolvedValueOnce(
+        response({
+          status: 302,
+          headers: {
+            location: 'https://store.myshopify.com',
+          },
+        }),
+      )
+
+      // When
+      const result = await isStorefrontPasswordCorrect('correct-password-&', 'Store.myshopify.com')
+
+      // Then
+      expect(result).toBe(true)
+      expect(fetch).toBeCalledWith('https://Store.myshopify.com/password', {
+        body: 'form_type=storefront_password&utf8=%E2%9C%93&password=correct-password-%26',
+        headers: {
+          'cache-control': 'no-cache',
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        method: 'POST',
+        redirect: 'manual',
+      })
+    })
+
     test('returns false when the password is incorrect', async () => {
       // Given
       vi.mocked(fetch).mockResolvedValueOnce(

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -22,13 +22,14 @@ export async function isStorefrontPasswordProtected(storeURL: string): Promise<b
  * If the password is correct, SFR will respond with a 302 to redirect to the storefront
  */
 export async function isStorefrontPasswordCorrect(password: string | undefined, store: string) {
+  const storeUrl = prependHttps(store)
   const params = new URLSearchParams()
 
   params.append('form_type', 'storefront_password')
   params.append('utf8', '✓')
   params.append('password', password ?? '')
 
-  const response = await fetch(`${prependHttps(store)}/password`, {
+  const response = await fetch(`${storeUrl}/password`, {
     headers: {
       'cache-control': 'no-cache',
       'content-type': 'application/x-www-form-urlencoded',
@@ -43,7 +44,10 @@ export async function isStorefrontPasswordCorrect(password: string | undefined, 
       `Too many incorrect password attempts. Please try again after ${response.headers.get('retry-after')} seconds.`,
     )
   }
-  return response.status === 302 && response.headers.get('location') === `${prependHttps(store)}/`
+
+  const isValidRedirect = new RegExp(`^${storeUrl}/?$`, 'i')
+
+  return response.status === 302 && isValidRedirect.test(response.headers.get('location') ?? '')
 }
 
 export async function getStorefrontSessionCookies(


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/4733

### WHAT is this pull request doing?

This PR updates the logic that checks if a password is valid to be case insensitive when checking the password. Even if users authenticate with a capitalized domain, storefronts redirect users to the lowercased domain after the password request successfully passes.

### How to test your changes?

- Run `shopify theme dev --store <your_store_with_capitalized_letters>`

**Before**
![Screenshot 2024-11-13 at 08 45 43](https://github.com/user-attachments/assets/9549d410-bbf5-4b33-ac3c-4fdb1205b6aa)

**After**
![Screenshot 2024-11-13 at 08 45 15](https://github.com/user-attachments/assets/6f41016d-5fc5-4124-af22-6e226715c4ec)


### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
