### PR TITLE
Rethrow functions esbuild errors

### DIFF
--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -186,7 +186,12 @@ export async function buildFunctionExtension(
       await touchFile(bundlePath)
       await writeFile(bundlePath, base64Contents)
     }
-  } catch (error) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    const errors = error.errors ?? []
+    // If there is an `errors` array, it's an esbuild error, re-throw it directly.
+    if (errors.length) throw error
+
     const errorMessage = (error as Error).message ?? 'Unknown error occurred'
     throw new AbortError('Failed to build function.', errorMessage)
   } finally {

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -188,12 +188,14 @@ export async function buildFunctionExtension(
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    const errors = error.errors ?? []
-    // If there is an `errors` array, it's an esbuild error, re-throw it directly.
-    if (errors.length) throw error
-
+    // We capture and rethrow as AbortError to avoid random user-code errors being reported as CLI bugs.
+    // At the same time, we need to keep the ESBuild details for the logs. (the `errors` array)
     const errorMessage = (error as Error).message ?? 'Unknown error occurred'
-    throw new AbortError('Failed to build function.', errorMessage)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const newError: any = new AbortError('Failed to build function.', errorMessage)
+    // Inject ESBuild errors if present
+    newError.errors = error.errors
+    throw newError
   } finally {
     await releaseLock()
   }


### PR DESCRIPTION
### WHY are these changes introduced?

We want ESBuild errors from functions to appear in the dev logs.

### WHAT is this pull request doing?

If a javascript function throws an ESBuild error, re-throw as it is and the dev-session will automatically parse and format it.

### How to test your changes?

1. Create a javascript function extension
2. Run dev
3. Modify the function to have some syntax error. 
4. See that the error is properly shown in the dev log, with specific details on where it happened.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes