### PR TITLE
Remove doc generation from the changeset-manifests workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:affected": "nx affected --target=build",
     "refresh-templates": "nx run-many --target=refresh-templates --all --skip-nx-cache",
     "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache && bin/prettify-manifests.js && pnpm refresh-readme",
-    "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests && pnpm refresh-readme && pnpm refresh-documentation && bin/update-cli-kit-version.js && pnpm docs:generate",
+    "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests && pnpm refresh-readme && pnpm refresh-documentation && bin/update-cli-kit-version.js",
     "changeset-build-no-docs": "changeset version && pnpm install --no-frozen-lockfile && pnpm build && bin/update-cli-kit-version.js",
     "refresh-documentation": "nx run-many --target=refresh-documentation --all --skip-nx-cache",
     "refresh-readme": "nx run-many --target=refresh-readme --all --skip-nx-cache",


### PR DESCRIPTION
### WHY are these changes introduced?

We don't track doc autogen changes in Git anymore

### WHAT is this pull request doing?

Removes `pnpm docs:generate` from the `changeset-manifests` script in `package.json` as it's no longer needed (and honestly felt fairly awkwardly wedged in there in the first place).

### How to test your changes?

Not much to test directly, it's just 1 less step in CI...

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes