### PR TITLE
Controllable request behaviour

### DIFF
--- a/.changeset/two-bottles-dance.md
+++ b/.changeset/two-bottles-dance.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/app': minor
+---
+
+Automatic cancellation of slow network requests

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -10,7 +10,7 @@ import {
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppLogsSubscribeVariables} from '../../api/graphql/subscribe_to_app_logs.js'
 import {AppInterface} from '../../models/app/app.js'
-import {fetch, Response} from '@shopify/cli-kit/node/http'
+import {Response, shopifyFetch} from '@shopify/cli-kit/node/http'
 import {outputDebug, outputWarn} from '@shopify/cli-kit/node/output'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -131,10 +131,14 @@ export const fetchAppLogs = async (
     Authorization: `Bearer ${jwtToken}`,
     'User-Agent': userAgent,
   }
-  return fetch(url, {
-    method: 'GET',
-    headers,
-  })
+  return shopifyFetch(
+    url,
+    {
+      method: 'GET',
+      headers,
+    },
+    'non-blocking',
+  )
 }
 
 interface FetchAppLogsErrorOptions {

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -7,7 +7,7 @@ import {AppDeployOptions, AssetUrlSchema, DeveloperPlatformClient} from '../../u
 import {MinimalAppIdentifiers} from '../../models/organization.js'
 import {ExtensionUpdateDraftMutationVariables} from '../../api/graphql/partners/generated/update-draft.js'
 import {readFileSync} from '@shopify/cli-kit/node/fs'
-import {fetch, formData} from '@shopify/cli-kit/node/http'
+import {formData, fetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 import {AlertCustomSection, ListToken, TokenItem} from '@shopify/cli-kit/node/ui'
@@ -135,11 +135,15 @@ export async function uploadExtensionsBundle(
     const form = formData()
     const buffer = readFileSync(options.bundlePath)
     form.append('my_upload', buffer)
-    await fetch(signedURL, {
-      method: 'put',
-      body: buffer,
-      headers: form.getHeaders(),
-    })
+    await fetch(
+      signedURL,
+      {
+        method: 'put',
+        body: buffer,
+        headers: form.getHeaders(),
+      },
+      'slow-request',
+    )
   }
 
   const variables: AppDeployOptions = {

--- a/packages/app/src/cli/services/dev/processes/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session.ts
@@ -263,11 +263,15 @@ async function bundleExtensionsAndUpload(options: DevSessionProcessOptions): Pro
   const form = formData()
   const buffer = readFileSync(bundleZipPath)
   form.append('my_upload', buffer)
-  await fetch(signedURL, {
-    method: 'put',
-    body: buffer,
-    headers: form.getHeaders(),
-  })
+  await fetch(
+    signedURL,
+    {
+      method: 'put',
+      body: buffer,
+      headers: form.getHeaders(),
+    },
+    'slow-request',
+  )
 
   const payload: DevSessionPayload = {shopFqdn: options.storeFqdn, appId: options.appId, assetsUrl: signedURL}
 

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -183,7 +183,7 @@ export async function downloadBinary(bin: DownloadableBinary) {
   }
   await performActionWithRetryAfterRecovery(
     async () => {
-      const resp = await fetch(url)
+      const resp = await fetch(url, undefined, 'slow-request')
       if (resp.status !== 200) {
         throw new Error(`Downloading ${bin.name} failed with status code of ${resp.status}`)
       }

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -173,6 +173,7 @@
     "@types/semver": "^7.5.2",
     "@types/which": "3.0.4",
     "@vitest/coverage-istanbul": "^1.6.0",
+    "msw": "^2.7.1",
     "node-stream-zip": "^1.15.0",
     "ts-morph": "^17.0.1",
     "typedoc": "^0.27.6"

--- a/packages/cli-kit/src/private/node/api.test.ts
+++ b/packages/cli-kit/src/private/node/api.test.ts
@@ -64,13 +64,14 @@ describe('retryAwareRequest', () => {
       {
         request: mockRequestFn,
         url: 'https://example.com',
+        useNetworkLevelRetry: true,
+        maxRetryTimeMs: 10000,
       },
       undefined,
       undefined,
       {
         defaultDelayMs: 500,
         scheduleDelay: mockScheduleDelayFn,
-        enableNetworkLevelRetry: true,
       },
     )
     await vi.runAllTimersAsync()
@@ -113,13 +114,14 @@ describe('retryAwareRequest', () => {
       {
         request: mockRequestFn,
         url: 'https://example.com',
+        useNetworkLevelRetry: true,
+        maxRetryTimeMs: 10000,
       },
       undefined,
       undefined,
       {
         limitRetriesTo: 7,
         scheduleDelay: mockScheduleDelayFn,
-        enableNetworkLevelRetry: true,
       },
     )
 
@@ -160,12 +162,13 @@ describe('retryAwareRequest', () => {
       {
         request: mockRequestFn,
         url: 'https://example.com',
+        useNetworkLevelRetry: true,
+        maxRetryTimeMs: 10000,
       },
       undefined,
       mockUnauthorizedHandler,
       {
         scheduleDelay: vi.fn((fn) => fn()),
-        enableNetworkLevelRetry: true,
       },
     )
     await vi.runAllTimersAsync()
@@ -218,13 +221,14 @@ describe('retryAwareRequest', () => {
       {
         request: mockRequestFnEnabled,
         url: 'https://example.com',
+        useNetworkLevelRetry: true,
+        maxRetryTimeMs: 10000,
       },
       undefined,
       undefined,
       {
         defaultDelayMs: 500,
         scheduleDelay: mockScheduleDelayFn,
-        enableNetworkLevelRetry: true,
       },
     )
 
@@ -238,13 +242,13 @@ describe('retryAwareRequest', () => {
       {
         request: mockRequestFnDisabled,
         url: 'https://example.com',
+        useNetworkLevelRetry: false,
       },
       undefined,
       undefined,
       {
         defaultDelayMs: 500,
         scheduleDelay: mockScheduleDelayFn,
-        enableNetworkLevelRetry: false,
       },
     )
 

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -47,6 +47,7 @@ export const environmentVariables = {
   json: 'SHOPIFY_FLAG_JSON',
   neverUsePartnersApi: 'SHOPIFY_CLI_NEVER_USE_PARTNERS_API',
   skipNetworkLevelRetry: 'SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY',
+  maxRequestTimeForNetworkCalls: 'SHOPIFY_CLI_MAX_REQUEST_TIME_FOR_NETWORK_CALLS',
 }
 
 export const defaultThemeKitAccessDomain = 'theme-kit-access.shopifyapps.com'

--- a/packages/cli-kit/src/private/node/sleep-with-backoff.ts
+++ b/packages/cli-kit/src/private/node/sleep-with-backoff.ts
@@ -2,7 +2,7 @@ import {sleep} from '@shopify/cli-kit/node/system'
 
 const DEFAULT_RETRY_DELAY_MS = 300
 // 10 seconds default
-const DEFAULT_MAX_TIME_MS = 10000
+export const DEFAULT_MAX_TIME_MS = 10000
 
 interface BackoffResult {
   remainingMs: number

--- a/packages/cli-kit/src/public/node/api/admin.test.ts
+++ b/packages/cli-kit/src/public/node/api/admin.test.ts
@@ -99,7 +99,7 @@ describe('admin-rest-api', () => {
     const status = 200
     const headers = {'some-header': 123}
 
-    vi.spyOn(http, 'fetch').mockResolvedValue({
+    vi.spyOn(http, 'shopifyFetch').mockResolvedValue({
       json,
       status,
       headers: {raw: () => headers},
@@ -121,7 +121,7 @@ describe('admin-rest-api', () => {
     const headers = {'X-Shopify-Access-Token': `Bearer ${token}`, 'Content-Type': 'application/json'}
 
     vi.mocked(buildHeaders).mockReturnValue(headers)
-    const spyFetch = vi.spyOn(http, 'fetch').mockResolvedValue({
+    const spyFetch = vi.spyOn(http, 'shopifyFetch').mockResolvedValue({
       json,
       status,
       headers: {raw: () => ({})},
@@ -148,7 +148,7 @@ describe('admin-rest-api', () => {
     const headers = {'X-Shopify-Access-Token': `Bearer ${token}`, 'Content-Type': 'application/json'}
 
     vi.mocked(buildHeaders).mockReturnValue(headers)
-    const spyFetch = vi.spyOn(http, 'fetch').mockResolvedValue({
+    const spyFetch = vi.spyOn(http, 'shopifyFetch').mockResolvedValue({
       json: () => Promise.resolve({result: true}),
       status,
       headers: {raw: () => ({})},

--- a/packages/cli-kit/src/public/node/api/admin.ts
+++ b/packages/cli-kit/src/public/node/api/admin.ts
@@ -8,7 +8,7 @@ import {
   restRequestUrl,
   isThemeAccessSession,
 } from '../../../private/node/api/rest.js'
-import {fetch} from '../http.js'
+import {shopifyFetch} from '../http.js'
 import {PublicApiVersions} from '../../../cli/api/graphql/admin/generated/public_api_versions.js'
 import {normalizeStoreFqdn} from '../context/fqdn.js'
 import {themeKitAccessDomain} from '../../../private/node/constants.js'
@@ -192,7 +192,7 @@ export async function restRequest<T>(
   const body = restRequestBody<T>(requestBody)
 
   const headers = restRequestHeaders(session)
-  const response = await fetch(url, {
+  const response = await shopifyFetch(url, {
     headers,
     method,
     body,

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -98,8 +98,27 @@ export function blockPartnersAccess(): boolean {
  * If there is an error when calling a network API that looks like a DNS or connectivity issue, the CLI will by default
  * automatically retry the request.
  *
+ * @param environment - Process environment variables.
  * @returns True if the SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY environment variable is set.
  */
-export function skipNetworkLevelRetry(): boolean {
-  return isTruthy(getEnvironmentVariables()[environmentVariables.skipNetworkLevelRetry])
+export function skipNetworkLevelRetry(environment = getEnvironmentVariables()): boolean {
+  return isTruthy(environment[environmentVariables.skipNetworkLevelRetry])
+}
+
+/**
+ * Returns the default maximum request time for network calls in milliseconds.
+ *
+ * After this long, API requests may be cancelled by an AbortSignal. The limit can be overridden by setting the
+ * SHOPIFY_CLI_MAX_REQUEST_TIME_FOR_NETWORK_CALLS environment variable.
+ *
+ * @param environment - Process environment variables.
+ * @returns The maximum request time in milliseconds.
+ */
+export function maxRequestTimeForNetworkCallsMs(environment = getEnvironmentVariables()): number {
+  const maxRequestTime = environment[environmentVariables.maxRequestTimeForNetworkCalls]
+  if (maxRequestTime && !isNaN(Number(maxRequestTime))) {
+    return Number(maxRequestTime)
+  }
+  // 15 seconds is the default
+  return 15 * 1000
 }

--- a/packages/cli-kit/src/public/node/http.test.ts
+++ b/packages/cli-kit/src/public/node/http.test.ts
@@ -1,28 +1,219 @@
+import {downloadFile, shopifyFetch, formData, requestMode, fetch} from './http.js'
+import {mockAndCaptureOutput} from './testing/output.js'
 import {fileExists, inTemporaryDirectory, readFile} from './fs.js'
-import {downloadFile} from './http.js'
 import {joinPath} from './path.js'
-import {describe, expect, test, vi} from 'vitest'
-import nodeFetch, {Response} from 'node-fetch'
-import {Readable} from 'stream'
+import {getAllPublicMetadata} from './metadata.js'
+import {platformAndArch} from './os.js'
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi} from 'vitest'
+import {setupServer} from 'msw/node'
+import {delay, http, HttpResponse} from 'msw'
+import FormData from 'form-data'
 
-vi.mock('node-fetch', async () => {
-  const actual: any = await vi.importActual('node-fetch')
-  return {
-    ...actual,
-    default: vi.fn(),
-  }
+const DURATION_UNTIL_ABORT_IS_SEEN = 100
+
+const mockResponse = {hello: 'world!'}
+
+const handlers = [
+  http.get('https://shopify.example/working', () => {
+    return HttpResponse.json(mockResponse)
+  }),
+  http.get('https://shopify.example/a-slow-endpoint', async () => {
+    await delay(500)
+    return HttpResponse.json(mockResponse)
+  }),
+  http.get('https://shopify.example/a-blocked-endpoint', async () => {
+    await delay('infinite')
+    return HttpResponse.json(mockResponse)
+  }),
+  http.get('https://shopify.example/example.txt', async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder()
+        controller.enqueue(encoder.encode('Hello '))
+        controller.enqueue(encoder.encode('world'))
+        controller.close()
+      },
+    })
+    return new HttpResponse(stream, {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    })
+  }),
+  http.get('https://shopify.example/fails-to-download.txt', async () => {
+    return HttpResponse.error()
+  }),
+]
+
+// set up the server & clean-up
+const server = setupServer(...handlers)
+beforeAll(() => server.listen({onUnhandledRequest: 'error'}))
+afterAll(() => server.close())
+afterEach(() => {
+  server.resetHandlers()
+  server.events.removeAllListeners()
+})
+
+// set-up fake timers & clean-up
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('formData', () => {
+  test('make an empty form data object', () => {
+    const res = formData()
+    expect(res).toBeInstanceOf(FormData)
+    expect(res.getLengthSync()).toBe(0)
+  })
+})
+
+describe('shopifyFetch', () => {
+  test('make a successful request', async () => {
+    const mockOutput = mockAndCaptureOutput()
+    mockOutput.clear()
+    const response = shopifyFetch(`https://shopify.example/working?token=secret`)
+    await vi.runAllTimersAsync()
+    await expect(response).resolves.toBeDefined()
+
+    const realResponse = await response
+
+    expect(realResponse.status).toBe(200)
+    await expect(realResponse.json()).resolves.toEqual(mockResponse)
+
+    // NB: snapshot is not an option as the output is dynamic due to the completion time; fake timers don't cover performance.now()
+    expect(mockOutput.debug()).toContain(`Sending GET request to URL https://shopify.example/working?token=****`)
+    expect(mockOutput.debug()).toContain(`Request to https://shopify.example/working?token=**** completed in `)
+
+    const metadata = getAllPublicMetadata()
+    expect(metadata.cmd_all_timing_network_ms).toBeGreaterThan(0)
+  })
+
+  test('sets an abort signal by default', async () => {
+    const failing = shopifyFetch(`https://shopify.example/a-slow-endpoint`, undefined, {
+      useNetworkLevelRetry: false,
+      useAbortSignal: true,
+      timeoutMs: DURATION_UNTIL_ABORT_IS_SEEN,
+    })
+    await vi.advanceTimersByTimeAsync(DURATION_UNTIL_ABORT_IS_SEEN)
+
+    await expect(failing).rejects.toThrow('The operation was aborted.')
+  })
+
+  test('abort signal is seen as a retryable error', async () => {
+    // this test is complex with faked timers as we have the abort signal, the delay in response, and the retry logic
+    // all competing to run at the same time. so: we use real timers and some adjusted limits -- the test takes 500ms.
+    vi.useRealTimers()
+
+    const requests: string[] = []
+    server.events.on('request:start', ({request}) => {
+      requests.push(request.url)
+    })
+
+    // the limit is 1100ms, which is enough for two retries plus maximum slack (e.g. running in a slow environment)
+    const failingWithRetry = shopifyFetch(`https://shopify.example/a-blocked-endpoint`, undefined, {
+      useNetworkLevelRetry: true,
+      maxRetryTimeMs: 1100,
+      useAbortSignal: true,
+      timeoutMs: DURATION_UNTIL_ABORT_IS_SEEN,
+    })
+    await expect(failingWithRetry).rejects.toThrow('The operation was aborted.')
+
+    // we have enough time for two requests in our 500ms allowance:
+    // - we make a request
+    // - we give it 100ms before the abort signal is seen
+    // - we wait 300ms before a retry
+    // - we retry the request
+    // - there's 100ms before the abort signal is seen
+    // - the next delay would be 600ms
+    // - the next delay would take us over our 1100ms allowance, so retries are stopped
+    expect(requests).toEqual([
+      'https://shopify.example/a-blocked-endpoint',
+      'https://shopify.example/a-blocked-endpoint',
+    ])
+  })
+
+  test('provide an abort signal through a factory function', async () => {
+    const signalFn = () => AbortSignal.timeout(DURATION_UNTIL_ABORT_IS_SEEN)
+    const response = shopifyFetch(`https://shopify.example/a-slow-endpoint`, undefined, {
+      useNetworkLevelRetry: false,
+      useAbortSignal: signalFn,
+    })
+    await vi.advanceTimersByTimeAsync(DURATION_UNTIL_ABORT_IS_SEEN)
+
+    await expect(response).rejects.toThrow('The operation was aborted.')
+  })
+
+  test('provide a hard-coded abort signal', async () => {
+    const signalFn = AbortSignal.timeout(DURATION_UNTIL_ABORT_IS_SEEN)
+    const response = shopifyFetch(`https://shopify.example/a-slow-endpoint`, undefined, {
+      useNetworkLevelRetry: false,
+      useAbortSignal: signalFn,
+    })
+    await vi.advanceTimersByTimeAsync(DURATION_UNTIL_ABORT_IS_SEEN)
+
+    await expect(response).rejects.toThrow('The operation was aborted.')
+  })
+
+  test('provide an abort signal through request init option', async () => {
+    const signalFn = AbortSignal.timeout(DURATION_UNTIL_ABORT_IS_SEEN)
+    const response = shopifyFetch(
+      `https://shopify.example/a-slow-endpoint`,
+      {
+        signal: signalFn,
+      },
+      {
+        useNetworkLevelRetry: false,
+        useAbortSignal: false,
+      },
+    )
+    await vi.advanceTimersByTimeAsync(DURATION_UNTIL_ABORT_IS_SEEN)
+
+    await expect(response).rejects.toThrow('The operation was aborted.')
+  })
+})
+
+describe('fetch', () => {
+  test('make a successful request', async () => {
+    const mockOutput = mockAndCaptureOutput()
+    mockOutput.clear()
+    const response = fetch(`https://shopify.example/working?token=secret`)
+    await vi.runAllTimersAsync()
+    await expect(response).resolves.toBeDefined()
+
+    const realResponse = await response
+
+    expect(realResponse.status).toBe(200)
+    await expect(realResponse.json()).resolves.toEqual(mockResponse)
+
+    // plain fetch doesn't have the same debug output
+    expect(mockOutput.debug()).not.toContain(`Sending GET request to URL https://shopify.example/working`)
+    expect(mockOutput.debug()).toContain(`Request to https://shopify.example/working?token=**** completed in `)
+
+    const metadata = getAllPublicMetadata()
+    expect(metadata.cmd_all_timing_network_ms).toBeGreaterThan(0)
+  })
+
+  test('no abort signal by default', async () => {
+    const completes = fetch(`https://shopify.example/a-slow-endpoint`)
+
+    // unlike shopifyFetch, the abort signal won't interrupt the request
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(completes).resolves.toBeDefined()
+  })
 })
 
 describe('downloadFile', () => {
   test('Downloads a file from a URL to a local path', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
-      const url = 'https://example.com'
+      const url = 'https://shopify.example/example.txt'
       const filename = '/bin/example.txt'
       const to = joinPath(tmpDir, filename)
-      const response = new Response(Readable.from('Hello world'))
-
-      vi.mocked(nodeFetch).mockResolvedValue(response)
 
       // When
       const result = await downloadFile(url, to)
@@ -33,6 +224,106 @@ describe('downloadFile', () => {
       expect(result).toBe(to)
       expect(exists).toBe(true)
       expect(contents).toBe('Hello world')
+    })
+  })
+
+  const runningOnWindows = platformAndArch().platform === 'windows'
+
+  test.skipIf(runningOnWindows)('Cleans up if download fails', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const url = 'https://shopify.example/fails-to-download.txt'
+      const filename = '/bin/fails-to-download.txt'
+      const to = joinPath(tmpDir, filename)
+
+      // When
+      const result = downloadFile(url, to)
+
+      await expect(result).rejects.toThrow('Network error')
+
+      // no file if download fails
+      await expect(fileExists(to)).resolves.toBe(false)
+    })
+  })
+})
+
+describe('requestMode', () => {
+  const mockedEnv = {
+    SHOPIFY_CLI_MAX_REQUEST_TIME_FOR_NETWORK_CALLS: DURATION_UNTIL_ABORT_IS_SEEN.toString(),
+    SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY: 'false',
+  }
+
+  test('no preference uses default', () => {
+    const expected = {
+      useNetworkLevelRetry: true,
+      useAbortSignal: true,
+      timeoutMs: 100,
+      maxRetryTimeMs: 10000,
+    }
+    expect(requestMode(undefined, mockedEnv)).toEqual(expected)
+    expect(requestMode('default', mockedEnv)).toEqual(expected)
+  })
+
+  test('non-blocking requests', () => {
+    expect(requestMode('non-blocking', mockedEnv)).toEqual({
+      useNetworkLevelRetry: false,
+      useAbortSignal: true,
+      timeoutMs: 100,
+    })
+  })
+
+  test('slow-request requests', () => {
+    expect(requestMode('slow-request', mockedEnv)).toEqual({
+      useNetworkLevelRetry: false,
+      useAbortSignal: false,
+    })
+  })
+
+  test('default, with networkLevelRetry disabled', () => {
+    expect(
+      requestMode('default', {
+        ...mockedEnv,
+        SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY: 'true',
+      }),
+    ).toMatchObject({
+      useNetworkLevelRetry: false,
+      useAbortSignal: true,
+      timeoutMs: 100,
+    })
+  })
+
+  test('custom behaviour', () => {
+    expect(
+      requestMode({
+        useNetworkLevelRetry: false,
+        useAbortSignal: true,
+        timeoutMs: 100,
+      }),
+    ).toEqual({
+      useNetworkLevelRetry: false,
+      useAbortSignal: true,
+      timeoutMs: 100,
+    })
+  })
+
+  test('custom behaviour, with networkLevelRetry disabled', () => {
+    expect(
+      requestMode(
+        {
+          useNetworkLevelRetry: true,
+          maxRetryTimeMs: 10000,
+          useAbortSignal: true,
+          timeoutMs: 100,
+        },
+        {
+          ...mockedEnv,
+          SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY: 'true',
+        },
+      ),
+    ).toMatchObject({
+      useNetworkLevelRetry: false,
+      useAbortSignal: true,
+      timeoutMs: 100,
     })
   })
 })

--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -2,10 +2,12 @@
 import {dirname} from './path.js'
 import {createFileWriteStream, fileExistsSync, mkdirSync, unlinkFileSync} from './fs.js'
 import {runWithTimer} from './metadata.js'
-import {buildHeaders, httpsAgent, sanitizedHeadersOutput} from '../../private/node/api/headers.js'
+import {maxRequestTimeForNetworkCallsMs, skipNetworkLevelRetry} from './environment.js'
+import {httpsAgent, sanitizedHeadersOutput} from '../../private/node/api/headers.js'
 import {sanitizeURL} from '../../private/node/api/urls.js'
-import {outputContent, outputDebug} from '../../public/node/output.js'
-import {simpleRequestWithDebugLog} from '../../private/node/api.js'
+import {outputContent, outputDebug, outputToken} from '../../public/node/output.js'
+import {NetworkRetryBehaviour, simpleRequestWithDebugLog} from '../../private/node/api.js'
+import {DEFAULT_MAX_TIME_MS} from '../../private/node/sleep-with-backoff.js'
 import FormData from 'form-data'
 import nodeFetch, {RequestInfo, RequestInit, Response} from 'node-fetch'
 
@@ -20,6 +22,135 @@ export function formData(): FormData {
   return new FormData()
 }
 
+type AbortSignal = RequestInit['signal']
+
+type PresetFetchBehaviour = 'default' | 'non-blocking' | 'slow-request'
+
+type AutomaticCancellationBehaviour =
+  | {
+      useAbortSignal: true
+      timeoutMs: number
+    }
+  | {
+      useAbortSignal: false
+    }
+  | {
+      useAbortSignal: AbortSignal | (() => AbortSignal)
+    }
+
+type RequestBehaviour = NetworkRetryBehaviour & AutomaticCancellationBehaviour
+
+type RequestModeInput = PresetFetchBehaviour | RequestBehaviour
+
+/**
+ * Specify the behaviour of a network request.
+ *
+ * - default: Requests are automatically retried, and are subject to automatic cancellation if they're taking too long.
+ * This is generally desirable.
+ * - non-blocking: Requests are not retried if they fail with a network error, and are automatically cancelled if
+ * they're taking too long. This is good for throwaway requests, like polling or tracking.
+ * - slow-request: Requests are not retried if they fail with a network error, and are not automatically cancelled.
+ * This is good for slow requests that should be give the chance to complete, and are unlikely to be safe to retry.
+ *
+ * Some request behaviours may be de-activated by the environment, and this function takes care of that concern. You
+ * can also provide a customised request behaviour.
+ *
+ * @param preset - The preset to use.
+ * @param env - Process environment variables.
+ * @returns A request behaviour object.
+ */
+export function requestMode(
+  preset: RequestModeInput = 'default',
+  env: NodeJS.ProcessEnv = process.env,
+): RequestBehaviour {
+  const networkLevelRetryIsSupported = !skipNetworkLevelRetry(env)
+  switch (preset) {
+    case 'default':
+      return {
+        useNetworkLevelRetry: networkLevelRetryIsSupported,
+        maxRetryTimeMs: DEFAULT_MAX_TIME_MS,
+        useAbortSignal: true,
+        timeoutMs: maxRequestTimeForNetworkCallsMs(env),
+      }
+    case 'non-blocking':
+      return {
+        useNetworkLevelRetry: false,
+        useAbortSignal: true,
+        timeoutMs: maxRequestTimeForNetworkCallsMs(env),
+      }
+    case 'slow-request':
+      return {
+        useNetworkLevelRetry: false,
+        useAbortSignal: false,
+      }
+  }
+  return {
+    ...preset,
+    useNetworkLevelRetry: networkLevelRetryIsSupported && preset.useNetworkLevelRetry,
+  } as RequestBehaviour
+}
+
+interface FetchOptions {
+  url: RequestInfo
+  behaviour: RequestBehaviour
+  init?: RequestInit
+  logRequest: boolean
+  useHttpsAgent: boolean
+}
+
+/**
+ * Create an AbortSignal for automatic request cancellation, from a request behaviour.
+ *
+ * @param behaviour - The request behaviour.
+ * @returns An AbortSignal.
+ */
+export function abortSignalFromRequestBehaviour(behaviour: RequestBehaviour): AbortSignal {
+  let signal: AbortSignal
+  if (behaviour.useAbortSignal === true) {
+    signal = AbortSignal.timeout(behaviour.timeoutMs)
+  } else if (behaviour.useAbortSignal && typeof behaviour.useAbortSignal === 'function') {
+    signal = behaviour.useAbortSignal()
+  } else if (behaviour.useAbortSignal) {
+    signal = behaviour.useAbortSignal
+  }
+  return signal
+}
+
+async function innerFetch({url, behaviour, init, logRequest, useHttpsAgent}: FetchOptions): Promise<Response> {
+  if (logRequest) {
+    outputDebug(outputContent`Sending ${init?.method ?? 'GET'} request to URL ${sanitizeURL(url.toString())}
+With request headers:
+${sanitizedHeadersOutput((init?.headers ?? {}) as {[header: string]: string})}
+`)
+  }
+
+  let agent: RequestInit['agent']
+  if (useHttpsAgent) {
+    agent = await httpsAgent()
+  }
+
+  const request = async () => {
+    // each time we make the request, we need to potentially reset the abort signal, as the request logic may make
+    // the same request multiple times.
+    let signal = abortSignalFromRequestBehaviour(behaviour)
+
+    // it's possible to provide a signal through the request's init structure.
+    if (init?.signal) {
+      signal = init.signal
+    }
+
+    return nodeFetch(url, {...init, agent, signal})
+  }
+
+  return runWithTimer('cmd_all_timing_network_ms')(async () => {
+    return simpleRequestWithDebugLog({
+      url: url.toString(),
+      request,
+      ...behaviour,
+    })
+  })
+}
+
 /**
  * An interface that abstracts way node-fetch. When Node has built-in
  * support for "fetch" in the standard library, we can drop the node-fetch
@@ -28,45 +159,58 @@ export function formData(): FormData {
  * they are consistent with the Web API so if we drop node-fetch in the future
  * it won't require changes from the callers.
  *
+ * The CLI's fetch function supports special behaviours, like automatic retries. These are disabled by default through
+ * this function.
+ *
  * @param url - This defines the resource that you wish to fetch.
  * @param init - An object containing any custom settings that you want to apply to the request.
+ * @param preferredBehaviour - A request behaviour object that overrides the default behaviour.
  * @returns A promise that resolves with the response.
  */
-export async function fetch(url: RequestInfo, init?: RequestInit): Promise<Response> {
-  return runWithTimer('cmd_all_timing_network_ms')(() =>
-    simpleRequestWithDebugLog({url: url.toString(), request: () => nodeFetch(url, init)}),
-  )
+export async function fetch(
+  url: RequestInfo,
+  init?: RequestInit,
+  preferredBehaviour?: RequestModeInput,
+): Promise<Response> {
+  const options = {
+    url,
+    init,
+    logRequest: false,
+    useHttpsAgent: false,
+    // all special behaviours are disabled by default
+    behaviour: preferredBehaviour ? requestMode(preferredBehaviour) : requestMode('non-blocking'),
+  } as const
+
+  return innerFetch(options)
 }
 
 /**
  * A fetch function to use with Shopify services. The function ensures the right
  * TLS configuragion is used based on the environment in which the service is running
- * (e.g. Spin).
+ * (e.g. Spin). NB: headers/auth are the responsibility of the caller.
+ *
+ * By default, the CLI's fetch function's special behaviours, like automatic retries, are enabled.
  *
  * @param url - This defines the resource that you wish to fetch.
  * @param init - An object containing any custom settings that you want to apply to the request.
+ * @param preferredBehaviour - A request behaviour object that overrides the default behaviour.
  * @returns A promise that resolves with the response.
  */
-export async function shopifyFetch(url: RequestInfo, init?: RequestInit): Promise<Response> {
-  const sanitizedUrl = sanitizeURL(url.toString())
-  const options: RequestInit = {
-    ...(init ?? {}),
-    headers: {
-      ...(await buildHeaders()),
-      ...(init?.headers ?? {}),
-    },
+export async function shopifyFetch(
+  url: RequestInfo,
+  init?: RequestInit,
+  preferredBehaviour?: RequestModeInput,
+): Promise<Response> {
+  const options = {
+    url,
+    init,
+    logRequest: true,
+    useHttpsAgent: true,
+    // special behaviours enabled by default
+    behaviour: preferredBehaviour ? requestMode(preferredBehaviour) : requestMode(),
   }
 
-  outputDebug(outputContent`Sending ${options.method ?? 'GET'} request to URL ${sanitizedUrl}
-With request headers:
-${sanitizedHeadersOutput((options.headers ?? {}) as {[header: string]: string})}
-`)
-  return runWithTimer('cmd_all_timing_network_ms')(async () => {
-    return simpleRequestWithDebugLog({
-      url: url.toString(),
-      request: async () => nodeFetch(url, {...init, agent: await httpsAgent()}),
-    })
-  })
+  return innerFetch(options)
 }
 
 /**
@@ -88,13 +232,23 @@ export function downloadFile(url: string, to: string): Promise<string> {
 
       const file = createFileWriteStream(to)
 
+      // if we can't remove the file for some reason (seen on windows), that's ok -- it's in a temporary directory
+      const tryToRemoveFile = () => {
+        try {
+          unlinkFileSync(to)
+          // eslint-disable-next-line no-catch-all/no-catch-all, @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+          outputDebug(outputContent`Failed to remove file ${outputToken.path(to)}: ${err}`)
+        }
+      }
+
       file.on('finish', () => {
         file.close()
         resolve(to)
       })
 
       file.on('error', (err) => {
-        unlinkFileSync(to)
+        tryToRemoveFile()
         reject(err)
       })
 
@@ -103,7 +257,7 @@ export function downloadFile(url: string, to: string): Promise<string> {
           res.body?.pipe(file)
         })
         .catch((err) => {
-          unlinkFileSync(to)
+          tryToRemoveFile()
           reject(err)
         })
     })

--- a/packages/cli-kit/src/public/node/monorail.test.ts
+++ b/packages/cli-kit/src/public/node/monorail.test.ts
@@ -34,11 +34,15 @@ describe('monorail', () => {
   test('builds a request', async () => {
     const res = await publishMonorailEvent('fake_schema/0.0', {foo: 'bar'}, {baz: 'abc'})
     expect(res.type).toEqual('ok')
-    expect(http.fetch).toHaveBeenCalledWith(expectedURL, {
-      method: 'POST',
-      body: JSON.stringify({schema_id: 'fake_schema/0.0', payload: {foo: 'bar', baz: 'abc'}}),
-      headers: expectedHeaders,
-    })
+    expect(http.fetch).toHaveBeenCalledWith(
+      expectedURL,
+      {
+        method: 'POST',
+        body: JSON.stringify({schema_id: 'fake_schema/0.0', payload: {foo: 'bar', baz: 'abc'}}),
+        headers: expectedHeaders,
+      },
+      'non-blocking',
+    )
   })
 
   test('sanitizes the api_key from the debug log', async () => {

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -200,7 +200,7 @@ export async function publishMonorailEvent<TSchemaId extends keyof Schemas, TPay
     const body = JSON.stringify({schema_id: schemaId, payload})
     const headers = buildHeaders(currentTime)
 
-    const response = await fetch(url, {method: 'POST', body, headers})
+    const response = await fetch(url, {method: 'POST', body, headers}, 'non-blocking')
 
     if (response.status === 200) {
       outputDebug(outputContent`Analytics event sent: ${outputToken.json(sanitizePayload(payload))}`)

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -127,8 +127,12 @@ export async function getNotifications(): Promise<Notifications> {
  * @returns A string with the notifications.
  */
 export async function fetchNotifications(): Promise<Notifications> {
-  outputDebug(`Fetching  notifications...`)
-  const response = await fetch(url(), {signal: AbortSignal.timeout(3 * 1000)})
+  outputDebug(`Fetching notifications...`)
+  const response = await fetch(url(), undefined, {
+    useNetworkLevelRetry: false,
+    useAbortSignal: true,
+    timeoutMs: 3 * 1000,
+  })
   if (response.status !== 200) throw new Error(`Failed to fetch notifications: ${response.statusText}`)
   const rawNotifications = await response.text()
   const notifications: object = JSON.parse(rawNotifications)

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -5,7 +5,7 @@ import {
   ShopifyEssentialError,
 } from './storefront-session.js'
 import {describe, expect, test, vi} from 'vitest'
-import {fetch} from '@shopify/cli-kit/node/http'
+import {shopifyFetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {passwordProtected} from '@shopify/cli-kit/node/themes/api'
 import {type AdminSession} from '@shopify/cli-kit/node/session'
@@ -36,7 +36,7 @@ describe('Storefront API', () => {
   describe('getStorefrontSessionCookies', () => {
     test('retrieves only _shopify_essential cookie when no password is provided', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValueOnce(
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 200,
           headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
@@ -52,7 +52,7 @@ describe('Storefront API', () => {
 
     test('retrieves _shopify_essential and storefront_digest cookies when a password is provided', async () => {
       // Given
-      vi.mocked(fetch)
+      vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
             status: 200,
@@ -75,7 +75,7 @@ describe('Storefront API', () => {
 
     test(`throws an ShopifyEssentialError when _shopify_essential can't be defined`, async () => {
       // Given
-      vi.mocked(fetch)
+      vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
             status: 200,
@@ -104,7 +104,7 @@ describe('Storefront API', () => {
 
     test('throws an error when the password is wrong', async () => {
       // Given
-      vi.mocked(fetch)
+      vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
             status: 200,
@@ -155,7 +155,7 @@ describe('Storefront API', () => {
   describe('isStorefrontPasswordCorrect', () => {
     test('returns true when the password is correct', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValueOnce(
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 302,
           headers: {
@@ -169,7 +169,7 @@ describe('Storefront API', () => {
 
       // Then
       expect(result).toBe(true)
-      expect(fetch).toBeCalledWith('https://store.myshopify.com/password', {
+      expect(shopifyFetch).toBeCalledWith('https://store.myshopify.com/password', {
         body: 'form_type=storefront_password&utf8=%E2%9C%93&password=correct-password-%26',
         headers: {
           'cache-control': 'no-cache',
@@ -182,7 +182,7 @@ describe('Storefront API', () => {
 
     test('returns true when the password is correct and the store redirects to a localized URL', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValueOnce(
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 302,
           headers: {
@@ -200,7 +200,7 @@ describe('Storefront API', () => {
 
     test('returns true when the password is correct and the store name is capitalized', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValueOnce(
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 302,
           headers: {
@@ -214,7 +214,7 @@ describe('Storefront API', () => {
 
       // Then
       expect(result).toBe(true)
-      expect(fetch).toBeCalledWith('https://Store.myshopify.com/password', {
+      expect(shopifyFetch).toBeCalledWith('https://Store.myshopify.com/password', {
         body: 'form_type=storefront_password&utf8=%E2%9C%93&password=correct-password-%26',
         headers: {
           'cache-control': 'no-cache',
@@ -227,7 +227,7 @@ describe('Storefront API', () => {
 
     test('returns false when the password is incorrect', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValueOnce(
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 401,
         }),
@@ -242,7 +242,7 @@ describe('Storefront API', () => {
 
     test('returns false when the redirect location is incorrect', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValueOnce(
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 302,
           headers: {
@@ -260,7 +260,7 @@ describe('Storefront API', () => {
 
     test('returns false when the redirect location has a different origin', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValueOnce(
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 302,
           headers: {
@@ -278,7 +278,7 @@ describe('Storefront API', () => {
 
     test('throws an error when the server responds with "Too Many Requests"', async () => {
       // Given
-      vi.mocked(fetch).mockResolvedValueOnce(
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 429,
           headers: {

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -1,6 +1,6 @@
 import {parseCookies, serializeCookies} from './cookies.js'
 import {defaultHeaders} from './storefront-utils.js'
-import {fetch} from '@shopify/cli-kit/node/http'
+import {shopifyFetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {type AdminSession} from '@shopify/cli-kit/node/session'
@@ -24,7 +24,7 @@ export async function isStorefrontPasswordCorrect(password: string | undefined, 
   params.append('utf8', '✓')
   params.append('password', password ?? '')
 
-  const response = await fetch(`${storeUrl}/password`, {
+  const response = await shopifyFetch(`${storeUrl}/password`, {
     headers: {
       'cache-control': 'no-cache',
       'content-type': 'application/x-www-form-urlencoded',
@@ -92,7 +92,7 @@ async function sessionEssentialCookie(storeUrl: string, themeId: string, headers
 
   const url = `${storeUrl}?${params}`
 
-  const response = await fetch(url, {
+  const response = await shopifyFetch(url, {
     method: 'HEAD',
     redirect: 'manual',
     headers: {
@@ -130,7 +130,7 @@ async function enrichSessionWithStorefrontPassword(
 ) {
   const params = new URLSearchParams({password})
 
-  const response = await fetch(`${storeUrl}/password`, {
+  const response = await shopifyFetch(`${storeUrl}/password`, {
     method: 'POST',
     redirect: 'manual',
     body: params,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,9 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0)
+      msw:
+        specifier: ^2.7.1
+        version: 2.7.1(@types/node@18.19.70)(typescript@5.7.3)
       node-stream-zip:
         specifier: ^1.15.0
         version: 1.15.0
@@ -3033,6 +3036,25 @@ packages:
       read-pkg-up: 7.0.1
     dev: true
 
+  /@bundled-es-modules/cookie@2.0.1:
+    resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
+    dependencies:
+      cookie: 0.7.2
+    dev: true
+
+  /@bundled-es-modules/statuses@1.0.1:
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+    dependencies:
+      statuses: 2.0.1
+    dev: true
+
+  /@bundled-es-modules/tough-cookie@0.1.6:
+    resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
+    dependencies:
+      '@types/tough-cookie': 4.0.5
+      tough-cookie: 4.1.4
+    dev: true
+
   /@changesets/apply-release-plan@7.0.8:
     resolution: {integrity: sha512-qjMUj4DYQ1Z6qHawsn7S71SujrExJ+nceyKKyI9iB+M5p9lCL55afuEd6uLBPRpLGWQwkwvWegDHtwHJb1UjpA==}
     dependencies:
@@ -4752,7 +4774,7 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       '@inquirer/figures': 1.0.1
-      '@inquirer/type': 1.3.1
+      '@inquirer/type': 1.5.5
       '@types/mute-stream': 0.0.4
       '@types/node': 20.12.8
       '@types/wrap-ansi': 3.0.0
@@ -5105,6 +5127,18 @@ packages:
 
   /@microsoft/tsdoc@0.15.1:
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
+  /@mswjs/interceptors@0.37.6:
+    resolution: {integrity: sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+    dev: true
 
   /@napi-rs/wasm-runtime@0.2.4:
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
@@ -5761,6 +5795,21 @@ packages:
     resolution: {integrity: sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==}
     dependencies:
       '@octokit/openapi-types': 12.11.0
+    dev: true
+
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
     dev: true
 
   /@opentelemetry/api-logs@0.57.0:
@@ -7165,6 +7214,10 @@ packages:
       '@types/node': 18.19.70
     dev: true
 
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+    dev: true
+
   /@types/diff@5.2.0:
     resolution: {integrity: sha512-pjJH+02ukgJRW0mViDUA1cdC+wzSgRu0e4cPuogPLAw0i66y62iMP0ZlXoJAmoXrKRZnF3pMDwyKZsgNVlMX4A==}
     dev: true
@@ -7397,11 +7450,19 @@ packages:
       '@types/send': 0.17.4
     dev: true
 
+  /@types/statuses@2.0.5:
+    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+    dev: true
+
   /@types/tinycolor2@1.4.6:
     resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
 
   /@types/tmp@0.2.6:
     resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
+    dev: true
+
+  /@types/tough-cookie@4.0.5:
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
     dev: true
 
   /@types/unist@3.0.3:
@@ -9469,6 +9530,11 @@ packages:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
     dev: false
+
+  /cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+    dev: true
 
   /copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
@@ -11944,6 +12010,10 @@ packages:
       capital-case: 1.0.4
       tslib: 2.6.2
 
+  /headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+    dev: true
+
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -12517,6 +12587,10 @@ packages:
   /is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+    dev: true
 
   /is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
@@ -13643,6 +13717,40 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  /msw@2.7.1(@types/node@18.19.70)(typescript@5.7.3):
+    resolution: {integrity: sha512-TVT65uoWt9LE4lMTLBdClHBQVwvZv5ofac1YyE119nCrNyXf4ktdeVnWH9Fyt94Ifmiedhw6Npp4DSuVRSuRpw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 5.1.5(@types/node@18.19.70)
+      '@mswjs/interceptors': 0.37.6
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      graphql: 16.10.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.35.0
+      typescript: 5.7.3
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
   /mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     dev: true
@@ -14197,6 +14305,10 @@ packages:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
     dev: true
 
+  /outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+    dev: true
+
   /own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -14427,6 +14539,10 @@ packages:
   /path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
     dev: false
+
+  /path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+    dev: true
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -15844,7 +15960,6 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
-    dev: false
 
   /std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
@@ -15860,6 +15975,10 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+    dev: true
+
+  /strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
     dev: true
 
   /strict-uri-encode@2.0.0:
@@ -16574,6 +16693,11 @@ packages:
   /type-fest@4.23.0:
     resolution: {integrity: sha512-ZiBujro2ohr5+Z/hZWHESLz3g08BBdrdLMieYFULJO+tWc437sn8kQsWLJoZErY8alNhxre9K4p3GURAG11n+w==}
     engines: {node: '>=16'}
+
+  /type-fest@4.35.0:
+    resolution: {integrity: sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==}
+    engines: {node: '>=16'}
+    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}


### PR DESCRIPTION
### WHY are these changes introduced?

Improves network request handling in the CLI by introducing configurable request behaviours, timeouts, and retries. This enhances reliability and responsiveness of network operations across the codebase.

These are available for fetch & shopifyFetch, and used by the GraphQL stack.

These changes are backward-compatible for public interfaces in CLI kit, and test coverage for network APIs is greatly increased.

### WHAT is this pull request doing?

- Introduces `requestMode` to configure network request behaviors with presets:
  - `default`: Automatic retries and timeouts
  - `non-blocking`: No retries, with timeouts
  - `slow-request`: No retries or timeouts -- i.e. neutral
- Adds configurable abort signals and timeout controls for requests
- Enhances request retry logic with better error handling
- Updates network calls across the codebase to use appropriate request modes
- Adds comprehensive test coverage using MSW for network mocking

### How to test your changes?

See the downstack PR for a test script to follow.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes