### PR TITLE
Fix Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,27 +17,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
-      minor_versions:
-        dependency-type: "production"
-        update-types:
-          - 'minor'
-          - 'patch'
-        exclude-patterns:
-          - "oclif"
-          - "@oclif/*"
-          - "nx"
-          - "@nx/*"
-          - "ink"
-          - "typescript"
-          - "esbuild"
-          - "react"
-          - "@babel/*"
-          - "javy-cli"
-      development_dependencies:
-        dependency-type: "development"
-        update-types:
-          - 'minor'
-          - 'patch'
       oclif:
         patterns:
           - "oclif"
@@ -46,3 +25,25 @@ updates:
         patterns:
           - "nx"
           - "@nx/*"
+      esbuild:
+        patterns:
+          - "esbuild"
+      babel:
+        patterns:
+          - "@babel/*"
+      typescript:
+        patterns:
+          - "typescript"
+      minor_versions:
+        dependency-type: "production"
+        update-types:
+          - 'minor'
+          - 'patch'
+        exclude-patterns:
+          - "ink"
+          - "react"
+      development_dependencies:
+        dependency-type: "development"
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
### WHY are these changes introduced?

We are not grouping Dependabot PRs for some important dependencies, but then the separate PRs fail on CI because [we check that all the packages have the same version](https://github.com/Shopify/cli/blob/4aa84d12b46fe6af7530f9af9f62f2dca4f6f012/packages/features/steps/node-deps.steps.ts#L55) for them.

Example:
- https://github.com/Shopify/cli/pull/5141
- https://github.com/Shopify/cli/pull/5142
- https://github.com/Shopify/cli/pull/5143

### WHAT is this pull request doing?

- Create more groups for the important dependencies, so that we have a single PR for any of them
- Do not exclude them from `minor_versions`, because [if a dependency matches more than one rule, it's included in the first group that it matches](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--)

### How to test your changes?

Merge and pray

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
