### PR TITLE
Query app version directly by tag

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
@@ -4,12 +4,12 @@ import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
-export type AppVersionByIdQueryVariables = Types.Exact<{
-  versionId: Types.Scalars['ID']['input']
+export type AppVersionByTagQueryVariables = Types.Exact<{
+  versionTag: Types.Scalars['String']['input']
 }>
 
-export type AppVersionByIdQuery = {
-  version: {
+export type AppVersionByTagQuery = {
+  versionByTag: {
     id: string
     metadata: {message?: string | null; versionTag?: string | null}
     appModules: {
@@ -22,91 +22,18 @@ export type AppVersionByIdQuery = {
   }
 }
 
-export type VersionInfoFragment = {
-  id: string
-  metadata: {message?: string | null; versionTag?: string | null}
-  appModules: {
-    uuid: string
-    userIdentifier: string
-    handle: string
-    config: JsonMapType
-    specification: {identifier: string; externalIdentifier: string; name: string}
-  }[]
-}
-
-export const VersionInfoFragmentDoc = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'FragmentDefinition',
-      name: {kind: 'Name', value: 'VersionInfo'},
-      typeCondition: {kind: 'NamedType', name: {kind: 'Name', value: 'Version'}},
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {kind: 'Field', name: {kind: 'Name', value: 'id'}},
-          {
-            kind: 'Field',
-            name: {kind: 'Name', value: 'metadata'},
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {kind: 'Field', name: {kind: 'Name', value: 'message'}},
-                {kind: 'Field', name: {kind: 'Name', value: 'versionTag'}},
-              ],
-            },
-          },
-          {
-            kind: 'Field',
-            name: {kind: 'Name', value: 'appModules'},
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [{kind: 'FragmentSpread', name: {kind: 'Name', value: 'ReleasedAppModule'}}],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: {kind: 'Name', value: 'ReleasedAppModule'},
-      typeCondition: {kind: 'NamedType', name: {kind: 'Name', value: 'AppModule'}},
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
-          {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
-          {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
-          {kind: 'Field', name: {kind: 'Name', value: 'config'}},
-          {
-            kind: 'Field',
-            name: {kind: 'Name', value: 'specification'},
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
-                {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
-                {kind: 'Field', name: {kind: 'Name', value: 'name'}},
-              ],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<VersionInfoFragment, unknown>
-export const AppVersionById = {
+export const AppVersionByTag = {
   kind: 'Document',
   definitions: [
     {
       kind: 'OperationDefinition',
       operation: 'query',
-      name: {kind: 'Name', value: 'AppVersionById'},
+      name: {kind: 'Name', value: 'AppVersionByTag'},
       variableDefinitions: [
         {
           kind: 'VariableDefinition',
-          variable: {kind: 'Variable', name: {kind: 'Name', value: 'versionId'}},
-          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}}},
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'versionTag'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
         },
       ],
       selectionSet: {
@@ -114,12 +41,12 @@ export const AppVersionById = {
         selections: [
           {
             kind: 'Field',
-            name: {kind: 'Name', value: 'version'},
+            name: {kind: 'Name', value: 'versionByTag'},
             arguments: [
               {
                 kind: 'Argument',
-                name: {kind: 'Name', value: 'id'},
-                value: {kind: 'Variable', name: {kind: 'Name', value: 'versionId'}},
+                name: {kind: 'Name', value: 'tag'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'versionTag'}},
               },
             ],
             selectionSet: {
@@ -190,4 +117,4 @@ export const AppVersionById = {
       },
     },
   ],
-} as unknown as DocumentNode<AppVersionByIdQuery, AppVersionByIdQueryVariables>
+} as unknown as DocumentNode<AppVersionByTagQuery, AppVersionByTagQueryVariables>

--- a/packages/app/src/cli/api/graphql/app-management/queries/app-version-by-id.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/app-version-by-id.graphql
@@ -1,12 +1,16 @@
 query AppVersionById($versionId: ID!) {
   version(id: $versionId) {
-    id
-    metadata {
-      message
-      versionTag
-    }
-    appModules {
-      ...ReleasedAppModule
-    }
+    ...VersionInfo
+  }
+}
+
+fragment VersionInfo on Version {
+  id
+  metadata {
+    message
+    versionTag
+  }
+  appModules {
+    ...ReleasedAppModule
   }
 }

--- a/packages/app/src/cli/api/graphql/app-management/queries/app-version-by-tag.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/app-version-by-tag.graphql
@@ -1,0 +1,5 @@
+query AppVersionByTag($versionTag: String!) {
+  versionByTag(tag: $versionTag) {
+    ...VersionInfo
+  }
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Completes https://github.com/Shopify/develop-app-inner-loop/issues/1862

Depends on https://github.com/Shopify/shopify/pull/575881

<!--
  Context about the problem that’s being addressed.
-->

We are fetching all the versions from app management, and then iterating through them to find the one we want, and then re-fetching that one with full details. But we should just fetch the one we want immediately.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Uses a new `versionByTag` field to query for just the version we want (also saves us a request).

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
* List versions of an app you've deployed with `p shopify app versions list` and choose a different version than is currently deployed. (Best if the app has some extensions.)
* `p shopify app release --version YOUR_VERSION_TAG`
  * Ensure the version is found correctly
  * Ensure the diff looks correct

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
