### PR TITLE
Show `app init` success after loading the app

### DIFF
--- a/packages/app/src/cli/commands/app/init.ts
+++ b/packages/app/src/cli/commands/app/init.ts
@@ -7,7 +7,6 @@ import {validateFlavorValue, validateTemplateValue} from '../../services/init/va
 import {MinimalOrganizationApp, Organization, OrganizationApp} from '../../models/organization.js'
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {searchForAppsByNameFactory} from '../../services/dev/prompt-helpers.js'
-import {linkedAppContext} from '../../services/app-context.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
@@ -109,7 +108,7 @@ export default class Init extends AppCommand {
       cmd_create_app_template_url: promptAnswers.template,
     }))
 
-    const result = await initService({
+    const {app} = await initService({
       name: appName,
       selectedAppOrNameResult: selectAppResult,
       packageManager: inferredPackageManager,
@@ -121,14 +120,6 @@ export default class Init extends AppCommand {
       postCloneActions: {
         removeLockfilesFromGitignore: promptAnswers.templateType !== 'custom',
       },
-    })
-
-    const {app} = await linkedAppContext({
-      directory: result.outputDirectory,
-      clientId: undefined,
-      forceRelink: false,
-      userProvidedConfigName: undefined,
-      unsafeReportMode: false,
     })
 
     return {app}

--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -5,6 +5,7 @@ import {OrganizationApp} from '../../models/organization.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {loadConfigForAppCreation} from '../../models/app/loader.js'
 import {SelectAppOrNewAppNameResult} from '../../commands/app/init.js'
+import {linkedAppContext} from '../app-context.js'
 import {
   findUpAndReadPackageJson,
   lockfiles,
@@ -218,6 +219,14 @@ async function init(options: InitOptions) {
     false,
   )
 
+  const appContextResult = await linkedAppContext({
+    directory: outputDirectory,
+    clientId: undefined,
+    forceRelink: false,
+    userProvidedConfigName: undefined,
+    unsafeReportMode: false,
+  })
+
   renderSuccess({
     headline: [{userInput: hyphenizedName}, 'is ready for you to build!'],
     nextSteps: [
@@ -234,7 +243,7 @@ async function init(options: InitOptions) {
     ],
   })
 
-  return {outputDirectory}
+  return {app: appContextResult.app}
 }
 
 async function ensureAppDirectoryIsAvailable(directory: string, name: string): Promise<void> {


### PR DESCRIPTION
### WHY are these changes introduced?

App init shows the success message and then it still takes 1-2s to finish. 

### WHAT is this pull request doing?

Load the app BEFORE showing the success message.

### How to test your changes?

1. Run `shopify app init` to create a new app
2. Verify that after the success message, the command finishes immediately (it can still take up to 500ms to process analytics)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes