### PR TITLE
Switch packages/app to thread pooling for tests

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,3 +1,3 @@
 import config from '../../configurations/vite.config'
 
-export default config(__dirname, {poolStrategy: 'forks'})
+export default config(__dirname)


### PR DESCRIPTION
Running locally with benchmarking w/ hyperfine, the apps package appears to be stable with this change. It also seems to be a tad quicker. CI should confirm things more robustly.