### PR TITLE
Fix changeset github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: changeset
+name: Changeset Release
 
 on:
   workflow_dispatch:
@@ -16,9 +16,9 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  release:
-    name: Release
-    runs-on: shopify-ubuntu-latest
+  changeset-release:
+    name: Changeset Release
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits


### PR DESCRIPTION
### WHY are these changes introduced?

We can't use custom runners and need to default to `ubuntu-latest`

### WHAT is this pull request doing?

- Renames the workflow from "changeset" to "Changeset Release" for clarity
- Updates the job name to be more specific ("changeset-release")
- Switches from custom Shopify Ubuntu runner to standard `ubuntu-latest`

### How to test your changes?

1. Trigger the release workflow manually through GitHub Actions
2. Verify the workflow runs successfully on the new runner
3. Confirm the new naming appears correctly in the GitHub Actions UI

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes