### PR TITLE
Allow empty theme files to be uploaded

### DIFF
--- a/.changeset/honest-cobras-invite.md
+++ b/.changeset/honest-cobras-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix bug preventing empty theme files from uploading

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -119,15 +119,7 @@ export async function bulkUploadThemeAssets(
 
 function prepareFilesForUpload(assets: AssetParams[]): OnlineStoreThemeFilesUpsertFileInput[] {
   return assets.map((asset) => {
-    if (asset.value) {
-      return {
-        filename: asset.key,
-        body: {
-          type: 'TEXT' as const,
-          value: asset.value,
-        },
-      }
-    } else if (asset.attachment) {
+    if (asset.attachment) {
       return {
         filename: asset.key,
         body: {
@@ -136,7 +128,13 @@ function prepareFilesForUpload(assets: AssetParams[]): OnlineStoreThemeFilesUpse
         },
       }
     } else {
-      unexpectedGraphQLError('Asset must have a value or attachment')
+      return {
+        filename: asset.key,
+        body: {
+          type: 'TEXT' as const,
+          value: asset.value ?? '',
+        },
+      }
     }
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Patch for 3.71

See: https://github.com/Shopify/cli/pull/5015