### PR TITLE
Use the auto-generated UID for asset upload path

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -355,7 +355,7 @@ export class App<
           type: module.externalType,
           handle: module.handle,
           uid: module.uid,
-          assets: module.configuration.uid ?? module.handle,
+          assets: module.uid,
           target: module.contextValue,
           config: (config ?? {}) as JsonMapType,
         }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2442 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

If this is the first time deploying and there is no UID, the autogenerated UID won't yet be found in `module.configuration`. So we are falling back to putting the app handle in the manifest as the assets path, but that doesn't exist. Instead, the assets are found under a path corresponding to the generated UID.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

All singleton `shopify.app.toml`-based modules don't need assets, so even though they should technically use `module.handle` here, it basically doesn't matter. And for all other extension types, `module.uid` is the correct value to use here.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
On app management, create a new app, generate an extension, delete the UID from the generated TOML, and deploy. It should succeed on the first run.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
