### PR TITLE
Check that @shopify/shopify_function has a `run` module

### DIFF
--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -4,7 +4,7 @@ import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {inTemporaryDirectory, mkdir, writeFile} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, mkdir, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {build as esBuild} from 'esbuild'
 
 vi.mock('@shopify/cli-kit/node/system')
@@ -63,6 +63,10 @@ async function installShopifyLibrary(tmpDir: string) {
   const shopifyFunction = joinPath(shopifyFunctionDir, 'index.ts')
   await mkdir(shopifyFunctionDir)
   await writeFile(shopifyFunction, '')
+
+  const runModule = joinPath(shopifyFunctionDir, 'run.ts')
+  await writeFile(runModule, '')
+
   return shopifyFunction
 }
 
@@ -112,7 +116,23 @@ describe('bundleExtension', () => {
       const got = bundleExtension(ourFunction, {stdout, stderr, signal, app})
 
       // Then
-      await expect(got).rejects.toThrow(/Could not find the Shopify Function runtime/)
+      await expect(got).rejects.toThrow(/Could not find the Shopify Functions JavaScript library/)
+    })
+  })
+
+  test('errors if shopify library lacks the run module', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const ourFunction = await testFunctionExtension({dir: tmpDir})
+      ourFunction.entrySourceFilePath = joinPath(tmpDir, 'src/index.ts')
+      const shopifyFunction = await installShopifyLibrary(tmpDir)
+      await removeFile(joinPath(shopifyFunction, '..', 'run.ts'))
+
+      // When
+      const got = bundleExtension(ourFunction, {stdout, stderr, signal, app})
+
+      // Then
+      await expect(got).rejects.toThrow(/Could not find the Shopify Functions JavaScript library/)
     })
   })
 
@@ -173,6 +193,7 @@ describe('ExportJavyBuilder', () => {
         // Given
         const ourFunction = await testFunctionExtension({dir: tmpDir})
         ourFunction.entrySourceFilePath = joinPath(tmpDir, 'src/index.ts')
+        const shopifyFunction = await installShopifyLibrary(tmpDir)
 
         // When
         const got = builder.bundle(
@@ -210,6 +231,7 @@ describe('ExportJavyBuilder', () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         const ourFunction = await testFunctionExtension({dir: tmpDir})
+        const shopifyFunction = await installShopifyLibrary(tmpDir)
 
         // When
         const got = builder.bundle(ourFunction, {stdout, stderr, signal, app})


### PR DESCRIPTION
### WHY are these changes introduced?

Catches a runtime error when building JS Shopify Functions, by checking the required runtime module exists.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/bbpWxqQonx8yAyrpRnzP/0f450351-2571-4132-b2bb-558865db75c3.png)

### WHAT is this pull request doing?

Adds validation to check for the existence of the `run.ts` module in the `@shopify/shopify_function` package during the function build process. Later in the build process we inject an explicit dependency on this module (`import __runFunction from "@shopify/shopify_function/run"`).

If the module is missing, it throws a clear error message prompting users to update their dependencies.

This doesn't occur often, and the library is stable, but it may be possible if dependencies have been corrupted or the developer is using a customised or very old dependency.

There were checks for the module being present, but these were only applied in the case where a function was a single default export, as opposed to our currently supported approach.

### How to test your changes?

With this branch or a snapshot build

1. Make a new app
1. Generate a new Shopify Function using JS
2. Manually delete the `run.ts` file from `node_modules/@shopify/shopify_function/` in the function's `node_modules` folder
3. Attempt to build the function
4. Verify that an appropriate error message is displayed
5. Restore the correct package version and verify the build succeeds

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes