### PR TITLE
Include business platform ID in bugsnag info

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -228,7 +228,7 @@ export async function addBugsnagMetadata(event: any, config: Interfaces.Config):
   const commandData = {} as {[key: string]: unknown}
   const environmentData = {} as {[key: string]: unknown}
   const miscData = {} as {[key: string]: unknown}
-  const appKeys = ['api_key', 'partner_id', 'project_type']
+  const appKeys = ['api_key', 'business_platform_id', 'partner_id', 'project_type']
   const commandKeys = ['command']
   const environmentKeys = ['cli_version', 'node_version', 'uname']
 


### PR DESCRIPTION
### WHY are these changes introduced?

Adds support for tracking business platform IDs in error reporting metadata, enabling better error tracking and debugging capabilities for business platform related issues.

### WHAT is this pull request doing?

Adds `business_platform_id` to the list of app keys that are collected and included in error reporting metadata.

### How to test your changes?

1. Trigger an error in an app that includes a business platform ID
2. Verify that the error report in bugsnag includes the business platform ID in the metadata

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes