### PR TITLE
Do not report 401 or 404 as unhandled when fetching apiVersions

### DIFF
--- a/packages/cli-kit/src/public/node/api/admin.ts
+++ b/packages/cli-kit/src/public/node/api/admin.ts
@@ -1,7 +1,7 @@
 import {graphqlRequest, graphqlRequestDoc, GraphQLResponseOptions, GraphQLVariables} from './graphql.js'
 import {AdminSession} from '../session.js'
 import {outputContent, outputToken} from '../../../public/node/output.js'
-import {BugError, AbortError} from '../error.js'
+import {AbortError, BugError} from '../error.js'
 import {
   restRequestBody,
   restRequestHeaders,
@@ -131,8 +131,10 @@ async function fetchApiVersions(session: AdminSession): Promise<ApiVersion[]> {
         )})`,
         outputContent`If you're not the owner, create a dev store staff account for yourself`,
       )
-    } else if (error instanceof ClientError) {
-      throw new BugError(
+    }
+    if (error instanceof ClientError) {
+      const ErrorClass = error.response.status === 401 || error.response.status === 404 ? AbortError : BugError
+      throw new ErrorClass(
         `Unknown client error connecting to your store ${session.storeFqdn}: ${error.message} ${error.response.status} ${error.response.data}`,
       )
     } else {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://app.bugsnag.com/shopify/cli/errors/672a0db6b60d9e0f0cba175d

We are reporting 401 and 404 responses from some requests as unhandled errors

### WHAT is this pull request doing?

Use AbortError (handled) in those cases instead of BugError (unhandled)

### How to test your changes?

`SHOPIFY_CLI_ENV=production p shopify theme list --store wrong --verbose`

Before:
```
2025-02-20T09:24:24.744Z: Reporting unhandled error to Bugsnag: Unknown client error connecting to your store wrong.myshopify.com: GraphQL Error (Code: 404): {"response":{"errors":"Not Found","status":404,"headers":{}},"request":{"query":"query publicApiVersions {\n  publicApiVersions {\n    handle\n    supported\n    __typename\n  }\n}","variables":{}}} 404 undefined
```

After:
```
2025-02-20T10:32:14.570Z: Reporting handled error to Bugsnag: Unknown client error connecting to your store wrong.myshopify.com: GraphQL Error (Code: 404): {"response":{"errors":"Not Found","status":404,"headers":{}},"request":{"query":"query publicApiVersions {\n  publicApiVersions {\n    handle\n    supported\n    __typename\n  }\n}","variables":{}}} 404 undefined
```

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
