### PR TITLE
Display field for app management errors

### DIFF
--- a/packages/app/src/cli/api/graphql/app_deploy.ts
+++ b/packages/app/src/cli/api/graphql/app_deploy.ts
@@ -87,7 +87,7 @@ export interface AppDeploySchema {
           message: string
         }[]
       }[]
-    }
+    } | null
     userErrors: {
       field?: string[] | null
       message: string

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -12,7 +12,7 @@ import {joinPath, dirname} from '@shopify/cli-kit/node/path'
 import {outputNewline, outputInfo, formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
-import type {Task} from '@shopify/cli-kit/node/ui'
+import type {InlineToken, Task} from '@shopify/cli-kit/node/ui'
 
 export interface DeployOptions {
   /** The app to be built and uploaded */
@@ -160,8 +160,9 @@ async function outputCompletionMessage({
   release: boolean
   uploadExtensionsBundleResult: UploadExtensionsBundleOutput
 }) {
-  const linkAndMessage = [
-    {link: {label: uploadExtensionsBundleResult.versionTag ?? 'version', url: uploadExtensionsBundleResult.location}},
+  const {location} = uploadExtensionsBundleResult
+  const linkAndMessage: InlineToken[] = [
+    ...(location ? [{link: {label: uploadExtensionsBundleResult.versionTag ?? 'version', url: location}}] : []),
     uploadExtensionsBundleResult.message ? `\n${uploadExtensionsBundleResult.message}` : '',
   ]
   if (release) {

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -132,20 +132,14 @@ describe('uploadExtensionsBundle', () => {
     })
   })
 
-  test("throws a specific error based on what is returned from partners when response doesn't include an app version", async () => {
+  test("throws a specific error based on what is returned from any backend when response doesn't include an app version", async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const errorResponse: AppDeploySchema = {
         appDeploy: {
-          appVersion: {
-            uuid: 'uuid',
-            id: 1,
-            versionTag: 'version-tag',
-            location: 'location',
-            message: 'message',
-            appModuleVersions: [],
-          },
+          appVersion: null,
           userErrors: [
+            // Partners style errors
             {
               message: 'Missing expected key(s).',
               field: ['base'],
@@ -206,6 +200,13 @@ describe('uploadExtensionsBundle', () => {
                 },
               ],
             },
+            // App Management style errors
+            {
+              message: 'is not allowed',
+              category: 'invalid',
+              field: ['customers_redact_url'],
+              details: [],
+            },
           ],
         },
       }
@@ -242,6 +243,11 @@ describe('uploadExtensionsBundle', () => {
       } catch (error: any) {
         expect(error.message).toEqual("Version couldn't be created.")
         expect(error.customSections).toEqual([
+          // App Management error
+          {
+            body: 'customers_redact_url: is not allowed',
+          },
+          // Partners errors
           {
             title: 'amortizable-marketplace-ext',
             body: [

--- a/packages/eslint-plugin-cli/rules/no-inline-graphql.js
+++ b/packages/eslint-plugin-cli/rules/no-inline-graphql.js
@@ -121,7 +121,7 @@ const knownFailures = {
     'f48a44e2dae39f1b33ac685971740e3705f2754de5fdf1d6f1fbb3492bc62be2',
   'packages/app/src/cli/api/graphql/app_active_version.ts':
     '685d858cf3ad636fe8d771707715dd9a793e4aa4529f843eac3df625efd4d5be',
-  'packages/app/src/cli/api/graphql/app_deploy.ts': 'ff060a322caebf8722fc2f0e2e1cec08fbb861fb258af2417fc430006b2c903e',
+  'packages/app/src/cli/api/graphql/app_deploy.ts': 'f7eb5241cecb5e4a83597c045a4bc1fe76c7f4bf3783aadabc8d0eab9e32b441',
   'packages/app/src/cli/api/graphql/app_release.ts': '3acace031157856c88dc57506d81364c084fb5ca66ab5c6ff59393ab5255846d',
   'packages/app/src/cli/api/graphql/app_version_by_tag.ts':
     'a3231389ceb20eec4cab51186678b032e52d8f3e4df3078ce1a33c8ae83ac7fa',


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2487 <!-- link to issue if one exists -->

We are not properly displaying app management errors - the field is not included in the error message.

Turns out this is due to discrepancies in the error format coming from Partners vs. App Management.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Updates the error handling so we always display the field if available.

Note much of this PR is handling that `appVersion` is nullable (and will be null when the version fails to be created), which we weren't allowing for previously.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

1. In a dev environment, make [this change](https://github.com/Shopify/develop-app-inner-loop/issues/2487#issuecomment-2637811899)
2. Add this content to your app TOML:
    ```toml
    [[webhooks.subscriptions]]
    compliance_topics = ["customers/data_request", "customers/redact", "shop/redact"]
    uri = "https://example.com"
    ```
3. Try to deploy your app

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
