### PR TITLE
Fix GraphQL codegen PR job to actually generate PR each time

### DIFF
--- a/.github/workflows/update-graphql-deps.yml
+++ b/.github/workflows/update-graphql-deps.yml
@@ -51,7 +51,7 @@ jobs:
           git commit -m "update generated graphql files"
           git push --set-upstream origin auto-update-graphql-deps --force
 
-          if ! gh pr view auto-update-graphql-deps &>/dev/null; then
+          if (gh pr ls -H auto-update-graphql-deps | wc -l | grep 0 &>/dev/null); then
             gh pr create --title "Update generated GraphQL files" \
               --body "This auto-generated PR updates the generated graphql files" \
               --head auto-update-graphql-deps


### PR DESCRIPTION
Previously it would exit successfully because a PR already exists. It just happens to be a closed PR. So now we attempt to list open PRs, and if there are none, we open one.

Bottom line, the job works now, and you can see the first PR here: #5499 