### PR TITLE
Add support to the theme access app staging

### DIFF
--- a/packages/cli-kit/src/private/node/context/utilities.ts
+++ b/packages/cli-kit/src/private/node/context/utilities.ts
@@ -1,7 +1,7 @@
 /**
  * Returns whether an environment variable has been set and is non-empty
  */
-export function isSet(variable: string | undefined): boolean {
+export function isSet(variable: string | undefined): variable is string {
   if (variable === undefined || variable.trim() === '') {
     return false
   }

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -8,6 +8,8 @@ import {
   cloudEnvironment,
   macAddress,
   isAppManagementDisabled,
+  getThemeKitAccessDomain,
+  opentelemetryDomain,
 } from './local.js'
 import {getPartnersToken} from '../environment.js'
 import {fileExists} from '../fs.js'
@@ -304,5 +306,53 @@ describe('ciPlatform', () => {
       name: 'azure',
       metadata: {},
     })
+  })
+})
+
+describe('getThemeKitAccessDomain', () => {
+  test('returns default domain when env var not set', () => {
+    // Given
+    const env = {}
+
+    // When
+    const got = getThemeKitAccessDomain(env)
+
+    // Then
+    expect(got).toBe('theme-kit-access.shopifyapps.com')
+  })
+
+  test('returns custom domain when env var set', () => {
+    // Given
+    const env = {SHOPIFY_CLI_THEME_KIT_ACCESS_DOMAIN: 'theme-kit-staging.shopifyapps.com'}
+
+    // When
+    const got = getThemeKitAccessDomain(env)
+
+    // Then
+    expect(got).toBe('theme-kit-staging.shopifyapps.com')
+  })
+})
+
+describe('opentelemetryDomain', () => {
+  test('returns default domain when env var not set', () => {
+    // Given
+    const env = {}
+
+    // When
+    const got = opentelemetryDomain(env)
+
+    // Then
+    expect(got).toBe('https://otlp-http-production-cli.shopifysvc.com')
+  })
+
+  test('returns custom domain when env var set', () => {
+    // Given
+    const env = {SHOPIFY_CLI_OTEL_EXPORTER_OTLP_ENDPOINT: 'custom-otel-domain.com'}
+
+    // When
+    const got = opentelemetryDomain(env)
+
+    // Then
+    expect(got).toBe('custom-otel-domain.com')
   })
 })

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -1,7 +1,7 @@
 import {isSpin} from './spin.js'
 import {isTruthy} from './utilities.js'
 import {getCIMetadata, isSet, Metadata} from '../../../private/node/context/utilities.js'
-import {environmentVariables, pathConstants} from '../../../private/node/constants.js'
+import {defaultThemeKitAccessDomain, environmentVariables, pathConstants} from '../../../private/node/constants.js'
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
 import {getPartnersToken} from '../environment.js'
@@ -288,6 +288,22 @@ export function macAddress(): Promise<string> {
 }
 
 /**
+ * Get the domain for theme kit access.
+ *
+ * It can be overridden via the SHOPIFY_CLI_THEME_KIT_ACCESS_DOMAIN environment
+ * variable.
+ *
+ * @param env - The environment variables from the environment of the process.
+ *
+ * @returns The domain for theme kit access.
+ */
+export function getThemeKitAccessDomain(env = process.env): string {
+  const domain = env[environmentVariables.themeKitAccessDomain]
+
+  return isSet(domain) ? domain : defaultThemeKitAccessDomain
+}
+
+/**
  * Get the domain to send OTEL metrics to.
  *
  * It can be overridden via the SHOPIFY_CLI_OTEL_EXPORTER_OTLP_ENDPOINT environment variable.
@@ -295,11 +311,10 @@ export function macAddress(): Promise<string> {
  * @param env - The environment variables from the environment of the current process.
  * @returns The domain to send OTEL metrics to.
  */
-export function opentelemetryDomain(env = process.env): string | undefined {
-  if (isSet(env[environmentVariables.otelURL])) {
-    return env[environmentVariables.otelURL]
-  }
-  return 'https://otlp-http-production-cli.shopifysvc.com'
+export function opentelemetryDomain(env = process.env): string {
+  const domain = env[environmentVariables.otelURL]
+
+  return isSet(domain) ? domain : 'https://otlp-http-production-cli.shopifysvc.com'
 }
 
 export type CIMetadata = Metadata

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
@@ -5,6 +5,7 @@ import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {fetch, type Response} from '@shopify/cli-kit/node/http'
 import {createError} from 'h3'
+import {getThemeKitAccessDomain} from '@shopify/cli-kit/node/context/local'
 
 export async function render(session: DevServerSession, context: DevServerRenderContext): Promise<Response> {
   const url = buildStorefrontUrl(session, context)
@@ -131,7 +132,7 @@ function buildStorefrontUrl(session: DevServerSession, {path, sectionId, appBloc
 
 export function buildBaseStorefrontUrl(session: AdminSession) {
   if (isThemeAccessSession(session)) {
-    return 'https://theme-kit-access.shopifyapps.com/cli/sfr'
+    return `https://${getThemeKitAccessDomain()}/cli/sfr`
   } else {
     return `https://${session.storeFqdn}`
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/535

### WHAT is this pull request doing?

This PR exposes the Theme Access main in the `cli-kit` package (which centralizes the logic to handle custom Theme Access domains).

I'm not adding a changeset as this is not a user-facing change.

### How to test your changes?

- Check the steps to test this change [here](https://github.com/Shopify/developer-tools-team/issues/535#issuecomment-2636119478)

**Before**:

![Image](https://github.com/user-attachments/assets/49587a84-0776-44c2-b2ce-ff4a0fd652f6)

**After**:

![Image](https://github.com/user-attachments/assets/d74c3df7-6e4b-4e77-ab82-f4d82c62b9cc)

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
