### PR TITLE
Allow empty theme files to be uploaded

### DIFF
--- a/.changeset/honest-cobras-invite.md
+++ b/.changeset/honest-cobras-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix bug preventing empty theme files from uploading

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # Theme team and CLI owners should review theme changes
 packages/cli-kit/src/private/themes/* @shopify/advanced-edits @shopify/app-inner-loop
-packages/cli-kit/src/public/themes/* @shopify/advanced-edits @shopify/app-inner-loop
+packages/cli-kit/src/public/**/themes/* @shopify/advanced-edits @shopify/app-inner-loop
 packages/theme/** @shopify/advanced-edits @shopify/app-inner-loop
 
 # These are metafiles that can be reviewed by anyone

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -119,15 +119,7 @@ export async function bulkUploadThemeAssets(
 
 function prepareFilesForUpload(assets: AssetParams[]): OnlineStoreThemeFilesUpsertFileInput[] {
   return assets.map((asset) => {
-    if (asset.value) {
-      return {
-        filename: asset.key,
-        body: {
-          type: 'TEXT' as const,
-          value: asset.value,
-        },
-      }
-    } else if (asset.attachment) {
+    if (asset.attachment) {
       return {
         filename: asset.key,
         body: {
@@ -136,7 +128,13 @@ function prepareFilesForUpload(assets: AssetParams[]): OnlineStoreThemeFilesUpse
         },
       }
     } else {
-      unexpectedGraphQLError('Asset must have a value or attachment')
+      return {
+        filename: asset.key,
+        body: {
+          type: 'TEXT' as const,
+          value: asset.value ?? '',
+        },
+      }
     }
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

- Fixes https://github.com/Shopify/cli/issues/5010

We recently migrated the CLI to use the new GraphQL endpoints to upload theme files. We had logic in the code that would throw a GraphQL error if the file/asset being uploaded did not have a value or attachment. Unfortunately this was falsely targeting newly created files that have a value of an empty string `''`.

### WHAT is this pull request doing?

This PR removes the GraphQL error raising entirely. The only scenario we check for now is if there is a valid `attachment` otherwise we'll always upload the file as a `TEXT` file with an empty string or the value itself.

### How to test your changes?

1. Pull down this branch and run `pnpm run build`
2. In a local theme folder, create a new empty file `touch snippets/empty.liquid`
3. Run `shopify theme dev --path /your/theme/with/empty/file`

You should not see an error. 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
