### PR TITLE
Update mutation variables for AppVersionCreate

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
@@ -6,8 +6,7 @@ import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/co
 
 export type CreateAppVersionMutationVariables = Types.Exact<{
   appId: Types.Scalars['ID']['input']
-  appSource: Types.AppSourceInput
-  name: Types.Scalars['String']['input']
+  version: Types.AppVersionInput
   metadata?: Types.InputMaybe<Types.VersionMetadataInput>
 }>
 
@@ -49,13 +48,8 @@ export const CreateAppVersion = {
         },
         {
           kind: 'VariableDefinition',
-          variable: {kind: 'Variable', name: {kind: 'Name', value: 'appSource'}},
-          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'AppSourceInput'}}},
-        },
-        {
-          kind: 'VariableDefinition',
-          variable: {kind: 'Variable', name: {kind: 'Name', value: 'name'}},
-          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'version'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'AppVersionInput'}}},
         },
         {
           kind: 'VariableDefinition',
@@ -77,13 +71,8 @@ export const CreateAppVersion = {
               },
               {
                 kind: 'Argument',
-                name: {kind: 'Name', value: 'appSource'},
-                value: {kind: 'Variable', name: {kind: 'Name', value: 'appSource'}},
-              },
-              {
-                kind: 'Argument',
-                name: {kind: 'Name', value: 'name'},
-                value: {kind: 'Variable', name: {kind: 'Name', value: 'name'}},
+                name: {kind: 'Name', value: 'version'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'version'}},
               },
               {
                 kind: 'Argument',

--- a/packages/app/src/cli/api/graphql/app-management/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/types.d.ts
@@ -47,28 +47,6 @@ export type Scalars = {
   URL: {input: string; output: string}
 }
 
-/** The input fields for an app module. */
-export type AppModuleInput = {
-  /** Configuration for the module. */
-  config: Scalars['JSON']['input']
-  /** Human-readable identifier for the module. */
-  handle?: InputMaybe<Scalars['String']['input']>
-  /** Identifier for the module's specification. */
-  specificationIdentifier: Scalars['String']['input']
-  /** The location where the module will be surfaced. */
-  target?: InputMaybe<Scalars['String']['input']>
-  /** User-specified identifier for the module, unique to the app. */
-  uid?: InputMaybe<Scalars['String']['input']>
-}
-
-/** The input fields for data and configuration that represent an app. */
-export type AppSourceInput = {
-  /** Modules that make up the app. */
-  appModules: AppModuleInput[]
-  /** URL for app assets. */
-  assetsUrl?: InputMaybe<Scalars['URL']['input']>
-}
-
 /** The input fields used to create a new app version. */
 export type AppVersionInput = {
   /** The manifest from which to create the app version. */

--- a/packages/app/src/cli/api/graphql/app-management/queries/create-app-version.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/create-app-version.graphql
@@ -1,5 +1,5 @@
-mutation CreateAppVersion($appId: ID!, $appSource: AppSourceInput!, $name: String!, $metadata: VersionMetadataInput) {
-  appVersionCreate(appId: $appId, appSource: $appSource, name: $name, metadata: $metadata) {
+mutation CreateAppVersion($appId: ID!, $version: AppVersionInput!, $metadata: VersionMetadataInput) {
+  appVersionCreate(appId: $appId, version: $version, metadata: $metadata) {
     version {
       id
       appModules {


### PR DESCRIPTION
### WHY are these changes introduced?

Following up to https://github.com/Shopify/cli/pull/5436 per [this issue](https://github.com/Shopify/develop-app-inner-loop/issues/2530). Per these issues, we've updated the API shape on the back-end and need to update the CLI to match.

### WHAT is this pull request doing?

This changes the `CreateAppVersion` GraphQL call to use the updated `AppVersionInput` data shape. I've also added an `AppVersionSourceWithUrl` interface to help to ensure that we're conforming to the API locally. See the [previous PR](https://github.com/Shopify/cli/pull/5436) for a brief discussion of that.

We also didn't have any tests for the `deploy` command, so I've added some.

### How to test your changes?

- `p shopify app init`
- `p shopify app deploy` - which will exercise the non-source-url branch
- `p shopify app generate extension` and pick e.g. Admin Action or another extension that uses assets.
- `p shopify app deploy` - which will exercise the source-url branch


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
