### PR TITLE
Make usePollAppLogs tests more predictable

### DIFF
--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
@@ -1,3 +1,4 @@
+import {useSelfAdjustingInterval} from './useSelfAdjustingInterval.js'
 import {
   ONE_MILLION,
   POLLING_INTERVAL_MS,
@@ -13,7 +14,7 @@ import {
 } from '../../../../utils.js'
 import {ErrorResponse, SuccessResponse, AppLogOutput, PollFilters, AppLogPayload} from '../../../../types.js'
 import {pollAppLogs} from '../../../poll-app-logs.js'
-import {useState, useEffect} from 'react'
+import {useState, Dispatch, SetStateAction, useRef, useCallback} from 'react'
 import {formatLocalDate} from '@shopify/cli-kit/common/string'
 
 interface UsePollAppLogsOptions {
@@ -23,101 +24,138 @@ interface UsePollAppLogsOptions {
   storeNameById: Map<string, string>
 }
 
-export function usePollAppLogs({initialJwt, filters, resubscribeCallback, storeNameById}: UsePollAppLogsOptions) {
-  const [errors, setErrors] = useState<string[]>([])
-  const [appLogOutputs, setAppLogOutputs] = useState<AppLogOutput[]>([])
+async function performPoll({
+  jwtToken,
+  cursor,
+  filters,
+  storeNameById,
+  setErrors,
+  setAppLogOutputs,
+  resubscribeCallback,
+}: {
+  jwtToken: string
+  cursor?: string
+  filters: PollFilters
+  storeNameById: Map<string, string>
+  setErrors: Dispatch<SetStateAction<string[]>>
+  setAppLogOutputs: Dispatch<SetStateAction<AppLogOutput[]>>
+  resubscribeCallback: () => Promise<string>
+}) {
+  let nextJwtToken = jwtToken
+  let retryIntervalMs = POLLING_INTERVAL_MS
+  let nextCursor = cursor
+  const response = await pollAppLogs({jwtToken, cursor, filters})
 
-  useEffect(() => {
-    const poll = async ({jwtToken, cursor, filters}: {jwtToken: string; cursor?: string; filters: PollFilters}) => {
-      let nextJwtToken = jwtToken
-      let retryIntervalMs = POLLING_INTERVAL_MS
-      const response = await pollAppLogs({jwtToken, cursor, filters})
+  const errorResponse = response as ErrorResponse
 
-      const errorResponse = response as ErrorResponse
+  if (errorResponse.errors) {
+    const result = await handleFetchAppLogsError({
+      response: errorResponse,
+      onThrottle: (retryIntervalMs) => {
+        setErrors(['Request throttled while polling app logs.', `Retrying in ${retryIntervalMs / 1000}s`])
+      },
+      onUnknownError: (retryIntervalMs) => {
+        setErrors(['Error while polling app logs', `Retrying in ${retryIntervalMs / 1000}s`])
+      },
+      onResubscribe: () => {
+        return resubscribeCallback()
+      },
+    })
 
-      if (errorResponse.errors) {
-        const result = await handleFetchAppLogsError({
-          response: errorResponse,
-          onThrottle: (retryIntervalMs) => {
-            setErrors(['Request throttled while polling app logs.', `Retrying in ${retryIntervalMs / 1000}s`])
-          },
-          onUnknownError: (retryIntervalMs) => {
-            setErrors(['Error while polling app logs', `Retrying in ${retryIntervalMs / 1000}s`])
-          },
-          onResubscribe: () => {
-            return resubscribeCallback()
-          },
-        })
+    if (result.nextJwtToken) {
+      nextJwtToken = result.nextJwtToken
+    }
+    retryIntervalMs = result.retryIntervalMs
+  } else {
+    setErrors((errors) => (errors.length ? [] : errors))
 
-        if (result.nextJwtToken) {
-          nextJwtToken = result.nextJwtToken
+    const {appLogs} = response as SuccessResponse
+    nextCursor = (response as SuccessResponse).cursor
+
+    if (appLogs) {
+      for (const log of appLogs) {
+        let appLog: AppLogPayload
+        let description
+        let executionTime
+
+        const storeName = storeNameById.get(log.shop_id.toString())
+        if (storeName === undefined) {
+          continue
         }
-        retryIntervalMs = result.retryIntervalMs
-      } else {
-        setErrors((errors) => (errors.length ? [] : errors))
-      }
 
-      const {cursor: nextCursor, appLogs} = response as SuccessResponse
-
-      if (appLogs) {
-        for (const log of appLogs) {
-          let appLog: AppLogPayload
-          let description
-          let executionTime
-
-          const storeName = storeNameById.get(log.shop_id.toString())
-          if (storeName === undefined) {
+        switch (log.log_type) {
+          case LOG_TYPE_FUNCTION_RUN:
+            appLog = parseFunctionRunPayload(log.payload)
+            description = `export "${appLog.export}" executed in ${(appLog.fuelConsumed / ONE_MILLION).toFixed(
+              4,
+            )}M instructions`
+            break
+          case LOG_TYPE_RESPONSE_FROM_CACHE:
+            appLog = parseNetworkAccessResponseFromCachePayload(log.payload)
+            description = 'network access response retrieved from cache'
+            break
+          case LOG_TYPE_REQUEST_EXECUTION_IN_BACKGROUND:
+            appLog = parseNetworkAccessRequestExecutionInBackgroundPayload(log.payload)
+            description = 'network access request executing in background'
+            break
+          case LOG_TYPE_REQUEST_EXECUTION:
+            appLog = parseNetworkAccessRequestExecutedPayload(log.payload)
+            executionTime =
+              appLog.connectTimeMs && appLog.writeReadTimeMs ? appLog.connectTimeMs + appLog.writeReadTimeMs : null
+            description = `network access request executed${executionTime ? ` in ${executionTime} ms` : ''}`
+            break
+          default:
             continue
-          }
+        }
 
-          switch (log.log_type) {
-            case LOG_TYPE_FUNCTION_RUN:
-              appLog = parseFunctionRunPayload(log.payload)
-              description = `export "${appLog.export}" executed in ${(appLog.fuelConsumed / ONE_MILLION).toFixed(
-                4,
-              )}M instructions`
-              break
-            case LOG_TYPE_RESPONSE_FROM_CACHE:
-              appLog = parseNetworkAccessResponseFromCachePayload(log.payload)
-              description = 'network access response retrieved from cache'
-              break
-            case LOG_TYPE_REQUEST_EXECUTION_IN_BACKGROUND:
-              appLog = parseNetworkAccessRequestExecutionInBackgroundPayload(log.payload)
-              description = 'network access request executing in background'
-              break
-            case LOG_TYPE_REQUEST_EXECUTION:
-              appLog = parseNetworkAccessRequestExecutedPayload(log.payload)
-              executionTime =
-                appLog.connectTimeMs && appLog.writeReadTimeMs ? appLog.connectTimeMs + appLog.writeReadTimeMs : null
-              description = `network access request executed${executionTime ? ` in ${executionTime} ms` : ''}`
-              break
-            default:
-              return
-          }
+        const prefix = {
+          status: log.status === 'success' ? 'Success' : 'Failure',
+          source: log.source,
+          storeName,
+          description,
+          logTimestamp: formatLocalDate(log.log_timestamp),
+        }
 
-          const prefix = {
-            status: log.status === 'success' ? 'Success' : 'Failure',
-            source: log.source,
-            storeName,
-            description,
-            logTimestamp: formatLocalDate(log.log_timestamp),
-          }
-
+        if (appLog) {
           setAppLogOutputs((prev) => [...prev, {appLog, prefix}])
         }
       }
-
-      setTimeout(() => {
-        poll({jwtToken: nextJwtToken, cursor: nextCursor || cursor, filters}).catch((error) => {
-          throw error
-        })
-      }, retryIntervalMs)
     }
+  }
 
-    poll({jwtToken: initialJwt, cursor: '', filters}).catch((error) => {
-      throw error
+  return {nextJwtToken, retryIntervalMs, cursor: nextCursor ?? cursor}
+}
+
+export function usePollAppLogs({initialJwt, filters, resubscribeCallback, storeNameById}: UsePollAppLogsOptions) {
+  const [errors, setErrors] = useState<string[]>([])
+  const [appLogOutputs, setAppLogOutputs] = useState<AppLogOutput[]>([])
+  const nextJwtToken = useRef(initialJwt)
+  const retryIntervalMs = useRef(0)
+  const cursor = useRef<string | undefined>('')
+
+  const performPollCallback = useCallback(async () => {
+    const res = await performPoll({
+      jwtToken: nextJwtToken.current,
+      cursor: cursor.current,
+      filters,
+      storeNameById,
+      setErrors,
+      setAppLogOutputs,
+      resubscribeCallback,
     })
+
+    // ESLint is concerned about these updates being atomic, but the approach to useSelfAdjustingInterval ensures that is the case.
+    // eslint-disable-next-line require-atomic-updates
+    nextJwtToken.current = res.nextJwtToken
+    // eslint-disable-next-line require-atomic-updates
+    cursor.current = res.cursor
+
+    retryIntervalMs.current = res.retryIntervalMs
+
+    return {retryIntervalMs: retryIntervalMs.current}
   }, [])
+
+  useSelfAdjustingInterval(performPollCallback)
 
   return {appLogOutputs, errors}
 }

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/useSelfAdjustingInterval.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/useSelfAdjustingInterval.test.tsx
@@ -1,0 +1,108 @@
+import {useSelfAdjustingInterval} from './useSelfAdjustingInterval.js'
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest'
+import React from 'react'
+import {render} from '@shopify/cli-kit/node/testing/ui'
+
+function renderHook<THookResult>(renderHookCallback: () => THookResult) {
+  const result: {
+    lastResult: THookResult | undefined
+    lastError: unknown | undefined
+  } = {
+    lastResult: undefined,
+    lastError: undefined,
+  }
+
+  const MockComponent = () => {
+    try {
+      const hookResult = renderHookCallback()
+      result.lastResult = hookResult
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (errorFromHook) {
+      result.lastError = errorFromHook
+    }
+
+    return null
+  }
+
+  const {unmount} = render(<MockComponent />)
+
+  return {
+    lastResult: result.lastResult,
+    lastError: result.lastError,
+    unmount,
+  }
+}
+
+describe('useSelfAdjustingInterval', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+  })
+
+  test('calls callback immediately and sets up next interval', async () => {
+    const callback = vi.fn().mockResolvedValue({retryIntervalMs: 1000})
+
+    renderHook(() => useSelfAdjustingInterval(callback))
+
+    // Initial call at t=0
+    await vi.advanceTimersByTimeAsync(0)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Next call after retryIntervalMs
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  test('adjusts interval based on callback return value', async () => {
+    const callback = vi
+      .fn()
+      .mockResolvedValueOnce({retryIntervalMs: 1000})
+      .mockResolvedValueOnce({retryIntervalMs: 2000})
+      .mockResolvedValueOnce({retryIntervalMs: null})
+    renderHook(() => useSelfAdjustingInterval(callback))
+
+    // Initial call
+    await vi.advanceTimersByTimeAsync(0)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Next call after 1000ms
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(callback).toHaveBeenCalledTimes(2)
+
+    // Next call after 2000ms
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(callback).toHaveBeenCalledTimes(3)
+
+    // Doesn't get called again because retryIntervalMs is null
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(callback).toHaveBeenCalledTimes(3)
+  })
+
+  test('deals with the callback throwing an error', async () => {
+    const callback = vi.fn().mockRejectedValue(new Error('test error'))
+    const {lastResult} = renderHook(() => useSelfAdjustingInterval(callback))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(lastResult).toBeUndefined()
+  })
+
+  test('cleans up timeout on unmount', async () => {
+    const callback = vi.fn().mockResolvedValue({retryIntervalMs: 1000})
+
+    const {unmount} = renderHook(() => useSelfAdjustingInterval(callback))
+
+    // give it a moment to set up the interval
+    await vi.advanceTimersByTimeAsync(0)
+    expect(vi.getTimerCount()).toBe(1)
+
+    // unmount and give it a moment to clean up the interval
+    unmount()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/useSelfAdjustingInterval.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/useSelfAdjustingInterval.ts
@@ -1,0 +1,26 @@
+import {useRef, useEffect} from 'react'
+
+export function useSelfAdjustingInterval<T extends {retryIntervalMs: number | null}>(callback: () => Promise<T>) {
+  const savedCallback = useRef(callback)
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    let id: NodeJS.Timeout
+    function tick() {
+      const ret = savedCallback.current()
+      ret
+        .then(({retryIntervalMs}) => {
+          if (retryIntervalMs) {
+            id = setTimeout(tick, retryIntervalMs)
+          }
+        })
+        .catch(() => {
+          // stop interval on error/rejection
+        })
+    }
+    id = setTimeout(tick, 0)
+    return () => id && clearTimeout(id)
+  }, [])
+}


### PR DESCRIPTION
We have had the occasional flakey test in usePollAppLogs. This affects our build process so is worth improving; I've taken a stab at it.

I broke out the self-adjusting interval element of the polling hook into its own hook and tests

I also adjusted the app log polling hook more generally:
- I pulled out the interesting/business logic part of the hook into a method. This leaves the hook a lot easier to reason about
- Within the hook, I used React references for any non-stateful instance variables