### PR TITLE
Fix extension_directories wildcards to always be recursive

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -1,4 +1,5 @@
 import {
+  AppSchema,
   CurrentAppConfiguration,
   LegacyAppConfiguration,
   getAppScopes,
@@ -91,6 +92,33 @@ describe('app schema validation', () => {
       delete config.client_id
 
       expect(isCurrentAppSchema(config)).toBe(false)
+    })
+
+    test('extension_directories should be transformed to double asterisks', () => {
+      const config = {
+        ...CORRECT_CURRENT_APP_SCHEMA,
+        extension_directories: ['extensions/*'],
+      }
+      const parsed = AppSchema.parse(config)
+      expect(parsed.extension_directories).toEqual(['extensions/**'])
+    })
+
+    test('extension_directories is not transformed if it ends with double asterisks', () => {
+      const config = {
+        ...CORRECT_CURRENT_APP_SCHEMA,
+        extension_directories: ['extensions/**'],
+      }
+      const parsed = AppSchema.parse(config)
+      expect(parsed.extension_directories).toEqual(['extensions/**'])
+    })
+
+    test('extension_directories is not transformed if it doesnt end with a wildcard', () => {
+      const config = {
+        ...CORRECT_CURRENT_APP_SCHEMA,
+        extension_directories: ['extensions'],
+      }
+      const parsed = AppSchema.parse(config)
+      expect(parsed.extension_directories).toEqual(['extensions'])
     })
   })
 })

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -30,6 +30,7 @@ const CORRECT_CURRENT_APP_SCHEMA: CurrentAppConfiguration = {
   path: '',
   name: 'app 1',
   client_id: '12345',
+  extension_directories: ['extensions/*'],
   webhooks: {
     api_version: '2023-04',
     privacy_compliance: {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -59,7 +59,8 @@ function removeTrailingPathSeparator(value: string[] | undefined) {
 // If a path ends with a single asterisk, modify it to end with a double asterisk.
 // This is to support the glob pattern used by chokidar and watch for changes in subfolders.
 function fixSingleWildcards(value: string[] | undefined) {
-  return value?.map((dir) => dir.replace(/\*$/, '**'))
+  // eslint-disable-next-line no-useless-escape
+  return value?.map((dir) => dir.replace(/([^\*])\*$/, '$1**'))
 }
 
 /**

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -23,6 +23,12 @@ import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
 
 // Schemas for loading app configuration
 
+const ExtensionDirectoriesSchema = zod
+  .array(zod.string())
+  .optional()
+  .transform(removeTrailingPathSeparator)
+  .transform(fixSingleWildcards)
+
 /**
  * Schema for a freshly minted app template.
  */
@@ -34,7 +40,7 @@ export const LegacyAppSchema = zod
       .string()
       .transform((scopes) => normalizeDelimitedString(scopes) ?? '')
       .default(''),
-    extension_directories: zod.array(zod.string()).optional().transform(removeTrailingPathSeparator),
+    extension_directories: ExtensionDirectoriesSchema,
     web_directories: zod.array(zod.string()).optional(),
     webhooks: zod
       .object({
@@ -49,6 +55,13 @@ function removeTrailingPathSeparator(value: string[] | undefined) {
   // eslint-disable-next-line no-useless-escape
   return value?.map((dir) => dir.replace(/[\/\\]+$/, ''))
 }
+
+// If a path ends with a single asterisk, modify it to end with a double asterisk.
+// This is to support the glob pattern used by chokidar and watch for changes in subfolders.
+function fixSingleWildcards(value: string[] | undefined) {
+  return value?.map((dir) => dir.replace(/\*$/, '**'))
+}
+
 /**
  * Schema for a normal, linked app. Properties from modules are not validated.
  */
@@ -62,7 +75,7 @@ export const AppSchema = zod.object({
       include_config_on_deploy: zod.boolean().optional(),
     })
     .optional(),
-  extension_directories: zod.array(zod.string()).optional().transform(removeTrailingPathSeparator),
+  extension_directories: ExtensionDirectoriesSchema,
   web_directories: zod.array(zod.string()).optional(),
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the handling of custom extension directory paths in app configuration by ensuring proper glob pattern support for watching changes in subfolders.

### WHAT is this pull request doing?

Adds functionality to automatically convert single asterisk wildcards (`*`) to double asterisks (`**`) in extension directory paths. This ensures proper recursive watching of subdirectories when using chokidar for file watching during `dev`.

### How to test your changes?

1. Create an app with and put some extensions in a folder called `custom_extensions`
2. Ensure your app.toml has `extension_directories = ['custom_extensions/*']`
2. Run `dev`
3. Verify that changes in extension files are properly detected and HMR works.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes