### PR TITLE
Stop updating the app urls in the app toml when using the app management API

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2366,7 +2366,7 @@ wrong = "property"
       redirectUrlWhitelist: ['http://custom.dev/auth'],
     }
     app.allExtensions[0]!.devUUID = customDevUUID
-    app.devApplicationURLs = customAppURLs
+    app.setDevApplicationURLs(customAppURLs)
 
     // When
     const reloadedApp = await reloadApp(app)

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -23,6 +23,7 @@ import {bundleThemeExtension} from '../../services/extensions/bundle.js'
 import {Identifiers} from '../app/identifiers.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationWithoutPath, CurrentAppConfiguration} from '../app/app.js'
+import {ApplicationURLs} from '../../services/dev/urls.js'
 import {ok} from '@shopify/cli-kit/node/result'
 import {constantize, slugify} from '@shopify/cli-kit/common/string'
 import {hashString, nonRandomUUID} from '@shopify/cli-kit/node/crypto'
@@ -425,6 +426,16 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   ): Promise<string | undefined> {
     if (!this.specification.getDevSessionActionUpdateMessage) return undefined
     return this.specification.getDevSessionActionUpdateMessage(this.configuration, appConfig, storeFqdn)
+  }
+
+  /**
+   * Patches the configuration with the app dev URLs if applicable
+   * Only for modules that use the app URL in their configuration.
+   * @param urls - The app dev URLs
+   */
+  patchWithAppDevURLs(urls: ApplicationURLs) {
+    if (!this.specification.patchWithAppDevURLs) return
+    this.specification.patchWithAppDevURLs(this.configuration, urls)
   }
 
   private buildHandle() {

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -6,6 +6,7 @@ import {blocks} from '../../constants.js'
 import {Flag} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationWithoutPath, CurrentAppConfiguration} from '../app/app.js'
 import {loadLocalesConfig} from '../../utilities/extensions/locales-configuration.js'
+import {ApplicationURLs} from '../../services/dev/urls.js'
 import {Result} from '@shopify/cli-kit/node/result'
 import {capitalize} from '@shopify/cli-kit/common/string'
 import {ParseConfigurationResult, zod} from '@shopify/cli-kit/node/schema'
@@ -77,6 +78,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
     appConfig: CurrentAppConfiguration,
     storeFqdn: string,
   ) => Promise<string>
+  patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
 
   /**
    * If required, convert configuration from the format used in the local filesystem to that expected by the platform.
@@ -233,6 +235,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
     appConfig: CurrentAppConfiguration,
     storeFqdn: string,
   ) => Promise<string>
+  patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
 }): ExtensionSpecification<TConfiguration> {
   const appModuleFeatures = spec.appModuleFeatures ?? (() => [])
   return createExtensionSpecification({
@@ -246,6 +249,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
     experience: 'configuration',
     uidStrategy: spec.uidStrategy ?? 'single',
     getDevSessionActionUpdateMessage: spec.getDevSessionActionUpdateMessage,
+    patchWithAppDevURLs: spec.patchWithAppDevURLs,
   })
 }
 

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -51,6 +51,11 @@ const appAccessSpec = createConfigExtensionSpecification({
     const scopesURL = await buildAppURLForWeb(storeFqdn, appConfig.client_id)
     return outputContent`Scopes updated. ${outputToken.link('Open app to accept scopes.', scopesURL)}`.value
   },
+  patchWithAppDevURLs: (config, urls) => {
+    if ('auth' in config && urls.redirectUrlWhitelist) {
+      config.auth = {redirect_urls: urls.redirectUrlWhitelist}
+    }
+  },
 })
 
 export default appAccessSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
@@ -24,6 +24,11 @@ const appHomeSpec = createConfigExtensionSpecification({
   identifier: AppHomeSpecIdentifier,
   schema: AppHomeSchema,
   transformConfig: AppHomeTransformConfig,
+  patchWithAppDevURLs: (config, urls) => {
+    if ('application_url' in config) {
+      config.application_url = urls.applicationUrl
+    }
+  },
 })
 
 export default appHomeSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
@@ -17,6 +17,15 @@ export const AppProxySpecIdentifier = 'app_proxy'
 const appProxySpec: ExtensionSpecification = createConfigExtensionSpecification({
   identifier: AppProxySpecIdentifier,
   schema: AppProxySchema,
+  patchWithAppDevURLs: (config, urls) => {
+    if ('app_proxy' in config && urls.appProxy) {
+      config.app_proxy = {
+        url: urls.appProxy.proxyUrl,
+        subpath: urls.appProxy.proxySubPath,
+        prefix: urls.appProxy.proxySubPathPrefix,
+      }
+    }
+  },
 })
 
 export default appProxySpec

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -276,12 +276,17 @@ async function handleUpdatingOfPartnerUrls(
         localApp,
         apiKey,
       })
-      // When running dev app urls are pushed directly to API Client config instead of creating a new app version
-      // so current app version and API Client config will have diferent url values.
+
       if (shouldUpdateURLs) {
-        await updateURLs(newURLs, apiKey, developerPlatformClient, localApp)
-        // eslint-disable-next-line require-atomic-updates
-        localApp.devApplicationURLs = newURLs
+        if (developerPlatformClient.supportsDevSessions) {
+          // For dev sessions, store the new URLs in the local app so that the manifest can be patched with them
+          // The local toml is not updated.
+          localApp.setDevApplicationURLs(newURLs)
+        } else {
+          // When running dev app urls are pushed directly to API Client config instead of creating a new app version
+          // so current app version and API Client config will have diferent url values.
+          await updateURLs(newURLs, apiKey, developerPlatformClient, localApp)
+        }
       }
     }
   }


### PR DESCRIPTION
### WHY are these changes introduced?

For dev sessions we don't want to update the toml, but to inject the Application URLs directly in the toml at runtime.

### WHAT is this pull request doing?

Refactors the partner URL updating logic to:
- Store new URLs in the local app for dev sessions without updating the TOML file
- Maintain existing URL update behavior for non-dev session environments

### How to test your changes?

Remember that you can find the manifest in `./shopify/bundle` while running `app dev`

1. Start `dev` with dev sessions enabled
  - Having `automatically_update_urls_on_dev = true`:
    - Verify that tunnel URLs are included in the manifest and not in the toml
    - Verify that modifying the URLs in the toml during `dev`, doesn't update them in the manifest (the manifest keeps the tunnel URL and ignores url changes from the toml)
  - Having  `automatically_update_urls_on_dev = false`:
    - Verify that tunnel URLs are NOT included in the manifest, the manifest should include a copy of the urls value from the toml
     - Verify that modifying the URLs in the toml during `dev`, DO also update them in the manifest.


2. Start `dev` without dev sessions
   - Verify that tunnel URLs are updated in the toml.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes