### PR TITLE
[Bug Fix] Reduce theme upload batch size to prevent timeout

### DIFF
--- a/.changeset/heavy-frogs-pretend.md
+++ b/.changeset/heavy-frogs-pretend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+[Bug Fix] Reduce theme upload batch size to prevent timeout

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -17,10 +17,18 @@ interface UploadOptions {
 type ChecksumWithSize = Checksum & {size: number}
 type FileBatch = ChecksumWithSize[]
 
+/**
+ * Even though the API itself can handle a higher batch size, we limit the batch file count + bytesize
+ * to avoid timeout issues happening on the theme access proxy level.
+ *
+ * The higher the batch size, the longer the proxy request lasts. We should also generally avoid long running
+ * queries against our API (i.e. over 30 seconds). There is no specific reason for these values, but were
+ * previously used against the AssetController.
+ */
 // Limits for Bulk Requests
-export const MAX_BATCH_FILE_COUNT = 50
-// 10MB
-export const MAX_BATCH_BYTESIZE = 1024 * 1024 * 10
+export const MAX_BATCH_FILE_COUNT = 20
+// 1MB
+export const MAX_BATCH_BYTESIZE = 1024 * 1024
 export const MAX_UPLOAD_RETRY_COUNT = 2
 
 export function uploadTheme(


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/cli/issues/5031

### WHAT is this pull request doing?

A previous [PR](https://github.com/Shopify/cli/pull/4792/files#diff-c4edcc1629cc0813d96396f1661f9f69fcdbece0f346f9d53dc99b6233abd5f1R21) changed the endpoint to upload the themes files from REST API to GraphQL API
- The new endpoint did not cause the issue, but the PR also increased the theme upload batch size
- This is generally fine when using the CLI through regular user login, but fails when requests are being proxied through Theme Access App

### How to test your changes?

- Instead Theme Access App on your store
- Set environment variables in terminal
```
export SHOPIFY_CLI_THEME_TOKEN=<password from app>
export SHOPIFY_FLAG_STORE=<store>
export SHOPIFY_FLAG_FORCE="1"
```
- Run this CLI branch against an existing theme
  - `npx shopify theme push --theme="bug-dec16" --unpublished --verbose --path=<path-to-repo>`
- theme should be uploaded

NOTE: Also try uploading a LOT of asset files AND with large asset files (e.g. download large images in asset folder)

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
