### PR TITLE
Fix error handler for invalid TOML files

### DIFF
--- a/.changeset/small-guests-brake.md
+++ b/.changeset/small-guests-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Better error message for certain types of invalid app TOML files

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -82,7 +82,7 @@ export async function loadConfigurationFileContent(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (err: any) {
     // TOML errors have line, pos and col properties
-    if (err.line && err.pos && err.col) {
+    if (err.line !== undefined && err.pos !== undefined && err.col !== undefined) {
       return abortOrReport(
         outputContent`Fix the following error in ${outputToken.path(filepath)}:\n${err.message}`,
         {},


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue where TOML configuration file errors were not being properly detected when error properties contained falsy values (such as occurring on the zero-th column).

### WHAT is this pull request doing?

Updates the error property check in the configuration file loader to explicitly verify if properties are undefined, rather than relying on truthy/falsy evaluation.

### How to test your changes?

1. Create a TOML configuration file with an error at position 0
2. Run the CLI command that loads the configuration
3. Verify that the error is properly detected and reported

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes