### PR TITLE
Update mutation variables for AppCreate

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/create-app.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-app.ts
@@ -5,8 +5,7 @@ import {JsonMapType} from '@shopify/cli-kit/node/toml'
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
 export type CreateAppMutationVariables = Types.Exact<{
-  appSource: Types.AppSourceInput
-  name: Types.Scalars['String']['input']
+  initialVersion: Types.AppVersionInput
 }>
 
 export type CreateAppMutation = {
@@ -26,13 +25,8 @@ export const CreateApp = {
       variableDefinitions: [
         {
           kind: 'VariableDefinition',
-          variable: {kind: 'Variable', name: {kind: 'Name', value: 'appSource'}},
-          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'AppSourceInput'}}},
-        },
-        {
-          kind: 'VariableDefinition',
-          variable: {kind: 'Variable', name: {kind: 'Name', value: 'name'}},
-          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'initialVersion'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'AppVersionInput'}}},
         },
       ],
       selectionSet: {
@@ -44,13 +38,8 @@ export const CreateApp = {
             arguments: [
               {
                 kind: 'Argument',
-                name: {kind: 'Name', value: 'appSource'},
-                value: {kind: 'Variable', name: {kind: 'Name', value: 'appSource'}},
-              },
-              {
-                kind: 'Argument',
-                name: {kind: 'Name', value: 'name'},
-                value: {kind: 'Variable', name: {kind: 'Name', value: 'name'}},
+                name: {kind: 'Name', value: 'initialVersion'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'initialVersion'}},
               },
             ],
             selectionSet: {

--- a/packages/app/src/cli/api/graphql/app-management/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/types.d.ts
@@ -69,6 +69,14 @@ export type AppSourceInput = {
   assetsUrl?: InputMaybe<Scalars['URL']['input']>
 }
 
+/** The input fields used to create a new app version. */
+export type AppVersionInput = {
+  /** The manifest from which to create the app version. */
+  source?: InputMaybe<Scalars['JSON']['input']>
+  /** URL referencing the source from which to create the app version. */
+  sourceUrl?: InputMaybe<Scalars['URL']['input']>
+}
+
 /** Possible error codes that can be returned by AppManagement. */
 export type Code =
   /** Access denied. */

--- a/packages/app/src/cli/api/graphql/app-management/queries/create-app.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/create-app.graphql
@@ -1,5 +1,5 @@
-mutation CreateApp($appSource: AppSourceInput!, $name: String!) {
-  appCreate(appSource: $appSource, name: $name) {
+mutation CreateApp($initialVersion: AppVersionInput!) {
+  appCreate(initialVersion: $initialVersion) {
     app {
       id
       key

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -323,24 +323,21 @@ describe('createApp', () => {
 
     // Then
     expect(webhooksRequest).toHaveBeenCalledWith(org.id, expect.anything(), 'token', expect.any(Object))
-    expect(appManagementRequestDoc).toHaveBeenCalledWith(
-      org.id,
-      CreateApp,
-      'token',
-      expect.objectContaining({
-        appSource: {
-          appModules: expect.arrayContaining([
+    expect(appManagementRequestDoc).toHaveBeenCalledWith(org.id, CreateApp, 'token', {
+      initialVersion: {
+        source: {
+          name: 'app-name',
+          modules: expect.arrayContaining([
             {
               config: {
                 api_version: '2025-01',
               },
-              specificationIdentifier: 'webhooks',
-              uid: 'webhooks',
+              type: 'webhooks',
             },
           ]),
         },
-      }),
-    )
+      },
+    })
   })
 
   test('creates app successfully and returns expected app structure', async () => {


### PR DESCRIPTION
Per https://github.com/Shopify/temp-project-mover-megswim-20250605132259/issues/45, update the `AppCreate` mutation to use app manifests via the `AppVersionInput` object.

### WHY are these changes introduced?

We updated the API shape + need the CLI to follow suit.

### WHAT is this pull request doing?

Changing the `AppCreate` mutation to use `AppVersionInput` instead of `AppSourceInput`. Because the GraphQL interface specifies a very generic JSON type, Added the `AppVersionSource` interface to help ensure we're using the right data shape.

The alternative to `AppVersionSource` would be for the API to somehow advertise the expected shape of the `AppSource` manifest. Since this shape isn't expected to evolve over time, I feel that it's OK to hard-code into both sides of the API (as `AppVersionSource` in the CLI, and as `Source` in `shop/world`). But I could be convinced otherwise.

### How to test your changes?

If you can create an app, it's working: `p shopify app init` and then create a new app.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
