### PR TITLE
update CLI app not found error message

### DIFF
--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -5,6 +5,7 @@ import {createExtension} from './dev/create-extension.js'
 import {CachedAppInfo} from './local-storage.js'
 import {patchAppConfigurationFile} from './app/patch-app-configuration-file.js'
 import {DeployOptions} from './deploy.js'
+import {isServiceAccount, isUserAccount} from './context/partner-account-info.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
 import {
   AppInterface,
@@ -38,10 +39,30 @@ export const InvalidApiKeyErrorMessage = (apiKey: string) => {
   }
 }
 
-export const resetHelpMessage: Token[] = [
-  'You can pass ',
+export const resetHelpMessage = [
+  'You can pass',
   {command: '--reset'},
-  ' to your command to reset your app configuration.',
+  'to your command to reset your app configuration.',
+]
+
+const appNotFoundHelpMessage = (accountIdentifier: string, isOrg = false) => [
+  {
+    list: {
+      title: 'Next steps:',
+      items: [
+        'Check that your account has permission to develop apps for this organization or contact the owner of the organization to grant you permission',
+        [
+          'Run',
+          {command: 'shopify auth logout'},
+          'to log into a different',
+          isOrg ? 'organization' : 'account',
+          'than',
+          {bold: accountIdentifier},
+        ],
+        ['Pass', {command: '--reset'}, 'to your command to create a new app'],
+      ],
+    },
+  },
 ]
 
 interface AppFromIdOptions {
@@ -65,7 +86,23 @@ export const appFromIdentifiers = async (options: AppFromIdOptions): Promise<Org
     apiKey: options.apiKey,
     organizationId,
   })
-  if (!app) throw new AbortError([`Couldn't find the app with Client ID`, {command: options.apiKey}], resetHelpMessage)
+  if (!app) {
+    const accountInfo = await developerPlatformClient.accountInfo()
+    let identifier = 'Unknown account'
+    let isOrg = false
+
+    if (isServiceAccount(accountInfo)) {
+      identifier = accountInfo.orgName
+      isOrg = true
+    } else if (isUserAccount(accountInfo)) {
+      identifier = accountInfo.email
+    }
+
+    throw new AbortError(
+      [`No app with client ID`, {command: options.apiKey}, 'found'],
+      appNotFoundHelpMessage(identifier, isOrg),
+    )
+  }
   return app
 }
 

--- a/packages/app/src/cli/services/logs.test.ts
+++ b/packages/app/src/cli/services/logs.test.ts
@@ -237,11 +237,11 @@ describe('logs', () => {
           },
         },
         '\n',
-        'You can pass ',
+        'You can pass',
         {
           command: '--reset',
         },
-        ' to your command to reset your app configuration.',
+        'to your command to reset your app configuration.',
       ],
       headline: 'Using shopify.app.toml for default values:',
     })


### PR DESCRIPTION
### WHY are these changes introduced?

closes: https://github.com/Shopify/develop-app-inner-loop/issues/2460

### WHAT is this pull request doing?

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/183IglXPcqlyh0IdGCI5/5572833c-4f7f-4de2-a9cb-dbe7583cffa0.png)

co-authored by @Kenneth-Ye 

- updates the app not found message to be a bit more specific as well as provide some helpful next steps
- we predict this scenario may be more common with the swapping between dev dash / partners contexts

### How to test your changes?

- create an app via partners or management API
- then try to run any app command against that app using the _other_ API to see the new error banner

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
