### PR TITLE
Report business platform ID instead of partner ID when relevant

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -18,6 +18,7 @@ import {
   OrganizationApp,
   MinimalOrganizationApp,
   AppApiKeyAndOrgId,
+  OrganizationSource,
 } from '../organization.js'
 import {RemoteSpecification} from '../../api/graphql/extension_specifications.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
@@ -176,6 +177,7 @@ export function testOrganization(): Organization {
   return {
     id: '1',
     businessName: 'org1',
+    source: OrganizationSource.BusinessPlatform,
   }
 }
 

--- a/packages/app/src/cli/services/app-context.test.ts
+++ b/packages/app/src/cli/services/app-context.test.ts
@@ -233,11 +233,12 @@ describe('linkedAppContext', () => {
       const meta = metadata.getAllPublicMetadata()
       expect(meta).toEqual(
         expect.objectContaining({
-          partner_id: tryParseInt(mockRemoteApp.organizationId),
+          business_platform_id: tryParseInt(mockOrganization.id),
           api_key: mockRemoteApp.apiKey,
           cmd_app_reset_used: false,
         }),
       )
+      expect(meta).not.toHaveProperty('partner_id')
     })
   })
 

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -29,6 +29,7 @@ export interface Schemas {
       env_plugin_installed_all?: Optional<string>
     }
     public: {
+      business_platform_id?: Optional<number>
       partner_id?: Optional<number>
       command: string
       project_type?: Optional<string>

--- a/packages/cli-kit/src/public/node/plugins.ts
+++ b/packages/cli-kit/src/public/node/plugins.ts
@@ -28,7 +28,11 @@ export async function fanoutHooks<TPluginMap extends HookReturnsPerPlugin, TEven
   return Object.fromEntries(res.successes.map(({result, plugin}) => [plugin.name, result])) as any
 }
 
-type AppSpecificMonorailFields = PickByPrefix<MonorailEventPublic, 'app_', 'project_type' | 'api_key' | 'partner_id'> &
+type AppSpecificMonorailFields = PickByPrefix<
+  MonorailEventPublic,
+  'app_',
+  'project_type' | 'api_key' | 'partner_id' | 'business_platform_id'
+> &
   PickByPrefix<MonorailEventPublic, 'cmd_extensions_'> &
   PickByPrefix<MonorailEventPublic, 'cmd_scaffold_'>
 


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure we are tracking BP orgs and Partner orgs separately.

### WHAT is this pull request doing?

Introduces a new `business_platform_id` field in analytics tracking to differentiate between Partner and Business Platform organizations. When working with a Business Platform organization, the system now logs the `business_platform_id` instead of the `partner_id`.

### How to test your changes?

Check that when working with App Management, the correct field is reported in analytics (see verbose logs)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes