### PR TITLE
Prototype CLI passing operations to deploy for discount functions

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -562,6 +562,13 @@ function defaultFunctionConfiguration(): FunctionConfigType {
     api_version: '2022-07',
     configuration_ui: true,
     metafields: [],
+    targeting: [
+      {
+        target: 'purchase.discount.cart_run',
+        export: 'run',
+        operations: ['addProductDiscounts', 'addOrderDiscounts'],
+      },
+    ],
   }
 }
 

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -566,7 +566,7 @@ function defaultFunctionConfiguration(): FunctionConfigType {
       {
         target: 'purchase.discount.cart_run',
         export: 'run',
-        features: ['addProductDiscounts', 'addOrderDiscounts'],
+        operations: ['addProductDiscounts', 'addOrderDiscounts'],
       },
     ],
   }

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -566,7 +566,7 @@ function defaultFunctionConfiguration(): FunctionConfigType {
       {
         target: 'purchase.discount.cart_run',
         export: 'run',
-        operations: ['addProductDiscounts', 'addOrderDiscounts'],
+        features: ['addProductDiscounts', 'addOrderDiscounts'],
       },
     ],
   }

--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -42,7 +42,7 @@ describe('functionConfiguration', () => {
       {
         target: 'purchase.discount.cart_run',
         export: 'run',
-        operations: ['addProductDiscounts', 'addOrderDiscounts'],
+        features: ['addProductDiscounts', 'addOrderDiscounts'],
       },
     ],
   }
@@ -94,7 +94,7 @@ describe('functionConfiguration', () => {
             export: 'run',
             handle: 'purchase.discount.cart_run',
             input_query: undefined,
-            operations: '["addProductDiscounts", "addOrderDiscounts"]',
+            features: '["addProductDiscounts", "addOrderDiscounts"]',
           },
         ],
         module_id: expect.any(String),

--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -42,7 +42,7 @@ describe('functionConfiguration', () => {
       {
         target: 'purchase.discount.cart_run',
         export: 'run',
-        features: ['addProductDiscounts', 'addOrderDiscounts'],
+        operations: ['addProductDiscounts', 'addOrderDiscounts'],
       },
     ],
   }
@@ -94,7 +94,7 @@ describe('functionConfiguration', () => {
             export: 'run',
             handle: 'purchase.discount.cart_run',
             input_query: undefined,
-            features: '["addProductDiscounts", "addOrderDiscounts"]',
+            operations: '["addProductDiscounts", "addOrderDiscounts"]',
           },
         ],
         module_id: expect.any(String),

--- a/packages/app/src/cli/models/extensions/specifications/function.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.test.ts
@@ -38,6 +38,13 @@ describe('functionConfiguration', () => {
         key: 'key',
       },
     },
+    targeting: [
+      {
+        target: 'purchase.discount.cart_run',
+        export: 'run',
+        operations: ['addProductDiscounts', 'addOrderDiscounts'],
+      },
+    ],
   }
 
   beforeEach(async () => {
@@ -82,7 +89,14 @@ describe('functionConfiguration', () => {
         },
         enable_creation_ui: true,
         localization: {},
-        targets: undefined,
+        targets: [
+          {
+            export: 'run',
+            handle: 'purchase.discount.cart_run',
+            input_query: undefined,
+            operations: '["addProductDiscounts", "addOrderDiscounts"]',
+          },
+        ],
         module_id: expect.any(String),
       })
     })

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -57,6 +57,7 @@ const FunctionExtensionSchema = BaseSchema.extend({
         target: zod.string(),
         input_query: zod.string().optional(),
         export: zod.string().optional(),
+        operations: zod.array(zod.string()).optional(),
       }),
     )
     .optional(),
@@ -97,7 +98,7 @@ const functionSpec = createExtensionSpecification({
             inputQuery = await readInputQuery(joinPath(directory, config.input_query))
           }
 
-          return {handle: config.target, export: config.export, input_query: inputQuery}
+          return {handle: config.target, export: config.export, input_query: inputQuery, operations: config.operations}
         }),
       ))
 

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -57,7 +57,7 @@ const FunctionExtensionSchema = BaseSchema.extend({
         target: zod.string(),
         input_query: zod.string().optional(),
         export: zod.string().optional(),
-        features: zod.array(zod.string()).optional(),
+        operations: zod.array(zod.string()).optional(),
       }),
     )
     .optional(),
@@ -98,7 +98,7 @@ const functionSpec = createExtensionSpecification({
             inputQuery = await readInputQuery(joinPath(directory, config.input_query))
           }
 
-          return {handle: config.target, export: config.export, input_query: inputQuery, features: config.features}
+          return {handle: config.target, export: config.export, input_query: inputQuery, operations: config.operations}
         }),
       ))
 

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -57,7 +57,7 @@ const FunctionExtensionSchema = BaseSchema.extend({
         target: zod.string(),
         input_query: zod.string().optional(),
         export: zod.string().optional(),
-        operations: zod.array(zod.string()).optional(),
+        features: zod.array(zod.string()).optional(),
       }),
     )
     .optional(),
@@ -98,7 +98,7 @@ const functionSpec = createExtensionSpecification({
             inputQuery = await readInputQuery(joinPath(directory, config.input_query))
           }
 
-          return {handle: config.target, export: config.export, input_query: inputQuery, operations: config.operations}
+          return {handle: config.target, export: config.export, input_query: inputQuery, features: config.features}
         }),
       ))
 

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -243,7 +243,7 @@ describe('deploy', () => {
         {
           handle: 'purchase.discount.cart_run',
           export: 'run',
-          features: '["addProductDiscounts", "addOrderDiscounts"]',
+          operations: '["addProductDiscounts", "addOrderDiscounts"]',
         },
       ],
     }

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -243,7 +243,7 @@ describe('deploy', () => {
         {
           handle: 'purchase.discount.cart_run',
           export: 'run',
-          operations: '["addProductDiscounts", "addOrderDiscounts"]',
+          features: '["addProductDiscounts", "addOrderDiscounts"]',
         },
       ],
     }

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -239,6 +239,13 @@ describe('deploy', () => {
       api_version: functionExtension.configuration.api_version,
       enable_creation_ui: true,
       localization: {},
+      targets: [
+        {
+          handle: 'purchase.discount.cart_run',
+          export: 'run',
+          operations: '["addProductDiscounts", "addOrderDiscounts"]',
+        },
+      ],
     }
 
     // When
@@ -258,7 +265,7 @@ describe('deploy', () => {
         {
           uuid: functionExtension.localIdentifier,
           config: JSON.stringify(mockedFunctionConfiguration),
-          context: '',
+          context: 'purchase.discount.cart_run',
           handle: functionExtension.handle,
           specificationIdentifier: undefined,
           uid: functionExtension.uid,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

To allow us to obtain values for operations passed by partners for a discount function and pass it to core to persist on the ShopifyVM::Domain::Functions model. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Making `operations` part of the functions deploy config for app deploys. 

### How to test your changes?

Create a discount function that uses the new discounts api and checkout this [core branch commit](https://github.com/shop/world/pull/1535/commits/2234029defae18ea1e6f21c0dbd2b5436253ee75) in your spin instance. The TOML file should look like the following: 
![Screenshot 2025-03-04 at 3 48 09 PM](https://github.com/user-attachments/assets/9d9559f6-e8e2-4309-ba98-157b934a985f)

Check partners internal to find the app and the function config with operations present under targets after deployment.  

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
