### PR TITLE
Fetch notifications in background II

### DIFF
--- a/.changeset/violet-carrots-argue.md
+++ b/.changeset/violet-carrots-argue.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fetch notifications in background

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -3,14 +3,12 @@ import {reportAnalyticsEvent} from '../analytics.js'
 import {outputDebug} from '../../../public/node/output.js'
 import BaseCommand from '../base-command.js'
 import * as metadata from '../../../public/node/metadata.js'
-import {fetchNotificationsInBackground} from '../notifications-system.js'
 import {Command, Hook} from '@oclif/core'
 
 // This hook is called after each successful command run. More info: https://oclif.io/docs/hooks
 export const hook: Hook.Postrun = async ({config, Command}) => {
   await detectStopCommand(Command as unknown as typeof Command)
   await reportAnalyticsEvent({config, exitMode: 'ok'})
-  if (!Command.hidden) fetchNotificationsInBackground(Command.id)
   deprecationsHook(Command)
 
   const command = Command.id.replace(/:/g, ' ')

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -3,12 +3,14 @@ import {reportAnalyticsEvent} from '../analytics.js'
 import {outputDebug} from '../../../public/node/output.js'
 import BaseCommand from '../base-command.js'
 import * as metadata from '../../../public/node/metadata.js'
+import {fetchNotificationsInBackground} from '../notifications-system.js'
 import {Command, Hook} from '@oclif/core'
 
 // This hook is called after each successful command run. More info: https://oclif.io/docs/hooks
 export const hook: Hook.Postrun = async ({config, Command}) => {
   await detectStopCommand(Command as unknown as typeof Command)
   await reportAnalyticsEvent({config, exitMode: 'ok'})
+  if (!Command.hidden) fetchNotificationsInBackground(Command.id)
   deprecationsHook(Command)
 
   const command = Command.id.replace(/:/g, ' ')
@@ -26,10 +28,10 @@ async function detectStopCommand(commandClass: Command.Class | typeof BaseComman
     const stopCommand = (commandClass as typeof BaseCommand).analyticsStopCommand()
     if (stopCommand) {
       const {commandStartOptions} = metadata.getAllSensitiveMetadata()
+      if (!commandStartOptions) return
       await metadata.addSensitiveMetadata(() => ({
         commandStartOptions: {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          ...commandStartOptions!,
+          ...commandStartOptions,
           startTime: currentTime,
           startCommand: stopCommand,
         },

--- a/packages/cli-kit/src/public/node/hooks/prerun.ts
+++ b/packages/cli-kit/src/public/node/hooks/prerun.ts
@@ -24,7 +24,7 @@ export const hook: Hook.Prerun = async (options) => {
   await warnOnAvailableUpgrade()
   outputDebug(`Running command ${commandContent.command}`)
   await startAnalytics({commandContent, args, commandClass: options.Command as unknown as typeof Command})
-  if (!Command.hidden) fetchNotificationsInBackground(Command.id)
+  if (!options.Command.hidden) fetchNotificationsInBackground(options.Command.id)
 }
 
 export function parseCommandContent(cmdInfo: {id: string; aliases: string[]; pluginAlias?: string}): CommandContent {

--- a/packages/cli-kit/src/public/node/hooks/prerun.ts
+++ b/packages/cli-kit/src/public/node/hooks/prerun.ts
@@ -5,6 +5,7 @@ import {outputDebug, outputWarn} from '../../../public/node/output.js'
 import {getOutputUpdateCLIReminder} from '../../../public/node/upgrade.js'
 import Command from '../../../public/node/base-command.js'
 import {runAtMinimumInterval} from '../../../private/node/conf-store.js'
+import {fetchNotificationsInBackground} from '../notifications-system.js'
 import {Hook} from '@oclif/core'
 
 export declare interface CommandContent {
@@ -23,6 +24,7 @@ export const hook: Hook.Prerun = async (options) => {
   await warnOnAvailableUpgrade()
   outputDebug(`Running command ${commandContent.command}`)
   await startAnalytics({commandContent, args, commandClass: options.Command as unknown as typeof Command})
+  if (!Command.hidden) fetchNotificationsInBackground(Command.id)
 }
 
 export function parseCommandContent(cmdInfo: {id: string; aliases: string[]; pluginAlias?: string}): CommandContent {

--- a/packages/cli-kit/src/public/node/notifications-system.test.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.test.ts
@@ -1,12 +1,19 @@
-import {Notification, filterNotifications, showNotificationsIfNeeded} from './notifications-system.js'
+import {
+  Notification,
+  fetchNotificationsInBackground,
+  filterNotifications,
+  showNotificationsIfNeeded,
+} from './notifications-system.js'
 import {renderError, renderInfo, renderWarning} from './ui.js'
 import {sniffForJson} from './path.js'
-import {cacheRetrieve, cacheRetrieveOrRepopulate} from '../../private/node/conf-store.js'
+import {exec} from './system.js'
+import {cacheRetrieve} from '../../private/node/conf-store.js'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 vi.mock('./ui.js')
 vi.mock('../../private/node/conf-store.js')
 vi.mock('./path.js')
+vi.mock('./system.js')
 
 const betweenVersins1and2: Notification = {
   id: 'betweenVersins1and2',
@@ -333,7 +340,7 @@ describe('showNotificationsIfNeeded', () => {
   test('an info notification triggers a renderInfo call', async () => {
     // Given
     const notifications = [infoNotification]
-    vi.mocked(cacheRetrieveOrRepopulate).mockResolvedValue(JSON.stringify({notifications}))
+    vi.mocked(cacheRetrieve).mockReturnValue({value: JSON.stringify({notifications}), timestamp: 0})
 
     // When
     await showNotificationsIfNeeded(undefined, {SHOPIFY_UNIT_TEST: 'false'})
@@ -345,7 +352,7 @@ describe('showNotificationsIfNeeded', () => {
   test('a warning notification triggers a renderWarning call', async () => {
     // Given
     const notifications = [warningNotification]
-    vi.mocked(cacheRetrieveOrRepopulate).mockResolvedValue(JSON.stringify({notifications}))
+    vi.mocked(cacheRetrieve).mockReturnValue({value: JSON.stringify({notifications}), timestamp: 0})
 
     // When
     await showNotificationsIfNeeded(undefined, {SHOPIFY_UNIT_TEST: 'false'})
@@ -357,7 +364,7 @@ describe('showNotificationsIfNeeded', () => {
   test('an error notification triggers a renderError call and throws an error', async () => {
     // Given
     const notifications = [errorNotification]
-    vi.mocked(cacheRetrieveOrRepopulate).mockResolvedValue(JSON.stringify({notifications}))
+    vi.mocked(cacheRetrieve).mockReturnValue({value: JSON.stringify({notifications}), timestamp: 0})
 
     // When
     await expect(showNotificationsIfNeeded(undefined, {SHOPIFY_UNIT_TEST: 'false'})).rejects.toThrowError()
@@ -369,7 +376,7 @@ describe('showNotificationsIfNeeded', () => {
   test('notifications are skipped on CI', async () => {
     // Given
     const notifications = [infoNotification]
-    vi.mocked(cacheRetrieveOrRepopulate).mockResolvedValue(JSON.stringify({notifications}))
+    vi.mocked(cacheRetrieve).mockReturnValue({value: JSON.stringify({notifications}), timestamp: 0})
 
     // When
     await showNotificationsIfNeeded(undefined, {SHOPIFY_UNIT_TEST: 'false', CI: 'true'})
@@ -381,7 +388,7 @@ describe('showNotificationsIfNeeded', () => {
   test('notifications are skipped on tests', async () => {
     // Given
     const notifications = [infoNotification]
-    vi.mocked(cacheRetrieveOrRepopulate).mockResolvedValue(JSON.stringify({notifications}))
+    vi.mocked(cacheRetrieve).mockReturnValue({value: JSON.stringify({notifications}), timestamp: 0})
 
     // When
     await showNotificationsIfNeeded(undefined, {SHOPIFY_UNIT_TEST: 'true'})
@@ -393,7 +400,7 @@ describe('showNotificationsIfNeeded', () => {
   test('notifications are skipped when using --json flag', async () => {
     // Given
     const notifications = [infoNotification]
-    vi.mocked(cacheRetrieveOrRepopulate).mockResolvedValue(JSON.stringify({notifications}))
+    vi.mocked(cacheRetrieve).mockReturnValue({value: JSON.stringify({notifications}), timestamp: 0})
     vi.mocked(sniffForJson).mockReturnValue(true)
 
     // When
@@ -406,12 +413,42 @@ describe('showNotificationsIfNeeded', () => {
   test('notifications are skipped when using SHOPIFY_FLAG_JSON', async () => {
     // Given
     const notifications = [infoNotification]
-    vi.mocked(cacheRetrieveOrRepopulate).mockResolvedValue(JSON.stringify({notifications}))
+    vi.mocked(cacheRetrieve).mockReturnValue({value: JSON.stringify({notifications}), timestamp: 0})
 
     // When
     await showNotificationsIfNeeded(undefined, {SHOPIFY_UNIT_TEST: 'false', SHOPIFY_FLAG_JSON: 'true'})
 
     // Then
     expect(renderInfo).not.toHaveBeenCalled()
+  })
+})
+
+describe('fetchNotificationsInBackground', () => {
+  test('calls the expected Shopify binary for global installation', async () => {
+    // Given / When
+    fetchNotificationsInBackground('theme:init', ['shopify', 'theme', 'init'], {SHOPIFY_UNIT_TEST: 'false'})
+
+    // Then
+    expect(exec).toHaveBeenCalledWith('shopify', ['notifications', 'list'], expect.anything())
+  })
+
+  test('calls the expected Shopify binary for local installation', async () => {
+    // Given / When
+    fetchNotificationsInBackground('theme:init', ['npm', 'run', 'shopify', 'theme', 'init'], {
+      SHOPIFY_UNIT_TEST: 'false',
+    })
+
+    // Then
+    expect(exec).toHaveBeenCalledWith('npm', ['run', 'shopify', 'notifications', 'list'], expect.anything())
+  })
+
+  test('calls the expected Shopify binary for dev environment', async () => {
+    // Given / When
+    fetchNotificationsInBackground('theme:init', ['node', 'packages/cli/bin/dev.js', 'theme', 'init'], {
+      SHOPIFY_UNIT_TEST: 'false',
+    })
+
+    // Then
+    expect(exec).toHaveBeenCalledWith('node', ['packages/cli/bin/dev.js', 'notifications', 'list'], expect.anything())
   })
 })

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -4,6 +4,7 @@ import {cwd, dirname} from './path.js'
 import {treeKill} from './tree-kill.js'
 import {isTruthy} from './context/utilities.js'
 import {renderWarning} from './ui.js'
+import {platformAndArch} from './os.js'
 import {shouldDisplayColors, outputDebug} from '../../public/node/output.js'
 import {execa, ExecaChildProcess} from 'execa'
 import which from 'which'
@@ -57,7 +58,9 @@ export async function captureOutput(command: string, args: string[], options?: E
 export async function exec(command: string, args: string[], options?: ExecOptions): Promise<void> {
   const commandProcess = buildExec(command, args, options)
 
-  if (options?.background) {
+  const runningOnWindows = platformAndArch().platform === 'windows'
+  if (options?.background && !runningOnWindows) {
+    // Detaching on Windows causes a new terminal to open
     commandProcess.unref()
   }
 

--- a/packages/cli/src/cli/services/commands/notifications.ts
+++ b/packages/cli/src/cli/services/commands/notifications.ts
@@ -6,6 +6,7 @@ import {
   Notification,
   stringifyFilters,
   getNotifications,
+  fetchNotifications,
 } from '@shopify/cli-kit/node/notifications-system'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 import {renderSelectPrompt, renderTextPrompt, renderSuccess, renderTable, TableColumn} from '@shopify/cli-kit/node/ui'
@@ -95,7 +96,7 @@ export async function generate() {
 }
 
 export async function list() {
-  const notifications: Notifications = await getNotifications()
+  const notifications = await fetchNotifications()
 
   const columns: TableColumn<{type: string; title: string; message: string; filters: string}> = {
     type: {header: 'Type', color: 'dim'},
@@ -107,7 +108,7 @@ export async function list() {
   const rows = notifications.notifications.map((notification: Notification) => {
     return {
       type: notification.type,
-      title: notification.title || '',
+      title: notification.title ?? '',
       message: notification.message,
       filters: stringifyFilters(notification),
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://app.bugsnag.com/shopify/cli/errors/673374fe41bcaf15edcf8ac7

> [!NOTE]
> There was a first attempt (https://github.com/Shopify/cli/pull/5020) reverted in https://github.com/Shopify/cli/pull/5234
> 
> The difference from the previous PR:
> - The process is run in background only for Mac/Linux, because in Windows it opens a new terminal window
> - The process is run at the beginning of the command (prerun) instead of the end (postrun), so most of the times the fetch will finish before the command itself.

We were fetching the notifications at the beginning of each command and caching the result for 1 hour. That approach has two disadvantages:
- When the network operation hangs or takes too long (the timeout is 3 seconds), the command has to wait with no feedback for the user ([error example](https://app.bugsnag.com/shopify/cli/errors/673374fe41bcaf15edcf8ac7?event_id=67407225010cf312ace50000&i=em&m=ea))
- If we want to send an urgent notification (like a downtime), we have to wait for the local cache to expire (up to 1 hour)

### WHAT is this pull request doing?

- Fetch the notifications in a detached process (except for Windows) that is run when the command starts, so the users don't have to wait, and save the result in the cache
- At the beginning of each command, we check the cache to show the required notifications

https://github.com/user-attachments/assets/ed9746d6-c2e2-4437-820d-5e764d6ff3b8

### How to test your changes?

Install the snapshot from this branch: `npm i -g @shopify/cli@0.0.0-snapshot-20250218132157 --@shopify:registry=https://registry.npmjs.org`

- `shopify cache clear`
- `shopify version` => the notifications are downloaded when the command finishes
- `shopify version` => notification should be shown
- `shopify version` => no more notifications

The cache in Mac is stored here: `~/Library/Preferences/shopify-cli-kit-nodejs/config.json`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
