### PR TITLE
Fix snapit message

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -32,11 +32,15 @@ jobs:
           github_comment_included_packages: '@shopify/cli'
           custom_message_suffix: "
             > [!TIP]
-            > If you get an ETARGET error, try to install it with NPM adding the flag `--@shopify:registry=https://registry.npmjs.org`
+
+            > If you get an `ETARGET` error, install it with NPM and the flag `--@shopify:registry=https://registry.npmjs.org`
 
             > [!CAUTION]
+
             > After installing, validate the version by running just `shopify` in your terminal.
+
             > If the versions don't match, you might have multiple global instances installed.
+
             > Use `which shopify` to find out which one you are running and uninstall it."
           build_script: "pnpm nx run-many --target=bundle --all --skip-nx-cache --output-style=stream"
         env:


### PR DESCRIPTION
### WHY are these changes introduced?

Continuation of https://github.com/Shopify/cli/pull/5382

The generated message is missing line breaks, so it's not showing it as expected:

```
[!TIP] > If you get an ETARGET error, try to install it with NPM adding the flag --@shopify:registry=https://registry.npmjs.org
[!CAUTION] > After installing, validate the version by running just shopify in your terminal. > If the versions don't match, you might have multiple global instances installed. > Use which shopify to find out which one you are running and uninstall it.
```

### WHAT is this pull request doing?

Adds additional line breaks

### How to test your changes?

Tested the output by editing [this comment](https://github.com/Shopify/cli/pull/5348#issuecomment-2663246307)

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
