### PR TITLE
[ShopifyVM] Dev Dash - app logs

### DIFF
--- a/packages/app/src/cli/api/graphql/functions/generated/schema-definition-by-target.ts
+++ b/packages/app/src/cli/api/graphql/functions/generated/schema-definition-by-target.ts
@@ -82,3 +82,78 @@ export const SchemaDefinitionByTarget = {
     },
   ],
 } as unknown as DocumentNode<SchemaDefinitionByTargetQuery, SchemaDefinitionByTargetQueryVariables>
+
+// Move to separat file OR import these types correctly
+export type AppLogsSubscribeQueryVariables = {
+  shopIds: string[]
+  apiKey: string
+}
+
+export type AppLogsSubscribeQuery = {
+  appLogsSubscribe: {
+    jwtToken: string
+    success: boolean
+    errors?: string[]
+  }
+}
+
+export const AppLogsSubscribe = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'AppLogsSubscribe'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'shopIds'}},
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'ListType',
+              type: {
+                kind: 'NonNullType',
+                type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}}
+              }
+            }
+          }
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'apiKey'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}}
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'appLogsSubscribe'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'shopIds'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'shopIds'}}
+              },
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'apiKey'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'apiKey'}}
+              }
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {kind: 'Field', name: {kind: 'Name', value: 'jwtToken'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'success'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'errors'}}
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+} as unknown as DocumentNode<AppLogsSubscribeQuery, AppLogsSubscribeQueryVariables>

--- a/packages/app/src/cli/api/graphql/functions/generated/schema-definition-by-target.ts
+++ b/packages/app/src/cli/api/graphql/functions/generated/schema-definition-by-target.ts
@@ -83,7 +83,8 @@ export const SchemaDefinitionByTarget = {
   ],
 } as unknown as DocumentNode<SchemaDefinitionByTargetQuery, SchemaDefinitionByTargetQueryVariables>
 
-// Move to separat file OR import these types correctly
+// NOTE: These will be generated once CORE PR is merged
+// I have placed them here for the time being
 export type AppLogsSubscribeQueryVariables = {
   shopIds: string[]
   apiKey: string
@@ -114,15 +115,15 @@ export const AppLogsSubscribe = {
               kind: 'ListType',
               type: {
                 kind: 'NonNullType',
-                type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}}
-              }
-            }
-          }
+                type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}},
+              },
+            },
+          },
         },
         {
           kind: 'VariableDefinition',
           variable: {kind: 'Variable', name: {kind: 'Name', value: 'apiKey'}},
-          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}}
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
         },
       ],
       selectionSet: {
@@ -135,25 +136,25 @@ export const AppLogsSubscribe = {
               {
                 kind: 'Argument',
                 name: {kind: 'Name', value: 'shopIds'},
-                value: {kind: 'Variable', name: {kind: 'Name', value: 'shopIds'}}
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'shopIds'}},
               },
               {
                 kind: 'Argument',
                 name: {kind: 'Name', value: 'apiKey'},
-                value: {kind: 'Variable', name: {kind: 'Name', value: 'apiKey'}}
-              }
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'apiKey'}},
+              },
             ],
             selectionSet: {
               kind: 'SelectionSet',
               selections: [
                 {kind: 'Field', name: {kind: 'Name', value: 'jwtToken'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'success'}},
-                {kind: 'Field', name: {kind: 'Name', value: 'errors'}}
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ]
+                {kind: 'Field', name: {kind: 'Name', value: 'errors'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
 } as unknown as DocumentNode<AppLogsSubscribeQuery, AppLogsSubscribeQueryVariables>

--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
@@ -506,15 +506,8 @@ describe('pollAppLogs', () => {
     expect(shopifyFetch).toHaveBeenCalledWith(expectedUrl, {
       method: 'GET',
       headers: {
-        Accept: 'application/json',
         Authorization: 'Bearer jwtToken',
-        'Content-Type': 'application/json',
         'User-Agent': 'Shopify CLI; v=3.76.0',
-        'X-Client-ID': 'shopify-cli-development',
-        'X-Identity-Context':
-          '{"client_id":"shopify-cli-development","scopes":["https://api.shopify.com/auth/organization.apps.manage"]}',
-        'X-Identity-Scope': 'https://api.shopify.com/auth/organization.apps.manage',
-        'X-Shopify-Access-Token': 'Bearer jwtToken',
       },
     })
   })

--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
@@ -1,14 +1,14 @@
 import {pollAppLogs} from './poll-app-logs.js'
 import {writeAppLogsToFile} from './write-app-logs.js'
 import {FunctionRunLog} from '../types.js'
-import {partnersFqdn, appManagementFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {OrganizationSource} from '../../../models/organization.js'
+import {appManagementFqdn, partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {describe, expect, test, vi, beforeEach, afterEach} from 'vitest'
 import {shopifyFetch} from '@shopify/cli-kit/node/http'
 import * as components from '@shopify/cli-kit/node/ui/components'
 import * as output from '@shopify/cli-kit/node/output'
 import camelcaseKeys from 'camelcase-keys'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
-import {OrganizationSource} from '../../../models/organization.js'
 
 const JWT_TOKEN = 'jwtToken'
 const API_KEY = 'apiKey'
@@ -20,8 +20,8 @@ const FQDN = await partnersFqdn()
 const LOGS = '1\\n2\\n3\\n4\\n'
 const FUNCTION_ERROR = 'function_error'
 const FUNCTION_RUN = 'function_run'
-const APP_ID = "180457"
-const ORG_ID = "1"
+const APP_ID = '180457'
+const ORG_ID = '1'
 
 const INPUT = {
   cart: {
@@ -487,10 +487,11 @@ describe('pollAppLogs', () => {
 
   test('polls and re-polls the request to dev dashboard endpoint when using BusinessPlatform', async () => {
     // Given
-    const expectedUrl = `https://app.shopify.com/functions/unstable/organizations/1/180457/app_logs/poll`
+    const fdqn = await appManagementFqdn()
+    const expectedUrl = `https://${fdqn}/functions/unstable/organizations/1/180457/app_logs/poll`
 
     // When
-    const result =await pollAppLogs({
+    await pollAppLogs({
       stdout,
       appLogsFetchInput: {jwtToken: JWT_TOKEN},
       apiKey: API_KEY,
@@ -502,22 +503,19 @@ describe('pollAppLogs', () => {
     })
 
     // When/Then
-    expect(shopifyFetch).toHaveBeenCalledWith(
-      expectedUrl,
-      {
-        method: 'GET',
-        headers: {
-          'Accept': 'application/json',
-          'Authorization': 'Bearer jwtToken',
-          'Content-Type': 'application/json',
-          'User-Agent': 'Shopify CLI; v=3.76.0',
-          'X-Client-ID': 'shopify-cli-development',
-          'X-Identity-Context': '{"client_id":"shopify-cli-development","scopes":["https://api.shopify.com/auth/organization.apps.manage"]}',
-          'X-Identity-Scope': 'https://api.shopify.com/auth/organization.apps.manage',
-          'X-Shopify-Access-Token': 'Bearer jwtToken',
-        }
+    expect(shopifyFetch).toHaveBeenCalledWith(expectedUrl, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer jwtToken',
+        'Content-Type': 'application/json',
+        'User-Agent': 'Shopify CLI; v=3.76.0',
+        'X-Client-ID': 'shopify-cli-development',
+        'X-Identity-Context':
+          '{"client_id":"shopify-cli-development","scopes":["https://api.shopify.com/auth/organization.apps.manage"]}',
+        'X-Identity-Scope': 'https://api.shopify.com/auth/organization.apps.manage',
+        'X-Shopify-Access-Token': 'Bearer jwtToken',
       },
-    )
+    })
   })
-
 })

--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.ts
@@ -1,4 +1,4 @@
-import { writeAppLogsToFile } from './write-app-logs.js'
+import {writeAppLogsToFile} from './write-app-logs.js'
 import {
   POLLING_INTERVAL_MS,
   POLLING_ERROR_RETRY_INTERVAL_MS,
@@ -14,17 +14,17 @@ import {
   handleFetchAppLogsError,
   fetchAppLogsDevDashboard,
 } from '../utils.js'
-import { AppLogData, ErrorResponse, FunctionRunLog } from '../types.js'
-import { outputContent, outputDebug, outputToken, outputWarn } from '@shopify/cli-kit/node/output'
-import { useConcurrentOutputContext } from '@shopify/cli-kit/node/ui/components'
+import {AppLogData, ErrorResponse, FunctionRunLog} from '../types.js'
+import {OrganizationSource} from '../../../models/organization.js'
+import {outputContent, outputDebug, outputToken, outputWarn} from '@shopify/cli-kit/node/output'
+import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
+import {Response} from '@shopify/cli-kit/node/http'
 import camelcaseKeys from 'camelcase-keys'
-import { Writable } from 'stream'
-import { OrganizationSource } from '../../../models/organization.js'
-import { Response } from '@shopify/cli-kit/node/http'
+import {Writable} from 'stream'
 
 export const pollAppLogs = async ({
   stdout,
-  appLogsFetchInput: { jwtToken, cursor },
+  appLogsFetchInput: {jwtToken, cursor},
   apiKey,
   resubscribeCallback,
   storeName,
@@ -33,7 +33,7 @@ export const pollAppLogs = async ({
   appId,
 }: {
   stdout: Writable
-  appLogsFetchInput: { jwtToken: string; cursor?: string }
+  appLogsFetchInput: {jwtToken: string; cursor?: string}
   apiKey: string
   resubscribeCallback: () => Promise<string>
   storeName: string
@@ -45,18 +45,18 @@ export const pollAppLogs = async ({
     let nextJwtToken = jwtToken
     let retryIntervalMs = POLLING_INTERVAL_MS
 
-    const isDevDashboard = organizationSource === OrganizationSource.BusinessPlatform;
+    const isDevDashboard = organizationSource === OrganizationSource.BusinessPlatform
 
     const httpResponse: Response = isDevDashboard
       ? await fetchAppLogsDevDashboard(jwtToken, orgId, appId, cursor)
-      : await fetchAppLogs(jwtToken, cursor);
+      : await fetchAppLogs(jwtToken, cursor)
 
     const response = await httpResponse.json()
-    const { errors } = response as { errors: string[] }
+    const {errors} = response as {errors: string[]}
 
     if (errors) {
       const errorResponse = {
-        errors: errors.map((error) => ({ message: error, status: httpResponse.status })),
+        errors: errors.map((error) => ({message: error, status: httpResponse.status})),
       } as ErrorResponse
 
       const result = await handleFetchAppLogsError({
@@ -87,12 +87,12 @@ export const pollAppLogs = async ({
     }
 
     if (data.app_logs) {
-      const { app_logs: appLogs } = data
+      const {app_logs: appLogs} = data
 
       for (const log of appLogs) {
         let payload = JSON.parse(log.payload)
         // eslint-disable-next-line no-await-in-loop
-        await useConcurrentOutputContext({ outputPrefix: log.source, stripAnsi: false }, async () => {
+        await useConcurrentOutputContext({outputPrefix: log.source, stripAnsi: false}, async () => {
           if (log.log_type === LOG_TYPE_FUNCTION_RUN) {
             handleFunctionRunLog(log, payload, stdout)
             payload = new FunctionRunLog(camelcaseKeys(payload))
@@ -165,7 +165,7 @@ export const pollAppLogs = async ({
   }
 }
 
-function handleFunctionRunLog(log: AppLogData, payload: { [key: string]: unknown }, stdout: Writable) {
+function handleFunctionRunLog(log: AppLogData, payload: {[key: string]: unknown}, stdout: Writable) {
   const fuel = ((payload.fuel_consumed as number) / ONE_MILLION).toFixed(4)
   if (log.status === 'success') {
     stdout.write(`Function export "${payload.export as string}" executed successfully using ${fuel}M instructions.`)
@@ -186,7 +186,7 @@ function handleFunctionRunLog(log: AppLogData, payload: { [key: string]: unknown
   }
 }
 
-function handleFunctionNetworkAccessLog(log: AppLogData, payload: { [key: string]: unknown }, stdout: Writable) {
+function handleFunctionNetworkAccessLog(log: AppLogData, payload: {[key: string]: unknown}, stdout: Writable) {
   if (log.log_type === LOG_TYPE_RESPONSE_FROM_CACHE) {
     stdout.write('Function network access response retrieved from cache.')
   } else if (log.log_type === LOG_TYPE_REQUEST_EXECUTION_IN_BACKGROUND) {

--- a/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.test.ts
@@ -1,6 +1,8 @@
 import {pollAppLogs} from './poll-app-logs.js'
 import {fetchAppLogs} from '../utils.js'
+import {OrganizationSource} from '../../../models/organization.js'
 import {describe, test, vi, expect} from 'vitest'
+
 
 vi.mock('@shopify/cli-kit/node/output')
 vi.mock('@shopify/cli-kit/node/context/fqdn')
@@ -58,9 +60,16 @@ describe('pollProcess', () => {
 
     // // When
     const result = await pollAppLogs({
-      jwtToken: MOCKED_JWT_TOKEN,
-      cursor: MOCKED_CURSOR,
-      filters: EMPTY_FILTERS,
+      pollOptions: {
+        jwtToken: MOCKED_JWT_TOKEN,
+        cursor: MOCKED_CURSOR,
+        filters: EMPTY_FILTERS,
+      },
+      options: {
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
+      },
     })
 
     expect(result).toEqual({
@@ -76,9 +85,16 @@ describe('pollProcess', () => {
 
     // // When
     const result = await pollAppLogs({
-      jwtToken: MOCKED_JWT_TOKEN,
-      cursor: MOCKED_CURSOR,
-      filters: {status: 'failure', sources: ['extensions.my-function', 'extensions.my-other-function']},
+      pollOptions: {
+        jwtToken: MOCKED_JWT_TOKEN,
+        cursor: MOCKED_CURSOR,
+        filters: {status: 'failure', sources: ['extensions.my-function', 'extensions.my-other-function']},
+      },
+      options: {
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
+      },
     })
 
     expect(result).toEqual({
@@ -100,9 +116,16 @@ describe('pollProcess', () => {
 
     // When
     const result = await pollAppLogs({
-      jwtToken: MOCKED_JWT_TOKEN,
-      cursor: MOCKED_CURSOR,
-      filters: EMPTY_FILTERS,
+      pollOptions: {
+        jwtToken: MOCKED_JWT_TOKEN,
+        cursor: MOCKED_CURSOR,
+        filters: EMPTY_FILTERS,
+      },
+      options: {
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
+      },
     })
 
     // Then
@@ -125,9 +148,16 @@ describe('pollProcess', () => {
     // When/Then
     await expect(() =>
       pollAppLogs({
-        jwtToken: MOCKED_JWT_TOKEN,
-        cursor: MOCKED_CURSOR,
-        filters: EMPTY_FILTERS,
+        pollOptions: {
+          jwtToken: MOCKED_JWT_TOKEN,
+          cursor: MOCKED_CURSOR,
+          filters: EMPTY_FILTERS,
+        },
+        options: {
+          organizationSource: OrganizationSource.Partners,
+          orgId: '1',
+          appId: '1',
+        },
       }),
     ).rejects.toThrowError()
   })

--- a/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.ts
@@ -1,9 +1,21 @@
+import {OrganizationSource} from '../../../models/organization.js'
 import {PollOptions, AppLogData, PollResponse, PollFilters} from '../types.js'
-import {fetchAppLogs} from '../utils.js'
+import {fetchAppLogs, fetchAppLogsDevDashboard} from '../utils.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {Response} from '@shopify/cli-kit/node/http'
 
-export const pollAppLogs = async ({jwtToken, cursor, filters}: PollOptions): Promise<PollResponse> => {
-  const response = await fetchAppLogs(jwtToken, cursor, filters)
+export const pollAppLogs = async ({
+  pollOptions: {jwtToken, cursor, filters},
+  options: {organizationSource, orgId, appId},
+}: {
+  pollOptions: PollOptions
+  options: {organizationSource: OrganizationSource; orgId: string; appId: string}
+}): Promise<PollResponse> => {
+  const isDevDashboard = organizationSource === OrganizationSource.BusinessPlatform
+
+  const response: Response = isDevDashboard
+    ? await fetchAppLogsDevDashboard(jwtToken, orgId, appId, cursor)
+    : await fetchAppLogs(jwtToken, cursor)
 
   const responseJson = await response.json()
   if (!response.ok) {

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
@@ -2,9 +2,11 @@ import {renderJsonLogs} from './render-json-logs.js'
 import {pollAppLogs} from './poll-app-logs.js'
 import {handleFetchAppLogsError} from '../utils.js'
 import {testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
+import {OrganizationSource} from '../../../models/organization.js'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 import {describe, expect, vi, test, beforeEach, afterEach} from 'vitest'
 import {formatLocalDate} from '@shopify/cli-kit/common/string'
+
 
 vi.mock('./poll-app-logs')
 vi.mock('../utils', async (importOriginal) => {
@@ -50,6 +52,9 @@ describe('renderJsonLogs', () => {
         organizationId: '1',
       },
       storeNameById,
+      organizationSource: OrganizationSource.Partners,
+      orgId: '1',
+      appId: '1',
     })
 
     expect(outputInfo).toHaveBeenNthCalledWith(
@@ -96,6 +101,9 @@ describe('renderJsonLogs', () => {
         organizationId: '1',
       },
       storeNameById,
+      organizationSource: OrganizationSource.Partners,
+      orgId: '1',
+      appId: '1',
     })
 
     expect(outputInfo).not.toHaveBeenCalled()
@@ -126,6 +134,9 @@ describe('renderJsonLogs', () => {
         organizationId: '1',
       },
       storeNameById,
+      organizationSource: OrganizationSource.Partners,
+      orgId: '1',
+      appId: '1',
     })
 
     expect(outputInfo).toHaveBeenCalledWith(

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
@@ -47,6 +47,7 @@ describe('renderJsonLogs', () => {
       options: {
         variables: {shopIds: ['1'], apiKey: 'key', token: 'token'},
         developerPlatformClient: testDeveloperPlatformClient(),
+        organizationId: '1',
       },
       storeNameById,
     })
@@ -92,6 +93,7 @@ describe('renderJsonLogs', () => {
       options: {
         variables: {shopIds: ['1'], apiKey: 'key', token: 'token'},
         developerPlatformClient: testDeveloperPlatformClient(),
+        organizationId: '1',
       },
       storeNameById,
     })
@@ -121,6 +123,7 @@ describe('renderJsonLogs', () => {
       options: {
         variables: {shopIds: [], apiKey: '', token: ''},
         developerPlatformClient: testDeveloperPlatformClient(),
+        organizationId: '1',
       },
       storeNameById,
     })

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
@@ -7,18 +7,29 @@ import {
   toFormattedAppLogJson,
   parseAppLogPayload,
 } from '../utils.js'
+import {OrganizationSource} from '../../../models/organization.js'
 import {outputInfo} from '@shopify/cli-kit/node/output'
+
 
 export async function renderJsonLogs({
   pollOptions: {cursor, filters, jwtToken},
   options: {variables, developerPlatformClient, organizationId},
   storeNameById,
+  organizationSource,
+  orgId,
+  appId,
 }: {
   pollOptions: PollOptions
   options: SubscribeOptions
   storeNameById: Map<string, string>
+  organizationSource: OrganizationSource
+  orgId: string
+  appId: string
 }): Promise<void> {
-  const response = await pollAppLogs({cursor, filters, jwtToken})
+  const response = await pollAppLogs({
+    pollOptions: {jwtToken, cursor, filters},
+    options: {organizationSource, orgId, appId},
+  })
   let retryIntervalMs = POLLING_INTERVAL_MS
   let nextJwtToken = jwtToken
 
@@ -73,6 +84,9 @@ export async function renderJsonLogs({
         filters,
       },
       storeNameById,
+      organizationSource,
+      orgId,
+      appId,
     }).catch((error) => {
       throw error
     })

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
@@ -11,7 +11,7 @@ import {outputInfo} from '@shopify/cli-kit/node/output'
 
 export async function renderJsonLogs({
   pollOptions: {cursor, filters, jwtToken},
-  options: {variables, developerPlatformClient},
+  options: {variables, developerPlatformClient, organizationId},
   storeNameById,
 }: {
   pollOptions: PollOptions
@@ -34,7 +34,7 @@ export async function renderJsonLogs({
         outputInfo(JSON.stringify({message: 'Error while polling app logs.', retry_in_ms: retryIntervalMs}))
       },
       onResubscribe: () => {
-        return subscribeToAppLogs(developerPlatformClient, variables)
+        return subscribeToAppLogs(developerPlatformClient, variables, organizationId)
       },
     })
 
@@ -66,7 +66,7 @@ export async function renderJsonLogs({
 
   setTimeout(() => {
     renderJsonLogs({
-      options: {variables, developerPlatformClient},
+      options: {variables, developerPlatformClient, organizationId},
       pollOptions: {
         jwtToken: nextJwtToken || jwtToken,
         cursor: nextCursor || cursor,

--- a/packages/app/src/cli/services/app-logs/logs-command/ui.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui.tsx
@@ -3,14 +3,21 @@ import {PollOptions, SubscribeOptions} from '../types.js'
 import {subscribeToAppLogs} from '../utils.js'
 import React from 'react'
 import {render} from '@shopify/cli-kit/node/ui'
+import {OrganizationSource} from '../../../models/organization.js'
 
 export async function renderLogs({
   pollOptions,
   options: {variables, developerPlatformClient, organizationId},
   storeNameById,
+  organizationSource,
+  orgId,
+  appId,
 }: {
   pollOptions: PollOptions
   options: SubscribeOptions
+  organizationSource: OrganizationSource
+  orgId: string
+  appId: string
   storeNameById: Map<string, string>
 }) {
   const resubscribeCallback = async () => {
@@ -18,6 +25,13 @@ export async function renderLogs({
   }
 
   return render(
-    <Logs pollOptions={pollOptions} resubscribeCallback={resubscribeCallback} storeNameById={storeNameById} />,
+    <Logs
+      pollOptions={pollOptions}
+      resubscribeCallback={resubscribeCallback}
+      storeNameById={storeNameById}
+      organizationSource={organizationSource}
+      orgId={orgId}
+      appId={appId}
+    />,
   )
 }

--- a/packages/app/src/cli/services/app-logs/logs-command/ui.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui.tsx
@@ -6,7 +6,7 @@ import {render} from '@shopify/cli-kit/node/ui'
 
 export async function renderLogs({
   pollOptions,
-  options: {variables, developerPlatformClient},
+  options: {variables, developerPlatformClient, organizationId},
   storeNameById,
 }: {
   pollOptions: PollOptions
@@ -14,7 +14,7 @@ export async function renderLogs({
   storeNameById: Map<string, string>
 }) {
   const resubscribeCallback = async () => {
-    return subscribeToAppLogs(developerPlatformClient, variables)
+    return subscribeToAppLogs(developerPlatformClient, variables, organizationId)
   }
 
   return render(

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
@@ -9,10 +9,12 @@ import {
   NetworkAccessRequestExecutionInBackgroundLog,
   NetworkAccessResponseFromCacheLog,
 } from '../../../types.js'
+import {OrganizationSource} from '../../../../../models/organization.js'
 import {describe, test, vi, expect} from 'vitest'
 import {render} from '@shopify/cli-kit/node/testing/ui'
 import React from 'react'
 import {unstyled} from '@shopify/cli-kit/node/output'
+
 
 vi.mock('./hooks/usePollAppLogs.js')
 
@@ -111,6 +113,9 @@ describe('Logs', () => {
           pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
+          organizationSource={OrganizationSource.Partners}
+          orgId="1"
+          appId="1"
         />,
       )
 
@@ -159,6 +164,9 @@ describe('Logs', () => {
           pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
+          organizationSource={OrganizationSource.Partners}
+          orgId="1"
+          appId="1"
         />,
       )
 
@@ -208,6 +216,9 @@ describe('Logs', () => {
           pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
+          organizationSource={OrganizationSource.Partners}
+          orgId="1"
+          appId="1"
         />,
       )
 
@@ -261,6 +272,9 @@ describe('Logs', () => {
           pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
+          organizationSource={OrganizationSource.Partners}
+          orgId="1"
+          appId="1"
         />,
       )
 
@@ -321,6 +335,9 @@ describe('Logs', () => {
           pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
+          organizationSource={OrganizationSource.Partners}
+          orgId="1"
+          appId="1"
         />,
       )
 
@@ -382,6 +399,9 @@ describe('Logs', () => {
           pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
+          organizationSource={OrganizationSource.Partners}
+          orgId="1"
+          appId="1"
         />,
       )
 
@@ -430,6 +450,9 @@ describe('Logs', () => {
           pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
+          organizationSource={OrganizationSource.Partners}
+          orgId="1"
+          appId="1"
         />,
       )
 
@@ -477,6 +500,9 @@ describe('Logs', () => {
           pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
+          organizationSource={OrganizationSource.Partners}
+          orgId="1"
+          appId="1"
         />,
       )
 
@@ -512,6 +538,9 @@ describe('Logs', () => {
         pollOptions={{jwtToken: MOCKED_JWT_TOKEN, filters: EMPTY_FILTERS, cursor: MOCKED_CURSOR}}
         resubscribeCallback={mockedResubscribeCallback}
         storeNameById={new Map()}
+        organizationSource={OrganizationSource.Partners}
+        orgId="1"
+        appId="1"
       />,
     )
 

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.tsx
@@ -12,13 +12,16 @@ import {
 import {prettyPrintJsonIfPossible} from '../../../utils.js'
 
 import React, {FunctionComponent} from 'react'
-
+import {OrganizationSource} from '../../../../../models/organization.js'
 import {Box, Text} from '@shopify/cli-kit/node/ink'
 
 interface LogsProps {
   resubscribeCallback: () => Promise<string>
   pollOptions: PollOptions
   storeNameById: Map<string, string>
+  organizationSource: OrganizationSource
+  orgId: string
+  appId: string
 }
 
 const getBackgroundExecutionReasonMessage = (reason: BackgroundExecutionReason): string => {
@@ -32,8 +35,23 @@ const getBackgroundExecutionReasonMessage = (reason: BackgroundExecutionReason):
   }
 }
 
-const Logs: FunctionComponent<LogsProps> = ({pollOptions: {jwtToken, filters}, resubscribeCallback, storeNameById}) => {
-  const {appLogOutputs, errors} = usePollAppLogs({filters, initialJwt: jwtToken, resubscribeCallback, storeNameById})
+const Logs: FunctionComponent<LogsProps> = ({
+  pollOptions: {jwtToken, filters},
+  resubscribeCallback,
+  storeNameById,
+  organizationSource,
+  orgId,
+  appId,
+}) => {
+  const {appLogOutputs, errors} = usePollAppLogs({
+    filters,
+    initialJwt: jwtToken,
+    resubscribeCallback,
+    storeNameById,
+    organizationSource,
+    orgId,
+    appId,
+  })
 
   return (
     <>

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
@@ -15,6 +15,7 @@ import {
   NetworkAccessRequestExecutionInBackgroundLog,
   NetworkAccessResponseFromCacheLog,
 } from '../../../../types.js'
+import {OrganizationSource} from '../../../../../../models/organization.js'
 import {render} from '@shopify/cli-kit/node/testing/ui'
 import {test, describe, vi, beforeEach, afterEach, expect} from 'vitest'
 import React from 'react'
@@ -204,6 +205,9 @@ describe('usePollAppLogs', () => {
         filters: EMPTY_FILTERS,
         resubscribeCallback,
         storeNameById: STORE_NAME_BY_ID,
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
       }),
     )
 
@@ -323,6 +327,9 @@ describe('usePollAppLogs', () => {
         filters: EMPTY_FILTERS,
         resubscribeCallback,
         storeNameById: STORE_NAME_BY_ID,
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
       }),
     )
 
@@ -331,15 +338,33 @@ describe('usePollAppLogs', () => {
 
     // Initial invocation, 401 returned
     expect(mockedPollAppLogs).toHaveBeenNthCalledWith(1, {
-      jwtToken: MOCKED_JWT_TOKEN,
-      cursor: '',
-      filters: EMPTY_FILTERS,
+      options: {
+        appId: '1',
+        orgId: '1',
+        organizationSource: OrganizationSource.Partners,
+      },
+      pollOptions: {
+        cursor: '',
+        filters: EMPTY_FILTERS,
+        jwtToken: MOCKED_JWT_TOKEN,
+      },
     })
     expect(resubscribeCallback).toHaveBeenCalledOnce()
 
     // Follow up invocation, which invokes resubscribeCallback
     await vi.advanceTimersToNextTimerAsync()
-    expect(mockedPollAppLogs).toHaveBeenNthCalledWith(2, {jwtToken: NEW_JWT_TOKEN, cursor: '', filters: EMPTY_FILTERS})
+    expect(mockedPollAppLogs).toHaveBeenNthCalledWith(2, {
+      options: {
+        appId: '1',
+        orgId: '1',
+        organizationSource: OrganizationSource.Partners,
+      },
+      pollOptions: {
+        cursor: '',
+        filters: EMPTY_FILTERS,
+        jwtToken: NEW_JWT_TOKEN,
+      },
+    })
 
     expect(vi.getTimerCount()).toEqual(1)
   })
@@ -361,6 +386,9 @@ describe('usePollAppLogs', () => {
         filters: EMPTY_FILTERS,
         resubscribeCallback,
         storeNameById: STORE_NAME_BY_ID,
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
       }),
     )
 
@@ -400,6 +428,9 @@ describe('usePollAppLogs', () => {
         filters: EMPTY_FILTERS,
         resubscribeCallback,
         storeNameById: STORE_NAME_BY_ID,
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
       }),
     )
 
@@ -437,6 +468,9 @@ describe('usePollAppLogs', () => {
         filters: EMPTY_FILTERS,
         resubscribeCallback: vi.fn().mockResolvedValue(MOCKED_JWT_TOKEN),
         storeNameById: STORE_NAME_BY_ID,
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
       }),
     )
 
@@ -461,6 +495,9 @@ describe('usePollAppLogs', () => {
         filters: EMPTY_FILTERS,
         resubscribeCallback,
         storeNameById: new Map(),
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
       }),
     )
 

--- a/packages/app/src/cli/services/app-logs/types.ts
+++ b/packages/app/src/cli/services/app-logs/types.ts
@@ -171,6 +171,7 @@ export interface SubscribeOptions {
     apiKey: string
     token: string
   }
+  organizationId: string
 }
 
 export interface PollOptions {

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -182,20 +182,9 @@ export const fetchAppLogsDevDashboard = async (
   const url = await generateFetchAppLogUrlDevDashboard(organizationId, appId, cursor, filters)
   const userAgent = `Shopify CLI; v=${CLI_KIT_VERSION}`
 
-  const identityContext = {
-    client_id: 'shopify-cli-development',
-    scopes: ['https://api.shopify.com/auth/organization.apps.manage'],
-  }
-
   const headers = {
     Authorization: `Bearer ${jwtToken}`,
     'User-Agent': userAgent,
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    'X-Client-ID': 'shopify-cli-development',
-    'X-Identity-Context': JSON.stringify(identityContext),
-    'X-Identity-Scope': 'https://api.shopify.com/auth/organization.apps.manage',
-    'X-Shopify-Access-Token': `Bearer ${jwtToken}`,
   }
 
   return shopifyFetch(url, {
@@ -215,6 +204,8 @@ export const handleFetchAppLogsError = async (
   input: FetchAppLogsErrorOptions,
 ): Promise<{retryIntervalMs: number; nextJwtToken: string | null}> => {
   const {errors} = input.response
+
+  console.log("errors", errors)
 
   let retryIntervalMs = POLLING_INTERVAL_MS
   let nextJwtToken = null
@@ -301,9 +292,9 @@ export const subscribeToAppLogs = async (
   variables: AppLogsSubscribeVariables,
   organizationId: string,
 ): Promise<string> => {
-  console.log('vairalb', variables, organizationId)
   const result = await developerPlatformClient.subscribeToAppLogs(variables, organizationId)
   const {jwtToken, success, errors} = result.appLogsSubscribe
+  console.log("jwt subscribed?", jwtToken)
   outputDebug(`Token: ${jwtToken}\n`)
   outputDebug(`API Key: ${variables.apiKey}\n`)
   if (errors && errors.length > 0) {

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -145,7 +145,6 @@ const generateFetchAppLogUrlDevDashboard = async (
   return url
 }
 
-
 export const fetchAppLogs = async (
   jwtToken: string,
   cursor?: string,
@@ -185,13 +184,13 @@ export const fetchAppLogsDevDashboard = async (
 
   const identityContext = {
     client_id: 'shopify-cli-development',
-    scopes: ['https://api.shopify.com/auth/organization.apps.manage']
+    scopes: ['https://api.shopify.com/auth/organization.apps.manage'],
   }
 
   const headers = {
-    'Authorization': `Bearer ${jwtToken}`,
+    Authorization: `Bearer ${jwtToken}`,
     'User-Agent': userAgent,
-    'Accept': 'application/json',
+    Accept: 'application/json',
     'Content-Type': 'application/json',
     'X-Client-ID': 'shopify-cli-development',
     'X-Identity-Context': JSON.stringify(identityContext),
@@ -204,8 +203,6 @@ export const fetchAppLogsDevDashboard = async (
     headers,
   })
 }
-
-
 
 interface FetchAppLogsErrorOptions {
   response: ErrorResponse
@@ -304,6 +301,7 @@ export const subscribeToAppLogs = async (
   variables: AppLogsSubscribeVariables,
   organizationId: string,
 ): Promise<string> => {
+  console.log('vairalb', variables, organizationId)
   const result = await developerPlatformClient.subscribeToAppLogs(variables, organizationId)
   const {jwtToken, success, errors} = result.appLogsSubscribe
   outputDebug(`Token: ${jwtToken}\n`)

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -196,8 +196,6 @@ export const fetchAppLogsDevDashboard = async (
     'X-Client-ID': 'shopify-cli-development',
     'X-Identity-Context': JSON.stringify(identityContext),
     'X-Identity-Scope': 'https://api.shopify.com/auth/organization.apps.manage',
-    'X-Request-ID': crypto.randomUUID(),
-    'X-Shopify-Privacy-Level': 'default',
     'X-Shopify-Access-Token': `Bearer ${jwtToken}`,
   }
 

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
@@ -2,11 +2,11 @@ import {setupAppLogsPollingProcess, subscribeAndStartPolling} from './app-logs-p
 import {testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
 import {pollAppLogs} from '../../app-logs/dev/poll-app-logs.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {OrganizationSource} from '../../../models/organization.js'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {createLogsDir} from '@shopify/cli-kit/node/logs'
 import {describe, expect, vi, Mock, beforeEach, test} from 'vitest'
 import {outputWarn} from '@shopify/cli-kit/node/output'
-import { OrganizationSource } from '../../../models/organization.js'
 
 vi.mock('@shopify/cli-kit/node/logs')
 vi.mock('@shopify/cli-kit/node/output')
@@ -94,7 +94,7 @@ describe('app-logs-polling', () => {
       )
 
       // Then
-      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables)
+      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables, '1')
       expect(createLogsDir).toHaveBeenCalledWith(API_KEY)
       expect(pollAppLogs).toHaveBeenCalledOnce()
       expect(vi.mocked(pollAppLogs).mock.calls[0]?.[0]).toMatchObject({
@@ -102,7 +102,7 @@ describe('app-logs-polling', () => {
         appLogsFetchInput: {jwtToken: JWT_TOKEN},
         apiKey: API_KEY,
         storeName: 'storeName',
-        organizationSource: OrganizationSource.Partners,
+        organizationSource: OrganizationSource.BusinessPlatform,
         orgId: '1',
         appId: '1',
         resubscribeCallback: expect.any(Function),
@@ -128,7 +128,7 @@ describe('app-logs-polling', () => {
       )
 
       // Then
-      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables)
+      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables, '1')
       expect(outputWarn).toHaveBeenCalledWith(`Errors subscribing to app logs: uh oh, another error`)
       expect(outputWarn).toHaveBeenCalledWith(`App log streaming is not available in this session.`)
       expect(createLogsDir).not.toHaveBeenCalled()

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
@@ -6,6 +6,7 @@ import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {createLogsDir} from '@shopify/cli-kit/node/logs'
 import {describe, expect, vi, Mock, beforeEach, test} from 'vitest'
 import {outputWarn} from '@shopify/cli-kit/node/output'
+import { OrganizationSource } from '../../../models/organization.js'
 
 vi.mock('@shopify/cli-kit/node/logs')
 vi.mock('@shopify/cli-kit/node/output')
@@ -28,6 +29,8 @@ describe('app-logs-polling', () => {
         developerPlatformClient,
         subscription: {shopIds: SHOP_IDS, apiKey: API_KEY},
         storeName: 'storeName',
+        organizationId: '1',
+        appId: '1',
       })
 
       // Then
@@ -52,6 +55,9 @@ describe('app-logs-polling', () => {
       shopIds: SHOP_IDS,
       apiKey: API_KEY,
       token: TOKEN,
+      organizationId: '1',
+      appId: '1',
+      organizationSource: OrganizationSource.Partners,
     }
 
     let subscribeToAppLogs: Mock
@@ -82,6 +88,8 @@ describe('app-logs-polling', () => {
           developerPlatformClient,
           appLogsSubscribeVariables,
           storeName: 'storeName',
+          organizationId: '1',
+          appId: '1',
         },
       )
 
@@ -93,6 +101,11 @@ describe('app-logs-polling', () => {
         stdout,
         appLogsFetchInput: {jwtToken: JWT_TOKEN},
         apiKey: API_KEY,
+        storeName: 'storeName',
+        organizationSource: OrganizationSource.Partners,
+        orgId: '1',
+        appId: '1',
+        resubscribeCallback: expect.any(Function),
       })
     })
 
@@ -109,6 +122,8 @@ describe('app-logs-polling', () => {
           developerPlatformClient,
           appLogsSubscribeVariables,
           storeName: 'storeName',
+          organizationId: '1',
+          appId: '1',
         },
       )
 

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
@@ -62,7 +62,7 @@ export const subscribeAndStartPolling: DevProcessFunction<SubscribeAndStartPolli
 ) => {
   try {
     const jwtToken = await subscribeToAppLogs(developerPlatformClient, appLogsSubscribeVariables, organizationId)
-    const organizationSource = await developerPlatformClient.organizationSource
+    const organizationSource = developerPlatformClient.organizationSource
 
     const apiKey = appLogsSubscribeVariables.apiKey
     await createLogsDir(apiKey)

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -186,6 +186,8 @@ export async function setupDevProcesses({
             apiKey,
           },
           storeName: storeFqdn,
+          organizationId: remoteApp.organizationId,
+          appId: remoteApp.id,
         })
       : undefined,
     await setupAppWatcherProcess({

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -187,7 +187,7 @@ export async function setupDevProcesses({
           },
           storeName: storeFqdn,
           organizationId: remoteApp.organizationId,
-          appId: remoteApp.id,
+          appId: String(numberFromGid(remoteApp.id)),
         })
       : undefined,
     await setupAppWatcherProcess({
@@ -259,4 +259,8 @@ export const startProxyServer: DevProcessFunction<{port: number; rules: {[key: s
 ) => {
   const {server} = await getProxyingWebServer(rules, abortSignal)
   await server.listen(port)
+}
+
+function numberFromGid(gid: string): number {
+  return Number(gid.match(/^gid.*\/(\d+)$/)![1])
 }

--- a/packages/app/src/cli/services/logs.test.ts
+++ b/packages/app/src/cli/services/logs.test.ts
@@ -158,14 +158,21 @@ describe('logs', () => {
     expectedStoreMap.set('2', 'other-fqdn')
     expect(consoleLog).toHaveBeenCalledWith('{"subscribedToStores":["store-fqdn","other-fqdn"]}')
     expect(consoleLog).toHaveBeenCalledWith('{"message":"Waiting for app logs..."}')
-    expect(spy).toHaveBeenCalledWith({
-      options: {
-        developerPlatformClient: expect.anything(),
-        variables: {shopIds: ['1', '2'], apiKey: expect.anything(), token: expect.anything()},
-      },
-      pollOptions: expect.anything(),
-      storeNameById: expectedStoreMap,
-    })
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {
+          developerPlatformClient: expect.anything(),
+          organizationId: '1',
+          variables: {
+            shopIds: ['1', '2'],
+            apiKey: expect.any(String),
+            token: expect.any(String),
+          },
+        },
+        pollOptions: expect.anything(),
+        storeNameById: expectedStoreMap,
+      }),
+    )
   })
 
   test('should load additional stores in TTY mode', async () => {
@@ -194,14 +201,30 @@ describe('logs', () => {
     expectedStoreMap.set('1', 'store-fqdn')
     expectedStoreMap.set('2', 'other-fqdn')
     expect(consoleLog).toHaveBeenCalledWith('Waiting for app logs...\n')
-    expect(spy).toHaveBeenCalledWith({
-      options: {
-        developerPlatformClient: expect.anything(),
-        variables: {shopIds: ['1', '2'], apiKey: expect.anything(), token: expect.anything()},
-      },
-      pollOptions: expect.anything(),
-      storeNameById: expectedStoreMap,
-    })
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {
+          developerPlatformClient: expect.anything(),
+          organizationId: '1',
+          variables: {
+            shopIds: ['1', '2'],
+            apiKey: expect.any(String),
+            token: expect.any(String),
+          },
+        },
+        pollOptions: expect.objectContaining({
+          filters: {
+            sources: ['extensions.source'],
+            status: 'status',
+          },
+          jwtToken: expect.any(String),
+        }),
+        storeNameById: expectedStoreMap,
+        appId: expect.any(String),
+        orgId: expect.any(String),
+        organizationSource: expect.any(String),
+      }),
+    )
   })
 
   test('should render custom info box', async () => {

--- a/packages/app/src/cli/services/logs.ts
+++ b/packages/app/src/cli/services/logs.ts
@@ -53,7 +53,7 @@ export async function logs(commandOptions: LogsOptions) {
     token: '',
   }
 
-  const jwtToken = await subscribeToAppLogs(developerPlatformClient, variables)
+  const jwtToken = await subscribeToAppLogs(developerPlatformClient, variables, commandOptions.organization.id)
 
   const filters = {
     status: commandOptions.status,
@@ -72,6 +72,7 @@ export async function logs(commandOptions: LogsOptions) {
       options: {
         variables,
         developerPlatformClient,
+        organizationId: commandOptions.organization.id,
       },
       pollOptions,
       storeNameById: logsConfig.storeNameById,
@@ -82,6 +83,7 @@ export async function logs(commandOptions: LogsOptions) {
       options: {
         variables,
         developerPlatformClient,
+        organizationId: commandOptions.organization.id,
       },
       pollOptions,
       storeNameById: logsConfig.storeNameById,

--- a/packages/app/src/cli/services/logs.ts
+++ b/packages/app/src/cli/services/logs.ts
@@ -54,7 +54,7 @@ export async function logs(commandOptions: LogsOptions) {
   }
 
   const jwtToken = await subscribeToAppLogs(developerPlatformClient, variables, commandOptions.organization.id)
-  const organizationSource = await developerPlatformClient.organizationSource
+  const organizationSource = developerPlatformClient.organizationSource
 
   const filters = {
     status: commandOptions.status,

--- a/packages/app/src/cli/services/logs.ts
+++ b/packages/app/src/cli/services/logs.ts
@@ -54,6 +54,7 @@ export async function logs(commandOptions: LogsOptions) {
   }
 
   const jwtToken = await subscribeToAppLogs(developerPlatformClient, variables, commandOptions.organization.id)
+  const organizationSource = await developerPlatformClient.organizationSource
 
   const filters = {
     status: commandOptions.status,
@@ -76,6 +77,9 @@ export async function logs(commandOptions: LogsOptions) {
       },
       pollOptions,
       storeNameById: logsConfig.storeNameById,
+      organizationSource: organizationSource,
+      orgId: commandOptions.organization.id,
+      appId: remoteApp.id,
     })
   } else {
     consoleLog('Waiting for app logs...\n')
@@ -87,6 +91,9 @@ export async function logs(commandOptions: LogsOptions) {
       },
       pollOptions,
       storeNameById: logsConfig.storeNameById,
+      organizationSource: organizationSource,
+      orgId: commandOptions.organization.id,
+      appId: String(numberFromGid(remoteApp.id)),
     })
   }
 }
@@ -142,4 +149,8 @@ function renderAppLogsConfigInfo(
     headline: configFile ? `Using ${fileName} for default values:` : 'Using these settings:',
     body,
   })
+}
+
+function numberFromGid(gid: string): number {
+  return Number(gid.match(/^gid.*\/(\d+)$/)![1])
 }

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -273,7 +273,7 @@ export interface DeveloperPlatformClient {
   ) => Promise<string | null>
   migrateToUiExtension: (input: MigrateToUiExtensionVariables) => Promise<MigrateToUiExtensionSchema>
   toExtensionGraphQLType: (input: string) => string
-  subscribeToAppLogs: (input: AppLogsSubscribeVariables) => Promise<AppLogsSubscribeResponse>
+  subscribeToAppLogs: (input: AppLogsSubscribeVariables, organizationId: string) => Promise<AppLogsSubscribeResponse>
   appDeepLink: (app: MinimalAppIdentifiers) => Promise<string>
   devSessionCreate: (input: DevSessionOptions) => Promise<DevSessionCreateMutation>
   devSessionUpdate: (input: DevSessionOptions) => Promise<DevSessionUpdateMutation>

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -112,8 +112,7 @@ import {
   SchemaDefinitionByTargetQueryVariables,
   AppLogsSubscribeQueryVariables,
   AppLogsSubscribeQuery,
-  AppLogsSubscribe
-
+  AppLogsSubscribe,
 } from '../../api/graphql/functions/generated/schema-definition-by-target.js'
 import {
   SchemaDefinitionByApiType,
@@ -140,7 +139,7 @@ import {developerDashboardFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {webhooksRequest} from '@shopify/cli-kit/node/api/webhooks'
 import {functionsRequestDoc} from '@shopify/cli-kit/node/api/functions'
 import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
-import { gql } from 'graphql-request'
+import {gql} from 'graphql-request'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 const TEMPLATE_JSON_URL = 'https://cdn.shopify.com/static/cli/extensions/templates.json'
@@ -177,7 +176,6 @@ interface AppLogsSubscribeVariables {
   apiKey: string
   token: string
 }
-
 
 export class AppManagementClient implements DeveloperPlatformClient {
   public readonly clientName = ClientName.AppManagement
@@ -827,7 +825,10 @@ export class AppManagementClient implements DeveloperPlatformClient {
     throw new BugError('Not implemented: currentAccountInfo')
   }
 
-  async subscribeToAppLogs(input: AppLogsSubscribeVariables, organizationId: string): Promise<AppLogsSubscribeResponse> {
+  async subscribeToAppLogs(
+    input: AppLogsSubscribeVariables,
+    organizationId: string,
+  ): Promise<AppLogsSubscribeResponse> {
     const apiKey = input.apiKey
 
     const {app} = await this.activeAppVersionRawResult({apiKey, organizationId})
@@ -844,15 +845,13 @@ export class AppManagementClient implements DeveloperPlatformClient {
           shopIds: input.shopIds,
           apiKey: input.apiKey,
         },
-      );
+      )
       return result
     } catch (error) {
       // TODO: handle error
       throw new Error(`Not Implemented: ${JSON.stringify(input)}`)
     }
   }
-
-
 
   async targetSchemaDefinition(
     input: SchemaDefinitionByTargetQueryVariables,
@@ -863,9 +862,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       const {app} = await this.activeAppVersionRawResult({apiKey, organizationId})
       const appIdNumber = String(numberFromGid(app.id))
       const token = await this.token()
-      console.log(organizationId)
-      console.log(appIdNumber)
-      console.log(token)
+
       const result = await functionsRequestDoc<SchemaDefinitionByTargetQuery, SchemaDefinitionByTargetQueryVariables>(
         organizationId,
         SchemaDefinitionByTarget,
@@ -1117,4 +1114,3 @@ function appModuleVersion(mod: ReleasedAppModuleFragment): Required<AppModuleVer
     },
   }
 }
-

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -566,7 +566,7 @@ export class PartnersClient implements DeveloperPlatformClient {
     return input.toUpperCase()
   }
 
-  async subscribeToAppLogs(input: AppLogsSubscribeVariables): Promise<AppLogsSubscribeResponse> {
+  async subscribeToAppLogs(input: AppLogsSubscribeVariables, _organizationId: string): Promise<AppLogsSubscribeResponse> {
     return this.request(AppLogsSubscribeMutation, input)
   }
 

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -566,7 +566,10 @@ export class PartnersClient implements DeveloperPlatformClient {
     return input.toUpperCase()
   }
 
-  async subscribeToAppLogs(input: AppLogsSubscribeVariables, _organizationId: string): Promise<AppLogsSubscribeResponse> {
+  async subscribeToAppLogs(
+    input: AppLogsSubscribeVariables,
+    _organizationId: string,
+  ): Promise<AppLogsSubscribeResponse> {
     return this.request(AppLogsSubscribeMutation, input)
   }
 


### PR DESCRIPTION
Part of: https://github.com/Shopify/shopify-functions/issues/605

Note:

We will need the relevant Core and Partners PR to be merged and do not have them merged. Hoping to get review on the approach I've taken, specically around how we fetch the app logs.

For polling app logs, in `dev` and `logs`, I've added this to determine which client to use.

```
  const response: Response = isDevDashboard
    ? await fetchAppLogsDevDashboard(jwtToken, orgId, appId, cursor)
    : await fetchAppLogs(jwtToken, cursor)
```

Another option or alternative, is we can move the `fetchAppLogs` to the `DeveloperPlatformClient`, but think this would involved a larger refactor and would prefer to tackle in another PR or issue. 

-----------------------

### WHY are these changes introduced?

This PR is for integrating **app logs polling with the developer dashboard**. 

Background:

There is 2 steps for polling:
1. Subscribe - This is done through the `DeveloperPlatformClient`
    - I updated the interface to accept `organizationId: string`, we also need `appId`  for the request, we alraedy have access to that through the cli context
    - CLI will make a 'subscribe' request to receive a JWT token from partners
    - simple approach we can just implement the method and make request to dev dash endpoint 

2. Fetch App Logs - is a bit more complicated since we dont use the `DeveloperPlatformClient`
    - polling app logs is called through separate but similar code paths for `dev` and `logs`
    - Currently, how we call `pollAppLogs` in the CLI, there is no concept of what client is being used (to know whether to make request to partners or app management)
    - added `fetchAppLogsDevDashboard`
    
  

### WHAT is this pull request doing?

1. Update the `subscribeToAppLogs` for the `app-management-client` to make request to new core endpoint (which will proxy request to partners for now) Endpoint on this branch.
    - Needs Jacob's core branch ` js.add-app-log-endpoints-2`
    - need to pass `appId`, and `orgId` for app management requests, which are now passed in

2. Update polling app logs for `dev` and `logs`
- Since this is not on the developer platform client, CLI will not know where to make the request
- Added the `organizationSource` to know which endpoint to make request to
- implemented similar changes for both commands

### How to test your changes?

Will need:
```
Core:  03-07-expose_dev_dash_route_to_manage_app_logs
Partners: js.app-logs-prototype-2
```

🎩

```
pnpm run shopify app dev --path=./path-to-app

pnpm run shopify app logs --path=./path-to-app
```

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
