### PR TITLE
Improve examples for commands with static args II

### DIFF
--- a/docs-shopify.dev/commands/examples/app-config-use.example.sh
+++ b/docs-shopify.dev/commands/examples/app-config-use.example.sh
@@ -1,1 +1,1 @@
-shopify app config use [flags]
+app config use [config] [flags]

--- a/docs-shopify.dev/commands/examples/help.example.sh
+++ b/docs-shopify.dev/commands/examples/help.example.sh
@@ -1,1 +1,1 @@
-shopify help [flags]
+help [command] [flags]

--- a/docs-shopify.dev/commands/examples/search.example.sh
+++ b/docs-shopify.dev/commands/examples/search.example.sh
@@ -1,1 +1,1 @@
-shopify search
+search [query]

--- a/docs-shopify.dev/commands/examples/theme-init.example.sh
+++ b/docs-shopify.dev/commands/examples/theme-init.example.sh
@@ -1,1 +1,1 @@
-theme init [name]
+theme init [name] [flags]

--- a/docs-shopify.dev/generated/generated_docs_data.json
+++ b/docs-shopify.dev/generated/generated_docs_data.json
@@ -203,7 +203,7 @@
         "tabs": [
           {
             "title": "app config use",
-            "code": "shopify app config use [flags]",
+            "code": "app config use [config] [flags]",
             "language": "bash"
           }
         ],
@@ -2509,7 +2509,7 @@
         "tabs": [
           {
             "title": "help",
-            "code": "shopify help [flags]",
+            "code": "help [command] [flags]",
             "language": "bash"
           }
         ],
@@ -4554,7 +4554,7 @@
         "tabs": [
           {
             "title": "search",
-            "code": "shopify search",
+            "code": "search [query]",
             "language": "bash"
           }
         ],
@@ -5252,7 +5252,7 @@
         "tabs": [
           {
             "title": "theme init",
-            "code": "theme init [name]",
+            "code": "theme init [name] [flags]",
             "language": "bash"
           }
         ],

--- a/packages/app/src/cli/commands/app/config/use.ts
+++ b/packages/app/src/cli/commands/app/config/use.ts
@@ -17,6 +17,8 @@ export default class ConfigUse extends AppCommand {
 
   static description = this.descriptionWithoutMarkdown()
 
+  static usage = `app config use [config] [flags]`
+
   static flags = {
     ...globalFlags,
     ...appFlagsWithoutConfig,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 <!-- commands -->
 * [`shopify app build`](#shopify-app-build)
 * [`shopify app config link`](#shopify-app-config-link)
-* [`shopify app config use [CONFIG]`](#shopify-app-config-use-config)
+* [`shopify app config use [config] [flags]`](#shopify-app-config-use-config-flags)
 * [`shopify app deploy`](#shopify-app-deploy)
 * [`shopify app dev`](#shopify-app-dev)
 * [`shopify app env pull`](#shopify-app-env-pull)
@@ -26,7 +26,7 @@
 * [`shopify config autocorrect off`](#shopify-config-autocorrect-off)
 * [`shopify config autocorrect on`](#shopify-config-autocorrect-on)
 * [`shopify config autocorrect status`](#shopify-config-autocorrect-status)
-* [`shopify help [COMMAND]`](#shopify-help-command)
+* [`shopify help [command] [flags]`](#shopify-help-command-flags)
 * [`shopify hydrogen build`](#shopify-hydrogen-build)
 * [`shopify hydrogen check RESOURCE`](#shopify-hydrogen-check-resource)
 * [`shopify hydrogen codegen`](#shopify-hydrogen-codegen)
@@ -61,13 +61,13 @@
 * [`shopify plugins uninstall [PLUGIN]`](#shopify-plugins-uninstall-plugin)
 * [`shopify plugins unlink [PLUGIN]`](#shopify-plugins-unlink-plugin)
 * [`shopify plugins update`](#shopify-plugins-update)
-* [`shopify search [QUERY]`](#shopify-search-query)
+* [`shopify search [query]`](#shopify-search-query)
 * [`shopify theme check`](#shopify-theme-check)
 * [`shopify theme console`](#shopify-theme-console)
 * [`shopify theme delete`](#shopify-theme-delete)
 * [`shopify theme dev`](#shopify-theme-dev)
 * [`shopify theme info`](#shopify-theme-info)
-* [`shopify theme init [name]`](#shopify-theme-init-name)
+* [`shopify theme init [name] [flags]`](#shopify-theme-init-name-flags)
 * [`shopify theme language-server`](#shopify-theme-language-server)
 * [`shopify theme list`](#shopify-theme-list)
 * [`shopify theme metafields pull`](#shopify-theme-metafields-pull)
@@ -138,13 +138,13 @@ DESCRIPTION
   (https://shopify.dev/docs/apps/tools/cli/configuration) page.
 ```
 
-## `shopify app config use [CONFIG]`
+## `shopify app config use [config] [flags]`
 
 Activate an app configuration.
 
 ```
 USAGE
-  $ shopify app config use [CONFIG] [--client-id <value> | ] [--no-color] [--path <value>] [--reset | ] [--verbose]
+  $ shopify app config use [config] [flags]
 
 ARGUMENTS
   CONFIG  The name of the app configuration. Can be 'shopify.app.staging.toml' or simply 'staging'.
@@ -853,13 +853,13 @@ DESCRIPTION
   When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.
 ```
 
-## `shopify help [COMMAND]`
+## `shopify help [command] [flags]`
 
 Display help for Shopify CLI
 
 ```
 USAGE
-  $ shopify help [COMMAND...] [-n]
+  $ shopify help [command] [flags]
 
 ARGUMENTS
   COMMAND...  Command to show help for.
@@ -1673,13 +1673,13 @@ DESCRIPTION
   Update installed plugins.
 ```
 
-## `shopify search [QUERY]`
+## `shopify search [query]`
 
 Starts a search on shopify.dev.
 
 ```
 USAGE
-  $ shopify search [QUERY]
+  $ shopify search [query]
 
 DESCRIPTION
   Starts a search on shopify.dev.
@@ -1927,13 +1927,13 @@ DESCRIPTION
   specific theme.
 ```
 
-## `shopify theme init [name]`
+## `shopify theme init [name] [flags]`
 
 Clones a Git repository to use as a starting point for building a new theme.
 
 ```
 USAGE
-  $ shopify theme init [name]
+  $ shopify theme init [name] [flags]
 
 ARGUMENTS
   NAME  Name of the new theme

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -246,7 +246,8 @@
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Activate an app configuration."
+      "summary": "Activate an app configuration.",
+      "usage": "app config use [config] [flags]"
     },
     "app:deploy": {
       "aliases": [
@@ -2660,7 +2661,8 @@
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": false
+      "strict": false,
+      "usage": "help [command] [flags]"
     },
     "hydrogen:build": {
       "aliases": [
@@ -4780,7 +4782,8 @@
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "usage": "search [query]"
     },
     "theme:check": {
       "aliases": [
@@ -5448,7 +5451,7 @@
       "pluginType": "core",
       "strict": true,
       "summary": "Clones a Git repository to use as a starting point for building a new theme.",
-      "usage": "theme init [name]"
+      "usage": "theme init [name] [flags]"
     },
     "theme:language-server": {
       "aliases": [

--- a/packages/cli/src/cli/commands/help.ts
+++ b/packages/cli/src/cli/commands/help.ts
@@ -8,6 +8,8 @@ export default class HelpCommand extends Command {
 
   static description = 'Display help for Shopify CLI'
 
+  static usage = `help [command] [flags]`
+
   static flags = {
     'nested-commands': Flags.boolean({
       char: 'n',

--- a/packages/cli/src/cli/commands/search.ts
+++ b/packages/cli/src/cli/commands/search.ts
@@ -5,6 +5,8 @@ import {Args} from '@oclif/core'
 export default class Search extends Command {
   static description = 'Starts a search on shopify.dev.'
 
+  static usage = `search [query]`
+
   static examples = [
     `# open the search modal on Shopify.dev
     shopify search

--- a/packages/theme/src/cli/commands/theme/init.ts
+++ b/packages/theme/src/cli/commands/theme/init.ts
@@ -10,8 +10,6 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 export default class Init extends ThemeCommand {
   static summary = 'Clones a Git repository to use as a starting point for building a new theme.'
 
-  static usage = 'theme init [name]'
-
   static descriptionWithMarkdown = `Clones a Git repository to your local machine to use as the starting point for building a theme.
 
   If no Git repository is specified, then this command creates a copy of [Dawn](https://github.com/Shopify/dawn), Shopify's example theme, with the specified name in the current folder. If no name is provided, then you're prompted to enter one.
@@ -20,6 +18,8 @@ export default class Init extends ThemeCommand {
   `
 
   static description = this.descriptionWithoutMarkdown()
+
+  static usage = 'theme init [name] [flags]'
 
   static args = {
     name: Args.string({


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/5433 I tried to update the examples, but the files are auto-generated, so they were overwritten

### WHAT is this pull request doing?

Adds a `static usage` for the required commands and regenerate the documentation

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
