### PR TITLE
Skip notifications when using --json

### DIFF
--- a/.changeset/sixty-years-stare.md
+++ b/.changeset/sixty-years-stare.md
@@ -2,4 +2,4 @@
 '@shopify/cli-kit': patch
 ---
 
-Skip notifications when using --json
+Skip notifications when using --json, -j or SHOPIFY_FLAG_JSON

--- a/.changeset/sixty-years-stare.md
+++ b/.changeset/sixty-years-stare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Skip notifications when using --json

--- a/docs-shopify.dev/commands/interfaces/app-function-replay.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-replay.interface.ts
@@ -13,7 +13,7 @@ export interface appfunctionreplay {
   '-c, --config <value>'?: string
 
   /**
-   * Output the function run result as a JSON object.
+   * Output the result as JSON.
    * @environment SHOPIFY_FLAG_JSON
    */
   '-j, --json'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-function-run.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-run.interface.ts
@@ -19,7 +19,7 @@ export interface appfunctionrun {
   '-i, --input <value>'?: string
 
   /**
-   * Log the run result as a JSON object.
+   * Output the result as JSON.
    * @environment SHOPIFY_FLAG_JSON
    */
   '-j, --json'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-info.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-info.interface.ts
@@ -7,10 +7,10 @@ export interface appinfo {
   '-c, --config <value>'?: string
 
   /**
-   * format output as JSON
+   * Output the result as JSON.
    * @environment SHOPIFY_FLAG_JSON
    */
-  '--json'?: ''
+  '-j, --json'?: ''
 
   /**
    * Disable color output.

--- a/docs-shopify.dev/commands/interfaces/app-logs.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-logs.interface.ts
@@ -13,7 +13,7 @@ export interface applogs {
   '-c, --config <value>'?: string
 
   /**
-   * Log the run result as a JSON object.
+   * Output the result as JSON.
    * @environment SHOPIFY_FLAG_JSON
    */
   '-j, --json'?: ''

--- a/docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts
@@ -13,10 +13,10 @@ export interface appversionslist {
   '-c, --config <value>'?: string
 
   /**
-   * Output the versions list as JSON.
+   * Output the result as JSON.
    * @environment SHOPIFY_FLAG_JSON
    */
-  '--json'?: ''
+  '-j, --json'?: ''
 
   /**
    * Disable color output.

--- a/docs-shopify.dev/commands/interfaces/theme-info.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-info.interface.ts
@@ -13,10 +13,10 @@ export interface themeinfo {
   '-e, --environment <value>'?: string
 
   /**
-   * Output the theme info as JSON.
+   * Output the result as JSON.
    * @environment SHOPIFY_FLAG_JSON
    */
-  '--json'?: ''
+  '-j, --json'?: ''
 
   /**
    * Disable color output.

--- a/docs-shopify.dev/commands/interfaces/theme-list.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-list.interface.ts
@@ -13,10 +13,10 @@ export interface themelist {
   '--id <value>'?: string
 
   /**
-   * Output the theme list as JSON.
+   * Output the result as JSON.
    * @environment SHOPIFY_FLAG_JSON
    */
-  '--json'?: ''
+  '-j, --json'?: ''
 
   /**
    * Only list themes that contain the given name.

--- a/docs-shopify.dev/commands/interfaces/theme-push.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-push.interface.ts
@@ -25,7 +25,7 @@ export interface themepush {
   '-x, --ignore <value>'?: string
 
   /**
-   * Output JSON instead of a UI.
+   * Output the result as JSON.
    * @environment SHOPIFY_FLAG_JSON
    */
   '-j, --json'?: ''

--- a/docs-shopify.dev/generated/generated_docs_data.json
+++ b/docs-shopify.dev/generated/generated_docs_data.json
@@ -868,7 +868,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "-j, --json",
                 "value": "\"\"",
-                "description": "Output the function run result as a JSON object.",
+                "description": "Output the result as JSON.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_JSON"
               },
@@ -891,7 +891,7 @@
                 "environmentValue": "SHOPIFY_FLAG_WATCH"
               }
             ],
-            "value": "export interface appfunctionreplay {\n  /**\n   * Application's Client ID\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the function run result as a JSON object.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.\n   * @environment SHOPIFY_FLAG_LOG\n   */\n  '-l, --log <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Re-run the function when the source code changes.\n   * @environment SHOPIFY_FLAG_WATCH\n   */\n  '-w, --watch'?: ''\n}"
+            "value": "export interface appfunctionreplay {\n  /**\n   * Application's Client ID\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.\n   * @environment SHOPIFY_FLAG_LOG\n   */\n  '-l, --log <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Re-run the function when the source code changes.\n   * @environment SHOPIFY_FLAG_WATCH\n   */\n  '-w, --watch'?: ''\n}"
           }
         }
       }
@@ -987,12 +987,12 @@
                 "syntaxKind": "PropertySignature",
                 "name": "-j, --json",
                 "value": "\"\"",
-                "description": "Log the run result as a JSON object.",
+                "description": "Output the result as JSON.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_JSON"
               }
             ],
-            "value": "export interface appfunctionrun {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Name of the WebAssembly export to invoke.\n   * @environment SHOPIFY_FLAG_EXPORT\n   */\n  '-e, --export <value>'?: string\n\n  /**\n   * The input JSON to pass to the function. If omitted, standard input is used.\n   * @environment SHOPIFY_FLAG_INPUT\n   */\n  '-i, --input <value>'?: string\n\n  /**\n   * Log the run result as a JSON object.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appfunctionrun {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Name of the WebAssembly export to invoke.\n   * @environment SHOPIFY_FLAG_EXPORT\n   */\n  '-e, --export <value>'?: string\n\n  /**\n   * The input JSON to pass to the function. If omitted, standard input is used.\n   * @environment SHOPIFY_FLAG_INPUT\n   */\n  '-i, --input <value>'?: string\n\n  /**\n   * Output the result as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -1409,15 +1409,6 @@
               {
                 "filePath": "docs-shopify.dev/commands/interfaces/app-info.interface.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "--json",
-                "value": "\"\"",
-                "description": "format output as JSON",
-                "isOptional": true,
-                "environmentValue": "SHOPIFY_FLAG_JSON"
-              },
-              {
-                "filePath": "docs-shopify.dev/commands/interfaces/app-info.interface.ts",
-                "syntaxKind": "PropertySignature",
                 "name": "--no-color",
                 "value": "\"\"",
                 "description": "Disable color output.",
@@ -1459,9 +1450,18 @@
                 "description": "The name of the app configuration.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
+              },
+              {
+                "filePath": "docs-shopify.dev/commands/interfaces/app-info.interface.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "-j, --json",
+                "value": "\"\"",
+                "description": "Output the result as JSON.",
+                "isOptional": true,
+                "environmentValue": "SHOPIFY_FLAG_JSON"
               }
             ],
-            "value": "export interface appinfo {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * format output as JSON\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Outputs environment variables necessary for running and deploying web/.\n   * @environment SHOPIFY_FLAG_OUTPUT_WEB_ENV\n   */\n  '--web-env'?: ''\n}"
+            "value": "export interface appinfo {\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Outputs environment variables necessary for running and deploying web/.\n   * @environment SHOPIFY_FLAG_OUTPUT_WEB_ENV\n   */\n  '--web-env'?: ''\n}"
           }
         }
       }
@@ -1759,7 +1759,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "-j, --json",
                 "value": "\"\"",
-                "description": "Log the run result as a JSON object.",
+                "description": "Output the result as JSON.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_JSON"
               },
@@ -1773,7 +1773,7 @@
                 "environmentValue": "SHOPIFY_FLAG_STORE"
               }
             ],
-            "value": "export interface applogs {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Log the run result as a JSON object.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Filters output to the specified log source.\n   * @environment SHOPIFY_FLAG_SOURCE\n   */\n  '--source <value>'?: string\n\n  /**\n   * Filters output to the specified status (success or failure).\n   * @environment SHOPIFY_FLAG_STATUS\n   */\n  '--status <value>'?: string\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface applogs {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Filters output to the specified log source.\n   * @environment SHOPIFY_FLAG_SOURCE\n   */\n  '--source <value>'?: string\n\n  /**\n   * Filters output to the specified status (success or failure).\n   * @environment SHOPIFY_FLAG_STATUS\n   */\n  '--status <value>'?: string\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -1931,15 +1931,6 @@
               {
                 "filePath": "docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "--json",
-                "value": "\"\"",
-                "description": "Output the versions list as JSON.",
-                "isOptional": true,
-                "environmentValue": "SHOPIFY_FLAG_JSON"
-              },
-              {
-                "filePath": "docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts",
-                "syntaxKind": "PropertySignature",
                 "name": "--no-color",
                 "value": "\"\"",
                 "description": "Disable color output.",
@@ -1972,9 +1963,18 @@
                 "description": "The name of the app configuration.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
+              },
+              {
+                "filePath": "docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "-j, --json",
+                "value": "\"\"",
+                "description": "Output the result as JSON.",
+                "isOptional": true,
+                "environmentValue": "SHOPIFY_FLAG_JSON"
               }
             ],
-            "value": "export interface appversionslist {\n  /**\n   * The Client ID to fetch versions for.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the versions list as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface appversionslist {\n  /**\n   * The Client ID to fetch versions for.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -4996,15 +4996,6 @@
               {
                 "filePath": "docs-shopify.dev/commands/interfaces/theme-info.interface.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "--json",
-                "value": "\"\"",
-                "description": "Output the theme info as JSON.",
-                "isOptional": true,
-                "environmentValue": "SHOPIFY_FLAG_JSON"
-              },
-              {
-                "filePath": "docs-shopify.dev/commands/interfaces/theme-info.interface.ts",
-                "syntaxKind": "PropertySignature",
                 "name": "--no-color",
                 "value": "\"\"",
                 "description": "Disable color output.",
@@ -5050,6 +5041,15 @@
               {
                 "filePath": "docs-shopify.dev/commands/interfaces/theme-info.interface.ts",
                 "syntaxKind": "PropertySignature",
+                "name": "-j, --json",
+                "value": "\"\"",
+                "description": "Output the result as JSON.",
+                "isOptional": true,
+                "environmentValue": "SHOPIFY_FLAG_JSON"
+              },
+              {
+                "filePath": "docs-shopify.dev/commands/interfaces/theme-info.interface.ts",
+                "syntaxKind": "PropertySignature",
                 "name": "-s, --store <value>",
                 "value": "string",
                 "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
@@ -5066,7 +5066,7 @@
                 "environmentValue": "SHOPIFY_FLAG_THEME_ID"
               }
             ],
-            "value": "export interface themeinfo {\n  /**\n   * Retrieve info from your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the theme info as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themeinfo {\n  /**\n   * Retrieve info from your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the result as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -5254,15 +5254,6 @@
               {
                 "filePath": "docs-shopify.dev/commands/interfaces/theme-list.interface.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "--json",
-                "value": "\"\"",
-                "description": "Output the theme list as JSON.",
-                "isOptional": true,
-                "environmentValue": "SHOPIFY_FLAG_JSON"
-              },
-              {
-                "filePath": "docs-shopify.dev/commands/interfaces/theme-list.interface.ts",
-                "syntaxKind": "PropertySignature",
                 "name": "--name <value>",
                 "value": "string",
                 "description": "Only list themes that contain the given name.",
@@ -5317,6 +5308,15 @@
               {
                 "filePath": "docs-shopify.dev/commands/interfaces/theme-list.interface.ts",
                 "syntaxKind": "PropertySignature",
+                "name": "-j, --json",
+                "value": "\"\"",
+                "description": "Output the result as JSON.",
+                "isOptional": true,
+                "environmentValue": "SHOPIFY_FLAG_JSON"
+              },
+              {
+                "filePath": "docs-shopify.dev/commands/interfaces/theme-list.interface.ts",
+                "syntaxKind": "PropertySignature",
                 "name": "-s, --store <value>",
                 "value": "string",
                 "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
@@ -5324,7 +5324,7 @@
                 "environmentValue": "SHOPIFY_FLAG_STORE"
               }
             ],
-            "value": "export interface themelist {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Only list theme with the given ID.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Output the theme list as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Only list themes that contain the given name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Only list themes with the given role.\n   * @environment SHOPIFY_FLAG_ROLE\n   */\n  '--role <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themelist {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Only list theme with the given ID.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Output the result as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Only list themes that contain the given name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Only list themes with the given role.\n   * @environment SHOPIFY_FLAG_ROLE\n   */\n  '--role <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }
@@ -5860,7 +5860,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "-j, --json",
                 "value": "\"\"",
-                "description": "Output JSON instead of a UI.",
+                "description": "Output the result as JSON.",
                 "isOptional": true,
                 "environmentValue": "SHOPIFY_FLAG_JSON"
               },
@@ -5937,7 +5937,7 @@
                 "environmentValue": "SHOPIFY_FLAG_IGNORE"
               }
             ],
-            "value": "export interface themepush {\n  /**\n   * Allow push to a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Push theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output JSON instead of a UI.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Push theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting remote files that don't exist locally.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+            "value": "export interface themepush {\n  /**\n   * Allow push to a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Push theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output the result as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Push theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting remote files that don't exist locally.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed).\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path to your theme directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
           }
         }
       }

--- a/packages/app/src/cli/commands/app/function/replay.ts
+++ b/packages/app/src/cli/commands/app/function/replay.ts
@@ -3,7 +3,7 @@ import {replay} from '../../../services/function/replay.js'
 import {appFlags} from '../../../flags.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
 import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 
 export default class FunctionReplay extends AppCommand {
@@ -17,6 +17,7 @@ export default class FunctionReplay extends AppCommand {
     ...globalFlags,
     ...appFlags,
     ...functionFlags,
+    ...jsonFlag,
     'api-key': Flags.string({
       hidden: true,
       description: "Application's API key",
@@ -34,12 +35,6 @@ export default class FunctionReplay extends AppCommand {
       description:
         'Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.',
       env: 'SHOPIFY_FLAG_LOG',
-    }),
-    json: Flags.boolean({
-      char: 'j',
-      hidden: false,
-      description: 'Output the function run result as a JSON object.',
-      env: 'SHOPIFY_FLAG_JSON',
     }),
     watch: Flags.boolean({
       char: 'w',

--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -2,7 +2,7 @@ import {functionFlags, inFunctionContext, getOrGenerateSchemaPath} from '../../.
 import {runFunction} from '../../../services/function/runner.js'
 import {appFlags} from '../../../flags.js'
 import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 import {renderAutocompletePrompt, isTTY} from '@shopify/cli-kit/node/ui'
 import {outputDebug} from '@shopify/cli-kit/node/output'
@@ -20,6 +20,7 @@ export default class FunctionRun extends AppCommand {
     ...globalFlags,
     ...appFlags,
     ...functionFlags,
+    ...jsonFlag,
     input: Flags.string({
       char: 'i',
       description: 'The input JSON to pass to the function. If omitted, standard input is used.',
@@ -30,12 +31,6 @@ export default class FunctionRun extends AppCommand {
       hidden: false,
       description: 'Name of the WebAssembly export to invoke.',
       env: 'SHOPIFY_FLAG_EXPORT',
-    }),
-    json: Flags.boolean({
-      char: 'j',
-      hidden: false,
-      description: 'Log the run result as a JSON object.',
-      env: 'SHOPIFY_FLAG_JSON',
     }),
   }
 

--- a/packages/app/src/cli/commands/app/info.ts
+++ b/packages/app/src/cli/commands/app/info.ts
@@ -3,7 +3,7 @@ import {Format, info} from '../../services/info.js'
 import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {linkedAppContext} from '../../services/app-context.js'
 import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 
 export default class AppInfo extends AppCommand {
@@ -21,11 +21,7 @@ export default class AppInfo extends AppCommand {
   static flags = {
     ...globalFlags,
     ...appFlags,
-    json: Flags.boolean({
-      hidden: false,
-      description: 'format output as JSON',
-      env: 'SHOPIFY_FLAG_JSON',
-    }),
+    ...jsonFlag,
     'web-env': Flags.boolean({
       hidden: false,
       description: 'Outputs environment variables necessary for running and deploying web/.',

--- a/packages/app/src/cli/commands/app/logs.ts
+++ b/packages/app/src/cli/commands/app/logs.ts
@@ -7,7 +7,7 @@ import {linkedAppContext} from '../../services/app-context.js'
 import {storeContext} from '../../services/store-context.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 
 export default class Logs extends AppCommand {
   static summary = 'Stream detailed logs for your Shopify app.'
@@ -26,6 +26,7 @@ export default class Logs extends AppCommand {
   static flags = {
     ...globalFlags,
     ...appFlags,
+    ...jsonFlag,
     'api-key': Dev.flags['api-key'],
     'client-id': Dev.flags['client-id'],
     store: Flags.string({
@@ -45,11 +46,6 @@ export default class Logs extends AppCommand {
       description: 'Filters output to the specified status (success or failure).',
       options: ['success', 'failure'],
       env: 'SHOPIFY_FLAG_STATUS',
-    }),
-    json: Flags.boolean({
-      char: 'j',
-      description: 'Log the run result as a JSON object.',
-      env: 'SHOPIFY_FLAG_JSON',
     }),
   }
 

--- a/packages/app/src/cli/commands/app/versions/list.ts
+++ b/packages/app/src/cli/commands/app/versions/list.ts
@@ -3,7 +3,7 @@ import versionList from '../../../services/versions-list.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
 import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {linkedAppContext} from '../../../services/app-context.js'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {Args, Flags} from '@oclif/core'
 
 export default class VersionsList extends AppCommand {
@@ -18,6 +18,7 @@ export default class VersionsList extends AppCommand {
   static flags = {
     ...globalFlags,
     ...appFlags,
+    ...jsonFlag,
     'api-key': Flags.string({
       hidden: true,
       description: "Application's API key to fetch versions for.",
@@ -29,11 +30,6 @@ export default class VersionsList extends AppCommand {
       description: 'The Client ID to fetch versions for.',
       env: 'SHOPIFY_FLAG_CLIENT_ID',
       exclusive: ['config'],
-    }),
-    json: Flags.boolean({
-      description: 'Output the versions list as JSON.',
-      default: false,
-      env: 'SHOPIFY_FLAG_JSON',
     }),
   }
 

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -42,7 +42,7 @@ import {
 import {resolveFramework} from '@shopify/cli-kit/node/framework'
 import {hashString} from '@shopify/cli-kit/node/crypto'
 import {JsonMapType, decodeToml} from '@shopify/cli-kit/node/toml'
-import {joinPath, dirname, basename, relativePath, relativizePath, sniffForJson} from '@shopify/cli-kit/node/path'
+import {joinPath, dirname, basename, relativePath, relativizePath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputDebug, OutputMessage, outputToken} from '@shopify/cli-kit/node/output'
 import {joinWithAnd, slugify} from '@shopify/cli-kit/common/string'
@@ -52,6 +52,7 @@ import {renderInfo} from '@shopify/cli-kit/node/ui'
 import {currentProcessIsGlobal} from '@shopify/cli-kit/node/is-global'
 import {showNotificationsIfNeeded} from '@shopify/cli-kit/node/notifications-system'
 import {globalCLIVersion, localCLIVersion} from '@shopify/cli-kit/node/version'
+import {jsonOutputEnabled} from '@shopify/cli-kit/node/environment'
 
 const defaultExtensionDirectory = 'extensions/*'
 
@@ -401,7 +402,7 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
     const localVersion = dependencies['@shopify/cli'] && (await localCLIVersion(directory))
     const globalVersion = await globalCLIVersion()
 
-    if (localVersion && globalVersion && !sniffForJson() && !alreadyShownCLIWarning) {
+    if (localVersion && globalVersion && !jsonOutputEnabled() && !alreadyShownCLIWarning) {
       const currentInstallation = currentProcessIsGlobal() ? 'global installation' : 'local dependency'
 
       const warningContent = {

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -82,7 +82,6 @@
                 "./context/local.js",
                 "./custom-oclif-loader.js",
                 "@oclif/core",
-                "../../private/node/constants.js",
                 "./path.js",
                 "./system.js",
                 "./ui.js"
@@ -91,6 +90,7 @@
                 "@oclif/core",
                 "./context/utilities.js",
                 "../../private/node/conf-store.js",
+                "../../private/node/constants.js",
                 "url"
               ]
             }

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -44,6 +44,7 @@ export const environmentVariables = {
   refreshToken: 'SHOPIFY_CLI_REFRESH_TOKEN',
   otelURL: 'SHOPIFY_CLI_OTEL_EXPORTER_OTLP_ENDPOINT',
   themeKitAccessDomain: 'SHOPIFY_CLI_THEME_KIT_ACCESS_DOMAIN',
+  json: 'SHOPIFY_FLAG_JSON',
 }
 
 export const defaultThemeKitAccessDomain = 'theme-kit-access.shopifyapps.com'

--- a/packages/cli-kit/src/public/node/cli.ts
+++ b/packages/cli-kit/src/public/node/cli.ts
@@ -1,5 +1,6 @@
 import {isTruthy} from './context/utilities.js'
 import {cacheClear} from '../../private/node/conf-store.js'
+import {environmentVariables} from '../../private/node/constants.js'
 import {Flags} from '@oclif/core'
 
 /**
@@ -141,7 +142,7 @@ export const jsonFlag = {
     description: 'Output the result as JSON.',
     hidden: false,
     default: false,
-    env: 'SHOPIFY_FLAG_JSON',
+    env: environmentVariables.json,
   }),
 }
 

--- a/packages/cli-kit/src/public/node/cli.ts
+++ b/packages/cli-kit/src/public/node/cli.ts
@@ -135,6 +135,16 @@ export const globalFlags = {
   }),
 }
 
+export const jsonFlag = {
+  json: Flags.boolean({
+    char: 'j',
+    description: 'Output the result as JSON.',
+    hidden: false,
+    default: false,
+    env: 'SHOPIFY_FLAG_JSON',
+  }),
+}
+
 /**
  * Clear the CLI cache, used to store some API responses and handle notifications status
  */

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -76,8 +76,9 @@ export function getIdentityTokenInformation(): {accessToken: string; refreshToke
 /**
  * Checks if the JSON output is enabled via flag (--json or -j) or environment variable (SHOPIFY_FLAG_JSON).
  *
+ * @param environment - Process environment variables.
  * @returns True if the JSON output is enabled, false otherwise.
  */
-export function jsonOutputEnabled(): boolean {
-  return sniffForJson() || isTruthy(getEnvironmentVariables().SHOPIFY_FLAG_JSON)
+export function jsonOutputEnabled(environment = getEnvironmentVariables()): boolean {
+  return sniffForJson() || isTruthy(environment.SHOPIFY_FLAG_JSON)
 }

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -1,4 +1,6 @@
 import {nonRandomUUID} from './crypto.js'
+import {isTruthy} from './context/utilities.js'
+import {sniffForJson} from './path.js'
 import {environmentVariables, systemEnvironmentVariables} from '../../private/node/constants.js'
 
 /**
@@ -69,4 +71,13 @@ export function getIdentityTokenInformation(): {accessToken: string; refreshToke
     refreshToken,
     userId: nonRandomUUID(identityToken),
   }
+}
+
+/**
+ * Checks if the JSON output is enabled via flag (--json or -j) or environment variable (SHOPIFY_FLAG_JSON).
+ *
+ * @returns True if the JSON output is enabled, false otherwise.
+ */
+export function jsonOutputEnabled(): boolean {
+  return sniffForJson() || isTruthy(getEnvironmentVariables().SHOPIFY_FLAG_JSON)
 }

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -80,5 +80,5 @@ export function getIdentityTokenInformation(): {accessToken: string; refreshToke
  * @returns True if the JSON output is enabled, false otherwise.
  */
 export function jsonOutputEnabled(environment = getEnvironmentVariables()): boolean {
-  return sniffForJson() || isTruthy(environment.SHOPIFY_FLAG_JSON)
+  return sniffForJson() || isTruthy(environment[environmentVariables.json])
 }

--- a/packages/cli-kit/src/public/node/notifications-system.test.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.test.ts
@@ -402,4 +402,16 @@ describe('showNotificationsIfNeeded', () => {
     // Then
     expect(renderInfo).not.toHaveBeenCalled()
   })
+
+  test('notifications are skipped when using SHOPIFY_FLAG_JSON', async () => {
+    // Given
+    const notifications = [infoNotification]
+    vi.mocked(cacheRetrieveOrRepopulate).mockResolvedValue(JSON.stringify({notifications}))
+
+    // When
+    await showNotificationsIfNeeded(undefined, {SHOPIFY_UNIT_TEST: 'false', SHOPIFY_FLAG_JSON: 'true'})
+
+    // Then
+    expect(renderInfo).not.toHaveBeenCalled()
+  })
 })

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -79,7 +79,7 @@ export async function showNotificationsIfNeeded(
 }
 
 function skipNotifications(environment: NodeJS.ProcessEnv): boolean {
-  return isTruthy(environment.CI) || isTruthy(environment.SHOPIFY_UNIT_TEST) || jsonOutputEnabled()
+  return isTruthy(environment.CI) || isTruthy(environment.SHOPIFY_UNIT_TEST) || jsonOutputEnabled(environment)
 }
 
 /**

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -5,7 +5,7 @@ import {outputDebug} from './output.js'
 import {zod} from './schema.js'
 import {AbortSilentError} from './error.js'
 import {isTruthy} from './context/utilities.js'
-import {sniffForJson} from './path.js'
+import {jsonOutputEnabled} from './environment.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
 import {
   NotificationKey,
@@ -79,7 +79,7 @@ export async function showNotificationsIfNeeded(
 }
 
 function skipNotifications(environment: NodeJS.ProcessEnv): boolean {
-  return isTruthy(environment.CI) || isTruthy(environment.SHOPIFY_UNIT_TEST) || sniffForJson()
+  return isTruthy(environment.CI) || isTruthy(environment.SHOPIFY_UNIT_TEST) || jsonOutputEnabled()
 }
 
 /**

--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -172,12 +172,11 @@ export function sniffForPath(argv = process.argv): string | undefined {
 }
 
 /**
- * Returns whether the `--json` flag is present in the arguments.
+ * Returns whether the `--json` or `-j` flags are present in the arguments.
  *
- * @param argv - The arguments to search for the `--json` flag.
- * @returns Whether the `--json` flag is present in the arguments.
+ * @param argv - The arguments to search for the `--json` and `-j` flags.
+ * @returns Whether the `--json` or `-j` flag is present in the arguments.
  */
 export function sniffForJson(argv = process.argv): boolean {
-  const jsonFlagIndex = argv.indexOf('--json')
-  return jsonFlagIndex !== -1
+  return argv.includes('--json') || argv.includes('-j')
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -344,7 +344,7 @@ USAGE
 
 FLAGS
   -c, --config=<value>     The name of the app configuration.
-  -j, --json               Output the function run result as a JSON object.
+  -j, --json               Output the result as JSON.
   -l, --log=<value>        Specifies a log identifier to replay instead of selecting from a list. The identifier is
                            provided in the output of `shopify app dev` and is the suffix of the log file name.
   -w, --[no-]watch         Re-run the function when the source code changes.
@@ -373,7 +373,7 @@ FLAGS
   -c, --config=<value>  The name of the app configuration.
   -e, --export=<value>  Name of the WebAssembly export to invoke.
   -i, --input=<value>   The input JSON to pass to the function. If omitted, standard input is used.
-  -j, --json            Log the run result as a JSON object.
+  -j, --json            Output the result as JSON.
       --no-color        Disable color output.
       --path=<value>    The path to your function directory.
       --verbose         Increase the verbosity of the output.
@@ -496,11 +496,11 @@ Print basic information about your app and extensions.
 
 ```
 USAGE
-  $ shopify app info [-c <value>] [--json] [--no-color] [--path <value>] [--verbose] [--web-env]
+  $ shopify app info [-c <value>] [-j] [--no-color] [--path <value>] [--verbose] [--web-env]
 
 FLAGS
   -c, --config=<value>  The name of the app configuration.
-      --json            format output as JSON
+  -j, --json            Output the result as JSON.
       --no-color        Disable color output.
       --path=<value>    The path to your app directory.
       --verbose         Increase the verbosity of the output.
@@ -554,7 +554,7 @@ USAGE
 
 FLAGS
   -c, --config=<value>     The name of the app configuration.
-  -j, --json               Log the run result as a JSON object.
+  -j, --json               Output the result as JSON.
   -s, --store=<value>...   Store URL. Must be an existing development or Shopify Plus sandbox store.
       --client-id=<value>  The Client ID of your app.
       --no-color           Disable color output.
@@ -629,13 +629,12 @@ List deployed versions of your app.
 
 ```
 USAGE
-  $ shopify app versions list [FILE] [--client-id <value> | -c <value>] [--json] [--no-color] [--path <value>]
-    [--verbose]
+  $ shopify app versions list [FILE] [--client-id <value> | -c <value>] [-j] [--no-color] [--path <value>] [--verbose]
 
 FLAGS
   -c, --config=<value>     The name of the app configuration.
+  -j, --json               Output the result as JSON.
       --client-id=<value>  The Client ID to fetch versions for.
-      --json               Output the versions list as JSON.
       --no-color           Disable color output.
       --path=<value>       The path to your app directory.
       --verbose            Increase the verbosity of the output.
@@ -1871,16 +1870,16 @@ Displays information about your theme environment, including your current store.
 
 ```
 USAGE
-  $ shopify theme info [-d] [-e <value>] [--json] [--no-color] [--password <value>] [-s <value>] [-t <value>]
+  $ shopify theme info [-d] [-e <value>] [-j] [--no-color] [--password <value>] [-s <value>] [-t <value>]
     [--verbose]
 
 FLAGS
   -d, --development          Retrieve info from your development theme.
   -e, --environment=<value>  The environment to apply to the current command.
+  -j, --json                 Output the result as JSON.
   -s, --store=<value>        Store URL. It can be the store prefix (example) or the full myshopify.com URL
                              (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>        Theme ID or name of the remote theme.
-      --json                 Output the theme info as JSON.
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
       --verbose              Increase the verbosity of the output.
@@ -1948,15 +1947,15 @@ Lists the themes in your store, along with their IDs and statuses.
 
 ```
 USAGE
-  $ shopify theme list [-e <value>] [--id <value>] [--json] [--name <value>] [--no-color] [--password <value>]
+  $ shopify theme list [-e <value>] [--id <value>] [-j] [--name <value>] [--no-color] [--password <value>]
     [--role live|unpublished|development] [-s <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>  The environment to apply to the current command.
+  -j, --json                 Output the result as JSON.
   -s, --store=<value>        Store URL. It can be the store prefix (example) or the full myshopify.com URL
                              (example.myshopify.com, https://example.myshopify.com).
       --id=<value>           Only list theme with the given ID.
-      --json                 Output the theme list as JSON.
       --name=<value>         Only list themes that contain the given name.
       --no-color             Disable color output.
       --password=<value>     Password generated from the Theme Access app.
@@ -2106,7 +2105,7 @@ FLAGS
   -a, --allow-live           Allow push to a live theme.
   -d, --development          Push theme files from your remote development theme.
   -e, --environment=<value>  The environment to apply to the current command.
-  -j, --json                 Output JSON instead of a UI.
+  -j, --json                 Output the result as JSON.
   -l, --live                 Push theme files from your remote live theme.
   -n, --nodelete             Prevent deleting remote files that don't exist locally.
   -o, --only=<value>...      Download only the specified files (Multiple flags allowed).

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -767,7 +767,7 @@
         "json": {
           "allowNo": false,
           "char": "j",
-          "description": "Output the function run result as a JSON object.",
+          "description": "Output the result as JSON.",
           "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
           "name": "json",
@@ -869,7 +869,7 @@
         "json": {
           "allowNo": false,
           "char": "j",
-          "description": "Log the run result as a JSON object.",
+          "description": "Output the result as JSON.",
           "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
           "name": "json",
@@ -1383,7 +1383,8 @@
         },
         "json": {
           "allowNo": false,
-          "description": "format output as JSON",
+          "char": "j",
+          "description": "Output the result as JSON.",
           "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
           "name": "json",
@@ -1583,8 +1584,9 @@
         "json": {
           "allowNo": false,
           "char": "j",
-          "description": "Log the run result as a JSON object.",
+          "description": "Output the result as JSON.",
           "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
           "name": "json",
           "type": "boolean"
         },
@@ -1877,8 +1879,10 @@
         },
         "json": {
           "allowNo": false,
-          "description": "Output the versions list as JSON.",
+          "char": "j",
+          "description": "Output the result as JSON.",
           "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
           "name": "json",
           "type": "boolean"
         },
@@ -5047,8 +5051,10 @@
         },
         "json": {
           "allowNo": false,
-          "description": "Output the theme info as JSON.",
+          "char": "j",
+          "description": "Output the result as JSON.",
           "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
           "name": "json",
           "type": "boolean"
         },
@@ -5236,8 +5242,10 @@
         },
         "json": {
           "allowNo": false,
-          "description": "Output the theme list as JSON.",
+          "char": "j",
+          "description": "Output the result as JSON.",
           "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
           "name": "json",
           "type": "boolean"
         },
@@ -5710,8 +5718,9 @@
         "json": {
           "allowNo": false,
           "char": "j",
-          "description": "Output JSON instead of a UI.",
+          "description": "Output the result as JSON.",
           "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
           "name": "json",
           "type": "boolean"
         },

--- a/packages/theme/src/cli/commands/theme/info.ts
+++ b/packages/theme/src/cli/commands/theme/info.ts
@@ -5,7 +5,7 @@ import ThemeCommand from '../../utilities/theme-command.js'
 import {Flags} from '@oclif/core'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {formatSection, outputInfo} from '@shopify/cli-kit/node/output'
 
 export default class Info extends ThemeCommand {
@@ -14,6 +14,7 @@ export default class Info extends ThemeCommand {
 
   static flags = {
     ...globalFlags,
+    ...jsonFlag,
     store: themeFlags.store,
     password: themeFlags.password,
     environment: themeFlags.environment,
@@ -26,11 +27,6 @@ export default class Info extends ThemeCommand {
       char: 't',
       description: 'Theme ID or name of the remote theme.',
       env: 'SHOPIFY_FLAG_THEME_ID',
-    }),
-    json: Flags.boolean({
-      description: 'Output the theme info as JSON.',
-      default: false,
-      env: 'SHOPIFY_FLAG_JSON',
     }),
   }
 

--- a/packages/theme/src/cli/commands/theme/list.ts
+++ b/packages/theme/src/cli/commands/theme/list.ts
@@ -5,13 +5,14 @@ import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {Flags} from '@oclif/core'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 
 export default class List extends ThemeCommand {
   static description = 'Lists the themes in your store, along with their IDs and statuses.'
 
   static flags = {
     ...globalFlags,
+    ...jsonFlag,
     password: themeFlags.password,
     store: themeFlags.store,
     role: Flags.custom<Role>({
@@ -26,11 +27,6 @@ export default class List extends ThemeCommand {
     id: Flags.integer({
       description: 'Only list theme with the given ID.',
       env: 'SHOPIFY_FLAG_ID',
-    }),
-    json: Flags.boolean({
-      description: 'Output the theme list as JSON.',
-      default: false,
-      env: 'SHOPIFY_FLAG_JSON',
     }),
     environment: themeFlags.environment,
   }

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -2,7 +2,7 @@ import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {push, PushFlags} from '../../services/push.js'
 import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 
 export default class Push extends ThemeCommand {
   static summary = 'Uploads your local theme files to the connected store, overwriting the remote version if specified.'
@@ -43,6 +43,7 @@ export default class Push extends ThemeCommand {
   static flags = {
     ...globalFlags,
     ...themeFlags,
+    ...jsonFlag,
     theme: Flags.string({
       char: 't',
       description: 'Theme ID or name of the remote theme.',
@@ -79,11 +80,6 @@ export default class Push extends ThemeCommand {
       description: 'Skip downloading the specified files (Multiple flags allowed).',
       multiple: true,
       env: 'SHOPIFY_FLAG_IGNORE',
-    }),
-    json: Flags.boolean({
-      char: 'j',
-      description: 'Output JSON instead of a UI.',
-      env: 'SHOPIFY_FLAG_JSON',
     }),
     'allow-live': Flags.boolean({
       char: 'a',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/4925

### WHAT is this pull request doing?

- Prevents notifications from being shown when the `--json` or `-j` flags are used, or the `SHOPIFY_FLAG_JSON` environment variable
- Unifies the usage of the `--json` flag across commands. Some where missing the shortcut `-j` and the descriptions were different.
- Applies the same logic to the `showMultipleCLIWarningIfNeeded`, where we were only checking for `--json`

### How to test your changes?

- `pnpm i -g @shopify/cli@0.0.0-snapshot-20241127122146`
- `SHOPIFY_CLI_NOTIFICATIONS_URL=https://shopify.link/MNbn shopify theme list`
- `SHOPIFY_CLI_NOTIFICATIONS_URL=https://shopify.link/MNbn shopify theme list --json`
- `SHOPIFY_CLI_NOTIFICATIONS_URL=https://shopify.link/MNbn shopify theme list -j`
- `SHOPIFY_FLAG_JSON=1 SHOPIFY_CLI_NOTIFICATIONS_URL=https://shopify.link/MNbn shopify theme list`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
