### PR TITLE
Use `.shopify/.gitignore` instead of appending to `.gitignore`

### DIFF
--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -11,8 +11,6 @@ export const configurationFileNames = {
   web: 'shopify.web.toml',
   appEnvironments: 'shopify.environments.toml',
   lockFile: '.shopify.lock',
-  hiddenConfig: 'project.json',
-  hiddenFolder: '.shopify',
 } as const
 
 export const dotEnvFileNames = {

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3432,9 +3432,9 @@ describe('loadHiddenConfig', () => {
       expect(JSON.parse(fileContent)).toEqual({})
 
       // Verify .gitignore was updated
-      const gitIgnore = joinPath(tmpDir, '.gitignore')
+      const gitIgnore = joinPath(tmpDir, '.shopify', '.gitignore')
       const gitIgnoreContent = await readFile(gitIgnore)
-      expect(gitIgnoreContent).toContain('.shopify')
+      expect(gitIgnoreContent).toEqual('# Ignore the entire .shopify directory\n*')
     })
   })
 

--- a/packages/app/src/cli/services/store-context.ts
+++ b/packages/app/src/cli/services/store-context.ts
@@ -3,10 +3,8 @@ import {convertToTransferDisabledStoreIfNeeded, selectStore} from './dev/select-
 import {LoadedAppContextOutput} from './app-context.js'
 import {OrganizationStore} from '../models/organization.js'
 import metadata from '../metadata.js'
-import {configurationFileNames} from '../constants.js'
 import {hashString} from '@shopify/cli-kit/node/crypto'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {addToGitIgnore} from '@shopify/cli-kit/node/git'
 
 /**
  * Input options for the `storeContext` function.
@@ -63,7 +61,6 @@ export async function storeContext({
   // Save the selected store in the hidden config file
   if (selectedStore.shopDomain !== cachedStoreURL || !devStoreUrlFromHiddenConfig) {
     await app.updateHiddenConfig({dev_store_url: selectedStore.shopDomain})
-    await addToGitIgnore(app.directory, configurationFileNames.hiddenFolder)
   }
 
   return selectedStore

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -72,6 +72,8 @@ export function createGitIgnore(directory: string, template: GitIgnoreTemplate):
  *
  * @param root - The directory containing the .gitignore file.
  * @param entry - The entry to add to the .gitignore file.
+ *
+ * @deprecated We should not edit the user's existing gitignore.
  */
 export function addToGitIgnore(root: string, entry: string): void {
   const gitIgnorePath = joinPath(root, '.gitignore')

--- a/packages/cli-kit/src/public/node/hiddenFolder.test.ts
+++ b/packages/cli-kit/src/public/node/hiddenFolder.test.ts
@@ -1,0 +1,60 @@
+import {withHiddenConfigPathIn, withHiddenShopifyFolderIn} from './hiddenFolder.js'
+import {joinPath} from './path.js'
+import {fileExists, inTemporaryDirectory} from './fs.js'
+import {describe, test, expect, vi} from 'vitest'
+import {execa} from 'execa'
+
+describe(withHiddenShopifyFolderIn, () => {
+  test('creates a hidden .shopify folder with a .gitignore file in the given directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      await gitInit(tmpDir)
+      const callbackReturnValue = Symbol('callbackReturnValue')
+      const callback = vi.fn().mockReturnValue(callbackReturnValue)
+      const expectedHiddenFolder = joinPath(tmpDir, '.shopify')
+      const arbitraryHiddenFile = joinPath(expectedHiddenFolder, 'arbitrary-hidden-file')
+      const appLevelGitignore = joinPath(tmpDir, '.gitignore')
+
+      // When
+      const result = withHiddenShopifyFolderIn(tmpDir, callback)
+
+      // Then
+      expect(callback).toHaveBeenCalledWith(expectedHiddenFolder)
+      expect(result).toBe(callbackReturnValue)
+      await expect(fileExists(expectedHiddenFolder)).resolves.toBe(true)
+      await expect(isGitIgnored(tmpDir, arbitraryHiddenFile)).resolves.toBe(true)
+      await expect(fileExists(appLevelGitignore)).resolves.toBe(false)
+    })
+  })
+})
+
+describe(withHiddenConfigPathIn, () => {
+  test('yields the path to a hidden and gitignored project.json file to the callback', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      await gitInit(tmpDir)
+      const callbackReturnValue = Symbol('callbackReturnValue')
+      const callback = vi.fn().mockReturnValue(callbackReturnValue)
+      const expectedHiddenConfigPath = joinPath(tmpDir, '.shopify', 'project.json')
+      const appLevelGitignore = joinPath(tmpDir, '.gitignore')
+
+      // When
+      const result = withHiddenConfigPathIn(tmpDir, callback)
+
+      // Then
+      expect(callback).toHaveBeenCalledWith(expectedHiddenConfigPath)
+      expect(result).toBe(callbackReturnValue)
+      await expect(isGitIgnored(tmpDir, expectedHiddenConfigPath)).resolves.toBe(true)
+      await expect(fileExists(appLevelGitignore)).resolves.toBe(false)
+    })
+  })
+})
+
+function gitInit(dir: string) {
+  return execa('git', ['init'], {cwd: dir})
+}
+
+async function isGitIgnored(dir: string, path: string) {
+  const {stdout} = await execa('git', ['check-ignore', path], {cwd: dir})
+  return stdout.trim() === path
+}

--- a/packages/cli-kit/src/public/node/hiddenFolder.ts
+++ b/packages/cli-kit/src/public/node/hiddenFolder.ts
@@ -1,0 +1,35 @@
+import {joinPath} from './path.js'
+import {mkdirSync, writeFileSync} from 'fs'
+
+const HIDDEN_FOLDER_NAME = '.shopify'
+const HIDDEN_CONFIG_PATH = 'project.json'
+
+/**
+ * Creates a git ignored hidden .shopify folder in the given app directory, and pass its path to the given callback.
+ *
+ * @param appDirectory - The directory of the app.
+ * @param callback - A callback that receives the path to the hidden folder.
+ * @returns The value returned by the callback function.
+ */
+export function withHiddenShopifyFolderIn<T>(appDirectory: string, callback: (hiddenFolder: string) => T): T {
+  const hiddenFolder = joinPath(appDirectory, HIDDEN_FOLDER_NAME)
+  mkdirSync(hiddenFolder, {recursive: true})
+  writeFileSync(joinPath(hiddenFolder, '.gitignore'), `# Ignore the entire ${HIDDEN_FOLDER_NAME} directory\n*`)
+
+  return callback(hiddenFolder)
+}
+
+/**
+ * Calls the given callback with the path to the config file in the hidden .shopify folder,
+ * ensuring the hidden folder is set up first.
+ *
+ * @param appDirectory - The directory of the app.
+ * @param callback - A callback that receives the path to the hidden config file.
+ * @returns The value returned by the callback function.
+ */
+export function withHiddenConfigPathIn<T>(appDirectory: string, callback: (hiddenConfigPath: string) => T): T {
+  return withHiddenShopifyFolderIn(appDirectory, (hiddenFolder) => {
+    const hiddenConfigPath = joinPath(hiddenFolder, HIDDEN_CONFIG_PATH)
+    return callback(hiddenConfigPath)
+  })
+}

--- a/packages/theme/src/cli/services/metafields-pull.ts
+++ b/packages/theme/src/cli/services/metafields-pull.ts
@@ -6,9 +6,9 @@ import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/ses
 import {cwd, joinPath} from '@shopify/cli-kit/node/path'
 import {metafieldDefinitionsByOwnerType} from '@shopify/cli-kit/node/themes/api'
 import {renderError, renderSuccess} from '@shopify/cli-kit/node/ui'
-import {fileExistsSync, mkdirSync, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {writeFileSync} from '@shopify/cli-kit/node/fs'
 import {outputDebug} from '@shopify/cli-kit/node/output'
-import {addToGitIgnore} from '@shopify/cli-kit/node/git'
+import {withHiddenShopifyFolderIn} from '@shopify/cli-kit/node/hiddenFolder'
 
 interface MetafieldsPullOptions {
   path: string
@@ -158,15 +158,10 @@ async function executeMetafieldsPull(session: AdminSession, options: MetafieldsP
 }
 
 function writeMetafieldDefinitionsToFile(path: string, content: unknown) {
-  const shopifyDirectory = joinPath(path, '.shopify')
-  mkdirSync(shopifyDirectory)
+  withHiddenShopifyFolderIn(path, (shopifyDirectory) => {
+    const filePath = joinPath(shopifyDirectory, 'metafields.json')
+    const fileContent = JSON.stringify(content, null, 2)
 
-  const filePath = joinPath(shopifyDirectory, 'metafields.json')
-  const fileContent = JSON.stringify(content, null, 2)
-
-  if (!fileExistsSync(filePath)) {
-    addToGitIgnore(path, '.shopify')
-  }
-
-  writeFileSync(filePath, fileContent)
+    writeFileSync(filePath, fileContent)
+  })
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We should avoid "dirtying" the host application's `.gitignore`.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Instead of writing to the host application's `.gitignore` to hide the `.shopify` directory, we can write a `.gitignore` in the directory itself, which makes the directory self-ignoring.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Test coverage should be good enough, but you could use the previous version of the CLI to perform a task which writes to `.gitignore`, and inspect that it wrote to it, then repeat that task using this branch and ensure the `.shopify` directory and its contents remain ignored even if `.gitignore` doesn't contain `.shopify`.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
