### PR TITLE
Make launcher option for CLI optional

### DIFF
--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -91,7 +91,8 @@
                 "./context/utilities.js",
                 "../../private/node/conf-store.js",
                 "../../private/node/constants.js",
-                "url"
+                "url",
+                "./cli-launcher.js"
               ]
             }
           ]

--- a/packages/cli-kit/src/public/node/cli.ts
+++ b/packages/cli-kit/src/public/node/cli.ts
@@ -1,4 +1,5 @@
 import {isTruthy} from './context/utilities.js'
+import {launchCLI as defaultLaunchCli} from './cli-launcher.js'
 import {cacheClear} from '../../private/node/conf-store.js'
 import {environmentVariables} from '../../private/node/constants.js'
 import {Flags} from '@oclif/core'
@@ -74,7 +75,7 @@ function forceNoColor(argv: string[] = process.argv, env: NodeJS.ProcessEnv = pr
  */
 export async function runCLI(
   options: RunCLIOptions & {runInCreateMode?: boolean},
-  launchCLI: (options: {moduleURL: string}) => Promise<void>,
+  launchCLI: (options: {moduleURL: string}) => Promise<void> = defaultLaunchCli,
   argv: string[] = process.argv,
   env: NodeJS.ProcessEnv = process.env,
   versions: NodeJS.ProcessVersions = process.versions,
@@ -111,7 +112,7 @@ async function addInitToArgvWhenRunningCreateCLI(
  */
 export async function runCreateCLI(
   options: RunCLIOptions,
-  launchCLI: (options: {moduleURL: string}) => Promise<void>,
+  launchCLI: (options: {moduleURL: string}) => Promise<void> = defaultLaunchCli,
   argv: string[] = process.argv,
   env: NodeJS.ProcessEnv = process.env,
   versions: NodeJS.ProcessVersions = process.versions,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,7 +20,6 @@ import {commands as PluginCommandsCommands} from '@oclif/plugin-commands'
 import {commands as PluginPluginsCommands} from '@oclif/plugin-plugins'
 import {DidYouMeanCommands} from '@shopify/plugin-did-you-mean'
 import {runCLI} from '@shopify/cli-kit/node/cli'
-import {launchCLI} from '@shopify/cli-kit/node/cli-launcher'
 import {renderFatalError} from '@shopify/cli-kit/node/ui'
 import {FatalError} from '@shopify/cli-kit/node/error'
 import fs from 'fs'
@@ -67,13 +66,10 @@ interface RunShopifyCLIOptions {
 }
 
 async function runShopifyCLI({development}: RunShopifyCLIOptions) {
-  await runCLI(
-    {
-      moduleURL: import.meta.url,
-      development,
-    },
-    launchCLI,
-  )
+  await runCLI({
+    moduleURL: import.meta.url,
+    development,
+  })
 }
 
 // Hide plugins command

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -1,15 +1,11 @@
 import {commands} from '@shopify/app'
 import {runCreateCLI} from '@shopify/cli-kit/node/cli'
-import {launchCLI} from '@shopify/cli-kit/node/cli-launcher'
 
 async function runCreateAppCLI(development: boolean) {
-  await runCreateCLI(
-    {
-      moduleURL: import.meta.url,
-      development,
-    },
-    launchCLI,
-  )
+  await runCreateCLI({
+    moduleURL: import.meta.url,
+    development,
+  })
 }
 
 export const COMMANDS: unknown = {


### PR DESCRIPTION
### WHY are these changes introduced?

Makes the `launchCLI` parameter optional in `runCLI` and `runCreateCLI` functions. This reverts a change to the external contract of `@shopify/cli-kit` introduced in https://github.com/Shopify/cli/pull/4842

### WHAT is this pull request doing?

- Sets a default launcher param if one is not provided.

### How to test your changes?

Run `shopify` CLI app & create app commands to verify they work without explicit launcher.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes