### PR TITLE
Fix function drafts

### DIFF
--- a/.changeset/wicked-singers-explode.md
+++ b/.changeset/wicked-singers-explode.md
@@ -1,5 +1,0 @@
----
-'@shopify/app': patch
----
-
-Fix function drafts not working during dev

--- a/.changeset/wicked-singers-explode.md
+++ b/.changeset/wicked-singers-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix function drafts not working during dev

--- a/packages/app/src/cli/services/dev/update-extension.test.ts
+++ b/packages/app/src/cli/services/dev/update-extension.test.ts
@@ -206,7 +206,7 @@ describe('updateExtensionDraft()', () => {
       const content = 'test content'
       const base64Content = Buffer.from(content).toString('base64')
       await mkdir(joinPath(mockExtension.directory, 'dist'))
-      const outputPath = mockExtension.getOutputPathForDirectory(tmpDir)
+      const outputPath = mockExtension.outputPath
       await mkdir(dirname(outputPath))
       await writeFile(outputPath, content)
 

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -50,7 +50,7 @@ export async function updateExtensionDraft({
     // When updating just the theme extension draft, upload the files as part of the config.
     config = await themeExtensionConfig(extension)
   } else {
-    config = (await extension.deployConfig({apiKey, appConfiguration})) || {}
+    config = (await extension.deployConfig({apiKey, appConfiguration})) ?? {}
   }
 
   const draftableConfig: {[key: string]: unknown} = {
@@ -58,7 +58,9 @@ export async function updateExtensionDraft({
     serialized_script: encodedFile,
   }
   if (extension.isFunctionExtension) {
-    const compiledFiles = await readFile(outputPath, {encoding: 'base64'})
+    // For function drafts we need to use the `extension.outputPath` instead of `bundlePath`
+    // The wasm in the bundle path is encoded in base64.
+    const compiledFiles = await readFile(extension.outputPath, {encoding: 'base64'})
     draftableConfig.uploaded_files = {'dist/index.wasm': compiledFiles}
   }
   const extensionInput: ExtensionUpdateDraftMutationVariables = {


### PR DESCRIPTION
### WHY are these changes introduced?

Function drafts were not working correctly during development mode due to incorrect file path handling and encoding issues.

### WHAT is this pull request doing?

Fixes function drafts by using the correct `extension.outputPath` instead of `bundlePath` when reading WASM files. The WASM files in the bundle path were being encoded in base64, causing compatibility issues. 

### How to test your changes?

1. Create a function extension in your app
2. Run `dev`
3. Verify that function drafts are now working correctly

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes