### PR TITLE
`use-localhost` improvements and tweaks

### DIFF
--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -6,6 +6,7 @@ import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {linkedAppContext} from '../../services/app-context.js'
 import {storeContext} from '../../services/store-context.js'
 import {generateCertificate} from '../../utilities/mkcert.js'
+import {generateCertificatePrompt} from '../../prompts/dev.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -160,7 +161,10 @@ If you're using the Ruby app template, then you need to complete the following s
             },
           })
 
-          return generateCertificate({appDirectory})
+          return generateCertificate({
+            appDirectory,
+            onRequiresConfirmation: generateCertificatePrompt,
+          })
         },
       }
     } else if (flags['tunnel-url']) {

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -150,14 +150,14 @@ If you're using the Ruby app template, then you need to complete the following s
           renderInfo({
             headline: 'localhost development is experimental.',
             body: [
-              'The --use-localhost flag has limitations. ',
+              'The --use-localhost flag has limitations.',
               'It works for testing App Bridge, Admin UI, Checkout UI or Pixels.',
               "It won't work for Webhooks, Flow Actions, App Proxy or POS features.",
-              'If you encounter any issues, please provide feedback:',
+              'Please report any issues and provide feedback on the dev community:',
             ],
             link: {
-              label: 'Feedback',
-              url: 'https://community.shopify.dev/new-topic?title=[Feedback%20for%20--use-localhost]&category=shopify-cli-libraries&tags=app-dev-on-localhost',
+              label: 'Create a feedback post',
+              url: 'https://community.shopify.dev/new-topic?category=shopify-cli-libraries&tags=app-dev-on-localhost',
             },
           })
 

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -6,7 +6,6 @@ import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
 import {linkedAppContext} from '../../services/app-context.js'
 import {storeContext} from '../../services/store-context.js'
 import {generateCertificate} from '../../utilities/mkcert.js'
-import {downloadMkcert} from '../../prompts/dev.js'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
@@ -161,10 +160,7 @@ If you're using the Ruby app template, then you need to complete the following s
             },
           })
 
-          return generateCertificate({
-            appDirectory,
-            onRequiresDownloadConfirmation: downloadMkcert,
-          })
+          return generateCertificate({appDirectory})
         },
       }
     } else if (flags['tunnel-url']) {

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -211,10 +211,10 @@ function updateURLsPromptWithDevSessions(currentAppUrl: string, urls: Applicatio
   })
 }
 
-export function downloadMkcert() {
+export function generateCertificatePrompt() {
   return renderConfirmationPrompt({
-    message: "--use-localhost requires `mkcert`, but it's not found. Download it now?",
-    confirmationMessage: 'Yes, download mkcert',
+    message: '--use-localhost requires a certificate for `localhost`. Generate it now?',
+    confirmationMessage: 'Yes, use mkcert to generate it',
     cancellationMessage: "No, I'll provide it manually",
   })
 }

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -48,7 +48,7 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 
 interface NoTunnel {
   mode: 'no-tunnel-use-localhost'
-  provideCertificate: (appDirectory: string) => Promise<{keyContent: string; certContent: string}>
+  provideCertificate: (appDirectory: string) => Promise<{keyContent: string; certContent: string; certPath: string}>
 }
 
 interface AutoTunnel {
@@ -343,10 +343,11 @@ async function setupNetworkingOptions(
 
   let reverseProxyCert
   if (tunnelOptions.mode === 'no-tunnel-use-localhost') {
-    const {keyContent, certContent} = await tunnelOptions.provideCertificate(appDirectory)
+    const {keyContent, certContent, certPath} = await tunnelOptions.provideCertificate(appDirectory)
     reverseProxyCert = {
       key: keyContent,
       cert: certContent,
+      certPath,
     }
   }
 

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -104,6 +104,7 @@ describe('setup-dev-processes', () => {
       reverseProxyCert: {
         cert: 'cert',
         key: 'key',
+        certPath: 'localhost.pem',
       },
       currentUrls: {
         applicationUrl: 'https://example.com/application',

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -266,7 +266,10 @@ export const startProxyServer: DevProcessFunction<{
   port: number
   rules: {[key: string]: string}
   localhostCert?: LocalhostCert
-}> = async ({abortSignal}, {port, rules, localhostCert}) => {
+}> = async ({abortSignal, stdout}, {port, rules, localhostCert}) => {
   const {server} = await getProxyingWebServer(rules, abortSignal, localhostCert)
+  stdout.write(
+    `Proxy server started on port ${port} ${localhostCert ? `with certificate ${localhostCert.certPath}` : ''}`,
+  )
   await server.listen(port)
 }

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
@@ -180,4 +180,5 @@ const localhostCert = {
     'fbw6iqA335rMbN/+jBGZ2ixrrro7lc3RKI0oayLHT1QnszQdZy+SAfV3a++nwbkC\n' +
     'Sad3b/7iWHY=\n' +
     '-----END CERTIFICATE-----\n',
+  certPath: 'localhost.pem',
 }

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -7,6 +7,7 @@ import * as https from 'https'
 export interface LocalhostCert {
   key: string
   cert: string
+  certPath: string
 }
 
 export async function getProxyingWebServer(

--- a/packages/app/src/cli/utilities/mkcert.test.ts
+++ b/packages/app/src/cli/utilities/mkcert.test.ts
@@ -6,6 +6,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 import which from 'which'
 import {downloadGitHubRelease} from '@shopify/cli-kit/node/github'
 import {testWithTempDir} from '@shopify/cli-kit/node/testing/test-with-temp-dir'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 vi.mock('@shopify/cli-kit/node/system')
 vi.mock('which')
@@ -23,10 +24,10 @@ describe('mkcert', () => {
         await writeFile(joinPath(appDirectory, '.shopify', 'localhost.pem'), 'cert')
       })
 
-      const onRequiresDownloadConfirmation = vi.fn()
-      const {keyContent, certContent} = await generateCertificate({
+      const onRequiresConfirmation = vi.fn().mockReturnValue(true)
+      const {keyContent, certContent, certPath} = await generateCertificate({
         appDirectory,
-        onRequiresDownloadConfirmation,
+        onRequiresConfirmation,
         env: {
           SHOPIFY_CLI_MKCERT_BINARY: '/path/to/mkcert',
         },
@@ -35,6 +36,7 @@ describe('mkcert', () => {
 
       expect(keyContent).toBe('key')
       expect(certContent).toBe('cert')
+      expect(certPath).toBe(joinPath('.shopify', 'localhost.pem'))
     })
 
     testWithTempDir('generates a certificate using mkcert from default path', async ({tempDir}) => {
@@ -52,15 +54,16 @@ describe('mkcert', () => {
         await writeFile(joinPath(appDirectory, '.shopify', 'localhost.pem'), 'cert')
       })
 
-      const onRequiresDownloadConfirmation = vi.fn()
-      const {keyContent, certContent} = await generateCertificate({
+      const onRequiresConfirmation = vi.fn().mockReturnValue(true)
+      const {keyContent, certContent, certPath} = await generateCertificate({
         appDirectory,
-        onRequiresDownloadConfirmation,
+        onRequiresConfirmation,
         platform: 'linux',
       })
 
       expect(keyContent).toBe('key')
       expect(certContent).toBe('cert')
+      expect(certPath).toBe(joinPath('.shopify', 'localhost.pem'))
     })
 
     testWithTempDir('generates a certificate using mkcert from system PATH', async ({tempDir}) => {
@@ -76,15 +79,16 @@ describe('mkcert', () => {
         await writeFile(joinPath(appDirectory, '.shopify', 'localhost.pem'), 'cert')
       })
 
-      const onRequiresDownload = vi.fn()
-      const {keyContent, certContent} = await generateCertificate({
+      const onRequiresConfirmation = vi.fn().mockReturnValue(true)
+      const {keyContent, certContent, certPath} = await generateCertificate({
         appDirectory,
-        onRequiresDownloadConfirmation: onRequiresDownload,
+        onRequiresConfirmation,
         platform: 'linux',
       })
 
       expect(keyContent).toBe('key')
       expect(certContent).toBe('cert')
+      expect(certPath).toBe(joinPath('.shopify', 'localhost.pem'))
     })
 
     testWithTempDir('generates a certificate using a downloaded mkcert', async ({tempDir}) => {
@@ -98,16 +102,17 @@ describe('mkcert', () => {
         await writeFile(joinPath(appDirectory, '.shopify', 'localhost.pem'), 'cert')
       })
 
-      const onRequiresDownloadConfirmation = vi.fn().mockReturnValue(true)
-      const {keyContent, certContent} = await generateCertificate({
+      const onRequiresConfirmation = vi.fn().mockReturnValue(true)
+      const {keyContent, certContent, certPath} = await generateCertificate({
         appDirectory,
-        onRequiresDownloadConfirmation,
+        onRequiresConfirmation,
         platform: 'linux',
       })
 
       expect(keyContent).toBe('key')
       expect(certContent).toBe('cert')
-      expect(onRequiresDownloadConfirmation).toHaveBeenCalled()
+      expect(certPath).toBe(joinPath('.shopify', 'localhost.pem'))
+      expect(onRequiresConfirmation).toHaveBeenCalled()
       expect(downloadGitHubRelease).toHaveBeenCalledWith(
         'FiloSottile/mkcert',
         'v1.4.4',
@@ -127,22 +132,59 @@ describe('mkcert', () => {
         await writeFile(joinPath(appDirectory, '.shopify', 'localhost.pem'), 'cert')
       })
 
-      const onRequiresDownloadConfirmation = vi.fn().mockReturnValue(true)
-      const {keyContent, certContent} = await generateCertificate({
+      const onRequiresConfirmation = vi.fn().mockReturnValue(true)
+      const {keyContent, certContent, certPath} = await generateCertificate({
         appDirectory,
-        onRequiresDownloadConfirmation,
+        onRequiresConfirmation,
         platform: 'win32',
       })
 
       expect(keyContent).toBe('key')
       expect(certContent).toBe('cert')
-      expect(onRequiresDownloadConfirmation).toHaveBeenCalled()
+      expect(certPath).toBe(joinPath('.shopify', 'localhost.pem'))
+      expect(onRequiresConfirmation).toHaveBeenCalled()
       expect(downloadGitHubRelease).toHaveBeenCalledWith(
         'FiloSottile/mkcert',
         'v1.4.4',
         expect.any(String),
         mkcertDefaultPath,
       )
+    })
+
+    testWithTempDir('skips certificate generation if the user does not confirm', async ({tempDir}) => {
+      const appDirectory = tempDir
+      const onRequiresConfirmation = vi.fn().mockReturnValue(false)
+      const generatePromise = generateCertificate({
+        appDirectory,
+        onRequiresConfirmation,
+        platform: 'linux',
+      })
+
+      await expect(generatePromise).rejects.toThrow(AbortError)
+      expect(onRequiresConfirmation).toHaveBeenCalled()
+      expect(exec).not.toHaveBeenCalled()
+      expect(downloadGitHubRelease).not.toHaveBeenCalled()
+    })
+
+    testWithTempDir('skips certificate generation if the certificate already exists', async ({tempDir}) => {
+      const appDirectory = tempDir
+      await mkdir(joinPath(appDirectory, '.shopify'))
+      await writeFile(joinPath(appDirectory, '.shopify', 'localhost-key.pem'), 'key')
+      await writeFile(joinPath(appDirectory, '.shopify', 'localhost.pem'), 'cert')
+
+      const onRequiresConfirmation = vi.fn()
+      const {keyContent, certContent, certPath} = await generateCertificate({
+        appDirectory,
+        onRequiresConfirmation,
+        platform: 'linux',
+      })
+
+      expect(keyContent).toBe('key')
+      expect(certContent).toBe('cert')
+      expect(certPath).toBe(joinPath('.shopify', 'localhost.pem'))
+      expect(onRequiresConfirmation).not.toHaveBeenCalled()
+      expect(exec).not.toHaveBeenCalled()
+      expect(downloadGitHubRelease).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/app/src/cli/utilities/mkcert.ts
+++ b/packages/app/src/cli/utilities/mkcert.ts
@@ -106,7 +106,7 @@ export async function generateCertificate({
 
   outputInfo(outputContent`Generating self-signed certificate for localhost. You may be prompted for your password.`)
   await exec(mkcertPath, ['-install', '-key-file', keyPath, '-cert-file', certPath, 'localhost'])
-  outputInfo(outputContent`${outputToken.successIcon()} Certificate generated at ${relativeCertPath}`)
+  outputInfo(outputContent`${outputToken.successIcon()} Certificate generated at ${relativeCertPath}\n`)
 
   return {
     keyContent: await readFile(keyPath),

--- a/packages/app/src/cli/utilities/mkcert.ts
+++ b/packages/app/src/cli/utilities/mkcert.ts
@@ -1,7 +1,7 @@
 import {environmentVariableNames} from '../constants.js'
 import {exec} from '@shopify/cli-kit/node/system'
 import {downloadGitHubRelease} from '@shopify/cli-kit/node/github'
-import {joinPath} from '@shopify/cli-kit/node/path'
+import {joinPath, relativePath} from '@shopify/cli-kit/node/path'
 import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
 import {outputContent, outputDebug, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
@@ -94,7 +94,7 @@ export async function generateCertificate({
   env = process.env,
   platform = process.platform,
   arch = process.arch,
-}: GenerateCertificateOptions): Promise<{keyContent: string; certContent: string}> {
+}: GenerateCertificateOptions): Promise<{keyContent: string; certContent: string; certPath: string}> {
   const mkcertPath = await getMkcertPath(appDirectory, onRequiresDownloadConfirmation, env, platform, arch)
 
   outputDebug(outputContent`${mkcertSnippet} found at: ${outputToken.path(mkcertPath)}`)
@@ -105,5 +105,9 @@ export async function generateCertificate({
   await exec(mkcertPath, ['-install', '-key-file', keyPath, '-cert-file', certPath, 'localhost'])
   outputInfo(outputContent`${outputToken.successIcon()} ${mkcertSnippet} is installed`)
 
-  return {keyContent: await readFile(keyPath), certContent: await readFile(certPath)}
+  return {
+    keyContent: await readFile(keyPath),
+    certContent: await readFile(certPath),
+    certPath: relativePath(appDirectory, certPath),
+  }
 }

--- a/packages/app/src/cli/utilities/mkcert.ts
+++ b/packages/app/src/cli/utilities/mkcert.ts
@@ -1,5 +1,4 @@
 import {environmentVariableNames} from '../constants.js'
-import {generateCertificatePrompt} from '../prompts/dev.js'
 import {exec} from '@shopify/cli-kit/node/system'
 import {downloadGitHubRelease} from '@shopify/cli-kit/node/github'
 import {joinPath, relativePath} from '@shopify/cli-kit/node/path'
@@ -61,6 +60,7 @@ async function downloadMkcert(targetPath: string, platform: NodeJS.Platform, arc
 
 interface GenerateCertificateOptions {
   appDirectory: string
+  onRequiresConfirmation: () => Promise<boolean>
   resetFirst?: boolean
   env?: NodeJS.ProcessEnv
   platform?: NodeJS.Platform
@@ -79,6 +79,7 @@ interface GenerateCertificateOptions {
  */
 export async function generateCertificate({
   appDirectory,
+  onRequiresConfirmation,
   env = process.env,
   platform = process.platform,
   arch = process.arch,
@@ -96,7 +97,7 @@ export async function generateCertificate({
     }
   }
 
-  const shouldGenerate = await generateCertificatePrompt()
+  const shouldGenerate = await onRequiresConfirmation()
   if (!shouldGenerate) {
     throw new AbortError(`Localhost certificate and key are required at ${relativeCertPath} and ${relativeKeyPath}`)
   }

--- a/packages/cli-kit/src/public/node/github.ts
+++ b/packages/cli-kit/src/public/node/github.ts
@@ -5,7 +5,7 @@ import {writeFile, mkdir, inTemporaryDirectory, moveFile, chmod} from './fs.js'
 import {dirname, joinPath} from './path.js'
 import {runWithTimer} from './metadata.js'
 import {AbortError} from './error.js'
-import {outputContent, outputDebug, outputInfo, outputToken} from '../../public/node/output.js'
+import {outputContent, outputDebug, outputToken} from '../../public/node/output.js'
 
 class GitHubClientError extends Error {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -138,7 +138,7 @@ export async function downloadGitHubRelease(
   const url = `https://github.com/${repo}/releases/download/${version}/${assetName}`
 
   return runWithTimer('cmd_all_timing_network_ms')(async () => {
-    outputInfo(outputContent`🌍 Downloading ${outputToken.link(assetName, url)}`)
+    outputDebug(outputContent`Downloading ${outputToken.link(assetName, url)}`)
     await inTemporaryDirectory(async (tmpDir) => {
       const tempPath = joinPath(tmpDir, assetName)
       let response: Response


### PR DESCRIPTION
Some suggested DX adjustments to this PR:

* I’m checking if the cert already exists, and just prompting for that. I removed the existing prompt for mkcert download. (We don’t prompt for other binary downloads)
* Simplified the output for when we do need to generate a cert
* If the cert already exists, nothing new is output before the standard dev logs
* Added a log line for the proxy server indicating the port and cert it’s using
* Some language and URL tweaks to the info banner