### PR TITLE
Fix dest already exists error by setting overwrite flag

### DIFF
--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -164,7 +164,7 @@ export async function downloadBinary(bin: DownloadableBinary) {
         const outputStream = createFileWriteStream(tmpFile)
         await bin.processResponse(responseStream, outputStream)
         await chmod(tmpFile, 0o775)
-        await moveFile(tmpFile, bin.path)
+        await moveFile(tmpFile, bin.path, {overwrite: true})
       })
     },
     async () => {},


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

If a Shopify Functions-related binary is downloaded in parallel, every download after the first one completes will fail with a `dest already exists` error because `move` by default throws this error if a file already exists.

### WHAT is this pull request doing?

Instructs the CLI to overwrite when downloading the binary. It's going to be the same binary anyway.

### How to test your changes?

This is going to be difficult to test because it relies on parallelism which isn't deterministic.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
