### PR TITLE
Add `.shopify/metafields.json` to `.gitignore` by default

### DIFF
--- a/.changeset/mean-seas-hide.md
+++ b/.changeset/mean-seas-hide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+When the `.shopify/metafields.json` file gets created, the CLI now proposes to add it to `.gitignore` by default

--- a/packages/cli-kit/src/public/node/fs.test.ts
+++ b/packages/cli-kit/src/public/node/fs.test.ts
@@ -16,6 +16,7 @@ import {
   generateRandomNameForSubdirectory,
   readFileSync,
   glob,
+  detectEOL,
 } from './fs.js'
 import {joinPath} from './path.js'
 import {takeRandomFromArray} from '../common/array.js'
@@ -281,5 +282,40 @@ describe('glob', () => {
 
     // Then
     expect(FastGlob).toBeCalledWith('pattern', {dot: false})
+  })
+})
+
+describe('detectEOL', () => {
+  test('detects the EOL of a file', async () => {
+    // Given
+    const fileContent = 'test\ncontent'
+
+    // When
+    const eol = detectEOL(fileContent)
+
+    // Then
+    expect(eol).toEqual('\n')
+  })
+
+  test('detects the EOL of a file with CRLF', async () => {
+    // Given
+    const fileContent = 'test\r\ncontent'
+
+    // When
+    const eol = detectEOL(fileContent)
+
+    // Then
+    expect(eol).toEqual('\r\n')
+  })
+
+  test('returns the default EOL if no EOL is found', async () => {
+    // Given
+    const fileContent = 'testcontent'
+
+    // When
+    const eol = detectEOL(fileContent)
+
+    // Then
+    expect(eol).toEqual('\n')
   })
 })

--- a/packages/cli-kit/src/public/node/fs.test.ts
+++ b/packages/cli-kit/src/public/node/fs.test.ts
@@ -22,9 +22,11 @@ import {joinPath} from './path.js'
 import {takeRandomFromArray} from '../common/array.js'
 import {describe, expect, test, vi} from 'vitest'
 import FastGlob from 'fast-glob'
+import * as os from 'os'
 
 vi.mock('../common/array.js')
 vi.mock('fast-glob')
+vi.mock('os')
 
 describe('inTemporaryDirectory', () => {
   test('ties the lifecycle of the temporary directory to the lifecycle of the callback', async () => {
@@ -311,6 +313,7 @@ describe('detectEOL', () => {
   test('returns the default EOL if no EOL is found', async () => {
     // Given
     const fileContent = 'testcontent'
+    vi.mocked(os).EOL = '\n'
 
     // When
     const eol = detectEOL(fileContent)

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -514,6 +514,17 @@ export async function glob(pattern: Pattern | Pattern[], options?: GlobOptions):
 export function pathToFileURL(path: string): URL {
   return pathToFile(path)
 }
+
+/**
+ * Returns the operating system's end-of-line marker.
+ * On POSIX systems this is `\n`, on Windows this is `\r\n`.
+ *
+ * @returns The platform-specific EOL string.
+ */
+export function eol(): string {
+  return os.EOL
+}
+
 /**
  * Find a file by walking parent directories.
  *

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -516,13 +516,39 @@ export function pathToFileURL(path: string): URL {
 }
 
 /**
- * Returns the operating system's end-of-line marker.
- * On POSIX systems this is `\n`, on Windows this is `\r\n`.
- *
- * @returns The platform-specific EOL string.
+ * The operating system-specific end-of-line marker:
+ * - `\n` on POSIX
+ * - `\r\n` on Windows
  */
-export function eol(): string {
-  return os.EOL
+export type EOL = '\r\n' | '\n'
+
+/**
+ * Detects the end-of-line marker used in a string.
+ *
+ * @param content - file contents to analyze
+ *
+ * @returns The detected end-of-line marker
+ */
+export function detectEOL(content: string): EOL {
+  const match = content.match(/\r\n|\n/g)
+
+  if (!match) {
+    return defaultEOL()
+  }
+
+  const crlf = match.filter((eol) => eol === '\r\n').length
+  const lf = match.filter((eol) => eol === '\n').length
+
+  return crlf > lf ? '\r\n' : '\n'
+}
+
+/**
+ * Returns the operating system's end-of-line marker.
+ *
+ * @returns The OS-specific end-of-line marker
+ */
+export function defaultEOL(): EOL {
+  return os.EOL as EOL
 }
 
 /**

--- a/packages/theme/src/cli/services/metafields-pull.test.ts
+++ b/packages/theme/src/cli/services/metafields-pull.test.ts
@@ -6,7 +6,7 @@ import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/ses
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {metafieldDefinitionsByOwnerType} from '@shopify/cli-kit/node/themes/api'
 import {describe, test, vi, beforeEach, expect, afterEach} from 'vitest'
-import {fileExists, inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {eol, fileExists, inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
 
 vi.mock('../utilities/theme-store.js')
 vi.mock('../utilities/theme-ui.js')
@@ -85,9 +85,8 @@ describe('metafields-pull', () => {
 
   test('should add metafields to .gitignore', async () => {
     // Given
-    vi.mocked(metafieldDefinitionsByOwnerType).mockImplementation((type: any, _session: AdminSession) => {
-      if (type !== 'PRODUCT') return Promise.resolve([])
-      return Promise.resolve([fakeMetafieldDefinition])
+    vi.mocked(metafieldDefinitionsByOwnerType).mockImplementation(() => {
+      return Promise.resolve([])
     })
 
     await inTemporaryDirectory(async (tmpDir) => {
@@ -100,7 +99,7 @@ describe('metafields-pull', () => {
 
       // Then
       await expect(fileExists(gitIgnorePath)).resolves.toBe(true)
-      await expect(readFile(gitIgnorePath)).resolves.toBe('.DS_Store\n.shopify/metafields.json')
+      await expect(readFile(gitIgnorePath)).resolves.toBe(`.DS_Store${eol()}.shopify/metafields.json`)
     })
 
     expect(capturedOutput.info()).toContain('Metafield definitions have been successfully downloaded.')

--- a/packages/theme/src/cli/services/metafields-pull.test.ts
+++ b/packages/theme/src/cli/services/metafields-pull.test.ts
@@ -92,14 +92,14 @@ describe('metafields-pull', () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const gitIgnorePath = `${tmpDir}/.gitignore`
-      writeFileSync(gitIgnorePath, '.DS_Store')
+      writeFileSync(gitIgnorePath, '.DS_Store\n.shopify/secrets.json')
 
       // When
       await metafieldsPull({path: tmpDir})
 
       // Then
       await expect(fileExists(gitIgnorePath)).resolves.toBe(true)
-      await expect(readFile(gitIgnorePath)).resolves.toBe(`.DS_Store\n.shopify/metafields.json`)
+      await expect(readFile(gitIgnorePath)).resolves.toBe(`.DS_Store\n.shopify/secrets.json\n.shopify`)
     })
 
     expect(capturedOutput.info()).toContain('Metafield definitions have been successfully downloaded.')

--- a/packages/theme/src/cli/services/metafields-pull.test.ts
+++ b/packages/theme/src/cli/services/metafields-pull.test.ts
@@ -6,7 +6,7 @@ import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/ses
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {metafieldDefinitionsByOwnerType} from '@shopify/cli-kit/node/themes/api'
 import {describe, test, vi, beforeEach, expect, afterEach} from 'vitest'
-import {eol, fileExists, inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {fileExists, inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
 
 vi.mock('../utilities/theme-store.js')
 vi.mock('../utilities/theme-ui.js')
@@ -99,7 +99,7 @@ describe('metafields-pull', () => {
 
       // Then
       await expect(fileExists(gitIgnorePath)).resolves.toBe(true)
-      await expect(readFile(gitIgnorePath)).resolves.toBe(`.DS_Store${eol()}.shopify/metafields.json`)
+      await expect(readFile(gitIgnorePath)).resolves.toBe(`.DS_Store\n.shopify/metafields.json`)
     })
 
     expect(capturedOutput.info()).toContain('Metafield definitions have been successfully downloaded.')

--- a/packages/theme/src/cli/services/metafields-pull.ts
+++ b/packages/theme/src/cli/services/metafields-pull.ts
@@ -6,7 +6,7 @@ import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/ses
 import {cwd, joinPath} from '@shopify/cli-kit/node/path'
 import {metafieldDefinitionsByOwnerType} from '@shopify/cli-kit/node/themes/api'
 import {renderError, renderSuccess} from '@shopify/cli-kit/node/ui'
-import {eol, fileExistsSync, mkdirSync, readFileSync, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {detectEOL, fileExistsSync, mkdirSync, readFileSync, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 
 interface MetafieldsPullOptions {
@@ -185,5 +185,7 @@ function addToGitIgnore(root: string, entry: string) {
     return
   }
 
-  writeFileSync(gitIgnorePath, `${gitIgnoreContent}${eol()}${entry}`)
+  const eol = detectEOL(gitIgnoreContent.toString())
+
+  writeFileSync(gitIgnorePath, `${gitIgnoreContent}${eol}${entry}`)
 }

--- a/packages/theme/src/cli/services/metafields-pull.ts
+++ b/packages/theme/src/cli/services/metafields-pull.ts
@@ -6,7 +6,7 @@ import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/ses
 import {cwd, joinPath} from '@shopify/cli-kit/node/path'
 import {metafieldDefinitionsByOwnerType} from '@shopify/cli-kit/node/themes/api'
 import {renderError, renderSuccess} from '@shopify/cli-kit/node/ui'
-import {mkdirSync, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {fileExistsSync, mkdirSync, readFileSync, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 
 interface MetafieldsPullOptions {
@@ -161,5 +161,29 @@ function writeMetafieldDefinitionsToFile(path: string, content: unknown) {
   mkdirSync(shopifyDirectory)
 
   const filePath = joinPath(shopifyDirectory, 'metafields.json')
-  writeFileSync(filePath, JSON.stringify(content, null, 2))
+  const fileContent = JSON.stringify(content, null, 2)
+
+  if (!fileExistsSync(filePath)) {
+    addToGitIgnore(path, '.shopify/metafields.json')
+  }
+
+  writeFileSync(filePath, fileContent)
+}
+
+function addToGitIgnore(root: string, entry: string) {
+  const gitIgnorePath = joinPath(root, '.gitignore')
+
+  if (!fileExistsSync(gitIgnorePath)) {
+    // When the .gitignore file does not exist, the CLI should not be opinionated about creating it
+    return
+  }
+
+  const gitIgnoreContent = readFileSync(gitIgnorePath)
+
+  if (gitIgnoreContent.includes(entry)) {
+    // The file already existing in the .gitignore
+    return
+  }
+
+  writeFileSync(gitIgnorePath, `${gitIgnoreContent}\n${entry}`)
 }

--- a/packages/theme/src/cli/services/metafields-pull.ts
+++ b/packages/theme/src/cli/services/metafields-pull.ts
@@ -6,7 +6,7 @@ import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/ses
 import {cwd, joinPath} from '@shopify/cli-kit/node/path'
 import {metafieldDefinitionsByOwnerType} from '@shopify/cli-kit/node/themes/api'
 import {renderError, renderSuccess} from '@shopify/cli-kit/node/ui'
-import {fileExistsSync, mkdirSync, readFileSync, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {eol, fileExistsSync, mkdirSync, readFileSync, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 
 interface MetafieldsPullOptions {
@@ -185,5 +185,5 @@ function addToGitIgnore(root: string, entry: string) {
     return
   }
 
-  writeFileSync(gitIgnorePath, `${gitIgnoreContent}\n${entry}`)
+  writeFileSync(gitIgnorePath, `${gitIgnoreContent}${eol()}${entry}`)
 }

--- a/packages/theme/src/cli/services/metafields-pull.ts
+++ b/packages/theme/src/cli/services/metafields-pull.ts
@@ -164,7 +164,7 @@ function writeMetafieldDefinitionsToFile(path: string, content: unknown) {
   const fileContent = JSON.stringify(content, null, 2)
 
   if (!fileExistsSync(filePath)) {
-    addToGitIgnore(path, '.shopify/metafields.json')
+    addToGitIgnore(path, '.shopify')
   }
 
   writeFileSync(filePath, fileContent)
@@ -178,14 +178,13 @@ function addToGitIgnore(root: string, entry: string) {
     return
   }
 
-  const gitIgnoreContent = readFileSync(gitIgnorePath)
+  const gitIgnoreContent = readFileSync(gitIgnorePath).toString()
+  const eol = detectEOL(gitIgnoreContent)
 
-  if (gitIgnoreContent.includes(entry)) {
+  if (gitIgnoreContent.split(eol).includes(entry)) {
     // The file already existing in the .gitignore
     return
   }
-
-  const eol = detectEOL(gitIgnoreContent.toString())
 
   writeFileSync(gitIgnorePath, `${gitIgnoreContent}${eol}${entry}`)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5183

We've noticed a significant number of users discussing whether to ignore the `.shopify/metafields.json` file. While this decision ultimately rests with the developer, ignoring it by default seems like a sensible approach. This PR proposes implementing that default.

### WHAT is this pull request doing?

This PR updates the `.shopify/metafields.json` creation to also add it to `.gitignore`.

### How to test your changes?

- Run `shopify theme metafields pull`
- Notice that, when the .shopify/metafields.json file is created, it's also added in the gitingore

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes




