### PR TITLE
Dont introspect token if already expired

### DIFF
--- a/packages/cli-kit/src/private/node/session/validate.test.ts
+++ b/packages/cli-kit/src/private/node/session/validate.test.ts
@@ -167,6 +167,7 @@ describe('validateSession', () => {
 
     // Then
     expect(got).toBe('needs_refresh')
+    expect(validateIdentityToken).not.toHaveBeenCalled()
   })
 
   test('returns needs_refresh if requesting partners and is expired', async () => {
@@ -184,6 +185,7 @@ describe('validateSession', () => {
 
     // Then
     expect(got).toBe('needs_refresh')
+    expect(validateIdentityToken).not.toHaveBeenCalled()
   })
 
   test('returns needs_refresh if requesting storefront and is expired', async () => {
@@ -201,6 +203,7 @@ describe('validateSession', () => {
 
     // Then
     expect(got).toBe('needs_refresh')
+    expect(validateIdentityToken).not.toHaveBeenCalled()
   })
 
   test('returns needs_refresh if requesting admin and is expired', async () => {
@@ -218,6 +221,7 @@ describe('validateSession', () => {
 
     // Then
     expect(got).toBe('needs_refresh')
+    expect(validateIdentityToken).not.toHaveBeenCalled()
   })
 
   test('returns needs_refresh if session does not include requested store', async () => {
@@ -235,5 +239,6 @@ describe('validateSession', () => {
 
     // Then
     expect(got).toBe('needs_refresh')
+    expect(validateIdentityToken).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Optimizes the token validation flow by deferring the identity token validation until after checking for token expiration, reducing unnecessary API calls.

### WHAT is this pull request doing?

- Moves the identity token validation check to occur after token expiration checks.

### How to test your changes?

This one is hard to tophat:

1. Use the CLI with an expired token (wait two hours without using the CLI?)
2. Verify the token refresh flow is triggered without making unnecessary identity validation calls (running in verbose)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes