### PR TITLE
Rename bundle to bundle-for-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "type-check": "nx run-many --target=type-check --all --skip-nx-cache",
     "type-check:affected": "nx affected --target=type-check",
     "build": "nx run-many --target=build --all --skip-nx-cache",
-    "bundle": "nx run-many --target=bundle --all --skip-nx-cache",
+    "bundle-for-release": "nx run-many --target=bundle --all --skip-nx-cache",
     "build:affected": "nx affected --target=build",
     "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache",
     "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache && bin/prettify-manifests.js && pnpm refresh-readme",

--- a/shipit.nightly.yml
+++ b/shipit.nightly.yml
@@ -22,7 +22,7 @@ deploy:
     - bash -i -c "if [ -f '.changeset/pre.json' ]; then npm_config_loglevel=verbose pnpm changeset pre exit; fi"
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset version --snapshot nightly"
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset-manifests"
-    - bash -i -c "npm_config_loglevel=verbose NODE_ENV=production pnpm bundle"
+    - bash -i -c "npm_config_loglevel=verbose NODE_ENV=production pnpm bundle-for-release"
     - bash -i -c "npm_config_loglevel=verbose node bin/create-cli-duplicate-package.js"
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset publish --tag nightly"
     - bash -i -c "./bin/package.js"

--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -12,7 +12,7 @@ dependencies:
 deploy:
   override:
     - bash -i -c "npm_config_loglevel=verbose pnpm clean"
-    - bash -i -c "npm_config_loglevel=verbose NODE_ENV=production pnpm bundle"
+    - bash -i -c "npm_config_loglevel=verbose NODE_ENV=production pnpm bundle-for-release"
     - bash -i -c "npm_config_loglevel=verbose node bin/create-cli-duplicate-package.js"
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset publish"
     - bash -i -c "./bin/package.js"

--- a/shipit.stable.yml.sample
+++ b/shipit.stable.yml.sample
@@ -12,7 +12,7 @@ dependencies:
 deploy:
   override:
     - bash -i -c "npm_config_loglevel=verbose pnpm clean"
-    - bash -i -c "npm_config_loglevel=verbose NODE_ENV=production pnpm bundle"
+    - bash -i -c "npm_config_loglevel=verbose NODE_ENV=production pnpm bundle-for-release"
     - bash -i -c "npm_config_loglevel=verbose node bin/create-cli-duplicate-package.js"
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset publish"
     # When this is no longer the latest stable version, do 2 things:

--- a/shipit.stable_3_71.yml
+++ b/shipit.stable_3_71.yml
@@ -12,7 +12,7 @@ dependencies:
 deploy:
   override:
     - bash -i -c "npm_config_loglevel=verbose pnpm clean"
-    - bash -i -c "npm_config_loglevel=verbose NODE_ENV=production pnpm bundle"
+    - bash -i -c "npm_config_loglevel=verbose NODE_ENV=production pnpm bundle-for-release"
     - bash -i -c "npm_config_loglevel=verbose node bin/create-cli-duplicate-package.js"
     - bash -i -c "npm_config_loglevel=verbose pnpm changeset publish"
     # When this is no longer the latest stable version, do 2 things:


### PR DESCRIPTION
### WHY are these changes introduced?

To prevent people from running `pnpm bundle` locally, which might break their CLI dev environment.

### WHAT is this pull request doing?

Renames the `bundle` script to `bundle-for-release` in package.json and updates all shipit configuration files to use the new script name. This change makes it more explicit that this bundling step is specifically for the release process and should not be used locally.

### How to test your changes?

1. Run `pnpm bundle-for-release` to verify the renamed script works as expected
2. Verify that the nightly/snapshot build process completes successfully

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact