### PR TITLE
Update preview URL based on dev session status

### DIFF
--- a/packages/app/src/cli/services/dev/processes/previewable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/previewable-extension.ts
@@ -81,9 +81,6 @@ export async function setupPreviewableExtensionsProcess({
   checkoutCartUrl?: string
 }): Promise<PreviewableExtensionProcess | undefined> {
   const previewableExtensions = allExtensions.filter((ext) => ext.isPreviewable)
-  if (previewableExtensions.length === 0) {
-    return
-  }
 
   const cartUrl = await buildCartURLIfNeeded(previewableExtensions, storeFqdn, checkoutCartUrl)
 

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -337,7 +337,7 @@ describe('setup-dev-processes', () => {
       graphiqlKey: 'somekey',
     })
 
-    expect(res.processes[2]).toMatchObject({
+    expect(res.processes[3]).toMatchObject({
       type: 'dev-session',
       prefix: 'dev-session',
       function: pushUpdatesForDevSession,

--- a/packages/app/src/cli/utilities/extensions/locales-configuration.ts
+++ b/packages/app/src/cli/utilities/extensions/locales-configuration.ts
@@ -5,7 +5,7 @@ import fs from 'fs'
 
 export async function loadLocalesConfig(extensionPath: string, extensionIdentifier: string) {
   const localesPaths = await glob(joinPath(extensionPath, 'locales/*.json'))
-  if (localesPaths.length === 0) return {}
+  if (!localesPaths || localesPaths.length === 0) return {}
 
   // Bundle validations
   const defaultLanguageCode = findDefaultLocale(localesPaths)


### PR DESCRIPTION
### WHY are these changes introduced?

For dev-sessions, update the preview URL dynamically depending on whether the app has previewable extensions or not.

### WHAT is this pull request doing?

- Adds dynamic preview URL updates in dev sessions based on extension previewability
- Introduces a new `devSessionPreviewURL` state to track and update the preview URL
- Updates the UI to reflect preview URL changes in real-time

### How to test your changes?

1. Start a dev session with no previewable extensions (no UI ext.)
   - Verify the default app preview URL is displayed

2. Add a previewable extension (admin-action for example)
   - Verify the preview URL updates to show the dev console URL
   - Press 'p' to confirm the new URL opens correctly

3. Remove all previewable extensions
   - Verify the preview URL reverts to the default app preview URL

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes