### PR TITLE
Handle if openUrl fails

### DIFF
--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -60,13 +60,21 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
   outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
   const linkToken = outputToken.link(jsonResult.verification_uri_complete)
 
-  if (isCloudEnvironment()) {
+  const cloudMessage = () => {
     outputInfo(outputContent`👉 Open this link to start the auth process: ${linkToken}`)
+  }
+
+  if (isCloudEnvironment()) {
+    cloudMessage()
   } else {
     outputInfo('👉 Press any key to open the login page on your browser')
     await keypress()
-    await openURL(jsonResult.verification_uri_complete)
-    outputInfo(outputContent`Opened link to start the auth process: ${linkToken}`)
+    const opened = await openURL(jsonResult.verification_uri_complete)
+    if (opened) {
+      outputInfo(outputContent`Opened link to start the auth process: ${linkToken}`)
+    } else {
+      cloudMessage()
+    }
   }
 
   return {

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -27,10 +27,17 @@ export interface ExecOptions {
  * Opens a URL in the user's default browser.
  *
  * @param url - URL to open.
+ * @returns A promise that resolves true if the URL was opened successfully, false otherwise.
  */
-export async function openURL(url: string): Promise<void> {
+export async function openURL(url: string): Promise<boolean> {
   const externalOpen = await import('open')
-  await externalOpen.default(url)
+  try {
+    await externalOpen.default(url)
+    return true
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (error) {
+    return false
+  }
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://app.bugsnag.com/shopify/cli/errors/66ee2691df0c3356706e3473

Improves the authentication flow when the browser cannot be automatically opened by providing a fallback to display the authentication URL, as we would on an unsupported session.

### WHAT is this pull request doing?

Enhances the `openURL` function to return a boolean indicating success/failure of opening the URL. When the browser cannot be opened automatically, the CLI now displays a clickable link instead of propagating an exception.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes