### PR TITLE
Increase localization file size limit

### DIFF
--- a/packages/app/src/cli/utilities/extensions/locales-configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/locales-configuration.test.ts
@@ -50,7 +50,7 @@ describe('loadLocalesConfig', () => {
 
       await mkdir(localesPath)
       await writeFile(enDefault, JSON.stringify({hello: 'Hello'}))
-      const bigArray = new Array(5000).fill('a')
+      const bigArray = new Array(6000).fill('a')
       await writeFile(es, JSON.stringify(bigArray))
 
       // When
@@ -101,7 +101,7 @@ describe('loadLocalesConfig', () => {
       const es = joinPath(localesPath, 'es.json')
 
       await mkdir(localesPath)
-      const bigArray = JSON.stringify(new Array(3000).fill('a'))
+      const bigArray = JSON.stringify(new Array(4000).fill('a'))
 
       await writeFile(en, JSON.stringify(bigArray))
       await writeFile(es, JSON.stringify(bigArray))

--- a/packages/app/src/cli/utilities/extensions/locales-configuration.ts
+++ b/packages/app/src/cli/utilities/extensions/locales-configuration.ts
@@ -3,7 +3,7 @@ import {glob} from '@shopify/cli-kit/node/fs'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
 import fs from 'fs'
 
-const L10N_FILE_SIZE_LIMIT = 16 * 1024
+const L10N_FILE_SIZE_LIMIT = 20 * 1024
 const L10N_BUNDLE_SIZE_LIMIT = 256 * 1024
 
 export async function loadLocalesConfig(extensionPath: string, extensionIdentifier: string) {


### PR DESCRIPTION
### WHY are these changes introduced?

The current file size limit of 16KB for extension localization files is too restrictive for some use cases.

### WHAT is this pull request doing?

Increases the extension localization file size limit from 16KB to 20KB while maintaining the overall bundle size limit of 256KB.

### How to test your changes?

1. Create a localization file larger than 16KB but smaller than 20KB
2. Verify the extension can be deployed without size limit errors
3. Verify files over 20KB still trigger appropriate error messages

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes