### PR TITLE
Cleanup props for Dev.tsx

### DIFF
--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -72,9 +72,9 @@ export interface DevOptions {
 export async function dev(commandOptions: DevOptions) {
   const config = await prepareForDev(commandOptions)
   await actionsBeforeSettingUpDevProcesses(config)
-  const {processes, graphiqlUrl, previewUrl, devSessionStatusManager} = await setupDevProcesses(config)
+  const {processes, devSessionStatusManager} = await setupDevProcesses(config)
   await actionsBeforeLaunchingDevProcesses(config)
-  await launchDevProcesses({processes, previewUrl, graphiqlUrl, config, devSessionStatusManager})
+  await launchDevProcesses({processes, config, devSessionStatusManager})
 }
 
 async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
@@ -328,14 +328,10 @@ async function setupNetworkingOptions(
 
 async function launchDevProcesses({
   processes,
-  previewUrl,
-  graphiqlUrl,
   config,
   devSessionStatusManager,
 }: {
   processes: DevProcesses
-  previewUrl: string
-  graphiqlUrl: string | undefined
   config: DevConfig
   devSessionStatusManager: DevSessionStatusManager
 }) {
@@ -371,9 +367,6 @@ async function launchDevProcesses({
 
   return renderDev({
     processes: processesForTaskRunner,
-    previewUrl,
-    graphiqlUrl,
-    graphiqlPort: config.graphiqlPort,
     app,
     abortController,
     developerPreview: developerPreviewController(apiKey, developerPlatformClient),

--- a/packages/app/src/cli/services/dev/processes/dev-session-status-manager.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session-status-manager.test.ts
@@ -12,6 +12,7 @@ describe('DevSessionStatusManager', () => {
     expect(devSessionStatusManager.status).toEqual({
       isReady: false,
       previewURL: undefined,
+      graphiqlUrl: undefined,
     })
   })
 
@@ -21,6 +22,7 @@ describe('DevSessionStatusManager', () => {
     expect(devSessionStatusManager.status).toEqual({
       isReady: true,
       previewURL: undefined,
+      graphiqlUrl: undefined,
     })
   })
 
@@ -31,11 +33,13 @@ describe('DevSessionStatusManager', () => {
     devSessionStatusManager.updateStatus({
       isReady: true,
       previewURL: 'http://localhost:3000',
+      graphiqlUrl: 'http://localhost:3000/graphiql',
     })
 
     expect(listener).toHaveBeenCalledWith({
       isReady: true,
       previewURL: 'http://localhost:3000',
+      graphiqlUrl: 'http://localhost:3000/graphiql',
     })
   })
 
@@ -47,6 +51,7 @@ describe('DevSessionStatusManager', () => {
     devSessionStatusManager.updateStatus({
       isReady: true,
       previewURL: 'http://localhost:3000',
+      graphiqlUrl: 'http://localhost:3000/graphiql',
     })
 
     // Clear the mock to start fresh
@@ -56,6 +61,7 @@ describe('DevSessionStatusManager', () => {
     devSessionStatusManager.updateStatus({
       isReady: true,
       previewURL: 'http://localhost:3000',
+      graphiqlUrl: 'http://localhost:3000/graphiql',
     })
 
     expect(listener).not.toHaveBeenCalled()
@@ -66,6 +72,7 @@ describe('DevSessionStatusManager', () => {
     devSessionStatusManager.updateStatus({
       isReady: true,
       previewURL: 'http://localhost:3000',
+      graphiqlUrl: 'http://localhost:3000/graphiql',
     })
 
     devSessionStatusManager.reset()
@@ -73,6 +80,7 @@ describe('DevSessionStatusManager', () => {
     expect(devSessionStatusManager.status).toEqual({
       isReady: false,
       previewURL: undefined,
+      graphiqlUrl: undefined,
     })
   })
 
@@ -86,6 +94,7 @@ describe('DevSessionStatusManager', () => {
     expect(originalStatus).toEqual({
       isReady: false,
       previewURL: undefined,
+      graphiqlUrl: undefined,
     })
   })
 })

--- a/packages/app/src/cli/services/dev/processes/dev-session-status-manager.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session-status-manager.ts
@@ -4,12 +4,20 @@ import {EventEmitter} from 'events'
 export interface DevSessionStatus {
   isReady: boolean
   previewURL?: string
+  graphiqlUrl?: string
 }
 
+/**
+ * This class handles status updates between the DevSession and the Dev UI renderer.
+ *
+ * When there is a dev-session update that should be reflected in the UI,
+ * the DevSessionStatusManager will emit an event that the Dev UI renderer will listen for.
+ */
 export class DevSessionStatusManager extends EventEmitter {
   private currentStatus: DevSessionStatus = {
     isReady: false,
     previewURL: undefined,
+    graphiqlUrl: undefined,
   }
 
   constructor(defaultStatus?: DevSessionStatus) {
@@ -34,6 +42,7 @@ export class DevSessionStatusManager extends EventEmitter {
     this.currentStatus = {
       isReady: false,
       previewURL: undefined,
+      graphiqlUrl: undefined,
     }
   }
 }

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -156,7 +156,9 @@ describe('setup-dev-processes', () => {
       graphiqlKey,
     })
 
-    expect(res.previewUrl).toBe('https://example.com/proxy/extensions/dev-console')
+    expect(res.devSessionStatusManager.status.previewURL).toBe('https://example.com/proxy/extensions/dev-console')
+    expect(res.devSessionStatusManager.status.graphiqlUrl).toBe('http://localhost:1234/graphiql?key=somekey')
+
     expect(res.processes[0]).toMatchObject({
       type: 'web',
       prefix: 'web-backend-frontend',

--- a/packages/app/src/cli/services/dev/ui.test.tsx
+++ b/packages/app/src/cli/services/dev/ui.test.tsx
@@ -1,17 +1,9 @@
 import {renderDev} from './ui.js'
 import {Dev} from './ui/components/Dev.js'
 import {DevSessionStatusManager} from './processes/dev-session-status-manager.js'
-import {
-  testApp,
-  testDeveloperPlatformClient,
-  testFunctionExtension,
-  testThemeExtensions,
-  testUIExtension,
-} from '../../models/app/app.test-data.js'
-import {AppInterface} from '../../models/app/app.js'
+import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
-import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
 
@@ -27,11 +19,14 @@ const developerPreview = {
 }
 
 const developerPlatformClient = testDeveloperPlatformClient()
-const devSessionStatusManager = new DevSessionStatusManager()
+const devSessionStatusManager = new DevSessionStatusManager({
+  isReady: true,
+  previewURL: 'https://lala.cloudflare.io/',
+  graphiqlUrl: 'https://lala.cloudflare.io/graphiql',
+})
 
 afterEach(() => {
   mockAndCaptureOutput().clear()
-  devSessionStatusManager.reset()
 })
 
 describe('ui', () => {
@@ -44,10 +39,7 @@ describe('ui', () => {
       }
 
       const processes = [concurrentProcess]
-      const previewUrl = 'https://lala.cloudflare.io/'
-      const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
       const shopFqdn = 'mystore.shopify.io'
-      const graphiqlPort = 1234
       const app = {
         canEnablePreviewMode: true,
         developmentStorePreviewEnabled: false,
@@ -61,9 +53,6 @@ describe('ui', () => {
 
       await renderDev({
         processes,
-        previewUrl,
-        graphiqlUrl,
-        graphiqlPort,
         app,
         abortController,
         developerPreview,
@@ -88,10 +77,7 @@ describe('ui', () => {
       }
 
       const processes = [concurrentProcess]
-      const previewUrl = 'https://lala.cloudflare.io/'
-      const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
       const shopFqdn = 'mystore.shopify.io'
-      const graphiqlPort = 1234
       const app = {
         canEnablePreviewMode: true,
         developmentStorePreviewEnabled: false,
@@ -105,9 +91,6 @@ describe('ui', () => {
 
       await renderDev({
         processes,
-        previewUrl,
-        graphiqlUrl,
-        graphiqlPort,
         app,
         abortController,
         developerPreview,
@@ -128,10 +111,7 @@ describe('ui', () => {
       }
 
       const processes = [concurrentProcess]
-      const previewUrl = 'https://lala.cloudflare.io/'
-      const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
       const shopFqdn = 'mystore.shopify.io'
-      const graphiqlPort = 1234
       const app = {
         canEnablePreviewMode: false,
         developmentStorePreviewEnabled: false,
@@ -145,9 +125,6 @@ describe('ui', () => {
 
       await renderDev({
         processes,
-        previewUrl,
-        graphiqlUrl,
-        graphiqlPort,
         app,
         abortController,
         developerPreview,
@@ -168,10 +145,7 @@ describe('ui', () => {
       }
 
       const processes = [concurrentProcess]
-      const previewUrl = 'https://lala.cloudflare.io/'
-      const graphiqlUrl = 'https://lala.cloudflare.io/graphiql'
       const shopFqdn = 'mystore.shopify.io'
-      const graphiqlPort = 1234
       const app = {
         canEnablePreviewMode: true,
         developmentStorePreviewEnabled: false,
@@ -186,9 +160,6 @@ describe('ui', () => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       renderDev({
         processes,
-        previewUrl,
-        graphiqlUrl,
-        graphiqlPort,
         app,
         abortController,
         developerPreview,
@@ -203,26 +174,3 @@ describe('ui', () => {
     })
   })
 })
-
-async function mockApp(newConfig = false): Promise<AppInterface> {
-  const nodeDependencies: {[key: string]: string} = {}
-  nodeDependencies['@shopify/cli'] = '2.2.2'
-
-  const functionExtension = await testFunctionExtension()
-  const themeExtension = await testThemeExtensions()
-  const uiExtension = await testUIExtension()
-  const configurationPath = joinPath('/', newConfig ? 'shopify.app.staging.toml' : 'shopify.app.toml')
-
-  const result = testApp(
-    {
-      name: 'my-super-customer-accounts-app',
-      directory: '/',
-      nodeDependencies,
-      allExtensions: [functionExtension, themeExtension, uiExtension],
-    },
-    newConfig ? 'current' : 'legacy',
-  )
-  result.configuration.path = configurationPath
-
-  return result
-}

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -7,11 +7,8 @@ import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 
 export async function renderDev({
   processes,
-  previewUrl,
   app,
   abortController,
-  graphiqlUrl,
-  graphiqlPort,
   developerPreview,
   shopFqdn,
   devSessionStatusManager,
@@ -21,10 +18,7 @@ export async function renderDev({
       <Dev
         processes={processes}
         abortController={abortController}
-        previewUrl={previewUrl}
         app={app}
-        graphiqlUrl={graphiqlUrl}
-        graphiqlPort={graphiqlPort}
         developerPreview={developerPreview}
         isEditionWeek={isEditionWeek()}
         shopFqdn={shopFqdn}

--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -13,7 +13,7 @@ import {
 } from '@shopify/cli-kit/node/testing/ui'
 import {AbortController, AbortSignal} from '@shopify/cli-kit/node/abort'
 import React from 'react'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {unstyled} from '@shopify/cli-kit/node/output'
 import {openURL} from '@shopify/cli-kit/node/system'
 import {Writable} from 'stream'
@@ -42,8 +42,12 @@ const developerPreview = {
   update: vi.fn(async (_state: boolean) => true),
 }
 
-afterEach(() => {
-  devSessionStatusManager.reset()
+beforeEach(() => {
+  devSessionStatusManager.updateStatus({
+    isReady: true,
+    previewURL: 'https://shopify.com',
+    graphiqlUrl: 'http://localhost:1234/graphiql',
+  })
 })
 
 describe('Dev', () => {
@@ -89,9 +93,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess, frontendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -171,9 +172,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess, frontendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -205,14 +203,11 @@ describe('Dev', () => {
   })
 
   test('opens the previewUrl when p is pressed', async () => {
-    // When
+    // Given
     const renderInstance = render(
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -238,9 +233,6 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -268,9 +260,6 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -313,9 +302,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -380,9 +366,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -441,9 +424,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -495,9 +475,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={abortController}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -539,9 +516,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         pollingTime={200}
         developerPreview={developerPreview}
@@ -608,9 +582,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={{
           ...testApp,
           canEnablePreviewMode: false,
@@ -667,9 +638,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         pollingTime={200}
         developerPreview={developerPreview}
@@ -710,9 +678,6 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -777,9 +742,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -829,9 +791,6 @@ describe('Dev', () => {
       <Dev
         processes={[backendProcess]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -870,9 +829,6 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -913,9 +869,6 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -952,9 +905,6 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={testApp}
         developerPreview={developerPreview}
         shopFqdn="mystore.shopify.io"
@@ -1008,9 +958,6 @@ describe('Dev', () => {
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl="https://shopify.com"
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={{
           ...testApp,
           canEnablePreviewMode: false,
@@ -1067,15 +1014,12 @@ describe('Dev', () => {
     // Given
     const initialPreviewUrl = 'https://shopify.com'
     const newPreviewUrl = 'https://my-new-preview-url.shopify.com'
-    devSessionStatusManager.updateStatus({isReady: true, previewURL: undefined})
+    devSessionStatusManager.updateStatus({isReady: true, previewURL: initialPreviewUrl})
 
     const renderInstance = render(
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl={initialPreviewUrl}
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={{
           ...testApp,
           developerPlatformClient: {
@@ -1111,15 +1055,12 @@ describe('Dev', () => {
     // Given
     const initialPreviewUrl = 'https://shopify.com'
     const newPreviewUrl = 'https://my-new-preview-url.shopify.com'
-    devSessionStatusManager.updateStatus({isReady: true, previewURL: undefined})
+    devSessionStatusManager.updateStatus({isReady: true, previewURL: initialPreviewUrl})
 
     const renderInstance = render(
       <Dev
         processes={[]}
         abortController={new AbortController()}
-        previewUrl={initialPreviewUrl}
-        graphiqlUrl="https://graphiql.shopify.com"
-        graphiqlPort={1234}
         app={{
           ...testApp,
           developerPlatformClient: {


### PR DESCRIPTION
### WHY are these changes introduced?

We are passing many variables through the component tree to get to the dev.tsx component and then have logic there to decide what to show.

### WHAT is this pull request doing?

- Moves preview URL and GraphiQL URL management into `DevSessionStatusManager`
- Removes URL-related props from the `Dev.tsx` component
- `Dev.tsx` is no longer responsible of building any URL
- Consolidate most state into a single `setState` for the whole `DevSessionStatus`

### How to test your changes?

1. Start a dev session
2. Verify preview URL and GraphiQL URL are correctly displayed
3. Test URL shortcuts (p for preview, g for GraphiQL) work as expected.
4. (optional). Repeat the test from the previous PR: adding/removing ui-extensions updates the Preview URL.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix