### PR TITLE
Add flag to allow —unpublished to reuse theme names

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2208,6 +2208,7 @@ FLAGS
       --password=<value>     Password generated from the Theme Access app.
       --path=<value>         The path to your theme directory.
       --strict               Require theme check to pass without errors before pushing. Warnings are allowed.
+      --unique-name          Make the push to an unpublished theme
       --verbose              Increase the verbosity of the output.
 
 DESCRIPTION

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6281,6 +6281,21 @@
           "name": "theme",
           "type": "option"
         },
+        "unique-name": {
+          "allowNo": false,
+          "description": "Make the push to an unpublished theme",
+          "env": "SHOPIFY_FLAG_UNIQUENAME",
+          "name": "unique-name",
+          "relationships": [
+            {
+              "flags": [
+                "unpublished"
+              ],
+              "type": "all"
+            }
+          ],
+          "type": "boolean"
+        },
         "unpublished": {
           "allowNo": false,
           "char": "u",

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -64,6 +64,17 @@ export default class Push extends ThemeCommand {
       description: 'Create a new unpublished theme and push to it.',
       env: 'SHOPIFY_FLAG_UNPUBLISHED',
     }),
+    'unique-name': Flags.boolean({
+      description: 'Make the push to an unpublished theme reuse the name',
+      env: 'SHOPIFY_FLAG_UNIQUE_NAME',
+      default: false,
+      relationships: [
+        {
+          type: 'all',
+          flags: ['unpublished'],
+        },
+      ],
+    }),
     nodelete: Flags.boolean({
       char: 'n',
       description: `Prevent deleting remote files that don't exist locally.`,
@@ -114,6 +125,7 @@ export default class Push extends ThemeCommand {
       development: flags.development,
       live: flags.live,
       unpublished: flags.unpublished,
+      uniqueName: flags['unique-name'],
       nodelete: flags.nodelete,
       only: flags.only,
       ignore: flags.ignore,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #2699

```shell
shopify theme push —theme <name> --unpublished
```

Repeated calls the above command generates multiple themes with identical names. If you're using theme names to map to git branches in CI, this causes a problem. You need an idempotent way to push themes.

We want something like:

```shell
shopify theme push --theme <name> —-unpublished --upsert
```


### WHAT is this pull request doing?

In this PR, I add a flag to optionally allow to `--unpublished` to update a theme if there is already one with the passed name. The flag is dependent on `--unpublished` so we should get the nice OCLIF errors if it's passed without `--unpublished`

Here's my rationale:

This command pushes to a theme named "Iteration", but the theme with that name must exist. If it doesn't, an error is output.
```shell
shopify theme push --theme "Iteration"
```

So we add the `--unpublished` flag, to allow us to create a new, unpublished theme with the passed name.

```shell
shopify theme push --theme "Iteration" --unpublished
```

Then, we want to provide more information to this push to reuse the theme with the matching name if it exists.

```shell
shopify theme push --theme "Iteration" --unpublished --upsert
```


### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
