### PR TITLE
All validations errors should be handled by the dev-session

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -165,7 +165,7 @@ export class AppEventWatcher extends EventEmitter {
           this.emit('all', appEvent)
         })
         .catch((error) => {
-          this.options.stderr.write(`Error handling event: ${error.message}`)
+          this.emit('error', error)
         })
     })
     await this.fileWatcher.start()
@@ -201,6 +201,12 @@ export class AppEventWatcher extends EventEmitter {
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       this.once('ready', listener)
     }
+    return this
+  }
+
+  onError(listener: (error: Error) => Promise<void> | void) {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    this.addListener('error', listener)
     return this
   }
 

--- a/packages/app/src/cli/services/dev/processes/dev-session.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session.test.ts
@@ -200,6 +200,7 @@ describe('pushUpdatesForDevSession', () => {
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Action required'))
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Scopes updated'))
     expect(contextSpy).toHaveBeenCalledWith({outputPrefix: 'dev-session', stripAnsi: false}, expect.anything())
+    contextSpy.mockRestore()
   })
 
   test('update is retried if there is an error', async () => {
@@ -272,5 +273,19 @@ describe('pushUpdatesForDevSession', () => {
     // Then
     expect(devSessionStatus().isDevSessionReady).toBe(false)
     expect(devSessionStatus().devSessionPreviewURL).toBeUndefined()
+  })
+
+  test('handles error events from the app watcher', async () => {
+    // Given
+    const testError = new Error('Watcher error')
+
+    // When
+    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+    appWatcher.emit('error', testError)
+    await flushPromises()
+
+    // Then
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Error'))
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Watcher error'))
   })
 })

--- a/packages/app/src/cli/services/dev/processes/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session.ts
@@ -166,6 +166,9 @@ export const pushUpdatesForDevSession: DevProcessFunction<DevSessionOptions> = a
       const result = await bundleExtensionsAndUpload({...processOptions, app: event.app})
       await handleDevSessionResult(result, {...processOptions, app: event.app})
     })
+    .onError(async (error) => {
+      await handleDevSessionResult({status: 'unknown-error', error}, processOptions)
+    })
 }
 
 async function handleDevSessionResult(


### PR DESCRIPTION
### WHY are these changes introduced?

Improves error handling in the dev-session process by properly propagating and displaying errors that occur during the load, build and watch phases.

### WHAT is this pull request doing?

- Adds error event handling to the `AppEventWatcher` class
- Propagates build errors through the event system instead of writing directly to stderr
- Implements error handling for uncaught errors in the dev session

### How to test your changes?

1. Start a dev-session
2. Make a change in a toml that would break validation (using a number were a string is expected)
3. Verify the error is corrrectly shown in the dev log in red.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes