### PR TITLE
Ensure we handle binary files in parseThemeFileContent

### DIFF
--- a/.changeset/tasty-peaches-perform.md
+++ b/.changeset/tasty-peaches-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix binary files being corrupted on theme pull


### PR DESCRIPTION
### WHY are these changes introduced?

- Fixes https://github.com/Shopify/cli/issues/5224

`writeThemeFile` needs an `attachment` attribute in order to properly write a base64 encoded string to the file system: https://github.com/Shopify/cli/blob/main/packages/theme/src/cli/utilities/theme-fs.ts#L270-L282

Previous to this PR we've been attempting to write `base64` encoded files as `utf-8` which has resulted in files like images and fonts being corrupted when users run `shopify theme pull`.

### WHAT is this pull request doing?

Updates `parseThemeFileContent` to return either a `value` or `attachment` attribute depending on the content that we're serving and adds tests for the function.

### How to test your changes?

1. Pull down this branch `git fetch origin gg-fix-binary-files && git switch gg-fix-binary-files`
2. Install dependencies`pnpm install`
3. Ensure you have binary files in your remote theme (make sure to have small images and large images to test both the `OnlineStoreThemeFileBodyBase64` and `OnlineStoreThemeFileBodyUrl` flows
4. Make sure the files in your remote theme that you're testing are not already in your local environment
5. Run `pnpm shopify:run theme pull --path <path-to-theme>`
6. Ensure the binary files are successfully downloaded and are not corrupt (you can double check that this branch is fixing the issue by checking out `main` and re-running the command to see the corrupted files)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
