### PR TITLE
Improve auth process for docker environments

### DIFF
--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -12,15 +12,18 @@ import {isTTY} from '../../../public/node/ui.js'
 import {err, ok} from '../../../public/node/result.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {Response} from 'node-fetch'
+import {isCI} from '@shopify/cli-kit/node/system'
 
 vi.mock('../../../public/node/context/fqdn.js')
 vi.mock('./identity')
 vi.mock('../../../public/node/http.js')
 vi.mock('../../../public/node/ui.js')
 vi.mock('./exchange.js')
+vi.mock('../../../public/node/system.js')
 
 beforeEach(() => {
   vi.mocked(isTTY).mockReturnValue(true)
+  vi.mocked(isCI).mockReturnValue(false)
 })
 
 describe('requestDeviceAuthorization', () => {

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -6,7 +6,7 @@ import {shopifyFetch} from '../../../public/node/http.js'
 import {outputContent, outputDebug, outputInfo, outputToken} from '../../../public/node/output.js'
 import {AbortError, BugError} from '../../../public/node/error.js'
 import {isCloudEnvironment} from '../../../public/node/context/local.js'
-import {openURL} from '../../../public/node/system.js'
+import {isCI, openURL} from '../../../public/node/system.js'
 import {isTTY, keypress} from '../../../public/node/ui.js'
 
 export interface DeviceAuthorizationResponse {
@@ -50,7 +50,7 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
 
   outputInfo('\nTo run this command, log in to Shopify.')
 
-  if (!isTTY()) {
+  if (isCI()) {
     throw new AbortError(
       'Authorization is required to continue, but the current environment does not support interactive prompts.',
       'To resolve this, specify credentials in your environment, or run the command in an interactive environment such as your local terminal.',
@@ -64,7 +64,7 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
     outputInfo(outputContent`👉 Open this link to start the auth process: ${linkToken}`)
   }
 
-  if (isCloudEnvironment()) {
+  if (isCloudEnvironment() || !isTTY()) {
     cloudMessage()
   } else {
     outputInfo('👉 Press any key to open the login page on your browser')

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -181,3 +181,12 @@ export function terminalSupportsPrompting(): boolean {
   }
   return Boolean(process.stdin.isTTY && process.stdout.isTTY)
 }
+
+/**
+ * Check if the current environment is a CI environment.
+ *
+ * @returns True if the current environment is a CI environment.
+ */
+export function isCI(): boolean {
+  return isTruthy(process.env.CI)
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue where the CLI would fail to authenticate in non-interactive environments that aren't CI environments.

Fixes https://github.com/Shopify/cli/issues/5496

### WHAT is this pull request doing?

- Adds a new `isCI()` function to check if the current environment is a CI environment
- Updates the device authorization flow to:
  - Only throw an error in CI environments, not in all non-TTY environments
  - Show the cloud message in both cloud environments and non-TTY environments

### How to test your changes?

1. Run the CLI in a non-interactive environment that isn't a CI environment (e.g., pipe the output to a file)
2. Verify that the authentication flow shows the cloud message instead of failing
3. Test in a regular terminal to ensure the updated prompt message is displayed correctly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes