### PR TITLE
Improve mechanism that adds `.shopify` to `.gitignore` to avoid duplicate entries

### DIFF
--- a/.changeset/curvy-kangaroos-flow.md
+++ b/.changeset/curvy-kangaroos-flow.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+Improve mechanism that adds `.shopify` to `.gitignore` to avoid duplicate entries

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -137,6 +137,7 @@
     "gradient-string": "2.0.2",
     "graphql": "16.8.1",
     "graphql-request": "5.2.0",
+    "ignore": "6.0.2",
     "ink": "4.4.1",
     "is-interactive": "2.0.0",
     "jose": "5.9.6",

--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -444,4 +444,38 @@ describe('addToGitIgnore()', () => {
       expect(gitIgnoreContent).toBe('node_modules\ndist\n.shopify\n')
     })
   })
+
+  test('does nothing when .shopify/* pattern exists in .gitignore', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const gitIgnorePath = `${tmpDir}/.gitignore`
+      const gitIgnoreContent = '.shopify/*\nnode_modules\n'
+
+      writeFileSync(gitIgnorePath, gitIgnoreContent)
+
+      // When
+      git.addToGitIgnore(tmpDir, '.shopify')
+
+      // Then
+      const actualContent = readFileSync(gitIgnorePath).toString()
+      expect(actualContent).toBe(gitIgnoreContent)
+    })
+  })
+
+  test('does nothing when .shopify/** pattern exists in .gitignore', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const gitIgnorePath = `${tmpDir}/.gitignore`
+      const gitIgnoreContent = '.shopify/**\nnode_modules\n'
+
+      writeFileSync(gitIgnorePath, gitIgnoreContent)
+
+      // When
+      git.addToGitIgnore(tmpDir, '.shopify')
+
+      // Then
+      const actualContent = readFileSync(gitIgnorePath).toString()
+      expect(actualContent).toBe(gitIgnoreContent)
+    })
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,9 @@ importers:
       graphql-request:
         specifier: 5.2.0
         version: 5.2.0(graphql@16.8.1)
+      ignore:
+        specifier: 6.0.2
+        version: 6.0.2
       ink:
         specifier: 4.4.1
         version: 4.4.1(@types/react@17.0.2)(react@18.2.0)
@@ -4322,7 +4325,7 @@ packages:
       debug: 4.4.0(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
-      ignore: 5.3.1
+      ignore: 5.3.2
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -11413,7 +11416,7 @@ packages:
       glob-parent: 6.0.2
       globals: 13.24.0
       graphemer: 1.4.0
-      ignore: 5.3.1
+      ignore: 5.3.2
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5286

### WHAT is this pull request doing?

Instead of manipulating raw strings, now `addToGitIgnore` uses the `ignore` module (already being used by [apps](https://github.com/Shopify/cli/blob/8b7f3b0b3e66a1d34498ff3026fc1b00363ee27b/packages/app/package.json#L71)), so we may prevent equivalent patterns from being added.

It's important to notice though, that not all patterns reported on Fixes https://github.com/Shopify/cli/issues/5286 are equivalent as we may notice in the screenshot below:

![image](https://github.com/user-attachments/assets/c138651b-b6bd-42f0-88c7-6569c1966ff2)


### How to test your changes?

- Run `shopify theme metafields pull`
- Remove `.shopify/metafields.json`
- Remove any `.shopify` entry from `.gitignore`
- Notice that, when the `.shopify/metafields.json` file is created, an entry is also added in the `.gitignore`


### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes


