### PR TITLE
Fix exception raised when selectOrCreateApp fails to find an app

### DIFF
--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -4,6 +4,7 @@ import {Organization, MinimalOrganizationApp, OrganizationApp} from '../../model
 import {getCachedCommandInfo, setCachedCommandTomlPreference} from '../local-storage.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationFileName} from '../../models/app/loader.js'
+import {BugError} from '@shopify/cli-kit/node/error'
 
 /**
  * Select an app from env, list or create a new one:
@@ -45,7 +46,14 @@ export async function selectOrCreateApp(
     if (selectedToml) setCachedCommandTomlPreference(selectedToml)
 
     const fullSelectedApp = await developerPlatformClient.appFromId(app)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return fullSelectedApp!
+
+    if (!fullSelectedApp) {
+      // This is unlikely, and a bug. But we still want a nice user facing message plus appropriate context logged.
+      throw new BugError(
+        `Unable to fetch app ${app.apiKey} from Shopify`,
+        'Try running `shopify app config link` to connect to an app you have access to.',
+      )
+    }
+    return fullSelectedApp
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an unhandled error thrown when selectOrCreateApp fails to do either.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Instead of using `!`, handles the case where the app is `undefined`.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
