### PR TITLE
Patch the app manifest with the development URLs, add tests

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -71,6 +71,8 @@ import {
 } from '../../api/graphql/partners/generated/update-draft.js'
 import {SchemaDefinitionByTargetQueryVariables} from '../../api/graphql/functions/generated/schema-definition-by-target.js'
 import {SchemaDefinitionByApiTypeQueryVariables} from '../../api/graphql/functions/generated/schema-definition-by-api-type.js'
+import {AppHomeSpecIdentifier} from '../extensions/specifications/app_config_app_home.js'
+import {AppProxySpecIdentifier} from '../extensions/specifications/app_config_app_proxy.js'
 import {vi} from 'vitest'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
@@ -120,6 +122,7 @@ export function testApp(app: Partial<AppInterface> = {}, schemaType: 'current' |
     configSchema: (app.configSchema ?? AppConfigurationSchema) as any,
     remoteFlags: app.remoteFlags ?? [],
     hiddenConfig: app.hiddenConfig ?? {},
+    devApplicationURLs: app.devApplicationURLs,
   })
 
   if (app.updateDependencies) {
@@ -335,6 +338,55 @@ export async function testAppAccessConfigExtension(
     configurationPath: 'shopify.app.toml',
     directory: directory ?? './',
     specification: appAccessSpec,
+  })
+
+  return extension
+}
+
+export async function testAppHomeConfigExtension(): Promise<ExtensionInstance> {
+  const configuration = {
+    name: 'App Home',
+    type: 'app_home',
+    handle: 'app-home',
+    application_url: 'https://example.com',
+    embedded: true,
+    metafields: [],
+  }
+
+  const allSpecs = await loadLocalExtensionsSpecifications()
+  const specification = allSpecs.find((spec) => spec.identifier === AppHomeSpecIdentifier)!
+
+  const extension = new ExtensionInstance({
+    configuration,
+    configurationPath: '',
+    directory: './',
+    specification,
+  })
+
+  return extension
+}
+
+export async function testAppProxyConfigExtension(): Promise<ExtensionInstance> {
+  const configuration = {
+    name: 'App Proxy',
+    type: 'app_proxy',
+    handle: 'app-proxy',
+    metafields: [],
+    app_proxy: {
+      url: 'https://example.com',
+      subpath: 'apps',
+      prefix: 'apps',
+    },
+  }
+
+  const allSpecs = await loadLocalExtensionsSpecifications()
+  const specification = allSpecs.find((spec) => spec.identifier === AppProxySpecIdentifier)!
+
+  const extension = new ExtensionInstance({
+    configuration,
+    configurationPath: '',
+    directory: './',
+    specification,
   })
 
   return extension

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -473,15 +473,6 @@ describe('allExtensions', () => {
   })
 })
 
-describe('patchManifestWithDevURLs', () => {
-  test('patches the manifest with the development URLs', () => {
-    const app = testApp({})
-
-    const manifest = app.manifest()
-    expect(manifest).toContain(app.devApplicationURLs?.applicationUrl)
-  })
-})
-
 describe('manifest', () => {
   test('generates a manifest with basic app information and modules', async () => {
     // Given
@@ -590,14 +581,7 @@ describe('manifest', () => {
 
   test('does not patch URLs when devApplicationURLs is not available', async () => {
     // Given
-    const appHome = await testUIExtension({
-      type: 'app_home',
-      configuration: {
-        name: 'App Home',
-        type: 'app_home',
-        handle: 'app-home',
-      },
-    })
+    const appHome = await testAppHomeConfigExtension()
 
     const app = await testApp({
       name: 'my-app',
@@ -618,12 +602,15 @@ describe('manifest', () => {
       handle: '',
       modules: [
         {
-          type: 'app_home',
+          type: 'app_home_external',
           handle: 'app-home',
           uid: appHome.uid,
           assets: appHome.uid,
           target: appHome.contextValue,
-          config: {},
+          config: {
+            app_url: 'https://example.com',
+            embedded: true,
+          },
         },
       ],
     })

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -18,11 +18,14 @@ import {
   testWebhookExtensions,
   testEditorExtensionCollection,
   testAppAccessConfigExtension,
+  testAppHomeConfigExtension,
+  testAppProxyConfigExtension,
 } from './app.test-data.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
 import {FunctionConfigType} from '../extensions/specifications/function.js'
 import {WebhooksConfig} from '../extensions/specifications/types/app_config_webhook.js'
 import {EditorExtensionCollectionType} from '../extensions/specifications/editor_extension_collection.js'
+import {ApplicationURLs} from '../../services/dev/urls.js'
 import {describe, expect, test} from 'vitest'
 import {inTemporaryDirectory, mkdir, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -467,6 +470,163 @@ describe('allExtensions', () => {
     )
 
     expect(app.allExtensions).toContain(configExtension)
+  })
+})
+
+describe('patchManifestWithDevURLs', () => {
+  test('patches the manifest with the development URLs', () => {
+    const app = testApp({})
+
+    const manifest = app.manifest()
+    expect(manifest).toContain(app.devApplicationURLs?.applicationUrl)
+  })
+})
+
+describe('manifest', () => {
+  test('generates a manifest with basic app information and modules', async () => {
+    // Given
+    const appAccessModule = await testAppAccessConfigExtension()
+
+    const app = await testApp({
+      name: 'my-app',
+      allExtensions: [appAccessModule],
+      configuration: {
+        ...DEFAULT_CONFIG,
+        client_id: 'test-client-id',
+      },
+    })
+
+    // When
+    const manifest = await app.manifest()
+
+    // Then
+    expect(manifest).toEqual({
+      name: 'my-app',
+      handle: '',
+      modules: [
+        {
+          type: 'app_access_external',
+          handle: 'app-access',
+          uid: appAccessModule.uid,
+          assets: appAccessModule.uid,
+          target: appAccessModule.contextValue,
+          config: expect.objectContaining({
+            redirect_url_allowlist: ['https://example.com/auth/callback'],
+          }),
+        },
+      ],
+    })
+  })
+
+  test('patches the manifest with development URLs when available', async () => {
+    // Given
+    const appHome = await testAppHomeConfigExtension()
+    const appAccess = await testAppAccessConfigExtension()
+    const appProxy = await testAppProxyConfigExtension()
+
+    const devApplicationURLs: ApplicationURLs = {
+      applicationUrl: 'https://new-url.io',
+      redirectUrlWhitelist: ['https://new-url.io/auth/callback'],
+      appProxy: {
+        proxyUrl: 'https://new-proxy-url.io',
+        proxySubPath: '/updated-path',
+        proxySubPathPrefix: 'updated-prefix',
+      },
+    }
+
+    const app = await testApp({
+      name: 'my-app',
+      allExtensions: [appHome, appProxy, appAccess],
+      configuration: {
+        ...DEFAULT_CONFIG,
+        client_id: 'test-client-id',
+      },
+      devApplicationURLs,
+    })
+
+    // When
+    const manifest = await app.manifest()
+
+    // Then
+    expect(manifest).toEqual({
+      name: 'my-app',
+      handle: '',
+      modules: [
+        {
+          type: 'app_home_external',
+          handle: 'app-home',
+          uid: appHome.uid,
+          assets: appHome.uid,
+          target: appHome.contextValue,
+          config: expect.objectContaining({
+            app_url: 'https://new-url.io',
+          }),
+        },
+        {
+          type: 'app_proxy_external',
+          handle: 'app-proxy',
+          uid: appProxy.uid,
+          assets: appProxy.uid,
+          target: appProxy.contextValue,
+          config: expect.objectContaining({
+            url: 'https://new-proxy-url.io',
+            subpath: '/updated-path',
+            prefix: 'updated-prefix',
+          }),
+        },
+        {
+          type: 'app_access_external',
+          handle: 'app-access',
+          uid: appAccess.uid,
+          assets: appAccess.uid,
+          target: appAccess.contextValue,
+          config: expect.objectContaining({
+            redirect_url_allowlist: ['https://new-url.io/auth/callback'],
+          }),
+        },
+      ],
+    })
+  })
+
+  test('does not patch URLs when devApplicationURLs is not available', async () => {
+    // Given
+    const appHome = await testUIExtension({
+      type: 'app_home',
+      configuration: {
+        name: 'App Home',
+        type: 'app_home',
+        handle: 'app-home',
+      },
+    })
+
+    const app = await testApp({
+      name: 'my-app',
+      allExtensions: [appHome],
+      configuration: {
+        ...DEFAULT_CONFIG,
+        client_id: 'test-client-id',
+      },
+      devApplicationURLs: undefined,
+    })
+
+    // When
+    const manifest = await app.manifest()
+
+    // Then
+    expect(manifest).toEqual({
+      name: 'my-app',
+      handle: '',
+      modules: [
+        {
+          type: 'app_home',
+          handle: 'app-home',
+          uid: appHome.uid,
+          assets: appHome.uid,
+          target: appHome.contextValue,
+          config: {},
+        },
+      ],
+    })
   })
 })
 

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -495,7 +495,7 @@ export class App<
   /**
    * Patches the manifest with the development URLs.
    * @param modules - All App modules
-   * @returns All app moduels with patches applied.
+   * @returns All app modules with patches applied.
    */
   private patchManifestWithDevURLs(modules: {type: string; config: JsonMapType}[]) {
     if (!this.devApplicationURLs) return modules

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -373,6 +373,7 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
       configSchema,
       remoteFlags: this.remoteFlags,
       hiddenConfig,
+      devApplicationURLs: this.previousApp?.devApplicationURLs,
     })
 
     // Show CLI notifications that are targetted for when your app has specific extension types

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -1,8 +1,8 @@
 import {
-  FrontendURLOptions,
   ApplicationURLs,
-  generateFrontendURL,
+  FrontendURLOptions,
   generateApplicationURLs,
+  generateFrontendURL,
   getURLs,
   shouldOrPromptUpdateURLs,
   startTunnelPlugin,
@@ -151,7 +151,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
   const previousAppId = getCachedAppInfo(commandOptions.directory)?.previousAppId
   const apiKey = remoteApp.apiKey
 
-  const {shouldUpdateURLs, newURLs} = await handleUpdatingOfPartnerUrls(
+  const partnerUrlsUpdated = await handleUpdatingOfPartnerUrls(
     webs,
     commandOptions.update,
     network,
@@ -162,12 +162,6 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
     developerPlatformClient,
   )
 
-  // If the user chose to update the URLs automatically AND there are new URLs
-  // Store them in the app so that the manifest can be patched with them
-  if (shouldUpdateURLs && newURLs) {
-    app.devApplicationURLs = newURLs
-  }
-
   return {
     storeFqdn: store.shopDomain,
     storeId: store.shopId,
@@ -177,7 +171,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
     developerPlatformClient,
     commandOptions,
     network,
-    partnerUrlsUpdated: shouldUpdateURLs,
+    partnerUrlsUpdated,
     graphiqlPort,
     graphiqlKey,
   }
@@ -266,10 +260,9 @@ async function handleUpdatingOfPartnerUrls(
 ) {
   const {backendConfig, frontendConfig} = frontAndBackendConfig(webs)
   let shouldUpdateURLs = false
-  let newURLs: ApplicationURLs | undefined
   if (frontendConfig ?? backendConfig) {
     if (commandSpecifiedToUpdate) {
-      newURLs = generateApplicationURLs(
+      const newURLs = generateApplicationURLs(
         network.proxyUrl,
         webs.map(({configuration}) => configuration.auth_callback_path).find((path) => path),
         localApp.configuration.app_proxy,
@@ -284,10 +277,14 @@ async function handleUpdatingOfPartnerUrls(
       })
       // When running dev app urls are pushed directly to API Client config instead of creating a new app version
       // so current app version and API Client config will have diferent url values.
-      if (shouldUpdateURLs) await updateURLs(newURLs, apiKey, developerPlatformClient, localApp)
+      if (shouldUpdateURLs) {
+        await updateURLs(newURLs, apiKey, developerPlatformClient, localApp)
+        // eslint-disable-next-line require-atomic-updates
+        localApp.devApplicationURLs = newURLs
+      }
     }
   }
-  return {shouldUpdateURLs, newURLs}
+  return shouldUpdateURLs
 }
 
 async function setupNetworkingOptions(


### PR DESCRIPTION
### WHY are these changes introduced?

Enables the CLI to patch app manifests with development URLs during local development, ensuring that app home, app proxy, and app access configurations use the correct development URLs instead of production URLs.

### WHAT is this pull request doing?

- Adds support for patching app manifests with development URLs during local development
- Introduces new test data helpers for app home and app proxy extensions
- Updates the app model to store and use development URLs when generating manifests

### How to test your changes?

1. Create an app with app home, app proxy, and app access extensions
2. Run the dev command
3. Verify that the manifest (inside `./shopify/bundle`) includes the correct development URLs.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes