### PR TITLE
Collapse verbose output by default in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -59,7 +59,15 @@ body:
     attributes:
       label: Verbose output
       description: If you're using npm rerun the command with `-- --verbose` or if you're using yarn or pnpm rerun the command with `--verbose`
-      render: shell
+      value: |-
+        <details>
+          <summary>Verbose output</summary>
+
+          ```
+          Paste the output here!
+          ```
+
+        </details>
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
### WHY are these changes introduced?

The verbose output is usually too big and requires a lot of scrolling in the issues

### WHAT is this pull request doing?

Updates the bug report template to add a default value to the verbose output with some markdown to enable collapsing it.

It will look like this:

<details>
  <summary>Verbose output</summary>

  ```
  Paste the output here!
  ```

</details>

### How to test your changes?

Merge and create an issue

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
