### PR TITLE
[Fix] Skip UID update when in unsafe report mode

### DIFF
--- a/packages/app/src/cli/services/app-context.test.ts
+++ b/packages/app/src/cli/services/app-context.test.ts
@@ -1,5 +1,6 @@
 import {linkedAppContext} from './app-context.js'
 import {fetchSpecifications} from './generate/fetch-extension-specifications.js'
+import {addUidToTomlsIfNecessary} from './app/add-uid-to-extension-toml.js'
 import link from './app/config/link.js'
 import {appFromIdentifiers} from './context.js'
 
@@ -259,6 +260,7 @@ describe('linkedAppContext', () => {
       })
 
       // Then
+      expect(vi.mocked(addUidToTomlsIfNecessary)).not.toHaveBeenCalled()
       expect(loadSpy).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({mode: 'report'}))
       loadSpy.mockRestore()
     })
@@ -280,6 +282,7 @@ describe('linkedAppContext', () => {
       })
 
       // Then
+      expect(vi.mocked(addUidToTomlsIfNecessary)).toHaveBeenCalled()
       expect(loadSpy).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({mode: 'strict'}))
       loadSpy.mockRestore()
     })

--- a/packages/app/src/cli/services/app-context.ts
+++ b/packages/app/src/cli/services/app-context.ts
@@ -101,7 +101,12 @@ export async function linkedAppContext({
   await logMetadata(remoteApp, organization, forceRelink)
 
   // Add UIDs to extension TOML files if using app-management.
-  await addUidToTomlsIfNecessary(localApp.allExtensions, developerPlatformClient)
+  // If in unsafe report mode, it is possible the UIDs are not loaded in memory
+  // even if they are present in the file, so we can't be sure whether or not
+  // it's necessary.
+  if (!unsafeReportMode) {
+    await addUidToTomlsIfNecessary(localApp.allExtensions, developerPlatformClient)
+  }
 
   return {app: localApp, remoteApp, developerPlatformClient, specifications, organization}
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

When we run `app info` on an app with an invalid extension TOML:

1. The TOML loading fails, but is in unsafe report mode so execution can continue
2. We replace the config with a default empty object [here](https://github.com/Shopify/cli/blob/3a87534b82e20b7ad9398a0fcc19673f2546dabe/packages/app/src/cli/models/app/loader.ts#L167)
3. Our code thinks there's no UID
4. It inserts a second UID into the file, making it invalid 🤦 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Skips the UID update when in unsafe report mode, as:

1. We haven't built sufficient confidence that it is correct to update
2. We probably shouldn't edit files on `app info` anyway!

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

1. Create an app with an extension and change a type (e.g. string to number) in the `shopify.extension.toml` file
2. Run `shopify app info` twice.

On the second time (on `main`), it will fail with a double UID error. But on this branch, if you start with a clean file, you can run it many times and not hit this issue.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
