### PR TITLE
Flatten nx graph

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -26,11 +26,7 @@
       ]
     },
     "lint": {},
-    "lint:fix": {
-      "dependsOn": [
-        "build"
-      ]
-    },
+    "lint:fix": {},
     "type-check": {
       "dependsOn": [
         "^build"

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -45,7 +45,6 @@
     },
     "test:coverage": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
       "options": {
         "command": "pnpm vitest run --reporter json --coverage --outputFile ./coverage/report.json",
         "cwd": "packages/app"
@@ -53,7 +52,6 @@
     },
     "test:watch": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest watch",
         "cwd": "packages/app"

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -70,9 +70,6 @@
     },
     "test:coverage": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        "build"
-      ],
       "options": {
         "command": "pnpm vitest run --reporter json --coverage --outputFile ./coverage/report.json",
         "cwd": "packages/cli-kit"

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -59,7 +59,6 @@
     },
     "test:watch": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest watch",
         "cwd": "packages/cli"

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -52,7 +52,6 @@
     },
     "test:watch": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest watch",
         "cwd": "packages/create-app"

--- a/packages/plugin-cloudflare/project.json
+++ b/packages/plugin-cloudflare/project.json
@@ -37,7 +37,6 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest run",
         "cwd": "packages/plugin-cloudflare"
@@ -45,7 +44,6 @@
     },
     "test:watch": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest watch",
         "cwd": "packages/plugin-cloudflare"

--- a/packages/plugin-did-you-mean/project.json
+++ b/packages/plugin-did-you-mean/project.json
@@ -37,7 +37,6 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest run",
         "cwd": "packages/plugin-did-you-mean"
@@ -45,7 +44,6 @@
     },
     "test:watch": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest watch",
         "cwd": "packages/plugin-did-you-mean"

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -46,7 +46,6 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest run",
         "cwd": "packages/theme"
@@ -54,7 +53,6 @@
     },
     "test:watch": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest watch",
         "cwd": "packages/theme"

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -45,7 +45,6 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest run",
         "cwd": "packages/ui-extensions-dev-console"
@@ -53,7 +52,6 @@
     },
     "test:watch": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest watch",
         "cwd": "packages/ui-extensions-dev-console"

--- a/packages/ui-extensions-server-kit/project.json
+++ b/packages/ui-extensions-server-kit/project.json
@@ -56,7 +56,6 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest run",
         "cwd": "packages/ui-extensions-server-kit"
@@ -64,7 +63,6 @@
     },
     "test:watch": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "pnpm vitest watch",
         "cwd": "packages/ui-extensions-server-kit"


### PR DESCRIPTION
This PR flattens the NX task graph for `lint`, `test` and their variations (e.g. `test:coverage`)

This makes running these tasks simpler and quicker -- there are no longer any pre-requisite activities. These activities may have been required at one time but as the project has evolved they have become redundant.