### PR TITLE
Workflow to deprecate shopify-cli-extensions in NPM

### DIFF
--- a/.github/workflows/deprecate-shopify-cli-extensions.yml
+++ b/.github/workflows/deprecate-shopify-cli-extensions.yml
@@ -1,0 +1,17 @@
+name: Deprecate shopify-cli-extensions
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Deprecate shopify-cli-extensions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deprecate
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          npm deprecate @shopify/shopify-cli-extensions@"*" "$MESSAGE"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          MESSAGE: Please use @shopify/cli instead.


### PR DESCRIPTION
### WHY are these changes introduced?

We want to deprecate [@shopify/shopify-cli-extensions](https://www.npmjs.com/package/@shopify/shopify-cli-extensions) in NPM.

### WHAT is this pull request doing?

Adds a one-time GitHub action to deprecate the package in NPM, by using the [npm deprecate](https://docs.npmjs.com/cli/v8/commands/npm-deprecate) command.

That will include a warning in the NPM website and the command line when installing it: https://docs.npmjs.com/using-deprecated-packages

It can be reversed.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
