### PR TITLE
fix: ignore zod errors for json schema validations

### DIFF
--- a/packages/app/src/cli/utilities/json-schema.ts
+++ b/packages/app/src/cli/utilities/json-schema.ts
@@ -56,7 +56,7 @@ export async function unifiedConfigurationParserFactory(
       errorSet.add(key)
       return true
     })
-    if (zodParse.state !== 'ok' || errors.length > 0) {
+    if (jsonSchemaParse.state !== 'ok') {
       return {
         state: 'error',
         data: undefined,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

JSON schema extension contracts validations were being ignored. Custom CLI validations were still being used to validate json-schemas from the server. As we move to the CLI being a dumb client, respecting the server schema file will help make moving to the new world faster
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Switching from zod validations to json-schema validations for extensions with json-schemas

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
