### PR TITLE
Use AppWatcher for function replay

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -119,7 +119,7 @@ export class AppEventWatcher extends EventEmitter {
       })
   }
 
-  async start(options?: OutputContextOptions, buildExtensionsFirst?: boolean) {
+  async start(options?: OutputContextOptions, buildExtensionsFirst = true) {
     if (this.started) return
     this.started = true
 

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -119,7 +119,7 @@ export class AppEventWatcher extends EventEmitter {
       })
   }
 
-  async start(options?: OutputContextOptions) {
+  async start(options?: OutputContextOptions, buildExtensionsFirst?: boolean) {
     if (this.started) return
     this.started = true
 
@@ -134,8 +134,10 @@ export class AppEventWatcher extends EventEmitter {
     await this.esbuildManager.createContexts(this.app.realExtensions.filter((ext) => ext.isESBuildExtension))
 
     // Initial build of all extensions
-    this.initialEvents = this.app.realExtensions.map((ext) => ({type: EventType.Updated, extension: ext}))
-    await this.buildExtensions(this.initialEvents)
+    if (buildExtensionsFirst) {
+      this.initialEvents = this.app.realExtensions.map((ext) => ({type: EventType.Updated, extension: ext}))
+      await this.buildExtensions(this.initialEvents)
+    }
 
     // Start the file system watcher
     await startFileWatcher(this.app, this.options, (events) => {

--- a/packages/app/src/cli/services/function/ui/components/Replay/Replay.test.tsx
+++ b/packages/app/src/cli/services/function/ui/components/Replay/Replay.test.tsx
@@ -1,7 +1,7 @@
 import {Replay} from './Replay.js'
 import {useFunctionWatcher} from './hooks/useFunctionWatcher.js'
 import {FunctionRunFromRunner} from './types.js'
-import {testFunctionExtension, testApp} from '../../../../../models/app/app.test-data.js'
+import {testFunctionExtension, testAppLinked} from '../../../../../models/app/app.test-data.js'
 import {ExtensionInstance} from '../../../../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../../../../models/extensions/specifications/function.js'
 import {FunctionRunData} from '../../../replay.js'
@@ -85,7 +85,7 @@ describe('Replay', () => {
       <Replay
         selectedRun={SELECTED_RUN}
         abortController={new AbortController()}
-        app={testApp()}
+        app={testAppLinked()}
         extension={extension}
       />,
     )
@@ -109,7 +109,7 @@ describe('Replay', () => {
       <Replay
         selectedRun={SELECTED_RUN}
         abortController={new AbortController()}
-        app={testApp()}
+        app={testAppLinked()}
         extension={extension}
       />,
     )
@@ -129,7 +129,12 @@ describe('Replay', () => {
     vi.mocked(useFunctionWatcher).mockImplementation(mockedUseFunctionWatcher)
 
     const renderInstanceReplay = render(
-      <Replay selectedRun={SELECTED_RUN} abortController={abortController} app={testApp()} extension={extension} />,
+      <Replay
+        selectedRun={SELECTED_RUN}
+        abortController={abortController}
+        app={testAppLinked()}
+        extension={extension}
+      />,
     )
 
     const promise = renderInstanceReplay.waitUntilExit()
@@ -155,7 +160,12 @@ describe('Replay', () => {
     vi.mocked(useFunctionWatcher).mockImplementation(mockedUseFunctionWatcher)
 
     const renderInstanceReplay = render(
-      <Replay selectedRun={SELECTED_RUN} abortController={abortController} app={testApp()} extension={extension} />,
+      <Replay
+        selectedRun={SELECTED_RUN}
+        abortController={abortController}
+        app={testAppLinked()}
+        extension={extension}
+      />,
     )
 
     const promise = renderInstanceReplay.waitUntilExit()

--- a/packages/app/src/cli/services/function/ui/components/Replay/Replay.tsx
+++ b/packages/app/src/cli/services/function/ui/components/Replay/Replay.tsx
@@ -5,6 +5,7 @@ import {ExtensionInstance} from '../../../../../models/extensions/extension-inst
 import {FunctionConfigType} from '../../../../../models/extensions/specifications/function.js'
 import {AppLinkedInterface} from '../../../../../models/app/app.js'
 import {prettyPrintJsonIfPossible} from '../../../../app-logs/utils.js'
+import {AppEventWatcher} from '../../../../dev/app-events/app-event-watcher.js'
 import figures from '@shopify/cli-kit/node/figures'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import React, {FunctionComponent} from 'react'
@@ -22,11 +23,13 @@ export interface ReplayProps {
 const Replay: FunctionComponent<ReplayProps> = ({selectedRun, abortController, app, extension}) => {
   const {isAborted} = useAbortSignal(abortController.signal)
   const {isRawModeSupported: canUseShortcuts} = useStdin()
+  const appWatcher = new AppEventWatcher(app)
   const {logs, statusMessage, recentFunctionRuns, error} = useFunctionWatcher({
     selectedRun,
     abortController,
     app,
     extension,
+    appWatcher,
   })
 
   useInput(

--- a/packages/app/src/cli/services/function/ui/components/Replay/Replay.tsx
+++ b/packages/app/src/cli/services/function/ui/components/Replay/Replay.tsx
@@ -3,7 +3,7 @@ import {useFunctionWatcher} from './hooks/useFunctionWatcher.js'
 import {FunctionRunData} from '../../../replay.js'
 import {ExtensionInstance} from '../../../../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../../../../models/extensions/specifications/function.js'
-import {AppInterface} from '../../../../../models/app/app.js'
+import {AppLinkedInterface} from '../../../../../models/app/app.js'
 import {prettyPrintJsonIfPossible} from '../../../../app-logs/utils.js'
 import figures from '@shopify/cli-kit/node/figures'
 import {AbortController} from '@shopify/cli-kit/node/abort'
@@ -15,7 +15,7 @@ import {handleCtrlC} from '@shopify/cli-kit/node/ui'
 export interface ReplayProps {
   selectedRun: FunctionRunData
   abortController: AbortController
-  app: AppInterface
+  app: AppLinkedInterface
   extension: ExtensionInstance<FunctionConfigType>
 }
 

--- a/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.test.tsx
+++ b/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.test.tsx
@@ -82,6 +82,7 @@ describe('useFunctionWatcher', () => {
         abortController: ABORT_CONTROLLER,
         app: APP,
         extension: EXTENSION,
+        appWatcher: new AppEventWatcher(APP),
       }),
     )
     // needed to await the render

--- a/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.test.tsx
+++ b/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.test.tsx
@@ -1,9 +1,8 @@
 import {useFunctionWatcher} from './useFunctionWatcher.js'
 import {FunctionRunData} from '../../../../replay.js'
-import {testApp, testFunctionExtension} from '../../../../../../models/app/app.test-data.js'
-import {setupExtensionWatcher} from '../../../../../dev/extension/bundler.js'
+import {testAppLinked, testFunctionExtension} from '../../../../../../models/app/app.test-data.js'
 import {runFunction} from '../../../../runner.js'
-import {AbortError} from '@shopify/cli-kit/node/error'
+import {AppEventWatcher, EventType} from '../../../../../dev/app-events/app-event-watcher.js'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import {render} from '@shopify/cli-kit/node/testing/ui'
 import {test, describe, vi, beforeEach, afterEach, expect} from 'vitest'
@@ -40,7 +39,7 @@ const SELECTED_RUN = {
 } as FunctionRunData
 
 const ABORT_CONTROLLER = new AbortController()
-const APP = testApp()
+const APP = testAppLinked()
 const EXTENSION = await testFunctionExtension()
 
 const EXEC_RESPONSE = {
@@ -89,7 +88,6 @@ describe('useFunctionWatcher', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     // Then
-    expect(setupExtensionWatcher).toHaveBeenCalledOnce()
     expect(runFunction).toHaveBeenCalledOnce()
     expect(hook.lastResult?.recentFunctionRuns[0]).toEqual({...EXEC_RESPONSE, type: 'functionRun'})
   })
@@ -99,6 +97,8 @@ describe('useFunctionWatcher', () => {
     vi.mocked(runFunction)
       .mockImplementationOnce(runFunctionMockImplementation(EXEC_RESPONSE))
       .mockImplementationOnce(runFunctionMockImplementation(SECOND_EXEC_RESPONSE))
+    const appWatcher = new AppEventWatcher(APP)
+    const event = {extensionEvents: [{type: EventType.Updated, extension: EXTENSION}]}
 
     // When
     const hook = renderHook(() =>
@@ -107,22 +107,23 @@ describe('useFunctionWatcher', () => {
         abortController: ABORT_CONTROLLER,
         app: APP,
         extension: EXTENSION,
+        appWatcher,
       }),
     )
+
     // needed to await the render
     await vi.advanceTimersByTimeAsync(0)
 
     expect(hook.lastResult?.recentFunctionRuns[0]).toEqual({...EXEC_RESPONSE, type: 'functionRun'})
     expect(hook.lastResult?.recentFunctionRuns[1]).toEqual({...EXEC_RESPONSE, type: 'functionRun'})
 
-    // .mock.calls returns an array of the calls, which each contain the arguments
-    await vi.mocked(setupExtensionWatcher).mock.calls[0]![0].onChange()
+    appWatcher.emit('all', event)
+    await vi.advanceTimersByTimeAsync(0)
 
     expect(hook.lastResult?.recentFunctionRuns[0]).toEqual({...SECOND_EXEC_RESPONSE, type: 'functionRun'})
     expect(hook.lastResult?.recentFunctionRuns[1]).toEqual({...EXEC_RESPONSE, type: 'functionRun'})
 
     // Then
-    expect(setupExtensionWatcher).toHaveBeenCalledOnce()
     expect(runFunction).toHaveBeenCalledTimes(2)
   })
 
@@ -130,6 +131,12 @@ describe('useFunctionWatcher', () => {
     // Given
     const expectedError = new Error('error!')
     vi.mocked(runFunction).mockImplementationOnce(runFunctionMockImplementation(EXEC_RESPONSE))
+    const appWatcher = new AppEventWatcher(APP)
+    const event = {
+      extensionEvents: [
+        {type: EventType.Updated, extension: EXTENSION, buildResult: {status: 'error', error: expectedError.message}},
+      ],
+    }
 
     // When
     const hook = renderHook(() =>
@@ -138,46 +145,19 @@ describe('useFunctionWatcher', () => {
         abortController: ABORT_CONTROLLER,
         app: APP,
         extension: EXTENSION,
+        appWatcher,
       }),
     )
 
     // needed to await the render
     await vi.advanceTimersByTimeAsync(0)
 
-    // .mock.calls returns an array of the calls, which each contain the arguments
-    await vi.mocked(setupExtensionWatcher).mock.calls[0]![0].onReloadAndBuildError(expectedError)
+    appWatcher.emit('all', event)
+    await vi.advanceTimersByTimeAsync(0)
 
     // Then
     expect(runFunction).toHaveBeenCalledOnce()
-    expect(setupExtensionWatcher).toHaveBeenCalledOnce()
     expect(hook.lastResult?.error).toEqual('Error while reloading and building extension: error!')
-  })
-
-  test('renders fatal error in onReloadAndBuildError', async () => {
-    // Given
-    const expectedError = new AbortError('abort!')
-    vi.mocked(runFunction).mockImplementationOnce(runFunctionMockImplementation(EXEC_RESPONSE))
-
-    // When
-    const hook = renderHook(() =>
-      useFunctionWatcher({
-        selectedRun: SELECTED_RUN,
-        abortController: ABORT_CONTROLLER,
-        app: APP,
-        extension: EXTENSION,
-      }),
-    )
-
-    // needed to await the render
-    await vi.advanceTimersByTimeAsync(0)
-
-    // .mock.calls returns an array of the calls, which each contain the arguments
-    await vi.mocked(setupExtensionWatcher).mock.calls[0]![0].onReloadAndBuildError(expectedError)
-
-    // Then
-    expect(runFunction).toHaveBeenCalledOnce()
-    expect(setupExtensionWatcher).toHaveBeenCalledOnce()
-    expect(hook.lastResult?.error).toEqual('Fatal error while reloading and building extension: abort!')
   })
 })
 

--- a/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
+++ b/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
@@ -17,7 +17,7 @@ interface WatchFunctionForReplayOptions {
   abortController: AbortController
   app: AppLinkedInterface
   extension: ExtensionInstance<FunctionConfigType>
-  appWatcher?: AppEventWatcher
+  appWatcher: AppEventWatcher
 }
 
 export function useFunctionWatcher({
@@ -50,8 +50,6 @@ export function useFunctionWatcher({
 
   const [statusMessage, setStatusMessage] = useState(`Watching for changes to ${selectedRun.source}...`)
 
-  const appWatcherInstance = appWatcher ?? new AppEventWatcher(app)
-
   useEffect(() => {
     const watchAbortController = new AbortController()
     abortController.signal.addEventListener('abort', () => {
@@ -73,7 +71,7 @@ export function useFunctionWatcher({
     }
 
     const startWatchingFunction = async () => {
-      appWatcherInstance.onEvent(async (event) => {
+      appWatcher.onEvent(async (event) => {
         const functionExt = event.extensionEvents.find((extEvent) => extEvent.extension.handle === extension.handle)
         if (!functionExt || functionExt.type !== EventType.Updated) return
         if (functionExt.buildResult?.status === 'error') {
@@ -92,7 +90,7 @@ export function useFunctionWatcher({
         },
       })
 
-      await appWatcherInstance.start({stdout: customStdout, stderr: customStdout, signal: watchAbortController.signal})
+      await appWatcher.start({stdout: customStdout, stderr: customStdout, signal: watchAbortController.signal})
     }
 
     // eslint-disable-next-line promise/catch-or-return, @typescript-eslint/no-floating-promises

--- a/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
+++ b/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
@@ -1,26 +1,32 @@
 import {FunctionRunData} from '../../../../replay.js'
-import {AppInterface} from '../../../../../../models/app/app.js'
+import {AppLinkedInterface} from '../../../../../../models/app/app.js'
 import {FunctionConfigType} from '../../../../../../models/extensions/specifications/function.js'
 import {ExtensionInstance} from '../../../../../../models/extensions/extension-instance.js'
-import {setupExtensionWatcher} from '../../../../../dev/extension/bundler.js'
 import {FunctionRunFromRunner, ReplayLog} from '../types.js'
 import {runFunction} from '../../../../runner.js'
+import {AppEventWatcher, EventType} from '../../../../../dev/app-events/app-event-watcher.js'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import {useEffect, useState} from 'react'
 import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {treeKill} from '@shopify/cli-kit/node/tree-kill'
-import {FatalError} from '@shopify/cli-kit/node/error'
 import {Writable} from 'stream'
 
 interface WatchFunctionForReplayOptions {
   selectedRun: FunctionRunData
   abortController: AbortController
-  app: AppInterface
+  app: AppLinkedInterface
   extension: ExtensionInstance<FunctionConfigType>
+  appWatcher?: AppEventWatcher
 }
 
-export function useFunctionWatcher({selectedRun, abortController, app, extension}: WatchFunctionForReplayOptions) {
+export function useFunctionWatcher({
+  selectedRun,
+  abortController,
+  app,
+  extension,
+  appWatcher,
+}: WatchFunctionForReplayOptions) {
   const functionRunFromSelectedRun = {
     type: 'functionRun',
     input: selectedRun.payload.input,
@@ -44,6 +50,8 @@ export function useFunctionWatcher({selectedRun, abortController, app, extension
 
   const [statusMessage, setStatusMessage] = useState(`Watching for changes to ${selectedRun.source}...`)
 
+  const appWatcherInstance = appWatcher ?? new AppEventWatcher(app)
+
   useEffect(() => {
     const watchAbortController = new AbortController()
     abortController.signal.addEventListener('abort', () => {
@@ -65,6 +73,18 @@ export function useFunctionWatcher({selectedRun, abortController, app, extension
     }
 
     const startWatchingFunction = async () => {
+      appWatcherInstance.onEvent(async (event) => {
+        const functionExt = event.extensionEvents.find((extEvent) => extEvent.extension.handle === extension.handle)
+        if (!functionExt || functionExt.type !== EventType.Updated) return
+        if (functionExt.buildResult?.status === 'error') {
+          setError(`Error while reloading and building extension: ${functionExt.buildResult?.error}`)
+          return
+        }
+        setError(undefined)
+        setStatusMessage('Re-running with latest changes...')
+        await runFunction()
+      })
+
       const customStdout = new Writable({
         write(chunk, _enconding, next) {
           setLogs((logs) => [...logs, {type: 'systemMessage', message: chunk.toString()}])
@@ -72,26 +92,7 @@ export function useFunctionWatcher({selectedRun, abortController, app, extension
         },
       })
 
-      await setupExtensionWatcher({
-        extension,
-        app,
-        stdout: customStdout,
-        stderr: customStdout,
-        onChange: async () => {
-          setError(undefined)
-          setStatusMessage('Re-running with latest changes...')
-          await runFunction()
-        },
-        onReloadAndBuildError: async (error) => {
-          if (error instanceof FatalError) {
-            // eslint-disable-next-line @typescript-eslint/no-base-to-string
-            setError(`Fatal error while reloading and building extension: ${error.formattedMessage || error.message}`)
-          } else {
-            setError(`Error while reloading and building extension: ${error.message}`)
-          }
-        },
-        signal: watchAbortController.signal,
-      })
+      await appWatcherInstance.start({stdout: customStdout, stderr: customStdout, signal: watchAbortController.signal})
     }
 
     // eslint-disable-next-line promise/catch-or-return, @typescript-eslint/no-floating-promises

--- a/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
+++ b/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
@@ -90,7 +90,7 @@ export function useFunctionWatcher({
         },
       })
 
-      await appWatcher.start({stdout: customStdout, stderr: customStdout, signal: watchAbortController.signal})
+      await appWatcher.start({stdout: customStdout, stderr: customStdout, signal: watchAbortController.signal}, false)
     }
 
     // eslint-disable-next-line promise/catch-or-return, @typescript-eslint/no-floating-promises


### PR DESCRIPTION
### WHY are these changes introduced?

Migrates the function replay functionality to use the new app event watcher system instead of the legacy extension watcher.

### WHAT is this pull request doing?

- Replaces `setupExtensionWatcher` with `AppEventWatcher` for function replay functionality
- Updates type requirements from `AppInterface` to `AppLinkedInterface`
- Simplifies error handling by leveraging the app event watcher's built-in error reporting
- Removes redundant test assertions related to the old watcher setup

### How to test your changes?

1. Create a function extension
2. Run the function with `--replay`
3. Make changes to the function code
4. Verify that the function reruns automatically
5. Introduce a build error and verify error messages are displayed correctly

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes