### PR TITLE
Improve loading bar resizes

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextAnimation.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable id-length */
-import {Text} from 'ink'
+import {Text, useStdout} from 'ink'
 import React, {memo, useCallback, useLayoutEffect, useRef, useState} from 'react'
 import gradient from 'gradient-string'
 
@@ -33,17 +33,23 @@ const TextAnimation = memo(({text, maxWidth}: TextAnimationProps): JSX.Element =
   const frame = useRef(0)
   const [renderedFrame, setRenderedFrame] = useState(text)
   const timeout = useRef<NodeJS.Timeout>()
+  const {stdout} = useStdout()
+  const [width, setWidth] = useState(maxWidth ?? Math.floor(stdout.columns * 0.66))
+
+  stdout.on('resize', () => {
+    setWidth(Math.floor(stdout.columns * 0.66))
+  })
 
   const renderAnimation = useCallback(() => {
     const newFrame = frame.current + 1
     frame.current = newFrame
 
-    setRenderedFrame(rainbow(truncated(rotated(text, frame.current), maxWidth), frame.current))
+    setRenderedFrame(rainbow(truncated(rotated(text, frame.current), width), frame.current))
 
     timeout.current = setTimeout(() => {
       renderAnimation()
     }, 35)
-  }, [text, maxWidth])
+  }, [text, width])
 
   useLayoutEffect(() => {
     renderAnimation()


### PR DESCRIPTION
### WHY are these changes introduced?

The text animation component doesn't currently respond to terminal window resizing, and creates weird artifacts when resizing it.

### WHAT is this pull request doing?

Adds terminal resize handling to the TextAnimation component by:
- Dynamically calculating the width based on terminal size
- Updating the animation width when the terminal size changes

### How to test your changes?

Run `pnpm shopify kitchen-sink:async` and resize your terminal.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes