### PR TITLE
Clean up app management client module interpretation quality concerns

### DIFF
--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -13,6 +13,7 @@ export type Scalars = {
   Boolean: {input: boolean; output: boolean}
   Int: {input: number; output: number}
   Float: {input: number; output: number}
+  AccessRoleAssignee: {input: any; output: any}
   /** The ID for a AccessRole. */
   AccessRoleID: {input: any; output: any}
   AccessRoleRecordId: {input: any; output: any}
@@ -45,4 +46,4 @@ export type Scalars = {
   URL: {input: string; output: string}
 }
 
-export type Store = 'APP_DEVELOPMENT' | 'DEVELOPMENT' | 'PRODUCTION'
+export type Store = 'APP_DEVELOPMENT' | 'DEVELOPMENT' | 'DEVELOPMENT_SUPERSET' | 'PRODUCTION'

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -11,7 +11,13 @@ import {
   getAppVersionedSchema,
 } from './app.js'
 import {ExtensionTemplate} from './template.js'
-import {Organization, OrganizationStore, MinimalAppIdentifiers, OrganizationApp} from '../organization.js'
+import {
+  Organization,
+  OrganizationStore,
+  MinimalAppIdentifiers,
+  OrganizationApp,
+  MinimalOrganizationApp,
+} from '../organization.js'
 import {RemoteSpecification} from '../../api/graphql/extension_specifications.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
 import {loadLocalExtensionsSpecifications} from '../extensions/load-specifications.js'
@@ -21,8 +27,9 @@ import {PartnersSession} from '../../services/context/partner-account-info.js'
 import {WebhooksConfig} from '../extensions/specifications/types/app_config_webhook.js'
 import {PaymentsAppExtensionConfigType} from '../extensions/specifications/payments_app_extension.js'
 import {
-  ActiveAppVersion,
+  AppVersion,
   AppVersionIdentifiers,
+  AppVersionWithContext,
   AssetUrlSchema,
   CreateAppOptions,
   DeveloperPlatformClient,
@@ -41,7 +48,6 @@ import {SendSampleWebhookSchema, SendSampleWebhookVariables} from '../../service
 import {PublicApiVersionsSchema} from '../../services/webhook/request-api-versions.js'
 import {WebhookTopicsSchema, WebhookTopicsVariables} from '../../services/webhook/request-topics.js'
 import {AppReleaseSchema} from '../../api/graphql/app_release.js'
-import {AppVersionByTagSchema, AppVersionByTagVariables} from '../../api/graphql/app_version_by_tag.js'
 import {AppVersionsDiffSchema, AppVersionsDiffVariables} from '../../api/graphql/app_versions_diff.js'
 import {
   MigrateFlowExtensionSchema,
@@ -1118,21 +1124,17 @@ const emptyAppVersions = {
   },
 }
 
-const emptyActiveAppVersion: ActiveAppVersion = {
+const emptyActiveAppVersion: AppVersion = {
   appModuleVersions: [],
 }
 
-const appVersionByTagResponse: AppVersionByTagSchema = {
-  app: {
-    appVersion: {
-      id: 1,
-      uuid: 'uuid',
-      versionTag: 'version-tag',
-      location: 'location',
-      message: 'MESSAGE',
-      appModuleVersions: [],
-    },
-  },
+const appVersionByTagResponse: AppVersionWithContext = {
+  id: 1,
+  uuid: 'uuid',
+  versionTag: 'version-tag',
+  location: 'location',
+  message: 'MESSAGE',
+  appModuleVersions: [],
 }
 
 const appVersionsDiffResponse: AppVersionsDiffSchema = {
@@ -1307,7 +1309,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     appExtensionRegistrations: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppExtensionRegistrations),
     appVersions: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppVersions),
     activeAppVersion: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyActiveAppVersion),
-    appVersionByTag: (_input: AppVersionByTagVariables) => Promise.resolve(appVersionByTagResponse),
+    appVersionByTag: (_app: MinimalOrganizationApp, _tag: string) => Promise.resolve(appVersionByTagResponse),
     appVersionsDiff: (_input: AppVersionsDiffVariables) => Promise.resolve(appVersionsDiffResponse),
     createExtension: (_input: ExtensionCreateVariables) => Promise.resolve(extensionCreateResponse),
     updateExtension: (_input: ExtensionUpdateDraftMutationVariables) => Promise.resolve(extensionUpdateResponse),

--- a/packages/app/src/cli/services/app/select-app.ts
+++ b/packages/app/src/cli/services/app/select-app.ts
@@ -1,10 +1,5 @@
 import {MinimalOrganizationApp} from '../../models/organization.js'
-import {
-  Flag,
-  AppModuleVersion,
-  DeveloperPlatformClient,
-  ActiveAppVersion,
-} from '../../utilities/developer-platform-client.js'
+import {Flag, AppModuleVersion, DeveloperPlatformClient, AppVersion} from '../../utilities/developer-platform-client.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {AppConfigurationUsedByCli} from '../../models/extensions/specifications/types/app_config.js'
 import {deepMergeObjects} from '@shopify/cli-kit/common/object'
@@ -30,7 +25,7 @@ export async function fetchAppRemoteConfiguration(
   developerPlatformClient: DeveloperPlatformClient,
   specifications: ExtensionSpecification[],
   flags: Flag[],
-  activeAppVersion?: ActiveAppVersion,
+  activeAppVersion?: AppVersion,
 ) {
   const appVersion = activeAppVersion || (await developerPlatformClient.activeAppVersion(remoteApp))
   const appModuleVersionsConfig =

--- a/packages/app/src/cli/services/context/breakdown-extensions.test.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.test.ts
@@ -21,7 +21,7 @@ import {OrganizationApp, MinimalAppIdentifiers} from '../../models/organization.
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {AppVersionsDiffExtensionSchema} from '../../api/graphql/app_versions_diff.js'
 import {versionDiffByVersion} from '../release/version-diff.js'
-import {ActiveAppVersion, AppModuleVersion, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {AppVersion, AppModuleVersion, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {describe, vi, test, beforeAll, expect} from 'vitest'
 import {setPathValue} from '@shopify/cli-kit/common/object'
@@ -281,7 +281,7 @@ const options = async (params: {
   remoteApp?: OrganizationApp
   release?: boolean
   developerPlatformClient?: DeveloperPlatformClient
-  activeAppVersion?: ActiveAppVersion
+  activeAppVersion?: AppVersion
 }) => {
   return {
     app: await LOCAL_APP(params.uiExtensions),

--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -11,7 +11,7 @@ import {
   fetchAppRemoteConfiguration,
   remoteAppConfigurationExtensionContent,
 } from '../app/select-app.js'
-import {ActiveAppVersion, AppModuleVersion, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {AppVersion, AppModuleVersion, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {
   AllAppExtensionRegistrationsQuerySchema,
   RemoteExtensionRegistrations,
@@ -136,7 +136,7 @@ export async function configExtensionsIdentifiersBreakdown({
   localApp: AppInterface
   versionAppModules?: AppModuleVersion[]
   release?: boolean
-  activeAppVersion?: ActiveAppVersion
+  activeAppVersion?: AppVersion
 }) {
   if (localApp.allExtensions.filter((extension) => extension.isAppConfigExtension).length === 0) return
   if (!release) return loadLocalConfigExtensionIdentifiersBreakdown(localApp)
@@ -170,7 +170,7 @@ async function resolveRemoteConfigExtensionIdentifiersBreakdown(
   remoteApp: MinimalOrganizationApp,
   app: AppInterface,
   versionAppModules?: AppModuleVersion[],
-  activeAppVersion?: ActiveAppVersion,
+  activeAppVersion?: AppVersion,
 ) {
   const remoteConfig: Partial<AppConfigurationUsedByCli> =
     (await fetchAppRemoteConfiguration(
@@ -337,7 +337,7 @@ async function resolveRemoteExtensionIdentifiersBreakdown(
   toCreate: LocalSource[],
   dashboardOnly: RemoteSource[],
   specs: ExtensionSpecification[],
-  activeAppVersion?: ActiveAppVersion,
+  activeAppVersion?: AppVersion,
 ): Promise<ExtensionIdentifiersBreakdown | undefined> {
   const version = activeAppVersion || (await developerPlatformClient.activeAppVersion(remoteApp))
   if (!version) return
@@ -359,7 +359,7 @@ async function resolveRemoteExtensionIdentifiersBreakdown(
 }
 
 function loadExtensionsIdentifiersBreakdown(
-  activeAppVersion: ActiveAppVersion,
+  activeAppVersion: AppVersion,
   localRegistration: IdentifiersExtensions,
   toCreate: LocalSource[],
   specs: ExtensionSpecification[],
@@ -392,7 +392,7 @@ function loadExtensionsIdentifiersBreakdown(
   }
 }
 
-function loadDashboardIdentifiersBreakdown(currentRegistrations: RemoteSource[], activeAppVersion: ActiveAppVersion) {
+function loadDashboardIdentifiersBreakdown(currentRegistrations: RemoteSource[], activeAppVersion: AppVersion) {
   const currentVersions =
     activeAppVersion?.appModuleVersions.filter(
       (module) => module.specification!.options.managementExperience === 'dashboard',

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -4,7 +4,7 @@ import {AppInterface} from '../../models/app/app.js'
 import {Identifiers} from '../../models/app/identifiers.js'
 import {MinimalOrganizationApp} from '../../models/organization.js'
 import {deployOrReleaseConfirmationPrompt} from '../../prompts/deploy-release.js'
-import {ActiveAppVersion, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {AppVersion, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
 
 export type PartnersAppForIdentifierMatching = MinimalOrganizationApp
@@ -19,7 +19,7 @@ export interface EnsureDeploymentIdsPresenceOptions {
   release: boolean
   remoteApp: PartnersAppForIdentifierMatching
   includeDraftExtensions?: boolean
-  activeAppVersion?: ActiveAppVersion
+  activeAppVersion?: AppVersion
 }
 
 export interface RemoteSource {

--- a/packages/app/src/cli/services/release.ts
+++ b/packages/app/src/cli/services/release.ts
@@ -42,7 +42,6 @@ export async function release(options: ReleaseOptions) {
     remoteApp,
     versionAppModules: versionDetails.appModuleVersions.map((appModuleVersion) => ({
       ...appModuleVersion,
-      ...(appModuleVersion.config ? {config: JSON.parse(appModuleVersion.config)} : {}),
     })),
     release: true,
   })

--- a/packages/app/src/cli/services/release/version-diff.test.ts
+++ b/packages/app/src/cli/services/release/version-diff.test.ts
@@ -1,6 +1,6 @@
 import {versionDiffByVersion} from './version-diff.js'
 import {testDeveloperPlatformClient, testOrganizationApp} from '../../models/app/app.test-data.js'
-import {AppVersionByTagSchema} from '../../api/graphql/app_version_by_tag.js'
+import {AppVersionWithContext} from '../../utilities/developer-platform-client.js'
 import {AppVersionsDiffSchema} from '../../api/graphql/app_versions_diff.js'
 import {describe, expect, test} from 'vitest'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
@@ -34,17 +34,13 @@ describe('versionDiffByVersion', () => {
 
   test('returns versionDiff and versionDetails when the version is found', async () => {
     // Given
-    const versionDetails: AppVersionByTagSchema = {
-      app: {
-        appVersion: {
-          id: 1,
-          uuid: 'uuid',
-          versionTag: 'versionTag',
-          location: 'location',
-          message: 'message',
-          appModuleVersions: [],
-        },
-      },
+    const versionDetails: AppVersionWithContext = {
+      id: 1,
+      uuid: 'uuid',
+      versionTag: 'versionTag',
+      location: 'location',
+      message: 'message',
+      appModuleVersions: [],
     }
     const versionsDiff: AppVersionsDiffSchema = {
       app: {
@@ -101,6 +97,6 @@ describe('versionDiffByVersion', () => {
     const result = await versionDiffByVersion(testOrganizationApp(), 'version', developerPlatformClient)
 
     // Then
-    expect(result).toEqual({versionsDiff: versionsDiff.app.versionsDiff, versionDetails: versionDetails.app.appVersion})
+    expect(result).toEqual({versionsDiff: versionsDiff.app.versionsDiff, versionDetails})
   })
 })

--- a/packages/app/src/cli/services/release/version-diff.ts
+++ b/packages/app/src/cli/services/release/version-diff.ts
@@ -1,6 +1,5 @@
 import {AppVersionsDiffSchema} from '../../api/graphql/app_versions_diff.js'
-import {AppVersionByTagSchema} from '../../api/graphql/app_version_by_tag.js'
-import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {AppVersionWithContext, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {MinimalOrganizationApp} from '../../models/organization.js'
 import {renderError} from '@shopify/cli-kit/node/ui'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
@@ -11,7 +10,7 @@ export async function versionDiffByVersion(
   developerPlatformClient: DeveloperPlatformClient,
 ): Promise<{
   versionsDiff: AppVersionsDiffSchema['app']['versionsDiff']
-  versionDetails: AppVersionByTagSchema['app']['appVersion']
+  versionDetails: AppVersionWithContext
 }> {
   const versionDetails = await versionDetailsByTag(app, versionTag, developerPlatformClient)
   const {
@@ -30,9 +29,7 @@ async function versionDetailsByTag(
   developerPlatformClient: DeveloperPlatformClient,
 ) {
   try {
-    const {
-      app: {appVersion},
-    }: AppVersionByTagSchema = await developerPlatformClient.appVersionByTag(app, versionTag)
+    const appVersion = await developerPlatformClient.appVersionByTag(app, versionTag)
     return appVersion
   } catch (err) {
     renderError({

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -25,7 +25,6 @@ import {
 } from '../api/graphql/development_preview.js'
 import {FindAppPreviewModeSchema, FindAppPreviewModeVariables} from '../api/graphql/find_app_preview_mode.js'
 import {AppReleaseSchema} from '../api/graphql/app_release.js'
-import {AppVersionByTagSchema} from '../api/graphql/app_version_by_tag.js'
 import {AppVersionsDiffSchema} from '../api/graphql/app_versions_diff.js'
 import {SendSampleWebhookSchema, SendSampleWebhookVariables} from '../services/webhook/request-sample.js'
 import {PublicApiVersionsSchema} from '../services/webhook/request-api-versions.js'
@@ -160,8 +159,16 @@ export interface AppModuleVersion {
   specification?: AppModuleVersionSpecification
 }
 
-export interface ActiveAppVersion {
+export interface AppVersion {
   appModuleVersions: AppModuleVersion[]
+}
+
+export type AppVersionWithContext = AppVersion & {
+  id: number
+  uuid: string
+  versionTag?: string | null
+  location: string
+  message: string
 }
 
 export type AppDeployOptions = AppDeployVariables & {
@@ -218,11 +225,11 @@ export interface DeveloperPlatformClient {
   storeByDomain: (orgId: string, shopDomain: string) => Promise<FindStoreByDomainSchema>
   appExtensionRegistrations: (
     app: MinimalAppIdentifiers,
-    activeAppVersion?: ActiveAppVersion,
+    activeAppVersion?: AppVersion,
   ) => Promise<AllAppExtensionRegistrationsQuerySchema>
   appVersions: (app: OrganizationApp) => Promise<AppVersionsQuerySchema>
-  activeAppVersion: (app: MinimalAppIdentifiers) => Promise<ActiveAppVersion | undefined>
-  appVersionByTag: (app: MinimalOrganizationApp, tag: string) => Promise<AppVersionByTagSchema>
+  activeAppVersion: (app: MinimalAppIdentifiers) => Promise<AppVersion | undefined>
+  appVersionByTag: (app: MinimalOrganizationApp, tag: string) => Promise<AppVersionWithContext>
   appVersionsDiff: (app: MinimalOrganizationApp, version: AppVersionIdentifiers) => Promise<AppVersionsDiffSchema>
   generateSignedUploadUrl: (app: MinimalAppIdentifiers) => Promise<AssetUrlSchema>
   createExtension: (input: ExtensionCreateVariables) => Promise<ExtensionCreateSchema>

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -154,7 +154,6 @@ interface AppModuleVersionSpecification {
 export interface AppModuleVersion {
   registrationId: string
   registrationUuid?: string
-  registrationUid?: string
   registrationTitle: string
   config?: object
   type: string

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -389,7 +389,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
     app.appModuleVersions.forEach((mod) => {
       const registration = {
         id: mod.registrationId,
-        uid: mod.registrationUid!,
         uuid: mod.registrationUuid!,
         title: mod.registrationTitle,
         type: mod.type,
@@ -472,7 +471,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
           appModuleVersions: versionInfo.appModules.map((mod: ReleasedAppModuleFragment) => {
             return {
               registrationId: mod.uuid,
-              registrationUid: mod.uuid,
               registrationUuid: mod.uuid,
               registrationTitle: mod.handle,
               type: mod.specification.externalIdentifier,
@@ -534,7 +532,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
       appModuleVersions: result.app.activeRelease.version.appModules.map((mod) => {
         return {
           registrationId: mod.uuid,
-          registrationUid: mod.uuid,
           registrationUuid: mod.uuid,
           registrationTitle: mod.handle,
           type: mod.specification.externalIdentifier,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Responding to comments by @shauns regarding code quality ([1](https://github.com/Shopify/cli/pull/4777/files#r1846175012), [2](https://github.com/Shopify/cli/pull/4777/files#r1846173629))

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Removes an extra field being passed around but not used (`registrationUid`), and reorganizes types to be more logical (rather than Partners-centric) which also allows DRYing up some code in `AppManagementClient` around the shared logical types.

Most importantly, `config` is now passed around as an object rather than a JSON string.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

In both Partners and App Management:

1. Create a new app
2. Generate some extensions (admin link work well)
3. Deploy a version, confirming that the diff appears correctly
4. Re-release the initial version before deploying extensions, confirming the diff appears correctly (extensions are eliminated)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
