### PR TITLE
Create app with latest api version

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -75,7 +75,6 @@ import {
 import {ListOrganizations} from '../../api/graphql/business-platform-destinations/generated/organizations.js'
 import {AppHomeSpecIdentifier} from '../../models/extensions/specifications/app_config_app_home.js'
 import {BrandingSpecIdentifier} from '../../models/extensions/specifications/app_config_branding.js'
-import {WebhooksSpecIdentifier} from '../../models/extensions/specifications/app_config_webhook.js'
 import {AppAccessSpecIdentifier} from '../../models/extensions/specifications/app_config_app_access.js'
 import {CONFIG_EXTENSION_IDS} from '../../models/extensions/extension-instance.js'
 import {DevSessionCreate, DevSessionCreateMutation} from '../../api/graphql/app-dev/generated/dev-session-create.js'
@@ -117,6 +116,7 @@ import {
   SchemaDefinitionByApiTypeQuery,
   SchemaDefinitionByApiTypeQueryVariables,
 } from '../../api/graphql/functions/generated/schema-definition-by-api-type.js'
+import {WebhooksSpecIdentifier} from '../../models/extensions/specifications/app_config_webhook.js'
 import {ensureAuthenticatedAppManagement, ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
@@ -369,7 +369,15 @@ export class AppManagementClient implements DeveloperPlatformClient {
       directory?: string
     },
   ): Promise<OrganizationApp> {
-    const variables = createAppVars(name, options?.isLaunchable, options?.scopesArray)
+    // Query for latest api version
+    const apiVersions = await this.apiVersions(org.id)
+    const apiVersion =
+      apiVersions.publicApiVersions
+        .filter((version) => version !== 'unstable')
+        .sort()
+        .at(-1) ?? 'unstable'
+
+    const variables = createAppVars(name, options?.isLaunchable, options?.scopesArray, apiVersion)
 
     const mutation = CreateApp
     const result = await appManagementRequestDoc(org.id, mutation, await this.token(), variables)
@@ -909,7 +917,12 @@ export class AppManagementClient implements DeveloperPlatformClient {
 const MAGIC_URL = 'https://shopify.dev/apps/default-app-home'
 const MAGIC_REDIRECT_URL = 'https://shopify.dev/apps/default-app-home/api/auth'
 
-function createAppVars(name: string, isLaunchable = true, scopesArray?: string[]): CreateAppMutationVariables {
+function createAppVars(
+  name: string,
+  isLaunchable = true,
+  scopesArray?: string[],
+  apiVersion?: string,
+): CreateAppMutationVariables {
   return {
     appSource: {
       appModules: [
@@ -932,7 +945,7 @@ function createAppVars(name: string, isLaunchable = true, scopesArray?: string[]
           // Change the uid to WebhooksSpecIdentifier
           uid: 'webhooks',
           specificationIdentifier: WebhooksSpecIdentifier,
-          config: {api_version: '2024-01'},
+          config: {api_version: apiVersion},
         },
         {
           // Change the uid to AppAccessSpecIdentifier


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2468

Creating an app with `USE_APP_MANAGEMENT_API=1 shopify app init` and then deploying the app fails because the default webhooks that come in the template require the `2025-01` webhooks api version.

<img width="626" alt="Screenshot 2025-01-13 at 11 09 04 AM" src="https://github.com/user-attachments/assets/b2eb8f56-1d92-4ae3-a7c0-66b8190b6cc9" />

This PR queries for the latest Webhook API Version before creating an app.

shopify(dev)> CoreApiVersioning.non_private_app_schedule.accessible_versions.map(&:handle)
=> ["2024-01", "2024-04", "2024-07", "2024-10", "2025-01", "2025-04", "unstable"]
<img width="379" alt="Screenshot 2025-01-13 at 11 10 40 AM" src="https://github.com/user-attachments/assets/92cc5748-052c-4398-840e-d6f15505babe" />

To tophat:
- Use the App Management API `export USE_APP_MANAGEMENT_API=1`
- Create an app with `shopify app init`
- Notice in the template the web api version is latest. Should be 2025-04 as of today. 
- Attempt to deploy with `shopify app deploy`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
