### PR TITLE
Store hidden config per client ID

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -9,6 +9,7 @@ import {
   AppLoaderMode,
   getAppConfigurationState,
   loadConfigForAppCreation,
+  loadHiddenConfig,
 } from './loader.js'
 import {LegacyAppSchema, WebConfigurationSchema} from './app.js'
 import {DEFAULT_CONFIG, buildVersionedAppSchema, getWebhookConfig} from './app.test-data.js'
@@ -29,7 +30,7 @@ import {
   PackageJson,
   pnpmWorkspaceFile,
 } from '@shopify/cli-kit/node/node-package-manager'
-import {inTemporaryDirectory, moveFile, mkdir, mkTmpDir, rmdir, writeFile} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, moveFile, mkdir, mkTmpDir, rmdir, writeFile, readFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname, cwd, normalizePath} from '@shopify/cli-kit/node/path'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
@@ -3328,6 +3329,143 @@ dev = "echo 'Hello, world!'"
         directory: tmpDir,
         isEmbedded: false,
       })
+    })
+  })
+})
+
+describe('loadHiddenConfig', () => {
+  test('returns empty object if no client_id in configuration', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configuration = {
+        path: joinPath(tmpDir, 'shopify.app.toml'),
+        scopes: 'write_products',
+      }
+
+      // When
+      const got = await loadHiddenConfig(tmpDir, configuration)
+
+      // Then
+      expect(got).toEqual({})
+    })
+  })
+
+  test('returns empty object if hidden config file does not exist', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configuration = {
+        path: joinPath(tmpDir, 'shopify.app.toml'),
+        client_id: '12345',
+      }
+      await writeFile(joinPath(tmpDir, '.gitignore'), '')
+
+      // When
+      const got = await loadHiddenConfig(tmpDir, configuration)
+
+      // Then
+      expect(got).toEqual({})
+
+      // Verify empty config file was created
+      const hiddenConfigPath = joinPath(tmpDir, '.shopify', 'project.json')
+      const fileContent = await readFile(hiddenConfigPath)
+      expect(JSON.parse(fileContent)).toEqual({})
+
+      // Verify .gitignore was updated
+      const gitIgnore = joinPath(tmpDir, '.gitignore')
+      const gitIgnoreContent = await readFile(gitIgnore)
+      expect(gitIgnoreContent).toContain('.shopify')
+    })
+  })
+
+  test('returns config for client_id if hidden config file exists', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configuration = {
+        path: joinPath(tmpDir, 'shopify.app.toml'),
+        client_id: '12345',
+      }
+      const hiddenConfigPath = joinPath(tmpDir, '.shopify', 'project.json')
+      await mkdir(dirname(hiddenConfigPath))
+      await writeFile(
+        hiddenConfigPath,
+        JSON.stringify({
+          '12345': {someKey: 'someValue'},
+          'other-id': {otherKey: 'otherValue'},
+        }),
+      )
+
+      // When
+      const got = await loadHiddenConfig(tmpDir, configuration)
+
+      // Then
+      expect(got).toEqual({someKey: 'someValue'})
+    })
+  })
+
+  test('returns empty object if client_id not found in existing hidden config', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configuration = {
+        path: joinPath(tmpDir, 'shopify.app.toml'),
+        client_id: 'not-found',
+      }
+      const hiddenConfigPath = joinPath(tmpDir, '.shopify', 'project.json')
+      await mkdir(dirname(hiddenConfigPath))
+      await writeFile(
+        hiddenConfigPath,
+        JSON.stringify({
+          'other-id': {someKey: 'someValue'},
+        }),
+      )
+
+      // When
+      const got = await loadHiddenConfig(tmpDir, configuration)
+
+      // Then
+      expect(got).toEqual({})
+    })
+  })
+
+  test('returns empty object if hidden config has an old format with just a dev_store_url', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configuration = {
+        path: joinPath(tmpDir, 'shopify.app.toml'),
+        client_id: 'not-found',
+      }
+      const hiddenConfigPath = joinPath(tmpDir, '.shopify', 'project.json')
+      await mkdir(dirname(hiddenConfigPath))
+      await writeFile(
+        hiddenConfigPath,
+        JSON.stringify({
+          dev_store_url: 'https://dev-store.myshopify.com',
+        }),
+      )
+
+      // When
+      const got = await loadHiddenConfig(tmpDir, configuration)
+
+      // Then
+      expect(got).toEqual({dev_store_url: 'https://dev-store.myshopify.com'})
+    })
+  })
+
+  test('returns empty object if hidden config file is invalid JSON', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configuration = {
+        path: joinPath(tmpDir, 'shopify.app.toml'),
+        client_id: '12345',
+      }
+      const hiddenConfigPath = joinPath(tmpDir, '.shopify', 'project.json')
+      await mkdir(dirname(hiddenConfigPath))
+      await writeFile(hiddenConfigPath, 'invalid json')
+
+      // When
+      const got = await loadHiddenConfig(tmpDir, configuration)
+
+      // Then
+      expect(got).toEqual({})
     })
   })
 })

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3426,7 +3426,7 @@ describe('loadHiddenConfig', () => {
     })
   })
 
-  test('returns empty object if hidden config has an old format with just a dev_store_url', async () => {
+  test('returns config if hidden config has an old format with just a dev_store_url', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const configuration = {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -33,6 +33,7 @@ import {WebhookSubscriptionSpecIdentifier} from '../extensions/specifications/ap
 import {WebhooksSchema} from '../extensions/specifications/app_config_webhook_schemas/webhooks_schema.js'
 import {loadLocalExtensionsSpecifications} from '../extensions/load-specifications.js'
 import {UIExtensionSchemaType} from '../extensions/specifications/ui_extension.js'
+import {patchAppHiddenConfigFile} from '../../services/app/patch-app-configuration-file.js'
 import {fileExists, readFile, glob, findPathUp, fileExistsSync, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
@@ -1086,8 +1087,10 @@ export async function loadHiddenConfig(
 
       // Migration from legacy format, can be safely removed in version >=3.77
       const oldConfig = allConfigs.dev_store_url
-      if (oldConfig !== undefined && typeof oldConfig === 'string') return {dev_store_url: oldConfig}
-
+      if (oldConfig !== undefined && typeof oldConfig === 'string') {
+        await patchAppHiddenConfigFile(hiddenConfigPath, configuration.client_id, {dev_store_url: oldConfig})
+        return {dev_store_url: oldConfig}
+      }
       return {}
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch {

--- a/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
+++ b/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
@@ -1,4 +1,4 @@
-import {patchAppConfigurationFile} from './patch-app-configuration-file.js'
+import {patchAppConfigurationFile, patchAppHiddenConfigFile} from './patch-app-configuration-file.js'
 import {getAppVersionedSchema} from '../../models/app/app.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {readFile, writeFileSync, inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
@@ -173,6 +173,87 @@ random_toml_field = "random_value"
 random_toml_field = "random_value"
 name = 123
 `)
+    })
+  })
+})
+
+describe('patchAppHiddenConfigFile', () => {
+  test('creates a new hidden config file when it does not exist', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = joinPath(tmpDir, '.project.json')
+      const clientId = '12345'
+      const config = {
+        dev_store_url: 'test-store.myshopify.com',
+      }
+
+      await patchAppHiddenConfigFile(configPath, clientId, config)
+
+      const updatedJsonFile = await readFile(configPath)
+      expect(JSON.parse(updatedJsonFile)).toEqual({
+        '12345': {
+          dev_store_url: 'test-store.myshopify.com',
+        },
+      })
+    })
+  })
+
+  test('updates existing hidden config file with new values', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = joinPath(tmpDir, '.project.json')
+      // Write initial config
+      const initialConfig = {
+        '12345': {
+          dev_store_url: 'old-store.myshopify.com',
+        },
+      }
+      writeFileSync(configPath, JSON.stringify(initialConfig, null, 2))
+
+      const clientId = '12345'
+      const config = {
+        dev_store_url: 'new-store.myshopify.com',
+      }
+
+      await patchAppHiddenConfigFile(configPath, clientId, config)
+
+      const updatedJsonFile = await readFile(configPath)
+      expect(JSON.parse(updatedJsonFile)).toEqual({
+        '12345': {
+          dev_store_url: 'new-store.myshopify.com',
+        },
+      })
+    })
+  })
+
+  test('preserves other client configurations when updating', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = joinPath(tmpDir, '.project.json')
+      // Write initial config with multiple clients
+      const initialConfig = {
+        '12345': {
+          dev_store_url: 'store-1.myshopify.com',
+        },
+        '67890': {
+          dev_store_url: 'store-2.myshopify.com',
+        },
+      }
+      writeFileSync(configPath, JSON.stringify(initialConfig, null, 2))
+
+      const clientId = '12345'
+      const config = {
+        dev_store_url: 'updated-store.myshopify.com',
+      }
+
+      await patchAppHiddenConfigFile(configPath, clientId, config)
+
+      const updatedJsonFile = await readFile(configPath)
+      expect(JSON.parse(updatedJsonFile)).toEqual({
+        '12345': {
+          dev_store_url: 'updated-store.myshopify.com',
+        },
+        '67890': {
+          dev_store_url: 'store-2.myshopify.com',
+        },
+      })
     })
   })
 })

--- a/packages/app/src/cli/services/app/patch-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/patch-app-configuration-file.ts
@@ -1,4 +1,5 @@
 import {addDefaultCommentsToToml} from './write-app-configuration-file.js'
+import {AppHiddenConfig} from '../../models/app/app.js'
 import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 import {readFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {zod} from '@shopify/cli-kit/node/schema'
@@ -42,4 +43,18 @@ export async function patchAppConfigurationFile({path, patch, schema}: PatchToml
 
 export function replaceArrayStrategy(_: unknown[], newArray: unknown[]): unknown[] {
   return newArray
+}
+
+export async function patchAppHiddenConfigFile(path: string, clientId: string, config: AppHiddenConfig) {
+  let configuration: {[key: string]: unknown} = {}
+  try {
+    const jsonContents = await readFile(path)
+    configuration = JSON.parse(jsonContents)
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    // Do nothing if the file doesn't exist or can't be loaded
+  }
+  const patch = {[clientId]: config}
+  const updatedConfig = deepMergeObjects(configuration, patch, replaceArrayStrategy)
+  await writeFile(path, JSON.stringify(updatedConfig, null, 2))
 }

--- a/packages/app/src/cli/services/store-context.test.ts
+++ b/packages/app/src/cli/services/store-context.test.ts
@@ -22,10 +22,15 @@ vi.mock('./dev/select-store')
 describe('storeContext', () => {
   const mockApp = testAppLinked({
     configuration: {
+      client_id: 'client_id',
+      name: 'app-config-name',
       build: {
         dev_store_url: 'cached-store.myshopify.com',
       },
     } as any,
+    hiddenConfig: {
+      dev_store_url: 'cached-store.myshopify.com',
+    },
   })
 
   const mockOrganization = testOrganization()
@@ -195,7 +200,7 @@ describe('storeContext', () => {
       await storeContext({appContextResult, forceReselectStore: false})
 
       const hiddenConfig = await readFile(appHiddenConfigPath(dir))
-      expect(hiddenConfig).toEqual('{\n  "dev_store_url": "test-store.myshopify.com"\n}')
+      expect(hiddenConfig).toEqual('{\n  "client_id": {\n    "dev_store_url": "test-store.myshopify.com"\n  }\n}')
     })
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

The current implementation stores dev store URLs in a flat structure, which can lead to conflicts when developers work with multiple organizations. This change introduces app-specific storage of dev store URLs.

### WHAT is this pull request doing?

Updates the hidden configuration structure to store dev store URLs under app-specific keys, preventing conflicts when connecting to different organizations. The change includes:

- Modifying the `AppHiddenConfig` interface to use app names as keys
- Using deep merge for config updates
- Updating store context handling to reference app-specific store URLs


Example:

```
{
  "testa8e113c942b95b54c1d0ffbc2": {
    "dev_store_url": "test-store-3.myshopify.com"
  },
  "test6f7048e1a203d6ae64c601f1": {
    "dev_store_url": "test-store-2.myshopify.com"
  }
}
```

### How to test your changes?

1. Create multiple app configurations in your app
2. Run dev commands for different apps
3. Verify that each app maintains its own dev store URL
4. Confirm that switching between apps preserves their respective store configurations

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes