### PR TITLE
Drive DCDD from server specifications

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -966,6 +966,23 @@ const testRemoteSpecifications: RemoteSpecification[] = [
         '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","additionalProperties":false,"properties":{"pattern":{"type":"string"},"name":{"type":"string"},"localization":{"type":"object","properties":{"marketing_channel":{"type":"string"}},"required":["marketing_channel"]}},"required":["pattern","localization"]}',
     },
   },
+  {
+    name: 'Remote Extension With Schema, Without local spec, config-style management',
+    externalName: 'Extension Test 4',
+    identifier: 'remote_only_extension_schema_config_style',
+    externalIdentifier: 'remote_only_extension_schema_config_style_external',
+    gated: false,
+    experience: 'configuration',
+    options: {
+      managementExperience: 'cli',
+      registrationLimit: 1,
+      uidIsClientProvided: false,
+    },
+    validationSchema: {
+      jsonSchema:
+        '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","additionalProperties":false,"properties":{"pattern":{"type":"string"},"name":{"type":"string"}},"required":["pattern"]}',
+    },
+  },
 ]
 
 const productSubscriptionUIExtensionTemplate: ExtensionTemplate = {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -131,7 +131,7 @@ export type SchemaForConfig<TConfig extends {path: string}> = ZodObjectOf<Omit<T
 
 export function getAppVersionedSchema(
   specs: ExtensionSpecification[],
-  allowDynamicallySpecifiedConfigs = false,
+  allowDynamicallySpecifiedConfigs = true,
 ): ZodObjectOf<Omit<CurrentAppConfiguration, 'path'>> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const schema = specs.reduce<any>((schema, spec) => spec.contributeToAppConfigurationSchema(schema), AppSchema)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -33,8 +33,8 @@ import {WebhookSubscriptionSpecIdentifier} from '../extensions/specifications/ap
 import {WebhooksSchema} from '../extensions/specifications/app_config_webhook_schemas/webhooks_schema.js'
 import {loadLocalExtensionsSpecifications} from '../extensions/load-specifications.js'
 import {UIExtensionSchemaType} from '../extensions/specifications/ui_extension.js'
-import {deepStrict, zod} from '@shopify/cli-kit/node/schema'
 import {fileExists, readFile, glob, findPathUp, fileExistsSync, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
+import {zod} from '@shopify/cli-kit/node/schema'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {
   getDependencies,
@@ -916,11 +916,7 @@ async function loadAppConfigurationFromState<
       }
     }
 
-    const parseStrictSchemaEnabled = specifications.length > 0
     schemaForConfigurationFile = appSchema
-    if (parseStrictSchemaEnabled) {
-      schemaForConfigurationFile = deepStrict(appSchema)
-    }
   }
 
   const configuration = (await parseConfigurationFile(

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -25,7 +25,6 @@ import themeSpec from './specifications/theme.js'
 import uiExtensionSpec from './specifications/ui_extension.js'
 import webPixelSpec from './specifications/web_pixel_extension.js'
 import editorExtensionCollectionSpecification from './specifications/editor_extension_collection.js'
-import customDataSpec, {CustomDataSpecIdentifier} from './specifications/custom_data.js'
 
 const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   BrandingSpecIdentifier,
@@ -36,7 +35,6 @@ const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   AppProxySpecIdentifier,
   PosSpecIdentifier,
   AppHomeSpecIdentifier,
-  CustomDataSpecIdentifier,
 ]
 
 /**
@@ -59,7 +57,6 @@ function loadSpecifications() {
     appPrivacyComplienceSpec,
     appWebhooksSpec,
     appWebhookSubscriptionSpec,
-    customDataSpec,
   ]
   const moduleSpecs = [
     checkoutPostPurchaseSpec,

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -249,47 +249,6 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
   })
 }
 
-/**
- * Create a zod object schema based on keys, but neutral as to content.
- *
- * Used for schemas that are supplemented by JSON schema contracts, but need to register top-level keys.
- */
-function neutralTopLevelSchema<TKey extends string>(...keys: TKey[]): zod.ZodObject<{[k in TKey]: zod.ZodAny}> {
-  return zod.object(
-    Object.fromEntries(
-      keys.map((key) => {
-        return [key, zod.any()]
-      }),
-    ),
-  ) as zod.ZodObject<{[k in TKey]: zod.ZodAny}>
-}
-
-/**
- * Create a new app config extension spec that uses contract-based validation.
- *
- * See {@link createConfigExtensionSpecification} for more about app config extensions.
- */
-export function createContractBasedConfigModuleSpecification<TKey extends string>(
-  identifier: string,
-  ...topLevelKeys: TKey[]
-): ExtensionSpecification {
-  const schema = neutralTopLevelSchema(...topLevelKeys)
-  return createConfigExtensionSpecification({
-    identifier,
-    schema,
-    transformConfig: {
-      // outgoing config is already scoped to this module and passed directly along
-      forward(obj) {
-        return obj
-      },
-      // incoming config from the platform is included in app config as-is
-      reverse(obj) {
-        return obj
-      },
-    },
-  })
-}
-
 export function createContractBasedModuleSpecification<TConfiguration extends BaseConfigType = BaseConfigType>(
   identifier: string,
   appModuleFeatures?: ExtensionFeature[],

--- a/packages/app/src/cli/models/extensions/specifications/custom_data.ts
+++ b/packages/app/src/cli/models/extensions/specifications/custom_data.ts
@@ -1,7 +1,0 @@
-import {createContractBasedConfigModuleSpecification} from '../specification.js'
-
-export const CustomDataSpecIdentifier = 'data'
-
-const customDataSpec = createContractBasedConfigModuleSpecification(CustomDataSpecIdentifier, 'product', 'metaobjects')
-
-export default customDataSpec

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.test.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.test.ts
@@ -77,12 +77,18 @@ describe('fetchExtensionSpecifications', () => {
       expect.arrayContaining([
         expect.objectContaining({
           identifier: 'remote_only_extension_schema',
+          uidStrategy: 'uuid',
         }),
         expect.objectContaining({
           identifier: 'remote_only_extension_schema_with_localization',
+          uidStrategy: 'uuid',
         }),
         expect.not.objectContaining({
           identifier: 'remote_only_extension_without_schema',
+        }),
+        expect.objectContaining({
+          identifier: 'remote_only_extension_schema_config_style',
+          uidStrategy: 'single',
         }),
       ]),
     )

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -69,6 +69,7 @@ async function mergeLocalAndRemoteSpecs(
       const normalisedSchema = await normaliseJsonSchema(remoteSpec.validationSchema.jsonSchema)
       const hasLocalization = normalisedSchema.properties?.localization !== undefined
       localSpec = createContractBasedModuleSpecification(remoteSpec.identifier, hasLocalization ? ['localization'] : [])
+      localSpec.uidStrategy = remoteSpec.options.uidIsClientProvided ? 'uuid' : 'single'
     }
     if (!localSpec) return undefined
 


### PR DESCRIPTION
Closes https://github.com/Shopify/develop-app-storage/issues/18

### WHY are these changes introduced?

Removes the custom data specification and improves handling of remote extension specifications with different UID strategies. As DCDD is an app.toml managed module, we need to be able to indicate that it's UID strategy is `single`

### WHAT is this pull request doing?

- Removes the custom data specification and its associated configuration
- Updates the UID strategy handling based on `uidIsClientProvided` flag

### How to test your changes?

1. Run the test suite to verify the updated remote specification handling
2. Tophat: make an app, connect to DL org (has module enabled), all the following should work.

- Run dev, add `[metaobjects.author.fields]\nbirthday="date"` , no failure
- Deploy same config, no failure
- Do a link into a new file, see the above config preserved

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes