### PR TITLE
Use the current embedded value when linking to new apps

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -433,11 +433,17 @@ export class App<
     return Boolean(frontendConfig ?? backendConfig)
   }
 
+  get appIsEmbedded() {
+    if (isCurrentAppSchema(this.configuration)) return this.configuration.embedded
+    return this.appIsLaunchable()
+  }
+
   creationDefaultOptions(): CreateAppOptions {
     return {
       isLaunchable: this.appIsLaunchable(),
       scopesArray: getAppScopesArray(this.configuration),
       name: this.name,
+      isEmbedded: this.appIsEmbedded,
       directory: this.directory,
     }
   }

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3205,6 +3205,7 @@ describe('loadConfigForAppCreation', () => {
         scopesArray: ['read_orders', 'write_products'],
         name: 'my-app',
         directory: tmpDir,
+        isEmbedded: false,
       })
     })
   })
@@ -3238,6 +3239,7 @@ dev = "echo 'Hello, world!'"
         scopesArray: ['write_products'],
         name: 'my-app',
         directory: tmpDir,
+        isEmbedded: true,
       })
     })
   })
@@ -3274,6 +3276,7 @@ dev = "echo 'Hello, world!'"
         scopesArray: ['write_products'],
         name: 'my-app',
         directory: tmpDir,
+        isEmbedded: true,
       })
     })
   })
@@ -3299,6 +3302,7 @@ dev = "echo 'Hello, world!'"
         scopesArray: ['read_orders', 'write_products'],
         name: 'my-app',
         directory: tmpDir,
+        isEmbedded: false,
       })
     })
   })
@@ -3322,6 +3326,7 @@ dev = "echo 'Hello, world!'"
         scopesArray: [],
         name: 'my-app',
         directory: tmpDir,
+        isEmbedded: false,
       })
     })
   })

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -220,11 +220,15 @@ export async function loadConfigForAppCreation(directory: string, name: string):
   const loader = new AppLoader({loadedConfiguration})
   const webs = await loader.loadWebs(directory)
 
+  const isLaunchable = webs.webs.some((web) => isWebType(web, WebType.Frontend) || isWebType(web, WebType.Backend))
+
   return {
-    isLaunchable: webs.webs.some((web) => isWebType(web, WebType.Frontend) || isWebType(web, WebType.Backend)),
+    isLaunchable,
     scopesArray: getAppScopesArray(config),
     name,
     directory,
+    // By default, and ONLY for `app init`, we consider the app as embedded if it is launchable.
+    isEmbedded: isLaunchable,
   }
 }
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -181,6 +181,7 @@ async function getAppCreationDefaultsFromLocalApp(options: LinkOptions): Promise
     scopesArray: [] as string[],
     name: '',
     directory: options.directory,
+    isEmbedded: false,
   }
   try {
     const app = await loadApp({

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -141,6 +141,7 @@ export interface CreateAppOptions {
   isLaunchable?: boolean
   scopesArray?: string[]
   directory?: string
+  isEmbedded?: boolean
 }
 
 interface AppModuleVersionSpecification {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -913,7 +913,7 @@ const MAGIC_URL = 'https://shopify.dev/apps/default-app-home'
 const MAGIC_REDIRECT_URL = 'https://shopify.dev/apps/default-app-home/api/auth'
 
 function createAppVars(options: CreateAppOptions, apiVersion?: string): CreateAppMutationVariables {
-  const {isLaunchable, scopesArray, name} = options
+  const {isLaunchable, scopesArray, name, isEmbedded} = options
   return {
     appSource: {
       appModules: [
@@ -923,7 +923,7 @@ function createAppVars(options: CreateAppOptions, apiVersion?: string): CreateAp
           specificationIdentifier: AppHomeSpecIdentifier,
           config: {
             app_url: isLaunchable ? 'https://example.com' : MAGIC_URL,
-            embedded: isLaunchable,
+            embedded: isEmbedded,
           },
         },
         {


### PR DESCRIPTION
### WHY are these changes introduced?

Adds support for embedded app configuration during app initialization, allowing better control over whether apps are embedded or not.

### WHAT is this pull request doing?

Introduces a new `isEmbedded` property to handle app embedding configuration:
- Adds `IsEmbedded` getter to the app model to determine embedded status.
- Updates app creation to consider embedded status when linking to new apps.
- Defaults to embedded = true for launchable apps during `app init`

### How to test your changes?
0. Using the app-managment API:

1. Run `app init` with a remix template
2. Verify the app is created with `embedded: true`
3. Run `app dev --reset` and select to create a new app
4. Verify the new toml is created with `embedded: true`
5. Modify the last toml to have `embedded: false`
6. Run `app dev --reset` and select to create a new app
7. Verify the new toml has `embedded: false`

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes