### PR TITLE
Modify Schema to Support Link Extension URL

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -46,6 +46,11 @@ const NewExtensionPointSchema = zod.object({
   should_render: ShouldRenderSchema.optional(),
   metafields: zod.array(MetafieldSchema).optional(),
   default_placement: zod.string().optional(),
+  urls: zod
+    .object({
+      edit: zod.string().optional(),
+    })
+    .optional(),
   capabilities: TargetCapabilitiesSchema.optional(),
   preloads: zod
     .object({

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -19,6 +19,9 @@ describe('ui_extension', async () => {
       should_render?: {
         module: string
       }
+      urls?: {
+        edit?: string
+      }
       build_manifest?: {
         assets: {
           main: {
@@ -58,6 +61,7 @@ describe('ui_extension', async () => {
         },
       },
       settings: {},
+      urls: {},
     }
 
     return new ExtensionInstance({
@@ -157,6 +161,7 @@ describe('ui_extension', async () => {
               },
             },
           },
+          urls: {},
         },
       ])
     })
@@ -209,6 +214,7 @@ describe('ui_extension', async () => {
           default_placement_reference: 'PLACEMENT_REFERENCE1',
           capabilities: undefined,
           preloads: {},
+          urls: {},
           build_manifest: {
             assets: {
               main: {
@@ -266,6 +272,7 @@ describe('ui_extension', async () => {
           target: 'EXTENSION::POINT::A',
           module: './src/ExtensionPointA.js',
           metafields: [],
+          urls: {},
           default_placement_reference: undefined,
           capabilities: {allow_direct_linking: true},
           preloads: {},
@@ -329,6 +336,73 @@ describe('ui_extension', async () => {
           default_placement_reference: undefined,
           capabilities: undefined,
           preloads: {chat: '/chat'},
+          urls: {},
+          build_manifest: {
+            assets: {
+              main: {
+                filepath: 'test-ui-extension.js',
+                module: './src/ExtensionPointA.js',
+              },
+            },
+          },
+        },
+      ])
+    })
+
+    test('targeting object accepts urls', async () => {
+      const allSpecs = await loadLocalExtensionsSpecifications()
+      const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
+      const configuration = {
+        targeting: [
+          {
+            target: 'EXTENSION::POINT::A',
+            module: './src/ExtensionPointA.js',
+            preloads: {chat: '/chat', not_supported: '/hello'},
+            urls: {
+              edit: '/bundles/products/101',
+            },
+          },
+        ],
+        api_version: '2023-01' as const,
+        name: 'UI Extension',
+        description: 'This is an ordinary test extension',
+        type: 'ui_extension',
+        handle: 'test-ui-extension',
+        capabilities: {
+          block_progress: false,
+          network_access: false,
+          api_access: false,
+          collect_buyer_consent: {
+            customer_privacy: true,
+            sms_marketing: false,
+          },
+          iframe: {
+            sources: [],
+          },
+        },
+        settings: {},
+      }
+
+      // When
+      const parsed = specification.parseConfigurationObject(configuration)
+      if (parsed.state !== 'ok') {
+        throw new Error("Couldn't parse configuration")
+      }
+
+      const got = parsed.data
+
+      // Then
+      expect(got.extension_points).toStrictEqual([
+        {
+          target: 'EXTENSION::POINT::A',
+          module: './src/ExtensionPointA.js',
+          metafields: [],
+          default_placement_reference: undefined,
+          capabilities: undefined,
+          preloads: {chat: '/chat'},
+          urls: {
+            edit: '/bundles/products/101',
+          },
           build_manifest: {
             assets: {
               main: {
@@ -404,6 +478,7 @@ describe('ui_extension', async () => {
               },
             },
           },
+          urls: {},
         },
       ])
     })

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -62,6 +62,7 @@ export const UIExtensionSchema = BaseSchema.extend({
         module: targeting.module,
         metafields: targeting.metafields ?? config.metafields ?? [],
         default_placement_reference: targeting.default_placement,
+        urls: targeting.urls ?? {},
         capabilities: targeting.capabilities,
         preloads: targeting.preloads ?? {},
         build_manifest: buildManifest,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes: https://github.com/Shopify/bundles-app/issues/2953?issue=Shopify%7Cbundles-app%7C2995 according to https://vault.shopify.io/gsd/projects/42594

### WHAT is this pull request doing?

Adds an additional `urls` field on the schema related to the link extension object.

### How to test your changes?

All tests pass. Sea of green 
<img width="502" alt="image" src="https://github.com/user-attachments/assets/d2a92a7f-1872-4fa7-b039-ea2cd483a940" />

Run tests in the `packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts` file.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
