### PR TITLE
[DNM] Custom data placeholder module is not required

### DIFF
--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -31,7 +31,7 @@ import {WebhookSubscriptionSpecIdentifier} from '../extensions/specifications/ap
 import {WebhooksSchema} from '../extensions/specifications/app_config_webhook_schemas/webhooks_schema.js'
 import {loadLocalExtensionsSpecifications} from '../extensions/load-specifications.js'
 import {UIExtensionSchemaType} from '../extensions/specifications/ui_extension.js'
-import {deepStrict, zod} from '@shopify/cli-kit/node/schema'
+import {zod} from '@shopify/cli-kit/node/schema'
 import {fileExists, readFile, glob, findPathUp, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {
@@ -905,17 +905,12 @@ async function loadAppConfigurationFromState<
           ...configState.basicConfiguration,
         }
         delete file.path
-        const appVersionedSchema = getAppVersionedSchema(specifications)
+        const appVersionedSchema = getAppVersionedSchema(specifications, true)
         appSchema = appVersionedSchema as SchemaForConfig<LoadedAppConfigFromConfigState<TConfig>>
         break
       }
     }
-
-    const parseStrictSchemaEnabled = specifications.length > 0
     schemaForConfigurationFile = appSchema
-    if (parseStrictSchemaEnabled) {
-      schemaForConfigurationFile = deepStrict(appSchema)
-    }
   }
 
   const configuration = (await parseConfigurationFile(

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -25,7 +25,6 @@ import themeSpec from './specifications/theme.js'
 import uiExtensionSpec from './specifications/ui_extension.js'
 import webPixelSpec from './specifications/web_pixel_extension.js'
 import editorExtensionCollectionSpecification from './specifications/editor_extension_collection.js'
-import customDataSpec, {CustomDataSpecIdentifier} from './specifications/custom_data.js'
 
 const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   BrandingSpecIdentifier,
@@ -36,7 +35,6 @@ const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   AppProxySpecIdentifier,
   PosSpecIdentifier,
   AppHomeSpecIdentifier,
-  CustomDataSpecIdentifier,
 ]
 
 /**
@@ -59,7 +57,6 @@ function loadSpecifications() {
     appPrivacyComplienceSpec,
     appWebhooksSpec,
     appWebhookSubscriptionSpec,
-    customDataSpec,
   ]
   const moduleSpecs = [
     checkoutPostPurchaseSpec,

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -249,47 +249,6 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
   })
 }
 
-/**
- * Create a zod object schema based on keys, but neutral as to content.
- *
- * Used for schemas that are supplemented by JSON schema contracts, but need to register top-level keys.
- */
-function neutralTopLevelSchema<TKey extends string>(...keys: TKey[]): zod.ZodObject<{[k in TKey]: zod.ZodAny}> {
-  return zod.object(
-    Object.fromEntries(
-      keys.map((key) => {
-        return [key, zod.any()]
-      }),
-    ),
-  ) as zod.ZodObject<{[k in TKey]: zod.ZodAny}>
-}
-
-/**
- * Create a new app config extension spec that uses contract-based validation.
- *
- * See {@link createConfigExtensionSpecification} for more about app config extensions.
- */
-export function createContractBasedConfigModuleSpecification<TKey extends string>(
-  identifier: string,
-  ...topLevelKeys: TKey[]
-): ExtensionSpecification {
-  const schema = neutralTopLevelSchema(...topLevelKeys)
-  return createConfigExtensionSpecification({
-    identifier,
-    schema,
-    transformConfig: {
-      // outgoing config is already scoped to this module and passed directly along
-      forward(obj) {
-        return obj
-      },
-      // incoming config from the platform is included in app config as-is
-      reverse(obj) {
-        return obj
-      },
-    },
-  })
-}
-
 export function createContractBasedModuleSpecification<TConfiguration extends BaseConfigType = BaseConfigType>(
   identifier: string,
   appModuleFeatures?: ExtensionFeature[],

--- a/packages/app/src/cli/models/extensions/specifications/custom_data.ts
+++ b/packages/app/src/cli/models/extensions/specifications/custom_data.ts
@@ -1,7 +1,0 @@
-import {createContractBasedConfigModuleSpecification} from '../specification.js'
-
-export const CustomDataSpecIdentifier = 'data'
-
-const customDataSpec = createContractBasedConfigModuleSpecification(CustomDataSpecIdentifier, 'product', 'metaobjects')
-
-export default customDataSpec

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -69,6 +69,11 @@ async function mergeLocalAndRemoteSpecs(
       const normalisedSchema = await normaliseJsonSchema(remoteSpec.validationSchema.jsonSchema)
       const hasLocalization = normalisedSchema.properties?.localization !== undefined
       localSpec = createContractBasedModuleSpecification(remoteSpec.identifier, hasLocalization ? ['localization'] : [])
+
+      // HACK -- pull from API when ready.
+      if (localSpec.identifier === 'data') {
+        localSpec.uidStrategy = 'single'
+      }
     }
     if (!localSpec) return undefined
 

--- a/packages/app/src/cli/utilities/json-schema.ts
+++ b/packages/app/src/cli/utilities/json-schema.ts
@@ -55,7 +55,7 @@ export async function unifiedConfigurationParserFactory(
     }
     return {
       state: 'ok',
-      data: zodValidatedData as BaseConfigType,
+      data: jsonSchemaParse.data as BaseConfigType,
       errors: undefined,
     }
   }

--- a/packages/cli-kit/src/public/node/json-schema.ts
+++ b/packages/cli-kit/src/public/node/json-schema.ts
@@ -39,7 +39,7 @@ export function jsonSchemaValidate(
   schema: SchemaObject,
   identifier: string,
 ): ParseConfigurationResult<unknown> & {rawErrors?: AjvError[]} {
-  const ajv = new Ajv({allowUnionTypes: true})
+  const ajv = new Ajv({allowUnionTypes: true, removeAdditional: true})
 
   ajv.addKeyword('x-taplo')
 


### PR DESCRIPTION
DNM - exploration

This shows how config modules -- modules specified in the app.toml file -- can be made solely server led. There are few small changes here:

- We no longer check that the app.toml matches the CLI-defined config zod schema precisely. We let unknown fields through
- When parsing using JSON schema, we return the JSON schema-validated data, rather than the source data
- We also remove any additional properties in this result, if `additionalProperties: false` is set. This means that JSON schema that covers a slice of the app.toml can be given the entire config, validate it, and return a data structure representing just thie piece that it validated. This is the same behaviour the internal zod schemas for app config follow.
- We remove the hard-coded custom data schema and use the server provided specification. We have to hack in that this module uses single-instance management

One side-effect of this is that completely unknown sections in the app.toml are ignored but don't cause validation to fail. This is a change. This may be desirable or not... if the reason a section is ignored is because it's called `[scopes]` then the developer probably meant `[access_scopes]` and so maybe silence isn't good. Alternatively it may be the right thing to validate things we known about and ignore things we don't.

This is tested in dev and deploy but not linking yet. We'd want to test this thoroughly I think as its a somewhat low level shift.