### PR TITLE
Network error request retries

### DIFF
--- a/.changeset/famous-lemons-work.md
+++ b/.changeset/famous-lemons-work.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Enable automatic retry for network errors (i.e. DNS or connectivity issues). Can be disabled with SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -46,6 +46,7 @@ export const environmentVariables = {
   themeKitAccessDomain: 'SHOPIFY_CLI_THEME_KIT_ACCESS_DOMAIN',
   json: 'SHOPIFY_FLAG_JSON',
   neverUsePartnersApi: 'SHOPIFY_CLI_NEVER_USE_PARTNERS_API',
+  skipNetworkLevelRetry: 'SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY',
 }
 
 export const defaultThemeKitAccessDomain = 'theme-kit-access.shopifyapps.com'

--- a/packages/cli-kit/src/private/node/sleep-with-backoff.test.ts
+++ b/packages/cli-kit/src/private/node/sleep-with-backoff.test.ts
@@ -1,0 +1,185 @@
+import {sleepWithBackoffUntil} from './sleep-with-backoff.js'
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest'
+
+describe('sleepWithBackoffUntil', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('yields immediately on first attempt', async () => {
+    const generator = sleepWithBackoffUntil(5000, 1000)
+    const start = Date.now()
+
+    const result = generator.next()
+    vi.runAllTimers()
+
+    expect(Date.now() - start).toBe(0)
+    await expect(result).resolves.toEqual({value: 0, done: false})
+  })
+
+  test('stops before exceeding time limit', async () => {
+    const generator = sleepWithBackoffUntil(5000, 1000)
+    const delays: number[] = []
+
+    // First attempt
+    let result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toEqual({value: 0, done: false})
+    delays.push(0)
+
+    // Second attempt
+    result = generator.next()
+    vi.advanceTimersByTime(1000)
+    await expect(result).resolves.toEqual({value: 1000, done: false})
+    delays.push(1000)
+
+    // Third attempt
+    result = generator.next()
+    vi.advanceTimersByTime(3000)
+    await expect(result).resolves.toEqual({value: 2000, done: false})
+    delays.push(2000)
+
+    // Should stop before next attempt (would be 7000ms)
+    result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toMatchObject({
+      done: true,
+      value: {iterations: 3},
+    })
+
+    expect(delays).toEqual([0, 1000, 2000])
+
+    result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toEqual({done: true})
+  })
+
+  test('uses default values when not specified', async () => {
+    const generator = sleepWithBackoffUntil()
+    const start = Date.now()
+
+    let result = generator.next()
+    vi.runAllTimers()
+    expect(Date.now() - start).toBe(0)
+    await expect(result).resolves.toEqual({value: 0, done: false})
+
+    result = generator.next()
+    vi.advanceTimersByTime(300)
+    expect(Date.now() - start).toBe(300)
+    await expect(result).resolves.toEqual({value: 300, done: false})
+  })
+
+  test('stops immediately if maxTimeMs is 0', async () => {
+    const generator = sleepWithBackoffUntil(0, 1000)
+    const result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toMatchObject({
+      done: true,
+      value: {
+        remainingMs: 0,
+        iterations: 0,
+      },
+    })
+  })
+
+  test('respects wall clock time including caller delays', async () => {
+    const generator = sleepWithBackoffUntil(5000, 1000)
+    const delays: number[] = []
+
+    // First attempt
+    let result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toEqual({value: 0, done: false})
+    delays.push(0)
+    // caller delay
+    vi.advanceTimersByTime(2000)
+
+    // Second attempt
+    result = generator.next()
+    vi.advanceTimersByTime(1000)
+    await expect(result).resolves.toEqual({value: 1000, done: false})
+    delays.push(1000)
+    // caller delay
+    vi.advanceTimersByTime(2000)
+
+    // Should stop due to elapsed time
+    result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toMatchObject({done: true})
+
+    expect(delays).toEqual([0, 1000])
+  })
+
+  test('returns remaining time and iteration count', async () => {
+    const generator = sleepWithBackoffUntil(5000, 1000)
+    const delays: number[] = []
+
+    // First attempt
+    let result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toEqual({value: 0, done: false})
+    delays.push(0)
+
+    // Second attempt
+    result = generator.next()
+    vi.advanceTimersByTime(1000)
+    await expect(result).resolves.toEqual({value: 1000, done: false})
+    delays.push(1000)
+
+    // Third attempt
+    result = generator.next()
+    vi.advanceTimersByTime(3000)
+    await expect(result).resolves.toEqual({value: 2000, done: false})
+    delays.push(2000)
+
+    // Should stop and return stats
+    result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toMatchObject({
+      done: true,
+      value: {
+        remainingMs: expect.any(Number),
+        iterations: 3,
+      },
+    })
+
+    const {value} = await result
+    expect((value as any).remainingMs).toBeGreaterThan(0)
+    expect((value as any).remainingMs).toBeLessThan(5000)
+  })
+
+  test('includes caller delays in remaining time calculation', async () => {
+    const generator = sleepWithBackoffUntil(5000, 1000)
+    const delays: number[] = []
+
+    // First attempt
+    let result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toEqual({value: 0, done: false})
+    delays.push(0)
+    // caller delay
+    vi.advanceTimersByTime(2000)
+
+    // Second attempt
+    result = generator.next()
+    vi.advanceTimersByTime(1000)
+    await expect(result).resolves.toEqual({value: 1000, done: false})
+    delays.push(1000)
+    // caller delay
+    vi.advanceTimersByTime(2000)
+
+    // Should stop and include caller delays in calculation
+    result = generator.next()
+    vi.runAllTimers()
+    await expect(result).resolves.toMatchObject({
+      done: true,
+      value: {iterations: 2},
+    })
+
+    expect(delays).toEqual([0, 1000])
+  })
+})

--- a/packages/cli-kit/src/private/node/sleep-with-backoff.ts
+++ b/packages/cli-kit/src/private/node/sleep-with-backoff.ts
@@ -1,0 +1,87 @@
+import {sleep} from '@shopify/cli-kit/node/system'
+
+const DEFAULT_RETRY_DELAY_MS = 300
+// 10 seconds default
+const DEFAULT_MAX_TIME_MS = 10000
+
+interface BackoffResult {
+  remainingMs: number
+  iterations: number
+}
+
+/**
+ * Calculates the delay for a given attempt in exponential backoff
+ *
+ * First result is zero, second result is firstDelayMs, third result is firstDelay * 2, then * 4, then * 8, etc.
+ *
+ * Delays are capped by a maximum value.
+ */
+function calculateBackoffDelay(
+  attempt: number,
+  firstDelayMs: number,
+  maximumDelayMs: number = DEFAULT_MAX_TIME_MS / 3,
+): number {
+  if (attempt === 0) {
+    return 0
+  }
+  const delayMultiplier = 2 ** (attempt - 1)
+  return Math.min(firstDelayMs * delayMultiplier, maximumDelayMs)
+}
+
+/**
+ * Common generator function for backoff implementations
+ */
+async function* backoffGenerator(
+  shouldContinue: (nextDelay: number) => boolean,
+  firstDelayMs: number,
+): AsyncGenerator<number, BackoffResult, unknown> {
+  let attempt = 0
+
+  while (true) {
+    const nextDelayMs = calculateBackoffDelay(attempt, firstDelayMs)
+    if (!shouldContinue(nextDelayMs)) {
+      return {remainingMs: 0, iterations: attempt}
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(nextDelayMs / 1000)
+    yield nextDelayMs
+    attempt++
+  }
+}
+
+/**
+ * Generator that sleeps with exponential backoff between yields, stopping before exceeding a time limit
+ *
+ * Yields the amount of time slept in milliseconds.
+ *
+ * @param maxTimeMs - Maximum total time in milliseconds before stopping
+ * @param firstDelayMs - First delay in milliseconds
+ * @returns Information about the backoff sequence: remaining time and iteration count
+ */
+export async function* sleepWithBackoffUntil(
+  maxTimeMs: number = DEFAULT_MAX_TIME_MS,
+  firstDelayMs: number = DEFAULT_RETRY_DELAY_MS,
+): AsyncGenerator<number, BackoffResult, unknown> {
+  if (maxTimeMs <= 0) {
+    return {remainingMs: 0, iterations: 0}
+  }
+
+  const startTime = Date.now()
+  const generator = backoffGenerator((nextDelay) => {
+    const elapsedTime = Date.now() - startTime
+    return elapsedTime + nextDelay <= maxTimeMs
+  }, firstDelayMs)
+
+  let attempt = 0
+  for await (const delayMs of generator) {
+    yield delayMs
+    attempt++
+  }
+
+  const elapsedTime = Date.now() - startTime
+  return {
+    remainingMs: maxTimeMs - elapsedTime,
+    iterations: attempt,
+  }
+}

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -91,3 +91,15 @@ export function jsonOutputEnabled(environment = getEnvironmentVariables()): bool
 export function blockPartnersAccess(): boolean {
   return isTruthy(getEnvironmentVariables()[environmentVariables.neverUsePartnersApi])
 }
+
+/**
+ * If true, the CLI should not use the network level retry.
+ *
+ * If there is an error when calling a network API that looks like a DNS or connectivity issue, the CLI will by default
+ * automatically retry the request.
+ *
+ * @returns True if the SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY environment variable is set.
+ */
+export function skipNetworkLevelRetry(): boolean {
+  return isTruthy(getEnvironmentVariables()[environmentVariables.skipNetworkLevelRetry])
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Network errors during API calls can be transient and should be automatically retried to improve reliability. Currently, the CLI only retries on explicit rate limit errors (code 429), but should also handle common network issues like DNS failures or connection timeouts, where we are confident this is the cause of the issue.

### WHAT is this pull request doing?

Network level retries are based on an elapsed time limit -- there are 10 seconds between starting the first attempt at the request and the retry loop being stopped. On each iteration of the retry loop, the delay is doubled. The first delay is 300ms, then 600 and so on.

The retry logic is implemented at a low level, and will affect all GraphQL and fetch requests made through CLI Kit. This includes non-GraphQL calls to `identity`.

Response-based retries -- using the HTTP response code & headers to trigger a retry -- are still supported and sit at a higher level than this.

- Adds network-level retry capability to API requests when encountering common network errors
- Implements exponential backoff for retries with configurable time limits
- Adds ability to disable network retries via `SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY` environment variable
- Includes comprehensive test coverage for the retry behaviour

### Testing

Adjusting `--path`, run:
```
SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY=1 p shopify app init --path=<app folder> --verbose
```
When you get to the Remix/JS question, switch off wifi. Observe that the CLI fails immediately after.

Then:
```
p shopify app init --path=<app folder> --verbose
```
Again, switch off wifi when you get to Remix/JS question. Observe that the CLI starts to retry requests with an slower gap in between each retry. It should take no more than 10s before exiting.

Run it one more time. This time reactivate wifi once retries have begun. Observe that the CLI recovers.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes