### PR TITLE
Store deploy artifacts in `.shopify`

### DIFF
--- a/packages/app/src/cli/services/deploy/bundle.test.ts
+++ b/packages/app/src/cli/services/deploy/bundle.test.ts
@@ -82,7 +82,7 @@ describe('bundleAndBuildExtensions', () => {
         file.writeFileSync(joinPath(bundleDirectory, 'index.wasm'), '')
       })
       functionExtension.buildForBundle = extensionBundleMock
-      const app = testApp({allExtensions: [functionExtension]})
+      const app = testApp({allExtensions: [functionExtension], directory: tmpDir})
 
       const extensions: {[key: string]: string} = {}
       for (const extension of app.allExtensions) {

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -3,7 +3,7 @@ import {Identifiers} from '../../models/app/identifiers.js'
 import {installJavy} from '../function/build.js'
 import {zip} from '@shopify/cli-kit/node/archiver'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
-import {inTemporaryDirectory, mkdirSync, touchFile, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {mkdir, rmdir, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderConcurrent} from '@shopify/cli-kit/node/ui'
 import {Writable} from 'stream'
@@ -15,41 +15,39 @@ interface BundleOptions {
 }
 
 export async function bundleAndBuildExtensions(options: BundleOptions) {
-  await inTemporaryDirectory(async (tmpDir) => {
-    const bundleDirectory = joinPath(tmpDir, 'bundle')
-    mkdirSync(bundleDirectory)
-    await touchFile(joinPath(bundleDirectory, '.shopify'))
+  const bundleDirectory = joinPath(options.app.directory, '.shopify', 'deploy-bundle')
+  await rmdir(bundleDirectory, {force: true})
+  await mkdir(bundleDirectory)
 
-    // Include manifest in bundle
-    const appManifest = await options.app.manifest()
-    const manifestPath = joinPath(bundleDirectory, 'manifest.json')
-    writeFileSync(manifestPath, JSON.stringify(appManifest, null, 2))
+  // Include manifest in bundle
+  const appManifest = await options.app.manifest()
+  const manifestPath = joinPath(bundleDirectory, 'manifest.json')
+  writeFileSync(manifestPath, JSON.stringify(appManifest, null, 2))
 
-    // Force the download of the javy binary in advance to avoid later problems,
-    // as it might be done multiple times in parallel. https://github.com/Shopify/cli/issues/2877
-    await installJavy(options.app)
+  // Force the download of the javy binary in advance to avoid later problems,
+  // as it might be done multiple times in parallel. https://github.com/Shopify/cli/issues/2877
+  await installJavy(options.app)
 
-    await renderConcurrent({
-      processes: options.app.allExtensions.map((extension) => {
-        return {
-          prefix: extension.localIdentifier,
-          action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
-            await extension.buildForBundle(
-              {stderr, stdout, signal, app: options.app, environment: 'production'},
-              bundleDirectory,
-              options.identifiers,
-            )
-          },
-        }
-      }),
-      showTimestamps: false,
-    })
-
-    if (options.bundlePath) {
-      await zip({
-        inputDirectory: bundleDirectory,
-        outputZipPath: options.bundlePath,
-      })
-    }
+  await renderConcurrent({
+    processes: options.app.allExtensions.map((extension) => {
+      return {
+        prefix: extension.localIdentifier,
+        action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
+          await extension.buildForBundle(
+            {stderr, stdout, signal, app: options.app, environment: 'production'},
+            bundleDirectory,
+            options.identifiers,
+          )
+        },
+      }
+    }),
+    showTimestamps: false,
   })
+
+  if (options.bundlePath) {
+    await zip({
+      inputDirectory: bundleDirectory,
+      outputZipPath: options.bundlePath,
+    })
+  }
 }

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -109,7 +109,7 @@ export class AppEventWatcher extends EventEmitter {
     super()
     this.app = app
     this.appURL = appURL
-    this.buildOutputPath = buildOutputPath ?? joinPath(app.directory, '.shopify', 'bundle')
+    this.buildOutputPath = buildOutputPath ?? joinPath(app.directory, '.shopify', 'dev-bundle')
     // Default options, to be overwritten by the start method
     this.options = {stdout: process.stdout, stderr: process.stderr, signal: new AbortSignal()}
     this.esbuildManager =

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
@@ -231,7 +231,7 @@ export class DevSession {
     this.bundleControllers.push(currentBundleController)
 
     if (currentBundleController.signal.aborted) return {status: 'aborted'}
-    const bundleZipPath = joinPath(dirname(this.bundlePath), `bundle.zip`)
+    const bundleZipPath = joinPath(dirname(this.bundlePath), `dev-bundle.zip`)
 
     // Create zip file with everything
     if (currentBundleController.signal.aborted) return {status: 'aborted'}


### PR DESCRIPTION
### WHY are these changes introduced?

To improve visibility of the code that's actually being deployed.
Instead of creating the "bundle" in a temporary folder, store it under `.shopify` so if a user really wants to, they can access the deployed code.

### WHAT is this pull request doing?

Renames bundle files to be more descriptive of their purpose:
FOR DEPLOY:
- Changes `bundle.zip` to `deploy-bundle.zip`
- Changes the bundle directory path to use `.shopify/deploy-bundle` instead of a temporary directory

FOR DEV:
- Renames the dev bundle to `dev-bundle.zip` and its directory to `.shopify/dev-bundle`

These changes make it clearer which bundles are for deployment and which are for development, improving maintainability and debugging.

### How to test your changes?

1. Run `shopify app deploy` and verify that the bundle is created with the new name `deploy-bundle.zip`
2. Run `shopify app dev` and verify that the development bundle is created with the name `dev-bundle.zip`
3. Check that the bundle directories are created in the `.shopify` folder with the appropriate names

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes