### PR TITLE
Refresh session on 401 for graphQL requests

### DIFF
--- a/packages/cli-kit/src/public/node/api/admin.ts
+++ b/packages/cli-kit/src/public/node/api/admin.ts
@@ -63,7 +63,17 @@ export async function adminRequestDoc<TResult, TVariables extends Variables>(
     token: session.token,
     addedHeaders,
   }
-  const result = graphqlRequestDoc<TResult, TVariables>({...opts, query, variables, responseOptions})
+  let unauthorizedHandler
+  if ('refresh' in session) {
+    unauthorizedHandler = session.refresh as () => Promise<void>
+  }
+  const result = graphqlRequestDoc<TResult, TVariables>({
+    ...opts,
+    query,
+    variables,
+    responseOptions,
+    unauthorizedHandler,
+  })
   return result
 }
 

--- a/packages/cli-kit/src/public/node/api/graphql.test.ts
+++ b/packages/cli-kit/src/public/node/api/graphql.test.ts
@@ -54,7 +54,7 @@ describe('graphqlRequest', () => {
       request: expect.any(Function),
       url: mockedAddress,
     }
-    expect(retryAwareRequest).toHaveBeenCalledWith(receivedObject, expect.any(Function))
+    expect(retryAwareRequest).toHaveBeenCalledWith(receivedObject, expect.any(Function), undefined)
   })
 })
 
@@ -95,6 +95,7 @@ describe('graphqlRequestDoc', () => {
         url: mockedAddress,
       },
       expect.any(Function),
+      undefined,
     )
     expect(debugRequest.debugLogRequestInfo).toHaveBeenCalledWith(
       'mockApi',

--- a/packages/cli-kit/src/public/node/api/graphql.ts
+++ b/packages/cli-kit/src/public/node/api/graphql.ts
@@ -26,16 +26,19 @@ interface GraphQLRequestBaseOptions<TResult> {
 type PerformGraphQLRequestOptions<TResult> = GraphQLRequestBaseOptions<TResult> & {
   queryAsString: string
   variables?: Variables
+  unauthorizedHandler?: () => Promise<void>
 }
 
 export type GraphQLRequestOptions<T> = GraphQLRequestBaseOptions<T> & {
   query: RequestDocument
   variables?: Variables
+  unauthorizedHandler?: () => Promise<void>
 }
 
 export type GraphQLRequestDocOptions<TResult, TVariables> = GraphQLRequestBaseOptions<TResult> & {
   query: TypedDocumentNode<TResult, TVariables> | TypedDocumentNode<TResult, Exact<{[key: string]: never}>>
   variables?: TVariables
+  unauthorizedHandler?: () => Promise<void>
 }
 
 export interface GraphQLResponseOptions<T> {
@@ -49,7 +52,7 @@ export interface GraphQLResponseOptions<T> {
  * @param options - GraphQL request options.
  */
 async function performGraphQLRequest<TResult>(options: PerformGraphQLRequestOptions<TResult>) {
-  const {token, addedHeaders, queryAsString, variables, api, url, responseOptions} = options
+  const {token, addedHeaders, queryAsString, variables, api, url, responseOptions, unauthorizedHandler} = options
   const headers = {
     ...addedHeaders,
     ...buildHeaders(token),
@@ -63,6 +66,7 @@ async function performGraphQLRequest<TResult>(options: PerformGraphQLRequestOpti
     const response = await retryAwareRequest(
       {request: () => client.rawRequest<TResult>(queryAsString, variables), url},
       responseOptions?.handleErrors === false ? undefined : errorHandler(api),
+      unauthorizedHandler,
     )
 
     if (responseOptions?.onResponse) {

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -370,31 +370,6 @@ describe('request errors', () => {
       // Then
     }).rejects.toThrowError(AbortError)
   })
-
-  test(`refresh the session when 401 errors happen`, async () => {
-    // Given
-    const id = 123
-    const assets: AssetParams[] = []
-
-    vi.spyOn(session, 'refresh').mockImplementation(vi.fn())
-    vi.mocked(restRequest)
-      .mockResolvedValueOnce({
-        json: {},
-        status: 401,
-        headers: {},
-      })
-      .mockResolvedValueOnce({
-        json: {},
-        status: 207,
-        headers: {},
-      })
-
-    // When
-    await bulkUploadThemeAssets(id, assets, session)
-
-    // Then
-    expect(session.refresh).toHaveBeenCalledOnce()
-  })
 })
 
 describe('bulkUploadThemeAssets', async () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

When running `shopify theme dev` for long periods of time, the session can timeout and needs to be refreshed. The client will receive 401 errors from the server until the session is refreshed.

We've fixed this for REST calls in https://github.com/Shopify/cli/pull/4790.

This PR does the same for graphQL calls.

Fixes #4897 

### WHAT is this pull request doing?

@karreiro and I decided the best way to approach this was to extend the functionality of `retryAwareRequest` so that when a 401 error occurs, and an `unauthorizedHandler` is provided, then we call the unauthorizedHandler and retry the request.

Further up the stack in the graphQL code, we use the session's refresh function as the unauthorizedHandler.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
