### PR TITLE
Update context to target mappings

### DIFF
--- a/.changeset/shiny-guests-give.md
+++ b/.changeset/shiny-guests-give.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Updated link extension import to match a target format similar to action extesions

--- a/packages/app/src/cli/services/admin-link/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/admin-link/extension-to-toml.test.ts
@@ -36,7 +36,7 @@ handle = "admin-link-title"
   [[extensions.targeting]]
   text = "admin link label"
   url = "https://google.es"
-  target = "admin.collection.item.link"
+  target = "admin.collection-details.action.link"
 `)
   })
 
@@ -72,7 +72,7 @@ handle = "bulk-action-title"
   [[extensions.targeting]]
   text = "bulk action label"
   url = "app://action/product?product_id=123#hash"
-  target = "admin.product.selection.link"
+  target = "admin.product-index.selection-action.link"
 `)
   })
   test('correctly builds a toml string for bulk_action extension with no path in an embedded app', () => {
@@ -107,7 +107,7 @@ handle = "bulk-action-title"
   [[extensions.targeting]]
   text = "bulk action label"
   url = "app://"
-  target = "admin.product.selection.link"
+  target = "admin.product-index.selection-action.link"
 `)
   })
   test('correctly builds a toml string for bulk_action extension with no path but search query in an embedded app', () => {
@@ -142,7 +142,7 @@ handle = "bulk-action-title"
   [[extensions.targeting]]
   text = "bulk action label"
   url = "app://?foo=bar"
-  target = "admin.product.selection.link"
+  target = "admin.product-index.selection-action.link"
 `)
   })
 })

--- a/packages/app/src/cli/services/admin-link/utils.test.ts
+++ b/packages/app/src/cli/services/admin-link/utils.test.ts
@@ -10,7 +10,7 @@ describe('admin link utils', () => {
     const target = contextToTarget(context)
 
     // Then
-    expect(target).toEqual('admin.collection.item.link')
+    expect(target).toEqual('admin.collection-details.action.link')
   })
   test('correctly parses from context `ORDERS#INDEX` to target', () => {
     // Given
@@ -20,6 +20,16 @@ describe('admin link utils', () => {
     const target = contextToTarget(context)
 
     // Then
-    expect(target).toEqual('admin.order.index.link')
+    expect(target).toEqual('admin.order-index.action.link')
+  })
+  test('correctly parses from context `CUSTOMERS#ACTION` to target', () => {
+    // Given
+    const context = 'CUSTOMERS#ACTION'
+
+    // When
+    const target = contextToTarget(context)
+
+    // Then
+    expect(target).toEqual('admin.customer-index.selection-action.link')
   })
 })

--- a/packages/app/src/cli/services/admin-link/utils.ts
+++ b/packages/app/src/cli/services/admin-link/utils.ts
@@ -4,27 +4,36 @@ export const contextToTarget = (context: string) => {
     throw new Error('Invalid context')
   }
   const domain = 'admin'
-  const subDomain = typeToSubDomain(splitContext[0] || '')
-  const entity = locationToEntity(splitContext[1] || '')
+  const subDomain = typeToSubDomain(splitContext[0] ?? '')
+  const entity = locationToEntity(splitContext[1] ?? '')
   const action = 'link'
 
-  return [domain, subDomain, entity, action].join('.')
+  if (entity === 'selection') {
+    return [domain, `${subDomain}-index`, `${entity}-action`, action].join('.')
+  } else {
+    return [domain, `${subDomain}-${entity}`, 'action', action].join('.')
+  }
 }
 
 const locationToEntity = (location: string) => {
   switch (location.toLocaleLowerCase()) {
     case 'show':
-      return 'item'
+      return 'details'
     case 'index':
       return 'index'
     case 'action':
       return 'selection'
     case 'fulfilled_card':
-      return 'fulfilled_card'
+      return 'fulfilled-card'
     default:
       throw new Error(`Invalid context location: ${location}`)
   }
 }
-const typeToSubDomain = (word: string) => {
-  return word.toLocaleLowerCase().replace(new RegExp(`(s)$`), '')
+const typeToSubDomain = (type: string) => {
+  switch (type.toLocaleLowerCase()) {
+    case 'variants':
+      return 'product-variant'
+    default:
+      return type.toLocaleLowerCase().replace(new RegExp(`(s)$`), '')
+  }
 }


### PR DESCRIPTION

### WHY are these changes introduced?

Updated mapping from context to target for legacy links. Previous mapping was not matching the convention for targets.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
