### PR TITLE
Remove unused args

### DIFF
--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -5,7 +5,7 @@ import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warning
 import {checkFolderIsValidApp} from '../../../models/app/loader.js'
 import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {linkedAppContext} from '../../../services/app-context.js'
-import {Args, Flags} from '@oclif/core'
+import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
 
@@ -60,10 +60,6 @@ export default class AppGenerateExtension extends AppCommand {
       env: 'SHOPIFY_FLAG_APP_API_KEY',
       exclusive: ['config'],
     }),
-  }
-
-  static args = {
-    file: Args.string(),
   }
 
   public static analyticsNameOverride(): string | undefined {

--- a/packages/app/src/cli/commands/app/versions/list.ts
+++ b/packages/app/src/cli/commands/app/versions/list.ts
@@ -4,7 +4,7 @@ import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warning
 import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {linkedAppContext} from '../../../services/app-context.js'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
-import {Args, Flags} from '@oclif/core'
+import {Flags} from '@oclif/core'
 
 export default class VersionsList extends AppCommand {
   static summary = 'List deployed versions of your app.'
@@ -25,10 +25,6 @@ export default class VersionsList extends AppCommand {
       env: 'SHOPIFY_FLAG_API_KEY',
       exclusive: ['config'],
     }),
-  }
-
-  static args = {
-    file: Args.string(),
   }
 
   public async run(): Promise<AppCommandOutput> {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,14 +12,14 @@
 * [`shopify app function run`](#shopify-app-function-run)
 * [`shopify app function schema`](#shopify-app-function-schema)
 * [`shopify app function typegen`](#shopify-app-function-typegen)
-* [`shopify app generate extension [FILE]`](#shopify-app-generate-extension-file)
+* [`shopify app generate extension`](#shopify-app-generate-extension)
 * [`shopify app import-extensions`](#shopify-app-import-extensions)
 * [`shopify app info`](#shopify-app-info)
 * [`shopify app init`](#shopify-app-init)
 * [`shopify app logs`](#shopify-app-logs)
 * [`shopify app logs sources`](#shopify-app-logs-sources)
 * [`shopify app:release --version <version>`](#shopify-apprelease---version-version)
-* [`shopify app versions list [FILE]`](#shopify-app-versions-list-file)
+* [`shopify app versions list`](#shopify-app-versions-list)
 * [`shopify app webhook trigger`](#shopify-app-webhook-trigger)
 * [`shopify auth logout`](#shopify-auth-logout)
 * [`shopify commands`](#shopify-commands)
@@ -454,13 +454,13 @@ DESCRIPTION
   function written in JavaScript.
 ```
 
-## `shopify app generate extension [FILE]`
+## `shopify app generate extension`
 
 Generate a new app Extension.
 
 ```
 USAGE
-  $ shopify app generate extension [FILE] [--client-id <value> | -c <value>] [--flavor
+  $ shopify app generate extension [--client-id <value> | -c <value>] [--flavor
     vanilla-js|react|typescript|typescript-react|wasm|rust] [-n <value>] [--no-color] [--path <value>] [--reset | ] [-t
     <value>] [-t <value>] [--verbose]
 
@@ -651,13 +651,13 @@ DESCRIPTION
   Releases an existing app version. Pass the name of the version that you want to release using the `--version` flag.
 ```
 
-## `shopify app versions list [FILE]`
+## `shopify app versions list`
 
 List deployed versions of your app.
 
 ```
 USAGE
-  $ shopify app versions list [FILE] [--client-id <value> | -c <value>] [-j] [--no-color] [--path <value>] [--reset | ]
+  $ shopify app versions list [--client-id <value> | -c <value>] [-j] [--no-color] [--path <value>] [--reset | ]
     [--verbose]
 
 FLAGS

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1237,9 +1237,6 @@
       "aliases": [
       ],
       "args": {
-        "file": {
-          "name": "file"
-        }
       },
       "customPluginName": "@shopify/app",
       "description": "Generates a new \"app extension\" (https://shopify.dev/docs/apps/app-extensions). For a list of app extensions that you can generate using this command, refer to \"Supported extensions\" (https://shopify.dev/docs/apps/structure/app-extensions/list).\n\n  Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure, refer to \"App structure\" (https://shopify.dev/docs/apps/tools/cli/structure) and the documentation for your extension.\n  ",
@@ -2080,9 +2077,6 @@
       "aliases": [
       ],
       "args": {
-        "file": {
-          "name": "file"
-        }
       },
       "customPluginName": "@shopify/app",
       "description": "Lists the deployed app versions. An app version is a snapshot of your app extensions.",


### PR DESCRIPTION
### WHY are these changes introduced?

A couple of commands have a `file` static argument, unused and undocumented: [app generate extension](https://github.com/Shopify/cli/blob/663aae197960a6848cb93a098906d83b69e5219e/packages/app/src/cli/commands/app/generate/extension.ts#L66), [app versions list](https://github.com/Shopify/cli/blob/663aae197960a6848cb93a098906d83b69e5219e/packages/app/src/cli/commands/app/versions/list.ts#L31)

### WHAT is this pull request doing?

Remove them

### How to test your changes?

- `p shopify app generate extension`
- `p shopify app generate extension --help`
- `p shopify app versions list`
- `p shopify app versions list --help`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
