### PR TITLE
Add generic cache for graphQL querys (as opt-in per query)

### DIFF
--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -11,17 +11,19 @@ export type IntrospectionUrlKey = `identity-introspection-url-${string}`
 export type PackageVersionKey = `npm-package-${string}`
 export type NotificationsKey = `notifications-${string}`
 export type NotificationKey = `notification-${string}`
+export type GraphQLRequestKey = `q-${string}-${string}-${string}`
 type MostRecentOccurrenceKey = `most-recent-occurrence-${string}`
 type RateLimitKey = `rate-limited-occurrences-${string}`
 
-type ExportedKey = IntrospectionUrlKey | PackageVersionKey | NotificationsKey | NotificationKey
+type ExportedKey = IntrospectionUrlKey | PackageVersionKey | NotificationsKey | NotificationKey | GraphQLRequestKey
 
 interface Cache {
   [introspectionUrlKey: IntrospectionUrlKey]: CacheValue<string>
   [packageVersionKey: PackageVersionKey]: CacheValue<string>
   [notifications: NotificationsKey]: CacheValue<string>
   [notification: NotificationKey]: CacheValue<string>
-  [MostRecentOccurrenceKey: MostRecentOccurrenceKey]: CacheValue<boolean>
+  [graphQLRequestKey: GraphQLRequestKey]: CacheValue<string>
+  [mostRecentOccurrenceKey: MostRecentOccurrenceKey]: CacheValue<boolean>
   [rateLimitKey: RateLimitKey]: CacheValue<number[]>
 }
 

--- a/packages/cli-kit/src/public/node/api/app-management.ts
+++ b/packages/cli-kit/src/public/node/api/app-management.ts
@@ -1,4 +1,4 @@
-import {GraphQLResponse, graphqlRequestDoc} from './graphql.js'
+import {CacheOptions, GraphQLResponse, graphqlRequestDoc} from './graphql.js'
 import {appManagementFqdn} from '../context/fqdn.js'
 import {setNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
 import Bottleneck from 'bottleneck'
@@ -32,6 +32,7 @@ async function setupRequest(orgId: string, token: string) {
  * @param query - GraphQL query to execute.
  * @param token - Partners token.
  * @param variables - GraphQL variables to pass to the query.
+ * @param cacheOptions - Cache options for the request. If not present, the request will not be cached.
  * @returns The response of the query of generic type <T>.
  */
 export async function appManagementRequestDoc<TResult, TVariables extends Variables>(
@@ -39,17 +40,20 @@ export async function appManagementRequestDoc<TResult, TVariables extends Variab
   query: TypedDocumentNode<TResult, TVariables>,
   token: string,
   variables?: TVariables,
+  cacheOptions?: CacheOptions,
 ): Promise<TResult> {
   const result = limiter.schedule<TResult>(async () =>
     graphqlRequestDoc<TResult, TVariables>({
       ...(await setupRequest(orgId, token)),
       query,
       variables,
+      cacheOptions,
     }),
   )
 
   return result
 }
+
 interface Deprecation {
   supportedUntilDate?: string
 }

--- a/packages/cli-kit/src/public/node/api/business-platform.ts
+++ b/packages/cli-kit/src/public/node/api/business-platform.ts
@@ -1,4 +1,4 @@
-import {Exact, GraphQLVariables, graphqlRequest, graphqlRequestDoc} from './graphql.js'
+import {CacheOptions, Exact, GraphQLVariables, graphqlRequest, graphqlRequestDoc} from './graphql.js'
 import {handleDeprecations} from './partners.js'
 import {businessPlatformFqdn} from '../context/fqdn.js'
 import {TypedDocumentNode} from '@graphql-typed-document-node/core'
@@ -27,17 +27,20 @@ async function setupRequest(token: string) {
  * @param query - GraphQL query to execute.
  * @param token - Business Platform token.
  * @param variables - GraphQL variables to pass to the query.
+ * @param cacheOptions - Cache options for the request. If not present, the request will not be cached.
  * @returns The response of the query of generic type <T>.
  */
 export async function businessPlatformRequest<T>(
   query: string,
   token: string,
   variables?: GraphQLVariables,
+  cacheOptions?: CacheOptions,
 ): Promise<T> {
   return graphqlRequest<T>({
     ...(await setupRequest(token)),
     query,
     variables,
+    cacheOptions,
   })
 }
 
@@ -47,17 +50,20 @@ export async function businessPlatformRequest<T>(
  * @param query - GraphQL query to execute.
  * @param token - Business Platform token.
  * @param variables - GraphQL variables to pass to the query.
+ * @param cacheOptions - Cache options for the request. If not present, the request will not be cached.
  * @returns The response of the query of generic type <TResult>.
  */
 export async function businessPlatformRequestDoc<TResult, TVariables extends Variables>(
   query: TypedDocumentNode<TResult, TVariables>,
   token: string,
   variables?: TVariables,
+  cacheOptions?: CacheOptions,
 ): Promise<TResult> {
   return graphqlRequestDoc<TResult, TVariables>({
     ...(await setupRequest(token)),
     query,
     variables,
+    cacheOptions,
   })
 }
 

--- a/packages/cli-kit/src/public/node/api/partners.ts
+++ b/packages/cli-kit/src/public/node/api/partners.ts
@@ -1,4 +1,4 @@
-import {graphqlRequest, GraphQLVariables, GraphQLResponse, graphqlRequestDoc} from './graphql.js'
+import {graphqlRequest, GraphQLVariables, GraphQLResponse, graphqlRequestDoc, CacheOptions} from './graphql.js'
 import {partnersFqdn} from '../context/fqdn.js'
 import {setNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
 import {TypedDocumentNode} from '@graphql-typed-document-node/core'
@@ -36,15 +36,22 @@ async function setupRequest(token: string) {
  * @param query - GraphQL query to execute.
  * @param token - Partners token.
  * @param variables - GraphQL variables to pass to the query.
+ * @param cacheOptions - Cache options.
  * @returns The response of the query of generic type <T>.
  */
-export async function partnersRequest<T>(query: string, token: string, variables?: GraphQLVariables): Promise<T> {
+export async function partnersRequest<T>(
+  query: string,
+  token: string,
+  variables?: GraphQLVariables,
+  cacheOptions?: CacheOptions,
+): Promise<T> {
   const opts = await setupRequest(token)
   const result = limiter.schedule(() =>
     graphqlRequest<T>({
       ...opts,
       query,
       variables,
+      cacheOptions,
     }),
   )
 


### PR DESCRIPTION
### WHY are these changes introduced?

Improve performance by adding caching capabilities to GraphQL requests in the CLI.

### WHAT is this pull request doing?

Adds caching support for GraphQL requests with configurable TTL options ranging from 1 hour to 30 days. The cache implementation:
- Adds `cacheTTL` and `cacheExtraKey` parameters to GraphQL request functions
- Implements cache key generation using query and variable hashing
- Provides predefined TTL options (1h, 6h, 12h, 1d, 3d, 7d, 14d, 30d)

### How to test your changes?

You'd need test in dev mode and adding some logs/breakpoints:
(or just test everything in the next PR in the stack that already enables Caching for some queries)

1. Modify a GraphQL request to enable caching:
```typescript
await graphqlRequest({
  query: "...",
  token: "...",
  {
    cacheTTL: "1h",
    cacheExtraKey: "optional-key"
  }  
})
```
2. Make the same request again within the TTL period
3. Verify that the second request returns cached data without making a network call


NOTE: The cache is not enabled right now for any existing query, that will happen in the following PR

### Measuring impact

- [x] Existing analytics will cater for this addition (network timing metrics will reflect cached responses)

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes