### PR TITLE
Fix exception raised when getTomls is passed a non-directory

### DIFF
--- a/packages/app/src/cli/utilities/app/config/getTomls.ts
+++ b/packages/app/src/cli/utilities/app/config/getTomls.ts
@@ -3,11 +3,12 @@ import {
   isValidFormatAppConfigurationFileName,
   loadConfigurationFileContent,
 } from '../../../models/app/loader.js'
+import {isDirectory} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {readdirSync} from 'fs'
 
 export async function getTomls(appDirectory?: string): Promise<{[clientId: string]: AppConfigurationFileName}> {
-  if (!appDirectory) {
+  if (!appDirectory || !(await isDirectory(appDirectory))) {
     return {}
   }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an unhandled exception where a user provided path causes getTomls to ungracefully fail if not a directory. We've only seen this one once!

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Puts a quick check in front of the rest of the function.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
