### PR TITLE
Skip notifications on init commands

### DIFF
--- a/.changeset/seven-jokes-impress.md
+++ b/.changeset/seven-jokes-impress.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+'@shopify/cli': patch
+---
+
+Skip notifications on init commands to fix create-app package

--- a/packages/cli-kit/src/public/node/hooks/prerun.ts
+++ b/packages/cli-kit/src/public/node/hooks/prerun.ts
@@ -24,7 +24,7 @@ export const hook: Hook.Prerun = async (options) => {
   await warnOnAvailableUpgrade()
   outputDebug(`Running command ${commandContent.command}`)
   await startAnalytics({commandContent, args, commandClass: options.Command as unknown as typeof Command})
-  if (!options.Command.hidden) fetchNotificationsInBackground(options.Command.id)
+  fetchNotificationsInBackground(options.Command.id)
 }
 
 export function parseCommandContent(cmdInfo: {id: string; aliases: string[]; pluginAlias?: string}): CommandContent {

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -169,7 +169,7 @@ export function fetchNotificationsInBackground(
   if (skipNotifications(currentCommand, environment)) return
 
   let command = 'shopify'
-  const args = ['notifications', 'list']
+  const args = ['notifications', 'list', '--ignore-errors']
   // Run the Shopify command the same way as the current execution when it's not the global installation
   if (argv[0] && argv[0] !== 'shopify') {
     command = argv[0]

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -13,6 +13,7 @@ import {fetch} from '@shopify/cli-kit/node/http'
 
 const URL = 'https://cdn.shopify.com/static/cli/notifications.json'
 const EMPTY_CACHE_MESSAGE = 'Cache is empty'
+const COMMANDS_TO_SKIP = ['notifications:list', 'notifications:generate', 'app:init', 'theme:init', 'cache:clear']
 
 function url(): string {
   return process.env.SHOPIFY_CLI_NOTIFICATIONS_URL ?? URL
@@ -55,27 +56,32 @@ export async function showNotificationsIfNeeded(
   environment: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
   try {
-    if (skipNotifications(environment) || jsonOutputEnabled(environment)) return
+    const commandId = getCurrentCommandId()
+    if (skipNotifications(commandId, environment) || jsonOutputEnabled(environment)) return
 
     const notifications = await getNotifications()
-    const commandId = getCurrentCommandId()
     const notificationsToShow = filterNotifications(notifications.notifications, commandId, currentSurfaces)
     outputDebug(`Notifications to show: ${notificationsToShow.length}`)
     await renderNotifications(notificationsToShow)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
+    if (error.message === EMPTY_CACHE_MESSAGE) {
+      outputDebug('Notifications to show: 0 (Cache is empty)')
+      return
+    }
     if (error.message === 'abort') throw new AbortSilentError()
-    const errorMessage = `Error retrieving notifications: ${error.message}`
+    const errorMessage = `Error showing notifications: ${error.message}`
     outputDebug(errorMessage)
-    if (error.message === EMPTY_CACHE_MESSAGE) return
     // This is very prone to becoming a circular dependency, so we import it dynamically
     const {sendErrorToBugsnag} = await import('./error-handler.js')
     await sendErrorToBugsnag(errorMessage, 'unexpected_error')
   }
 }
 
-function skipNotifications(environment: NodeJS.ProcessEnv = process.env): boolean {
-  return isTruthy(environment.CI) || isTruthy(environment.SHOPIFY_UNIT_TEST)
+function skipNotifications(currentCommand: string, environment: NodeJS.ProcessEnv = process.env): boolean {
+  return (
+    isTruthy(environment.CI) || isTruthy(environment.SHOPIFY_UNIT_TEST) || COMMANDS_TO_SKIP.includes(currentCommand)
+  )
 }
 
 /**
@@ -160,7 +166,7 @@ export function fetchNotificationsInBackground(
   argv = process.argv,
   environment: NodeJS.ProcessEnv = process.env,
 ): void {
-  if (skipNotifications(environment)) return
+  if (skipNotifications(currentCommand, environment)) return
 
   let command = 'shopify'
   const args = ['notifications', 'list']

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -137,8 +137,7 @@ function buildExec(command: string, args: string[], options?: ExecOptions): Exec
     detached: options?.background,
     cleanup: !options?.background,
   })
-  outputDebug(`
-Running system process${options?.background ? ' in background' : ''}:
+  outputDebug(`Running system process${options?.background ? ' in background' : ''}:
   · Command: ${command} ${args.join(' ')}
   · Working directory: ${executionCwd}
 `)

--- a/packages/cli/src/cli/commands/notifications/list.ts
+++ b/packages/cli/src/cli/commands/notifications/list.ts
@@ -1,11 +1,33 @@
 import {list} from '../../services/commands/notifications.js'
+import {Flags} from '@oclif/core'
 import Command from '@shopify/cli-kit/node/base-command'
+import {sendErrorToBugsnag} from '@shopify/cli-kit/node/error-handler'
 
 export default class List extends Command {
   static description = 'List current notifications configured for the CLI.'
   static hidden = true
 
+  static flags = {
+    'ignore-errors': Flags.boolean({
+      hidden: false,
+      description: "Don't fail if an error occurs.",
+      env: 'SHOPIFY_FLAG_IGNORE_ERRORS',
+    }),
+  }
+
   async run(): Promise<void> {
-    await list()
+    const {flags} = await this.parse(List)
+    try {
+      await list()
+    } catch (error) {
+      let message = `Error fetching notifications`
+      if (error instanceof Error) {
+        message = message.concat(`: ${error.message}`)
+      }
+      await sendErrorToBugsnag(message, 'expected_error')
+      if (!flags['ignore-errors']) {
+        throw error
+      }
+    }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5474

When running `npm/yarn/pnpm create @shopify/app@3.76.0`, it fails because it tries to fetch the notifications with the wrong binary.

### WHAT is this pull request doing?

- Skips notifications (fetch and show) on certain commands
- Improves error handling when running in background

### How to test your changes?

TBD

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
