### PR TITLE
Fix undescores in subdomain target when importing legacy links

### DIFF
--- a/packages/app/src/cli/services/admin-link/utils.test.ts
+++ b/packages/app/src/cli/services/admin-link/utils.test.ts
@@ -32,4 +32,14 @@ describe('admin link utils', () => {
     // Then
     expect(target).toEqual('admin.customer-index.selection-action.link')
   })
+  test('correctly parses from context `DRAFT_ORDERS#SHOW` to target', () => {
+    // Given
+    const context = 'DRAFT_ORDERS#SHOW'
+
+    // When
+    const target = contextToTarget(context)
+
+    // Then
+    expect(target).toEqual('admin.draft-order-details.action.link')
+  })
 })

--- a/packages/app/src/cli/services/admin-link/utils.ts
+++ b/packages/app/src/cli/services/admin-link/utils.ts
@@ -1,3 +1,5 @@
+import {hyphenate} from '@shopify/cli-kit/common/string'
+
 export const contextToTarget = (context: string) => {
   const splitContext = context.split('#')
   if (splitContext.length !== 2 || splitContext.some((part) => part === '' || part === undefined)) {
@@ -34,6 +36,6 @@ const typeToSubDomain = (type: string) => {
     case 'variants':
       return 'product-variant'
     default:
-      return type.toLocaleLowerCase().replace(new RegExp(`(s)$`), '')
+      return hyphenate(type.toLocaleLowerCase().replace(new RegExp(`(s)$`), ''))
   }
 }


### PR DESCRIPTION

### WHY are these changes introduced?
Target subdomains are kebab cased and context controllers are snake case. There was a missing transformation to switch casing.
### WHAT is this pull request doing?
Add hyphenate method to switch from snake case to kebab case

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
