### PR TITLE
show error message in replay command when no logs available

### DIFF
--- a/.changeset/lemon-eggs-exist.md
+++ b/.changeset/lemon-eggs-exist.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Improve error message in function replay command when log directory doesnt exist

--- a/packages/app/src/cli/services/function/replay.ts
+++ b/packages/app/src/cli/services/function/replay.ts
@@ -12,7 +12,7 @@ import {getLogsDir} from '@shopify/cli-kit/node/logs'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 
-import {readdirSync} from 'fs'
+import {existsSync, readdirSync} from 'fs'
 
 const LOG_SELECTOR_LIMIT = 100
 
@@ -124,7 +124,7 @@ async function findFunctionRun(
   functionHandle: string,
   identifier: string,
 ): Promise<string | undefined> {
-  const fileName = readdirSync(functionRunsDir).find((filename) => {
+  const fileName = getAllFunctionRunFileNames(functionRunsDir).find((filename) => {
     const fileMetadata = parseLogFilename(filename)
     return (
       fileMetadata?.namespace === 'extensions' &&
@@ -147,7 +147,7 @@ async function getRunFromSelector(functionRunsDir: string, functionHandle: strin
 }
 
 async function getFunctionRunData(functionRunsDir: string, functionHandle: string): Promise<FunctionRunData[]> {
-  const allFunctionRunFileNames = readdirSync(functionRunsDir)
+  const allFunctionRunFileNames = getAllFunctionRunFileNames(functionRunsDir)
     .filter((filename) => {
       // Expected format: 20240522_150641_827Z_extensions_my-function_abcdef.json
       const fileMetadata = parseLogFilename(filename)
@@ -190,4 +190,8 @@ async function getFunctionRunData(functionRunsDir: string, functionHandle: strin
 
 function getIdentifierFromFilename(fileName: string): string {
   return fileName.split('_').pop()!.substring(0, 6)
+}
+
+function getAllFunctionRunFileNames(functionRunsDir: string): string[] {
+  return existsSync(functionRunsDir) ? readdirSync(functionRunsDir) : []
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-functions/issues/599

If someone tries to run the function replay command without having any logs existing, they get an ugly error message:
<img width="915" alt="image" src="https://github.com/user-attachments/assets/e82eb209-2ada-4f25-9284-4758c190d9dd" />


### WHAT is this pull request doing?

Make that error nicer! If they directory doesn't exist, we can assume theres no logs. We already have nice error handling when theres no logs, but the directory exists.

### How to test your changes?

1. Blow away your logs folder. For me, this was: `rm -rf ~Library/Logs/shopify-cli-nodejs`
2. Run `pnpm shopify app function replay --path path_to_your_app`
3. Check the error, its now more readable  
  <img width="784" alt="image" src="https://github.com/user-attachments/assets/75dc2c24-8525-44a4-85ac-6c823a7d6a0f" />


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes. None needed.
