### PR TITLE
Check if app directory exists just before moving temp copy

### DIFF
--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -193,6 +193,8 @@ async function init(options: InitOptions) {
 
     await renderTasks(tasks)
 
+    // Ensure the app directory is available before moving the template scaffold
+    await ensureAppDirectoryIsAvailable(outputDirectory, hyphenizedName)
     await moveFile(templateScaffoldDir, outputDirectory)
   })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://app.bugsnag.com/shopify/cli/errors/669725e0d6faad0008d97c40

Fixes a potential race condition where template files could be moved before the target app directory is properly prepared.

### WHAT is this pull request doing?

Adds a directory availability check before moving template scaffold files during app initialization. This ensures the output directory exists and is ready before file operations begin.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes