### PR TITLE
[Themes] `Theme Dev` - Render asset upload errors coming from initial theme upload

### DIFF
--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -370,7 +370,17 @@ async function uploadBatch(
   // store the results in uploadResults, overwriting any existing results
   results.forEach((result) => {
     uploadResults.set(result.key, result)
+    updateUploadErrors(result, localThemeFileSystem)
   })
+}
+
+export function updateUploadErrors(result: Result, localThemeFileSystem: ThemeFileSystem) {
+  if (result.success) {
+    localThemeFileSystem.uploadErrors.delete(result.key)
+  } else {
+    const errors = result.errors?.asset ?? ['Response was not successful.']
+    localThemeFileSystem.uploadErrors.set(result.key, errors)
+  }
 }
 
 async function handleBulkUpload(


### PR DESCRIPTION
### WHY are these changes introduced?

When you run `theme dev`, we upload files that you modify, but we also **perform an initial theme upload in the background**.

This PR adds results from the initial background upload to the error overlay

### WHAT is this pull request doing?

Adds upload errors to the error overlay as the theme upload results are returned.

Known limitation - timing matters. 
If you open the localhost window BEFORE the results are returned, the overlay won't render until your next render.

I will introduce hot reloading in a follow-up 

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/JdHLnhebSbtZTZO01I1e/c4ab6ed3-e163-4809-92bc-fb7c4ee845d5.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/JdHLnhebSbtZTZO01I1e/c4ab6ed3-e163-4809-92bc-fb7c4ee845d5.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JdHLnhebSbtZTZO01I1e/c4ab6ed3-e163-4809-92bc-fb7c4ee845d5.mp4">Google Chrome - 127.0.0.1 (1).mp4</video>

### How to test your changes?

1. Attempt to upload a theme with invalid assets
2. Verify error messages are properly stored and displayed
3. Successfully upload assets and confirm errors are cleared
4. Test with various error scenarios to ensure proper error message handling

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes