### PR TITLE
Download Javy plugin with Javy binary

### DIFF
--- a/.changeset/shy-steaks-lay.md
+++ b/.changeset/shy-steaks-lay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Download Javy plugin ahead of time with Javy CLI

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -198,7 +198,8 @@ export async function installJavy(app: AppInterface) {
   const javyRequired = app.allExtensions.some((ext) => ext.features.includes('function') && ext.isJavaScript)
   if (javyRequired) {
     const javy = javyBinary()
-    await downloadBinary(javy)
+    const plugin = javyPluginBinary()
+    await Promise.all([downloadBinary(javy), downloadBinary(plugin)])
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Downloading the Javy plugin binary along with the Javy CLI binary to avoid downloading the plugin multiple times unnecessarily.

### WHAT is this pull request doing?

Updates the `installJavy` function to install both the Javy CLI and plugin.

### How to test your changes?

1. `pnpm clean`
2. `pnpm shopify app function build --path <path_to_function_extension>`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
