### PR TITLE
Use the shared addToGitIgnore function

### DIFF
--- a/packages/app/src/cli/services/store-context.ts
+++ b/packages/app/src/cli/services/store-context.ts
@@ -6,8 +6,7 @@ import metadata from '../metadata.js'
 import {configurationFileNames} from '../constants.js'
 import {hashString} from '@shopify/cli-kit/node/crypto'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {joinPath} from '@shopify/cli-kit/node/path'
-import {appendFile, readFile} from '@shopify/cli-kit/node/fs'
+import {addToGitIgnore} from '@shopify/cli-kit/node/git'
 
 /**
  * Input options for the `storeContext` function.
@@ -64,7 +63,7 @@ export async function storeContext({
   // Save the selected store in the hidden config file
   if (selectedStore.shopDomain !== cachedStoreURL || !devStoreUrlFromHiddenConfig) {
     await app.updateHiddenConfig({dev_store_url: selectedStore.shopDomain})
-    await addHiddenConfigToGitIgnoreIfNeeded(app.directory)
+    await addToGitIgnore(app.directory, configurationFileNames.hiddenFolder)
   }
 
   return selectedStore
@@ -79,17 +78,4 @@ async function logMetadata(selectedStore: OrganizationStore, resetUsed: boolean)
   await metadata.addSensitiveMetadata(() => ({
     store_fqdn: selectedStore.shopDomain,
   }))
-}
-
-/**
- * Adds the hidden config folder to the .gitignore file if it's not already there.
- *
- * This should be part of a larger mitration in the future.
- */
-async function addHiddenConfigToGitIgnoreIfNeeded(appDirectory: string) {
-  const gitIgnorePath = joinPath(appDirectory, '.gitignore')
-  const gitIgnoreContent = await readFile(gitIgnorePath)
-  if (!gitIgnoreContent.includes(configurationFileNames.hiddenFolder)) {
-    await appendFile(gitIgnorePath, `\n${configurationFileNames.hiddenFolder}/*\n`)
-  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Since the previous code was added, a new generic and shared function to add to gitignore was added to the code.

### WHAT is this pull request doing?

Use the shared function instead of a custom one.

### How to test your changes?

1. Create a new Shopify app
2. Run any command that triggers store selection
3. Verify that the `.shopify` directory is added to `.gitignore`
4. Verify that running the command multiple times doesn't create duplicate entries

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes