### PR TITLE
RemoteSpecfication includes uidIsClientProvided

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
@@ -11,7 +11,9 @@ export type FetchSpecificationsQuery = {
     identifier: string
     externalIdentifier: string
     features: string[]
-    uidStrategy: {appModuleLimit: number} | {appModuleLimit: number}
+    uidStrategy:
+      | {appModuleLimit: number; isClientProvided: boolean}
+      | {appModuleLimit: number; isClientProvided: boolean}
     validationSchema?: {jsonSchema: string} | null
   }[]
 }
@@ -43,6 +45,7 @@ export const FetchSpecifications = {
                     kind: 'SelectionSet',
                     selections: [
                       {kind: 'Field', name: {kind: 'Name', value: 'appModuleLimit'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'isClientProvided'}},
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],
                   },

--- a/packages/app/src/cli/api/graphql/app-management/queries/specifications.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/specifications.graphql
@@ -6,6 +6,7 @@ query fetchSpecifications {
     features
     uidStrategy {
       appModuleLimit
+      isClientProvided
     }
     validationSchema {
       jsonSchema

--- a/packages/app/src/cli/api/graphql/extension_specifications.ts
+++ b/packages/app/src/cli/api/graphql/extension_specifications.ts
@@ -39,6 +39,7 @@ export interface RemoteSpecification {
   options: {
     managementExperience: 'cli' | 'custom' | 'dashboard'
     registrationLimit: number
+    uidIsClientProvided: boolean
   }
   features?: {
     argo?: {

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -623,6 +623,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: true,
     },
     features: {
       argo: {
@@ -640,6 +641,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: true,
     },
   },
   {
@@ -652,6 +654,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: true,
     },
     features: {
       argo: {
@@ -669,6 +672,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 50,
+      uidIsClientProvided: true,
     },
     features: {
       argo: {
@@ -686,6 +690,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 5,
+      uidIsClientProvided: true,
     },
     features: {
       argo: {
@@ -705,6 +710,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: true,
     },
     features: {
       argo: {
@@ -722,6 +728,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'dashboard',
       registrationLimit: 100,
+      uidIsClientProvided: true,
     },
   },
   {
@@ -734,6 +741,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: true,
     },
     features: {
       argo: {
@@ -751,6 +759,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 100,
+      uidIsClientProvided: true,
     },
   },
   {
@@ -763,6 +772,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 100,
+      uidIsClientProvided: true,
     },
   },
   {
@@ -775,6 +785,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 300,
+      uidIsClientProvided: true,
     },
   },
   {
@@ -787,6 +798,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 100,
+      uidIsClientProvided: true,
     },
   },
   {
@@ -799,6 +811,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 50,
+      uidIsClientProvided: true,
     },
   },
   {
@@ -811,6 +824,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: true,
     },
   },
   {
@@ -823,6 +837,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: false,
     },
   },
   {
@@ -835,6 +850,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: false,
     },
   },
   {
@@ -847,6 +863,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: false,
     },
   },
   {
@@ -859,6 +876,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: false,
     },
   },
   {
@@ -871,6 +889,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: false,
     },
   },
   {
@@ -883,6 +902,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: false,
     },
   },
   {
@@ -895,6 +915,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: false,
     },
   },
   {
@@ -907,6 +928,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: true,
     },
   },
   {
@@ -919,6 +941,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: true,
     },
     validationSchema: {
       jsonSchema:
@@ -935,6 +958,7 @@ const testRemoteSpecifications: RemoteSpecification[] = [
     options: {
       managementExperience: 'cli',
       registrationLimit: 1,
+      uidIsClientProvided: true,
     },
     validationSchema: {
       jsonSchema:

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -321,6 +321,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
         options: {
           managementExperience: 'cli',
           registrationLimit: spec.uidStrategy.appModuleLimit,
+          uidIsClientProvided: spec.uidStrategy.isClientProvided,
         },
         experience: experience(spec.identifier),
         validationSchema: spec.validationSchema,

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -324,7 +324,14 @@ export class PartnersClient implements DeveloperPlatformClient {
   async specifications({apiKey}: MinimalAppIdentifiers): Promise<RemoteSpecification[]> {
     const variables: ExtensionSpecificationsQueryVariables = {api_key: apiKey}
     const result: ExtensionSpecificationsQuerySchema = await this.request(ExtensionSpecificationsQuery, variables)
-    return result.extensionSpecifications
+    // Partners client does not support isClientProvided. Safe to assume that all modules are extension-style.
+    return result.extensionSpecifications.map((spec) => ({
+      ...spec,
+      options: {
+        ...spec.options,
+        uidIsClientProvided: true,
+      },
+    }))
   }
 
   async templateSpecifications({apiKey}: MinimalAppIdentifiers): Promise<ExtensionTemplate[]> {

--- a/packages/eslint-plugin-cli/rules/no-inline-graphql.js
+++ b/packages/eslint-plugin-cli/rules/no-inline-graphql.js
@@ -143,7 +143,7 @@ const knownFailures = {
   'packages/app/src/cli/api/graphql/extension_migrate_to_ui_extension.ts':
     'dd3fb42d0b9327de627bd02295de9e08087266885777602a34b44bdc460c0285',
   'packages/app/src/cli/api/graphql/extension_specifications.ts':
-    'a514090fe981495a67123ccc7fcb74169d97f5b33551f9b8ebbbe6476bb66faa',
+    '1628d3252de6e390290264b5ae10a8d57861420fa638ce2f97f6e20d982b261c',
   'packages/app/src/cli/api/graphql/find_app.ts': '699def43534d0fdb4988b91e74a890778026960fd31662fecd86384ecfc05370',
   'packages/app/src/cli/api/graphql/find_app_preview_mode.ts':
     '8311925b338d4aba1957974bb815cfa8c5d8272226f68b8e74a69d91acc9c8cb',
@@ -152,7 +152,7 @@ const knownFailures = {
     '867f01113c20386d6a438dd56a6d241199e407eab928ab1ad9a7f233cd35c1be',
   'packages/app/src/cli/api/graphql/find_store_by_domain.ts':
     '0824f5baaab1ad419a7fa1d64824e306bd369430da47c7457ed72e74a1e94a9a',
-    'packages/app/src/cli/api/graphql/functions/api_schema_definition.ts':
+  'packages/app/src/cli/api/graphql/functions/api_schema_definition.ts':
     'e71100cf61919831681da1be8f12cd9067c4e3f2faf04c1b88b764fd8a275b82',
   'packages/app/src/cli/api/graphql/functions/target_schema_definition.ts':
     'd338c5d187ca8a1e1e68892987d780e540426faeba89df2dd9d8c96e193f5c13',


### PR DESCRIPTION
### WHY are these changes introduced?

Adds support for client-provided UIDs in app specifications, enabling the CLI to distinguish between extension-style and config-style modules based on their UID management approach.

### WHAT is this pull request doing?

- Adds `isClientProvided` field to the UID strategy in app specifications GraphQL query

### How to test your changes?

This is inert in isolation, as the option isn't used yet.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes