### PR TITLE
[Themes] Add debug logging for theme fetch errors

### DIFF
--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -55,6 +55,7 @@ export async function fetchTheme(id: number, session: AdminSession): Promise<The
      * Error handlers should not inspect GraphQL error messages directly, as
      * they are internationalized.
      */
+    outputDebug(`Error fetching theme with ID: ${id}`)
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Adds debug logging to report that themeFetch failed on top of the changes introduced in #5200

This is likely inconsequential, but may come in handy for debugging something in the future (even more so because the client will handle failures silently otherwise)

@karreiro  **Do we want to do this? Would we be adding too much noise?**