### PR TITLE
Add cron schedule for nightly releases via GH actions

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -1,6 +1,8 @@
-name: Release - Manual
+name: Release - Manual & Cron
 
 on:
+  schedule:
+    - cron: '0 6 * * *' # 6:00 AM UTC every day
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
### WHY are these changes introduced?

To automate the nightly release process by adding a daily scheduled trigger

### WHAT is this pull request doing?

Adds a daily scheduled trigger to the manual release workflow that runs at 6:00 AM UTC.

### How to test your changes?

1. Verify the cron syntax in the workflow file is correct: `0 6 * * *`
2. Monitor the workflow execution after merging to ensure it triggers at the specified time

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes