### PR TITLE
Make organization source required

### DIFF
--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -9,7 +9,7 @@ export enum OrganizationSource {
 export interface Organization {
   id: string
   businessName: string
-  source?: OrganizationSource
+  source: OrganizationSource
 }
 
 export interface AppApiKeyAndOrgId {

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -7,7 +7,7 @@ import {
   selectStorePrompt,
   updateURLsPrompt,
 } from './dev.js'
-import {Organization, OrganizationStore} from '../models/organization.js'
+import {Organization, OrganizationSource, OrganizationStore} from '../models/organization.js'
 import {testDeveloperPlatformClient, testOrganizationApp} from '../models/app/app.test-data.js'
 import {getTomls} from '../utilities/app/config/getTomls.js'
 import {searchForAppsByNameFactory} from '../services/dev/prompt-helpers.js'
@@ -21,10 +21,12 @@ vi.mock('../utilities/app/config/getTomls')
 const ORG1: Organization = {
   id: '1',
   businessName: 'org1',
+  source: OrganizationSource.BusinessPlatform,
 }
 const ORG2: Organization = {
   id: '2',
   businessName: 'org2',
+  source: OrganizationSource.BusinessPlatform,
 }
 const APP1 = testOrganizationApp({apiKey: 'key1'})
 const APP2 = testOrganizationApp({

--- a/packages/app/src/cli/services/app/config/link-service.test.ts
+++ b/packages/app/src/cli/services/app/config/link-service.test.ts
@@ -1,7 +1,7 @@
 import link from './link.js'
 import {testOrganizationApp, testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
 import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
-import {AppApiKeyAndOrgId, OrganizationApp} from '../../../models/organization.js'
+import {AppApiKeyAndOrgId, OrganizationApp, OrganizationSource} from '../../../models/organization.js'
 import {appNamePrompt, createAsNewAppPrompt, selectOrganizationPrompt} from '../../../prompts/dev.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
@@ -27,7 +27,11 @@ function buildDeveloperPlatformClient(): DeveloperPlatformClient {
       }
     },
     async orgAndApps(orgId) {
-      return {organization: {id: orgId, businessName: 'test'}, apps: [mockRemoteApp()], hasMorePages: false}
+      return {
+        organization: {id: orgId, businessName: 'test', source: OrganizationSource.BusinessPlatform},
+        apps: [mockRemoteApp()],
+        hasMorePages: false,
+      }
     },
     async createApp(org, name, options) {
       return testOrganizationApp({
@@ -58,7 +62,11 @@ describe('link, with minimal mocking', () => {
       vi.mocked(selectDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
       vi.mocked(createAsNewAppPrompt).mockResolvedValue(true)
       vi.mocked(appNamePrompt).mockResolvedValue('A user provided name')
-      vi.mocked(selectOrganizationPrompt).mockResolvedValue({id: '12345', businessName: 'test'})
+      vi.mocked(selectOrganizationPrompt).mockResolvedValue({
+        id: '12345',
+        businessName: 'test',
+        source: OrganizationSource.BusinessPlatform,
+      })
 
       const options = {
         directory: tmp,

--- a/packages/app/src/cli/services/app/env/show.test.ts
+++ b/packages/app/src/cli/services/app/env/show.test.ts
@@ -3,6 +3,7 @@ import {fetchOrganizations} from '../../dev/fetch.js'
 import {AppInterface} from '../../../models/app/app.js'
 import {selectOrganizationPrompt} from '../../../prompts/dev.js'
 import {testApp, testOrganizationApp} from '../../../models/app/app.test-data.js'
+import {OrganizationSource} from '../../../models/organization.js'
 import {describe, expect, vi, test} from 'vitest'
 import * as file from '@shopify/cli-kit/node/fs'
 import {stringifyMessage, unstyled} from '@shopify/cli-kit/node/output'
@@ -23,6 +24,7 @@ describe('env show', () => {
       id: '123',
       flags: {},
       businessName: 'test',
+      source: OrganizationSource.BusinessPlatform,
       apps: {nodes: []},
     }
     const organizationApp = testOrganizationApp()

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -1,6 +1,6 @@
 import {selectOrCreateApp} from './select-app.js'
 import {AppInterface, WebType} from '../../models/app/app.js'
-import {AppApiKeyAndOrgId, Organization} from '../../models/organization.js'
+import {AppApiKeyAndOrgId, Organization, OrganizationSource} from '../../models/organization.js'
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {testApp, testOrganizationApp, testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {describe, expect, vi, test} from 'vitest'
@@ -25,6 +25,7 @@ const LOCAL_APP: AppInterface = testApp({
 const ORG1: Organization = {
   id: '1',
   businessName: 'org1',
+  source: OrganizationSource.BusinessPlatform,
 }
 const APP1 = testOrganizationApp({apiKey: 'key1'})
 const APP2 = testOrganizationApp({

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -1,5 +1,5 @@
 import {selectStore} from './select-store.js'
-import {Organization, OrganizationStore} from '../../models/organization.js'
+import {Organization, OrganizationSource, OrganizationStore} from '../../models/organization.js'
 import {
   reloadStoreListPrompt,
   selectStorePrompt,
@@ -20,6 +20,7 @@ vi.mock('@shopify/cli-kit/node/context/spin')
 const ORG1: Organization = {
   id: '1',
   businessName: 'org1',
+  source: OrganizationSource.BusinessPlatform,
 }
 const STORE1: OrganizationStore = {
   shopId: '1',

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -1,6 +1,6 @@
 import {InfoOptions, info} from './info.js'
 import {AppInterface, AppLinkedInterface} from '../models/app/app.js'
-import {AppApiKeyAndOrgId, OrganizationApp} from '../models/organization.js'
+import {AppApiKeyAndOrgId, OrganizationApp, OrganizationSource} from '../models/organization.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
 import {
   testDeveloperPlatformClient,
@@ -30,6 +30,7 @@ const ORG1 = {
   flags: {},
   businessName: 'test',
   apps: {nodes: []},
+  source: OrganizationSource.BusinessPlatform,
 }
 
 function buildDeveloperPlatformClient(): DeveloperPlatformClient {

--- a/packages/app/src/cli/services/versions-list.test.ts
+++ b/packages/app/src/cli/services/versions-list.test.ts
@@ -1,7 +1,7 @@
 import versionList from './versions-list.js'
 import {renderCurrentlyUsedConfigInfo} from './context.js'
 import {testAppLinked, testDeveloperPlatformClient, testOrganizationApp} from '../models/app/app.test-data.js'
-import {Organization} from '../models/organization.js'
+import {Organization, OrganizationSource} from '../models/organization.js'
 import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {AppVersionsQuerySchema} from '../api/graphql/get_versions_list.js'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -17,6 +17,7 @@ afterEach(() => {
 const ORG1: Organization = {
   id: 'org-id',
   businessName: 'name of org 1',
+  source: OrganizationSource.BusinessPlatform,
 }
 
 const remoteApp = testOrganizationApp({organizationId: ORG1.id, apiKey: 'api-key', title: 'app-title', id: 'app-id'})

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
@@ -1,7 +1,7 @@
 import {PartnersClient} from './partners-client.js'
 import {CreateAppQuery} from '../../api/graphql/create_app.js'
 import {AppInterface, WebType} from '../../models/app/app.js'
-import {Organization, OrganizationStore} from '../../models/organization.js'
+import {Organization, OrganizationSource, OrganizationStore} from '../../models/organization.js'
 import {
   testPartnersUserSession,
   testApp,
@@ -32,11 +32,13 @@ const LOCAL_APP: AppInterface = testApp({
   name: 'my-app',
 })
 
-const ORG1: Organization = {
+type OrganizationInPartnersResponse = Omit<Organization, 'source'>
+
+const ORG1: OrganizationInPartnersResponse = {
   id: '1',
   businessName: 'org1',
 }
-const ORG2: Organization = {
+const ORG2: OrganizationInPartnersResponse = {
   id: '2',
   businessName: 'org2',
 }
@@ -88,7 +90,7 @@ describe('createApp', () => {
     }
 
     // When
-    const got = await partnersClient.createApp(ORG1, localApp.name, {
+    const got = await partnersClient.createApp({...ORG1, source: OrganizationSource.Partners}, localApp.name, {
       scopesArray: ['write_products'],
       isLaunchable: true,
     })
@@ -113,7 +115,7 @@ describe('createApp', () => {
     }
 
     // When
-    const got = await partnersClient.createApp(ORG1, LOCAL_APP.name, {
+    const got = await partnersClient.createApp({...ORG1, source: OrganizationSource.Partners}, LOCAL_APP.name, {
       isLaunchable: false,
       scopesArray: ['write_products'],
     })
@@ -132,7 +134,7 @@ describe('createApp', () => {
     })
 
     // When
-    const got = partnersClient.createApp(ORG2, LOCAL_APP.name)
+    const got = partnersClient.createApp({...ORG2, source: OrganizationSource.Partners}, LOCAL_APP.name)
 
     // Then
     await expect(got).rejects.toThrow(`some-error`)

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -298,9 +298,8 @@ export class PartnersClient implements DeveloperPlatformClient {
   async orgFromId(orgId: string): Promise<Organization | undefined> {
     const variables: FindOrganizationBasicVariables = {id: orgId}
     const result: FindOrganizationBasicQuerySchema = await this.request(FindOrganizationBasicQuery, variables)
-    const org: Organization | undefined = result.organizations.nodes[0]
-    if (org) org.source = OrganizationSource.Partners
-    return org
+    const org: Omit<Organization, 'source'> | undefined = result.organizations.nodes[0]
+    return org ? {...org, source: OrganizationSource.Partners} : undefined
   }
 
   async orgAndApps(orgId: string): Promise<Paginateable<{organization: Organization; apps: MinimalOrganizationApp[]}>> {


### PR DESCRIPTION
### WHY are these changes introduced?

Makes the `source` field required in the `Organization` type to ensure consistent handling of organization sources across the codebase. This prevents potential undefined behavior when dealing with organization sources, and - most relevant here - allows us to be sure we can report analytics with the correct org ID field.

### WHAT is this pull request doing?

Makes the `source` field non-optional in the `Organization` interface and updates all test files to include the required `source` field in organization objects. The changes ensure that organizations always have a defined source, either `BusinessPlatform` or `Partners`.

### How to test your changes?

Not much to test per se, I'd suggest tophatting with downstream PRs. All we're doing is being more strict about field requirements.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes