### PR TITLE
Add `addToGitIgnore` to cli-kit to append entries to existing `.gitignore` files

### DIFF
--- a/.changeset/thick-flies-rest.md
+++ b/.changeset/thick-flies-rest.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add `addToGitIgnore` to cli-kit to append entries to existing `.gitignore` files

--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -1,5 +1,5 @@
 import * as git from './git.js'
-import {appendFileSync} from './fs.js'
+import {appendFileSync, fileExistsSync, inTemporaryDirectory, readFileSync, writeFileSync} from './fs.js'
 import {hasGit} from './context/local.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import simpleGit from 'simple-git'
@@ -25,9 +25,15 @@ const simpleGitProperties = {
   status: mockedGitStatus,
 }
 
-vi.mock('./context/local.js')
-vi.mock('./fs.js')
 vi.mock('simple-git')
+vi.mock('./context/local.js')
+vi.mock('./fs.js', async () => {
+  const fs = await vi.importActual('./fs.js')
+  return {
+    ...fs,
+    appendFileSync: vi.fn(),
+  }
+})
 
 beforeEach(() => {
   vi.mocked(hasGit).mockResolvedValue(true)
@@ -373,5 +379,69 @@ describe('isGitClean()', () => {
 
     // Then
     expect(simpleGit).toHaveBeenCalledWith({baseDir: directory})
+  })
+})
+
+describe('addToGitIgnore()', () => {
+  test('does nothing when .gitignore does not exist', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const gitIgnorePath = `${tmpDir}/.gitignore`
+
+      // When
+      git.addToGitIgnore(tmpDir, '.shopify')
+
+      // Then
+      expect(fileExistsSync(gitIgnorePath)).toBe(false)
+    })
+  })
+
+  test('does nothing when pattern already exists in .gitignore', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const gitIgnorePath = `${tmpDir}/.gitignore`
+      const gitIgnoreContent = ' .shopify \nnode_modules\n'
+
+      writeFileSync(gitIgnorePath, gitIgnoreContent)
+
+      // When
+      git.addToGitIgnore(tmpDir, '.shopify')
+
+      // Then
+      const actualContent = readFileSync(gitIgnorePath).toString()
+      expect(actualContent).toBe(gitIgnoreContent)
+    })
+  })
+
+  test('appends pattern to .gitignore when file exists and pattern not present', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const gitIgnorePath = `${tmpDir}/.gitignore`
+
+      writeFileSync(gitIgnorePath, 'node_modules\ndist')
+
+      // When
+      git.addToGitIgnore(tmpDir, '.shopify')
+
+      // Then
+      const gitIgnoreContent = readFileSync(gitIgnorePath).toString()
+      expect(gitIgnoreContent).toBe('node_modules\ndist\n.shopify\n')
+    })
+  })
+
+  test('appends pattern to .gitignore when file exists and pattern not present without duplicating the last empty line', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const gitIgnorePath = `${tmpDir}/.gitignore`
+
+      writeFileSync(gitIgnorePath, 'node_modules\ndist\n')
+
+      // When
+      git.addToGitIgnore(tmpDir, '.shopify')
+
+      // Then
+      const gitIgnoreContent = readFileSync(gitIgnorePath).toString()
+      expect(gitIgnoreContent).toBe('node_modules\ndist\n.shopify\n')
+    })
   })
 })

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-base-to-string */
 import {hasGit, isTerminalInteractive} from './context/local.js'
-import {appendFileSync} from './fs.js'
+import {appendFileSync, detectEOL, fileExistsSync, readFileSync, writeFileSync} from './fs.js'
 import {AbortError} from './error.js'
-import {cwd} from './path.js'
+import {cwd, joinPath} from './path.js'
 import {runWithTimer} from './metadata.js'
 import {outputContent, outputToken, outputDebug} from '../../public/node/output.js'
 import git, {TaskOptions, SimpleGitProgressEvent, DefaultLogFields, ListLogLine, SimpleGit} from 'simple-git'
@@ -61,6 +61,38 @@ export function createGitIgnore(directory: string, template: GitIgnoreTemplate):
   }
 
   appendFileSync(filePath, fileContent)
+}
+
+/**
+ * Add an entry to an existing .gitignore file.
+ *
+ * If the .gitignore file doesn't exist, or if the entry is already present,
+ * no changes will be made.
+ *
+ * @param root - The directory containing the .gitignore file.
+ * @param entry - The entry to add to the .gitignore file.
+ */
+export function addToGitIgnore(root: string, entry: string): void {
+  const gitIgnorePath = joinPath(root, '.gitignore')
+
+  if (!fileExistsSync(gitIgnorePath)) {
+    // When the .gitignore file does not exist, the CLI should not be opinionated about creating it
+    return
+  }
+
+  const gitIgnoreContent = readFileSync(gitIgnorePath).toString()
+  const eol = detectEOL(gitIgnoreContent)
+
+  if (gitIgnoreContent.split(eol).some((line) => line.trim() === entry.trim())) {
+    // The file already existing in the .gitignore
+    return
+  }
+
+  if (gitIgnoreContent.endsWith(eol)) {
+    writeFileSync(gitIgnorePath, `${gitIgnoreContent}${entry}${eol}`)
+  } else {
+    writeFileSync(gitIgnorePath, `${gitIgnoreContent}${eol}${entry}${eol}`)
+  }
 }
 
 /**

--- a/packages/theme/src/cli/services/metafields-pull.test.ts
+++ b/packages/theme/src/cli/services/metafields-pull.test.ts
@@ -99,7 +99,7 @@ describe('metafields-pull', () => {
 
       // Then
       await expect(fileExists(gitIgnorePath)).resolves.toBe(true)
-      await expect(readFile(gitIgnorePath)).resolves.toBe(`.DS_Store\n.shopify/secrets.json\n.shopify`)
+      await expect(readFile(gitIgnorePath)).resolves.toBe(`.DS_Store\n.shopify/secrets.json\n.shopify\n`)
     })
 
     expect(capturedOutput.info()).toContain('Metafield definitions have been successfully downloaded.')

--- a/packages/theme/src/cli/services/metafields-pull.ts
+++ b/packages/theme/src/cli/services/metafields-pull.ts
@@ -6,8 +6,9 @@ import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/ses
 import {cwd, joinPath} from '@shopify/cli-kit/node/path'
 import {metafieldDefinitionsByOwnerType} from '@shopify/cli-kit/node/themes/api'
 import {renderError, renderSuccess} from '@shopify/cli-kit/node/ui'
-import {detectEOL, fileExistsSync, mkdirSync, readFileSync, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {fileExistsSync, mkdirSync, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {outputDebug} from '@shopify/cli-kit/node/output'
+import {addToGitIgnore} from '@shopify/cli-kit/node/git'
 
 interface MetafieldsPullOptions {
   path: string
@@ -168,23 +169,4 @@ function writeMetafieldDefinitionsToFile(path: string, content: unknown) {
   }
 
   writeFileSync(filePath, fileContent)
-}
-
-function addToGitIgnore(root: string, entry: string) {
-  const gitIgnorePath = joinPath(root, '.gitignore')
-
-  if (!fileExistsSync(gitIgnorePath)) {
-    // When the .gitignore file does not exist, the CLI should not be opinionated about creating it
-    return
-  }
-
-  const gitIgnoreContent = readFileSync(gitIgnorePath).toString()
-  const eol = detectEOL(gitIgnoreContent)
-
-  if (gitIgnoreContent.split(eol).includes(entry)) {
-    // The file already existing in the .gitignore
-    return
-  }
-
-  writeFileSync(gitIgnorePath, `${gitIgnoreContent}${eol}${entry}`)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This PR moves the `addToGitIgnore` to `cli-kit`, following the suggestion in this thread https://github.com/Shopify/cli/pull/5184#discussion_r1920304997

### WHAT is this pull request doing?

This PR moves the `addToGitIgnore` from the `theme` package to `cli-kit`, following the suggestion in the thread above.

### How to test your changes?

- Run `shopify theme metafields pull`
- Notice that, when the .shopify/metafields.json file is created, `.shopify` is also added in the gitignore

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
