### PR TITLE
bump function-runner version to v7.0.0

### DIFF
--- a/.changeset/eleven-rice-train.md
+++ b/.changeset/eleven-rice-train.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Bump function-runner version to v7.0.0

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs'
 import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
-const FUNCTION_RUNNER_VERSION = 'v6.5.0'
+const FUNCTION_RUNNER_VERSION = 'v7.0.0'
 const JAVY_VERSION = 'v4.0.0'
 // The Javy plugin version should match the plugin version used in the
 // function-runner version specified above.


### PR DESCRIPTION
### WHY are these changes introduced?

Bump function-runner to v7.0.0.

This new version returns a non-zero exit code whenever a function run fails ([PR](https://github.com/Shopify/function-runner/pull/401)). While this was a major version for function-runner, I don't believe it constitutes a major version for the CLI.

### How to test your changes?

- `rm -r packages/app/dist/cli/services/bin/` (clear out any cached downloaded binaries)
- `pnpm shopify app function build --path <path_to_function_extension>` (downloads and runs Javy)
- `echo "{}" | pnpm shopify app function run --path <path_to_function_extension>` (downloads and runs function-runner)
- Make your function error (for JS, just throw an error for example)
- Try running the function again, see a non-zero exit code

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes - none needed
