### PR TITLE
Emit status events from dev-session

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher-handler.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher-handler.ts
@@ -135,6 +135,6 @@ async function reload(app: AppLinkedInterface): Promise<AppLinkedInterface> {
     return newApp
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    throw new Error(`Error reloading app: ${error.message}`)
+    throw new Error(`Error reloading app: ${error.message}`, {cause: 'validation-error'})
   }
 }

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
@@ -146,6 +146,18 @@ const testCases: TestCase[] = [
     extensionEvents: [{type: EventType.Updated, extension: extension1, buildResult: {status: 'ok', uid: 'uid1'}}],
   },
   {
+    name: 'file_updated not affecting any extension',
+    fileWatchEvent: {
+      type: 'file_updated',
+      path: '/extensions/ui_extension_unknown/locales/en.json',
+      extensionPath: '/extensions/ui_extension_unknown',
+      startTime: [0, 0],
+    },
+    initialExtensions: [extension1, extension2, posExtension],
+    finalExtensions: [extension1, extension2, posExtension],
+    extensionEvents: [],
+  },
+  {
     name: 'file_created affecting a multiple extensions',
     fileWatchEvent: {
       type: 'file_created',

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -148,7 +148,7 @@ export class AppEventWatcher extends EventEmitter {
       handleWatcherEvents(events, this.app, this.options)
         .then(async (appEvent) => {
           if (appEvent?.extensionEvents.length === 0) outputDebug('Change detected, but no extensions were affected')
-          if (!appEvent || appEvent.extensionEvents.length === 0) return
+          if (!appEvent) return
 
           this.app = appEvent.app
           if (appEvent.appWasReloaded) this.fileWatcher?.updateApp(this.app)


### PR DESCRIPTION
### WHY are these changes introduced?

Improve DevSession feedback by showing the current status in the dynamic section of the terminal log footer.

### WHAT is this pull request doing?

- Adds specific error cause for app validation errors
- Introduces new status message handlers for different dev session states (build errors, ready state, loading, etc.)
- Ensures proper status updates when extensions are affected by changes


### How to test your changes?

1. Run `dev` command with dev-sessions enabled.
2. Verify status messages appear correctly for:
   - Initial loading state
   - Build errors (make a bad change in a extension code)
   - Validation errors (make a bad change in a toml file)
   - Successful updates
   - Ready state
3. Confirm status message automatically resets to "Ready" 2 seconds after an update

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes