### PR TITLE
Integrates subscribe and fetchAppLogs with developer dashboard 

### DIFF
--- a/.changeset/hip-mayflies-film.md
+++ b/.changeset/hip-mayflies-film.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+integrates app management client with developer dashboard endpoints for app logs

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-logs-subscribe.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-logs-subscribe.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type AppLogsSubscribeMutationVariables = Types.Exact<{
+  shopIds: Types.Scalars['Int']['input'][] | Types.Scalars['Int']['input']
+  apiKey: Types.Scalars['String']['input']
+}>
+
+export type AppLogsSubscribeMutation = {
+  appLogsSubscribe?: {jwtToken?: string | null; success?: boolean | null; errors?: string[] | null} | null
+}
+
+export const AppLogsSubscribe = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'AppLogsSubscribe'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'shopIds'}},
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'ListType',
+              type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'Int'}}},
+            },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'apiKey'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'appLogsSubscribe'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'shopIds'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'shopIds'}},
+              },
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'apiKey'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'apiKey'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {kind: 'Field', name: {kind: 'Name', value: 'jwtToken'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'success'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'errors'}},
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AppLogsSubscribeMutation, AppLogsSubscribeMutationVariables>

--- a/packages/app/src/cli/api/graphql/app-management/queries/app-logs-subscribe.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/app-logs-subscribe.graphql
@@ -1,0 +1,7 @@
+mutation AppLogsSubscribe($shopIds: [Int!]!, $apiKey: String!) {
+  appLogsSubscribe(shopIds: $shopIds, apiKey: $apiKey) {
+    jwtToken
+    success
+    errors
+  }
+}

--- a/packages/app/src/cli/api/graphql/subscribe_to_app_logs.ts
+++ b/packages/app/src/cli/api/graphql/subscribe_to_app_logs.ts
@@ -1,11 +1,5 @@
 import {gql} from 'graphql-request'
 
-export interface AppLogsSubscribeVariables {
-  shopIds: string[]
-  apiKey: string
-  token: string
-}
-
 export interface AppLogsSubscribeResponse {
   appLogsSubscribe: {
     success: boolean
@@ -14,6 +8,7 @@ export interface AppLogsSubscribeResponse {
   }
 }
 
+// eslint-disable-next-line @shopify/cli/no-inline-graphql
 export const AppLogsSubscribeMutation = gql`
   mutation AppLogsSubscribe($apiKey: String!, $shopIds: [ID!]!) {
     appLogsSubscribe(input: {apiKey: $apiKey, shopIds: $shopIds}) {

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -65,7 +65,7 @@ import {
 import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../../api/graphql/extension_migrate_app_module.js'
 import appWebhookSubscriptionSpec from '../extensions/specifications/app_config_webhook_subscription.js'
 import appAccessSpec from '../extensions/specifications/app_config_app_access.js'
-import {AppLogsSubscribeResponse, AppLogsSubscribeVariables} from '../../api/graphql/subscribe_to_app_logs.js'
+import {AppLogsSubscribeResponse} from '../../api/graphql/subscribe_to_app_logs.js'
 import {
   ExtensionUpdateDraftMutation,
   ExtensionUpdateDraftMutationVariables,
@@ -76,6 +76,7 @@ import {AppHomeSpecIdentifier} from '../extensions/specifications/app_config_app
 import {AppProxySpecIdentifier} from '../extensions/specifications/app_config_app_proxy.js'
 import {ExtensionSpecification} from '../extensions/specification.js'
 import {AppLogsOptions} from '../../services/app-logs/utils.js'
+import {AppLogsSubscribeMutationVariables} from '../../api/graphql/app-management/generated/app-logs-subscribe.js'
 import {vi} from 'vitest'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
@@ -1460,7 +1461,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
       Promise.resolve('schema'),
     migrateToUiExtension: (_input: MigrateToUiExtensionVariables) => Promise.resolve(migrateToUiExtensionResponse),
     toExtensionGraphQLType: (input: string) => input,
-    subscribeToAppLogs: (_input: AppLogsSubscribeVariables) => Promise.resolve(appLogsSubscribeResponse),
+    subscribeToAppLogs: (_input: AppLogsSubscribeMutationVariables) => Promise.resolve(appLogsSubscribeResponse),
     appLogs: (_options: AppLogsOptions): Promise<AppLogsResponse> =>
       Promise.resolve({
         app_logs: [

--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
@@ -249,6 +249,7 @@ describe('pollAppLogs', () => {
       developerPlatformClient,
       resubscribeCallback: MOCKED_RESUBSCRIBE_CALLBACK,
       storeName: 'storeName',
+      organizationId: 'organizationId',
     })
     await vi.advanceTimersToNextTimerAsync()
 
@@ -353,6 +354,7 @@ describe('pollAppLogs', () => {
       developerPlatformClient: mockedDeveloperPlatformClient,
       resubscribeCallback: MOCKED_RESUBSCRIBE_CALLBACK,
       storeName: 'storeName',
+      organizationId: 'organizationId',
     })
 
     expect(MOCKED_RESUBSCRIBE_CALLBACK).toHaveBeenCalled()
@@ -374,6 +376,7 @@ describe('pollAppLogs', () => {
       developerPlatformClient: mockedDeveloperPlatformClient,
       resubscribeCallback: MOCKED_RESUBSCRIBE_CALLBACK,
       storeName: 'storeName',
+      organizationId: 'organizationId',
     })
 
     expect(outputWarnSpy).toHaveBeenCalledWith('Request throttled while polling app logs.')
@@ -399,6 +402,7 @@ describe('pollAppLogs', () => {
       developerPlatformClient: mockedDeveloperPlatformClient,
       resubscribeCallback: MOCKED_RESUBSCRIBE_CALLBACK,
       storeName: 'storeName',
+      organizationId: 'organizationId',
     })
 
     // Then
@@ -441,6 +445,7 @@ describe('pollAppLogs', () => {
       developerPlatformClient: mockedDeveloperPlatformClient,
       resubscribeCallback: MOCKED_RESUBSCRIBE_CALLBACK,
       storeName: 'storeName',
+      organizationId: 'organizationId',
     })
 
     // When/Then

--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.ts
@@ -27,6 +27,7 @@ export const pollAppLogs = async ({
   developerPlatformClient,
   resubscribeCallback,
   storeName,
+  organizationId,
 }: {
   stdout: Writable
   appLogsFetchInput: AppLogsOptions
@@ -34,12 +35,13 @@ export const pollAppLogs = async ({
   developerPlatformClient: DeveloperPlatformClient
   resubscribeCallback: () => Promise<string>
   storeName: string
+  organizationId: string
 }) => {
   try {
     let nextJwtToken = jwtToken
     let retryIntervalMs = POLLING_INTERVAL_MS
 
-    const response = await developerPlatformClient.appLogs({jwtToken, cursor})
+    const response = await developerPlatformClient.appLogs({jwtToken, cursor}, organizationId)
 
     const {errors, status} = response as AppLogsError
     if (status !== 200) {
@@ -113,6 +115,7 @@ export const pollAppLogs = async ({
         developerPlatformClient,
         resubscribeCallback,
         storeName,
+        organizationId,
       }).catch((error) => {
         outputDebug(`Unexpected error during polling: ${error}}\n`)
       })
@@ -134,6 +137,7 @@ export const pollAppLogs = async ({
         developerPlatformClient,
         resubscribeCallback,
         storeName,
+        organizationId,
       }).catch((error) => {
         outputDebug(`Unexpected error during polling: ${error}}\n`)
       })

--- a/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.test.ts
@@ -35,6 +35,7 @@ const RESPONSE_DATA_SUCCESS = {
     },
   ],
   cursor: RETURNED_CURSOR,
+  status: 200,
 }
 
 const EMPTY_FILTERS = {status: undefined, sources: undefined}
@@ -62,7 +63,7 @@ describe('pollProcess', () => {
       appLogs: vi.fn().mockResolvedValueOnce(createMockResponse(RESPONSE_DATA_SUCCESS)),
     })
 
-    // // When
+    // When
     const result = await pollAppLogs({
       pollOptions: {
         jwtToken: MOCKED_JWT_TOKEN,
@@ -70,6 +71,7 @@ describe('pollProcess', () => {
         filters: EMPTY_FILTERS,
       },
       developerPlatformClient: mockedDeveloperPlatformClient,
+      organizationId: 'organizationId',
     })
 
     expect(result).toEqual({
@@ -84,7 +86,7 @@ describe('pollProcess', () => {
       appLogs: vi.fn().mockResolvedValueOnce(createMockResponse(RESPONSE_DATA_SUCCESS)),
     })
 
-    // // When
+    // When
     const result = await pollAppLogs({
       pollOptions: {
         jwtToken: MOCKED_JWT_TOKEN,
@@ -92,6 +94,7 @@ describe('pollProcess', () => {
         filters: {status: 'failure', sources: ['extensions.my-function', 'extensions.my-other-function']},
       },
       developerPlatformClient: mockedDeveloperPlatformClient,
+      organizationId: 'organizationId',
     })
 
     expect(result).toEqual({
@@ -118,6 +121,7 @@ describe('pollProcess', () => {
         filters: EMPTY_FILTERS,
       },
       developerPlatformClient: mockedDeveloperPlatformClient,
+      organizationId: 'organizationId',
     })
 
     // Then
@@ -147,6 +151,7 @@ describe('pollProcess', () => {
           filters: EMPTY_FILTERS,
         },
         developerPlatformClient: mockedDeveloperPlatformClient,
+        organizationId: 'organizationId',
       }),
     ).rejects.toThrowError()
   })

--- a/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/poll-app-logs.ts
@@ -5,13 +5,15 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 interface PollAppLogsOptions {
   pollOptions: PollOptions
   developerPlatformClient: DeveloperPlatformClient
+  organizationId: string
 }
 
 export const pollAppLogs = async ({
   pollOptions: {jwtToken, cursor, filters},
   developerPlatformClient,
+  organizationId,
 }: PollAppLogsOptions): Promise<PollResponse> => {
-  const response = await developerPlatformClient.appLogs({jwtToken, cursor})
+  const response = await developerPlatformClient.appLogs({jwtToken, cursor}, organizationId)
   const {errors, status} = response as AppLogsError
 
   if (status !== 200) {

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.test.ts
@@ -45,10 +45,11 @@ describe('renderJsonLogs', () => {
     await renderJsonLogs({
       pollOptions: {cursor: 'cursor', filters: {status: undefined, sources: undefined}, jwtToken: 'jwtToken'},
       options: {
-        variables: {shopIds: ['1'], apiKey: 'key', token: 'token'},
+        variables: {shopIds: [1], apiKey: 'key'},
         developerPlatformClient: testDeveloperPlatformClient(),
       },
       storeNameById,
+      organizationId: 'organizationId',
     })
 
     expect(outputInfo).toHaveBeenNthCalledWith(
@@ -90,10 +91,11 @@ describe('renderJsonLogs', () => {
     await renderJsonLogs({
       pollOptions: {cursor: 'cursor', filters: {status: undefined, sources: undefined}, jwtToken: 'jwtToken'},
       options: {
-        variables: {shopIds: ['1'], apiKey: 'key', token: 'token'},
+        variables: {shopIds: [1], apiKey: 'key'},
         developerPlatformClient: testDeveloperPlatformClient(),
       },
       storeNameById,
+      organizationId: 'organizationId',
     })
 
     expect(outputInfo).not.toHaveBeenCalled()
@@ -119,10 +121,11 @@ describe('renderJsonLogs', () => {
     await renderJsonLogs({
       pollOptions: {cursor: 'cursor', filters: {status: undefined, sources: undefined}, jwtToken: 'jwtToken'},
       options: {
-        variables: {shopIds: [], apiKey: '', token: ''},
+        variables: {shopIds: [], apiKey: ''},
         developerPlatformClient: testDeveloperPlatformClient(),
       },
       storeNameById,
+      organizationId: 'organizationId',
     })
 
     expect(outputInfo).toHaveBeenCalledWith(

--- a/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/render-json-logs.ts
@@ -13,12 +13,14 @@ export async function renderJsonLogs({
   pollOptions,
   options: {variables, developerPlatformClient},
   storeNameById,
+  organizationId,
 }: {
   pollOptions: PollOptions
   options: SubscribeOptions
   storeNameById: Map<string, string>
+  organizationId: string
 }): Promise<void> {
-  const response = await pollAppLogs({pollOptions, developerPlatformClient})
+  const response = await pollAppLogs({pollOptions, developerPlatformClient, organizationId})
   let retryIntervalMs = POLLING_INTERVAL_MS
   let nextJwtToken = pollOptions.jwtToken
 
@@ -34,7 +36,7 @@ export async function renderJsonLogs({
         outputInfo(JSON.stringify({message: 'Error while polling app logs.', retry_in_ms: retryIntervalMs}))
       },
       onResubscribe: () => {
-        return subscribeToAppLogs(developerPlatformClient, variables)
+        return subscribeToAppLogs(developerPlatformClient, variables, organizationId)
       },
     })
 
@@ -73,6 +75,7 @@ export async function renderJsonLogs({
         filters: pollOptions.filters,
       },
       storeNameById,
+      organizationId,
     }).catch((error) => {
       throw error
     })

--- a/packages/app/src/cli/services/app-logs/logs-command/ui.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui.tsx
@@ -8,13 +8,15 @@ export async function renderLogs({
   pollOptions,
   options: {variables, developerPlatformClient},
   storeNameById,
+  organizationId,
 }: {
   pollOptions: PollOptions
   options: SubscribeOptions
   storeNameById: Map<string, string>
+  organizationId: string
 }) {
   const resubscribeCallback = async () => {
-    return subscribeToAppLogs(developerPlatformClient, variables)
+    return subscribeToAppLogs(developerPlatformClient, variables, organizationId)
   }
 
   return render(
@@ -23,6 +25,7 @@ export async function renderLogs({
       resubscribeCallback={resubscribeCallback}
       storeNameById={storeNameById}
       developerPlatformClient={developerPlatformClient}
+      organizationId={organizationId}
     />,
   )
 }

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
@@ -31,6 +31,9 @@ const INPUT = {test: 'input'}
 const INPUT_BYTES = 10
 const OUTPUT_BYTES = 10
 
+const MOCKED_ORGANIZATION_ID = '123'
+const MOCKED_APP_ID = '456'
+
 const NETWORK_ACCESS_HTTP_REQUEST = {
   url: 'https://api.example.com/hello',
   method: 'GET',
@@ -113,6 +116,7 @@ describe('Logs', () => {
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
           developerPlatformClient={testDeveloperPlatformClient()}
+          organizationId={MOCKED_ORGANIZATION_ID}
         />,
       )
 
@@ -162,6 +166,7 @@ describe('Logs', () => {
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
           developerPlatformClient={testDeveloperPlatformClient()}
+          organizationId={MOCKED_ORGANIZATION_ID}
         />,
       )
 
@@ -212,6 +217,7 @@ describe('Logs', () => {
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
           developerPlatformClient={testDeveloperPlatformClient()}
+          organizationId={MOCKED_ORGANIZATION_ID}
         />,
       )
 
@@ -266,6 +272,7 @@ describe('Logs', () => {
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
           developerPlatformClient={testDeveloperPlatformClient()}
+          organizationId={MOCKED_ORGANIZATION_ID}
         />,
       )
 
@@ -327,6 +334,7 @@ describe('Logs', () => {
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
           developerPlatformClient={testDeveloperPlatformClient()}
+          organizationId={MOCKED_ORGANIZATION_ID}
         />,
       )
 
@@ -389,6 +397,7 @@ describe('Logs', () => {
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
           developerPlatformClient={testDeveloperPlatformClient()}
+          organizationId={MOCKED_ORGANIZATION_ID}
         />,
       )
 
@@ -438,6 +447,7 @@ describe('Logs', () => {
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
           developerPlatformClient={testDeveloperPlatformClient()}
+          organizationId={MOCKED_ORGANIZATION_ID}
         />,
       )
 
@@ -486,6 +496,7 @@ describe('Logs', () => {
           resubscribeCallback={vi.fn().mockResolvedValueOnce(MOCKED_JWT_TOKEN)}
           storeNameById={new Map()}
           developerPlatformClient={testDeveloperPlatformClient()}
+          organizationId={MOCKED_ORGANIZATION_ID}
         />,
       )
 
@@ -522,6 +533,7 @@ describe('Logs', () => {
         resubscribeCallback={mockedResubscribeCallback}
         storeNameById={new Map()}
         developerPlatformClient={testDeveloperPlatformClient()}
+        organizationId={MOCKED_ORGANIZATION_ID}
       />,
     )
 

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.tsx
@@ -21,6 +21,7 @@ interface LogsProps {
   pollOptions: PollOptions
   storeNameById: Map<string, string>
   developerPlatformClient: DeveloperPlatformClient
+  organizationId: string
 }
 
 const getBackgroundExecutionReasonMessage = (reason: BackgroundExecutionReason): string => {
@@ -39,6 +40,7 @@ const Logs: FunctionComponent<LogsProps> = ({
   resubscribeCallback,
   storeNameById,
   developerPlatformClient,
+  organizationId,
 }) => {
   const {appLogOutputs, errors} = usePollAppLogs({
     filters,
@@ -46,6 +48,7 @@ const Logs: FunctionComponent<LogsProps> = ({
     resubscribeCallback,
     storeNameById,
     developerPlatformClient,
+    organizationId,
   })
 
   return (

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
@@ -166,6 +166,9 @@ const POLL_APP_LOGS_FOR_LOGS_RESPONSE = {
   ],
 }
 
+const MOCKED_ORGANIZATION_ID = '123'
+const MOCKED_APP_ID = '456'
+
 const POLL_APP_LOGS_FOR_LOGS_401_RESPONSE = {
   errors: [{status: 401, message: 'Unauthorized'}],
 }
@@ -208,6 +211,7 @@ describe('usePollAppLogs', () => {
         resubscribeCallback,
         storeNameById: STORE_NAME_BY_ID,
         developerPlatformClient: mockedDeveloperPlatformClient,
+        organizationId: MOCKED_ORGANIZATION_ID,
       }),
     )
 
@@ -329,6 +333,7 @@ describe('usePollAppLogs', () => {
         resubscribeCallback,
         storeNameById: STORE_NAME_BY_ID,
         developerPlatformClient: mockedDeveloperPlatformClient,
+        organizationId: MOCKED_ORGANIZATION_ID,
       }),
     )
 
@@ -343,6 +348,7 @@ describe('usePollAppLogs', () => {
         filters: EMPTY_FILTERS,
       },
       developerPlatformClient: mockedDeveloperPlatformClient,
+      organizationId: MOCKED_ORGANIZATION_ID,
     })
     expect(resubscribeCallback).toHaveBeenCalledOnce()
 
@@ -351,6 +357,7 @@ describe('usePollAppLogs', () => {
     expect(mockedPollAppLogs).toHaveBeenNthCalledWith(2, {
       pollOptions: {jwtToken: NEW_JWT_TOKEN, cursor: '', filters: EMPTY_FILTERS},
       developerPlatformClient: mockedDeveloperPlatformClient,
+      organizationId: MOCKED_ORGANIZATION_ID,
     })
 
     expect(vi.getTimerCount()).toEqual(1)
@@ -376,6 +383,7 @@ describe('usePollAppLogs', () => {
         resubscribeCallback,
         storeNameById: STORE_NAME_BY_ID,
         developerPlatformClient: mockedDeveloperPlatformClient,
+        organizationId: MOCKED_ORGANIZATION_ID,
       }),
     )
 
@@ -418,6 +426,7 @@ describe('usePollAppLogs', () => {
         resubscribeCallback,
         storeNameById: STORE_NAME_BY_ID,
         developerPlatformClient: mockedDeveloperPlatformClient,
+        organizationId: MOCKED_ORGANIZATION_ID,
       }),
     )
 
@@ -458,6 +467,7 @@ describe('usePollAppLogs', () => {
         resubscribeCallback: vi.fn().mockResolvedValue(MOCKED_JWT_TOKEN),
         storeNameById: STORE_NAME_BY_ID,
         developerPlatformClient: mockedDeveloperPlatformClient,
+        organizationId: MOCKED_ORGANIZATION_ID,
       }),
     )
 
@@ -485,6 +495,7 @@ describe('usePollAppLogs', () => {
         resubscribeCallback,
         storeNameById: new Map(),
         developerPlatformClient: mockedDeveloperPlatformClient,
+        organizationId: MOCKED_ORGANIZATION_ID,
       }),
     )
 

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.ts
@@ -24,6 +24,7 @@ interface UsePollAppLogsOptions {
   resubscribeCallback: () => Promise<string>
   storeNameById: Map<string, string>
   developerPlatformClient: DeveloperPlatformClient
+  organizationId: string
 }
 
 async function performPoll({
@@ -31,6 +32,7 @@ async function performPoll({
   cursor,
   filters,
   storeNameById,
+  organizationId,
   setErrors,
   setAppLogOutputs,
   resubscribeCallback,
@@ -40,6 +42,7 @@ async function performPoll({
   cursor?: string
   filters: PollFilters
   storeNameById: Map<string, string>
+  organizationId: string
   setErrors: Dispatch<SetStateAction<string[]>>
   setAppLogOutputs: Dispatch<SetStateAction<AppLogOutput[]>>
   resubscribeCallback: () => Promise<string>
@@ -48,7 +51,11 @@ async function performPoll({
   let nextJwtToken = jwtToken
   let retryIntervalMs = POLLING_INTERVAL_MS
   let nextCursor = cursor
-  const response = await pollAppLogs({pollOptions: {jwtToken, cursor, filters}, developerPlatformClient})
+  const response = await pollAppLogs({
+    pollOptions: {jwtToken, cursor, filters},
+    developerPlatformClient,
+    organizationId,
+  })
 
   const errorResponse = response as ErrorResponse
 
@@ -136,6 +143,7 @@ export function usePollAppLogs({
   resubscribeCallback,
   storeNameById,
   developerPlatformClient,
+  organizationId,
 }: UsePollAppLogsOptions) {
   const [errors, setErrors] = useState<string[]>([])
   const [appLogOutputs, setAppLogOutputs] = useState<AppLogOutput[]>([])
@@ -153,6 +161,7 @@ export function usePollAppLogs({
       setAppLogOutputs,
       resubscribeCallback,
       developerPlatformClient,
+      organizationId,
     })
 
     // ESLint is concerned about these updates being atomic, but the approach to useSelfAdjustingInterval ensures that is the case.

--- a/packages/app/src/cli/services/app-logs/types.ts
+++ b/packages/app/src/cli/services/app-logs/types.ts
@@ -1,3 +1,4 @@
+import {AppLogsSubscribeMutationVariables} from '../../api/graphql/app-management/generated/app-logs-subscribe.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 
 export interface SuccessResponse {
@@ -166,11 +167,7 @@ export type AppLogPayload =
 
 export interface SubscribeOptions {
   developerPlatformClient: DeveloperPlatformClient
-  variables: {
-    shopIds: string[]
-    apiKey: string
-    token: string
-  }
+  variables: AppLogsSubscribeMutationVariables
 }
 
 export interface PollOptions {

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
@@ -11,7 +11,7 @@ vi.mock('@shopify/cli-kit/node/logs')
 vi.mock('@shopify/cli-kit/node/output')
 vi.mock('../../app-logs/dev/poll-app-logs.js')
 
-const SHOP_IDS = ['1', '2']
+const SHOP_IDS = [1, 2]
 const API_KEY = 'API_KEY'
 const TOKEN = 'token'
 const JWT_TOKEN = 'JWT'
@@ -28,6 +28,7 @@ describe('app-logs-polling', () => {
         developerPlatformClient,
         subscription: {shopIds: SHOP_IDS, apiKey: API_KEY},
         storeName: 'storeName',
+        organizationId: 'organizationId',
       })
 
       // Then
@@ -40,7 +41,6 @@ describe('app-logs-polling', () => {
           appLogsSubscribeVariables: {
             shopIds: SHOP_IDS,
             apiKey: API_KEY,
-            token: session.token,
           },
         },
       })
@@ -82,11 +82,12 @@ describe('app-logs-polling', () => {
           developerPlatformClient,
           appLogsSubscribeVariables,
           storeName: 'storeName',
+          organizationId: 'organizationId',
         },
       )
 
       // Then
-      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables)
+      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables, 'organizationId')
       expect(createLogsDir).toHaveBeenCalledWith(API_KEY)
       expect(pollAppLogs).toHaveBeenCalledOnce()
       expect(vi.mocked(pollAppLogs).mock.calls[0]?.[0]).toMatchObject({
@@ -109,11 +110,12 @@ describe('app-logs-polling', () => {
           developerPlatformClient,
           appLogsSubscribeVariables,
           storeName: 'storeName',
+          organizationId: 'organizationId',
         },
       )
 
       // Then
-      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables)
+      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables, 'organizationId')
       expect(outputWarn).toHaveBeenCalledWith(`Errors subscribing to app logs: uh oh, another error`)
       expect(outputWarn).toHaveBeenCalledWith(`App log streaming is not available in this session.`)
       expect(createLogsDir).not.toHaveBeenCalled()

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -449,9 +449,8 @@ describe('setup-dev-processes', () => {
       options: {
         developerPlatformClient,
         appLogsSubscribeVariables: {
-          shopIds: ['123456789'],
+          shopIds: [123456789],
           apiKey: 'api-key',
-          token: 'token',
         },
       },
     })

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -189,10 +189,11 @@ export async function setupDevProcesses({
       ? await setupAppLogsPollingProcess({
           developerPlatformClient,
           subscription: {
-            shopIds: [storeId],
+            shopIds: [Number(storeId)],
             apiKey,
           },
           storeName: storeFqdn,
+          organizationId: remoteApp.organizationId,
         })
       : undefined,
     await setupAppWatcherProcess({

--- a/packages/app/src/cli/services/logs.test.ts
+++ b/packages/app/src/cli/services/logs.test.ts
@@ -161,10 +161,14 @@ describe('logs', () => {
     expect(spy).toHaveBeenCalledWith({
       options: {
         developerPlatformClient: expect.anything(),
-        variables: {shopIds: ['1', '2'], apiKey: expect.anything(), token: expect.anything()},
+        variables: {
+          apiKey: expect.anything(),
+          shopIds: [1, 2],
+        },
       },
       pollOptions: expect.anything(),
       storeNameById: expectedStoreMap,
+      organizationId: organization.id,
     })
   })
 
@@ -197,10 +201,14 @@ describe('logs', () => {
     expect(spy).toHaveBeenCalledWith({
       options: {
         developerPlatformClient: expect.anything(),
-        variables: {shopIds: ['1', '2'], apiKey: expect.anything(), token: expect.anything()},
+        variables: {
+          apiKey: expect.anything(),
+          shopIds: [1, 2],
+        },
       },
       pollOptions: expect.anything(),
       storeNameById: expectedStoreMap,
+      organizationId: organization.id,
     })
   })
 

--- a/packages/app/src/cli/services/logs.ts
+++ b/packages/app/src/cli/services/logs.ts
@@ -48,12 +48,11 @@ export async function logs(commandOptions: LogsOptions) {
   }
 
   const variables = {
-    shopIds: logsConfig.storeIds,
+    shopIds: logsConfig.storeIds.map(Number),
     apiKey: remoteApp.apiKey,
-    token: '',
   }
 
-  const jwtToken = await subscribeToAppLogs(developerPlatformClient, variables)
+  const jwtToken = await subscribeToAppLogs(developerPlatformClient, variables, commandOptions.organization.id)
 
   const filters = {
     status: commandOptions.status,
@@ -75,6 +74,7 @@ export async function logs(commandOptions: LogsOptions) {
       },
       pollOptions,
       storeNameById: logsConfig.storeNameById,
+      organizationId: commandOptions.organization.id,
     })
   } else {
     consoleLog('Waiting for app logs...\n')
@@ -85,6 +85,7 @@ export async function logs(commandOptions: LogsOptions) {
       },
       pollOptions,
       storeNameById: logsConfig.storeNameById,
+      organizationId: commandOptions.organization.id,
     })
   }
 }

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -43,7 +43,6 @@ import {
   MigrateToUiExtensionSchema,
   MigrateToUiExtensionVariables,
 } from '../api/graphql/extension_migrate_to_ui_extension.js'
-import {AppLogsSubscribeVariables, AppLogsSubscribeResponse} from '../api/graphql/subscribe_to_app_logs.js'
 import {RemoteSpecification} from '../api/graphql/extension_specifications.js'
 import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../api/graphql/extension_migrate_app_module.js'
 import {AppConfiguration, isCurrentAppSchema} from '../models/app/app.js'
@@ -57,6 +56,10 @@ import {DevSessionUpdateMutation} from '../api/graphql/app-dev/generated/dev-ses
 import {DevSessionDeleteMutation} from '../api/graphql/app-dev/generated/dev-session-delete.js'
 import {AppLogsOptions} from '../services/app-logs/utils.js'
 import {AppLogData} from '../services/app-logs/types.js'
+import {
+  AppLogsSubscribeMutation,
+  AppLogsSubscribeMutationVariables,
+} from '../api/graphql/app-management/generated/app-logs-subscribe.js'
 import {isAppManagementDisabled} from '@shopify/cli-kit/node/context/local'
 import {blockPartnersAccess} from '@shopify/cli-kit/node/environment'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -220,6 +223,7 @@ export function filterDisabledFlags(disabledFlags: string[] = []): Flag[] {
 export interface AppLogsSuccess {
   app_logs: AppLogData[]
   cursor?: string
+  status: number
 }
 
 export interface AppLogsError {
@@ -287,8 +291,11 @@ export interface DeveloperPlatformClient {
   ) => Promise<string | null>
   migrateToUiExtension: (input: MigrateToUiExtensionVariables) => Promise<MigrateToUiExtensionSchema>
   toExtensionGraphQLType: (input: string) => string
-  subscribeToAppLogs: (input: AppLogsSubscribeVariables) => Promise<AppLogsSubscribeResponse>
-  appLogs: (options: AppLogsOptions) => Promise<AppLogsResponse>
+  subscribeToAppLogs: (
+    input: AppLogsSubscribeMutationVariables,
+    organizationId: string,
+  ) => Promise<AppLogsSubscribeMutation>
+  appLogs: (options: AppLogsOptions, organizationId: string) => Promise<AppLogsResponse>
   appDeepLink: (app: MinimalAppIdentifiers) => Promise<string>
   devSessionCreate: (input: DevSessionOptions) => Promise<DevSessionCreateMutation>
   devSessionUpdate: (input: DevSessionOptions) => Promise<DevSessionUpdateMutation>

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -130,11 +130,7 @@ import {
   MigrateAppModuleSchema,
   MigrateAppModuleVariables,
 } from '../../api/graphql/extension_migrate_app_module.js'
-import {
-  AppLogsSubscribeVariables,
-  AppLogsSubscribeMutation,
-  AppLogsSubscribeResponse,
-} from '../../api/graphql/subscribe_to_app_logs.js'
+import {AppLogsSubscribeMutation, AppLogsSubscribeResponse} from '../../api/graphql/subscribe_to_app_logs.js'
 
 import {AllOrgs} from '../../api/graphql/partners/generated/all-orgs.js'
 import {
@@ -156,12 +152,13 @@ import {
 } from '../../api/graphql/partners/generated/dev-stores-by-org.js'
 import {SchemaDefinitionByTargetQueryVariables} from '../../api/graphql/functions/generated/schema-definition-by-target.js'
 import {SchemaDefinitionByApiTypeQueryVariables} from '../../api/graphql/functions/generated/schema-definition-by-api-type.js'
-import {AppLogsOptions, generateFetchAppLogUrl} from '../../services/app-logs/utils.js'
 import {AppLogData} from '../../services/app-logs/types.js'
+import {AppLogsOptions} from '../../services/app-logs/utils.js'
+import {AppLogsSubscribeMutationVariables} from '../../api/graphql/app-management/generated/app-logs-subscribe.js'
 import {TypedDocumentNode} from '@graphql-typed-document-node/core'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {partnersRequest, partnersRequestDoc} from '@shopify/cli-kit/node/api/partners'
+import {generateFetchAppLogUrl, partnersRequest, partnersRequestDoc} from '@shopify/cli-kit/node/api/partners'
 import {CacheOptions, GraphQLVariables} from '@shopify/cli-kit/node/api/graphql'
 import {ensureAuthenticatedPartners} from '@shopify/cli-kit/node/session'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
@@ -563,7 +560,10 @@ export class PartnersClient implements DeveloperPlatformClient {
     return input.toUpperCase()
   }
 
-  async subscribeToAppLogs(input: AppLogsSubscribeVariables): Promise<AppLogsSubscribeResponse> {
+  async subscribeToAppLogs(
+    input: AppLogsSubscribeMutationVariables,
+    _organizationId: string,
+  ): Promise<AppLogsSubscribeResponse> {
     return this.request(AppLogsSubscribeMutation, input)
   }
 
@@ -571,7 +571,7 @@ export class PartnersClient implements DeveloperPlatformClient {
     return `https://${await partnersFqdn()}/${organizationId}/apps/${id}`
   }
 
