### PR TITLE
Bump Shopify/theme-tools packages

### DIFF
--- a/.changeset/good-plums-fail.md
+++ b/.changeset/good-plums-fail.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme': patch
+'@shopify/app': patch
+---
+
+Bump Shopify/theme-tools packages

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -57,7 +57,7 @@
     "@shopify/polaris": "12.10.0",
     "@shopify/polaris-icons": "8.0.0",
     "@shopify/theme": "3.72.0",
-    "@shopify/theme-check-node": "3.2.2",
+    "@shopify/theme-check-node": "3.4.0",
     "body-parser": "1.20.2",
     "camelcase-keys": "9.1.3",
     "chokidar": "3.5.3",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -43,8 +43,8 @@
   "dependencies": {
     "@oclif/core": "3.26.5",
     "@shopify/cli-kit": "3.72.0",
-    "@shopify/theme-check-node": "3.2.2",
-    "@shopify/theme-language-server-node": "2.2.2",
+    "@shopify/theme-check-node": "3.4.0",
+    "@shopify/theme-language-server-node": "2.3.2",
     "chokidar": "3.5.3",
     "h3": "1.12.0",
     "yaml": "2.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,8 +171,8 @@ importers:
         specifier: 3.72.0
         version: link:../theme
       '@shopify/theme-check-node':
-        specifier: 3.2.2
-        version: 3.2.2
+        specifier: 3.4.0
+        version: 3.4.0
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
@@ -697,11 +697,11 @@ importers:
         specifier: 3.72.0
         version: link:../cli-kit
       '@shopify/theme-check-node':
-        specifier: 3.2.2
-        version: 3.2.2
+        specifier: 3.4.0
+        version: 3.4.0
       '@shopify/theme-language-server-node':
-        specifier: 2.2.2
-        version: 2.2.2
+        specifier: 2.3.2
+        version: 2.3.2
       chokidar:
         specifier: 3.5.3
         version: 3.5.3
@@ -6153,8 +6153,8 @@ packages:
     engines: {node: '>=12.14.0'}
     dev: false
 
-  /@shopify/liquid-html-parser@2.1.1:
-    resolution: {integrity: sha512-5shGZTB7tK28MzawqBb82n6fbn+77U6al5UrOcUruBUj3GNqHJWjzZVPtXq4fQHrFpXFu6l11x+z+ggdUHT0Ng==}
+  /@shopify/liquid-html-parser@2.2.0:
+    resolution: {integrity: sha512-hD0XV+Re9BC3yMOshHCwU94LagW7LQTWPdtpU0IE/pMbco+ke7Hir1Ad7eloHAgzR+6iw4LzDEFuHFpKZWmGKw==}
     dependencies:
       line-column: 1.0.2
       ohm-js: 16.6.0
@@ -6272,10 +6272,10 @@ packages:
       react-reconciler: 0.26.2(react@17.0.2)
     dev: true
 
-  /@shopify/theme-check-common@3.2.2:
-    resolution: {integrity: sha512-rEbZ2kDzpOY+D7FUFi7VWQforLB99WJg8rCcJlzaJIAV4hkQpkjPPjzzXitg3JByVKzfLxocmIlysAVbmort1A==}
+  /@shopify/theme-check-common@3.4.0:
+    resolution: {integrity: sha512-raBezxKmlqy5sYJO2UYKc5b7hRVDeYPYfL9mBSqCqwa37jTkvy84U8G0IRjL8S/AfZWBHd2dJzhJ5RApONVijA==}
     dependencies:
-      '@shopify/liquid-html-parser': 2.1.1
+      '@shopify/liquid-html-parser': 2.2.0
       cross-fetch: 4.0.0
       json-to-ast: 2.1.0
       jsonc-parser: 3.2.1
@@ -6288,22 +6288,22 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-check-docs-updater@3.2.2:
-    resolution: {integrity: sha512-NXNviVnkGVEf0roDMvZptMODG97x/HiPDlWtHb4v4oyxIvg23jo1rcu8b3u9GnLmxTzWJWcW3tXJhQDqfTeErA==}
+  /@shopify/theme-check-docs-updater@3.4.0:
+    resolution: {integrity: sha512-4CdHvM1NhZhAtAe1VTsHfxcq8f17wIQYiq/u5s+niisM7cIYeyx7UfU5+ioIn+zE8K3cN9C/0riTgsZCBpDXJA==}
     hasBin: true
     dependencies:
-      '@shopify/theme-check-common': 3.2.2
+      '@shopify/theme-check-common': 3.4.0
       env-paths: 2.2.1
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@shopify/theme-check-node@3.2.2:
-    resolution: {integrity: sha512-X1mzKbNq0YlxRKsEKz/3MmS4CyHkiPNdCVXe/TzqwJlzumMQYtYxd+xMYT8n5nTG2Reuv/UhVXWbqhtNPbwBOw==}
+  /@shopify/theme-check-node@3.4.0:
+    resolution: {integrity: sha512-jekHMoktdD5xImSwsIPsFqn8c0TBejwypgjaEWyPqy6XF/QrPqCNtEstfsBRAWHLKqOgt/mFZumtN7Fmh2c4kQ==}
     dependencies:
-      '@shopify/theme-check-common': 3.2.2
-      '@shopify/theme-check-docs-updater': 3.2.2
+      '@shopify/theme-check-common': 3.4.0
+      '@shopify/theme-check-docs-updater': 3.4.0
       glob: 8.1.0
       vscode-uri: 3.0.8
       yaml: 2.3.2
@@ -6311,11 +6311,11 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-language-server-common@2.2.2:
-    resolution: {integrity: sha512-PPn6wfDnbvT++SGtET8DTb88kQWvkb9XKJ1t/b4r9cI0SOPtM+g2vcB336OdmddYeDfXCTnYwuEnBKfltEPTaQ==}
+  /@shopify/theme-language-server-common@2.3.2:
+    resolution: {integrity: sha512-GjrKjgjIL+QdQMbgcz9Xb4YG4Y6NHgqY0lsKghIhCJr0oedM5ICtFmYobLQE9YXabDnP3FqyfliGUcjVgIeyMA==}
     dependencies:
-      '@shopify/liquid-html-parser': 2.1.1
-      '@shopify/theme-check-common': 3.2.2
+      '@shopify/liquid-html-parser': 2.2.0
+      '@shopify/theme-check-common': 3.4.0
       '@vscode/web-custom-data': 0.4.9
       vscode-json-languageservice: 5.3.11
       vscode-languageserver: 8.1.0
@@ -6325,12 +6325,12 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-language-server-node@2.2.2:
-    resolution: {integrity: sha512-e3QrLn0GIxQiBAI9g7/UKr56IZO8g1+kSHk2Mq3EIhW2Tcn6YXSMIDrw6jkL0MXtcCng6hHgOSgAdqD4roa7Zw==}
+  /@shopify/theme-language-server-node@2.3.2:
+    resolution: {integrity: sha512-LjqTln6NXkN+fIosBdDLrUzec+HsbPtfQ2xXd0cZOq3TMZeFCF4sgHw76L5YDoUp/FnPkJQlkG76g3ZokjkhXw==}
     dependencies:
-      '@shopify/theme-check-docs-updater': 3.2.2
-      '@shopify/theme-check-node': 3.2.2
-      '@shopify/theme-language-server-common': 2.2.2
+      '@shopify/theme-check-docs-updater': 3.4.0
+      '@shopify/theme-check-node': 3.4.0
+      '@shopify/theme-language-server-common': 2.3.2
       glob: 8.1.0
       node-fetch: 2.7.0
       vscode-languageserver: 8.1.0
@@ -11332,6 +11332,7 @@ packages:
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2


### PR DESCRIPTION
### WHAT are these changes introduced?

Bumping the `theme-tools` packages.

#### `@shopify/theme-check-node`

Minor incremented `3.2.2` -> `3.4.0` ([changelog](https://github.com/Shopify/theme-tools/blob/main/packages/theme-check-node/CHANGELOG.md))

> [!NOTE] 
> A number of changes will be in the `theme-check-common` package ([changelog](https://github.com/Shopify/theme-tools/blob/main/packages/theme-check-common/CHANGELOG.md)) which is treated as a dependency.

Compare

#### `@shopify/theme-language-server-node `

Minor incremented `2.2.2` -> `2.3.2` ([changelog](https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-node/CHANGELOG.md))

> [!NOTE]
> A number of changes will be in the `theme-language-server-common` package ([changelog](https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/CHANGELOG.md)) which is treated as a dependency.

### How to test your changes?

#### theme-check

```sh
pnpm build
pnpm shopify:run theme check --path=<PATH TO THEME>
```

#### language-server

1. Configure the language server following the instructions for one of these editors: https://github.com/Shopify/theme-tools/wiki (note: if using VS Code do not install the extension)
2. Use the snapped version to test `npm i -g @shopify/cli@0.0.0-snapshot-20241209215945` 
3. Ensure new features work (e.g. filter parameter completion)

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
