### PR TITLE
Support migration of product configuration link to cli

### DIFF
--- a/packages/app/src/cli/commands/app/import-extensions.ts
+++ b/packages/app/src/cli/commands/app/import-extensions.ts
@@ -3,6 +3,7 @@ import {buildTomlObject as buildFlowTomlObject} from '../../services/flow/extens
 import {buildTomlObject as buildAdminLinkTomlObject} from '../../services/admin-link/extension-to-toml.js'
 import {buildTomlObject as buildMarketingActivityTomlObject} from '../../services/marketing_activity/extension-to-toml.js'
 import {buildTomlObject as buildSubscriptionLinkTomlObject} from '../../services/subscription_link/extension-to-toml.js'
+import {buildTomlObject as buildProductConfigurationLinkTomlObject} from '../../services/product_configuration_link/extension-to-toml.js'
 import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
 import {appFlags} from '../../flags.js'
 import {importExtensions} from '../../services/import-extensions.js'
@@ -62,6 +63,12 @@ const getMigrationChoices = (): MigrationChoice[] => [
     value: 'link extension',
     extensionTypes: ['app_link', 'bulk_action'],
     buildTomlObject: buildAdminLinkTomlObject,
+  },
+  {
+    label: 'Product Configuration Link Extensions',
+    value: 'product configuration link',
+    extensionTypes: ['product_configuration_link'],
+    buildTomlObject: buildProductConfigurationLinkTomlObject,
   },
 ]
 

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -17,6 +17,7 @@ import {
   UIModulesMap,
   SubscriptionModulesMap,
   AdminLinkModulesMap,
+  ProductConfigurationLinkModulesMap,
 } from '../dev/migrate-app-module.js'
 import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
@@ -56,6 +57,12 @@ export async function ensureExtensionsIds(
     dashboardExtensions,
     identifiers,
     AdminLinkModulesMap,
+  )
+  const productConfigurationLinkExtensionsToMigrate = getModulesToMigrate(
+    localExtensions,
+    dashboardExtensions,
+    identifiers,
+    ProductConfigurationLinkModulesMap,
   )
 
   let didMigrateDashboardExtensions = false
@@ -134,6 +141,20 @@ export async function ensureExtensionsIds(
       adminLinkExtensionsToMigrate,
       options.appId,
       'admin_link',
+      dashboardExtensions,
+      options.developerPlatformClient,
+    )
+    remoteExtensions = remoteExtensions.concat(newRemoteExtensions)
+    didMigrateDashboardExtensions = true
+  }
+
+  if (productConfigurationLinkExtensionsToMigrate.length > 0) {
+    const confirmedMigration = await extensionMigrationPrompt(productConfigurationLinkExtensionsToMigrate, false)
+    if (!confirmedMigration) throw new AbortSilentError()
+    const newRemoteExtensions = await migrateAppModules(
+      productConfigurationLinkExtensionsToMigrate,
+      options.appId,
+      'product_configuration_link_extension',
       dashboardExtensions,
       options.developerPlatformClient,
     )

--- a/packages/app/src/cli/services/dev/migrate-app-module.test.ts
+++ b/packages/app/src/cli/services/dev/migrate-app-module.test.ts
@@ -30,6 +30,7 @@ const defaultMap = {
   ],
   marketing_activity: ['marketing_activity_extension'],
   subscription_link_extension: ['subscription_link'],
+  product_configuration_link_extension: ['product_configuration_link'],
 }
 
 const defaultIdentifiers = {
@@ -48,14 +49,19 @@ describe('getModulesToMigrate()', () => {
     const localExtension = getLocalExtension({type: 'payments_extension', localIdentifier: 'module-A'})
     const localExtensionB = getLocalExtension({type: 'marketing_activity', localIdentifier: 'module-B'})
     const localExtensionC = getLocalExtension({type: 'subscription_link_extension', localIdentifier: 'module-C'})
+    const localExtensionD = getLocalExtension({
+      type: 'product_configuration_link_extension',
+      localIdentifier: 'module-D',
+    })
     const remoteExtension = getRemoteExtension({type: 'payments_app_credit_card', title: 'module-A', uuid: 'yy'})
     const remoteExtensionB = getRemoteExtension({type: 'marketing_activity_extension', title: 'module-B', uuid: 'xx'})
     const remoteExtensionC = getRemoteExtension({type: 'subscription_link', title: 'module-C', uuid: 'zz'})
+    const remoteExtensionD = getRemoteExtension({type: 'product_configuration_link', title: 'module-D', uuid: 'zz'})
 
     // When
     const toMigrate = getModulesToMigrate(
-      [localExtension, localExtensionB, localExtensionC],
-      [remoteExtension, remoteExtensionB, remoteExtensionC],
+      [localExtension, localExtensionB, localExtensionC, localExtensionD],
+      [remoteExtension, remoteExtensionB, remoteExtensionC, remoteExtensionD],
       {},
       defaultMap,
     )
@@ -65,6 +71,7 @@ describe('getModulesToMigrate()', () => {
       {local: localExtension, remote: remoteExtension},
       {local: localExtensionB, remote: remoteExtensionB},
       {local: localExtensionC, remote: remoteExtensionC},
+      {local: localExtensionD, remote: remoteExtensionD},
     ])
   })
 

--- a/packages/app/src/cli/services/dev/migrate-app-module.ts
+++ b/packages/app/src/cli/services/dev/migrate-app-module.ts
@@ -46,6 +46,10 @@ export const AdminLinkModulesMap = {
   admin_link: ['app_link', 'bulk_action'],
 }
 
+export const ProductConfigurationLinkModulesMap = {
+  product_configuration_link_extension: ['product_configuration_link'],
+}
+
 /**
  * Returns a list of local and remote extensions that need to be migrated.
  *

--- a/packages/app/src/cli/services/import-extensions.test.ts
+++ b/packages/app/src/cli/services/import-extensions.test.ts
@@ -64,6 +64,16 @@ const subscriptionLinkExtension: ExtensionRegistration = {
   },
 }
 
+const productConfigurationLinkExtension: ExtensionRegistration = {
+  id: 'idE',
+  title: 'titleE',
+  uuid: 'uuidE',
+  type: 'product_configuration_link',
+  activeVersion: {
+    config: '{}',
+  },
+}
+
 describe('import-extensions', () => {
   beforeEach(() => {
     // eslint-disable-next-line @shopify/cli/no-vi-manual-mock-clear
@@ -77,6 +87,7 @@ describe('import-extensions', () => {
       flowExtensionB,
       marketingActivityExtension,
       subscriptionLinkExtension,
+      productConfigurationLinkExtension,
     ])
     vi.mocked(renderSelectPrompt).mockResolvedValue('uuidA')
 
@@ -93,6 +104,7 @@ describe('import-extensions', () => {
           'flow_trigger_definition',
           'marketing_activity_extension',
           'subscription_link',
+          'product_configuration_link',
         ],
         buildTomlObject,
       })
@@ -114,6 +126,9 @@ describe('import-extensions', () => {
 
       const tomlPathD = joinPath(tmpDir, 'extensions', 'title-d', 'shopify.extension.toml')
       expect(fileExistsSync(tomlPathD)).toBe(false)
+
+      const tomlPathE = joinPath(tmpDir, 'extensions', 'title-e', 'shopify.extension.toml')
+      expect(fileExistsSync(tomlPathE)).toBe(false)
     })
   })
 
@@ -124,6 +139,7 @@ describe('import-extensions', () => {
       flowExtensionB,
       marketingActivityExtension,
       subscriptionLinkExtension,
+      productConfigurationLinkExtension,
     ])
     vi.mocked(renderSelectPrompt).mockResolvedValue('All')
 
@@ -140,13 +156,14 @@ describe('import-extensions', () => {
           'flow_trigger_definition',
           'marketing_activity_extension',
           'subscription_link',
+          'product_configuration_link',
         ],
         buildTomlObject,
       })
 
       expect(renderSuccess).toHaveBeenCalledWith({
         headline: ['Imported the following extensions from the dashboard:'],
-        body: '• "titleA" at: extensions/title-a\n• "titleB" at: extensions/title-b\n• "titleC" at: extensions/title-c\n• "titleD" at: extensions/title-d',
+        body: '• "titleA" at: extensions/title-a\n• "titleB" at: extensions/title-b\n• "titleC" at: extensions/title-c\n• "titleD" at: extensions/title-d\n• "titleE" at: extensions/title-e',
       })
 
       // Then
@@ -161,6 +178,9 @@ describe('import-extensions', () => {
 
       const tomlPathD = joinPath(tmpDir, 'extensions', 'title-d', 'shopify.extension.toml')
       expect(fileExistsSync(tomlPathD)).toBe(true)
+
+      const tomlPathE = joinPath(tmpDir, 'extensions', 'title-e', 'shopify.extension.toml')
+      expect(fileExistsSync(tomlPathE)).toBe(true)
     })
   })
 
@@ -180,6 +200,7 @@ describe('import-extensions', () => {
           'flow_trigger_definition',
           'marketing_activity_extension',
           'subscription_link',
+          'product_configuration_link',
         ],
         buildTomlObject,
       })
@@ -202,6 +223,9 @@ describe('import-extensions', () => {
 
       const tomlPathD = joinPath(tmpDir, 'extensions', 'title-d', 'shopify.extension.toml')
       expect(fileExistsSync(tomlPathD)).toBe(false)
+
+      const tomlPathE = joinPath(tmpDir, 'extensions', 'title-e', 'shopify.extension.toml')
+      expect(fileExistsSync(tomlPathE)).toBe(false)
     })
   })
 })

--- a/packages/app/src/cli/services/product_configuration_link/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/product_configuration_link/extension-to-toml.test.ts
@@ -1,0 +1,52 @@
+import {buildTomlObject, ProductConfigurationLinkDashboardConfig} from './extension-to-toml.js'
+import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
+import {describe, expect, test} from 'vitest'
+
+const defaultDashboardConfig: ProductConfigurationLinkDashboardConfig = {
+  pattern: '/bundles{?product_id,shop}&id={contract_id}',
+}
+
+describe('extension-to-toml', () => {
+  test('converts the dashboard config to the new cli config', () => {
+    // Given
+    const extension: ExtensionRegistration = {
+      id: '26237698049',
+      uuid: 'ad9947a9-bc0b-4855-82da-008aefbc1c71',
+      title: 'custom product configuration link',
+      type: 'product_configuration_link_extension',
+      draftVersion: {
+        config: JSON.stringify(defaultDashboardConfig),
+      },
+    }
+
+    // When
+    const got = buildTomlObject(extension)
+
+    // Then
+    expect(got).toEqual(`[[extensions]]
+type = "product_configuration_link_extension"
+name = "custom product configuration link"
+handle = "custom-product-configuration-link"
+pattern = "/bundles{?product_id,shop}&id={contract_id}"
+`)
+  })
+
+  test('truncates the handle if the title has >50 characters', () => {
+    // Given
+    const extension: ExtensionRegistration = {
+      id: '26237698049',
+      uuid: 'ad9947a9-bc0b-4855-82da-008aefbc1c71',
+      title: 'product configuration link @ test! 1234555555555444444777777888888812345555555554444447777778888888',
+      type: 'product_configuration_link_extension',
+      draftVersion: {
+        config: JSON.stringify(defaultDashboardConfig),
+      },
+    }
+
+    // When
+    const got = buildTomlObject(extension)
+
+    // Then
+    expect(got).toContain('handle = "product-configuration-link-test-123455555555544"')
+  })
+})

--- a/packages/app/src/cli/services/product_configuration_link/extension-to-toml.ts
+++ b/packages/app/src/cli/services/product_configuration_link/extension-to-toml.ts
@@ -1,0 +1,30 @@
+import {MAX_EXTENSION_HANDLE_LENGTH} from '../../models/extensions/schemas.js'
+import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registrations.js'
+import {encodeToml} from '@shopify/cli-kit/node/toml'
+import {slugify} from '@shopify/cli-kit/common/string'
+
+export interface ProductConfigurationLinkDashboardConfig {
+  pattern: string
+}
+
+/**
+ * Given a dashboard-built product configuration link extension config file, convert it to toml for the CLI extension
+ */
+export function buildTomlObject(extension: ExtensionRegistration): string {
+  const versionConfig = extension.activeVersion?.config ?? extension.draftVersion?.config
+  if (!versionConfig) throw new Error('No config found for extension')
+  const config: ProductConfigurationLinkDashboardConfig = JSON.parse(versionConfig)
+
+  const localExtensionRepresentation = {
+    extensions: [
+      {
+        type: 'product_configuration_link_extension',
+        name: extension.title,
+        handle: slugify(extension.title.substring(0, MAX_EXTENSION_HANDLE_LENGTH)),
+        pattern: config.pattern,
+      },
+    ],
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return encodeToml(localExtensionRepresentation as any)
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/bundles-app/issues/2841

### WHAT is this pull request doing?

Supports migrating dashboard-managed product configuration link extensions to become CLI managed as part of the dev and deploy commands.

### How to test your changes?

> [!warning] 
🎩 wont work until https://github.com/Shopify/shopify/pull/558141 and other dependencies are merged

Follow the steps described in https://github.com/Shopify/cli/pull/5054 to import product configuration link extensions to CLI. Once imported run `shopify app dev` or `shopify app deploy` to migrate the extension to be CLI managed.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
