### PR TITLE
CLI can't force fetch metafields when run by language-server

### DIFF
--- a/.changeset/cold-radios-applaud.md
+++ b/.changeset/cold-radios-applaud.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+[BugFix] CLI can't force fetch metafields when run by language-server

--- a/packages/theme/src/cli/services/metafields-pull.ts
+++ b/packages/theme/src/cli/services/metafields-pull.ts
@@ -95,8 +95,16 @@ const handleToOwnerType = {
 async function executeMetafieldsPull(session: AdminSession, options: MetafieldsPullOptions) {
   const {force, path, silent} = options
 
-  if (!(await hasRequiredThemeDirectories(path)) && !(await ensureDirectoryConfirmed(force))) {
-    return
+  if (!(await hasRequiredThemeDirectories(path))) {
+    // If this is not a theme, and the CLI is run by the language server, quick return
+    if (process.env.SHOPIFY_LANGUAGE_SERVER === '1') {
+      return
+    }
+
+    // Ensure the user is okay with running this command outside a theme
+    if (!(await ensureDirectoryConfirmed(force))) {
+      return
+    }
   }
 
   const promises = []


### PR DESCRIPTION
Part of https://github.com/Shopify/theme-tools/issues/724

### WHY are these changes introduced?

When CLI is run from language-server `ensureDirectoryConfirmed` will ALWAYS return `true` since the user can't input yes/no when dealing with non-theme directories.
- This means that `metafields.json` will always be fetched (even for non-theme projects)

Instead of changing the behavior of `ensureDirectoryConfirmed`, we (@karreiro and I) decided to add an env var that can be processed by CLI. This env var would only be set when run from the language-server.

### WHAT is this pull request doing?

- Ensures metafield definitions can't be force-fetched when running from language-server (VSCode extension)

### How to test your changes?

- Build the CLI
  - `pnpm run build`
- In theme-tools change `fetchMetafieldDefinitionsForURI` so that it points to a built version of this branch (i.e. `<some-path>/Shopify/cli/packages/cli/bin/dev.js`)
- Run theme-tools (i.e. F5)
- Create a workspace
- Add a theme project
- Add an theme app project
- Add a random folder that contains a liquid file
- Ensure that only the theme project has `.shopify/metafields.json`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
