### PR TITLE
Use uid as the default value for devUUID

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -151,11 +151,11 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     this.specification = options.specification
     this.handle = this.buildHandle()
     const uuidFromHandle = nonRandomUUID(this.handle)
-    this.devUUID = `dev-${uuidFromHandle}`
+    this.uid = this.configuration.uid ?? uuidFromHandle
+    this.devUUID = this.uid
     this.localIdentifier = this.handle
     this.idEnvironmentVariableName = `SHOPIFY_${constantize(this.localIdentifier)}_ID`
     this.outputPath = this.directory
-    this.uid = this.configuration.uid ?? uuidFromHandle
 
     if (this.features.includes('esbuild') || this.type === 'tax_calculation') {
       this.outputPath = joinPath(this.directory, 'dist', this.outputFileName)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an inconsistency in extension instance UUID assignment by ensuring the `devUUID` is derived from the configured `uid` value.

### WHAT is this pull request doing?

// TODO

### How to test your changes?

// TODO

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes