### PR TITLE
[Themes] Add support for generating liquid and JSON section files

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1905,13 +1905,12 @@ Creates and adds a new block file to your local theme directory
 
 ```
 USAGE
-  $ shopify theme generate block [-n <value>] [--no-color] [--path <value>] [-t text|image|video|product|collection]
-    [--verbose]
+  $ shopify theme generate block [-n <value>] [--no-color] [--path <value>] [-t basic] [--verbose]
 
 FLAGS
   -n, --name=<value>   Name of the block
   -t, --type=<option>  Type of block to generate
-                       <options: text|image|video|product|collection>
+                       <options: basic>
       --no-color       Disable color output.
       --path=<value>   The path to your theme directory.
       --verbose        Increase the verbosity of the output.
@@ -1933,16 +1932,17 @@ Creates and adds a new section file to your local theme directory
 
 ```
 USAGE
-  $ shopify theme generate section [-n <value>] [--no-color] [--path <value>] [-t
-    featured-collection|image-with-text|rich-text|custom] [--verbose]
+  $ shopify theme generate section [-x liquid|json] [-n <value>] [--no-color] [--path <value>] [-t basic] [--verbose]
 
 FLAGS
-  -n, --name=<value>   Name of the section
-  -t, --type=<option>  Type of section to generate
-                       <options: featured-collection|image-with-text|rich-text|custom>
-      --no-color       Disable color output.
-      --path=<value>   The path to your theme directory.
-      --verbose        Increase the verbosity of the output.
+  -n, --name=<value>        Name of the section
+  -t, --type=<option>       Type of section to generate
+                            <options: basic>
+  -x, --extension=<option>  File extension (liquid or json)
+                            <options: liquid|json>
+      --no-color            Disable color output.
+      --path=<value>        The path to your theme directory.
+      --verbose             Increase the verbosity of the output.
 
 DESCRIPTION
   Creates and adds a new section file to your local theme directory

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5369,11 +5369,7 @@
           "multiple": false,
           "name": "type",
           "options": [
-            "text",
-            "image",
-            "video",
-            "product",
-            "collection"
+            "basic"
           ],
           "type": "option"
         },
@@ -5405,6 +5401,19 @@
       "description": "Creates a new \"theme section\" (https://shopify.dev/docs/themes/architecture/sections) in your local theme directory.\n\n  The section is created in the `sections` directory with the basic structure needed, including schema, settings, and blocks.\n\n  You can specify the type of section to generate using the `--type` flag. The section will be created with appropriate default settings and blocks based on the type.",
       "descriptionWithMarkdown": "Creates a new [theme section](https://shopify.dev/docs/themes/architecture/sections) in your local theme directory.\n\n  The section is created in the `sections` directory with the basic structure needed, including schema, settings, and blocks.\n\n  You can specify the type of section to generate using the `--type` flag. The section will be created with appropriate default settings and blocks based on the type.",
       "flags": {
+        "extension": {
+          "char": "x",
+          "description": "File extension (liquid or json)",
+          "env": "SHOPIFY_FLAG_SECTION_FILE_TYPE",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "extension",
+          "options": [
+            "liquid",
+            "json"
+          ],
+          "type": "option"
+        },
         "force": {
           "allowNo": false,
           "char": "f",
@@ -5448,10 +5457,7 @@
           "multiple": false,
           "name": "type",
           "options": [
-            "featured-collection",
-            "image-with-text",
-            "rich-text",
-            "custom"
+            "basic"
           ],
           "type": "option"
         },

--- a/packages/theme/src/cli/commands/theme/generate/section.ts
+++ b/packages/theme/src/cli/commands/theme/generate/section.ts
@@ -1,11 +1,12 @@
 import {themeFlags} from '../../../flags.js'
 import ThemeCommand from '../../../utilities/theme-command.js'
 import {hasRequiredThemeDirectories} from '../../../utilities/theme-fs.js'
+import {generateSection} from '../../../services/generate/sections.js'
+import {SECTION_TYPES, FILE_TYPES, promptForType} from '../../../utilities/generator.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {renderSelectPrompt, renderSuccess, renderTextPrompt, renderWarning} from '@shopify/cli-kit/node/ui'
-
-const SECTION_TYPES = ['featured-collection', 'image-with-text', 'rich-text', 'custom']
+import {renderTextPrompt, renderWarning} from '@shopify/cli-kit/node/ui'
+import {cwd} from '@shopify/cli-kit/node/path'
 
 export default class GenerateSection extends ThemeCommand {
   static summary = 'Creates and adds a new section file to your local theme directory'
@@ -31,6 +32,12 @@ export default class GenerateSection extends ThemeCommand {
       description: 'Type of section to generate',
       options: [...SECTION_TYPES],
       env: 'SHOPIFY_FLAG_SECTION_TYPE',
+    }),
+    extension: Flags.string({
+      char: 'x',
+      description: 'File extension (liquid or json)',
+      options: [...FILE_TYPES],
+      env: 'SHOPIFY_FLAG_SECTION_FILE_TYPE',
     }),
     force: Flags.boolean({
       hidden: true,
@@ -58,16 +65,15 @@ export default class GenerateSection extends ThemeCommand {
         message: 'Name of the section',
       }))
 
-    const choices = SECTION_TYPES.map((type) => ({label: type, value: type}))
-    const type =
-      flags.type ??
-      (await renderSelectPrompt({
-        message: 'Type of section',
-        choices,
-      }))
+    const type = flags.type ?? (await promptForType('Type of section', SECTION_TYPES))
 
-    renderSuccess({
-      body: [`Placeholder: Generating section with name: ${name}, type: ${type}`],
+    const fileType = flags.extension ?? (await promptForType('File extension', FILE_TYPES))
+
+    await generateSection({
+      name,
+      type,
+      path: flags.path ?? cwd(),
+      fileType,
     })
   }
 }

--- a/packages/theme/src/cli/services/generate/sections.test.ts
+++ b/packages/theme/src/cli/services/generate/sections.test.ts
@@ -1,4 +1,4 @@
-import {generateSection} from './sections.js'
+import {generateSection, JSON_SECTION_HEADER} from './sections.js'
 import {describe, expect, test, vi} from 'vitest'
 import {fileExists, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -46,16 +46,17 @@ describe('generateSection', () => {
 
     await generateSection(mockJsonOptions)
 
-    const expectedContent = JSON.stringify(
-      {
-        type: 'header',
-        name: 'test-section',
-        settings: [],
-        order: [],
-      },
-      null,
-      2,
-    )
+    const expectedContent = `${JSON_SECTION_HEADER}
+${JSON.stringify(
+  {
+    type: 'header',
+    name: 'test-section',
+    settings: [],
+    order: [],
+  },
+  null,
+  2,
+)}`
 
     expect(writeFile).toHaveBeenCalledWith('theme/sections/test-section.json', expectedContent)
     expect(outputInfo).toHaveBeenCalledWith('Created section: theme/sections/test-section.json')

--- a/packages/theme/src/cli/services/generate/sections.test.ts
+++ b/packages/theme/src/cli/services/generate/sections.test.ts
@@ -1,0 +1,90 @@
+import {generateSection} from './sections.js'
+import {describe, expect, test, vi} from 'vitest'
+import {fileExists, writeFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {outputInfo} from '@shopify/cli-kit/node/output'
+
+vi.mock('@shopify/cli-kit/node/fs')
+vi.mock('@shopify/cli-kit/node/path')
+vi.mock('@shopify/cli-kit/node/output')
+
+describe('generateSection', () => {
+  const mockLiquidOptions = {
+    name: 'test-section',
+    type: 'featured-collection',
+    path: 'theme',
+    fileType: 'liquid',
+  } as const
+
+  const mockJsonOptions = {
+    name: 'test-section',
+    type: 'featured-collection',
+    path: 'theme',
+    fileType: 'json',
+  } as const
+
+  test('creates a new liquid section file with correct content', async () => {
+    vi.mocked(fileExists).mockResolvedValue(false)
+    vi.mocked(joinPath).mockReturnValue('theme/sections/test-section.liquid')
+
+    await generateSection(mockLiquidOptions)
+
+    const expectedContent = `{% schema %}
+{
+  "name": "test-section",
+  "settings": []
+}
+{% endschema %}`
+
+    expect(writeFile).toHaveBeenCalledWith('theme/sections/test-section.liquid', expectedContent)
+    expect(outputInfo).toHaveBeenCalledWith('Created section: theme/sections/test-section.liquid')
+  })
+
+  test('creates a new json section file with correct content', async () => {
+    vi.mocked(fileExists).mockResolvedValue(false)
+    vi.mocked(joinPath).mockReturnValue('theme/sections/test-section.json')
+
+    await generateSection(mockJsonOptions)
+
+    const expectedContent = JSON.stringify(
+      {
+        type: 'header',
+        name: 'test-section',
+        settings: [],
+        order: [],
+      },
+      null,
+      2,
+    )
+
+    expect(writeFile).toHaveBeenCalledWith('theme/sections/test-section.json', expectedContent)
+    expect(outputInfo).toHaveBeenCalledWith('Created section: theme/sections/test-section.json')
+  })
+
+  test('throws error if liquid section already exists', async () => {
+    vi.mocked(fileExists).mockResolvedValue(true)
+    vi.mocked(joinPath).mockReturnValue('theme/sections/test-section.liquid')
+
+    await expect(generateSection(mockLiquidOptions)).rejects.toThrow(
+      'Section test-section already exists at theme/sections/test-section.liquid',
+    )
+  })
+
+  test('throws error if json section already exists', async () => {
+    vi.mocked(fileExists).mockResolvedValue(true)
+    vi.mocked(joinPath).mockReturnValue('theme/sections/test-section.json')
+
+    await expect(generateSection(mockJsonOptions)).rejects.toThrow(
+      'Section test-section already exists at theme/sections/test-section.json',
+    )
+  })
+
+  test('throws error if another section already exists with the same name but a different file type', async () => {
+    vi.mocked(fileExists).mockResolvedValue(true)
+    vi.mocked(joinPath).mockReturnValue('theme/sections/test-section.liquid')
+
+    await expect(generateSection(mockLiquidOptions)).rejects.toThrow(
+      'Section test-section already exists at theme/sections/test-section.liquid',
+    )
+  })
+})

--- a/packages/theme/src/cli/services/generate/sections.ts
+++ b/packages/theme/src/cli/services/generate/sections.ts
@@ -1,0 +1,49 @@
+import {FileType, SectionType} from '../../utilities/generator.js'
+import {fileExists, writeFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {outputInfo} from '@shopify/cli-kit/node/output'
+
+export interface SectionGeneratorOptions {
+  name: string
+  type: SectionType
+  path: string
+  fileType: FileType
+}
+
+export async function generateSection(options: SectionGeneratorOptions) {
+  const sectionPath = joinPath(options.path, 'sections', `${options.name}.${options.fileType}`)
+
+  // Check if section already exists
+  if (await fileExists(sectionPath)) {
+    throw new Error(`Section ${options.name} already exists at ${sectionPath}`)
+  }
+
+  // Write the file
+  const content =
+    options.fileType === 'liquid' ? generateLiquidSectionContent(options) : generateJsonSectionContent(options)
+
+  await writeFile(sectionPath, content)
+  outputInfo(`Created section: ${sectionPath}`)
+}
+
+function generateLiquidSectionContent(options: SectionGeneratorOptions): string {
+  const baseSchema = {
+    name: options.name,
+    settings: [],
+  }
+
+  return `{% schema %}
+${JSON.stringify(baseSchema, null, 2)}
+{% endschema %}`
+}
+
+function generateJsonSectionContent(options: SectionGeneratorOptions): string {
+  const schema = {
+    type: 'header',
+    name: options.name,
+    settings: [],
+    order: [],
+  }
+
+  return JSON.stringify(schema, null, 2)
+}

--- a/packages/theme/src/cli/services/generate/sections.ts
+++ b/packages/theme/src/cli/services/generate/sections.ts
@@ -10,6 +10,16 @@ export interface SectionGeneratorOptions {
   fileType: FileType
 }
 
+export const JSON_SECTION_HEADER = `/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */`
+
 export async function generateSection(options: SectionGeneratorOptions) {
   const sectionPath = joinPath(options.path, 'sections', `${options.name}.${options.fileType}`)
 
@@ -45,5 +55,6 @@ function generateJsonSectionContent(options: SectionGeneratorOptions): string {
     order: [],
   }
 
-  return JSON.stringify(schema, null, 2)
+  return `${JSON_SECTION_HEADER}
+${JSON.stringify(schema, null, 2)}`
 }

--- a/packages/theme/src/cli/utilities/generator.ts
+++ b/packages/theme/src/cli/utilities/generator.ts
@@ -1,12 +1,15 @@
 import {renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 
 export const BLOCK_TYPES = ['basic']
-export const SECTION_TYPES = ['featured-collection', 'image-with-text', 'rich-text', 'custom']
+export const SECTION_TYPES = ['basic']
 export const TEMPLATE_TYPES = ['product', 'collection', 'page', 'blog', 'article', 'custom']
 
 export type BlockType = (typeof BLOCK_TYPES)[number]
 export type SectionType = (typeof SECTION_TYPES)[number]
 export type TemplateType = (typeof TEMPLATE_TYPES)[number]
+export type FileType = (typeof FILE_TYPES)[number]
+
+export const FILE_TYPES = ['liquid', 'json']
 
 export async function promptForType<T extends string>(message: string, types: ReadonlyArray<T>): Promise<T> {
   const choices = types.map((type) => ({label: type, value: type}))


### PR DESCRIPTION
### WHY are these changes introduced?

Adds support for generating theme sections with both Liquid and JSON file types, providing developers with more flexibility when creating new theme sections.

### WHAT is this pull request doing?

- Introduces a new `generateSection` service to handle section file creation
- Adds support for both Liquid and JSON section file types
- Implements file existence checks to prevent overwriting existing sections
- Updates the section generator command to handle the new file type option
- Adds comprehensive tests for the section generation functionality

### How to test your changes?

1. Run `theme generate section` and follow the prompts
2. Choose between Liquid or JSON file types
3. Verify the generated section file contains the correct structure
4. Try generating a section with a name that already exists to test error handling

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes