### PR TITLE
Replace rainbow bar with moving hill for no-color mode

### DIFF
--- a/.changeset/shiny-lions-marry.md
+++ b/.changeset/shiny-lions-marry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Improve display of loading bar in no-color mode

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
@@ -2,8 +2,28 @@ import {Task, Tasks} from './Tasks.js'
 import {getLastFrameAfterUnmount, render} from '../../testing/ui.js'
 import {unstyled} from '../../../../public/node/output.js'
 import {AbortController} from '../../../../public/node/abort.js'
+import {Stdout} from '../../ui.js'
 import React from 'react'
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {useStdout} from 'ink'
+
+vi.mock('ink', async () => {
+  const original: any = await vi.importActual('ink')
+  return {
+    ...original,
+    useStdout: vi.fn(),
+  }
+})
+
+beforeEach(() => {
+  vi.mocked(useStdout).mockReturnValue({
+    stdout: new Stdout({
+      columns: 80,
+      rows: 80,
+    }) as any,
+    write: () => {},
+  })
+})
 
 describe('Tasks', () => {
   test('shows a loading state at the start', async () => {
@@ -24,6 +44,58 @@ describe('Tasks', () => {
     // Then
     expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
       "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+      task 1 ..."
+    `)
+    expect(firstTaskFunction).toHaveBeenCalled()
+  })
+
+  test('shows a loading state that is useful in no-color mode', async () => {
+    // Given
+    const firstTaskFunction = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+    })
+
+    const firstTask = {
+      title: 'task 1',
+      task: firstTaskFunction,
+    }
+
+    // When
+    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} noColor />)
+
+    // Then
+    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
+      "▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁
+      task 1 ..."
+    `)
+    expect(firstTaskFunction).toHaveBeenCalled()
+  })
+
+  test('shrinks the no-color display for narrow screens', async () => {
+    // Given
+    vi.mocked(useStdout).mockReturnValue({
+      stdout: new Stdout({
+        columns: 10,
+        rows: 80,
+      }) as any,
+      write: () => {},
+    })
+
+    const firstTaskFunction = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+    })
+
+    const firstTask = {
+      title: 'task 1',
+      task: firstTaskFunction,
+    }
+
+    // When
+    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} noColor />)
+
+    // Then
+    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
+      "▂▃▄▅▆▇█▇▆▅▄▃▂▁▁
       task 1 ..."
     `)
     expect(firstTaskFunction).toHaveBeenCalled()

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
@@ -65,7 +65,7 @@ describe('Tasks', () => {
 
     // Then
     expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁
+      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁
       task 1 ..."
     `)
     expect(firstTaskFunction).toHaveBeenCalled()
@@ -95,7 +95,7 @@ describe('Tasks', () => {
 
     // Then
     expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▂▃▄▅▆▇█▇▆▅▄▃▂▁▁
+      "▁▁▂▃▄▅▆▇█▇▆▅▄▃▂
       task 1 ..."
     `)
     expect(firstTaskFunction).toHaveBeenCalled()

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
@@ -65,13 +65,13 @@ describe('Tasks', () => {
 
     // Then
     expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁
+      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆
       task 1 ..."
     `)
     expect(firstTaskFunction).toHaveBeenCalled()
   })
 
-  test('shrinks the no-color display for narrow screens', async () => {
+  test('truncates the no-color display correctly for narrow screens', async () => {
     // Given
     vi.mocked(useStdout).mockReturnValue({
       stdout: new Stdout({
@@ -95,7 +95,7 @@ describe('Tasks', () => {
 
     // Then
     expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▁▁▂▃▄▅▆▇█▇▆▅▄▃▂
+      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆
       task 1 ..."
     `)
     expect(firstTaskFunction).toHaveBeenCalled()

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
@@ -81,14 +81,9 @@ function Tasks<TContext>({
   const {twoThirds} = useLayout()
   let loadingBar = new Array(twoThirds).fill(loadingBarChar).join('')
   if (noColor ?? !shouldDisplayColors()) {
-    // fill loading bar with the no color chars, repeating until the length is two thirds but only using a whole number repeat of the no color chars
-    const repeatCount = Math.floor(twoThirds / gradualHillString.length)
-    if (repeatCount === 0) {
-      const shortRepeatCount = Math.floor(twoThirds / hillString.length)
-      loadingBar = hillString.repeat(Math.max(1, shortRepeatCount))
-    } else {
-      loadingBar = gradualHillString.repeat(repeatCount)
-    }
+    const fittingPattern = gradualHillString.length <= twoThirds ? gradualHillString : hillString
+    const fullyFittingRepeats = Math.floor(twoThirds / fittingPattern.length)
+    loadingBar = fittingPattern.repeat(Math.max(1, fullyFittingRepeats))
   }
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const [currentTask, setCurrentTask] = useState<Task<TContext>>(tasks[0]!)

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
@@ -10,15 +10,7 @@ import {Box, Text, useStdin, useInput} from 'ink'
 import React, {useRef, useState} from 'react'
 
 const loadingBarChar = '▀'
-// Chars that can be arranged to form a colorless horizontal figure that displays progress as it moves.
-// The string is 15 chars long so it can always be displayed even within a box inside a 20-char-wide terminal.
-const hillString = '▁▂▃▄▅▆▇█▇▆▅▄▃▂▁'
-// Like the hill string, but forming a gentler slope for motion that is less jarring
-const gradualHillString = hillString
-  .split('')
-  .map((char) => char.repeat(2).split(''))
-  .flat()
-  .join('')
+const hillString = '▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁'
 
 export interface Task<TContext = unknown> {
   title: string
@@ -81,9 +73,7 @@ function Tasks<TContext>({
   const {twoThirds} = useLayout()
   let loadingBar = new Array(twoThirds).fill(loadingBarChar).join('')
   if (noColor ?? !shouldDisplayColors()) {
-    const fittingPattern = gradualHillString.length <= twoThirds ? gradualHillString : hillString
-    const fullyFittingRepeats = Math.floor(twoThirds / fittingPattern.length)
-    loadingBar = fittingPattern.repeat(Math.max(1, fullyFittingRepeats))
+    loadingBar = hillString.repeat(Math.ceil(twoThirds / hillString.length))
   }
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const [currentTask, setCurrentTask] = useState<Task<TContext>>(tasks[0]!)
@@ -138,7 +128,7 @@ function Tasks<TContext>({
 
   return state === TasksState.Loading && !isAborted ? (
     <Box flexDirection="column">
-      <TextAnimation text={loadingBar} />
+      <TextAnimation text={loadingBar} maxWidth={twoThirds} />
       <Text>{currentTask.title} ...</Text>
     </Box>
   ) : null

--- a/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
@@ -15,13 +15,10 @@ function rainbow(text: string, frame: number) {
 }
 
 function rotated(text: string, steps: number) {
-  const textLength = text.length
-  return text
-    .split('')
-    .map((_, index) => {
-      return text[(index + steps) % textLength]
-    })
-    .join('')
+  const normalizedSteps = steps % text.length
+  const start = text.slice(-normalizedSteps)
+  const end = text.slice(0, -normalizedSteps)
+  return start + end
 }
 
 /**

--- a/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
@@ -14,6 +14,16 @@ function rainbow(text: string, frame: number) {
   return gradient(leftColor, rightColor)(text, {interpolation: 'hsv', hsvSpin: 'long'})
 }
 
+function rotated(text: string, steps: number) {
+  const textLength = text.length
+  return text
+    .split('')
+    .map((_, index) => {
+      return text[(index + steps) % textLength]
+    })
+    .join('')
+}
+
 /**
  * `TextAnimation` applies a rainbow animation to text.
  */
@@ -26,7 +36,7 @@ const TextAnimation = memo(({text}: TextAnimationProps): JSX.Element => {
     const newFrame = frame.current + 1
     frame.current = newFrame
 
-    setRenderedFrame(rainbow(text, frame.current))
+    setRenderedFrame(rainbow(rotated(text, frame.current), frame.current))
 
     timeout.current = setTimeout(() => {
       renderAnimation()

--- a/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
@@ -5,6 +5,7 @@ import gradient from 'gradient-string'
 
 interface TextAnimationProps {
   text: string
+  maxWidth?: number
 }
 
 function rainbow(text: string, frame: number) {
@@ -21,10 +22,14 @@ function rotated(text: string, steps: number) {
   return start + end
 }
 
+function truncated(text: string, maxWidth: number | undefined): string {
+  return maxWidth ? text.slice(0, maxWidth) : text
+}
+
 /**
  * `TextAnimation` applies a rainbow animation to text.
  */
-const TextAnimation = memo(({text}: TextAnimationProps): JSX.Element => {
+const TextAnimation = memo(({text, maxWidth}: TextAnimationProps): JSX.Element => {
   const frame = useRef(0)
   const [renderedFrame, setRenderedFrame] = useState(text)
   const timeout = useRef<NodeJS.Timeout>()
@@ -33,12 +38,12 @@ const TextAnimation = memo(({text}: TextAnimationProps): JSX.Element => {
     const newFrame = frame.current + 1
     frame.current = newFrame
 
-    setRenderedFrame(rainbow(rotated(text, frame.current), frame.current))
+    setRenderedFrame(rainbow(truncated(rotated(text, frame.current), maxWidth), frame.current))
 
     timeout.current = setTimeout(() => {
       renderAnimation()
     }, 35)
-  }, [text])
+  }, [text, maxWidth])
 
   useLayoutEffect(() => {
     renderAnimation()


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes the poor display of the loading bar in no-color terminals.

![image](https://github.com/user-attachments/assets/c577e35e-9b02-4aa6-b88d-887e2c0972da)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

https://github.com/user-attachments/assets/06e49f94-7982-4e32-b3bd-67a3275ecf78

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

```sh
$ p shopify kitchen-sink async
```

or any other command which uses a rainbow bar (e.g. creating a new app)

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact
- [x] Impact is unknown, a followup PR will includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
