### PR TITLE
Pass both tunnel & direct urls to dev render

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -71,9 +71,9 @@ export interface DevOptions {
 export async function dev(commandOptions: DevOptions) {
   const config = await prepareForDev(commandOptions)
   await actionsBeforeSettingUpDevProcesses(config)
-  const {processes, graphiqlUrl, previewUrl} = await setupDevProcesses(config)
+  const {processes, graphiqlUrl, appPreviewUrl, localProxyUrl} = await setupDevProcesses(config)
   await actionsBeforeLaunchingDevProcesses(config)
-  await launchDevProcesses({processes, previewUrl, graphiqlUrl, config})
+  await launchDevProcesses({processes, appPreviewUrl, localProxyUrl, graphiqlUrl, config})
 }
 
 async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
@@ -326,12 +326,14 @@ async function setupNetworkingOptions(
 
 async function launchDevProcesses({
   processes,
-  previewUrl,
+  appPreviewUrl,
+  localProxyUrl,
   graphiqlUrl,
   config,
 }: {
   processes: DevProcesses
-  previewUrl: string
+  appPreviewUrl: string
+  localProxyUrl: string
   graphiqlUrl: string | undefined
   config: DevConfig
 }) {
@@ -367,7 +369,8 @@ async function launchDevProcesses({
 
   return renderDev({
     processes: processesForTaskRunner,
-    previewUrl,
+    appPreviewUrl,
+    localProxyUrl,
     graphiqlUrl,
     graphiqlPort: config.graphiqlPort,
     app,

--- a/packages/app/src/cli/services/dev/processes/previewable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/previewable-extension.ts
@@ -81,9 +81,6 @@ export async function setupPreviewableExtensionsProcess({
   checkoutCartUrl?: string
 }): Promise<PreviewableExtensionProcess | undefined> {
   const previewableExtensions = allExtensions.filter((ext) => ext.isPreviewable)
-  if (previewableExtensions.length === 0) {
-    return
-  }
 
   const cartUrl = await buildCartURLIfNeeded(previewableExtensions, storeFqdn, checkoutCartUrl)
 

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -63,6 +63,20 @@ export interface DevConfig {
   graphiqlKey?: string
 }
 
+/**
+ * Result of the setupDevProcesses function.
+ *
+ * appPreviewUrl is a direct URL to the app in the dev store.
+ * localProxyUrl is the URL that is exposed to the internet (usually the tunnel URL)
+ * graphiqlUrl is the URL that the GraphiQL server will be running at.
+ */
+export interface SetupDevProcessesResult {
+  processes: DevProcesses
+  appPreviewUrl: string
+  localProxyUrl: string
+  graphiqlUrl: string | undefined
+}
+
 export async function setupDevProcesses({
   localApp,
   remoteAppUpdated,
@@ -76,7 +90,8 @@ export async function setupDevProcesses({
   graphiqlKey,
 }: DevConfig): Promise<{
   processes: DevProcesses
-  previewUrl: string
+  appPreviewUrl: string
+  localProxyUrl: string
   graphiqlUrl: string | undefined
 }> {
   const apiKey = remoteApp.apiKey
@@ -180,13 +195,10 @@ export async function setupDevProcesses({
   // Add http server proxy & configure ports, for processes that need it
   const processesWithProxy = await setPortsAndAddProxyProcess(processes, network.proxyPort)
 
-  // Decide on the appropriate preview URL for a session with these processes
-  const anyPreviewableExtensions = processesWithProxy.filter((process) => process.type === 'previewable-extension')
-  const previewUrl = anyPreviewableExtensions.length > 0 ? `${network.proxyUrl}/extensions/dev-console` : appPreviewUrl
-
   return {
     processes: processesWithProxy,
-    previewUrl,
+    appPreviewUrl,
+    localProxyUrl: `${network.proxyUrl}/extensions/dev-console`,
     graphiqlUrl: shouldRenderGraphiQL
       ? `http://localhost:${graphiqlPort}/graphiql${graphiqlKey ? `?key=${graphiqlKey}` : ''}`
       : undefined,

--- a/packages/app/src/cli/services/dev/ui.test.tsx
+++ b/packages/app/src/cli/services/dev/ui.test.tsx
@@ -41,7 +41,7 @@ describe('ui', () => {
       }
 
       const processes = [concurrentProcess]
-      const previewUrl = 'https://lala.cloudflare.io/'
+      const appPreviewUrl = 'https://lala.cloudflare.io/'
       const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
       const shopFqdn = 'mystore.shopify.io'
       const graphiqlPort = 1234
@@ -58,7 +58,8 @@ describe('ui', () => {
 
       await renderDev({
         processes,
-        previewUrl,
+        appPreviewUrl,
+        localProxyUrl: 'https://proxy-url.com',
         graphiqlUrl,
         graphiqlPort,
         app,
@@ -84,7 +85,7 @@ describe('ui', () => {
       }
 
       const processes = [concurrentProcess]
-      const previewUrl = 'https://lala.cloudflare.io/'
+      const appPreviewUrl = 'https://lala.cloudflare.io/'
       const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
       const shopFqdn = 'mystore.shopify.io'
       const graphiqlPort = 1234
@@ -101,7 +102,8 @@ describe('ui', () => {
 
       await renderDev({
         processes,
-        previewUrl,
+        appPreviewUrl,
+        localProxyUrl: 'https://proxy-url.com',
         graphiqlUrl,
         graphiqlPort,
         app,
@@ -123,7 +125,7 @@ describe('ui', () => {
       }
 
       const processes = [concurrentProcess]
-      const previewUrl = 'https://lala.cloudflare.io/'
+      const appPreviewUrl = 'https://lala.cloudflare.io/'
       const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
       const shopFqdn = 'mystore.shopify.io'
       const graphiqlPort = 1234
@@ -140,7 +142,8 @@ describe('ui', () => {
 
       await renderDev({
         processes,
-        previewUrl,
+        appPreviewUrl,
+        localProxyUrl: 'https://proxy-url.com',
         graphiqlUrl,
         graphiqlPort,
         app,
@@ -162,7 +165,7 @@ describe('ui', () => {
       }
 
       const processes = [concurrentProcess]
-      const previewUrl = 'https://lala.cloudflare.io/'
+      const appPreviewUrl = 'https://lala.cloudflare.io/'
       const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
       const shopFqdn = 'mystore.shopify.io'
       const graphiqlPort = 1234
@@ -178,7 +181,17 @@ describe('ui', () => {
       const abortController = new AbortController()
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      renderDev({processes, previewUrl, graphiqlUrl, graphiqlPort, app, abortController, developerPreview, shopFqdn})
+      renderDev({
+        processes,
+        appPreviewUrl,
+        localProxyUrl: 'https://proxy-url.com',
+        graphiqlUrl,
+        graphiqlPort,
+        app,
+        abortController,
+        developerPreview,
+        shopFqdn,
+      })
 
       await new Promise((resolve) => setTimeout(resolve, 100))
 

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -7,10 +7,11 @@ import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 
 export async function renderDev({
   processes,
-  previewUrl,
+  appPreviewUrl,
+  localProxyUrl,
+  graphiqlUrl,
   app,
   abortController,
-  graphiqlUrl,
   graphiqlPort,
   developerPreview,
   shopFqdn,
@@ -20,7 +21,8 @@ export async function renderDev({
       <Dev
         processes={processes}
         abortController={abortController}
-        previewUrl={previewUrl}
+        appPreviewUrl={appPreviewUrl}
+        localProxyUrl={localProxyUrl}
         app={app}
         graphiqlUrl={graphiqlUrl}
         graphiqlPort={graphiqlPort}
@@ -42,7 +44,7 @@ async function renderDevNonInteractive({
   app: {canEnablePreviewMode},
   abortController,
   developerPreview,
-}: Omit<DevProps, 'previewUrl' | 'graphiqlPort'>) {
+}: Omit<DevProps, 'appPreviewUrl' | 'localProxyUrl' | 'graphiqlPort'>) {
   if (canEnablePreviewMode) {
     await developerPreview.enable()
     abortController?.signal.addEventListener('abort', async () => {

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -88,7 +88,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess, frontendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -169,7 +170,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess, frontendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -207,7 +209,8 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -234,7 +237,8 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -263,7 +267,8 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -307,7 +312,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -373,7 +379,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -433,7 +440,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -486,7 +494,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -529,7 +538,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -597,7 +607,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={{
@@ -655,7 +666,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -697,7 +709,8 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -761,7 +774,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -812,7 +826,8 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -852,7 +867,8 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -892,7 +908,8 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -930,7 +947,8 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={testApp}
@@ -983,7 +1001,8 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
+        appPreviewUrl="https://shopify.com"
+        localProxyUrl="https://proxy-url.com"
         graphiqlUrl="https://graphiql.shopify.com"
         graphiqlPort={1234}
         app={{

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -25,7 +25,8 @@ export interface DeveloperPreviewController {
 export interface DevProps {
   processes: OutputProcess[]
   abortController: AbortController
-  previewUrl: string
+  localProxyUrl: string
+  appPreviewUrl: string
   graphiqlUrl?: string
   graphiqlPort: number
   app: {
@@ -52,7 +53,8 @@ const calculatePrefixColumnSize = (processes: OutputProcess[], extensions: Exten
 const Dev: FunctionComponent<DevProps> = ({
   abortController,
   processes,
-  previewUrl,
+  appPreviewUrl,
+  localProxyUrl,
   graphiqlUrl = '',
   graphiqlPort,
   app,
@@ -63,11 +65,14 @@ const Dev: FunctionComponent<DevProps> = ({
 }) => {
   const {canEnablePreviewMode, developmentStorePreviewEnabled} = app
 
+  const hasPreviewableExtensions = app.extensions.some((ext) => ext.isPreviewable)
+  const previewUrl = hasPreviewableExtensions ? localProxyUrl : appPreviewUrl
+
   const {isRawModeSupported: canUseShortcuts} = useStdin()
   const pollingInterval = useRef<NodeJS.Timeout>()
   const devSessionPollingInterval = useRef<NodeJS.Timeout>()
   const localhostGraphiqlUrl = `http://localhost:${graphiqlPort}/graphiql`
-  const defaultStatusMessage = `Preview URL: ${previewUrl}${
+  const defaultStatusMessage = `Preview URL: ${appPreviewUrl}${
     graphiqlUrl ? `\nGraphiQL URL: ${localhostGraphiqlUrl}` : ''
   }`
   const [statusMessage, setStatusMessage] = useState(defaultStatusMessage)


### PR DESCRIPTION
### WHY are these changes introduced?

In preparation for a new feature, we need the dev render process to have both possible preview URLs: the tunnel one (`localProxyURL` and the direct to store one `appPreviewURL`).

Then, in a future PR the dev render process will be able to show one or the other depending on the state of the app.

### WHAT is this pull request doing?

- Introduces distinct URL types: `appPreviewUrl` for direct app access and `localProxyUrl` for tunnel/proxy access
- Removes conditional logic that prevented previewable extensions setup when none existed.
- Updates the preview URL logic to show appropriate URLs based on extension presence

### How to test your changes?

1. Run `dev` command with an app that has previewable extensions
2. Verify that the correct preview URL is displayed based on extension presence
3. Test both scenarios:
   - App with previewable extensions should show the proxy/tunnel URL
   - App without previewable extensions should show the direct app URL

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes