### PR TITLE
Simplify CreateAppOptions and DefaultAppOptions into a single object

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1330,8 +1330,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     templateSpecifications: (_app: MinimalAppIdentifiers) => Promise.resolve(testRemoteExtensionTemplates),
     orgAndApps: (_orgId: string) =>
       Promise.resolve({organization: testOrganization(), apps: [testOrganizationApp()], hasMorePages: false}),
-    createApp: (_organization: Organization, _name: string, _options?: CreateAppOptions) =>
-      Promise.resolve(testOrganizationApp()),
+    createApp: (_organization: Organization, _options: CreateAppOptions) => Promise.resolve(testOrganizationApp()),
     devStoresForOrg: (_organizationId: string) => Promise.resolve({stores: [], hasMorePages: false}),
     storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve({organizations: {nodes: []}}),
     appExtensionRegistrations: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppExtensionRegistrations),

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -8,7 +8,7 @@ import {ExtensionSpecification, RemoteAwareExtensionSpecification} from '../exte
 import {AppConfigurationUsedByCli} from '../extensions/specifications/types/app_config.js'
 import {EditorExtensionCollectionType} from '../extensions/specifications/editor_extension_collection.js'
 import {UIExtensionSchema} from '../extensions/specifications/ui_extension.js'
-import {Flag} from '../../utilities/developer-platform-client.js'
+import {CreateAppOptions, Flag} from '../../utilities/developer-platform-client.js'
 import {AppAccessSpecIdentifier} from '../extensions/specifications/app_config_app_access.js'
 import {WebhookSubscriptionSchema} from '../extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.js'
 import {ZodObjectOf, zod} from '@shopify/cli-kit/node/schema'
@@ -271,7 +271,7 @@ export interface AppInterface<
   /**
    * If creating an app on the platform based on this app and its configuration, what default options should the app take?
    */
-  creationDefaultOptions(): AppCreationDefaultOptions
+  creationDefaultOptions(): CreateAppOptions
   manifest: () => Promise<JsonMapType>
   removeExtension: (extensionUid: string) => void
 }
@@ -430,14 +430,15 @@ export class App<
     const frontendConfig = this.webs.find((web) => isWebType(web, WebType.Frontend))
     const backendConfig = this.webs.find((web) => isWebType(web, WebType.Backend))
 
-    return Boolean(frontendConfig || backendConfig)
+    return Boolean(frontendConfig ?? backendConfig)
   }
 
-  creationDefaultOptions(): AppCreationDefaultOptions {
+  creationDefaultOptions(): CreateAppOptions {
     return {
       isLaunchable: this.appIsLaunchable(),
       scopesArray: getAppScopesArray(this.configuration),
       name: this.name,
+      directory: this.directory,
     }
   }
 
@@ -547,10 +548,4 @@ export async function getDependencyVersion(dependency: string, directory: string
   const packageContent = await readAndParsePackageJson(packagePath)
   if (!packageContent.version) return 'not_found'
   return {name: dependency, version: packageContent.version}
-}
-
-export interface AppCreationDefaultOptions {
-  isLaunchable: boolean
-  scopesArray: string[]
-  name: string
 }

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3204,6 +3204,7 @@ describe('loadConfigForAppCreation', () => {
         isLaunchable: false,
         scopesArray: ['read_orders', 'write_products'],
         name: 'my-app',
+        directory: tmpDir,
       })
     })
   })
@@ -3236,6 +3237,7 @@ dev = "echo 'Hello, world!'"
         isLaunchable: true,
         scopesArray: ['write_products'],
         name: 'my-app',
+        directory: tmpDir,
       })
     })
   })
@@ -3271,6 +3273,7 @@ dev = "echo 'Hello, world!'"
         isLaunchable: true,
         scopesArray: ['write_products'],
         name: 'my-app',
+        directory: tmpDir,
       })
     })
   })
@@ -3295,6 +3298,7 @@ dev = "echo 'Hello, world!'"
         isLaunchable: false,
         scopesArray: ['read_orders', 'write_products'],
         name: 'my-app',
+        directory: tmpDir,
       })
     })
   })
@@ -3317,6 +3321,7 @@ dev = "echo 'Hello, world!'"
         isLaunchable: false,
         scopesArray: [],
         name: 'my-app',
+        directory: tmpDir,
       })
     })
   })

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -15,7 +15,6 @@ import {
   LegacyAppConfiguration,
   BasicAppConfigurationWithoutModules,
   SchemaForConfig,
-  AppCreationDefaultOptions,
   AppLinkedInterface,
 } from './app.js'
 import {showMultipleCLIWarningIfNeeded} from './validation/multi-cli-warning.js'
@@ -26,7 +25,7 @@ import {ExtensionsArraySchema, UnifiedSchema} from '../extensions/schemas.js'
 import {ExtensionSpecification, RemoteAwareExtensionSpecification} from '../extensions/specification.js'
 import {getCachedAppInfo} from '../../services/local-storage.js'
 import use from '../../services/app/config/use.js'
-import {Flag} from '../../utilities/developer-platform-client.js'
+import {CreateAppOptions, Flag} from '../../utilities/developer-platform-client.js'
 import {findConfigFiles} from '../../prompts/config.js'
 import {WebhookSubscriptionSpecIdentifier} from '../extensions/specifications/app_config_webhook_subscription.js'
 import {WebhooksSchema} from '../extensions/specifications/app_config_webhook_schemas/webhooks_schema.js'
@@ -213,7 +212,7 @@ export async function checkFolderIsValidApp(directory: string) {
   )
 }
 
-export async function loadConfigForAppCreation(directory: string, name: string): Promise<AppCreationDefaultOptions> {
+export async function loadConfigForAppCreation(directory: string, name: string): Promise<CreateAppOptions> {
   const state = await getAppConfigurationState(directory)
   const config: AppConfiguration = state.state === 'connected-app' ? state.basicConfiguration : state.startingOptions
   const loadedConfiguration = await loadAppConfigurationFromState(state, [], [])
@@ -225,6 +224,7 @@ export async function loadConfigForAppCreation(directory: string, name: string):
     isLaunchable: webs.webs.some((web) => isWebType(web, WebType.Frontend) || isWebType(web, WebType.Backend)),
     scopesArray: getAppScopesArray(config),
     name,
+    directory,
   }
 }
 

--- a/packages/app/src/cli/services/app/config/link-service.test.ts
+++ b/packages/app/src/cli/services/app/config/link-service.test.ts
@@ -33,7 +33,7 @@ function buildDeveloperPlatformClient(): DeveloperPlatformClient {
         hasMorePages: false,
       }
     },
-    async createApp(org, name, options) {
+    async createApp(org, options) {
       return testOrganizationApp({
         requestedAccessScopes: options?.scopesArray,
         developerPlatformClient: this as DeveloperPlatformClient,

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -7,7 +7,6 @@ import {
   CliBuildPreferences,
   getAppScopes,
   LegacyAppConfiguration,
-  AppCreationDefaultOptions,
 } from '../../../models/app/app.js'
 import {OrganizationApp} from '../../../models/organization.js'
 import {selectConfigName} from '../../../prompts/config.js'
@@ -27,6 +26,7 @@ import {
   Flag,
   DeveloperPlatformClient,
   sniffServiceOptionsAndAppConfigToSelectPlatformClient,
+  CreateAppOptions,
 } from '../../../utilities/developer-platform-client.js'
 import {configurationFileNames} from '../../../constants.js'
 import {writeAppConfigurationFile} from '../write-app-configuration-file.js'
@@ -173,13 +173,14 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
  * @returns Default options for creating a new app; the app's actual directory if loaded.
  */
 async function getAppCreationDefaultsFromLocalApp(options: LinkOptions): Promise<{
-  creationOptions: AppCreationDefaultOptions
+  creationOptions: CreateAppOptions
   appDirectory?: string
 }> {
   const appCreationDefaults = {
     isLaunchable: false,
     scopesArray: [] as string[],
     name: '',
+    directory: options.directory,
   }
   try {
     const app = await loadApp({

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -152,7 +152,7 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
     }
   }
 
-  const remoteApp = await fetchOrCreateOrganizationApp(creationOptions, appDirectory)
+  const remoteApp = await fetchOrCreateOrganizationApp({...creationOptions, directory: appDirectory})
 
   developerPlatformClient = remoteApp.developerPlatformClient ?? developerPlatformClient
 

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -266,22 +266,11 @@ function includeConfigOnDeployPrompt(configPath: string): Promise<boolean> {
   })
 }
 
-export async function fetchOrCreateOrganizationApp(
-  options: CreateAppOptions,
-  directory?: string,
-): Promise<OrganizationApp> {
+export async function fetchOrCreateOrganizationApp(options: CreateAppOptions): Promise<OrganizationApp> {
   const org = await selectOrg()
   const developerPlatformClient = selectDeveloperPlatformClient({organization: org})
   const {organization, apps, hasMorePages} = await developerPlatformClient.orgAndApps(org.id)
-  const remoteApp = await selectOrCreateApp(
-    options.name,
-    apps,
-    hasMorePages,
-    organization,
-    developerPlatformClient,
-    options,
-    directory,
-  )
+  const remoteApp = await selectOrCreateApp(apps, hasMorePages, organization, developerPlatformClient, options)
   remoteApp.developerPlatformClient = developerPlatformClient
 
   await logMetadataForLoadedContext(remoteApp, developerPlatformClient.organizationSource)

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -7,13 +7,7 @@ import {patchAppConfigurationFile} from './app/patch-app-configuration-file.js'
 import {DeployOptions} from './deploy.js'
 import {isServiceAccount, isUserAccount} from './context/partner-account-info.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
-import {
-  AppInterface,
-  isCurrentAppSchema,
-  CurrentAppConfiguration,
-  AppCreationDefaultOptions,
-  AppLinkedInterface,
-} from '../models/app/app.js'
+import {AppInterface, isCurrentAppSchema, CurrentAppConfiguration, AppLinkedInterface} from '../models/app/app.js'
 import {Identifiers, updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
 import {Organization, OrganizationApp, OrganizationSource, OrganizationStore} from '../models/organization.js'
 import metadata from '../metadata.js'
@@ -25,7 +19,11 @@ import {
   DevelopmentStorePreviewUpdateInput,
   DevelopmentStorePreviewUpdateSchema,
 } from '../api/graphql/development_preview.js'
-import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../utilities/developer-platform-client.js'
+import {
+  CreateAppOptions,
+  DeveloperPlatformClient,
+  selectDeveloperPlatformClient,
+} from '../utilities/developer-platform-client.js'
 import {tryParseInt} from '@shopify/cli-kit/common/string'
 import {Token, TokenItem, renderConfirmationPrompt, renderInfo, renderWarning} from '@shopify/cli-kit/node/ui'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -269,18 +267,21 @@ function includeConfigOnDeployPrompt(configPath: string): Promise<boolean> {
 }
 
 export async function fetchOrCreateOrganizationApp(
-  options: AppCreationDefaultOptions,
+  options: CreateAppOptions,
   directory?: string,
 ): Promise<OrganizationApp> {
-  const {isLaunchable, scopesArray, name} = options
   const org = await selectOrg()
   const developerPlatformClient = selectDeveloperPlatformClient({organization: org})
   const {organization, apps, hasMorePages} = await developerPlatformClient.orgAndApps(org.id)
-  const remoteApp = await selectOrCreateApp(name, apps, hasMorePages, organization, developerPlatformClient, {
-    isLaunchable,
-    scopesArray,
+  const remoteApp = await selectOrCreateApp(
+    options.name,
+    apps,
+    hasMorePages,
+    organization,
+    developerPlatformClient,
+    options,
     directory,
-  })
+  )
   remoteApp.developerPlatformClient = developerPlatformClient
 
   await logMetadataForLoadedContext(remoteApp, developerPlatformClient.organizationSource)

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -59,7 +59,9 @@ describe('selectOrCreateApp', () => {
 
     // When
     const {developerPlatformClient} = mockDeveloperPlatformClient()
-    const got = await selectOrCreateApp(LOCAL_APP.name, APPS, false, ORG1, developerPlatformClient, {})
+    const got = await selectOrCreateApp(LOCAL_APP.name, APPS, false, ORG1, developerPlatformClient, {
+      name: 'app-name',
+    })
 
     // Then
     expect(got).toEqual(APP1)
@@ -75,7 +77,7 @@ describe('selectOrCreateApp', () => {
 
     // When
     const {developerPlatformClient} = mockDeveloperPlatformClient()
-    const got = await selectOrCreateApp(LOCAL_APP.name, APPS, false, ORG1, developerPlatformClient, {})
+    const got = await selectOrCreateApp(LOCAL_APP.name, APPS, false, ORG1, developerPlatformClient, {name: 'app-name'})
 
     // Then
     expect(got).toEqual({...APP1, newApp: true})

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -59,9 +59,7 @@ describe('selectOrCreateApp', () => {
 
     // When
     const {developerPlatformClient} = mockDeveloperPlatformClient()
-    const got = await selectOrCreateApp(LOCAL_APP.name, APPS, false, ORG1, developerPlatformClient, {
-      name: 'app-name',
-    })
+    const got = await selectOrCreateApp(APPS, false, ORG1, developerPlatformClient, {name: LOCAL_APP.name})
 
     // Then
     expect(got).toEqual(APP1)
@@ -77,11 +75,11 @@ describe('selectOrCreateApp', () => {
 
     // When
     const {developerPlatformClient} = mockDeveloperPlatformClient()
-    const got = await selectOrCreateApp(LOCAL_APP.name, APPS, false, ORG1, developerPlatformClient, {name: 'app-name'})
+    const got = await selectOrCreateApp(APPS, false, ORG1, developerPlatformClient, {name: LOCAL_APP.name})
 
     // Then
     expect(got).toEqual({...APP1, newApp: true})
     expect(appNamePrompt).toHaveBeenCalledWith(LOCAL_APP.name)
-    expect(developerPlatformClient.createApp).toHaveBeenCalledWith(ORG1, 'app-name', {})
+    expect(developerPlatformClient.createApp).toHaveBeenCalledWith(ORG1, {name: 'app-name'})
   })
 })

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -2,7 +2,7 @@ import {searchForAppsByNameFactory} from './prompt-helpers.js'
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {Organization, MinimalOrganizationApp, OrganizationApp} from '../../models/organization.js'
 import {getCachedCommandInfo, setCachedCommandTomlPreference} from '../local-storage.js'
-import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {CreateAppOptions, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationFileName} from '../../models/app/loader.js'
 import {BugError} from '@shopify/cli-kit/node/error'
 
@@ -21,11 +21,8 @@ export async function selectOrCreateApp(
   hasMorePages: boolean,
   org: Organization,
   developerPlatformClient: DeveloperPlatformClient,
-  options?: {
-    isLaunchable?: boolean
-    scopesArray?: string[]
-    directory?: string
-  },
+  options: CreateAppOptions,
+  directory?: string,
 ): Promise<OrganizationApp> {
   let createNewApp = apps.length === 0
   if (!createNewApp) {
@@ -33,10 +30,10 @@ export async function selectOrCreateApp(
   }
   if (createNewApp) {
     const name = await appNamePrompt(localAppName)
-    return developerPlatformClient.createApp(org, name, options)
+    return developerPlatformClient.createApp(org, {...options, name})
   } else {
     const app = await selectAppPrompt(searchForAppsByNameFactory(developerPlatformClient, org.id), apps, hasMorePages, {
-      directory: options?.directory,
+      directory,
     })
 
     const data = getCachedCommandInfo()

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -16,24 +16,22 @@ import {BugError} from '@shopify/cli-kit/node/error'
  * @returns The selected (or created) app
  */
 export async function selectOrCreateApp(
-  localAppName: string,
   apps: MinimalOrganizationApp[],
   hasMorePages: boolean,
   org: Organization,
   developerPlatformClient: DeveloperPlatformClient,
   options: CreateAppOptions,
-  directory?: string,
 ): Promise<OrganizationApp> {
   let createNewApp = apps.length === 0
   if (!createNewApp) {
     createNewApp = await createAsNewAppPrompt()
   }
   if (createNewApp) {
-    const name = await appNamePrompt(localAppName)
+    const name = await appNamePrompt(options.name)
     return developerPlatformClient.createApp(org, {...options, name})
   } else {
     const app = await selectAppPrompt(searchForAppsByNameFactory(developerPlatformClient, org.id), apps, hasMorePages, {
-      directory,
+      directory: options.directory,
     })
 
     const data = getCachedCommandInfo()

--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -200,7 +200,7 @@ async function init(options: InitOptions) {
   if (options.selectedAppOrNameResult.result === 'new') {
     const creationOptions = await loadConfigForAppCreation(outputDirectory, options.name)
     const org = options.selectedAppOrNameResult.org
-    app = await options.developerPlatformClient.createApp(org, options.name, creationOptions)
+    app = await options.developerPlatformClient.createApp(org, creationOptions)
   } else {
     app = options.selectedAppOrNameResult.app
   }

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -137,6 +137,7 @@ function selectDeveloperPlatformClientByConfig(configuration: AppConfiguration |
 }
 
 export interface CreateAppOptions {
+  name: string
   isLaunchable?: boolean
   scopesArray?: string[]
   directory?: string
@@ -222,7 +223,7 @@ export interface DeveloperPlatformClient {
   appsForOrg: (orgId: string, term?: string) => Promise<Paginateable<{apps: MinimalOrganizationApp[]}>>
   specifications: (app: MinimalAppIdentifiers) => Promise<RemoteSpecification[]>
   templateSpecifications: (app: MinimalAppIdentifiers) => Promise<ExtensionTemplate[]>
-  createApp: (org: Organization, name: string, options?: CreateAppOptions) => Promise<OrganizationApp>
+  createApp: (org: Organization, options: CreateAppOptions) => Promise<OrganizationApp>
   devStoresForOrg: (orgId: string, searchTerm?: string) => Promise<Paginateable<{stores: OrganizationStore[]}>>
   storeByDomain: (orgId: string, shopDomain: string) => Promise<FindStoreByDomainSchema>
   appExtensionRegistrations: (

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -319,7 +319,7 @@ describe('createApp', () => {
 
     // When
     client.token = () => Promise.resolve('token')
-    await client.createApp(org, 'app-name')
+    await client.createApp(org, {name: 'app-name'})
 
     // Then
     expect(webhooksRequest).toHaveBeenCalledWith(org.id, expect.anything(), 'token', expect.any(Object))
@@ -381,7 +381,7 @@ describe('createApp', () => {
 
     // When
     client.token = () => Promise.resolve('token')
-    const result = await client.createApp(org, appName)
+    const result = await client.createApp(org, {name: 'app-name'})
 
     // Then
     expect(result).toMatchObject(expectedApp)

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
@@ -90,10 +90,15 @@ describe('createApp', () => {
     }
 
     // When
-    const got = await partnersClient.createApp({...ORG1, source: OrganizationSource.Partners}, localApp.name, {
-      scopesArray: ['write_products'],
-      isLaunchable: true,
-    })
+    const got = await partnersClient.createApp(
+      {...ORG1, source: OrganizationSource.Partners},
+      {
+        name: localApp.name,
+        scopesArray: ['write_products'],
+        isLaunchable: true,
+        directory: '',
+      },
+    )
 
     // Then
     expect(got).toEqual({...APP1, newApp: true, developerPlatformClient: partnersClient})
@@ -115,10 +120,14 @@ describe('createApp', () => {
     }
 
     // When
-    const got = await partnersClient.createApp({...ORG1, source: OrganizationSource.Partners}, LOCAL_APP.name, {
-      isLaunchable: false,
-      scopesArray: ['write_products'],
-    })
+    const got = await partnersClient.createApp(
+      {...ORG1, source: OrganizationSource.Partners},
+      {
+        name: LOCAL_APP.name,
+        isLaunchable: false,
+        scopesArray: ['write_products'],
+      },
+    )
 
     // Then
     expect(got).toEqual({...APP1, newApp: true, developerPlatformClient: partnersClient})
@@ -134,7 +143,7 @@ describe('createApp', () => {
     })
 
     // When
-    const got = partnersClient.createApp({...ORG2, source: OrganizationSource.Partners}, LOCAL_APP.name)
+    const got = partnersClient.createApp({...ORG2, source: OrganizationSource.Partners}, {name: LOCAL_APP.name})
 
     // Then
     await expect(got).rejects.toThrow(`some-error`)

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -11,6 +11,7 @@ import {
   filterDisabledFlags,
   ClientName,
   AppVersionWithContext,
+  CreateAppOptions,
 } from '../developer-platform-client.js'
 import {fetchCurrentAccountInformation, PartnersSession} from '../../../cli/services/context/partner-account-info.js'
 import {
@@ -338,16 +339,8 @@ export class PartnersClient implements DeveloperPlatformClient {
     })
   }
 
-  async createApp(
-    org: Organization,
-    name: string,
-    options?: {
-      isLaunchable?: boolean
-      scopesArray?: string[]
-      directory?: string
-    },
-  ): Promise<OrganizationApp> {
-    const variables: CreateAppQueryVariables = getAppVars(org, name, options?.isLaunchable, options?.scopesArray)
+  async createApp(org: Organization, options: CreateAppOptions): Promise<OrganizationApp> {
+    const variables: CreateAppQueryVariables = getAppVars(org, options.name, options.isLaunchable, options.scopesArray)
     const result: CreateAppQuerySchema = await this.request(CreateAppQuery, variables)
     if (result.appCreate.userErrors.length > 0) {
       const errors = result.appCreate.userErrors.map((error) => error.message).join(', ')


### PR DESCRIPTION
### WHY are these changes introduced?

We had two very similar objects: `CreateAppOptions` and `AppCreationDefaultOptions`

We are refactoring and unifying everything to just use `CreateAppOptions`.

### WHAT is this pull request doing?

- Consolidates app creation options into a single `CreateAppOptions` interface
- Removes redundant name parameter from `createApp` method signatures
- Updates all callers to use the new unified options interface
- Ensures directory is consistently passed through creation options

### How to test your changes?

1. Create a new app using `shopify app init`
2. Link an existing app using `shopify app config link` 
3. Verify all app creation flows work as expected with proper options passed through

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes