### PR TITLE
Workflow to deprecate old packages in NPM

### DIFF
--- a/.github/workflows/deprecate-old-packages.yml
+++ b/.github/workflows/deprecate-old-packages.yml
@@ -1,0 +1,18 @@
+name: Deprecate old packages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Deprecate old packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deprecate
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          npm deprecate @shopify/app@"*" "$MESSAGE"
+          npm deprecate @shopify/theme@"*" "$MESSAGE"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          MESSAGE: This package is deprecated. As of Shopify CLI version 3.59.0, it is bundled with @shopify/cli. Please use that package instead.


### PR DESCRIPTION
### WHY are these changes introduced?

Since CLI 3.59, we are not releasing new versions of [@shopify/app](https://www.npmjs.com/package/@shopify/app) or [@shopify/theme](https://www.npmjs.com/package/@shopify/theme) because they are bundled with [@shopify/cli](https://www.npmjs.com/package/@shopify/cli).

But the old versions remain on NPM and it's confusing our users. Example: https://github.com/Shopify/cli/issues/5201

### WHAT is this pull request doing?

Adds a one-time GitHub action to deprecate all the versions of those packages in NPM, by using the [npm deprecate](https://docs.npmjs.com/cli/v8/commands/npm-deprecate) command.

That will include a warning in the NPM website and the command line when installing them: https://docs.npmjs.com/using-deprecated-packages

It can be reversed.

### How to test your changes?

Manually run and see if it works

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
