### PR TITLE
Get creation options without loading the app during `app init`

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3147,8 +3147,6 @@ describe('getAppConfigurationState', () => {
   })
 })
 
-// ... existing imports ...
-
 describe('loadConfigForAppCreation', () => {
   test('returns correct configuration for a basic app with no webs', async () => {
     // Given

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -8,6 +8,7 @@ import {
   checkFolderIsValidApp,
   AppLoaderMode,
   getAppConfigurationState,
+  loadConfigForAppCreation,
 } from './loader.js'
 import {LegacyAppSchema, WebConfigurationSchema} from './app.js'
 import {DEFAULT_CONFIG, buildVersionedAppSchema, getWebhookConfig} from './app.test-data.js'
@@ -3142,6 +3143,145 @@ describe('getAppConfigurationState', () => {
 
       const state = await getAppConfigurationState(tmpDir, undefined)
       expect(state).toMatchObject(resultShouldContain)
+    })
+  })
+})
+
+// ... existing imports ...
+
+describe('loadConfigForAppCreation', () => {
+  test('returns correct configuration for a basic app with no webs', async () => {
+    // Given
+    await inTemporaryDirectory(async (tmpDir) => {
+      const config = `
+        scopes = "write_products,read_orders"
+        name = "my-app"
+      `
+      await writeFile(joinPath(tmpDir, 'shopify.app.toml'), config)
+      await writeFile(joinPath(tmpDir, 'package.json'), '{}')
+
+      // When
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+
+      // Then
+      expect(result).toEqual({
+        isLaunchable: false,
+        scopesArray: ['read_orders', 'write_products'],
+        name: 'my-app',
+      })
+    })
+  })
+
+  test('returns correct configuration for an app with a frontend web', async () => {
+    // Given
+    await inTemporaryDirectory(async (tmpDir) => {
+      const config = `
+        scopes = "write_products"
+        name = "my-app"
+      `
+      await writeFile(joinPath(tmpDir, 'shopify.app.toml'), config)
+      await writeFile(joinPath(tmpDir, 'package.json'), '{}')
+
+      await writeFile(
+        joinPath(tmpDir, 'shopify.web.toml'),
+        `roles = ["frontend"]
+name = "web"
+
+[commands]
+dev = "echo 'Hello, world!'"
+        `,
+      )
+
+      // When
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+
+      // Then
+      expect(result).toEqual({
+        isLaunchable: true,
+        scopesArray: ['write_products'],
+        name: 'my-app',
+      })
+    })
+  })
+
+  test('returns correct configuration for an app with a backend web', async () => {
+    // Given
+    await inTemporaryDirectory(async (tmpDir) => {
+      const config = `
+        scopes = "write_products"
+        name = "my-app"
+      `
+      await writeFile(joinPath(tmpDir, 'shopify.app.toml'), config)
+      await writeFile(joinPath(tmpDir, 'package.json'), '{}')
+
+      // Create web directory with backend configuration
+      const webDir = joinPath(tmpDir, 'web')
+      await mkdir(webDir)
+      await writeFile(
+        joinPath(tmpDir, 'shopify.web.toml'),
+        `roles = ["backend"]
+name = "web"
+
+[commands]
+dev = "echo 'Hello, world!'"
+        `,
+      )
+
+      // When
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+
+      // Then
+      expect(result).toEqual({
+        isLaunchable: true,
+        scopesArray: ['write_products'],
+        name: 'my-app',
+      })
+    })
+  })
+
+  test('returns correct configuration for a connected app', async () => {
+    // Given
+    await inTemporaryDirectory(async (tmpDir) => {
+      const config = `
+        client_id = "12345"
+        name = "my-app"
+        [access_scopes]
+        scopes = "read_orders,write_products"
+      `
+      await writeFile(joinPath(tmpDir, 'shopify.app.toml'), config)
+      await writeFile(joinPath(tmpDir, 'package.json'), '{}')
+
+      // When
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+
+      // Then
+      expect(result).toEqual({
+        isLaunchable: false,
+        scopesArray: ['read_orders', 'write_products'],
+        name: 'my-app',
+      })
+    })
+  })
+
+  test('handles empty scopes correctly', async () => {
+    // Given
+    await inTemporaryDirectory(async (tmpDir) => {
+      const config = `
+        name = "my-app"
+        scopes = ""
+      `
+      await writeFile(joinPath(tmpDir, 'shopify.app.toml'), config)
+      await writeFile(joinPath(tmpDir, 'package.json'), '{}')
+
+      // When
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+
+      // Then
+      expect(result).toEqual({
+        isLaunchable: false,
+        scopesArray: [],
+        name: 'my-app',
+      })
     })
   })
 })

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -217,7 +217,7 @@ export async function loadConfigForAppCreation(directory: string, name: string):
   const config: AppConfiguration = state.state === 'connected-app' ? state.basicConfiguration : state.startingOptions
   const loadedConfiguration = await loadAppConfigurationFromState(state, [], [])
 
-  const loader = new AppLoader({mode: 'report', loadedConfiguration})
+  const loader = new AppLoader({loadedConfiguration})
   const webs = await loader.loadWebs(directory)
 
   return {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -15,6 +15,7 @@ import {
   LegacyAppConfiguration,
   BasicAppConfigurationWithoutModules,
   SchemaForConfig,
+  AppCreationDefaultOptions,
 } from './app.js'
 import {configurationFileNames, dotEnvFileNames} from '../../constants.js'
 import metadata from '../../metadata.js'
@@ -211,6 +212,26 @@ export async function checkFolderIsValidApp(directory: string) {
   )
 }
 
+export async function loadConfigForAppCreation(directory: string, name: string): Promise<AppCreationDefaultOptions> {
+  const state = await getAppConfigurationState(directory)
+  const config: AppConfiguration = state.state === 'connected-app' ? state.basicConfiguration : state.startingOptions
+  const scopesArray = getAppScopesArray(config)
+  const loadedConfiguration = await loadAppConfigurationFromState(state, [], [])
+
+  const loader = new AppLoader({
+    mode: 'report',
+    loadedConfiguration,
+  })
+  const webs = await loader.loadWebs(directory)
+  const isLaunchable = webs.webs.some((web) => isWebType(web, WebType.Frontend) || isWebType(web, WebType.Backend))
+
+  return {
+    isLaunchable,
+    scopesArray,
+    name,
+  }
+}
+
 /**
  * Load the local app from the given directory and using the provided extensions/functions specifications.
  * If the App contains extensions not supported by the current specs and mode is strict, it will throw an error.
@@ -342,6 +363,23 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
     return appClass
   }
 
+  async loadWebs(appDirectory: string, webDirectories?: string[]): Promise<{webs: Web[]; usedCustomLayout: boolean}> {
+    const defaultWebDirectory = '**'
+    const webConfigGlobs = [...(webDirectories ?? [defaultWebDirectory])].map((webGlob) => {
+      return joinPath(appDirectory, webGlob, configurationFileNames.web)
+    })
+    webConfigGlobs.push(`!${joinPath(appDirectory, '**/node_modules/**')}`)
+    const webTomlPaths = await glob(webConfigGlobs)
+
+    const webs = await Promise.all(webTomlPaths.map((path) => this.loadWeb(path)))
+    this.validateWebs(webs)
+
+    const webTomlsInStandardLocation = await glob(joinPath(appDirectory, `web/**/${configurationFileNames.web}`))
+    const usedCustomLayout = webDirectories !== undefined || webTomlsInStandardLocation.length !== webTomlPaths.length
+
+    return {webs, usedCustomLayout}
+  }
+
   private findSpecificationForType(type: string) {
     return this.specifications.find(
       (spec) =>
@@ -385,26 +423,6 @@ We recommend removing the @shopify/cli and @shopify/app dependencies from your p
       renderInfo(warningContent)
       alreadyShownCLIWarning = true
     }
-  }
-
-  private async loadWebs(
-    appDirectory: string,
-    webDirectories?: string[],
-  ): Promise<{webs: Web[]; usedCustomLayout: boolean}> {
-    const defaultWebDirectory = '**'
-    const webConfigGlobs = [...(webDirectories ?? [defaultWebDirectory])].map((webGlob) => {
-      return joinPath(appDirectory, webGlob, configurationFileNames.web)
-    })
-    webConfigGlobs.push(`!${joinPath(appDirectory, '**/node_modules/**')}`)
-    const webTomlPaths = await glob(webConfigGlobs)
-
-    const webs = await Promise.all(webTomlPaths.map((path) => this.loadWeb(path)))
-    this.validateWebs(webs)
-
-    const webTomlsInStandardLocation = await glob(joinPath(appDirectory, `web/**/${configurationFileNames.web}`))
-    const usedCustomLayout = webDirectories !== undefined || webTomlsInStandardLocation.length !== webTomlPaths.length
-
-    return {webs, usedCustomLayout}
   }
 
   private validateWebs(webs: Web[]): void {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -215,19 +215,14 @@ export async function checkFolderIsValidApp(directory: string) {
 export async function loadConfigForAppCreation(directory: string, name: string): Promise<AppCreationDefaultOptions> {
   const state = await getAppConfigurationState(directory)
   const config: AppConfiguration = state.state === 'connected-app' ? state.basicConfiguration : state.startingOptions
-  const scopesArray = getAppScopesArray(config)
   const loadedConfiguration = await loadAppConfigurationFromState(state, [], [])
 
-  const loader = new AppLoader({
-    mode: 'report',
-    loadedConfiguration,
-  })
+  const loader = new AppLoader({mode: 'report', loadedConfiguration})
   const webs = await loader.loadWebs(directory)
-  const isLaunchable = webs.webs.some((web) => isWebType(web, WebType.Frontend) || isWebType(web, WebType.Backend))
 
   return {
-    isLaunchable,
-    scopesArray,
+    isLaunchable: webs.webs.some((web) => isWebType(web, WebType.Frontend) || isWebType(web, WebType.Backend)),
+    scopesArray: getAppScopesArray(config),
     name,
   }
 }

--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -3,9 +3,8 @@ import cleanup from './template/cleanup.js'
 import link from '../app/config/link.js'
 import {OrganizationApp} from '../../models/organization.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
-import {loadApp} from '../../models/app/loader.js'
+import {loadConfigForAppCreation} from '../../models/app/loader.js'
 import {SelectAppOrNewAppNameResult} from '../../commands/app/init.js'
-import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {
   findUpAndReadPackageJson,
   lockfiles,
@@ -198,12 +197,9 @@ async function init(options: InitOptions) {
 
   let app: OrganizationApp
   if (options.selectedAppOrNameResult.result === 'new') {
-    // Load the local app to get the creation options.
-    // NOTE: need the specs to load the scopes, if we ever remove the local specs, we need to find a way to do this without them.
-    const specifications = await loadLocalExtensionsSpecifications()
-    const localApp = await loadApp({specifications, directory: outputDirectory, userProvidedConfigName: undefined})
+    const creationOptions = await loadConfigForAppCreation(outputDirectory, options.name)
     const org = options.selectedAppOrNameResult.org
-    app = await options.developerPlatformClient.createApp(org, options.name, localApp.creationDefaultOptions())
+    app = await options.developerPlatformClient.createApp(org, options.name, creationOptions)
   } else {
     app = options.selectedAppOrNameResult.app
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,7 +279,7 @@ importers:
         version: link:../app
       '@shopify/cli-hydrogen':
         specifier: 9.0.2
-        version: 9.0.2(react-dom@18.2.0)(react@18.2.0)
+        version: 9.0.2(@graphql-codegen/cli@5.0.2)(react-dom@17.0.2)(react@17.0.2)
       '@shopify/cli-kit':
         specifier: 3.70.0
         version: link:../cli-kit
@@ -6026,7 +6026,7 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@shopify/cli-hydrogen@9.0.2(react-dom@18.2.0)(react@18.2.0):
+  /@shopify/cli-hydrogen@9.0.2(@graphql-codegen/cli@5.0.2)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-KRlBmgik6fdzIw8z9Xj31swE2dIgTFavCSTS/tonumlu2RX5DrT2M+OTjiQv8s6wLJn5a4Nn6/+5Ds/hKGaKEQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -6052,6 +6052,7 @@ packages:
         optional: true
     dependencies:
       '@ast-grep/napi': 0.11.0
+      '@graphql-codegen/cli': 5.0.2(@types/node@18.19.3)(graphql@16.8.1)(typescript@5.2.2)
       '@oclif/core': 3.26.5
       '@shopify/cli-kit': link:packages/cli-kit
       '@shopify/oxygen-cli': 4.5.3(@oclif/core@3.26.5)(@shopify/cli-kit@packages+cli-kit)
@@ -6069,7 +6070,7 @@ packages:
       tar-fs: 2.1.1
       tempy: 3.0.0
       ts-morph: 20.0.0
-      use-resize-observer: 9.1.0(react-dom@18.2.0)(react@18.2.0)
+      use-resize-observer: 9.1.0(react-dom@17.0.2)(react@17.0.2)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -11309,7 +11310,6 @@ packages:
 
   /immutable@4.3.5:
     resolution: {integrity: sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==}
-    dev: true
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -13792,6 +13792,7 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.2
+    dev: false
 
   /react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -13909,6 +13910,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
 
   /read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -14299,7 +14301,6 @@ packages:
       chokidar: 3.5.3
       immutable: 4.3.5
       source-map-js: 1.2.0
-    dev: true
 
   /saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -14318,6 +14319,7 @@ packages:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
 
   /scuid@1.1.0:
     resolution: {integrity: sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==}
@@ -15614,15 +15616,15 @@ packages:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
     dev: true
 
-  /use-resize-observer@9.1.0(react-dom@18.2.0)(react@18.2.0):
+  /use-resize-observer@9.1.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==}
     peerDependencies:
       react: 16.8.0 - 18
       react-dom: 16.8.0 - 18
     dependencies:
       '@juggle/resize-observer': 3.4.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     dev: true
 
   /util-arity@1.1.0:
@@ -15710,7 +15712,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.3.1(@types/node@18.19.3)
+      vite: 5.3.1(@types/node@18.19.3)(sass@1.76.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15720,41 +15722,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-
-  /vite@5.3.1(@types/node@18.19.3):
-    resolution: {integrity: sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.19.3
-      esbuild: 0.21.5
-      postcss: 8.4.38
-      rollup: 4.18.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   /vite@5.3.1(@types/node@18.19.3)(sass@1.76.0):
     resolution: {integrity: sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==}
@@ -15791,7 +15758,6 @@ packages:
       sass: 1.76.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vitest@1.6.0(@types/node@18.19.3):
     resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
@@ -15836,7 +15802,7 @@ packages:
       strip-literal: 2.1.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.3.1(@types/node@18.19.3)
+      vite: 5.3.1(@types/node@18.19.3)(sass@1.76.0)
       vite-node: 1.6.0(@types/node@18.19.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
To create during `app init`, we need to load what we call the "Creation Options" which include two key values: the default scopes and whether the app is launchable or not.

We did this by loading the local app first to check those values, but we can't do that if the template has custom extensiosn, because we don't have the specifications at this point (because there is no remote app yet!)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Instead of loading the app: just load the basic configuration from the toml and the `webs` configuration. That's all we need for the creation options.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
The easiest way is to put a breakpoint in `services/init/init.ts` line 201.
Validate that the `creationOptions` object is valid in these three cases:
- An extensions-only app
- A default remix app
- A remix template with custom extensions and scopes (ask for an example of this)

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