-  async appLogs(options: AppLogsOptions): Promise<AppLogsResponse> {
+  async appLogs(options: AppLogsOptions, _organizationId: string): Promise<AppLogsResponse> {
     const response = await fetchAppLogs(options)
 
     try {

--- a/packages/cli-kit/src/public/node/api/app-management.ts
+++ b/packages/cli-kit/src/public/node/api/app-management.ts
@@ -1,6 +1,8 @@
 import {CacheOptions, GraphQLResponse, graphqlRequestDoc} from './graphql.js'
+import {addCursorAndFiltersToAppLogsUrl} from './utilities.js'
 import {appManagementFqdn} from '../context/fqdn.js'
 import {setNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
+import {buildHeaders} from '../../../private/node/api/headers.js'
 import Bottleneck from 'bottleneck'
 import {TypedDocumentNode} from '@graphql-typed-document-node/core'
 import {Variables} from 'graphql-request'
@@ -23,6 +25,23 @@ async function setupRequest(orgId: string, token: string) {
     url,
     responseOptions: {onResponse: handleDeprecations},
   }
+}
+
+export const appManagementHeaders = (token: string): {[key: string]: string} => {
+  return buildHeaders(token)
+}
+
+export const appManagementAppLogsUrl = async (
+  organizationId: string,
+  cursor?: string,
+  filters?: {
+    status?: string
+    source?: string
+  },
+): Promise<string> => {
+  const fqdn = await appManagementFqdn()
+  const url = `https://${fqdn}/app_management/unstable/organizations/${organizationId}/app_logs/poll`
+  return addCursorAndFiltersToAppLogsUrl(url, cursor, filters)
 }
 
 /**

--- a/packages/cli-kit/src/public/node/api/partners.ts
+++ b/packages/cli-kit/src/public/node/api/partners.ts
@@ -1,4 +1,5 @@
 import {graphqlRequest, GraphQLVariables, GraphQLResponse, graphqlRequestDoc, CacheOptions} from './graphql.js'
+import {addCursorAndFiltersToAppLogsUrl} from './utilities.js'
 import {partnersFqdn} from '../context/fqdn.js'
 import {setNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
 import {TypedDocumentNode} from '@graphql-typed-document-node/core'
@@ -56,6 +57,18 @@ export async function partnersRequest<T>(
   )
 
   return result
+}
+
+export const generateFetchAppLogUrl = async (
+  cursor?: string,
+  filters?: {
+    status?: string
+    source?: string
+  },
+): Promise<string> => {
+  const fqdn = await partnersFqdn()
+  const url = `https://${fqdn}/app_logs/poll`
+  return addCursorAndFiltersToAppLogsUrl(url, cursor, filters)
 }
 
 /**

--- a/packages/cli-kit/src/public/node/api/utilities.ts
+++ b/packages/cli-kit/src/public/node/api/utilities.ts
@@ -1,0 +1,24 @@
+export const addCursorAndFiltersToAppLogsUrl = (
+  baseUrl: string,
+  cursor?: string,
+  filters?: {
+    status?: string
+    source?: string
+  },
+): string => {
+  const url = new URL(baseUrl)
+
+  if (cursor) {
+    url.searchParams.append('cursor', cursor)
+  }
+
+  if (filters?.status) {
+    url.searchParams.append('status', filters.status)
+  }
+
+  if (filters?.source) {
+    url.searchParams.append('source', filters.source)
+  }
+
+  return url.toString()
+}


### PR DESCRIPTION
Requires: https://github.com/Shopify/cli/pull/5497
Requires: Partners - js.app-logs-prototype-2Request: Core - 03-07-expose_dev_dash_route_to_manage_app_logs
Part of: https://github.com/Shopify/temp-project-mover-Archetypically-20250320163947/issues/137

### WHY are these changes introduced?

This PR adds app logs functionality to the `AppManagementClient`, allowing app logs to be fetched through the Developer Platform client interface. 

Key changes:
- Implemented `subscribeToAppLogs` and `appLogs` methods in `AppManagementClient`
- Updated the `DeveloperPlatformClient` interface to include `organizationId` and `appId` parameters
    - `PartnersClient` will ignore them
- Added new `fetchAppLogsDevDashboard` in `utils`
- Updated all app logs related components to pass through organizationId and appId

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

All tests have been updated to include the new required parameters. The implementation has been tested with both Partners API and Developer Dashboard API backends.

Currently need different shops / app setup.

With app that lives in partners (I used prod):
```
pnpm run shopify app logs --path=./path-to-app

pnpm run shopify app dev --path=./path-to-app
````

Prod Dev Dashboard Setup
```
pnpm run shopify app logs --path=./path-to-app

pnpm run shopify app dev --path=./path-to-app
````


### Post-release steps


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
