### PR TITLE
Fix dev when resetting and creating a new app

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/create-app.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-app.ts
@@ -11,7 +11,7 @@ export type CreateAppMutationVariables = Types.Exact<{
 
 export type CreateAppMutation = {
   appCreate: {
-    app?: {id: string; key: string} | null
+    app?: {id: string; key: string; activeRoot: {clientCredentials: {secrets: {key: string}[]}}} | null
     userErrors: {category: string; message: string; on: JsonMapType}[]
   }
 }
@@ -64,6 +64,37 @@ export const CreateApp = {
                     selections: [
                       {kind: 'Field', name: {kind: 'Name', value: 'id'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'key'}},
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'activeRoot'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: {kind: 'Name', value: 'clientCredentials'},
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: {kind: 'Name', value: 'secrets'},
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {kind: 'Field', name: {kind: 'Name', value: 'key'}},
+                                        {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                                      ],
+                                    },
+                                  },
+                                  {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                                ],
+                              },
+                            },
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],
                   },

--- a/packages/app/src/cli/api/graphql/app-management/queries/create-app.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/create-app.graphql
@@ -3,6 +3,13 @@ mutation CreateApp($appSource: AppSourceInput!, $name: String!) {
     app {
       id
       key
+      activeRoot {
+        clientCredentials {
+          secrets {
+            key
+          }
+        }
+      }
     }
     userErrors {
       category

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -131,7 +131,7 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
   let developerPlatformClient = await sniffServiceOptionsAndAppConfigToSelectPlatformClient(options)
 
   const {creationOptions, appDirectory: possibleAppDirectory} = await getAppCreationDefaultsFromLocalApp(options)
-  const appDirectory = possibleAppDirectory || options.directory
+  const appDirectory = possibleAppDirectory ?? options.directory
 
   if (options.apiKey) {
     // Remote API Key provided by the caller, so use that app specifically
@@ -189,12 +189,9 @@ async function getAppCreationDefaultsFromLocalApp(options: LinkOptions): Promise
       userProvidedConfigName: options.baseConfigName,
       remoteFlags: undefined,
     })
-    const configuration = app.configuration
 
-    if (!isCurrentAppSchema(configuration)) {
-      return {creationOptions: app.creationDefaultOptions(), appDirectory: app.directory}
-    }
-    return {creationOptions: appCreationDefaults}
+    return {creationOptions: app.creationDefaultOptions(), appDirectory: app.directory}
+
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
     return {creationOptions: appCreationDefaults}

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -310,7 +310,12 @@ describe('createApp', () => {
       publicApiVersions: [{handle: '2024-07'}, {handle: '2024-10'}, {handle: '2025-01'}, {handle: 'unstable'}],
     }
     vi.mocked(webhooksRequest).mockResolvedValueOnce(mockedApiVersionResult)
-    vi.mocked(appManagementRequestDoc).mockResolvedValueOnce({appCreate: {app: {id: '1', key: 'key'}, userErrors: []}})
+    vi.mocked(appManagementRequestDoc).mockResolvedValueOnce({
+      appCreate: {
+        app: {id: '1', key: 'key', activeRoot: {clientCredentials: {secrets: [{key: 'secret'}]}}},
+        userErrors: [],
+      },
+    })
 
     // When
     client.token = () => Promise.resolve('token')
@@ -347,7 +352,7 @@ describe('createApp', () => {
       id: '1',
       key: 'api-key',
       apiKey: 'api-key',
-      apiSecretKeys: [],
+      apiSecretKeys: [{secret: 'secret'}],
       flags: [],
       grantedScopes: [],
       organizationId: '1',
@@ -364,6 +369,11 @@ describe('createApp', () => {
         app: {
           id: expectedApp.id,
           key: expectedApp.key,
+          activeRoot: {
+            clientCredentials: {
+              secrets: [{key: 'secret'}],
+            },
+          },
         },
         userErrors: [],
       },

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -390,11 +390,12 @@ export class AppManagementClient implements DeveloperPlatformClient {
     // Need to figure this out still
     const flags = filterDisabledFlags([])
     const createdApp = result.appCreate.app
+    const apiSecretKeys = createdApp.activeRoot.clientCredentials.secrets.map((secret) => ({secret: secret.key}))
     return {
       ...createdApp,
       title: name,
       apiKey: createdApp.key,
-      apiSecretKeys: [],
+      apiSecretKeys,
       grantedScopes: options?.scopesArray ?? [],
       organizationId: org.id,
       newApp: true,


### PR DESCRIPTION
### WHY are these changes introduced?

There is an issue when using `--reset` and linking to a new app. The CLI wasn't properly configuring this new app and if done during `app dev`, it was obtaining the apiSecret.

### WHAT is this pull request doing?

Make sure that we properly build the `AppCreationDefaultOptions` object when linking to a new app during a `--reset` command.

Make sure that we fetch the api secret also on `createApp` mutations, not only on `getApp` queries.

### How to test your changes?

1. export USE_APP_MANAGEMENT_API=1 
2. `shopify app init` and create a new app (api client) in a Plus org and choose the Remix template
3. `shopify app dev` and see the that app opens
4. stop the server and run `shopify app dev --reset` and create a new app (api client)
5. Verify that you don't see any vite error in the console and dev works
6. Verify that your new toml has `embedded = true`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes