### PR TITLE
[Theme] Change how assets are resolved

### DIFF
--- a/.changeset/chatty-lies-rescue.md
+++ b/.changeset/chatty-lies-rescue.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme': patch
----
-
-Change how assets are resolved internally to avoid issues with local tools.

--- a/.changeset/chatty-lies-rescue.md
+++ b/.changeset/chatty-lies-rescue.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Change how assets are resolved internally to avoid issues with local tools.

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "ignoreDependencies": [
       "eslint-plugin-react",
       "eslint-plugin-react-hooks",
-      "@shopify/cli",
       "@shopify/cli-hydrogen",
       "@shopify/theme-check-node",
       "@shopify/theme-check-docs-updater"

--- a/packages/theme/src/cli/utilities/asset-path.ts
+++ b/packages/theme/src/cli/utilities/asset-path.ts
@@ -1,13 +1,18 @@
-import {dirname, joinPath} from '@shopify/cli-kit/node/path'
-import {createRequire} from 'node:module'
-
-const require = createRequire(import.meta.url)
+import {findPathUp} from '@shopify/cli-kit/node/fs'
+import {joinPath, dirname} from '@shopify/cli-kit/node/path'
+import {fileURLToPath} from 'node:url'
 
 export async function resolveAssetPath(...subpaths: string[]) {
-  if (process.env.SHOPIFY_UNIT_TEST) {
-    return joinPath(__dirname, '..', '..', '..', ...subpaths)
+  const rootPkgJon = await findPathUp('package.json', {
+    cwd: fileURLToPath(import.meta.url),
+    type: 'file',
+  })
+
+  if (!rootPkgJon) {
+    throw new Error('Failed to find CLI root path')
   }
 
-  const cliRootPath = dirname(require.resolve('@shopify/cli/package.json'))
-  return joinPath(cliRootPath, 'dist', 'assets', ...subpaths)
+  return rootPkgJon.endsWith('/packages/theme/package.json')
+    ? joinPath(dirname(rootPkgJon), 'assets', ...subpaths)
+    : joinPath(dirname(rootPkgJon), 'dist', 'assets', ...subpaths)
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Originally reported [here](https://shopify.slack.com/archives/C05E3BDFDRB/p1737473033912099).

Under some unknown circumstances, NX might complain about circular dependencies:

<img width="1192" alt="image" src="https://github.com/user-attachments/assets/3dfb1f9e-fa39-4887-a8b6-991e185c4dc8" />


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Replace `require.resolve` with `findPathUp` to ensure Nx doesn't think `@shopify/cli` is a dependency.

### How to test your changes?

`shopify theme profile --url /` should still work.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
