### PR TITLE
Hide all banners that tell you to change app URL 

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -277,7 +277,7 @@ async function handleUpdatingOfPartnerUrls(
       // When running dev app urls are pushed directly to API Client config instead of creating a new app version
       // so current app version and API Client config will have diferent url values.
       if (shouldUpdateURLs) await updateURLs(newURLs, apiKey, developerPlatformClient, localApp)
-      await outputUpdateURLsResult(shouldUpdateURLs, newURLs, remoteApp, localApp)
+      await outputUpdateURLsResult(shouldUpdateURLs, newURLs, remoteApp, localApp, developerPlatformClient)
     }
   }
   return shouldUpdateURLs

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -18,7 +18,7 @@ import {fetchAppPreviewMode} from './dev/fetch.js'
 import {installAppDependencies} from './dependencies.js'
 import {DevConfig, DevProcesses, setupDevProcesses} from './dev/processes/setup-dev-processes.js'
 import {frontAndBackendConfig} from './dev/processes/utils.js'
-import {outputUpdateURLsResult, renderDev} from './dev/ui.js'
+import {renderDev} from './dev/ui.js'
 import {DeveloperPreviewController} from './dev/ui/components/Dev.js'
 import {DevProcessFunction} from './dev/processes/types.js'
 import {getCachedAppInfo, setCachedAppInfo} from './local-storage.js'
@@ -264,7 +264,7 @@ async function handleUpdatingOfPartnerUrls(
       const newURLs = generatePartnersURLs(
         network.proxyUrl,
         webs.map(({configuration}) => configuration.auth_callback_path).find((path) => path),
-        isCurrentAppSchema(localApp.configuration) ? localApp.configuration.app_proxy : undefined,
+        localApp.configuration.app_proxy,
       )
       shouldUpdateURLs = await shouldOrPromptUpdateURLs({
         currentURLs: network.currentUrls,
@@ -277,7 +277,6 @@ async function handleUpdatingOfPartnerUrls(
       // When running dev app urls are pushed directly to API Client config instead of creating a new app version
       // so current app version and API Client config will have diferent url values.
       if (shouldUpdateURLs) await updateURLs(newURLs, apiKey, developerPlatformClient, localApp)
-      await outputUpdateURLsResult(shouldUpdateURLs, newURLs, remoteApp, localApp, developerPlatformClient)
     }
   }
   return shouldUpdateURLs

--- a/packages/app/src/cli/services/dev/ui.test.tsx
+++ b/packages/app/src/cli/services/dev/ui.test.tsx
@@ -1,10 +1,9 @@
-import {outputUpdateURLsResult, renderDev} from './ui.js'
+import {renderDev} from './ui.js'
 import {Dev} from './ui/components/Dev.js'
 import {
   testApp,
   testDeveloperPlatformClient,
   testFunctionExtension,
-  testOrganizationApp,
   testThemeExtensions,
   testUIExtension,
 } from '../../models/app/app.test-data.js'
@@ -30,107 +29,6 @@ const developerPlatformClient = testDeveloperPlatformClient()
 
 afterEach(() => {
   mockAndCaptureOutput().clear()
-})
-
-describe('output', () => {
-  describe('outputUpdateURLsResult', () => {
-    const urls = {
-      applicationUrl: 'https://lala.cloudflare.io/',
-      redirectUrlWhitelist: ['https://lala.cloudflare.io/auth/callback'],
-    }
-
-    test('shows info about tunnel URL and links to Partners Dashboard when app is brand new', async () => {
-      // Given
-      const outputMock = mockAndCaptureOutput()
-      const localApp = await mockApp()
-
-      const remoteApp = testOrganizationApp({newApp: true})
-
-      // When
-      await outputUpdateURLsResult(true, urls, remoteApp, localApp)
-
-      // Then
-      expect(outputMock.output()).toMatchInlineSnapshot(`
-        "╭─ info ───────────────────────────────────────────────────────────────────────╮
-        │                                                                              │
-        │  For your convenience, we've given your app a default URL:                   │
-        │  https://lala.cloudflare.io/.                                                │
-        │                                                                              │
-        │  You can update your app's URL anytime in the Partners Dashboard [1] But     │
-        │  once your app is live, updating its URL will disrupt user access.           │
-        │                                                                              │
-        ╰──────────────────────────────────────────────────────────────────────────────╯
-        [1] https://partners.shopify.com/1/apps/1/edit
-        "
-      `)
-    })
-
-    test('shows nothing when urls were updated', async () => {
-      // Given
-      const outputMock = mockAndCaptureOutput()
-      const localApp = await mockApp()
-
-      const remoteApp = testOrganizationApp({newApp: false})
-
-      // When
-      await outputUpdateURLsResult(true, urls, remoteApp, localApp)
-
-      // Then
-      expect(outputMock.output()).toEqual('')
-    })
-
-    test('shows how to update app urls on partners when app is not brand new, urls were not updated and app uses legacy config', async () => {
-      // Given
-      const outputMock = mockAndCaptureOutput()
-      const localApp = await mockApp()
-
-      const remoteApp = testOrganizationApp({newApp: false})
-
-      // When
-      await outputUpdateURLsResult(false, urls, remoteApp, localApp)
-
-      // Then
-      expect(outputMock.output()).toMatchInlineSnapshot(`
-        "╭─ info ───────────────────────────────────────────────────────────────────────╮
-        │                                                                              │
-        │  To make URL updates manually, you can add the following URLs as redirects   │
-        │  in your Partners Dashboard [1]:                                             │
-        │                                                                              │
-        │                                                                              │
-        │    • https://lala.cloudflare.io/auth/callback                                │
-        │                                                                              │
-        ╰──────────────────────────────────────────────────────────────────────────────╯
-        [1] https://partners.shopify.com/1/apps/1/edit
-        "
-      `)
-    })
-
-    test('shows how to update app urls with config push when app is not brand new, urls were updated and app uses new config', async () => {
-      // Given
-      const outputMock = mockAndCaptureOutput()
-      const localApp = await mockApp(true)
-
-      const remoteApp = testOrganizationApp({newApp: false})
-
-      // When
-      await outputUpdateURLsResult(false, urls, remoteApp, localApp)
-
-      // Then
-      expect(outputMock.output()).toMatchInlineSnapshot(`
-        "╭─ info ───────────────────────────────────────────────────────────────────────╮
-        │                                                                              │
-        │  To update URLs manually, add the following URLs to                          │
-        │  shopify.app.staging.toml under auth > redirect_urls and run                 │
-        │   \`yarn shopify app config push --config=staging\`                            │
-        │                                                                              │
-        │                                                                              │
-        │    • https://lala.cloudflare.io/auth/callback                                │
-        │                                                                              │
-        ╰──────────────────────────────────────────────────────────────────────────────╯
-        "
-      `)
-    })
-  })
 })
 
 describe('ui', () => {

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -1,69 +1,9 @@
-import {PartnersURLs} from './urls.js'
 import {Dev, DevProps} from './ui/components/Dev.js'
-import {AppInterface, isCurrentAppSchema} from '../../models/app/app.js'
-import {OrganizationApp} from '../../models/organization.js'
-import {getAppConfigurationShorthand} from '../../models/app/loader.js'
-import {ClientName, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import React from 'react'
-import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {render, renderInfo} from '@shopify/cli-kit/node/ui'
-import {basename} from '@shopify/cli-kit/node/path'
-import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+import {render} from '@shopify/cli-kit/node/ui'
 import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
-
-export async function outputUpdateURLsResult(
-  updated: boolean,
-  urls: PartnersURLs,
-  remoteApp: OrganizationApp,
-  localApp: AppInterface,
-  developerPlatformClient?: DeveloperPlatformClient,
-) {
-  const usingAppManagementClient = developerPlatformClient?.clientName === ClientName.AppManagement
-  const dashboardURL = await partnersURL(remoteApp.organizationId, remoteApp.id)
-  if (remoteApp.newApp && !usingAppManagementClient) {
-    renderInfo({
-      headline: `For your convenience, we've given your app a default URL: ${urls.applicationUrl}.`,
-      body: [
-        "You can update your app's URL anytime in the",
-        dashboardURL,
-        'But once your app is live, updating its URL will disrupt user access.',
-      ],
-    })
-  } else if (!updated) {
-    if (isCurrentAppSchema(localApp.configuration)) {
-      const fileName = basename(localApp.configuration.path)
-      const configName = getAppConfigurationShorthand(fileName)
-      const pushCommandArgs = configName ? [`--config=${configName}`] : []
-
-      renderInfo({
-        body: [
-          `To update URLs manually, add the following URLs to ${fileName} under auth > redirect_urls and run\n`,
-          {
-            command: formatPackageManagerCommand(
-              localApp.packageManager,
-              `shopify app config push`,
-              ...pushCommandArgs,
-            ),
-          },
-          '\n\n',
-          {list: {items: urls.redirectUrlWhitelist}},
-        ],
-      })
-    } else {
-      renderInfo({
-        body: [
-          'To make URL updates manually, you can add the following URLs as redirects in your',
-          dashboardURL,
-          {char: ':'},
-          '\n\n',
-          {list: {items: urls.redirectUrlWhitelist}},
-        ],
-      })
-    }
-  }
-}
 
 export async function renderDev({
   processes,
@@ -94,15 +34,6 @@ export async function renderDev({
     )
   } else {
     await renderDevNonInteractive({processes, app, abortController, developerPreview, shopFqdn})
-  }
-}
-
-async function partnersURL(organizationId: string, appId: string) {
-  return {
-    link: {
-      label: 'Partners Dashboard',
-      url: `https://${await partnersFqdn()}/${organizationId}/apps/${appId}/edit`,
-    },
   }
 }
 

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -3,6 +3,7 @@ import {Dev, DevProps} from './ui/components/Dev.js'
 import {AppInterface, isCurrentAppSchema} from '../../models/app/app.js'
 import {OrganizationApp} from '../../models/organization.js'
 import {getAppConfigurationShorthand} from '../../models/app/loader.js'
+import {ClientName, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import React from 'react'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {render, renderInfo} from '@shopify/cli-kit/node/ui'
@@ -17,9 +18,11 @@ export async function outputUpdateURLsResult(
   urls: PartnersURLs,
   remoteApp: OrganizationApp,
   localApp: AppInterface,
+  developerPlatformClient?: DeveloperPlatformClient,
 ) {
+  const usingAppManagementClient = developerPlatformClient?.clientName === ClientName.AppManagement
   const dashboardURL = await partnersURL(remoteApp.organizationId, remoteApp.id)
-  if (remoteApp.newApp) {
+  if (remoteApp.newApp && !usingAppManagementClient) {
     renderInfo({
       headline: `For your convenience, we've given your app a default URL: ${urls.applicationUrl}.`,
       body: [

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -16,6 +16,7 @@ import {
 import {UpdateURLsVariables} from '../../api/graphql/update_urls.js'
 import {setCachedAppInfo} from '../local-storage.js'
 import {patchAppConfigurationFile} from '../app/patch-app-configuration-file.js'
+import {AppLinkedInterface} from '../../models/app/app.js'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {checkPortAvailability, getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
@@ -314,7 +315,7 @@ describe('shouldOrPromptUpdateURLs', () => {
       currentURLs,
       appDirectory: '/path',
       apiKey: 'api-key',
-      localApp: testApp({configuration: {...DEFAULT_CONFIG, client_id: 'different'}}, 'current'),
+      localApp: testApp({configuration: {...DEFAULT_CONFIG, client_id: 'different'}}, 'current') as AppLinkedInterface,
     }
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
@@ -334,7 +335,7 @@ describe('shouldOrPromptUpdateURLs', () => {
       currentURLs,
       appDirectory: '/path',
       apiKey: 'api-key',
-      localApp,
+      localApp: localApp as AppLinkedInterface,
     }
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -1,10 +1,5 @@
 import {updateURLsPrompt} from '../../prompts/dev.js'
-import {
-  AppConfigurationInterface,
-  AppInterface,
-  CurrentAppConfiguration,
-  isCurrentAppSchema,
-} from '../../models/app/app.js'
+import {AppConfigurationInterface, AppLinkedInterface, CurrentAppConfiguration} from '../../models/app/app.js'
 import {UpdateURLsSchema, UpdateURLsVariables} from '../../api/graphql/update_urls.js'
 import {setCachedAppInfo} from '../local-storage.js'
 import {AppConfigurationUsedByCli} from '../../models/extensions/specifications/types/app_config.js'
@@ -202,7 +197,7 @@ export async function updateURLs(
     throw new AbortError(errors)
   }
 
-  if (localApp && isCurrentAppSchema(localApp.configuration) && localApp.configuration.client_id === apiKey) {
+  if (localApp && localApp.configuration.client_id === apiKey) {
     const patch = {
       application_url: urls.applicationUrl,
       auth: {
@@ -243,7 +238,7 @@ interface ShouldOrPromptUpdateURLsOptions {
   appDirectory: string
   cachedUpdateURLs?: boolean
   newApp?: boolean
-  localApp?: AppInterface
+  localApp?: AppLinkedInterface
   apiKey: string
 }
 
@@ -258,7 +253,7 @@ export async function shouldOrPromptUpdateURLs(options: ShouldOrPromptUpdateURLs
       options.currentURLs.redirectUrlWhitelist,
     )
 
-    if (options.localApp && isCurrentAppSchema(options.localApp.configuration)) {
+    if (options.localApp) {
       const localConfiguration = options.localApp.configuration
       localConfiguration.build = {
         ...localConfiguration.build,


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2348

Removes this app url change banner since it is no longer needed by Developer Dashboard apps or apps using consistent dev
<img width="861" alt="Screenshot 2025-01-08 at 2 45 41 PM" src="https://github.com/user-attachments/assets/d0ed4f44-5676-4642-8dd1-0a8a816e568c" />

Additionally, `isCurrentAppSchema` is always true now, so we remove some of the mentions of it from the files we are touching.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

**From within the CLI folder:**

**Try not using the App Management API first and confirm partners dashboard app url update banner doesn't show**
- Create an app `p shopify app init`
- Choose **a remix app** 
- `p shopify app dev --path ./name-of-your-app --reset`
- You should **not** see the app url banner saying you can change App URL on Partners.

**Now try using the App Management API and confirm partners dashboard app url update banner doesn't show**
- `USE_APP_MANAGEMENT_API=1 p shopify app dev --path ./name-of-your-app --reset`
  - This flag makes the CLI use the App Management API 
  - We are attempting to dev but with reset flag so you can choose the option '**create as new app**' from dropdown 
  - Choose creating a new app, and put it a new app name and create a new TOML file
  - <img width="356" alt="Screenshot 2025-01-08 at 2 45 12 PM" src="https://github.com/user-attachments/assets/73d3af07-c7f6-46c4-8955-193b8e20337a" />
  - You still shouldn't see any banner

**Confirm that the app config push banner is gone:**
- Confirm that in TOML you do not have `automatically_update_urls_on_dev` defined
-`USE_APP_MANAGEMENT_API=1 p shopify app dev --path ./name-of-your-app`
- When asked to update App URL's select no, never:
```
?  Have Shopify automatically update your app's URL in order to create a preview experience?
✔  No, never
```
- You should **not see** this banner
<img width="815" alt="Screenshot 2025-01-13 at 3 57 13 PM" src="https://github.com/user-attachments/assets/79a1040f-e423-4853-b93f-20237e3040d6" />

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
