### PR TITLE
Create alias for `theme check`

### DIFF
--- a/.changeset/dirty-penguins-develop.md
+++ b/.changeset/dirty-penguins-develop.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme': patch
+'@shopify/cli': patch
+---
+
+Adding alias for `theme check`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4948,6 +4948,7 @@
       },
       "hasDynamicHelp": false,
       "hiddenAliases": [
+        "vibe:check"
       ],
       "id": "theme:check",
       "pluginAlias": "@shopify/cli",

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -29,6 +29,8 @@ export default class Check extends ThemeCommand {
 
   static description = this.descriptionWithoutMarkdown()
 
+  static hiddenAliases: string[] = ['vibe:check']
+
   static flags = {
     ...globalFlags,
     path: themeFlags.path,


### PR DESCRIPTION
### WHY are these changes introduced?

- Adding alias for theme check

### WHAT is this pull request doing?

- Adding a hidden alias so it isn't officially documented, but exists

### How to test your changes?

- run the original command and its alias

### Post-release steps


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes