### PR TITLE
[Theme] Fix local dev proxy for checkout and accounts/logout

### DIFF
--- a/.changeset/giant-crews-act.md
+++ b/.changeset/giant-crews-act.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix the local dev proxy for `/checkouts` and `/accounts/logout` to avoid 401 and 403 errors.

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
@@ -235,6 +235,11 @@ describe('dev proxy', () => {
       expect(canProxyRequest(event)).toBeTruthy()
     })
 
+    test('should proxy Checkout requests as they are not supported by the SFR client', () => {
+      const event = createH3Event('GET', '/checkouts/xyz')
+      expect(canProxyRequest(event)).toBeTruthy()
+    })
+
     test('should proxy CDN requests', () => {
       const event = createH3Event('GET', '/cdn/some-path')
       expect(canProxyRequest(event)).toBeTruthy()
@@ -293,6 +298,11 @@ describe('dev proxy', () => {
 
     test('should proxy /account/login/multipass/<token> requests', () => {
       const event = createH3Event('GET', '/account/login/multipass/<token>')
+      expect(canProxyRequest(event)).toBeTruthy()
+    })
+
+    test('should proxy /account/logout requests', () => {
+      const event = createH3Event('GET', '/account/logout')
       expect(canProxyRequest(event)).toBeTruthy()
     })
   })

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -201,9 +201,11 @@ function patchProxiedResponseHeaders(ctx: DevServerContext, event: H3Event, resp
   const locationHeader = response.headers.get('Location')
   if (locationHeader) {
     const url = new URL(locationHeader, 'https://shopify.dev')
-    url.searchParams.delete('_fd')
-    url.searchParams.delete('pb')
-    setResponseHeader(event, 'Location', url.href.replace(url.origin, ''))
+    if (!CHECKOUT_PATTERN.test(url.pathname)) {
+      url.searchParams.delete('_fd')
+      url.searchParams.delete('pb')
+      setResponseHeader(event, 'Location', url.href.replace(url.origin, ''))
+    }
   }
 
   // Cookies are set for the vanity domain, fix it for localhost:

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -29,7 +29,8 @@ export const VANITY_CDN_PREFIX = '/cdn/'
 export const EXTENSION_CDN_PREFIX = '/ext/cdn/'
 
 const CART_PATTERN = /^\/cart\//
-const ACCOUNT_PATTERN = /^\/account(\/login\/multipass(\/[^/]+)?)?\/?$/
+const CHECKOUT_PATTERN = /^\/checkouts\/(?!internal\/)/
+const ACCOUNT_PATTERN = /^\/account(\/login\/multipass(\/[^/]+)?|\/logout)?\/?$/
 const VANITY_CDN_PATTERN = new RegExp(`^${VANITY_CDN_PREFIX}`)
 const EXTENSION_CDN_PATTERN = new RegExp(`^${EXTENSION_CDN_PREFIX}`)
 
@@ -81,6 +82,7 @@ export function getProxyHandler(_theme: Theme, ctx: DevServerContext) {
 export function canProxyRequest(event: H3Event) {
   if (event.method !== 'GET') return true
   if (event.path.match(CART_PATTERN)) return true
+  if (event.path.match(CHECKOUT_PATTERN)) return true
   if (event.path.match(ACCOUNT_PATTERN)) return true
   if (event.path.match(VANITY_CDN_PATTERN)) return true
   if (event.path.match(EXTENSION_CDN_PATTERN)) return true


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Related to #5103



<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Fixes `/account/logout` route, and adds a temporary workaround for `/checkouts/...` to use the production domain while we figure out how to properly proxy checkout from localhost.

### How to test your changes?

- Try adding items to the cart, then go to checkout. It should not show any 40x error. It should go to the .myshopify.com domain without the localhost proxy.

- Check that `/account/logout` doesn't show 40x error.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
