### PR TITLE
Update CODEOWNERS to replace advanced-edits with developer-tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,13 +2,13 @@
 * @shopify/app-inner-loop
 
 # Theme team and CLI owners should review theme changes
-packages/cli-kit/src/private/themes/* @shopify/advanced-edits @shopify/app-inner-loop
-packages/cli-kit/src/public/**/themes/* @shopify/advanced-edits @shopify/app-inner-loop
-packages/theme/** @shopify/advanced-edits @shopify/app-inner-loop
+packages/cli-kit/src/private/themes/* @shopify/developer-tools @shopify/app-inner-loop
+packages/cli-kit/src/public/**/themes/* @shopify/developer-tools @shopify/app-inner-loop
+packages/theme/** @shopify/developer-tools @shopify/app-inner-loop
 
 # These are metafiles that can be reviewed by anyone
-.changeset/* @shopify/advanced-edits @shopify/app-inner-loop
-.github/CODEOWNERS @shopify/advanced-edits @shopify/app-inner-loop
-docs-shopify.dev/**  @shopify/advanced-edits @shopify/app-inner-loop
-packages/cli/oclif.manifest.json @shopify/advanced-edits @shopify/app-inner-loop
-packages/cli/README.md @shopify/advanced-edits @shopify/app-inner-loop
+.changeset/* @shopify/developer-tools @shopify/app-inner-loop
+.github/CODEOWNERS @shopify/developer-tools @shopify/app-inner-loop
+docs-shopify.dev/**  @shopify/developer-tools @shopify/app-inner-loop
+packages/cli/oclif.manifest.json @shopify/developer-tools @shopify/app-inner-loop
+packages/cli/README.md @shopify/developer-tools @shopify/app-inner-loop


### PR DESCRIPTION
### WHY are these changes introduced?

Updates CODEOWNERS to reflect the team name change from `@shopify/advanced-edits` to `@shopify/developer-tools`.

### WHAT is this pull request doing?

Replaces all instances of the `@shopify/advanced-edits` team with `@shopify/developer-tools` in the CODEOWNERS file, maintaining the same file ownership structure and permissions.

### How to test your changes?

1. Create a PR that modifies any of the listed paths
2. Verify that the `@shopify/developer-tools` team is automatically requested for review

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes