### PR TITLE
[Themes] Improve instrumentation in theme profile service

### DIFF
--- a/packages/theme/src/cli/services/profile.ts
+++ b/packages/theme/src/cli/services/profile.ts
@@ -7,7 +7,7 @@ import {openURL} from '@shopify/cli-kit/node/system'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {writeFile, tempDirectory} from '@shopify/cli-kit/node/fs'
-import {outputInfo} from '@shopify/cli-kit/node/output'
+import {outputDebug, outputInfo} from '@shopify/cli-kit/node/output'
 
 export async function profile(
   adminSession: AdminSession,
@@ -50,6 +50,7 @@ export async function profile(
 async function openProfile(profileJson: string) {
   // Adapted from https://github.com/jlfwong/speedscope/blob/146477a8508a6d2da697cb0ea0a426ba81b3e8dc/bin/cli.js#L63
   let urlToOpen = await resolveAssetPath('speedscope', 'index.html')
+  outputDebug(`[Theme Profile] Resolved URL to open: ${urlToOpen}`)
 
   const filename = 'liquid-profile'
   const sourceBase64 = Buffer.from(profileJson).toString('base64')
@@ -57,15 +58,21 @@ async function openProfile(profileJson: string) {
 
   const filePrefix = `speedscope-${Number(new Date())}-${process.pid}`
   const jsPath = joinPath(tempDirectory(), `${filePrefix}.js`)
+  outputDebug(`[Theme Profile] writing JS file to: ${jsPath}`)
   await writeFile(jsPath, jsSource)
+  outputDebug(`[Theme Profile] JS file created successfully: ${jsPath}`)
   urlToOpen += `#localProfilePath=${jsPath}`
 
   // For some silly reason, the OS X open command ignores any query parameters or hash parameters
   // passed as part of the URL. To get around this weird issue, we'll create a local HTML file
   // that just redirects.
   const htmlPath = joinPath(tempDirectory(), `${filePrefix}.html`)
+  outputDebug(`[Theme Profile] writing HTML file to: ${htmlPath}`)
   await writeFile(htmlPath, `<script>window.location=${JSON.stringify(urlToOpen)}</script>`)
+  outputDebug(`[Theme Profile] HTML file created successfully: ${htmlPath}`)
 
   urlToOpen = `file://${htmlPath}`
-  await openURL(urlToOpen)
+  outputDebug(`[Theme Profile] Opening URL: ${urlToOpen}`)
+  const opened = await openURL(urlToOpen)
+  outputDebug(`[Theme Profile] URL opened successfully: ${opened}`)
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Improves logging / ability to debug issues with `theme profile`. This will help debug will `theme profile` is not working on WSL

Motivation: https://github.com/Shopify/cli/issues/5414

### WHAT is this pull request doing?
- Add debug logs to improve our visibility into the `theme profile` command

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
