### PR TITLE
Add missing permissions to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
   changeset-release:
     name: Changeset Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
         # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
@@ -29,15 +33,12 @@ jobs:
         with:
           node-version: 18.20.3
       - name: Create Release Pull Request
-        uses: Wandalen/wretry.action@e6cf3db7de3777ba5f999f903c2f4efdd9ac7288 # pin@v1.0.36
+        uses: changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a #  pin@v1
         with:
-          action: changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a # pin@v1
-          attempt_limit: 3
-          attempt_delay: 2000
-          with: |
-            version: pnpm changeset-manifests
-            title: Version Packages - ${{ github.ref_name }}
-            publish: pnpm release latest
+          version: pnpm changeset-manifests
+          title: Version Packages - ${{ github.ref_name }}
+          publish: pnpm release latest
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/release
+++ b/bin/release
@@ -23,11 +23,6 @@ if [ "$tag" = "nightly" ] || [ "$tag" = "experimental" ]; then
   ./bin/update-cli-kit-version.js
 fi
 
-if [ "$tag" = "latest" ]; then
-  pnpm changeset-manifests
-fi
-
-
 # Bundle the packages
 pnpm bundle-for-release
 


### PR DESCRIPTION
### WHY are these changes introduced?

The release script will fail in the next release cycle if we don't change this.

### WHAT is this pull request doing?

Fixes permissions issues in the GitHub Actions release workflow. We need those to sign with provenance in the next release.

### How to test your changes?

Nothing to test, just wait for the next release and see that the release script works.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes