### PR TITLE
Drop test:js from CLI Kit

### DIFF
--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -53,7 +53,6 @@
     "lint:fix": "nx lint:fix",
     "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
     "test": "nx test",
-    "test:js": "nx test:js",
     "test:coverage": "nx test:coverage",
     "test:watch": "nx test:watch",
     "type-check": "nx type-check",

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -63,16 +63,6 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        "test:js"
-      ],
-      "options": {
-        "commands": [],
-        "cwd": "packages/cli-kit"
-      }
-    },
-    "test:js": {
-      "executor": "nx:run-commands",
       "options": {
         "command": "pnpm vitest run",
         "cwd": "packages/cli-kit"


### PR DESCRIPTION
We no longer need the `test:js` task for CLI Kit, now that Ruby is exorcised from the repo. This simplifies our task graph.