### PR TITLE
Update CODEOWNERS file patterns and add CLI README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,6 @@ packages/theme/** @shopify/advanced-edits @shopify/app-inner-loop
 # These are metafiles that can be reviewed by anyone
 .changeset/* @shopify/advanced-edits @shopify/app-inner-loop
 .github/CODEOWNERS @shopify/advanced-edits @shopify/app-inner-loop
-docs-shopify.dev/*  @shopify/advanced-edits @shopify/app-inner-loop
+docs-shopify.dev/**  @shopify/advanced-edits @shopify/app-inner-loop
 packages/cli/oclif.manifest.json @shopify/advanced-edits @shopify/app-inner-loop
-
+packages/cli/README.md @shopify/advanced-edits @shopify/app-inner-loop


### PR DESCRIPTION
- Add subfolders to `docs-shopify.dev` 
- Update README.md

Motivation: Self serve for PR's like https://github.com/Shopify/cli/pull/4900/files where we add a new flag

