### PR TITLE
[Themes] Skip proxy fallback for known rendering requests

### DIFF
--- a/.changeset/great-clocks-dress.md
+++ b/.changeset/great-clocks-dress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix masking 404 errors as 200 when using Section Rendering API.

--- a/packages/theme/src/cli/utilities/theme-environment/html.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/html.ts
@@ -45,7 +45,7 @@ export function getHtmlHandler(theme: Theme, ctx: DevServerContext) {
       replaceTemplates: getInMemoryTemplates(ctx, browserPathname, getCookie(event, 'localization')?.toLowerCase()),
     })
       .then(async (response) => {
-        if (response.status >= 400 && response.status < 500) {
+        if (response.status >= 400 && response.status < 500 && !isKnownRenderingRequest(event)) {
           // We have tried to render a route that can't be handled by SFR.
           // Ideally, this should be caught by `canProxyRequest` in `proxy.ts`,
           // but we can't be certain for all cases (e.g. an arbitrary app's route).
@@ -103,6 +103,14 @@ function createErrorPageResponse(
     ...responseInit,
     headers: responseInit.headers ?? {'Content-Type': 'text/html; charset=utf-8'},
   })
+}
+
+/**
+ * Detects routes and params that indicate this request should be handled by SFR.
+ */
+function isKnownRenderingRequest(event: H3Event) {
+  const searchParams = new URLSearchParams(event.path.split('?')[1])
+  return ['section_id', 'sections', 'app_block_id'].some((key) => searchParams.has(key))
 }
 
 async function tryProxyRequest(event: H3Event, ctx: DevServerContext, response: Response) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Requests using Section Rendering API and such don't need the proxy fallback since we are sure they are supposed to go to SFR. This is a quick fix to make logs easier for an issue that @jamesmengo is debugging.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
