### PR TITLE
[Fix] Mock notifications-system in base-command tests

### DIFF
--- a/packages/cli-kit/src/public/node/base-command.test.ts
+++ b/packages/cli-kit/src/public/node/base-command.test.ts
@@ -11,6 +11,7 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {Flags} from '@oclif/core'
 
 vi.mock('./system.js')
+vi.mock('./notifications-system.js')
 
 beforeEach(() => {
   vi.mocked(terminalSupportsPrompting).mockReturnValue(true)


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, tests will fail if a notification is published to the CLI. This causes CI to break in PR's.

This also won't get caught in main until the next PR triggers the CI pipeline, since the notification is pushed in a different repo.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JdHLnhebSbtZTZO01I1e/a3a062a2-840e-4089-ab09-cfe2e841943f.png)

### WHAT is this pull request doing?

Adds a mock for the notifications-system module in the base-command test file to prevent potential test interference.

### How to test your changes?

1. Run the test suite for cli-kit package
2. Verify all tests pass and there are no unexpected interactions with the notifications system

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes