### PR TITLE
Support precheck-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,24 @@ eslint-report.json
 
 # Generated docs
 docs/api
+
+vite.config.ts.timestamp*
+
+# from nested gitignores
+packages/app/assets/dev-console
+packages/ui-extensions-server-kit/*.d.ts
+packages/ui-extensions-server-kit/!typings.d.ts
+packages/ui-extensions-server-kit/index.*
+packages/ui-extensions-server-kit/testing.*
+packages/ui-extensions-server-kit/dist
+packages/app/src/cli/api/graphql/*/*_schema.graphql
+packages/ui-extensions-test-utils/*.d.ts
+packages/ui-extensions-test-utils/!typings.d.ts
+packages/ui-extensions-test-utils/dist
+packages/ui-extensions-dev-console/*.js
+packages/ui-extensions-dev-console/*.d.ts
+packages/ui-extensions-dev-console/!typings.d.ts
+packages/ui-extensions-dev-console/.eslintrc.js
+packages/ui-extensions-dev-console/css-transform.js
+packages/ui-extensions-dev-console/dist
+packages/cli-kit/src/cli/api/graphql/*/*_schema.graphql

--- a/packages/app/.gitignore
+++ b/packages/app/.gitignore
@@ -1,1 +1,0 @@
-/assets/dev-console

--- a/packages/app/src/cli/api/graphql/.gitignore
+++ b/packages/app/src/cli/api/graphql/.gitignore
@@ -1,1 +1,0 @@
-*_schema.graphql

--- a/packages/cli-kit/src/cli/api/graphql/.gitignore
+++ b/packages/cli-kit/src/cli/api/graphql/.gitignore
@@ -1,1 +1,0 @@
-*_schema.graphql

--- a/packages/ui-extensions-dev-console/.gitignore
+++ b/packages/ui-extensions-dev-console/.gitignore
@@ -1,6 +1,0 @@
-*.js
-*.d.ts
-!typings.d.ts
-!.eslintrc.js
-!css-transform.js
-dist

--- a/packages/ui-extensions-server-kit/.gitignore
+++ b/packages/ui-extensions-server-kit/.gitignore
@@ -1,5 +1,0 @@
-*.d.ts
-!typings.d.ts
-/index.*
-/testing.*
-dist

--- a/packages/ui-extensions-test-utils/.gitignore
+++ b/packages/ui-extensions-test-utils/.gitignore
@@ -1,3 +1,0 @@
-*.d.ts
-!typings.d.ts
-dist


### PR DESCRIPTION
Pulls all gitignore rules into the root gitignore file. Our local dev tools expect this to be the case.