### PR TITLE
Filter non-previewable extensions from the dev-console

### DIFF
--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -136,6 +136,7 @@ export async function devUIExtensions(options: ExtensionDevOptions): Promise<voi
 
   const eventHandler = async ({extensionEvents}: AppEvent) => {
     for (const event of extensionEvents) {
+      if (!event.extension.isPreviewable) continue
       const status = event.buildResult?.status === 'ok' ? 'success' : 'error'
 
       switch (event.type) {

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -38,15 +38,15 @@ export async function getUIExtensionPayload(
         },
       },
       capabilities: {
-        blockProgress: extension.configuration.capabilities?.block_progress || false,
-        networkAccess: extension.configuration.capabilities?.network_access || false,
-        apiAccess: extension.configuration.capabilities?.api_access || false,
+        blockProgress: extension.configuration.capabilities?.block_progress ?? false,
+        networkAccess: extension.configuration.capabilities?.network_access ?? false,
+        apiAccess: extension.configuration.capabilities?.api_access ?? false,
         collectBuyerConsent: {
-          smsMarketing: extension.configuration.capabilities?.collect_buyer_consent?.sms_marketing || false,
-          customerPrivacy: extension.configuration.capabilities?.collect_buyer_consent?.customer_privacy || false,
+          smsMarketing: extension.configuration.capabilities?.collect_buyer_consent?.sms_marketing ?? false,
+          customerPrivacy: extension.configuration.capabilities?.collect_buyer_consent?.customer_privacy ?? false,
         },
         iframe: {
-          sources: extension.configuration.capabilities?.iframe?.sources || [],
+          sources: extension.configuration.capabilities?.iframe?.sources ?? [],
         },
       },
       development: {
@@ -55,14 +55,14 @@ export async function getUIExtensionPayload(
         root: {
           url,
         },
-        hidden: options.currentDevelopmentPayload?.hidden || false,
+        hidden: options.currentDevelopmentPayload?.hidden ?? false,
         localizationStatus,
-        status: options.currentDevelopmentPayload?.status || 'success',
-        ...(options.currentDevelopmentPayload || {status: 'success'}),
+        status: options.currentDevelopmentPayload?.status ?? 'success',
+        ...(options.currentDevelopmentPayload ?? {status: 'success'}),
       },
       extensionPoints,
       localization: localization ?? null,
-      metafields: extension.configuration.metafields.length === 0 ? null : extension.configuration.metafields,
+      metafields: extension.configuration.metafields?.length === 0 ? null : extension.configuration.metafields,
       type: extension.configuration.type,
 
       externalType: extension.externalType,


### PR DESCRIPTION
### WHY are these changes introduced?

There was a bug where adding a non-previewable extensions during a dev-session would cause a crash, because we tried to add that extension to the dev-console process as well.

### WHAT is this pull request doing?

- For the previewable process (dev-console), ignore any change related to non-previewable extensions.

### How to test your changes?

1. Run a dev-session with just an admin-action extension (or any ui-extension)
2. Add a new webhook to your toml file.
3. Verify the session is updated and it doesn't crash.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes