### PR TITLE
Remove remaining refs to app ID when only API key is needed

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -137,7 +137,6 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
     // Remote API Key provided by the caller, so use that app specifically
     const remoteApp = await appFromIdentifiers({
       apiKey: options.apiKey,
-      id: options.appId,
       developerPlatformClient,
       organizationId: options.organizationId,
     })

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -46,7 +46,6 @@ export const resetHelpMessage: Token[] = [
 
 interface AppFromIdOptions {
   apiKey: string
-  id?: string
   organizationId?: string
   developerPlatformClient: DeveloperPlatformClient
 }


### PR DESCRIPTION
Quick followup to #4918 removing an unnecessary param