### PR TITLE
Config modules schemas inherit from BaseSchema

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -73,6 +73,7 @@ import {SchemaDefinitionByTargetQueryVariables} from '../../api/graphql/function
 import {SchemaDefinitionByApiTypeQueryVariables} from '../../api/graphql/functions/generated/schema-definition-by-api-type.js'
 import {AppHomeSpecIdentifier} from '../extensions/specifications/app_config_app_home.js'
 import {AppProxySpecIdentifier} from '../extensions/specifications/app_config_app_proxy.js'
+import {ExtensionSpecification} from '../extensions/specification.js'
 import {vi} from 'vitest'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
@@ -337,7 +338,7 @@ export async function testAppAccessConfigExtension(
     configuration,
     configurationPath: 'shopify.app.toml',
     directory: directory ?? './',
-    specification: appAccessSpec,
+    specification: appAccessSpec as unknown as ExtensionSpecification,
   })
 
   return extension
@@ -495,7 +496,7 @@ export async function testSingleWebhookSubscriptionExtension({
     configuration,
     configurationPath: 'shopify.app.toml',
     directory: './',
-    specification: appWebhookSubscriptionSpec,
+    specification: appWebhookSubscriptionSpec as unknown as ExtensionSpecification,
   })
 
   return webhooksExtension

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -1997,6 +1997,7 @@ wrong = "property"
         auth: {
           redirect_urls: ['https://example.com/api/auth'],
         },
+        name: 'for-testing-webhooks',
       },
       // this is the webhooks extension
       {
@@ -2007,10 +2008,12 @@ wrong = "property"
             {topics: ['orders/delete'], uri: 'https://example.com'},
           ],
         },
+        name: 'for-testing-webhooks',
       },
       {
         application_url: 'https://example.com/lala',
         embedded: true,
+        name: 'for-testing-webhooks',
       },
       // this is a webhook subscription extension
       {

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -73,7 +73,7 @@ function loadSpecifications() {
     uiExtensionSpec,
     webPixelSpec,
     editorExtensionCollectionSpecification,
-  ] as ExtensionSpecification[]
+  ]
 
-  return [...configModuleSpecs, ...moduleSpecs]
+  return [...configModuleSpecs, ...moduleSpecs] as ExtensionSpecification[]
 }

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -1,11 +1,12 @@
 import {buildAppURLForWeb} from '../../../utilities/app/app-url.js'
 import {validateUrl} from '../../app/validation/common.js'
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {BaseSchema} from '../schemas.js'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {normalizeDelimitedString} from '@shopify/cli-kit/common/string'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const AppAccessSchema = zod.object({
+const AppAccessSchema = BaseSchema.extend({
   access: zod
     .object({
       admin: zod
@@ -52,7 +53,7 @@ const appAccessSpec = createConfigExtensionSpecification({
     return outputContent`Scopes updated. ${outputToken.link('Open app to accept scopes.', scopesURL)}`.value
   },
   patchWithAppDevURLs: (config, urls) => {
-    if ('auth' in config && urls.redirectUrlWhitelist) {
+    if (urls.redirectUrlWhitelist) {
       config.auth = {redirect_urls: urls.redirectUrlWhitelist}
     }
   },

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
@@ -1,8 +1,9 @@
 import {validateUrl} from '../../app/validation/common.js'
+import {BaseSchema} from '../schemas.js'
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const AppHomeSchema = zod.object({
+const AppHomeSchema = BaseSchema.extend({
   application_url: validateUrl(zod.string({required_error: 'Valid URL is required'})),
   embedded: zod.boolean({required_error: 'Boolean is required', invalid_type_error: 'Value must be Boolean'}),
   app_preferences: zod
@@ -25,9 +26,7 @@ const appHomeSpec = createConfigExtensionSpecification({
   schema: AppHomeSchema,
   transformConfig: AppHomeTransformConfig,
   patchWithAppDevURLs: (config, urls) => {
-    if ('application_url' in config) {
-      config.application_url = urls.applicationUrl
-    }
+    config.application_url = urls.applicationUrl
   },
 })
 

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
@@ -1,8 +1,9 @@
 import {validateUrl} from '../../app/validation/common.js'
-import {ExtensionSpecification, createConfigExtensionSpecification} from '../specification.js'
+import {ExtensionSpecification, TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {BaseSchema} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const AppProxySchema = zod.object({
+const AppProxySchema = BaseSchema.extend({
   app_proxy: zod
     .object({
       url: validateUrl(zod.string({invalid_type_error: 'Value must be a valid URL'})),
@@ -14,11 +15,18 @@ const AppProxySchema = zod.object({
 
 export const AppProxySpecIdentifier = 'app_proxy'
 
+const AppProxyTransformConfig: TransformationConfig = {
+  url: 'app_proxy.url',
+  subpath: 'app_proxy.subpath',
+  prefix: 'app_proxy.prefix',
+}
+
 const appProxySpec: ExtensionSpecification = createConfigExtensionSpecification({
   identifier: AppProxySpecIdentifier,
   schema: AppProxySchema,
+  transformConfig: AppProxyTransformConfig,
   patchWithAppDevURLs: (config, urls) => {
-    if ('app_proxy' in config && urls.appProxy) {
+    if (urls.appProxy) {
       config.app_proxy = {
         url: urls.appProxy.proxyUrl,
         subpath: urls.appProxy.proxySubPath,

--- a/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
@@ -1,7 +1,8 @@
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {BaseSchema} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const BrandingSchema = zod.object({
+const BrandingSchema = BaseSchema.extend({
   name: zod.string({required_error: 'String is required'}).max(30, {message: 'String must be less than 30 characters'}),
   handle: zod
     .string({required_error: 'String is required'})

--- a/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.ts
@@ -1,7 +1,8 @@
-import {createConfigExtensionSpecification} from '../specification.js'
+import {createConfigExtensionSpecification, TransformationConfig} from '../specification.js'
+import {BaseSchema} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const PosConfigurationSchema = zod.object({
+const PosConfigurationSchema = BaseSchema.extend({
   pos: zod
     .object({
       embedded: zod.boolean({invalid_type_error: 'Value must be Boolean'}),
@@ -11,9 +12,14 @@ const PosConfigurationSchema = zod.object({
 
 export const PosSpecIdentifier = 'point_of_sale'
 
+const PosTransformConfig: TransformationConfig = {
+  embedded: 'pos.embedded',
+}
+
 const appPOSSpec = createConfigExtensionSpecification({
   identifier: PosSpecIdentifier,
   schema: PosConfigurationSchema,
+  transformConfig: PosTransformConfig,
 })
 
 export default appPOSSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhooks_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhooks_schema.ts
@@ -3,6 +3,7 @@ import {webhookValidator} from '../validation/app_config_webhook.js'
 import {WebhookSubscriptionUriValidation} from '../validation/common.js'
 import {SingleWebhookSubscriptionSchema} from '../app_config_webhook_subscription.js'
 import {mergeAllWebhooks} from '../transform/app_config_webhook.js'
+import {BaseSchema} from '../../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const WebhooksConfigSchema = zod.object({
@@ -22,6 +23,6 @@ const WebhooksConfigSchema = zod.object({
 
 export type SingleWebhookSubscriptionType = zod.infer<typeof SingleWebhookSubscriptionSchema>
 
-export const WebhooksSchema = zod.object({
+export const WebhooksSchema = BaseSchema.extend({
   webhooks: WebhooksConfigSchema.superRefine(webhookValidator),
 })

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -29,6 +29,7 @@ import {ExtensionCreateSchema} from '../../api/graphql/extension_create.js'
 import appPOSSpec from '../../models/extensions/specifications/app_config_point_of_sale.js'
 import appWebhookSubscriptionSpec from '../../models/extensions/specifications/app_config_webhook_subscription.js'
 import {getModulesToMigrate} from '../dev/migrate-app-module.js'
+import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {beforeEach, describe, expect, vi, test, beforeAll} from 'vitest'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
 import {setPathValue} from '@shopify/cli-kit/common/object'
@@ -1104,7 +1105,7 @@ describe('groupRegistrationByUidStrategy', () => {
         type: 'POINT_OF_SALE',
       },
     ]
-    const specifications = [appPOSSpec, appWebhookSubscriptionSpec]
+    const specifications = [appPOSSpec, appWebhookSubscriptionSpec] as ExtensionSpecification[]
 
     const dynamicUidStrategySpec = specifications.find(
       (spec) => spec.identifier === dynamicUidStrategyExtension.type.toLowerCase(),


### PR DESCRIPTION
### WHY are these changes introduced?

The WHY is explained in the previous PR in the stack, but basically:

ALL extensions schemas should inherit from the same BaseSchema so that we can properly use generics and access the typed configuration correctly.

TL;DR
Thanks to this we move from:
```ts
if ('application_url' in config) {
    config.application_url = urls.applicationUrl
}
```

to just
```
  config.application_url = urls.applicationUrl
```

### WHAT is this pull request doing?

- Adds proper type annotations to extension specification schemas
- Extends `BaseSchema` in all app config schemas for consistency
- Adds missing transformation configurations for app proxy and point of sale extensions (these are needed so that no additional properties are accidentally included)

### How to test your changes?

1. Run the test suite to ensure all tests pass
2. Create a new app with various extension types to verify they load correctly
3. Verify that app proxy and point of sale extensions work as expected with the new transformation configurations

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes