### PR TITLE
Fixed `shopify theme dev` to avoid emitting full page reload events when files are updated successfully

### DIFF
--- a/.changeset/wicked-cats-obey.md
+++ b/.changeset/wicked-cats-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fixed `shopify theme dev` to avoid emitting full page reload events when files are updated successfully, preventing conflicts with hot-reloading.


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/583

### WHAT is this pull request doing?

This PR updates the error overlay to only reload the page when there was an error being loaded.

### How to test your changes?

- Run `shopify theme dev`
- Update a section file
- Notice that hot-reloading works

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
