### PR TITLE
Improve manual release script

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -5,11 +5,11 @@ on:
     inputs:
       tag:
         description: 'Tag'
-        default: 'latest'
+        default: 'nightly'
         type: choice
         options:
-          - latest
           - nightly
+          - latest
           - experimental
 
 concurrency:
@@ -25,6 +25,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
+      contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/bin/release
+++ b/bin/release
@@ -4,7 +4,7 @@ tag=$1
 
 ## If no tag is provided, default to latest
 if [ -z "$tag" ]; then
-  tag="latest"
+  tag="nightly"
 fi
 
 if [ "$tag" != "latest" ] && [ "$tag" != "nightly" ] && [ "$tag" != "experimental" ]; then
@@ -36,8 +36,10 @@ node bin/create-cli-duplicate-package.js
 # Publish the packages
 pnpm changeset publish --tag $tag
 
+# if [ "$tag" = "latest" ]; then
 # Create a PR to update homebrew
 ./bin/package.js
 
 # Create a PR to update the docs
 ./bin/create-doc-pr.js
+# fi


### PR DESCRIPTION
### WHY are these changes introduced?

Updates the default release tag from "latest" to "nightly" and adds conditional logic for Homebrew and documentation updates.

### WHAT is this pull request doing?

- Changes the default release tag from "latest" to "nightly" in both the GitHub workflow and release script -> Safer to default to `nightly`
- Adds required permissions for contents and pull-requests in the GitHub workflow -> test to see if this is enough to open a PR in a private repo.
- Makes Homebrew and documentation PR creation conditional, only running when the tag is "latest"

### How to test your changes?

1. Trigger a manual release without specifying a tag to verify it defaults to "nightly"
2. Trigger a release with "latest" tag to verify Homebrew and documentation PRs are created
3. Trigger a release with "nightly" or "experimental" tags to verify no additional PRs are created

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes