### PR TITLE
Remove watch options from bundle extension functions

### DIFF
--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -3,7 +3,7 @@ import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {themeExtensionFiles} from '../../utilities/extensions/theme.js'
 import {EsbuildEnvVarRegex, environmentVariableNames} from '../../constants.js'
 import {flowTemplateExtensionFiles} from '../../utilities/extensions/flow-template.js'
-import {context as esContext, BuildResult, formatMessagesSync} from 'esbuild'
+import {context as esContext, formatMessagesSync} from 'esbuild'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {copyFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, relativePath} from '@shopify/cli-kit/node/path'
@@ -21,13 +21,6 @@ interface BundleOptions {
   stdin: StdinOptions
   stdout: Writable
   stderr: Writable
-
-  /**
-   * When provided, the bundling process keeps running and notifying about changes.
-   * When ESBuild detects changes in any of the modules of the graph it re-bundles it
-   * and calls this watch function.
-   */
-  watch?: (result: BuildResult | null) => Promise<void>
 
   /**
    * This signal allows the caller to stop the watching process.
@@ -64,19 +57,9 @@ interface BundleOptions {
 export async function bundleExtension(options: BundleOptions, processEnv = process.env) {
   const esbuildOptions = getESBuildOptions(options, processEnv)
   const context = await esContext(esbuildOptions)
-  if (options.watch) {
-    await context.watch()
-  } else {
-    const result = await context.rebuild()
-    onResult(result, options)
-    await context.dispose()
-  }
-
-  if (options.watchSignal) {
-    options.watchSignal.addEventListener('abort', async () => {
-      await context.dispose()
-    })
-  }
+  const result = await context.rebuild()
+  onResult(result, options)
+  await context.dispose()
 }
 
 export async function bundleThemeExtension(
@@ -152,18 +135,6 @@ export function getESBuildOptions(options: BundleOptions, processEnv = process.e
     plugins: getPlugins(options.stdin.resolveDir, processEnv),
     target: 'es6',
     resolveExtensions: ['.tsx', '.ts', '.js', '.json', '.esnext', '.mjs', '.ejs'],
-  }
-  if (options.watch) {
-    const watch = options.watch
-    esbuildOptions.plugins?.push({
-      name: 'rebuild-plugin',
-      setup(build) {
-        build.onEnd(async (result) => {
-          onResult(result, options)
-          await watch(result)
-        })
-      },
-    })
   }
 
   if (options.sourceMaps) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
AppWatcher should be the only one responsible for watching changes in extensions.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Removes unused `watch` options from the ui extension bundler.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Nothing to test, this is removing unused code.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
