### PR TITLE
Update to cli-hydrogen 9.0.6

### DIFF
--- a/.changeset/lemon-eggs-end.md
+++ b/.changeset/lemon-eggs-end.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Update to cli-hydrogen 9.0.6

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -115,7 +115,7 @@
     "@shopify/plugin-cloudflare": "3.75.0",
     "@shopify/plugin-did-you-mean": "3.75.0",
     "@shopify/theme": "3.75.0",
-    "@shopify/cli-hydrogen": "9.0.5",
+    "@shopify/cli-hydrogen": "9.0.6",
     "@typescript-eslint/eslint-plugin": "7.13.1",
     "@vitest/coverage-istanbul": "^1.6.0",
     "esbuild-plugin-copy": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,8 +265,8 @@ importers:
         specifier: 3.75.0
         version: link:../app
       '@shopify/cli-hydrogen':
-        specifier: 9.0.5
-        version: 9.0.5(@graphql-codegen/cli@5.0.4)(react-dom@17.0.2)(react@17.0.2)
+        specifier: 9.0.6
+        version: 9.0.6(@graphql-codegen/cli@5.0.4)(react-dom@17.0.2)(react@17.0.2)
       '@shopify/cli-kit':
         specifier: 3.75.0
         version: link:../cli-kit
@@ -6307,8 +6307,8 @@ packages:
     resolution: {integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==}
     dev: true
 
-  /@shopify/cli-hydrogen@9.0.5(@graphql-codegen/cli@5.0.4)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-x0eOZD9oZl3IMwhapJLvBG0hfuGe8BCE14LJXBLJdcgKRXFHAHjQcve+0CH01oD9yY/e1oGe5u8wb7dpVeT+Mw==}
+  /@shopify/cli-hydrogen@9.0.6(@graphql-codegen/cli@5.0.4)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-ldDKQX36pGIioIVC1gMwjlOQNBLXSe0TfaARdz7Dw8D31C0vtiHMi62fiQCZXb3vBs24yvPTqWbikF3pyINzig==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -6342,6 +6342,7 @@ packages:
       chokidar: 3.5.3
       cli-truncate: 4.0.0
       diff: 5.2.0
+      get-east-asian-width: 1.3.0
       get-port: 7.1.0
       gunzip-maybe: 1.4.2
       prettier: 2.8.8
@@ -11573,6 +11574,11 @@ packages:
 
   /get-east-asian-width@1.2.0:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /get-east-asian-width@1.3.0:
+    resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
     dev: true
 


### PR DESCRIPTION
### WHY are these changes introduced?

Updates the Hydrogen CLI dependency to the latest version which includes improved terminal output handling for East Asian characters.

### WHAT is this pull request doing?

Updates `@shopify/cli-hydrogen` from version 9.0.5 to 9.0.6.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes