### PR TITLE
Improve vitest performance using thread pool

### DIFF
--- a/configurations/vite.config.ts
+++ b/configurations/vite.config.ts
@@ -12,7 +12,11 @@ const TIMEOUTS = {
   debug: 180000,
 }
 
-export default function config(packagePath: string) {
+interface ConfigOptions {
+  poolStrategy: 'threads' | 'forks'
+}
+
+export default function config(packagePath: string, {poolStrategy}: ConfigOptions = {poolStrategy: 'threads'}) {
   // always treat environment as one that doesn't support hyperlinks -- otherwise assertions are hard to keep consistent
   process.env['FORCE_HYPERLINK'] = '0'
   process.env['FORCE_COLOR'] = '1'
@@ -38,7 +42,7 @@ export default function config(packagePath: string) {
       mockReset: true,
       setupFiles: [path.join(__dirname, './vitest/setup.js')],
       reporters: ['verbose', 'hanging-process'],
-      threads: false,
+      pool: poolStrategy,
       coverage: {
         provider: 'istanbul',
         include: ['**/src/**'],

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,3 +1,3 @@
 import config from '../../configurations/vite.config'
 
-export default config(__dirname)
+export default config(__dirname, {poolStrategy: 'forks'})


### PR DESCRIPTION
Switches the default pool option for vitest to threads: https://vitest.dev/guide/improving-performance#test-isolation -- this should be quicker.

I tested this with hyperfine locally and found it improved performance. `--no-isolation` did not.

NB: I have left the apps package using the forked process approach: test clean-up isn't correct there at present.