### PR TITLE
Make a dependabot group for dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
         update-types: ["version-update:semver-major"]
     groups:
       minor_versions:
+        dependency-type: "production"
         update-types:
           - 'minor'
           - 'patch'
@@ -32,6 +33,11 @@ updates:
           - "react"
           - "@babel/*"
           - "javy-cli"
+      development_dependencies:
+        dependency-type: "development"
+        update-types:
+          - 'minor'
+          - 'patch'
       oclif:
         patterns:
           - "oclif"


### PR DESCRIPTION
### WHY are these changes introduced?

Updates Dependabot configuration to better organize dependency updates by grouping all dev dependencies together