### PR TITLE
Don't show dev shortcuts until dev session is ready

### DIFF
--- a/packages/app/src/cli/services/dev/processes/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session.ts
@@ -59,6 +59,12 @@ let bundleControllers: AbortController[] = []
 // Since the watcher can emit events before the dev session is ready, we need to keep track of the status
 let isDevSessionReady = false
 
+export function devSessionStatus() {
+  return {
+    isDevSessionReady,
+  }
+}
+
 export async function setupDevSessionProcess({
   app,
   apiKey,


### PR DESCRIPTION
### WHY are these changes introduced?

When running `app dev` and using dev sessions, you shouldn't interact with the app/graphiql until the session is ready.

### WHAT is this pull request doing?

- Adds a new `devSessionStatus` function to expose when the dev session is ready
- Implements polling in `Dev.tsx` to check dev session status before displaying keyboard shortcuts
- Conditionally renders keyboard shortcuts based on dev session status

### How to test your changes?

1. Start a dev session and verify keyboard shortcuts only appear after the session is ready

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes