### PR TITLE
Fix `shopify theme dev` to no longer fail when development themes expire in internationalized stores

### DIFF
--- a/.changeset/lemon-pants-add.md
+++ b/.changeset/lemon-pants-add.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+Fix `shopify theme dev` to no longer fail when development themes expire in internationalized stores

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -59,7 +59,7 @@ describe('fetchTheme', () => {
   test('returns undefined when a theme is not found', async () => {
     const errorResponse = {
       status: 200,
-      errors: [{message: 'Theme does not exist'} as any],
+      errors: [{message: 'Tema não existe'} as any],
     }
     vi.mocked(adminRequestDoc).mockRejectedValue(new ClientError(errorResponse, {query: ''}))
 

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -25,33 +25,36 @@ import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {Result, Checksum, Key, Theme, ThemeAsset, Operation} from '@shopify/cli-kit/node/themes/types'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {sleep} from '@shopify/cli-kit/node/system'
-import {ClientError} from 'graphql-request'
 
 export type ThemeParams = Partial<Pick<Theme, 'name' | 'role' | 'processing' | 'src'>>
 export type AssetParams = Pick<ThemeAsset, 'key'> & Partial<Pick<ThemeAsset, 'value' | 'attachment'>>
 
 export async function fetchTheme(id: number, session: AdminSession): Promise<Theme | undefined> {
+  const gid = composeThemeGid(id)
+
   try {
-    const response = await adminRequestDoc(GetTheme, session, {id: composeThemeGid(id)}, undefined, {
+    const {theme} = await adminRequestDoc(GetTheme, session, {id: gid}, undefined, {
       handleErrors: false,
     })
-    const {theme} = response
-    if (!theme) {
-      return undefined
+
+    if (theme) {
+      return buildTheme({
+        id: parseGid(theme.id),
+        processing: theme.processing,
+        role: theme.role.toLowerCase(),
+        name: theme.name,
+      })
     }
-    return buildTheme({
-      id: parseGid(theme.id),
-      processing: theme.processing,
-      role: theme.role.toLowerCase(),
-      name: theme.name,
-    })
-  } catch (error) {
-    if (error instanceof ClientError) {
-      if (error.response?.errors?.[0]?.message === 'Theme does not exist') {
-        return undefined
-      }
-    }
-    throw new AbortError(`Failed to fetch theme: ${id}`)
+
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (_error) {
+    /**
+     * Consumers of this and other theme APIs in this file expect either a theme
+     * or `undefined`.
+     *
+     * Error handlers should not inspect GraphQL error messages directly, as
+     * they are internationalized.
+     */
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5192

Users were facing the error above because internationalized stores return internationalized error messages in the new GQL API, which were not being handled as expected in the CLI.

### WHAT is this pull request doing?
This PR changes the `fetchTheme` API to no longer abort or throw an error. API consumers are already handling the absence of the theme when the function returns undefined. Some abort the execution, but others create the necessary theme.

I've checked other possible similar scenarios, and I spotted no more occurrences of error messages being handled this way, so this PR should be enough.

### How to test your changes?

- Run `dev cd dawn`
- Run `shopify theme dev` and get your development theme id
- Update `~/Library/Preferences/shopify-cli-development-theme-config-nodejs/config.json` by appending `1` to your development theme id there (now, your development theme will no longer exist)
- Run `dev cd dawn`
- Run `shopify theme dev`
- Notice it just creates a new development theme

**Before**:
![Screenshot 2025-01-15 at 13 43 39](https://github.com/user-attachments/assets/91247e5a-3394-4d69-a87e-598e4f9bb2fc)

**After**:
![Screenshot 2025-01-15 at 13 44 10](https://github.com/user-attachments/assets/75cb04dd-9931-4578-8f43-24de8f1e97b9)

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
