### PR TITLE
Enable search for dev stores

### DIFF
--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/list_app_dev_stores.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/list_app_dev_stores.ts
@@ -3,7 +3,9 @@ import * as Types from './types.js'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
-export type ListAppDevStoresQueryVariables = Types.Exact<{[key: string]: never}>
+export type ListAppDevStoresQueryVariables = Types.Exact<{
+  searchTerm?: Types.InputMaybe<Types.Scalars['String']['input']>
+}>
 
 export type ListAppDevStoresQuery = {
   organization?: {
@@ -20,6 +22,7 @@ export type ListAppDevStoresQuery = {
           shortName?: string | null
         }
       }[]
+      pageInfo: {hasNextPage: boolean}
     } | null
   } | null
 }
@@ -31,6 +34,13 @@ export const ListAppDevStores = {
       kind: 'OperationDefinition',
       operation: 'query',
       name: {kind: 'Name', value: 'ListAppDevStores'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'searchTerm'}},
+          type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}},
+        },
+      ],
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
@@ -70,6 +80,11 @@ export const ListAppDevStores = {
                         ],
                       },
                     },
+                    {
+                      kind: 'Argument',
+                      name: {kind: 'Name', value: 'search'},
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'searchTerm'}},
+                    },
                   ],
                   selectionSet: {
                     kind: 'SelectionSet',
@@ -96,6 +111,17 @@ export const ListAppDevStores = {
                                 ],
                               },
                             },
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'pageInfo'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'hasNextPage'}},
                             {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                           ],
                         },

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/queries/list_app_dev_stores.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/queries/list_app_dev_stores.graphql
@@ -1,18 +1,21 @@
-  query ListAppDevStores {
-    organization {
-      id
-      name
-      accessibleShops(filters: {field: STORE_TYPE, operator: EQUALS, value: "app_development"}) {
-        edges {
-          node {
-            id
-            externalId
-            name
-            storeType
-            primaryDomain
-            shortName
-          }
+query ListAppDevStores($searchTerm: String) {
+  organization {
+    id
+    name
+    accessibleShops(filters: {field: STORE_TYPE, operator: EQUALS, value: "app_development"}, search: $searchTerm) {
+      edges {
+        node {
+          id
+          externalId
+          name
+          storeType
+          primaryDomain
+          shortName
         }
+      }
+      pageInfo {
+        hasNextPage
       }
     }
   }
+}

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1329,7 +1329,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
       Promise.resolve({organization: testOrganization(), apps: [testOrganizationApp()], hasMorePages: false}),
     createApp: (_organization: Organization, _name: string, _options?: CreateAppOptions) =>
       Promise.resolve(testOrganizationApp()),
-    devStoresForOrg: (_organizationId: string) => Promise.resolve([]),
+    devStoresForOrg: (_organizationId: string) => Promise.resolve({stores: [], hasMorePages: false}),
     storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve({organizations: {nodes: []}}),
     appExtensionRegistrations: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppExtensionRegistrations),
     appVersions: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppVersions),

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -49,6 +49,14 @@ const STORE2: OrganizationStore = {
   transferDisabled: false,
   convertableToPartnerTest: false,
 }
+const STORE3: OrganizationStore = {
+  shopId: '3',
+  link: 'link3',
+  shopDomain: 'domain3',
+  shopName: 'store3',
+  transferDisabled: false,
+  convertableToPartnerTest: false,
+}
 
 beforeEach(() => {
   vi.mocked(getTomls).mockResolvedValue({})
@@ -198,6 +206,34 @@ describe('selectStore', () => {
       choices: [
         {label: 'store1 (domain1)', value: '1'},
         {label: 'store2 (domain2)', value: '2'},
+      ],
+      hasMorePages: false,
+      search: expect.any(Function),
+    })
+  })
+
+  test('returns correct store if user selects one after searching', async () => {
+    // Given
+    const stores: OrganizationStore[] = [STORE1, STORE2]
+    vi.mocked(renderAutocompletePrompt).mockImplementation(async ({search}) => {
+      const searchResults = await search!('')
+      return searchResults.data[0]!.value
+    })
+
+    // When
+    const got = await selectStorePrompt({
+      stores,
+      showDomainOnPrompt: defaultShowDomainOnPrompt,
+      onSearchForStoresByName: (_term: string) => Promise.resolve({stores: [STORE3], hasMorePages: false}),
+    })
+
+    // Then
+    expect(got).toEqual(STORE3)
+    expect(renderAutocompletePrompt).toHaveBeenCalledWith({
+      message: 'Which store would you like to use to view your project?',
+      choices: [
+        {label: 'store1', value: '1'},
+        {label: 'store2', value: '2'},
       ],
       hasMorePages: false,
       search: expect.any(Function),

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -141,7 +141,7 @@ describe('selectStore', () => {
     const stores: OrganizationStore[] = []
 
     // When
-    const got = await selectStorePrompt(stores, defaultShowDomainOnPrompt)
+    const got = await selectStorePrompt({stores, showDomainOnPrompt: defaultShowDomainOnPrompt})
 
     // Then
     expect(got).toEqual(undefined)
@@ -154,7 +154,7 @@ describe('selectStore', () => {
     const outputMock = mockAndCaptureOutput()
 
     // When
-    const got = await selectStorePrompt(stores, defaultShowDomainOnPrompt)
+    const got = await selectStorePrompt({stores, showDomainOnPrompt: defaultShowDomainOnPrompt})
 
     // Then
     expect(got).toEqual(STORE1)
@@ -168,7 +168,7 @@ describe('selectStore', () => {
     vi.mocked(renderAutocompletePrompt).mockResolvedValue('2')
 
     // When
-    const got = await selectStorePrompt(stores, defaultShowDomainOnPrompt)
+    const got = await selectStorePrompt({stores, showDomainOnPrompt: defaultShowDomainOnPrompt})
 
     // Then
     expect(got).toEqual(STORE2)
@@ -178,6 +178,8 @@ describe('selectStore', () => {
         {label: 'store1', value: '1'},
         {label: 'store2', value: '2'},
       ],
+      hasMorePages: false,
+      search: expect.any(Function),
     })
   })
 
@@ -187,7 +189,7 @@ describe('selectStore', () => {
     vi.mocked(renderAutocompletePrompt).mockResolvedValue('2')
 
     // When
-    const got = await selectStorePrompt(stores, true)
+    const got = await selectStorePrompt({stores, showDomainOnPrompt: true})
 
     // Then
     expect(got).toEqual(STORE2)
@@ -197,6 +199,8 @@ describe('selectStore', () => {
         {label: 'store1 (domain1)', value: '1'},
         {label: 'store2 (domain2)', value: '2'},
       ],
+      hasMorePages: false,
+      search: expect.any(Function),
     })
   })
 })

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -3,7 +3,12 @@ import {Organization, MinimalOrganizationApp, OrganizationStore, MinimalAppIdent
 import {getTomls} from '../utilities/app/config/getTomls.js'
 import {setCachedCommandTomlMap} from '../services/local-storage.js'
 import {Paginateable} from '../utilities/developer-platform-client.js'
-import {renderAutocompletePrompt, renderConfirmationPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
+import {
+  RenderAutocompleteOptions,
+  renderAutocompletePrompt,
+  renderConfirmationPrompt,
+  renderTextPrompt,
+} from '@shopify/cli-kit/node/ui'
 import {outputCompleted} from '@shopify/cli-kit/node/output'
 
 export async function selectOrganizationPrompt(organizations: Organization[]): Promise<Organization> {
@@ -78,7 +83,7 @@ export async function selectStorePrompt({
     return stores[0]
   }
 
-  const toAnswer = (store: OrganizationStore) => {
+  const storeToChoice = (store: OrganizationStore): RenderAutocompleteOptions<string>['choices'][number] => {
     let label = store.shopName
     if (showDomainOnPrompt && store.shopDomain) {
       label = `${store.shopName} (${store.shopDomain})`
@@ -86,25 +91,25 @@ export async function selectStorePrompt({
     return {label, value: store.shopId}
   }
 
-  let currentStoreChoices = stores
+  let currentStores = stores
 
   const id = await renderAutocompletePrompt({
     message: 'Which store would you like to use to view your project?',
-    choices: currentStoreChoices.map(toAnswer),
+    choices: currentStores.map(storeToChoice),
     hasMorePages,
     search: async (term) => {
       const result = await onSearchForStoresByName(term)
-      currentStoreChoices = result.stores
+      currentStores = result.stores
 
       return {
-        data: currentStoreChoices.map(toAnswer),
+        data: currentStores.map(storeToChoice),
         meta: {
           hasNextPage: result.hasMorePages,
         },
       }
     },
   })
-  return stores.find((store) => store.shopId === id)
+  return currentStores.find((store) => store.shopId === id)
 }
 
 export async function confirmConversionToTransferDisabledStorePrompt(): Promise<boolean> {

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -60,11 +60,16 @@ describe('selectStore', async () => {
     vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE1)
 
     // When
-    const got = await selectStore([STORE1, STORE2], ORG1, testDeveloperPlatformClient())
+    const got = await selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, testDeveloperPlatformClient())
 
     // Then
     expect(got).toEqual(STORE1)
-    expect(selectStorePrompt).toHaveBeenCalledWith([STORE1, STORE2], defaultShowDomainOnPrompt)
+    expect(selectStorePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stores: [STORE1, STORE2],
+        showDomainOnPrompt: defaultShowDomainOnPrompt,
+      }),
+    )
   })
 
   test('selectStorePrompt is called with showDomainOnPrompt = true if clientName is app-management', async () => {
@@ -73,11 +78,16 @@ describe('selectStore', async () => {
     const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.AppManagement})
 
     // When
-    const got = await selectStore([STORE1, STORE2], ORG1, developerPlatformClient)
+    const got = await selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient)
 
     // Then
     expect(got).toEqual(STORE1)
-    expect(selectStorePrompt).toHaveBeenCalledWith([STORE1, STORE2], true)
+    expect(selectStorePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stores: [STORE1, STORE2],
+        showDomainOnPrompt: true,
+      }),
+    )
   })
 
   test('prompts user to convert store to non-transferable if selection is invalid', async () => {
@@ -86,11 +96,16 @@ describe('selectStore', async () => {
     vi.mocked(confirmConversionToTransferDisabledStorePrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await selectStore([STORE1, STORE2], ORG1, testDeveloperPlatformClient())
+    const got = await selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, testDeveloperPlatformClient())
 
     // Then
     expect(got).toEqual(STORE2)
-    expect(selectStorePrompt).toHaveBeenCalledWith([STORE1, STORE2], defaultShowDomainOnPrompt)
+    expect(selectStorePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stores: [STORE1, STORE2],
+        showDomainOnPrompt: defaultShowDomainOnPrompt,
+      }),
+    )
     expect(confirmConversionToTransferDisabledStorePrompt).toHaveBeenCalled()
   })
 
@@ -101,11 +116,16 @@ describe('selectStore', async () => {
     vi.mocked(confirmConversionToTransferDisabledStorePrompt).mockResolvedValueOnce(false)
 
     // When
-    const got = await selectStore([STORE1, STORE2], ORG1, testDeveloperPlatformClient())
+    const got = await selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, testDeveloperPlatformClient())
 
     // Then
     expect(got).toEqual(STORE1)
-    expect(selectStorePrompt).toHaveBeenCalledWith([STORE1, STORE2], defaultShowDomainOnPrompt)
+    expect(selectStorePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stores: [STORE1, STORE2],
+        showDomainOnPrompt: defaultShowDomainOnPrompt,
+      }),
+    )
     expect(confirmConversionToTransferDisabledStorePrompt).toHaveBeenCalled()
   })
 
@@ -117,12 +137,17 @@ describe('selectStore', async () => {
     const developerPlatformClient = testDeveloperPlatformClient()
 
     // When
-    const got = await selectStore([STORE1, STORE2], ORG1, developerPlatformClient)
+    const got = await selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient)
 
     // Then
     expect(got).toEqual(STORE2)
     expect(developerPlatformClient.convertToTransferDisabledStore).not.toHaveBeenCalled()
-    expect(selectStorePrompt).toHaveBeenCalledWith([STORE1, STORE2], defaultShowDomainOnPrompt)
+    expect(selectStorePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stores: [STORE1, STORE2],
+        showDomainOnPrompt: defaultShowDomainOnPrompt,
+      }),
+    )
   })
 
   test('throws if store is non convertible', async () => {
@@ -130,7 +155,11 @@ describe('selectStore', async () => {
     vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE3)
 
     // When
-    const got = selectStore([STORE1, STORE2, STORE3], ORG1, testDeveloperPlatformClient())
+    const got = selectStore(
+      {stores: [STORE1, STORE2, STORE3], hasMorePages: false},
+      ORG1,
+      testDeveloperPlatformClient(),
+    )
 
     // Then
     await expect(got).rejects.toThrow('The store you specified (domain3) is not a dev store')
@@ -142,11 +171,16 @@ describe('selectStore', async () => {
     vi.mocked(reloadStoreListPrompt).mockResolvedValue(false)
 
     // When
-    const got = () => selectStore([STORE1, STORE2], ORG1, testDeveloperPlatformClient())
+    const got = () => selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, testDeveloperPlatformClient())
 
     // Then
     await expect(got).rejects.toThrowError()
-    expect(selectStorePrompt).toHaveBeenCalledWith([STORE1, STORE2], defaultShowDomainOnPrompt)
+    expect(selectStorePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stores: [STORE1, STORE2],
+        showDomainOnPrompt: defaultShowDomainOnPrompt,
+      }),
+    )
   })
 
   test('prompts user to create & reload, fetches 10 times and tries again if reload is true', async () => {
@@ -157,7 +191,7 @@ describe('selectStore', async () => {
     const developerPlatformClient = testDeveloperPlatformClient()
 
     // When
-    const got = selectStore([], ORG1, developerPlatformClient)
+    const got = selectStore({stores: [], hasMorePages: false}, ORG1, developerPlatformClient)
 
     // Then
     await expect(got).rejects.toThrow()

--- a/packages/app/src/cli/services/store-context.test.ts
+++ b/packages/app/src/cli/services/store-context.test.ts
@@ -76,7 +76,7 @@ describe('storeContext', () => {
     const appWithoutCachedStore = testAppLinked()
     const allStores = [mockStore, {...mockStore, shopId: 'store2', shopDomain: 'another-store.myshopify.com'}]
 
-    vi.mocked(mockDeveloperPlatformClient.devStoresForOrg).mockResolvedValue(allStores)
+    vi.mocked(mockDeveloperPlatformClient.devStoresForOrg).mockResolvedValue({stores: allStores, hasMorePages: false})
     vi.mocked(selectStore).mockResolvedValue(mockStore)
 
     const updatedAppContextResult = {...appContextResult, app: appWithoutCachedStore}
@@ -86,14 +86,18 @@ describe('storeContext', () => {
     })
 
     expect(mockDeveloperPlatformClient.devStoresForOrg).toHaveBeenCalledWith(mockOrganization.id)
-    expect(selectStore).toHaveBeenCalledWith(allStores, mockOrganization, mockDeveloperPlatformClient)
+    expect(selectStore).toHaveBeenCalledWith(
+      {stores: allStores, hasMorePages: false},
+      mockOrganization,
+      mockDeveloperPlatformClient,
+    )
     expect(result).toEqual(mockStore)
   })
 
   test('fetches and selects store when forceReselectStore is true', async () => {
     const allStores = [mockStore, {...mockStore, shopId: 'store2', shopDomain: 'another-store.myshopify.com'}]
 
-    vi.mocked(mockDeveloperPlatformClient.devStoresForOrg).mockResolvedValue(allStores)
+    vi.mocked(mockDeveloperPlatformClient.devStoresForOrg).mockResolvedValue({stores: allStores, hasMorePages: false})
     vi.mocked(selectStore).mockResolvedValue(mockStore)
 
     const result = await storeContext({
@@ -102,7 +106,11 @@ describe('storeContext', () => {
     })
 
     expect(mockDeveloperPlatformClient.devStoresForOrg).toHaveBeenCalledWith(mockOrganization.id)
-    expect(selectStore).toHaveBeenCalledWith(allStores, mockOrganization, mockDeveloperPlatformClient)
+    expect(selectStore).toHaveBeenCalledWith(
+      {stores: allStores, hasMorePages: false},
+      mockOrganization,
+      mockDeveloperPlatformClient,
+    )
     expect(result).toEqual(mockStore)
   })
 
@@ -115,7 +123,7 @@ describe('storeContext', () => {
   test('throws an error when selectStore fails', async () => {
     const appWithoutCachedStore = testAppLinked()
 
-    vi.mocked(mockDeveloperPlatformClient.devStoresForOrg).mockResolvedValue([])
+    vi.mocked(mockDeveloperPlatformClient.devStoresForOrg).mockResolvedValue({stores: [], hasMorePages: false})
     vi.mocked(selectStore).mockRejectedValue(new Error('No stores available'))
     const updatedAppContextResult = {...appContextResult, app: appWithoutCachedStore}
 

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -222,7 +222,7 @@ export interface DeveloperPlatformClient {
   specifications: (app: MinimalAppIdentifiers) => Promise<RemoteSpecification[]>
   templateSpecifications: (app: MinimalAppIdentifiers) => Promise<ExtensionTemplate[]>
   createApp: (org: Organization, name: string, options?: CreateAppOptions) => Promise<OrganizationApp>
-  devStoresForOrg: (orgId: string) => Promise<OrganizationStore[]>
+  devStoresForOrg: (orgId: string, searchTerm?: string) => Promise<Paginateable<{stores: OrganizationStore[]}>>
   storeByDomain: (orgId: string, shopDomain: string) => Promise<FindStoreByDomainSchema>
   appExtensionRegistrations: (
     app: MinimalAppIdentifiers,

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -397,11 +397,12 @@ export class AppManagementClient implements DeveloperPlatformClient {
   // we are returning OrganizationStore type here because we want to keep types consistent btwn
   // partners-client and app-management-client. Since we need transferDisabled and convertableToPartnerTest values
   // from the Partners OrganizationStore schema, we will return this type for now
-  async devStoresForOrg(orgId: string): Promise<OrganizationStore[]> {
+  async devStoresForOrg(orgId: string, searchTerm?: string): Promise<Paginateable<{stores: OrganizationStore[]}>> {
     const storesResult = await businessPlatformOrganizationsRequestDoc<ListAppDevStoresQuery>(
       ListAppDevStores,
       await this.businessPlatformToken(),
       orgId,
+      {searchTerm},
     )
     const organization = storesResult.organization
 
@@ -410,7 +411,10 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
 
     const shopArray = organization.accessibleShops?.edges.map((value) => value.node) ?? []
-    return mapBusinessPlatformStoresToOrganizationStores(shopArray)
+    return {
+      stores: mapBusinessPlatformStoresToOrganizationStores(shopArray),
+      hasMorePages: storesResult.organization?.accessibleShops?.pageInfo.hasNextPage ?? false,
+    }
   }
 
   async appExtensionRegistrations(

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -358,10 +358,13 @@ export class PartnersClient implements DeveloperPlatformClient {
     return {...result.appCreate.app, organizationId: org.id, newApp: true, flags, developerPlatformClient: this}
   }
 
-  async devStoresForOrg(orgId: string): Promise<OrganizationStore[]> {
+  async devStoresForOrg(orgId: string): Promise<Paginateable<{stores: OrganizationStore[]}>> {
     const variables: DevStoresByOrgQueryVariables = {id: orgId}
     const result: DevStoresByOrgQuery = await this.requestDoc(DevStoresByOrg, variables)
-    return result.organizations.nodes![0]!.stores.nodes as OrganizationStore[]
+    return {
+      stores: result.organizations.nodes![0]!.stores.nodes as OrganizationStore[],
+      hasMorePages: false,
+    }
   }
 
   async appExtensionRegistrations(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2455

Allows developers to find dev stores in the list even if they have > 50 stores.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Enables autocomplete search for dev stores, just as we have for apps.

Note this will only work for BP orgs, it's not implemented for Partner orgs.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Using an org with > 50 dev stores, run `app dev` and search for a store by name that is beyond the first 50.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
