### PR TITLE
Create a new UI component for DevSessions

### DIFF
--- a/packages/app/src/cli/services/dev/processes/dev-session-status-manager.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session-status-manager.ts
@@ -4,12 +4,14 @@ import {EventEmitter} from 'events'
 export interface DevSessionStatus {
   isReady: boolean
   previewURL?: string
+  graphiqlURL?: string
 }
 
-class DevSessionStatusManager extends EventEmitter {
+export class DevSessionStatusManager extends EventEmitter {
   private currentStatus: DevSessionStatus = {
     isReady: false,
     previewURL: undefined,
+    graphiqlURL: undefined,
   }
 
   updateStatus(status: Partial<DevSessionStatus>) {
@@ -29,6 +31,7 @@ class DevSessionStatusManager extends EventEmitter {
     this.currentStatus = {
       isReady: false,
       previewURL: undefined,
+      graphiqlURL: undefined,
     }
   }
 }

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
@@ -26,6 +26,8 @@ const initialStatus: DevSessionStatus = {
   graphiqlURL: 'https://graphiql.shopify.com',
 }
 
+const onAbort = vi.fn()
+
 describe('DevSessionUI', () => {
   beforeEach(() => {
     devSessionStatusManager = new DevSessionStatusManager()
@@ -76,6 +78,7 @@ describe('DevSessionUI', () => {
         processes={[backendProcess, frontendProcess]}
         abortController={new AbortController()}
         devSessionStatusManager={devSessionStatusManager}
+        onAbort={onAbort}
       />,
     )
 
@@ -111,6 +114,7 @@ describe('DevSessionUI', () => {
         processes={[]}
         abortController={new AbortController()}
         devSessionStatusManager={devSessionStatusManager}
+        onAbort={onAbort}
       />,
     )
 
@@ -130,6 +134,7 @@ describe('DevSessionUI', () => {
         processes={[]}
         abortController={new AbortController()}
         devSessionStatusManager={devSessionStatusManager}
+        onAbort={onAbort}
       />,
     )
 
@@ -153,6 +158,7 @@ describe('DevSessionUI', () => {
         processes={[]}
         abortController={abortController}
         devSessionStatusManager={devSessionStatusManager}
+        onAbort={onAbort}
       />,
     )
 
@@ -179,6 +185,7 @@ describe('DevSessionUI', () => {
         processes={[]}
         abortController={abortController}
         devSessionStatusManager={devSessionStatusManager}
+        onAbort={onAbort}
       />,
     )
 
@@ -220,6 +227,7 @@ describe('DevSessionUI', () => {
         processes={[backendProcess]}
         abortController={abortController}
         devSessionStatusManager={devSessionStatusManager}
+        onAbort={onAbort}
       />,
     )
 
@@ -265,6 +273,7 @@ describe('DevSessionUI', () => {
         processes={[]}
         abortController={new AbortController()}
         devSessionStatusManager={devSessionStatusManager}
+        onAbort={onAbort}
       />,
     )
 
@@ -297,6 +306,7 @@ describe('DevSessionUI', () => {
         processes={[]}
         abortController={new AbortController()}
         devSessionStatusManager={devSessionStatusManager}
+        onAbort={onAbort}
       />,
     )
 
@@ -338,6 +348,7 @@ describe('DevSessionUI', () => {
         processes={[errorProcess]}
         abortController={abortController}
         devSessionStatusManager={devSessionStatusManager}
+        onAbort={onAbort}
       />,
     )
 

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
@@ -1,0 +1,351 @@
+import {DevSessionUI} from './DevSessionUI.js'
+import {DevSessionStatus, DevSessionStatusManager} from '../../processes/dev-session-status-manager.js'
+import {
+  getLastFrameAfterUnmount,
+  render,
+  sendInputAndWait,
+  waitForContent,
+  waitForInputsToBeReady,
+} from '@shopify/cli-kit/node/testing/ui'
+import {AbortController} from '@shopify/cli-kit/node/abort'
+import React from 'react'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {unstyled} from '@shopify/cli-kit/node/output'
+import {openURL} from '@shopify/cli-kit/node/system'
+import {Writable} from 'stream'
+
+vi.mock('@shopify/cli-kit/node/system')
+vi.mock('@shopify/cli-kit/node/context/local')
+vi.mock('@shopify/cli-kit/node/tree-kill')
+
+let devSessionStatusManager: DevSessionStatusManager
+
+const initialStatus: DevSessionStatus = {
+  isReady: true,
+  previewURL: 'https://shopify.com',
+  graphiqlURL: 'https://graphiql.shopify.com',
+}
+
+describe('DevSessionUI', () => {
+  beforeEach(() => {
+    devSessionStatusManager = new DevSessionStatusManager()
+    devSessionStatusManager.reset()
+    devSessionStatusManager.updateStatus(initialStatus)
+  })
+
+  test('renders a stream of concurrent outputs from sub-processes, shortcuts and URLs', async () => {
+    // Given
+    let backendPromiseResolve: () => void
+    let frontendPromiseResolve: () => void
+
+    const backendPromise = new Promise<void>(function (resolve, _reject) {
+      backendPromiseResolve = resolve
+    })
+
+    const frontendPromise = new Promise<void>(function (resolve, _reject) {
+      frontendPromiseResolve = resolve
+    })
+
+    const backendProcess = {
+      prefix: 'backend',
+      action: async (stdout: Writable, _stderr: Writable) => {
+        stdout.write('first backend message')
+        stdout.write('second backend message')
+        stdout.write('third backend message')
+
+        backendPromiseResolve()
+      },
+    }
+
+    const frontendProcess = {
+      prefix: 'frontend',
+      action: async (stdout: Writable, _stderr: Writable) => {
+        await backendPromise
+
+        stdout.write('first frontend message')
+        stdout.write('second frontend message')
+        stdout.write('third frontend message')
+
+        frontendPromiseResolve()
+      },
+    }
+
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[backendProcess, frontendProcess]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+      />,
+    )
+
+    await frontendPromise
+
+    // Then
+    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+      "00:00:00 │                   backend │ first backend message
+      00:00:00 │                   backend │ second backend message
+      00:00:00 │                   backend │ third backend message
+      00:00:00 │                  frontend │ first frontend message
+      00:00:00 │                  frontend │ second frontend message
+      00:00:00 │                  frontend │ third frontend message
+
+      ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+      › Press g │ open GraphiQL (Admin API) in your browser
+      › Press p │ preview in your browser
+      › Press q │ quit
+
+      Preview URL: https://shopify.com
+      GraphiQL URL: https://graphiql.shopify.com
+      "
+    `)
+
+    renderInstance.unmount()
+  })
+
+  test('opens the previewURL when p is pressed', async () => {
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+    await sendInputAndWait(renderInstance, 100, 'p')
+
+    // Then
+    expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://shopify.com')
+
+    renderInstance.unmount()
+  })
+
+  test('opens the graphiqlURL when g is pressed', async () => {
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+    await sendInputAndWait(renderInstance, 100, 'g')
+
+    // Then
+    expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://graphiql.shopify.com')
+
+    renderInstance.unmount()
+  })
+
+  test('quits when q is pressed', async () => {
+    // Given
+    const abortController = new AbortController()
+    const abort = vi.spyOn(abortController, 'abort')
+
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={abortController}
+        devSessionStatusManager={devSessionStatusManager}
+      />,
+    )
+
+    const promise = renderInstance.waitUntilExit()
+
+    await waitForInputsToBeReady()
+    renderInstance.stdin.write('q')
+
+    await promise
+
+    // Then
+    expect(abort).toHaveBeenCalledOnce()
+
+    renderInstance.unmount()
+  })
+
+  test('shows shutting down message when aborted', async () => {
+    // Given
+    const abortController = new AbortController()
+
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={abortController}
+        devSessionStatusManager={devSessionStatusManager}
+      />,
+    )
+
+    const promise = renderInstance.waitUntilExit()
+
+    abortController.abort()
+
+    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toContain('Shutting down dev ...')
+
+    await promise
+
+    expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+      ""
+    `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
+  })
+
+  test('shows error shutting down message when aborted with error', async () => {
+    // Given
+    const abortController = new AbortController()
+
+    const backendProcess: any = {
+      prefix: 'backend',
+      action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+        stdout.write('first backend message')
+        stdout.write('second backend message')
+        stdout.write('third backend message')
+
+        // await promise that never resolves
+        await new Promise(() => {})
+      },
+    }
+
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[backendProcess]}
+        abortController={abortController}
+        devSessionStatusManager={devSessionStatusManager}
+      />,
+    )
+
+    const promise = renderInstance.waitUntilExit()
+
+    abortController.abort('something went wrong')
+
+    expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+      "00:00:00 │                   backend │ first backend message
+      00:00:00 │                   backend │ second backend message
+      00:00:00 │                   backend │ third backend message
+
+      ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+      › Press g │ open GraphiQL (Admin API) in your browser
+      › Press p │ preview in your browser
+      › Press q │ quit
+
+      Shutting down dev because of an error ...
+      "
+    `)
+
+    await promise
+
+    expect(unstyled(getLastFrameAfterUnmount(renderInstance)!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
+      "00:00:00 │                   backend │ first backend message
+      00:00:00 │                   backend │ second backend message
+      00:00:00 │                   backend │ third backend message
+      "
+    `)
+
+    // unmount so that polling is cleared after every test
+    renderInstance.unmount()
+  })
+
+  test('updates UI when status changes through devSessionStatusManager', async () => {
+    // Given
+    devSessionStatusManager.reset()
+
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+
+    // Initial state
+    expect(unstyled(renderInstance.lastFrame()!)).not.toContain('preview in your browser')
+
+    // When status updates
+    devSessionStatusManager.updateStatus({
+      isReady: true,
+      previewURL: 'https://new-preview-url.shopify.com',
+      graphiqlURL: 'https://new-graphiql.shopify.com',
+    })
+
+    await waitForContent(renderInstance, 'preview in your browser')
+
+    // Then
+    expect(unstyled(renderInstance.lastFrame()!)).toContain('Preview URL: https://new-preview-url.shopify.com')
+    expect(unstyled(renderInstance.lastFrame()!)).toContain('GraphiQL URL: https://new-graphiql.shopify.com')
+    renderInstance.unmount()
+  })
+
+  test('updates UI when devSessionEnabled changes from false to true', async () => {
+    // Given
+    devSessionStatusManager.updateStatus({isReady: false})
+
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+
+    // Then
+    expect(unstyled(renderInstance.lastFrame()!)).not.toContain('Press p')
+    expect(unstyled(renderInstance.lastFrame()!)).not.toContain('Press g')
+    expect(unstyled(renderInstance.lastFrame()!)).not.toContain('Preview URL')
+    expect(unstyled(renderInstance.lastFrame()!)).not.toContain('GraphiQL URL')
+
+    // When
+    devSessionStatusManager.updateStatus({isReady: true})
+
+    await waitForInputsToBeReady()
+
+    // Then
+    expect(unstyled(renderInstance.lastFrame()!)).toContain('Press p')
+    expect(unstyled(renderInstance.lastFrame()!)).toContain('Press g')
+    expect(unstyled(renderInstance.lastFrame()!)).toContain('Preview URL: https://shopify.com')
+    expect(unstyled(renderInstance.lastFrame()!)).toContain('GraphiQL URL: https://graphiql.shopify.com')
+    renderInstance.unmount()
+  })
+
+  test('handles process errors by aborting', async () => {
+    // Given
+    const abortController = new AbortController()
+    const abort = vi.spyOn(abortController, 'abort')
+    const errorProcess = {
+      prefix: 'error',
+      action: async () => {
+        throw new Error('Test error')
+      },
+    }
+
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[errorProcess]}
+        abortController={abortController}
+        devSessionStatusManager={devSessionStatusManager}
+      />,
+    )
+
+    await expect(renderInstance.waitUntilExit()).rejects.toThrow('Test error')
+
+    // Then
+    expect(abort).toHaveBeenCalledWith(new Error('Test error'))
+
+    renderInstance.unmount()
+  })
+})

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
@@ -18,9 +18,15 @@ interface DevSesionUIProps {
   processes: OutputProcess[]
   abortController: AbortController
   devSessionStatusManager: DevSessionStatusManager
+  onAbort: () => Promise<void>
 }
 
-const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({abortController, processes, devSessionStatusManager}) => {
+const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
+  abortController,
+  processes,
+  devSessionStatusManager,
+  onAbort,
+}) => {
   const {isRawModeSupported: canUseShortcuts} = useStdin()
 
   const [isShuttingDownMessage, setIsShuttingDownMessage] = useState<string | undefined>(undefined)
@@ -39,6 +45,7 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({abortController, pro
         })
       }, 2000)
     }
+    await onAbort()
   })
 
   const errorHandledProcesses = useMemo(() => {

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
@@ -1,0 +1,165 @@
+import metadata from '../../../../metadata.js'
+import {DevSessionStatus, DevSessionStatusManager} from '../../processes/dev-session-status-manager.js'
+import {MAX_EXTENSION_HANDLE_LENGTH} from '../../../../models/extensions/schemas.js'
+import {OutputProcess} from '@shopify/cli-kit/node/output'
+import {ConcurrentOutput} from '@shopify/cli-kit/node/ui/components'
+import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
+import React, {FunctionComponent, useEffect, useMemo, useState} from 'react'
+import {AbortController, AbortSignal} from '@shopify/cli-kit/node/abort'
+import {Box, Text, useInput, useStdin} from '@shopify/cli-kit/node/ink'
+import {handleCtrlC} from '@shopify/cli-kit/node/ui'
+import {openURL} from '@shopify/cli-kit/node/system'
+import figures from '@shopify/cli-kit/node/figures'
+import {isUnitTest} from '@shopify/cli-kit/node/context/local'
+import {treeKill} from '@shopify/cli-kit/node/tree-kill'
+import {Writable} from 'stream'
+
+interface DevSesionUIProps {
+  processes: OutputProcess[]
+  abortController: AbortController
+  devSessionStatusManager: DevSessionStatusManager
+}
+
+const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({abortController, processes, devSessionStatusManager}) => {
+  const {isRawModeSupported: canUseShortcuts} = useStdin()
+
+  const [isShuttingDownMessage, setIsShuttingDownMessage] = useState<string | undefined>(undefined)
+  const [error, setError] = useState<string | undefined>(undefined)
+  const [status, setStatus] = useState<DevSessionStatus>(devSessionStatusManager.status)
+
+  const {isAborted} = useAbortSignal(abortController.signal, async (err) => {
+    if (err) {
+      setIsShuttingDownMessage('Shutting down dev because of an error ...')
+    } else {
+      setIsShuttingDownMessage('Shutting down dev ...')
+      setTimeout(() => {
+        if (isUnitTest()) return
+        treeKill(process.pid, 'SIGINT', false, () => {
+          process.exit(0)
+        })
+      }, 2000)
+    }
+  })
+
+  const errorHandledProcesses = useMemo(() => {
+    return processes.map((process) => {
+      return {
+        ...process,
+        action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
+          try {
+            return await process.action(stdout, stderr, signal)
+            // eslint-disable-next-line no-catch-all/no-catch-all
+          } catch (error) {
+            abortController.abort(error)
+          }
+        },
+      }
+    })
+  }, [processes, abortController])
+
+  // Subscribe to dev session status updates
+  useEffect(() => {
+    devSessionStatusManager.on('dev-session-update', setStatus)
+
+    return () => {
+      devSessionStatusManager.off('dev-session-update', setStatus)
+    }
+  }, [])
+
+  useInput(
+    (input, key) => {
+      handleCtrlC(input, key, () => abortController.abort())
+
+      const onInput = async () => {
+        try {
+          setError('')
+
+          if (input === 'p' && status.previewURL && status.isReady) {
+            await metadata.addPublicMetadata(() => ({
+              cmd_dev_preview_url_opened: true,
+            }))
+            await openURL(status.previewURL)
+          } else if (input === 'g' && status.graphiqlURL && status.isReady) {
+            await metadata.addPublicMetadata(() => ({
+              cmd_dev_graphiql_opened: true,
+            }))
+            await openURL(status.graphiqlURL)
+          } else if (input === 'q') {
+            abortController.abort()
+          }
+          // eslint-disable-next-line no-catch-all/no-catch-all
+        } catch (_) {
+          setError('Failed to handle your input.')
+        }
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      onInput()
+    },
+    {isActive: Boolean(canUseShortcuts)},
+  )
+
+  return (
+    <>
+      <ConcurrentOutput
+        processes={errorHandledProcesses}
+        prefixColumnSize={MAX_EXTENSION_HANDLE_LENGTH}
+        abortSignal={abortController.signal}
+        keepRunningAfterProcessesResolve={true}
+        useAlternativeColorPalette={true}
+      />
+      {/* eslint-disable-next-line no-negated-condition */}
+      {!isAborted ? (
+        <Box
+          marginY={1}
+          paddingTop={1}
+          flexDirection="column"
+          flexGrow={1}
+          borderStyle="single"
+          borderBottom={false}
+          borderLeft={false}
+          borderRight={false}
+          borderTop
+        >
+          {canUseShortcuts ? (
+            <Box flexDirection="column">
+              {status.graphiqlURL && status.isReady ? (
+                <Text>
+                  {figures.pointerSmall} Press <Text bold>g</Text> {figures.lineVertical} open GraphiQL (Admin API) in
+                  your browser
+                </Text>
+              ) : null}
+              {status.isReady ? (
+                <Text>
+                  {figures.pointerSmall} Press <Text bold>p</Text> {figures.lineVertical} preview in your browser
+                </Text>
+              ) : null}
+              <Text>
+                {figures.pointerSmall} Press <Text bold>q</Text> {figures.lineVertical} quit
+              </Text>
+            </Box>
+          ) : null}
+
+          <Box marginTop={canUseShortcuts ? 1 : 0} flexDirection="column">
+            {isShuttingDownMessage ? (
+              <Text>{isShuttingDownMessage}</Text>
+            ) : (
+              <>
+                {status.isReady && (
+                  <>
+                    <Text>{`Preview URL: ${status.previewURL}`}</Text>
+                    {status.graphiqlURL ? <Text>{`GraphiQL URL: ${status.graphiqlURL}`}</Text> : null}
+                  </>
+                )}
+              </>
+            )}
+          </Box>
+
+          {error ? <Text color="red">{error}</Text> : null}
+        </Box>
+      ) : null}
+    </>
+  )
+}
+
+export {DevSessionUI}


### PR DESCRIPTION
### WHY are these changes introduced?

The current UI component was getting too complex to support both legacy and new dev, with many conditionals and adding more props.

This PR aims to solve that by creating a simpler UI component specific for dev-sessions. So that we can keep evolving this one without affecting the current dev behaviour.


### WHAT is this pull request doing?

- Creates a new `DevSessionUI` component
- Has the same shortcuts support as the old component
- Can receive status updates via an injected devSessionStatusManager.

### How to test your changes?

Nothing to test, this component is not being used yet (will be in a following PR)

### Measuring impact

- [x] Existing analytics will cater for this addition (via cmd_dev_preview_url_opened and cmd_dev_graphiql_opened metrics)

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes