### PR TITLE
Add a command to specify the extension preview port

### DIFF
--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -103,6 +103,11 @@ If you're using the Ruby app template, then you need to complete the following s
       description: 'Local port of the theme app extension development server.',
       env: 'SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT',
     }),
+    'previewable-extension-port': Flags.integer({
+      hidden: false,
+      description: 'Local port of the extension preview development server.',
+      env: 'SHOPIFY_FLAG_PREVIEWABLE_EXTENSION_PORT',
+    }),
     notify: Flags.string({
       description:
         'The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.',
@@ -174,6 +179,7 @@ If you're using the Ruby app template, then you need to complete the following s
       noTunnel: flags['no-tunnel'],
       theme: flags.theme,
       themeExtensionPort: flags['theme-app-extension-port'],
+      previewableExtensionPort: flags['previewable-extension-port'],
       notify: flags.notify,
       graphiqlPort: flags['graphiql-port'],
       graphiqlKey: flags['graphiql-key'],

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -64,6 +64,7 @@ export interface DevOptions {
   noTunnel: boolean
   theme?: string
   themeExtensionPort?: number
+  previewableExtensionPort?: number
   notify?: string
   graphiqlPort?: number
   graphiqlKey?: string
@@ -117,6 +118,8 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
   if (!commandOptions.skipDependenciesInstallation && !app.usesWorkspaces) {
     await installAppDependencies(app)
   }
+
+  const previewableExtensionPort = commandOptions.previewableExtensionPort ?? (await getAvailableTCPPort())
 
   const graphiqlPort = commandOptions.graphiqlPort ?? (await getAvailableTCPPort(ports.graphiql))
   const {graphiqlKey} = commandOptions
@@ -175,6 +178,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
     partnerUrlsUpdated,
     graphiqlPort,
     graphiqlKey,
+    previewableExtensionPort
   }
 }
 

--- a/packages/app/src/cli/services/dev/processes/previewable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/previewable-extension.ts
@@ -76,7 +76,7 @@ export async function setupPreviewableExtensionsProcess({
   storeFqdn,
   checkoutCartUrl,
   ...options
-}: Omit<PreviewableExtensionOptions, 'pathPrefix' | 'previewableExtensions' | 'port' | 'cartUrl'> & {
+}: Omit<PreviewableExtensionOptions, 'pathPrefix' | 'previewableExtensions' | 'cartUrl'> & {
   allExtensions: ExtensionInstance[]
   checkoutCartUrl?: string
 }): Promise<PreviewableExtensionProcess | undefined> {
@@ -90,7 +90,6 @@ export async function setupPreviewableExtensionsProcess({
     function: launchPreviewableExtensionProcess,
     options: {
       pathPrefix: '/extensions',
-      port: -1,
       storeFqdn,
       previewableExtensions,
       cartUrl,

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -62,6 +62,7 @@ export interface DevConfig {
   partnerUrlsUpdated: boolean
   graphiqlPort: number
   graphiqlKey?: string
+  previewableExtensionPort: number
 }
 
 export async function setupDevProcesses({
@@ -75,6 +76,7 @@ export async function setupDevProcesses({
   network,
   graphiqlPort,
   graphiqlKey,
+  previewableExtensionPort,
 }: DevConfig): Promise<{
   processes: DevProcesses
   previewUrl: string
@@ -138,6 +140,7 @@ export async function setupDevProcesses({
       appId: remoteApp.id,
       appDirectory: reloadedApp.directory,
       appWatcher,
+      port: previewableExtensionPort,
     }),
     developerPlatformClient.supportsDevSessions
       ? await setupDevSessionProcess({
@@ -224,9 +227,7 @@ async function setPortsAndAddProxyProcess(processes: DevProcesses, proxyPort: nu
         }
         process.options.port = targetPort
       } else if (process.type === 'previewable-extension') {
-        const targetPort = await getAvailableTCPPort()
-        rules[process.options.pathPrefix] = `http://localhost:${targetPort}`
-        process.options.port = targetPort
+        rules[process.options.pathPrefix] = `http://localhost:${process.options.port}`
       }
 
       return {process, rules}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5424

Unable to configure Nginx config for random port of extension preview server when developing in Devcontainer

### WHAT is this pull request doing?

Adds the `--previewable-extension-port` flag to the dev command by example `--theme-app-extension-port`

### How to test your changes?

1. Create an App Remix
2. Create at least one extension
3. Run the application via `dev` command with `--previewable-extension-port 8021`
4. Verify that extension preview is available on port 8021 (possibly proxied by nginx).

![image](https://github.com/user-attachments/assets/062c1617-3275-4b92-9932-ad1f5dfbd8a7)

### Post-release steps

You will need to edit the documentation about `dev` flags

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
