### PR TITLE
Specify packageManager in all package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@8.15.7",
   "scripts": {
     "build-api-docs": "nx run-many --target=build-api-docs --all --skip-nx-cache",
     "build-dev-docs": "pnpm shopify docs generate && sh ./bin/docs/build-dev-docs.sh",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/app",
   "version": "3.74.0",
+  "packageManager": "pnpm@8.15.7",
   "description": "Utilities for loading, building, and publishing apps.",
   "homepage": "https://github.com/shopify/cli#readme",
   "private": true,

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/cli-kit",
   "version": "3.74.0",
+  "packageManager": "pnpm@8.15.7",
   "private": false,
   "description": "A set of utilities, interfaces, and models that are common across all the platform features",
   "keywords": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/cli",
   "version": "3.74.0",
+  "packageManager": "pnpm@8.15.7",
   "private": false,
   "description": "A CLI tool to build for the Shopify platform",
   "keywords": [

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/create-app",
   "version": "3.74.0",
+  "packageManager": "pnpm@8.15.7",
   "private": false,
   "description": "A CLI tool to create a new Shopify app.",
   "keywords": [

--- a/packages/eslint-plugin-cli/package.json
+++ b/packages/eslint-plugin-cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/eslint-plugin-cli",
   "version": "3.47.2",
+  "packageManager": "pnpm@8.15.7",
   "description": "Shopify CLI's ESLint rules and configs.",
   "keywords": [
     "eslint",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/features",
   "version": "0.12.0",
+  "packageManager": "pnpm@8.15.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-cloudflare/package.json
+++ b/packages/plugin-cloudflare/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/plugin-cloudflare",
   "version": "3.74.0",
+  "packageManager": "pnpm@8.15.7",
   "description": "Enables the creation of Cloudflare tunnels from `shopify app dev`, allowing previews from any device",
   "keywords": [
     "shopify",

--- a/packages/plugin-did-you-mean/package.json
+++ b/packages/plugin-did-you-mean/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/plugin-did-you-mean",
   "version": "3.74.0",
+  "packageManager": "pnpm@8.15.7",
   "private": true,
   "bugs": {
     "url": "https://github.com/Shopify/cli/issues"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/theme",
   "version": "3.74.0",
+  "packageManager": "pnpm@8.15.7",
   "private": true,
   "description": "Utilities for building and publishing themes",
   "homepage": "https://github.com/shopify/cli#readme",

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/ui-extensions-dev-console-app",
   "version": "3.74.0",
+  "packageManager": "pnpm@8.15.7",
   "private": true,
   "scripts": {
     "build": "nx build",

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/ui-extensions-server-kit",
   "version": "5.2.1",
+  "packageManager": "pnpm@8.15.7",
   "private": false,
   "license": "MIT",
   "exports": {

--- a/packages/ui-extensions-test-utils/package.json
+++ b/packages/ui-extensions-test-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shopify/ui-extensions-test-utils",
   "version": "3.26.0",
+  "packageManager": "pnpm@8.15.7",
   "private": true,
   "license": "MIT",
   "main": "dist/index",


### PR DESCRIPTION
### WHY are these changes introduced?

Dependabot is not working as expected because we haven't defined the package manager.

<img width="642" alt="cli 2025-01-29 11-05-41" src="https://github.com/user-attachments/assets/29005adc-b2ef-4d91-85da-8c802af2b7f2" />

https://github.com/Shopify/cli/network/updates/950752308

### WHAT is this pull request doing?

Adds the `packageManager` field to all the package.json files

### How to test your changes?

Merge and re-run dependabot

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
