### PR TITLE
[Themes] Add support for block liquid files in theme partitioning

### DIFF
--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -398,10 +398,19 @@ describe('theme-fs', () => {
         {key: 'sections/announcement-bar.liquid', checksum: '10'},
         {key: 'snippets/language-localization.liquid', checksum: '11'},
         {key: 'templates/404.context.uk.json', checksum: '11'},
+        {key: 'blocks/block.liquid', checksum: '12'},
       ]
       // When
-      const {sectionLiquidFiles, otherLiquidFiles, templateJsonFiles, otherJsonFiles, configFiles, staticAssetFiles} =
-        partitionThemeFiles(files)
+      const {
+        sectionLiquidFiles,
+        otherLiquidFiles,
+        templateJsonFiles,
+        otherJsonFiles,
+        configFiles,
+        staticAssetFiles,
+        contextualizedJsonFiles,
+        blockLiquidFiles,
+      } = partitionThemeFiles(files)
 
       // Then
       expect(sectionLiquidFiles).toEqual([{key: 'sections/announcement-bar.liquid', checksum: '10'}])
@@ -421,6 +430,8 @@ describe('theme-fs', () => {
         {key: 'assets/base.css', checksum: '1'},
         {key: 'assets/sparkle.gif', checksum: '3'},
       ])
+      expect(contextualizedJsonFiles).toEqual([{key: 'templates/404.context.uk.json', checksum: '11'}])
+      expect(blockLiquidFiles).toEqual([{key: 'blocks/block.liquid', checksum: '12'}])
     })
 
     test('should handle empty file array', () => {

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -34,7 +34,7 @@ const THEME_DIRECTORY_PATTERNS = [
 
 const THEME_PARTITION_REGEX = {
   sectionLiquidRegex: /^sections\/.+\.liquid$/,
-  liquidRegex: /\.liquid$/,
+  blockLiquidRegex: /^blocks\/.+\.liquid$/,
   configRegex: /^config\/(settings_schema|settings_data)\.json$/,
   sectionJsonRegex: /^sections\/.+\.json$/,
   templateJsonRegex: /^templates\/.+\.json$/,
@@ -318,12 +318,15 @@ export function partitionThemeFiles<T extends {key: string}>(files: T[]) {
   const contextualizedJsonFiles: T[] = []
   const configFiles: T[] = []
   const staticAssetFiles: T[] = []
+  const blockLiquidFiles: T[] = []
 
   files.forEach((file) => {
     const fileKey = file.key
     if (fileKey.endsWith('.liquid')) {
       if (THEME_PARTITION_REGEX.sectionLiquidRegex.test(fileKey)) {
         sectionLiquidFiles.push(file)
+      } else if (THEME_PARTITION_REGEX.blockLiquidRegex.test(fileKey)) {
+        blockLiquidFiles.push(file)
       } else {
         otherLiquidFiles.push(file)
       }
@@ -353,6 +356,7 @@ export function partitionThemeFiles<T extends {key: string}>(files: T[]) {
     otherJsonFiles,
     configFiles,
     staticAssetFiles,
+    blockLiquidFiles,
   }
 }
 

--- a/packages/theme/src/cli/utilities/theme-uploader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.test.ts
@@ -296,6 +296,7 @@ describe('theme-uploader', () => {
         ['templates/product.json', {key: 'templates/product.json', checksum: '6'}],
         ['assets/image.png', {key: 'assets/image.png', checksum: '7'}],
         ['templates/product.context.uk.json', {key: 'templates/product.context.uk.json', checksum: '8'}],
+        ['blocks/block.liquid', {key: 'blocks/block.liquid', checksum: '9'}],
       ]),
     )
 
@@ -310,21 +311,17 @@ describe('theme-uploader', () => {
     await renderThemeSyncProgress()
 
     // Then
-    expect(bulkUploadThemeAssets).toHaveBeenCalledTimes(7)
-    // Mininum theme files start first
+    expect(bulkUploadThemeAssets).toHaveBeenCalledTimes(8)
+    // Minimum theme files start first
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(1, remoteTheme.id, MINIMUM_THEME_ASSETS, adminSession)
     // Dependent assets start second
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
       2,
       remoteTheme.id,
-      [
-        {
-          key: 'sections/header.liquid',
-        },
-      ],
+      [{key: 'blocks/block.liquid'}],
       adminSession,
     )
-    // Independent assets start right before dependent assets start
+    // Independent assets start right after dependent assets start
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
       3,
       remoteTheme.id,
@@ -347,17 +344,18 @@ describe('theme-uploader', () => {
       remoteTheme.id,
       [
         {
-          key: 'sections/header-group.json',
+          key: 'sections/header.liquid',
         },
       ],
       adminSession,
     )
+
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
       5,
       remoteTheme.id,
       [
         {
-          key: 'templates/product.json',
+          key: 'sections/header-group.json',
         },
       ],
       adminSession,
@@ -367,13 +365,23 @@ describe('theme-uploader', () => {
       remoteTheme.id,
       [
         {
-          key: 'templates/product.context.uk.json',
+          key: 'templates/product.json',
         },
       ],
       adminSession,
     )
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
       7,
+      remoteTheme.id,
+      [
+        {
+          key: 'templates/product.context.uk.json',
+        },
+      ],
+      adminSession,
+    )
+    expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
+      8,
       remoteTheme.id,
       [
         {

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -168,6 +168,7 @@ function orderFilesToBeDeleted(files: Checksum[]): Checksum[] {
     ...fileSets.sectionJsonFiles,
     ...fileSets.otherJsonFiles,
     ...fileSets.sectionLiquidFiles,
+    ...fileSets.blockLiquidFiles,
     ...fileSets.otherLiquidFiles,
     ...fileSets.configFiles,
     ...fileSets.staticAssetFiles,
@@ -237,7 +238,8 @@ function buildUploadJob(
     (promise, fileType) => promise.then(() => uploadFileBatches(fileType)),
     Promise.resolve(),
   )
-  // Wait for dependent files upload to be started before starting this one:
+
+  // Dependant and independant files are uploaded concurrently
   const independentFilesUploadPromise = Promise.resolve().then(() => uploadFileBatches(independentFiles.flat()))
 
   const promise = Promise.all([dependentFilesUploadPromise, independentFilesUploadPromise]).then(() => {
@@ -289,6 +291,7 @@ function orderFilesToBeUploaded(files: ChecksumWithSize[]): {
     independentFiles: [fileSets.otherLiquidFiles, fileSets.otherJsonFiles, fileSets.staticAssetFiles],
     // Follow order of dependencies:
     dependentFiles: [
+      fileSets.blockLiquidFiles,
       fileSets.sectionLiquidFiles,
       fileSets.sectionJsonFiles,
       fileSets.templateJsonFiles,


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/develop-advanced-edits/issues/468

Adds support for theme block files when uploading theme

### WHAT is this pull request doing?
- Introduces explicit partitioning support for blocks folder
- Modifies theme uploads to upload blocks first

### How to test your changes?

1. Try uploading `horizon` from the CLI on the `CLI 3.71`+
2. Run `shopify theme push -u`
3. Verify that `custom-section` has an error like this: `Failed to upload file sections/custom-section.liquid:
-Invalid preset "Featured collection": invalid block type "featured-collection": undefined block type.`
4. Check out this branch and build
5. Run `pnpm shopify theme push -u`
6. Confirm that theme is uploaded with no errors

BEFORE
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JdHLnhebSbtZTZO01I1e/eeaba691-49a7-48fd-8036-07fbb5cd4afd.png)

AFTER
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JdHLnhebSbtZTZO01I1e/b85e1ff1-fde1-4643-8388-262a20a0fb46.png)


### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes