### PR TITLE
Cache CreateAssetURL for 1h

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -558,7 +558,13 @@ export class AppManagementClient implements DeveloperPlatformClient {
   }
 
   async generateSignedUploadUrl({organizationId}: MinimalAppIdentifiers): Promise<AssetUrlSchema> {
-    const result = await appManagementRequestDoc(organizationId, CreateAssetUrl, await this.token())
+    const result = await appManagementRequestDoc(
+      organizationId,
+      CreateAssetUrl,
+      await this.token(),
+      {},
+      {cacheTTL: {minutes: 59}},
+    )
     return {
       assetUrl: result.appRequestSourceUploadUrl.sourceUploadUrl,
       userErrors: result.appRequestSourceUploadUrl.userErrors,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-outer-loop/issues/1277

This PR should be merged first: https://github.com/shop/world/pull/14765

### WHAT is this pull request doing?

Caches the result of the query to retrieve the asset URL for 59 minutes (under 1h, which will be the expiration of the URLs), so that it can be re-used during a dev session, instead of making an extra request on every update (330ms to 1s).

### How to test your changes?

`shopify app dev` with App Management API

To simplify, I've actually used `cacheTTL: {minutes: 2}`, so that I could wait for the expiration and it can be tested against production, where the URL only works for 5 min.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
