### PR TITLE
Fix initial draft update

### DIFF
--- a/packages/app/src/cli/services/dev/processes/draftable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/draftable-extension.ts
@@ -45,7 +45,6 @@ export const pushUpdatesForDraftableExtensions: DevProcessFunction<DraftableExte
       .filter((ev) => ev.buildResult?.status === 'ok')
       .filter((ev) => draftableExtensions.includes(ev.extension.handle))
 
-    // for (const extensionEvent of extensionEvents) {
     const promises = extensionEvents.map(async (extensionEvent) => {
       const extension = extensionEvent.extension
       const registrationId = remoteExtensions[extension.localIdentifier]

--- a/packages/app/src/cli/services/dev/processes/draftable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/draftable-extension.ts
@@ -33,20 +33,24 @@ export const pushUpdatesForDraftableExtensions: DevProcessFunction<DraftableExte
   // as it might be done multiple times in parallel. https://github.com/Shopify/cli/issues/2877
   await installJavy(app)
 
+  const draftableExtensions = app.draftableExtensions.map((ext) => ext.handle)
+
   async function refreshToken() {
     await developerPlatformClient.refreshToken()
   }
 
-  const handleAppEvent = (event: AppEvent) => {
+  const handleAppEvent = async (event: AppEvent) => {
     const extensionEvents = event.extensionEvents
       .filter((ev) => ev.type === EventType.Updated)
       .filter((ev) => ev.buildResult?.status === 'ok')
+      .filter((ev) => draftableExtensions.includes(ev.extension.handle))
 
-    for (const extensionEvent of extensionEvents) {
+    // for (const extensionEvent of extensionEvents) {
+    const promises = extensionEvents.map(async (extensionEvent) => {
       const extension = extensionEvent.extension
       const registrationId = remoteExtensions[extension.localIdentifier]
       if (!registrationId) throw new AbortError(`Extension ${extension.localIdentifier} not found on remote app.`)
-      return useConcurrentOutputContext({outputPrefix: extension.outputPrefix}, async () => {
+      await useConcurrentOutputContext({outputPrefix: extension.outputPrefix}, async () => {
         return performActionWithRetryAfterRecovery(
           async () =>
             updateExtensionDraft({
@@ -62,7 +66,8 @@ export const pushUpdatesForDraftableExtensions: DevProcessFunction<DraftableExte
           refreshToken,
         )
       })
-    }
+    })
+    await Promise.all(promises)
   }
 
   appWatcher.onEvent(handleAppEvent).onStart(handleAppEvent)


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses potential race conditions when pushing updates for draftable extensions in parallel.

### WHAT is this pull request doing?

- Filters extension events to only process draftable extensions
- Implements concurrent processing of extension updates using `Promise.all`

### How to test your changes?

1. Run dev with multiple draftable extensions (admin-action, theme)
2. Verify that we send initial drafts for every extension. 

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes