### PR TITLE
allow dev dash apps to have optional modules

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -24,6 +24,7 @@ import {
   ActiveAppVersion,
   AppVersionIdentifiers,
   AssetUrlSchema,
+  ClientName,
   CreateAppOptions,
   DeveloperPlatformClient,
   DevSessionOptions,
@@ -111,6 +112,7 @@ export function testApp(app: Partial<AppInterface> = {}, schemaType: 'current' |
     specifications: app.specifications ?? [],
     configSchema: (app.configSchema ?? AppConfigurationSchema) as any,
     remoteFlags: app.remoteFlags ?? [],
+    developerPlatformClientName: app.developerPlatformClientName ?? ClientName.Partners,
   })
 
   if (app.updateDependencies) {
@@ -1284,7 +1286,7 @@ const appLogsSubscribeResponse: AppLogsSubscribeResponse = {
 
 export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClient> = {}): DeveloperPlatformClient {
   const clientStub: DeveloperPlatformClient = {
-    clientName: 'test',
+    clientName: ClientName.Partners,
     webUiName: 'Test Dashboard',
     requiresOrganization: false,
     supportsAtomicDeployments: false,
@@ -1364,10 +1366,13 @@ export const testPartnersServiceSession: PartnersSession = {
   userId: '1234-5678',
 }
 
-export async function buildVersionedAppSchema() {
+export async function buildVersionedAppSchema(developerPlatformClientName: ClientName = ClientName.Partners) {
   const configSpecifications = await configurationSpecifications()
   return {
-    schema: getAppVersionedSchema(configSpecifications),
+    schema: getAppVersionedSchema({
+      specifications: configSpecifications,
+      developerPlatformClientName,
+    }),
     configSpecifications,
   }
 }

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -20,7 +20,7 @@ import {getCachedAppInfo} from '../../services/local-storage.js'
 import use from '../../services/app/config/use.js'
 import {WebhooksSchema} from '../extensions/specifications/app_config_webhook_schemas/webhooks_schema.js'
 import {WebhooksConfig} from '../extensions/specifications/types/app_config_webhook.js'
-import {Flag} from '../../utilities/developer-platform-client.js'
+import {ClientName, Flag} from '../../utilities/developer-platform-client.js'
 import {describe, expect, beforeEach, afterEach, beforeAll, test, vi} from 'vitest'
 import {
   installNodeModules,
@@ -54,8 +54,18 @@ describe('load', () => {
 
   let tmpDir: string
 
-  function loadTestingApp(extras?: {remoteFlags?: Flag[]; mode?: AppLoaderMode}) {
-    return loadApp({directory: tmpDir, specifications, userProvidedConfigName: undefined, ...extras})
+  function loadTestingApp(extras?: {
+    remoteFlags?: Flag[]
+    mode?: AppLoaderMode
+    developerPlatformClientName?: ClientName
+  }) {
+    return loadApp({
+      directory: tmpDir,
+      specifications,
+      userProvidedConfigName: undefined,
+      developerPlatformClientName: ClientName.Partners,
+      ...extras,
+    })
   }
 
   const appConfiguration = `
@@ -164,9 +174,14 @@ automatically_update_urls_on_dev = true
       await rmdir(tmp, {force: true})
 
       // When/Then
-      await expect(loadApp({directory: tmp, specifications, userProvidedConfigName: undefined})).rejects.toThrow(
-        `Couldn't find directory ${tmp}`,
-      )
+      await expect(
+        loadApp({
+          directory: tmp,
+          specifications,
+          userProvidedConfigName: undefined,
+          developerPlatformClientName: ClientName.Partners,
+        }),
+      ).rejects.toThrow(`Couldn't find directory ${tmp}`)
     })
   })
 
@@ -175,9 +190,14 @@ automatically_update_urls_on_dev = true
     const currentDir = cwd()
 
     // When/Then
-    await expect(loadApp({directory: currentDir, specifications, userProvidedConfigName: undefined})).rejects.toThrow(
-      `Couldn't find an app toml file at ${currentDir}`,
-    )
+    await expect(
+      loadApp({
+        directory: currentDir,
+        specifications,
+        userProvidedConfigName: undefined,
+        developerPlatformClientName: ClientName.Partners,
+      }),
+    ).rejects.toThrow(`Couldn't find an app toml file at ${currentDir}`)
   })
 
   test('throws an error when the configuration file is invalid', async () => {
@@ -256,7 +276,12 @@ wrong = "property"
     await writeConfig(appConfiguration)
 
     // When
-    const app = await loadApp({directory: tmpDir, specifications: [], userProvidedConfigName: undefined})
+    const app = await loadApp({
+      directory: tmpDir,
+      specifications: [],
+      userProvidedConfigName: undefined,
+      developerPlatformClientName: ClientName.Partners,
+    })
 
     // Then
     expect(app.name).toBe('my_app')
@@ -760,7 +785,12 @@ wrong = "property"
     await writeFile(joinPath(blockPath('my-extension'), 'index.js'), '')
 
     // When
-    const app = await loadApp({directory: blockDir, specifications, userProvidedConfigName: undefined})
+    const app = await loadApp({
+      directory: blockDir,
+      specifications,
+      userProvidedConfigName: undefined,
+      developerPlatformClientName: ClientName.Partners,
+    })
 
     // Then
     expect(app.name).toBe('my_app')
@@ -896,9 +926,14 @@ wrong = "property"
     })
 
     // When
-    await expect(loadApp({directory: blockDir, specifications, userProvidedConfigName: undefined})).rejects.toThrow(
-      /Couldn't find an index.{js,jsx,ts,tsx} file in the directories/,
-    )
+    await expect(
+      loadApp({
+        directory: blockDir,
+        specifications,
+        userProvidedConfigName: undefined,
+        developerPlatformClientName: ClientName.Partners,
+      }),
+    ).rejects.toThrow(/Couldn't find an index.{js,jsx,ts,tsx} file in the directories/)
   })
 
   test('throws an error if the extension has a type non included in the specs', async () => {
@@ -2161,7 +2196,12 @@ wrong = "property"
     vi.mocked(use).mockResolvedValue('shopify.app.toml')
 
     // When
-    const result = loadApp({directory: tmpDir, specifications, userProvidedConfigName: 'non-existent'})
+    const result = loadApp({
+      directory: tmpDir,
+      specifications,
+      userProvidedConfigName: 'non-existent',
+      developerPlatformClientName: ClientName.Partners,
+    })
 
     // Then
     await expect(result).rejects.toThrow()
@@ -3159,7 +3199,7 @@ describe('loadConfigForAppCreation', () => {
       await writeFile(joinPath(tmpDir, 'package.json'), '{}')
 
       // When
-      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app', ClientName.Partners)
 
       // Then
       expect(result).toEqual({
@@ -3191,7 +3231,7 @@ dev = "echo 'Hello, world!'"
       )
 
       // When
-      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app', ClientName.Partners)
 
       // Then
       expect(result).toEqual({
@@ -3226,7 +3266,7 @@ dev = "echo 'Hello, world!'"
       )
 
       // When
-      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app', ClientName.Partners)
 
       // Then
       expect(result).toEqual({
@@ -3250,7 +3290,7 @@ dev = "echo 'Hello, world!'"
       await writeFile(joinPath(tmpDir, 'package.json'), '{}')
 
       // When
-      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app', ClientName.Partners)
 
       // Then
       expect(result).toEqual({
@@ -3272,7 +3312,7 @@ dev = "echo 'Hello, world!'"
       await writeFile(joinPath(tmpDir, 'package.json'), '{}')
 
       // When
-      const result = await loadConfigForAppCreation(tmpDir, 'my-app')
+      const result = await loadConfigForAppCreation(tmpDir, 'my-app', ClientName.Partners)
 
       // Then
       expect(result).toEqual({

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -595,6 +595,9 @@ We recommend removing the @shopify/cli and @shopify/app dependencies from your p
       appConfiguration,
       this.abortOrReport.bind(this),
     )
+
+    if (!specConfiguration.webhooks) return []
+
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const {api_version, subscriptions = []} = specConfiguration.webhooks
     // Find all unique subscriptions

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -3,7 +3,7 @@ import {ZodSchemaType, BaseConfigType, BaseSchema} from './schemas.js'
 import {ExtensionInstance} from './extension-instance.js'
 import {blocks} from '../../constants.js'
 
-import {Flag} from '../../utilities/developer-platform-client.js'
+import {ClientName, Flag} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationWithoutPath} from '../app/app.js'
 import {loadLocalesConfig} from '../../utilities/extensions/locales-configuration.js'
 import {Result} from '@shopify/cli-kit/node/result'
@@ -49,6 +49,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   registrationLimit: number
   experience: ExtensionExperience
   dependency?: string
+  schema: ZodSchemaType<TConfiguration>
   graphQLType?: string
   getBundleExtensionStdinContent?: (config: TConfiguration) => string
   deployConfig?: (
@@ -62,6 +63,10 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   buildValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   hasExtensionPointTarget?(config: TConfiguration, target: string): boolean
   appModuleFeatures: (config?: TConfiguration) => ExtensionFeature[]
+  customizeSchemaForDevPlatformClient?: (
+    platformClientName: ClientName,
+    currentSchema: ZodSchemaType<unknown>,
+  ) => ZodSchemaType<unknown>
 
   /**
    * If required, convert configuration from the format used in the local filesystem to that expected by the platform.
@@ -212,6 +217,10 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
   appModuleFeatures?: (config?: TConfiguration) => ExtensionFeature[]
   transformConfig?: TransformationConfig | CustomTransformationConfig
   uidStrategy?: UidStrategy
+  customizeSchemaForDevPlatformClient?: (
+    platformClientName: ClientName,
+    currentSchema: ZodSchemaType<unknown>,
+  ) => ZodSchemaType<unknown>
 }): ExtensionSpecification<TConfiguration> {
   const appModuleFeatures = spec.appModuleFeatures ?? (() => [])
   return createExtensionSpecification({
@@ -224,6 +233,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
     transformRemoteToLocal: resolveReverseAppConfigTransform(spec.schema, spec.transformConfig),
     experience: 'configuration',
     uidStrategy: spec.uidStrategy ?? 'single',
+    customizeSchemaForDevPlatformClient: spec.customizeSchemaForDevPlatformClient,
   })
 }
 

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_home.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_home.test.ts
@@ -1,5 +1,6 @@
 import spec from './app_config_app_home.js'
 import {placeholderAppConfiguration} from '../../app/app.test-data.js'
+import {ClientName} from '../../../utilities/developer-platform-client.js'
 import {describe, expect, test} from 'vitest'
 
 describe('app_home', () => {
@@ -49,6 +50,48 @@ describe('app_home', () => {
           url: 'https://my-preferences-url.dev',
         },
       })
+    })
+  })
+
+  describe('customizeSchemaForDevPlatformClient', () => {
+    test('when using Partners client, application_url and embedded fields become required', () => {
+      const appConfigSpec = spec
+      const schema = appConfigSpec.customizeSchemaForDevPlatformClient!(ClientName.Partners, appConfigSpec.schema)
+
+      expect(() => schema.parse({app_preferences: {url: 'https://valid-url.com'}})).toThrow()
+      expect(() =>
+        schema.parse({application_url: 'https://valid-url.com', app_preferences: {url: 'https://valid-url.com'}}),
+      ).toThrow()
+      expect(() => schema.parse({embedded: true, app_preferences: {url: 'https://valid-url.com'}})).toThrow()
+
+      expect(() =>
+        schema.parse({
+          application_url: 'https://valid-url.com',
+          embedded: true,
+          app_preferences: {
+            url: 'https://valid-url.com',
+          },
+        }),
+      ).not.toThrow()
+    })
+
+    test('when using non-Partners client, application_url and embedded fields remain optional', () => {
+      const appConfigSpec = spec
+      const schema = appConfigSpec.customizeSchemaForDevPlatformClient!(ClientName.AppManagement, appConfigSpec.schema)
+
+      expect(() => schema.parse({})).not.toThrow()
+      expect(() => schema.parse({application_url: 'https://valid-url.com'})).not.toThrow()
+      expect(() => schema.parse({embedded: true})).not.toThrow()
+      expect(() => schema.parse({app_preferences: {url: 'https://valid-url.com'}})).not.toThrow()
+      expect(() =>
+        schema.parse({
+          application_url: 'https://valid-url.com',
+          embedded: true,
+          app_preferences: {
+            url: 'https://valid-url.com',
+          },
+        }),
+      ).not.toThrow()
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
@@ -1,10 +1,18 @@
+import {ClientName} from '../../../utilities/developer-platform-client.js'
 import {validateUrl} from '../../app/validation/common.js'
+import {ZodSchemaType} from '../schemas.js'
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
+const applicationUrlValidator = validateUrl(zod.string({required_error: 'Valid URL is required'}))
+const embeddedValidator = zod.boolean({
+  required_error: 'Boolean is required',
+  invalid_type_error: 'Value must be Boolean',
+})
+
 const AppHomeSchema = zod.object({
-  application_url: validateUrl(zod.string({required_error: 'Valid URL is required'})),
-  embedded: zod.boolean({required_error: 'Boolean is required', invalid_type_error: 'Value must be Boolean'}),
+  application_url: applicationUrlValidator.optional(),
+  embedded: embeddedValidator.optional(),
   app_preferences: zod
     .object({
       url: validateUrl(zod.string().max(255, {message: 'String must be less than 255 characters'})),
@@ -24,6 +32,19 @@ const appHomeSpec = createConfigExtensionSpecification({
   identifier: AppHomeSpecIdentifier,
   schema: AppHomeSchema,
   transformConfig: AppHomeTransformConfig,
+  customizeSchemaForDevPlatformClient: (platformClientName: ClientName, currentSchema: ZodSchemaType<unknown>) => {
+    if (platformClientName === ClientName.Partners) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (currentSchema as any).merge(
+        zod.object({
+          application_url: applicationUrlValidator,
+          embedded: embeddedValidator,
+        }),
+      )
+    }
+
+    return currentSchema
+  },
 })
 
 export default appHomeSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook.test.ts
@@ -1,5 +1,6 @@
 import spec from './app_config_webhook.js'
 import {placeholderAppConfiguration} from '../../app/app.test-data.js'
+import {ClientName} from '../../../utilities/developer-platform-client.js'
 import {describe, expect, test} from 'vitest'
 
 describe('webhooks', () => {
@@ -59,6 +60,27 @@ describe('webhooks', () => {
           api_version: '2024-01',
         },
       })
+    })
+  })
+
+  describe('customizeSchemaForDevPlatformClient', () => {
+    test('when using Partners client, webhooks field becomes required', () => {
+      const webhookSpec = spec
+      const schema = webhookSpec.customizeSchemaForDevPlatformClient!(ClientName.Partners, webhookSpec.schema)
+
+      expect(() => schema.parse({})).toThrow()
+      expect(() => schema.parse({webhooks: {subscriptions: []}})).toThrow()
+      expect(() => schema.parse({webhooks: {api_version: '2024-01', subscriptions: []}})).not.toThrow()
+    })
+
+    test('when using non-Partners client, webhooks field remains optional', () => {
+      const webhookSpec = spec
+      const schema = webhookSpec.customizeSchemaForDevPlatformClient!(ClientName.AppManagement, webhookSpec.schema)
+
+      expect(() => schema.parse({})).not.toThrow()
+      // if webhooks field is present, we still always need api_version
+      expect(() => schema.parse({webhooks: {subscriptions: []}})).toThrow()
+      expect(() => schema.parse({webhooks: {api_version: '2024-01', subscriptions: []}})).not.toThrow()
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
@@ -1,6 +1,10 @@
-import {WebhooksSchema} from './app_config_webhook_schemas/webhooks_schema.js'
+import {WebhooksConfigSchema, WebhooksSchema} from './app_config_webhook_schemas/webhooks_schema.js'
 import {transformToWebhookConfig, transformFromWebhookConfig} from './transform/app_config_webhook.js'
+import {webhookValidator} from './validation/app_config_webhook.js'
 import {CustomTransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {ClientName} from '../../../utilities/developer-platform-client.js'
+import {ZodSchemaType} from '../schemas.js'
+import {zod} from '@shopify/cli-kit/node/schema'
 
 export const WebhooksSpecIdentifier = 'webhooks'
 
@@ -13,6 +17,18 @@ const appWebhooksSpec = createConfigExtensionSpecification({
   identifier: WebhooksSpecIdentifier,
   schema: WebhooksSchema,
   transformConfig: WebhookTransformConfig,
+  customizeSchemaForDevPlatformClient: (platformClientName: ClientName, currentSchema: ZodSchemaType<unknown>) => {
+    if (platformClientName === ClientName.Partners) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (currentSchema as any).merge(
+        zod.object({
+          webhooks: WebhooksConfigSchema.superRefine(webhookValidator),
+        }),
+      )
+    }
+
+    return currentSchema
+  },
 })
 
 export default appWebhooksSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhooks_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhooks_schema.ts
@@ -5,7 +5,7 @@ import {SingleWebhookSubscriptionSchema} from '../app_config_webhook_subscriptio
 import {mergeAllWebhooks} from '../transform/app_config_webhook.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const WebhooksConfigSchema = zod.object({
+export const WebhooksConfigSchema = zod.object({
   api_version: zod.string({required_error: 'String is required'}),
   privacy_compliance: zod
     .object({
@@ -23,5 +23,5 @@ const WebhooksConfigSchema = zod.object({
 export type SingleWebhookSubscriptionType = zod.infer<typeof SingleWebhookSubscriptionSchema>
 
 export const WebhooksSchema = zod.object({
-  webhooks: WebhooksConfigSchema.superRefine(webhookValidator),
+  webhooks: WebhooksConfigSchema.superRefine(webhookValidator).optional(),
 })

--- a/packages/app/src/cli/services/app-context.ts
+++ b/packages/app/src/cli/services/app-context.ts
@@ -89,6 +89,7 @@ export async function linkedAppContext({
     specifications,
     remoteFlags: remoteApp.flags,
     mode: unsafeReportMode ? 'report' : 'strict',
+    developerPlatformClientName: developerPlatformClient.clientName,
   })
 
   // If the remoteApp is the same as the linked one, update the cached info.

--- a/packages/app/src/cli/services/app/config/link-service.test.ts
+++ b/packages/app/src/cli/services/app/config/link-service.test.ts
@@ -1,6 +1,11 @@
 import link from './link.js'
 import {testOrganizationApp, testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
-import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {
+  ClientName,
+  DeveloperPlatformClient,
+  selectDeveloperPlatformClient,
+  sniffServiceOptionsAndAppConfigToSelectPlatformClient,
+} from '../../../utilities/developer-platform-client.js'
 import {MinimalAppIdentifiers, OrganizationApp} from '../../../models/organization.js'
 import {appNamePrompt, createAsNewAppPrompt, selectOrganizationPrompt} from '../../../prompts/dev.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
@@ -21,7 +26,9 @@ function buildDeveloperPlatformClient(): DeveloperPlatformClient {
     async appFromId({apiKey}: MinimalAppIdentifiers): Promise<OrganizationApp | undefined> {
       switch (apiKey) {
         case 'api-key':
-          return testOrganizationApp({developerPlatformClient: this as DeveloperPlatformClient})
+          return testOrganizationApp({
+            developerPlatformClient: this as DeveloperPlatformClient,
+          })
         default:
           return undefined
       }
@@ -35,6 +42,7 @@ function buildDeveloperPlatformClient(): DeveloperPlatformClient {
         developerPlatformClient: this as DeveloperPlatformClient,
       })
     },
+    clientName: ClientName.Partners,
   })
 }
 
@@ -56,6 +64,9 @@ describe('link, with minimal mocking', () => {
 
       const developerPlatformClient = buildDeveloperPlatformClient()
       vi.mocked(selectDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
+      vi.mocked(sniffServiceOptionsAndAppConfigToSelectPlatformClient).mockReturnValue(
+        Promise.resolve(developerPlatformClient),
+      )
       vi.mocked(createAsNewAppPrompt).mockResolvedValue(true)
       vi.mocked(appNamePrompt).mockResolvedValue('A user provided name')
       vi.mocked(selectOrganizationPrompt).mockResolvedValue({id: '12345', businessName: 'test'})

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -10,6 +10,7 @@ import {getAppConfigurationFileName, loadAppConfiguration} from '../../../models
 import {clearCurrentConfigFile, setCachedAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
 import {appFromId, logMetadataForLoadedContext} from '../../context.js'
+import {ClientName} from '../../../utilities/developer-platform-client.js'
 import {describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -89,6 +90,7 @@ describe('use', () => {
         configSchema,
         specifications: [],
         remoteFlags: [],
+        developerPlatformClientName: ClientName.Partners,
       })
 
       // When
@@ -157,6 +159,7 @@ describe('use', () => {
         configSchema,
         specifications: [],
         remoteFlags: [],
+        developerPlatformClientName: ClientName.Partners,
       })
 
       // When
@@ -198,6 +201,7 @@ describe('use', () => {
         configSchema,
         specifications: [],
         remoteFlags: [],
+        developerPlatformClientName: ClientName.Partners,
       })
 
       // When
@@ -241,6 +245,7 @@ describe('use', () => {
         configSchema,
         specifications: [],
         remoteFlags: [],
+        developerPlatformClientName: ClientName.Partners,
       })
       vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.something.toml')
       createConfigFile(directory, 'shopify.app.something.toml')
@@ -271,6 +276,7 @@ describe('use', () => {
         configSchema,
         specifications: [],
         remoteFlags: [],
+        developerPlatformClientName: ClientName.Partners,
       })
       vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.something.toml')
       createConfigFile(directory, 'shopify.app.something.toml')
@@ -301,6 +307,7 @@ describe('use', () => {
         configSchema,
         specifications: [],
         remoteFlags: [],
+        developerPlatformClientName: ClientName.Partners,
       })
       vi.mocked(getAppConfigurationFileName).mockReturnValue('shopify.app.something.toml')
       vi.mocked(appFromId).mockResolvedValue(REMOTE_APP)

--- a/packages/app/src/cli/services/app/config/use.ts
+++ b/packages/app/src/cli/services/app/config/use.ts
@@ -3,7 +3,7 @@ import {clearCurrentConfigFile, setCachedAppInfo} from '../../local-storage.js'
 import {selectConfigFile} from '../../../prompts/config.js'
 import {AppConfiguration, CurrentAppConfiguration, isCurrentAppSchema} from '../../../models/app/app.js'
 import {logMetadataForLoadedContext} from '../../context.js'
-import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {ClientName, DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -51,6 +51,7 @@ export default async function use({
   const {configuration} = await loadAppConfiguration({
     userProvidedConfigName: configFileName,
     directory,
+    developerPlatformClientName: ClientName.Partners,
   })
   setCurrentConfigPreference(configuration, {configFileName, directory})
 

--- a/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
+++ b/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
@@ -1,6 +1,7 @@
 import {patchAppConfigurationFile} from './patch-app-configuration-file.js'
 import {getAppVersionedSchema} from '../../models/app/app.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {ClientName} from '../../utilities/developer-platform-client.js'
 import {readFile, writeFileSync, inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {describe, expect, test} from 'vitest'
@@ -25,7 +26,11 @@ redirect_urls = [
 api_version = "2023-04"
 `
 
-const schema = getAppVersionedSchema(await loadLocalExtensionsSpecifications(), false)
+const schema = getAppVersionedSchema({
+  specifications: await loadLocalExtensionsSpecifications(),
+  developerPlatformClientName: ClientName.Partners,
+  allowDynamicallySpecifiedConfigs: false,
+})
 
 function writeDefaulToml(tmpDir: string) {
   const configPath = joinPath(tmpDir, 'shopify.app.toml')

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher-handler.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher-handler.ts
@@ -135,6 +135,7 @@ export async function reloadApp(app: AppLinkedInterface): Promise<AppLinkedInter
       directory: app.directory,
       userProvidedConfigName: basename(app.configuration.path),
       remoteFlags: app.remoteFlags,
+      developerPlatformClientName: app.developerPlatformClientName,
     })
     outputDebug(`App reloaded [${endHRTimeInMs(start)}ms]`)
     return newApp as AppLinkedInterface

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
@@ -288,6 +288,7 @@ describe('app-event-watcher when receiving a file event', () => {
         if (needsAppReload) {
           expect(loadApp).toHaveBeenCalledWith({
             specifications: expect.anything(),
+            developerPlatformClientName: 'partners',
             directory: expect.anything(),
             // The app is loaded with the same configuration file
             userProvidedConfigName: 'shopify.app.custom.toml',

--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -16,6 +16,7 @@ import {
 import {ExtensionTemplate} from '../../models/app/template.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {ClientName} from '../../utilities/developer-platform-client.js'
 import {describe, expect, vi, test} from 'vitest'
 import * as output from '@shopify/cli-kit/node/output'
 import {
@@ -63,7 +64,12 @@ describe('initialize a extension', async () => {
         specifications,
         onGetTemplateRepository,
       })
-      const app = await loadApp({directory: tmpDir, specifications, userProvidedConfigName: undefined})
+      const app = await loadApp({
+        directory: tmpDir,
+        specifications,
+        userProvidedConfigName: undefined,
+        developerPlatformClientName: ClientName.Partners,
+      })
       const generatedExtension = app.allExtensions[0]!
 
       expect(extensionDir).toEqual(joinPath(tmpDir, 'extensions', name))
@@ -96,7 +102,12 @@ describe('initialize a extension', async () => {
 
       expect(vi.mocked(addNPMDependenciesIfNeeded)).toHaveBeenCalledTimes(2)
 
-      const loadedApp = await loadApp({directory: tmpDir, specifications, userProvidedConfigName: undefined})
+      const loadedApp = await loadApp({
+        directory: tmpDir,
+        specifications,
+        userProvidedConfigName: undefined,
+        developerPlatformClientName: ClientName.Partners,
+      })
       expect(loadedApp.allExtensions.length).toEqual(2)
     })
   })
@@ -312,7 +323,12 @@ describe('initialize a extension', async () => {
       })
 
       // Then
-      const app = await loadApp({directory: tmpDir, specifications, userProvidedConfigName: undefined})
+      const app = await loadApp({
+        directory: tmpDir,
+        specifications,
+        userProvidedConfigName: undefined,
+        developerPlatformClientName: ClientName.Partners,
+      })
       const generatedFunction = app.allExtensions[0]!
       expect(extensionDir).toEqual(joinPath(tmpDir, 'extensions', name))
       expect(generatedFunction.configuration.name).toBe(name)
@@ -353,7 +369,12 @@ describe('initialize a extension', async () => {
         })
 
         // Then
-        const app = await loadApp({directory: tmpDir, specifications, userProvidedConfigName: undefined})
+        const app = await loadApp({
+          directory: tmpDir,
+          specifications,
+          userProvidedConfigName: undefined,
+          developerPlatformClientName: ClientName.Partners,
+        })
         const generatedFunction = app.allExtensions[0]!
         expect(extensionDir).toEqual(joinPath(tmpDir, 'extensions', name))
         expect(generatedFunction.configuration.name).toBe(name)
@@ -456,7 +477,12 @@ async function createFromTemplate({
 }: CreateFromTemplateOptions): Promise<string> {
   const result = await generateExtensionTemplate({
     extensionTemplate: specification,
-    app: await loadApp({directory: appDirectory, specifications, userProvidedConfigName: undefined}),
+    app: await loadApp({
+      directory: appDirectory,
+      specifications,
+      userProvidedConfigName: undefined,
+      developerPlatformClientName: ClientName.Partners,
+    }),
     extensionChoices: {name, flavor: extensionFlavor},
     developerPlatformClient: testDeveloperPlatformClient(),
     onGetTemplateRepository,

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -5,11 +5,9 @@ import {
   ExtensionSpecification,
   RemoteAwareExtensionSpecification,
 } from '../../models/extensions/specification.js'
-import {ClientName, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {MinimalAppIdentifiers} from '../../models/organization.js'
 import {unifiedConfigurationParserFactory} from '../../utilities/json-schema.js'
-import {AppHomeSpecIdentifier} from '../../models/extensions/specifications/app_config_app_home.js'
-import {WebhooksSpecIdentifier} from '../../models/extensions/specifications/app_config_webhook.js'
 import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {normaliseJsonSchema} from '@shopify/cli-kit/node/json-schema'
@@ -55,13 +53,8 @@ export async function fetchSpecifications({
     })
 
   const local = await loadLocalExtensionsSpecifications()
-  let updatedSpecs = await mergeLocalAndRemoteSpecs(local, extensionSpecifications)
-
-  if (developerPlatformClient.clientName === ClientName.AppManagement) {
-    updatedSpecs = appManagementSpecTransform(updatedSpecs)
-  }
-
-  return updatedSpecs
+  const updatedSpecs = await mergeLocalAndRemoteSpecs(local, extensionSpecifications)
+  return [...updatedSpecs]
 }
 
 async function mergeLocalAndRemoteSpecs(
@@ -120,24 +113,4 @@ async function mergeLocalAndRemoteSpecs(
   }
 
   return result
-}
-
-/**
- * The AppManagementClient has relaxed requirements for some extension specifications
- * This should be a temporary transform until we either use contracts for every spec, or all extensions are optional by default
- */
-function appManagementSpecTransform(specs: RemoteAwareExtensionSpecification[]) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return specs.map((spec: any) => {
-    if (spec.identifier === AppHomeSpecIdentifier) {
-      spec.schema.shape.application_url = spec.schema.shape.application_url.optional()
-      spec.schema.shape.embedded = spec.schema.shape.embedded.optional()
-    }
-
-    if (spec.identifier === WebhooksSpecIdentifier) {
-      spec.schema.shape.webhooks = spec.schema.shape.webhooks.optional()
-    }
-
-    return spec
-  })
 }

--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -197,7 +197,11 @@ async function init(options: InitOptions) {
 
   let app: OrganizationApp
   if (options.selectedAppOrNameResult.result === 'new') {
-    const creationOptions = await loadConfigForAppCreation(outputDirectory, options.name)
+    const creationOptions = await loadConfigForAppCreation(
+      outputDirectory,
+      options.name,
+      options.developerPlatformClient.clientName,
+    )
     const org = options.selectedAppOrNameResult.org
     app = await options.developerPlatformClient.createApp(org, options.name, creationOptions)
   } else {

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -103,6 +103,7 @@ export async function sniffServiceOptionsAndAppConfigToSelectPlatformClient(opti
     const {configuration} = await loadAppConfiguration({
       ...options,
       userProvidedConfigName: options.configName,
+      developerPlatformClientName: ClientName.Partners,
     })
     const developerPlatformClient = selectDeveloperPlatformClient({configuration})
     return developerPlatformClient
@@ -199,7 +200,7 @@ export function filterDisabledFlags(disabledFlags: string[] = []): Flag[] {
 }
 
 export interface DeveloperPlatformClient {
-  readonly clientName: string
+  readonly clientName: ClientName
   readonly webUiName: string
   readonly supportsAtomicDeployments: boolean
   readonly requiresOrganization: boolean


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes: https://github.com/Shopify/develop-app-inner-loop/issues/2290
- Our App schema currently requires application_url, embedded and the webhooks api_version to always be set
- This is not the case with app management apps, and will eventually never be the case with the greenfield vision of all app modules being optional

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/183IglXPcqlyh0IdGCI5/f4584ebb-c05a-4146-b4a9-bc2e7bb3a039.png)

### WHAT is this pull request doing?

- introduce a new specification schema modifier method `customizeSchemaForDevPlatformClient` that is run when fetching the App schema
- this merges any overrides into the schema, and is needed as another specification schema modifier method `contributeToAppConfigurationSchema` reduces its own changes on the base AppSchema, so we need to append onto this after as well

- I discussed with @shauns and making the partners client the "special" case seemed like the right idea, as eventually we'll be ripping all this out when all modules/specs are all optional.

- Due to the partner client dependency, I've had to "drill" the client name down quite a few levels, and default to "partners" on some occasions we don't have access to the org yet. I think this is fine, and I've been told to take the "drill" approach before, but please lmk what we think

### How to test your changes?

- you can link a management app that is missing `application_url`, `embedded` or `webhooks`
- you can create and deploy a management app missing these fields
- with a partners app, everything should operate as before, where all of these fields are required


[Dev Dash app spin link](https://dev.shopify.shopify-developer-dashboard-01bm.alex-montague.us.spin.dev/dashboard/2/apps/905743398573/versions)
[Partners app spin link](https://partners.shopify-developer-dashboard-01bm.alex-montague.us.spin.dev/1/apps/905743398574/edit)


#### 🎩  Partners App:

```toml
# partners app toml
# any missing application_url, embedded or webhooks throws error still
# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration

client_id = "5d44973d3cae826954b02396337f60fa"
name = "partners-spin-cli-app"
handle = "partners-spin-cli-app"

[webhooks]
api_version = "unstable"

[access_scopes]
# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
scopes = ""

[auth]
redirect_urls = [ "https://shopify.dev/apps/default-app-home/api/auth" ]

[pos]
embedded = false
```

on link:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/183IglXPcqlyh0IdGCI5/35e9334a-f375-4f6f-bf56-c31900f7ac6c.png)

on deploy:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/183IglXPcqlyh0IdGCI5/ebdc9357-ee2e-4f7c-a513-4fa4bd5694c2.png)


#### 🎩  Management App:

```toml
# management app toml
# missing application_url, embedded, or webhooks fields are fine
# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration

client_id = "008494d258802e2f1540d502316b4637"
app_id = "gid://shopify/App/905743398573"
organization_id = "2"
name = "my empty spin app"

[access_scopes]
# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
scopes = ""

[auth]
redirect_urls = [ ]
```

on link:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/183IglXPcqlyh0IdGCI5/054f30c9-2cf4-4e93-9e15-364dedd31480.png)

on deploy:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/183IglXPcqlyh0IdGCI5/5343bd36-309b-4ba6-b4ba-75527600fe48.png)

