### PR TITLE
Update `shopify theme dev` to no longer display redundant URLs

### DIFF
--- a/.changeset/pink-garlics-act.md
+++ b/.changeset/pink-garlics-act.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Update `shopify theme dev` to no longer display redundant URLs

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -108,13 +108,7 @@ describe('dev', () => {
         body: [
           {
             list: {
-              items: [
-                {
-                  link: {
-                    url: 'http://127.0.0.1:9292',
-                  },
-                },
-              ],
+              items: ['http://127.0.0.1:9292'],
               title: {
                 bold: 'Preview your theme',
               },
@@ -139,12 +133,7 @@ describe('dev', () => {
             },
           ],
           [
-            {
-              link: {
-                label: 'Share your theme preview',
-                url: 'https://my-store.myshopify.com/?preview_theme_id=123',
-              },
-            },
+            'Share your theme preview',
             {
               subdued: '(https://my-store.myshopify.com/?preview_theme_id=123)',
             },

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -114,13 +114,7 @@ export function renderLinks(store: string, themeId: string, host = DEFAULT_HOST,
       {
         list: {
           title: {bold: 'Preview your theme'},
-          items: [
-            {
-              link: {
-                url: localUrl,
-              },
-            },
-          ],
+          items: [localUrl],
         },
       },
     ],
@@ -142,12 +136,7 @@ export function renderLinks(store: string, themeId: string, host = DEFAULT_HOST,
         },
       ],
       [
-        {
-          link: {
-            label: 'Share your theme preview',
-            url: `${remoteUrl}/?preview_theme_id=${themeId}`,
-          },
-        },
+        'Share your theme preview',
         {
           subdued: `(${remoteUrl}/?preview_theme_id=${themeId})`,
         },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-advanced-edits/issues/424

We've received feedback that URLs in the `shopify theme dev` command are redundant, so this PR fixes that.

### WHAT is this pull request doing?

While the CLI-UI kit encourages the usage of hyperlinks, they appeared duplicated in some contexts. Additionally, most terminal emulators that do not support hyperlinks generally support clickable URLs, so this clean-up doesn't represent a change in the UX for most users, but cleans the UI for all of them.

### How to test your changes?

- Run `shopify theme dev`

![Screenshot 2024-11-14 at 10 55 33](https://github.com/user-attachments/assets/6c701fab-4599-44ce-b254-9234ed6b9e84)

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
