### PR TITLE
Remove unused metafield def owner type

### DIFF
--- a/.changeset/poor-radios-applaud.md
+++ b/.changeset/poor-radios-applaud.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+[internal] Remove unused metafield definition ownerType

--- a/packages/theme/src/cli/services/metafields-pull.test.ts
+++ b/packages/theme/src/cli/services/metafields-pull.test.ts
@@ -61,7 +61,6 @@ describe('metafields-pull', () => {
           {
             article: [],
             blog: [],
-            brand: [],
             collection: [],
             company: [],
             company_location: [],
@@ -126,7 +125,6 @@ describe('metafields-pull', () => {
           {
             article: [],
             blog: [],
-            brand: [],
             collection: [fakeMetafieldDefinition],
             company: [],
             company_location: [],

--- a/packages/theme/src/cli/services/metafields-pull.ts
+++ b/packages/theme/src/cli/services/metafields-pull.ts
@@ -74,7 +74,6 @@ export async function metafieldsPull(flags: MetafieldsPullFlags): Promise<void> 
 const handleToOwnerType = {
   article: 'ARTICLE',
   blog: 'BLOG',
-  brand: 'BRAND',
   collection: 'COLLECTION',
   company: 'COMPANY',
   company_location: 'COMPANY_LOCATION',


### PR DESCRIPTION
### WHY are these changes introduced?

Doesn't look like `brand` being an owner type exists anymore when fetching metafield definitions

We already removed it from os-web: https://github.com/Shopify/online-store-web/pull/21978/files

### WHAT is this pull request doing?

- removed unused metafield owner type from code

### How to test your changes?

n/a

### Post-release steps

n/a

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
