### PR TITLE
Update dev-session graphql queries

### DIFF
--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 import * as Types from './types.js'
+import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -8,7 +9,11 @@ export type DevSessionCreateMutationVariables = Types.Exact<{
   assetsUrl: Types.Scalars['String']['input']
 }>
 
-export type DevSessionCreateMutation = {devSessionCreate?: {userErrors: {message: string}[]} | null}
+export type DevSessionCreateMutation = {
+  devSessionCreate?: {
+    userErrors: {message: string; on: JsonMapType; field?: string[] | null; category: string}[]
+  } | null
+}
 
 export const DevSessionCreate = {
   kind: 'Document',
@@ -57,6 +62,9 @@ export const DevSessionCreate = {
                     kind: 'SelectionSet',
                     selections: [
                       {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'on'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'field'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'category'}},
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],
                   },

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 import * as Types from './types.js'
+import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -8,7 +9,11 @@ export type DevSessionUpdateMutationVariables = Types.Exact<{
   assetsUrl: Types.Scalars['String']['input']
 }>
 
-export type DevSessionUpdateMutation = {devSessionUpdate?: {userErrors: {message: string}[]} | null}
+export type DevSessionUpdateMutation = {
+  devSessionUpdate?: {
+    userErrors: {message: string; on: JsonMapType; field?: string[] | null; category: string}[]
+  } | null
+}
 
 export const DevSessionUpdate = {
   kind: 'Document',
@@ -57,6 +62,9 @@ export const DevSessionUpdate = {
                     kind: 'SelectionSet',
                     selections: [
                       {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'on'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'field'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'category'}},
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],
                   },

--- a/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-create.graphql
+++ b/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-create.graphql
@@ -2,6 +2,9 @@ mutation DevSessionCreate($appId: String!, $assetsUrl: String!) {
   devSessionCreate(appId: $appId, assetsUrl: $assetsUrl) {
     userErrors {
       message
+      on
+      field
+      category
     }
   }
 }

--- a/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-update.graphql
+++ b/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-update.graphql
@@ -2,6 +2,9 @@ mutation DevSessionUpdate($appId: String!, $assetsUrl: String!) {
   devSessionUpdate(appId: $appId, assetsUrl: $assetsUrl) {
     userErrors {
       message
+      on
+      field
+      category
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Part of a feature to improve errors in dev-sessions

### WHAT is this pull request doing?
Adds additional error fields (`on`, `field`, and `category`) to dev session GraphQL mutations to provide more detailed error information when creating or updating dev sessions.

### How to test your changes?


### Measuring impact
- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes