### PR TITLE
Default to using the latest patch version of shopify_function

### DIFF
--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -246,7 +246,7 @@ async function uiExtensionInit({
 
         if (templateLanguage === 'javascript') {
           await changeIndexFileExtension(directory, srcFileExtension)
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
           await removeUnwantedTemplateFilesPerFlavor(directory, extensionFlavor!.value)
         }
       },
@@ -299,7 +299,7 @@ function getSrcFileExtension(extensionFlavor: ExtensionFlavorValue): SrcFileExte
 export function getFunctionRuntimeDependencies(templateLanguage: string): DependencyVersion[] {
   const dependencies: DependencyVersion[] = []
   if (templateLanguage === 'javascript') {
-    dependencies.push({name: '@shopify/shopify_function', version: '1.0.0'})
+    dependencies.push({name: '@shopify/shopify_function', version: '~1.0.0'})
   }
   return dependencies
 }


### PR DESCRIPTION
I was going to update to use [v1.0.3](https://github.com/Shopify/shopify-function-javascript/releases/tag/v1.0.3) but shouldn't we just encourage use of the latest patch?