### PR TITLE
Improve dev session start

### DIFF
--- a/packages/app/src/cli/services/dev/processes/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session.ts
@@ -127,6 +127,8 @@ export const pushUpdatesForDevSession: DevProcessFunction<DevSessionOptions> = a
   await appWatcher.start()
 }
 
+// We shouldn't need this, as the dev session create mutation shouldn't hang, but it can be a temporary
+// utility to debug issues with the dev API.
 function startTimeout(processOptions: DevSessionProcessOptions) {
   setTimeout(() => {
     if (devSessionStatus !== 'ready') {

--- a/packages/app/src/cli/services/dev/processes/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session.ts
@@ -87,13 +87,6 @@ export const pushUpdatesForDevSession: DevProcessFunction<DevSessionOptions> = a
 
   await printLogMessage('Preparing dev session', processOptions.stdout)
 
-  setTimeout(() => {
-    if (devSessionStatus !== 'ready') {
-      printError('❌ Timeout, session failed to start in 20s, please try again.', processOptions.stdout).catch(() => {})
-      process.exit(1)
-    }
-  }, 20000)
-
   appWatcher
     .onEvent(async (event) => {
       if (devSessionStatus !== 'ready') {
@@ -132,6 +125,15 @@ export const pushUpdatesForDevSession: DevProcessFunction<DevSessionOptions> = a
 
   // Start watching for changes in the app
   await appWatcher.start()
+}
+
+function startTimeout(processOptions: DevSessionProcessOptions) {
+  setTimeout(() => {
+    if (devSessionStatus !== 'ready') {
+      printError('❌ Timeout, session failed to start in 30s, please try again.', processOptions.stdout).catch(() => {})
+      process.exit(1)
+    }
+  }, 30000)
 }
 
 async function handleDevSessionResult(
@@ -226,6 +228,7 @@ async function bundleExtensionsAndUpload(options: DevSessionProcessOptions): Pro
       await options.developerPlatformClient.devSessionUpdate(payload)
       return {status: 'updated'}
     } else {
+      startTimeout(options)
       await options.developerPlatformClient.devSessionCreate(payload)
       // eslint-disable-next-line require-atomic-updates
       devSessionStatus = 'ready'


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
There is a race condition that can prevent the dev-session to start.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Fix the race condition: the dev create process shouldn't be cancelled in any case
- If a change is detected before the session is ready, show a warning.
- Add a 30s timeout, if the session hasn't started in 30 seconds, exit the process and inform the user. (this shouldn't be necessary, but probably useful in the early stages for testing)
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Run `app dev` with the app management API
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
