### PR TITLE
Fix node install command when using yarn

### DIFF
--- a/.changeset/stupid-actors-report.md
+++ b/.changeset/stupid-actors-report.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix install node command when using yarn

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -111,7 +111,7 @@ describe('packageManagerFromUserAgent', () => {
 })
 
 describe('install', () => {
-  test('runs the install command', async () => {
+  test('runs the install command with npm', async () => {
     // Given
     const packageManager = 'npm'
     const directory = '/path/to/project'
@@ -125,6 +125,58 @@ describe('install', () => {
 
     // Then
     expect(mockedExec).toHaveBeenCalledWith(packageManager, ['install', 'arg1'], {
+      cwd: directory,
+    })
+  })
+
+  test('runs the install command with yarn', async () => {
+    // Given
+    const packageManager = 'yarn'
+    const directory = '/path/to/project'
+
+    // When
+    await installNodeModules({
+      directory,
+      packageManager,
+      args: ['arg1'],
+    })
+
+    // Then
+    expect(mockedExec).toHaveBeenCalledWith(packageManager, ['add', 'arg1'], {
+      cwd: directory,
+    })
+  })
+
+  test('runs the install command for all packages with npm', async () => {
+    // Given
+    const packageManager = 'npm'
+    const directory = '/path/to/project'
+
+    // When
+    await installNodeModules({
+      directory,
+      packageManager,
+    })
+
+    // Then
+    expect(mockedExec).toHaveBeenCalledWith(packageManager, ['install'], {
+      cwd: directory,
+    })
+  })
+
+  test('runs the install command for all packages with yarn', async () => {
+    // Given
+    const packageManager = 'yarn'
+    const directory = '/path/to/project'
+
+    // When
+    await installNodeModules({
+      directory,
+      packageManager,
+    })
+
+    // Then
+    expect(mockedExec).toHaveBeenCalledWith(packageManager, [], {
       cwd: directory,
     })
   })

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -199,7 +199,7 @@ export async function installNodeModules(options: InstallNodeModulesOptions): Pr
     stderr: options.stderr,
     signal: options.signal,
   }
-  let args = ['install']
+  let args = [options.packageManager === 'yarn' ? 'add' : 'install']
   if (options.args) {
     args = args.concat(options.args)
   }

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -199,7 +199,22 @@ export async function installNodeModules(options: InstallNodeModulesOptions): Pr
     stderr: options.stderr,
     signal: options.signal,
   }
-  let args = [options.packageManager === 'yarn' ? 'add' : 'install']
+  let args = []
+  /**
+   * If installing all packages:
+   * - `npm install`
+   * - `yarn`
+   * If installing named packages:
+   * - `npm install <package_name>`
+   * - `yarn add <package_name>`
+   */
+  if (options.packageManager === 'yarn') {
+    if (options.args) {
+      args.push('add')
+    }
+  } else {
+    args.push('install')
+  }
   if (options.args) {
     args = args.concat(options.args)
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixing `cli-kit` when running `shopify hydrogen upgrade` with `yarn`.

### WHAT is this pull request doing?

The exported `installNodeModules` from `cli-kit` assumes `install` arg works with all package managers that `cli` supports.

### How to test your changes?

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
