### PR TITLE
Skip unneeded CI checks for Dependabot

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -131,7 +131,7 @@ jobs:
   pr-platform-agnostic-lint:
     name: '[PR] Run lint with Node ${{ matrix.node }} in ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]) || github.event_name == 'merge_group'' }}
     timeout-minutes: 30
     strategy:
       matrix:
@@ -183,7 +183,7 @@ jobs:
   pr-platform-agnostic-knip:
     name: '[PR] Run knip with Node ${{ matrix.node }} in ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'}}
     timeout-minutes: 30
     strategy:
       matrix:
@@ -207,7 +207,7 @@ jobs:
   pr-platform-agnostic-graphql-schema:
     name: '[PR] Check graphql-codegen has been run'
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'}}
     timeout-minutes: 30
     strategy:
       matrix:
@@ -233,7 +233,7 @@ jobs:
   oclif-checks:
     name: '[PR] Check OCLIF manifests & readme & docs'
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]) || github.event_name == 'merge_group'' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -313,7 +313,7 @@ jobs:
   pr-test-coverage:
     name: '[PR] Run Test Coverage with Node ${{ matrix.node }} in ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}
-    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]) || github.event_name == 'merge_group'' }}
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
### WHY are these changes introduced?

Some checks are failing for Dependabot PRs, like [knip](https://github.com/Shopify/cli/actions/runs/13031805523/job/36352591159?pr=5298) or graphql-codegen, but we don't need them for those PRs that are only updating versions.

### WHAT is this pull request doing?

Just skip those checks for Dependabot PRs

### How to test your changes?

Merge and rebase a Dependabot PR

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
