### PR TITLE
Add support for Metafields to webhooks

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -428,6 +428,7 @@ export async function testSingleWebhookSubscriptionExtension({
     topic,
     api_version: '2024-01',
     uri: 'https://my-app.com/webhooks',
+    metafields: [{namespace: 'custom', key: 'test'}],
   },
 }: {
   emptyConfig?: boolean

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook.test.ts
@@ -1,6 +1,9 @@
 import spec from './app_config_webhook.js'
+import {webhookValidator} from './validation/app_config_webhook.js'
+import {WebhookSubscriptionSchema} from './app_config_webhook_schemas/webhook_subscription_schema.js'
 import {placeholderAppConfiguration} from '../../app/app.test-data.js'
 import {describe, expect, test} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
 
 describe('webhooks', () => {
   describe('transform', () => {
@@ -59,6 +62,218 @@ describe('webhooks', () => {
           api_version: '2024-01',
         },
       })
+    })
+  })
+
+  describe('validation', () => {
+    interface TestWebhookConfig {
+      api_version: string
+      subscriptions: unknown[]
+    }
+
+    function validateWebhooks(webhookConfig: TestWebhookConfig) {
+      const ctx = {
+        addIssue: (issue: zod.ZodIssue) => {
+          throw new Error(issue.message)
+        },
+        path: [],
+      } as zod.RefinementCtx
+
+      // First validate the schema for each subscription
+      for (const subscription of webhookConfig.subscriptions) {
+        const schemaResult = WebhookSubscriptionSchema.safeParse(subscription)
+        if (!schemaResult.success) {
+          return {
+            success: false,
+            error: new Error(schemaResult.error.issues[0]?.message ?? 'Invalid webhook subscription'),
+          }
+        }
+      }
+
+      // Then validate business rules
+      try {
+        webhookValidator(webhookConfig, ctx)
+        return {success: true, error: undefined}
+      } catch (error) {
+        if (error instanceof Error) {
+          return {success: false, error}
+        }
+        throw error
+      }
+    }
+
+    test('allows metafields when API version is 2025-04', () => {
+      // Given
+      const webhookConfig: TestWebhookConfig = {
+        api_version: '2025-04',
+        subscriptions: [
+          {
+            topics: ['orders/create'],
+            uri: 'https://example.com/webhooks',
+            metafields: [{namespace: 'custom', key: 'test'}],
+          },
+        ],
+      }
+
+      // When
+      const result = validateWebhooks(webhookConfig)
+
+      // Then
+      expect(result.success).toBe(true)
+    })
+
+    test('allows metafields when API version is unstable', () => {
+      // Given
+      const webhookConfig: TestWebhookConfig = {
+        api_version: 'unstable',
+        subscriptions: [
+          {
+            topics: ['orders/create'],
+            uri: 'https://example.com/webhooks',
+            metafields: [{namespace: 'custom', key: 'test'}],
+          },
+        ],
+      }
+
+      // When
+      const result = validateWebhooks(webhookConfig)
+
+      // Then
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects metafields when API version is earlier than 2025-04', () => {
+      // Given
+      const webhookConfig: TestWebhookConfig = {
+        api_version: '2024-01',
+        subscriptions: [
+          {
+            topics: ['orders/create'],
+            uri: 'https://example.com/webhooks',
+            metafields: [{namespace: 'custom', key: 'test'}],
+          },
+        ],
+      }
+
+      // When
+      const result = validateWebhooks(webhookConfig)
+
+      // Then
+      expect(result.success).toBe(false)
+      expect(result.error?.message).toBe(
+        'Webhook metafields are only supported in API version 2025-04 or later, or with version "unstable"',
+      )
+    })
+
+    test('validates metafields namespace and key are strings', () => {
+      // Given
+      const webhookConfig: TestWebhookConfig = {
+        api_version: '2025-04',
+        subscriptions: [
+          {
+            topics: ['orders/create'],
+            uri: 'https://example.com/webhooks',
+            metafields: [{namespace: 123, key: 'test'}],
+          },
+        ],
+      }
+
+      // When
+      const result = validateWebhooks(webhookConfig)
+
+      // Then
+      expect(result.success).toBe(false)
+      expect(result.error?.message).toBe('Metafield namespace must be a string')
+    })
+
+    test('allows configuration without metafields in older API versions', () => {
+      // Given
+      const webhookConfig: TestWebhookConfig = {
+        api_version: '2024-01',
+        subscriptions: [
+          {
+            topics: ['orders/create'],
+            uri: 'https://example.com/webhooks',
+          },
+        ],
+      }
+
+      // When
+      const result = validateWebhooks(webhookConfig)
+
+      // Then
+      expect(result.success).toBe(true)
+    })
+
+    test('allows empty metafields array in supported API versions', () => {
+      // Given
+      const webhookConfig: TestWebhookConfig = {
+        api_version: '2025-04',
+        subscriptions: [
+          {
+            topics: ['orders/create'],
+            uri: 'https://example.com/webhooks',
+            metafields: [],
+          },
+        ],
+      }
+
+      // When
+      const result = validateWebhooks(webhookConfig)
+
+      // Then
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects metafields with invalid property types', () => {
+      // Given
+      const webhookConfig: TestWebhookConfig = {
+        api_version: '2025-04',
+        subscriptions: [
+          {
+            topics: ['orders/create'],
+            uri: 'https://example.com/webhooks',
+            metafields: [
+              {
+                namespace: 123,
+                key: 'valid',
+              },
+            ],
+          },
+        ],
+      }
+
+      // When
+      const result = validateWebhooks(webhookConfig)
+
+      // Then
+      expect(result.success).toBe(false)
+      expect(result.error?.message).toBe('Metafield namespace must be a string')
+    })
+
+    test('rejects malformed metafields missing a required property', () => {
+      // Given
+      const webhookConfig: TestWebhookConfig = {
+        api_version: '2025-04',
+        subscriptions: [
+          {
+            topics: ['orders/create'],
+            uri: 'https://example.com/webhooks',
+            metafields: [
+              {
+                namespace: 'custom',
+              },
+            ],
+          },
+        ],
+      }
+
+      // When
+      const result = validateWebhooks(webhookConfig)
+
+      // Then
+      expect(result.success).toBe(false)
+      expect(result.error?.message).toBe('Required')
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
@@ -18,6 +18,15 @@ export const WebhookSubscriptionSchema = zod.object({
   }),
   include_fields: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
   filter: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
+  metafields: zod
+    .array(
+      zod.object({
+        namespace: zod.string({invalid_type_error: 'Metafield namespace must be a string'}),
+        key: zod.string({invalid_type_error: 'Metafield key must be a string'}),
+      }),
+      {invalid_type_error: 'Metafields must be an array of objects with namespace and key'},
+    )
+    .optional(),
   compliance_topics: zod
     .array(
       zod.enum([ComplianceTopic.CustomersRedact, ComplianceTopic.CustomersDataRequest, ComplianceTopic.ShopRedact]),

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.test.ts
@@ -1,4 +1,5 @@
 import spec from './app_config_webhook_subscription.js'
+import {WebhookSubscriptionSchema} from './app_config_webhook_schemas/webhook_subscription_schema.js'
 import {AppConfigurationWithoutPath} from '../../app/app.js'
 import {describe, expect, test} from 'vitest'
 
@@ -32,6 +33,40 @@ describe('webhook_subscription', () => {
         },
       })
     })
+
+    test('should preserve metafields during transformation', () => {
+      // Given
+      const object = {
+        api_version: '2025-04',
+        topic: 'orders/create',
+        uri: 'https://example.com/webhooks',
+        metafields: [
+          {namespace: 'custom', key: 'test1'},
+          {namespace: 'app', key: 'test2'},
+        ],
+      }
+
+      const webhookSpec = spec
+
+      // When
+      const result = webhookSpec.transformRemoteToLocal!(object)
+
+      // Then
+      expect(result).toMatchObject({
+        webhooks: {
+          subscriptions: [
+            {
+              topics: ['orders/create'],
+              uri: 'https://example.com/webhooks',
+              metafields: [
+                {namespace: 'custom', key: 'test1'},
+                {namespace: 'app', key: 'test2'},
+              ],
+            },
+          ],
+        },
+      })
+    })
   })
 
   describe('forwardTransform', () => {
@@ -51,6 +86,149 @@ describe('webhook_subscription', () => {
         uri: 'https://my-app-url.com/products',
         topics: ['products/create'],
       })
+    })
+
+    test('should preserve metafields during forward transformation', () => {
+      const object = {
+        topics: ['orders/create'],
+        uri: 'https://example.com/webhooks',
+        metafields: [
+          {namespace: 'custom', key: 'test1'},
+          {namespace: 'app', key: 'test2'},
+        ],
+      }
+
+      const webhookSpec = spec
+
+      const result = webhookSpec.transformLocalToRemote!(object, {
+        application_url: 'https://my-app-url.com/',
+      } as unknown as AppConfigurationWithoutPath)
+
+      expect(result).toEqual({
+        uri: 'https://example.com/webhooks',
+        topics: ['orders/create'],
+        metafields: [
+          {namespace: 'custom', key: 'test1'},
+          {namespace: 'app', key: 'test2'},
+        ],
+      })
+    })
+  })
+
+  describe('metafields validation', () => {
+    test('transforms metafields correctly in local to remote', () => {
+      // Given
+      const object = {
+        topics: ['products/create'],
+        uri: '/products',
+        metafields: [
+          {
+            namespace: 'custom',
+            key: 'test',
+          },
+        ],
+      }
+
+      const webhookSpec = spec
+
+      // When
+      const result = webhookSpec.transformLocalToRemote!(object, {
+        application_url: 'https://my-app-url.com/',
+      } as unknown as AppConfigurationWithoutPath)
+
+      // Then
+      expect(result).toEqual({
+        uri: 'https://my-app-url.com/products',
+        topics: ['products/create'],
+        metafields: [
+          {
+            namespace: 'custom',
+            key: 'test',
+          },
+        ],
+      })
+    })
+
+    test('preserves metafields in remote to local transform', () => {
+      // Given
+      const object = {
+        topic: 'products/create',
+        uri: 'https://my-app-url.com/products',
+        metafields: [
+          {
+            namespace: 'custom',
+            key: 'test',
+          },
+        ],
+      }
+
+      const webhookSpec = spec
+
+      // When
+      const result = webhookSpec.transformRemoteToLocal!(object)
+
+      // Then
+      expect(result).toMatchObject({
+        webhooks: {
+          subscriptions: [
+            {
+              topics: ['products/create'],
+              uri: 'https://my-app-url.com/products',
+              metafields: [
+                {
+                  namespace: 'custom',
+                  key: 'test',
+                },
+              ],
+            },
+          ],
+        },
+      })
+    })
+
+    test('rejects metafields with invalid property types', () => {
+      // Given
+      const object = {
+        topics: ['products/create'],
+        uri: '/products',
+        metafields: [
+          {
+            namespace: 123,
+            key: 'valid',
+          },
+        ],
+      }
+
+      // When
+      const result = WebhookSubscriptionSchema.safeParse(object)
+
+      // Then
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe('Metafield namespace must be a string')
+      }
+    })
+
+    test('rejects metafields with missing a required property', () => {
+      // Given
+      const object = {
+        topics: ['products/create'],
+        uri: '/products',
+        metafields: [
+          {
+            namespace: 'custom',
+          },
+        ],
+      }
+
+      // When
+      const result = WebhookSubscriptionSchema.safeParse(object)
+
+      // Then
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toMatch(/Required/)
+      }
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
@@ -13,6 +13,10 @@ interface TransformedWebhookSubscription {
   compliance_topics?: string[]
   include_fields?: string[]
   filter?: string
+  metafields?: {
+    namespace: string
+    key: string
+  }[]
 }
 
 export const SingleWebhookSubscriptionSchema = zod.object({
@@ -23,6 +27,15 @@ export const SingleWebhookSubscriptionSchema = zod.object({
   }),
   include_fields: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
   filter: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
+  metafields: zod
+    .array(
+      zod.object({
+        namespace: zod.string({invalid_type_error: 'Metafield namespace must be a string'}),
+        key: zod.string({invalid_type_error: 'Metafield key must be a string'}),
+      }),
+      {invalid_type_error: 'Metafields must be an array of objects with namespace and key'},
+    )
+    .optional(),
 })
 
 /* this transforms webhooks remotely to be accepted by the TOML

--- a/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
@@ -4,6 +4,10 @@ export interface WebhookSubscription {
   compliance_topics?: string[]
   include_fields?: string[]
   filter?: string
+  metafields?: {
+    namespace: string
+    key: string
+  }[]
 }
 
 interface PrivacyComplianceConfig {


### PR DESCRIPTION
### WHY are these changes introduced?

Add support for metafield identifiers in declarative webhook subscriptions, allowing apps to obtain metafields in their webhook payloads for their subscriptions. Core support was added [here](https://github.com/Shopify/shopify/pull/565800), documentation is added [here](https://github.com/Shopify/shopify-app-js/pull/1956), this adds cli support.

Applicable CLI support is being added [here](https://github.com/Shopify/cli/pull/5167)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
