### PR TITLE
Check for invalid node engine before running commands

### DIFF
--- a/packages/cli-kit/src/public/node/cli.test.ts
+++ b/packages/cli-kit/src/public/node/cli.test.ts
@@ -56,12 +56,13 @@ describe('cli', () => {
     expect(env.SHOPIFY_CLI_ENV).toBe('development')
   })
 
-  test('warns if running an old Node version', async () => {
+  test('exits if running an old Node version', async () => {
     const launchCLI = vi.fn()
     const outputMock = mockAndCaptureOutput()
-    await runCLI({moduleURL: 'test', development: false}, launchCLI, [], {}, {node: '17.9'} as any)
+    const run = runCLI({moduleURL: 'test', development: false}, launchCLI, [], {}, {node: '17.9'} as any)
+    await expect(run).rejects.toThrow()
     expect(outputMock.output()).toMatchInlineSnapshot(`
-      "╭─ warning ────────────────────────────────────────────────────────────────────╮
+      "╭─ error ──────────────────────────────────────────────────────────────────────╮
       │                                                                              │
       │  Upgrade to a supported Node version now.                                    │
       │                                                                              │

--- a/packages/cli-kit/src/public/node/cli.ts
+++ b/packages/cli-kit/src/public/node/cli.ts
@@ -15,14 +15,14 @@ interface RunCLIOptions {
   development: boolean
 }
 
-async function warnIfOldNodeVersion(versions: NodeJS.ProcessVersions = process.versions) {
+async function exitIfOldNodeVersion(versions: NodeJS.ProcessVersions = process.versions) {
   const nodeVersion = versions.node
   const nodeMajorVersion = Number(nodeVersion.split('.')[0])
 
   const currentSupportedNodeVersion = 18
   if (nodeMajorVersion < currentSupportedNodeVersion) {
-    const {renderWarning} = await import('./ui.js')
-    renderWarning({
+    const {renderError} = await import('./ui.js')
+    renderError({
       headline: 'Upgrade to a supported Node version now.',
       body: [
         `Node ${nodeMajorVersion} has reached end-of-life and poses security risks. When you upgrade to a`,
@@ -36,6 +36,7 @@ async function warnIfOldNodeVersion(versions: NodeJS.ProcessVersions = process.v
         "you'll be able to use Shopify CLI without interruption.",
       ],
     })
+    process.exit(1)
   }
 }
 
@@ -85,7 +86,7 @@ export async function runCLI(
     await addInitToArgvWhenRunningCreateCLI(options, argv)
   }
   forceNoColor(argv, env)
-  await warnIfOldNodeVersion(versions)
+  await exitIfOldNodeVersion(versions)
   return launchCLI({moduleURL: options.moduleURL})
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The CLI currently only warns users when running on an unsupported Node.js version. This can lead to potential security risks and compatibility issues if users continue using outdated versions.

### WHAT is this pull request doing?

Changes the behavior when detecting an old Node.js version from showing a warning to displaying an error and exiting the process. This enforces the requirement to use supported Node.js versions.

### How to test your changes?

Run `nvm use 16`. Run the CLI, confirm you see an error message and the CLI exits.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes