### PR TITLE
Custom data placeholder module is not required

### DIFF
--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -25,7 +25,6 @@ import themeSpec from './specifications/theme.js'
 import uiExtensionSpec from './specifications/ui_extension.js'
 import webPixelSpec from './specifications/web_pixel_extension.js'
 import editorExtensionCollectionSpecification from './specifications/editor_extension_collection.js'
-import customDataSpec, {CustomDataSpecIdentifier} from './specifications/custom_data.js'
 
 const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   BrandingSpecIdentifier,
@@ -36,7 +35,6 @@ const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   AppProxySpecIdentifier,
   PosSpecIdentifier,
   AppHomeSpecIdentifier,
-  CustomDataSpecIdentifier,
 ]
 
 /**
@@ -59,7 +57,6 @@ function loadSpecifications() {
     appPrivacyComplienceSpec,
     appWebhooksSpec,
     appWebhookSubscriptionSpec,
-    customDataSpec,
   ]
   const moduleSpecs = [
     checkoutPostPurchaseSpec,

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -249,47 +249,6 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
   })
 }
 
-/**
- * Create a zod object schema based on keys, but neutral as to content.
- *
- * Used for schemas that are supplemented by JSON schema contracts, but need to register top-level keys.
- */
-function neutralTopLevelSchema<TKey extends string>(...keys: TKey[]): zod.ZodObject<{[k in TKey]: zod.ZodAny}> {
-  return zod.object(
-    Object.fromEntries(
-      keys.map((key) => {
-        return [key, zod.any()]
-      }),
-    ),
-  ) as zod.ZodObject<{[k in TKey]: zod.ZodAny}>
-}
-
-/**
- * Create a new app config extension spec that uses contract-based validation.
- *
- * See {@link createConfigExtensionSpecification} for more about app config extensions.
- */
-export function createContractBasedConfigModuleSpecification<TKey extends string>(
-  identifier: string,
-  ...topLevelKeys: TKey[]
-): ExtensionSpecification {
-  const schema = neutralTopLevelSchema(...topLevelKeys)
-  return createConfigExtensionSpecification({
-    identifier,
-    schema,
-    transformConfig: {
-      // outgoing config is already scoped to this module and passed directly along
-      forward(obj) {
-        return obj
-      },
-      // incoming config from the platform is included in app config as-is
-      reverse(obj) {
-        return obj
-      },
-    },
-  })
-}
-
 export function createContractBasedModuleSpecification<TConfiguration extends BaseConfigType = BaseConfigType>(
   identifier: string,
   appModuleFeatures?: ExtensionFeature[],

--- a/packages/app/src/cli/models/extensions/specifications/custom_data.ts
+++ b/packages/app/src/cli/models/extensions/specifications/custom_data.ts
@@ -1,7 +1,0 @@
-import {createContractBasedConfigModuleSpecification} from '../specification.js'
-
-export const CustomDataSpecIdentifier = 'data'
-
-const customDataSpec = createContractBasedConfigModuleSpecification(CustomDataSpecIdentifier, 'product', 'metaobjects')
-
-export default customDataSpec


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/develop-app-storage/issues/18 

Removes the custom data extension specification which is no longer supported or needed in the CLI.

### WHAT is this pull request doing?

Removes the `custom_data.ts` specification file and its references from the extension loading system.

### How to test your changes?

Run the DCDD convergence script using a source version of the CLI. 

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes