### PR TITLE
Streamline dev check

### DIFF
--- a/configurations/tsconfig.json
+++ b/configurations/tsconfig.json
@@ -20,6 +20,7 @@
       "jsx": "react",
       "paths": {
         "@shopify/cli-kit/*": ["../packages/cli-kit/src/public/*"],
+        "@shopify/theme/*": ["../packages/theme/src/*"],
         "@shopify/cli-kit/typing/*": ["../packages/cli-kit/src/typing/*"],
       },
       "types": [

--- a/configurations/vite.config.ts
+++ b/configurations/vite.config.ts
@@ -67,5 +67,12 @@ export const aliases = (packagePath: string) => {
       },
     },
     {find: '@shopify/cli-kit', replacement: path.join(packagePath, '../cli-kit/src/index')},
+    {
+      find: /@shopify\/theme\/(.+)/,
+      replacement: (importedModule: string) => {
+        return path.join(packagePath, `../theme/src/${importedModule.replace('@shopify/theme/', '')}`)
+      },
+    },
+    {find: '@shopify/theme', replacement: path.join(packagePath, '../theme/src/index')},
   ]
 }

--- a/dev.yml
+++ b/dev.yml
@@ -1,4 +1,4 @@
-name: shopify-cli-next
+name: cli
 
 up:
   - node:
@@ -60,7 +60,5 @@ commands:
     run: bin/spin
 
 check:
-  build: pnpm build
   type-check: pnpm nx affected --target=type-check
   lint: pnpm nx affected --target=lint
-  unit-tests: pnpm nx affected --target=test --exclude=features

--- a/nx.json
+++ b/nx.json
@@ -56,7 +56,9 @@
           "graphql-codegen:generate:partners",
           "graphql-codegen:generate:webhooks",
           "graphql-codegen:postfix",
-          "graphql-codegen:formatting"
+          "graphql-codegen:formatting",
+          "type-check",
+          "lint"
         ],
         "runtimeCacheInputs": [
           "node bin/cache-inputs.js || node ../../bin/cache-inputs.js || node ../bin/cache-inputs.js"

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -38,7 +38,6 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest run",
         "cwd": "packages/app"

--- a/packages/app/tsconfig.build.json
+++ b/packages/app/tsconfig.build.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "exclude": ["**/*.test.ts"],
     "references": [
-      {"path": "../cli-kit"}
+      {"path": "../cli-kit"},
+      {"path": "../theme"}
     ]
 }

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -8,5 +8,5 @@
     "rootDir": "src",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
   },
-  "references": [{"path": "../cli-kit"}]
+  "references": [{"path": "../cli-kit"}, {"path": "../theme"}]
 }


### PR DESCRIPTION
Streamlines dev check and some internal dev commands

- app unit tests no longer require a full build
- dev check never runs build (this is covered by type-check)
- ~type-check is not dependent on build (its a full TS rebuild, doesn't need the extra step)~ wrong! it's needed
- type-check is a cached nx operation so should resolve quickly (sub 300ms)
- lint is a cached nx operation and should resolve quickly. very large saving in local development.