### PR TITLE
bump function-runner to 6.4.0

### DIFF
--- a/.changeset/purple-planets-hide.md
+++ b/.changeset/purple-planets-hide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update function-runner to v6.4.0

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs'
 import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
-const FUNCTION_RUNNER_VERSION = 'v6.3.0'
+const FUNCTION_RUNNER_VERSION = 'v6.4.0'
 const JAVY_VERSION = 'v4.0.0'
 // The Javy plugin version does not need to match the Javy version. It should
 // match the plugin version used in the function-runner version specified above.


### PR DESCRIPTION
### WHY are these changes introduced?
#gsd:43536

We are bumping the function input size limit. The function-runner package has been updated to reflect this.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

- `rm -r packages/app/dist/cli/services/bin/` (clear out any cached downloaded binaries)
- `pnpm shopify app function build --path <path_to_function_extension>` (downloads and runs Javy)
- `echo "{}" | pnpm shopify app function run --path <path_to_function_extension>` (downloads and runs function-runner)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
  - none needed
- [x] I've considered possible [documentation](https://shopify.dev) changes
  - none needed
