### PR TITLE
Refactor FileWatcher into a class

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher-handler.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher-handler.ts
@@ -120,7 +120,7 @@ async function ReloadAppHandler({event, app}: HandlerInput): Promise<AppEvent> {
   const deletedEvents = diff.deleted.map((ext) => ({type: EventType.Deleted, extension: ext}))
   const updatedEvents = diff.updated.map((ext) => ({type: EventType.Updated, extension: ext}))
   const extensionEvents = [...createdEvents, ...deletedEvents, ...updatedEvents]
-  return {app: newApp, extensionEvents, startTime: event.startTime, path: event.path}
+  return {app: newApp, extensionEvents, startTime: event.startTime, path: event.path, appWasReloaded: true}
 }
 
 /*

--- a/packages/app/src/cli/services/dev/app-events/file-watcher.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/file-watcher.test.ts
@@ -1,6 +1,5 @@
-import {OutputContextOptions, WatcherEvent, startFileWatcher} from './file-watcher.js'
+import {FileWatcher, OutputContextOptions, WatcherEvent} from './file-watcher.js'
 import {
-  testApp,
   testAppAccessConfigExtension,
   testAppConfigExtensions,
   testAppLinked,
@@ -176,7 +175,7 @@ const multiEventTestCases: TestCaseMultiEvent[] = [
 ]
 
 const outputOptions: OutputContextOptions = {stdout: process.stdout, stderr: process.stderr, signal: new AbortSignal()}
-const defaultApp = testApp({
+const defaultApp = testAppLinked({
   allExtensions: [extension1, extension1B, extension2, posExtension, appAccessExtension, functionExtension],
   directory: '/',
   configuration: {scopes: '', extension_directories: ['/extensions'], path: '/shopify.app.toml'},
@@ -207,7 +206,8 @@ describe('file-watcher events', () => {
       })
 
       // When
-      await startFileWatcher(app, outputOptions, vi.fn())
+      const watcher = new FileWatcher(app, outputOptions, vi.fn())
+      await watcher.start()
 
       // Then
       expect(watchSpy).toHaveBeenCalledWith([joinPath(dir, '/shopify.app.toml'), joinPath(dir, '/extensions')], {
@@ -231,7 +231,8 @@ describe('file-watcher events', () => {
 
       // When
       const onChange = vi.fn()
-      await startFileWatcher(defaultApp, outputOptions, onChange, 0)
+      const watcher = new FileWatcher(defaultApp, outputOptions, onChange, 0)
+      await watcher.start()
 
       // Then
       await flushPromises()
@@ -264,7 +265,8 @@ describe('file-watcher events', () => {
 
       // When
       const onChange = vi.fn()
-      await startFileWatcher(defaultApp, outputOptions, onChange)
+      const watcher = new FileWatcher(defaultApp, outputOptions, onChange, 0)
+      await watcher.start()
 
       // Then
       await flushPromises()

--- a/packages/app/src/cli/services/dev/app-events/file-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/file-watcher.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import {AppInterface} from '../../../models/app/app.js'
+import {AppLinkedInterface} from '../../../models/app/app.js'
 import {configurationFileNames} from '../../../constants.js'
 import {dirname, isSubpath, joinPath, normalizePath, relativePath} from '@shopify/cli-kit/node/path'
 import {FSWatcher} from 'chokidar'
@@ -46,53 +46,174 @@ export interface OutputContextOptions {
   signal: AbortSignal
 }
 
-/**
- * Watch for changes in the given app directory.
- *
- * It will watch for changes in the active config file and the extension directories.
- * When possible, changes will be interpreted to detect new/deleted extensions
- *
- * Changes to toml files will be reported as different events to other file changes.
- *
- * @param app - The app to watch
- * @param options - The output options
- * @param onChange - The callback to call when a change is detected
- */
-export async function startFileWatcher(
-  app: AppInterface,
-  options: OutputContextOptions,
-  onChange: (events: WatcherEvent[]) => void,
-  debounceTime = DEFAULT_DEBOUNCE_TIME_IN_MS,
-) {
-  const {default: chokidar} = await import('chokidar')
+export class FileWatcher {
+  private readonly onChange: (events: WatcherEvent[]) => void
+  private readonly options: OutputContextOptions
+  private readonly debouncedEmit: () => void
+  private app: AppLinkedInterface
+  private currentEvents: WatcherEvent[] = []
+  private ignored: {[key: string]: ignore.Ignore | undefined} = {}
+  private extensionPaths: string[] = []
 
-  const appConfigurationPath = app.configuration.path
-  const extensionDirectories = [...(app.configuration.extension_directories ?? ['extensions'])].map((directory) => {
-    return joinPath(app.directory, directory)
-  })
+  constructor(
+    app: AppLinkedInterface,
+    options: OutputContextOptions,
+    onChange: (events: WatcherEvent[]) => void,
+    debounceTime = DEFAULT_DEBOUNCE_TIME_IN_MS,
+  ) {
+    this.app = app
+    this.onChange = onChange
+    this.options = options
 
-  let currentEvents: WatcherEvent[] = []
+    /**
+     * Debounced function to emit the accumulated events.
+     * This function will be called at most once every 500ms to avoid emitting too many events in a short period.
+     */
+    this.debouncedEmit = debounce(this.emitEvents.bind(this), debounceTime)
+    this.updateApp(app)
+  }
+
+  updateApp(app: AppLinkedInterface) {
+    this.app = app
+    this.extensionPaths = this.app.realExtensions
+      .map((ext) => normalizePath(ext.directory))
+      .filter((dir) => dir !== this.app.directory)
+    for (const path of this.extensionPaths) {
+      if (this.ignored[path]) continue
+      this.ignored[path] = this.createIgnoreInstance(path)
+    }
+  }
 
   /**
-   * Debounced function to emit the accumulated events.
-   * This function will be called at most once every 500ms to avoid emitting too many events in a short period.
+   * Watch for changes in the given app directory.
+   *
+   * It will watch for changes in the active config file and the extension directories.
+   * When possible, changes will be interpreted to detect new/deleted extensions
+   *
+   * Changes to toml files will be reported as different events to other file changes.
+   *
+   * @param app - The app to watch
+   * @param options - The output options
+   * @param onChange - The callback to call when a change is detected
    */
-  const debouncedEmit = debounce(emitEvents, debounceTime)
+  async start() {
+    const {default: chokidar} = await import('chokidar')
+
+    const appConfigurationPath = this.app.configuration.path
+    const extensionDirectories = [...(this.app.configuration.extension_directories ?? ['extensions'])].map(
+      (directory) => {
+        return joinPath(this.app.directory, directory)
+      },
+    )
+
+    // Watch the extensions root directories and the app configuration file, nothing else.
+    const watchPaths = [appConfigurationPath, ...extensionDirectories]
+
+    // Read .gitignore files from extension directories and add the patterns to the ignored list
+
+    // Create watcher ignoring node_modules, git, test files, dist folders, vim swap files
+    // PENDING: Use .gitgnore from app and extensions to ignore files.
+    const watcher = chokidar.watch(watchPaths, {
+      ignored: ['**/node_modules/**', '**/.git/**', '**/*.test.*', '**/dist/**', '**/*.swp', '**/generated/**'],
+      persistent: true,
+      ignoreInitial: true,
+    })
+
+    // Start chokidar watcher for 'all' events
+    watcher.on('all', (event, path) => {
+      const startTime = startHRTime()
+      const isConfigAppPath = path === appConfigurationPath
+      const extensionPath =
+        this.extensionPaths.find((dir) => isSubpath(dir, path)) ?? (isConfigAppPath ? this.app.directory : 'unknown')
+      const isExtensionToml = path.endsWith('.extension.toml')
+      const isUnknownExtension = extensionPath === 'unknown'
+
+      outputDebug(`🌀: ${event} ${path.replace(this.app.directory, '')}\n`)
+
+      if (isUnknownExtension && !isExtensionToml && !isConfigAppPath) {
+        // Ignore an event if it's not part of an existing extension
+        // Except if it is a toml file (either app config or extension config)
+        return
+      }
+
+      switch (event) {
+        case 'change':
+          if (isUnknownExtension) {
+            // If the extension path is unknown, it means the extension was just created.
+            // We need to wait for the lock file to disappear before triggering the event.
+            return
+          }
+          if (isExtensionToml || isConfigAppPath) {
+            this.pushEvent({type: 'extensions_config_updated', path, extensionPath, startTime})
+          } else {
+            this.pushEvent({type: 'file_updated', path, extensionPath, startTime})
+          }
+          break
+        case 'add':
+          // If it's a normal non-toml file, just report a file_created event.
+          // If a toml file was added, a new extension(s) is being created.
+          // We need to wait for the lock file to disappear before triggering the event.
+          if (!isExtensionToml) {
+            this.pushEvent({type: 'file_created', path, extensionPath, startTime})
+            break
+          }
+          let totalWaitedTime = 0
+          const realPath = dirname(path)
+          const intervalId = setInterval(() => {
+            if (fileExistsSync(joinPath(realPath, configurationFileNames.lockFile))) {
+              outputDebug(`Waiting for extension to complete creation: ${path}\n`)
+              totalWaitedTime += EXTENSION_CREATION_WAIT_INTERVAL_IN_MS
+            } else {
+              clearInterval(intervalId)
+              this.extensionPaths.push(realPath)
+              this.pushEvent({type: 'extension_folder_created', path: realPath, extensionPath, startTime})
+            }
+            if (totalWaitedTime >= EXTENSION_CREATION_TIMEOUT_IN_MS) {
+              clearInterval(intervalId)
+              this.options.stderr.write(`Error loading new extension at path: ${path}.\n Please restart the process.`)
+            }
+          }, EXTENSION_CREATION_WAIT_INTERVAL_IN_MS)
+          break
+        case 'unlink':
+          // Ignore shoplock files
+          if (path.endsWith(configurationFileNames.lockFile)) break
+
+          if (isConfigAppPath) {
+            this.pushEvent({type: 'app_config_deleted', path, extensionPath, startTime})
+          } else if (isExtensionToml) {
+            // When a toml is deleted, we can consider every extension in that folder was deleted.
+            this.extensionPaths = this.extensionPaths.filter((extPath) => extPath !== extensionPath)
+            this.pushEvent({type: 'extension_folder_deleted', path: extensionPath, extensionPath, startTime})
+          } else {
+            // This could be an extension delete event, Wait 500ms to see if the toml is deleted or not.
+            setTimeout(() => {
+              // If the extensionPath is not longer in the list, the extension was deleted while the timeout was running.
+              if (!this.extensionPaths.includes(extensionPath)) return
+              this.pushEvent({type: 'file_deleted', path, extensionPath, startTime})
+            }, 500)
+          }
+          break
+        // These events are ignored
+        case 'addDir':
+        case 'unlinkDir':
+          break
+      }
+    })
+
+    this.listenForAbortOnWatcher(watcher)
+  }
 
   /**
    * Emits the accumulated events and resets the current events list.
    * It also logs the number of events emitted and their paths for debugging purposes.
    */
-  function emitEvents() {
-    const events = currentEvents
-    currentEvents = []
+  emitEvents() {
+    const events = this.currentEvents
+    this.currentEvents = []
     const message = `🔉 ${events.length} EVENTS EMITTED in files: ${events.map((event) => event.path).join('\n')}`
-    outputDebug(message, options.stdout)
-    onChange(events)
+    outputDebug(message, this.options.stdout)
+    this.onChange(events)
   }
-
-  // Each extension has its own ignore instance to avoid conflicts
-  const ignored: {[key: string]: ignore.Ignore | undefined} = {}
 
   /**
    * Adds a new event to the current events list and schedules the debounced emit function.
@@ -100,8 +221,8 @@ export async function startFileWatcher(
    *
    * @param event - The event to be added
    */
-  function pushEvent(event: WatcherEvent) {
-    const extension = app.realExtensions.find((ext) => ext.directory === event.extensionPath)
+  pushEvent(event: WatcherEvent) {
+    const extension = this.app.realExtensions.find((ext) => ext.directory === event.extensionPath)
     const watchPaths = extension?.devSessionWatchPaths
     // If the affected extension defines custom watch paths, ignore the event if it's not in the list
     if (watchPaths) {
@@ -111,148 +232,40 @@ export async function startFileWatcher(
 
     // When creating a new extension, also create a new Ignore instance.
     if (event.type === 'extension_folder_created') {
-      ignored[event.path] = createIgnoreInstance(event.path)
+      this.ignored[event.path] = this.createIgnoreInstance(event.path)
     }
 
     // If the event is ignored by the custom gitignore patterns, don't push it
-    if (event.extensionPath !== 'unknown' && ignored[event.extensionPath]) {
+    if (event.extensionPath !== 'unknown' && this.ignored[event.extensionPath]) {
       const relative = relativePath(event.extensionPath, event.path)
-      if (ignored[event.extensionPath]?.ignores(relative)) return
+      if (this.ignored[event.extensionPath]?.ignores(relative)) return
     }
 
     // If the event is already in the list, don't push it again
-    if (currentEvents.some((extEvent) => extEvent.path === event.path && extEvent.type === event.type)) return
-    currentEvents.push(event)
-    debouncedEmit()
+    if (this.currentEvents.some((extEvent) => extEvent.path === event.path && extEvent.type === event.type)) return
+    this.currentEvents.push(event)
+    this.debouncedEmit()
   }
 
-  // Current active extension paths (not defined in the main app configuration file)
-  // If a change happens outside of these paths, it will be ignored unless is for a new extension being created
-  // When a new extension is created, the path is added to this list
-  // When an extension is deleted, the path is removed from this list
-  // For every change, the corresponding extensionPath will be also reported in the event
-  let extensionPaths = app.realExtensions
-    .map((ext) => normalizePath(ext.directory))
-    .filter((dir) => dir !== app.directory)
-
-  // Watch the extensions root directories and the app configuration file, nothing else.
-  const watchPaths = [appConfigurationPath, ...extensionDirectories]
-
-  // For each extension directory, create an "Ignore" instance to ignore files based on the .gitignore file
-  for (const dir of extensionDirectories) {
-    ignored[dir] = createIgnoreInstance(dir)
+  listenForAbortOnWatcher = (watcher: FSWatcher) => {
+    this.options.signal.addEventListener('abort', () => {
+      outputDebug(`Closing file watcher`, this.options.stdout)
+      watcher
+        .close()
+        .then(() => outputDebug(`File watching closed`, this.options.stdout))
+        .catch((error: Error) => outputDebug(`File watching failed to close: ${error.message}`, this.options.stderr))
+    })
   }
 
-  // Create watcher ignoring node_modules, git, test files, dist folders, vim swap files
-  // PENDING: Use .gitgnore from app and extensions to ignore files.
-  const watcher = chokidar.watch(watchPaths, {
-    ignored: ['**/node_modules/**', '**/.git/**', '**/*.test.*', '**/dist/**', '**/*.swp', '**/generated/**'],
-    persistent: true,
-    ignoreInitial: true,
-  })
-
-  // Start chokidar watcher for 'all' events
-  watcher.on('all', (event, path) => {
-    const startTime = startHRTime()
-    const isConfigAppPath = path === appConfigurationPath
-    const extensionPath =
-      extensionPaths.find((dir) => isSubpath(dir, path)) ?? (isConfigAppPath ? app.directory : 'unknown')
-    const isExtensionToml = path.endsWith('.extension.toml')
-    const isUnknownExtension = extensionPath === 'unknown'
-
-    outputDebug(`🌀: ${event} ${path.replace(app.directory, '')}\n`)
-
-    if (isUnknownExtension && !isExtensionToml && !isConfigAppPath) {
-      // Ignore an event if it's not part of an existing extension
-      // Except if it is a toml file (either app config or extension config)
-      return
-    }
-
-    switch (event) {
-      case 'change':
-        if (isUnknownExtension) {
-          // If the extension path is unknown, it means the extension was just created.
-          // We need to wait for the lock file to disappear before triggering the event.
-          return
-        }
-        if (isExtensionToml || isConfigAppPath) {
-          pushEvent({type: 'extensions_config_updated', path, extensionPath, startTime})
-        } else {
-          pushEvent({type: 'file_updated', path, extensionPath, startTime})
-        }
-        break
-      case 'add':
-        // If it's a normal non-toml file, just report a file_created event.
-        // If a toml file was added, a new extension(s) is being created.
-        // We need to wait for the lock file to disappear before triggering the event.
-        if (!isExtensionToml) {
-          pushEvent({type: 'file_created', path, extensionPath, startTime})
-          break
-        }
-        let totalWaitedTime = 0
-        const realPath = dirname(path)
-        const intervalId = setInterval(() => {
-          if (fileExistsSync(joinPath(realPath, configurationFileNames.lockFile))) {
-            outputDebug(`Waiting for extension to complete creation: ${path}\n`)
-            totalWaitedTime += EXTENSION_CREATION_WAIT_INTERVAL_IN_MS
-          } else {
-            clearInterval(intervalId)
-            extensionPaths.push(realPath)
-            pushEvent({type: 'extension_folder_created', path: realPath, extensionPath, startTime})
-          }
-          if (totalWaitedTime >= EXTENSION_CREATION_TIMEOUT_IN_MS) {
-            clearInterval(intervalId)
-            options.stderr.write(`Error loading new extension at path: ${path}.\n Please restart the process.`)
-          }
-        }, EXTENSION_CREATION_WAIT_INTERVAL_IN_MS)
-        break
-      case 'unlink':
-        // Ignore shoplock files
-        if (path.endsWith(configurationFileNames.lockFile)) break
-
-        if (isConfigAppPath) {
-          pushEvent({type: 'app_config_deleted', path, extensionPath, startTime})
-        } else if (isExtensionToml) {
-          // When a toml is deleted, we can consider every extension in that folder was deleted.
-          extensionPaths = extensionPaths.filter((extPath) => extPath !== extensionPath)
-          pushEvent({type: 'extension_folder_deleted', path: extensionPath, extensionPath, startTime})
-        } else {
-          // This could be an extension delete event, Wait 500ms to see if the toml is deleted or not.
-          setTimeout(() => {
-            // If the extensionPath is not longer in the list, the extension was deleted while the timeout was running.
-            if (!extensionPaths.includes(extensionPath)) return
-            pushEvent({type: 'file_deleted', path, extensionPath, startTime})
-          }, 500)
-        }
-        break
-      // These events are ignored
-      case 'addDir':
-      case 'unlinkDir':
-        break
-    }
-  })
-
-  listenForAbortOnWatcher(watcher, options)
-}
-
-const listenForAbortOnWatcher = (watcher: FSWatcher, options: OutputContextOptions) => {
-  options.signal.addEventListener('abort', () => {
-    outputDebug(`Closing file watcher`, options.stdout)
-    watcher
-      .close()
-      .then(() => outputDebug(`File watching closed`, options.stdout))
-      .catch((error: Error) => outputDebug(`File watching failed to close: ${error.message}`, options.stderr))
-  })
-}
-
-// Creates an "Ignore" instance for the given path if a .gitignore file exists, otherwise undefined
-function createIgnoreInstance(path: string): ignore.Ignore | undefined {
-  const gitIgnorePath = joinPath(path, '.gitignore')
-  if (!fileExistsSync(gitIgnorePath)) return undefined
-  const gitIgnoreContent = readFileSync(gitIgnorePath)
-    .toString()
-    .split('\n')
-    .map((pattern) => pattern.trim())
-    .filter((pattern) => pattern !== '' && !pattern.startsWith('#'))
-  return ignore.default().add(gitIgnoreContent)
+  // Returns an ignore instance for the given path if a .gitignore file exists, otherwise undefined
+  createIgnoreInstance(path: string): ignore.Ignore | undefined {
+    const gitIgnorePath = joinPath(path, '.gitignore')
+    if (!fileExistsSync(gitIgnorePath)) return undefined
+    const gitIgnoreContent = readFileSync(gitIgnorePath)
+      .toString()
+      .split('\n')
+      .map((pattern) => pattern.trim())
+      .filter((pattern) => pattern !== '' && !pattern.startsWith('#'))
+    return ignore.default().add(gitIgnoreContent)
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The file watcher system needs to maintain accurate context when the app configuration changes, particularly for handling new extensions added mid-dev.

### WHAT is this pull request doing?

Refactors the file watcher into a class-based implementation that can update its internal state when the app configuration changes. This enables proper tracking of new extensions and their associated watch/ignore paths.

Adds an `appWasReloaded` property to the AppEvent from the AppEventWatcher. To add extra context for event consumers.

### How to test your changes?

1. Run dev
2. Create a new extension (best to try with a rust based function) in a different terminal.
3. Verify the file watcher properly detects the new extension
4. Make changes in the function files (by default, only *.rs and *.graphql should trigger events)

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes