### PR TITLE
Refactor app management client to prepare for new BP mutation

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -3,7 +3,7 @@ import {
   GatedExtensionTemplate,
   allowedTemplates,
   diffAppModules,
-  encodedGidFromId,
+  encodedGidFromOrganizationId,
   versionDeepLink,
 } from './app-management-client.js'
 import {OrganizationBetaFlagsQuerySchema} from './app-management-client/graphql/organization_beta_flags.js'
@@ -134,7 +134,7 @@ describe('templateSpecifications', () => {
     vi.mocked(fetch).mockImplementation(mockedFetch)
     const mockedFetchFlagsResponse: OrganizationBetaFlagsQuerySchema = {
       organization: {
-        id: encodedGidFromId(orgApp.organizationId),
+        id: encodedGidFromOrganizationId(orgApp.organizationId),
         flag_allowedFlag: true,
       },
     }
@@ -161,7 +161,7 @@ describe('templateSpecifications', () => {
     vi.mocked(fetch).mockImplementation(mockedFetch)
     const mockedFetchFlagsResponse: OrganizationBetaFlagsQuerySchema = {
       organization: {
-        id: encodedGidFromId(orgApp.organizationId),
+        id: encodedGidFromOrganizationId(orgApp.organizationId),
         flag_allowedFlag: true,
         flag_notAllowedFlag: false,
       },
@@ -186,7 +186,7 @@ describe('templateSpecifications', () => {
     }`,
       'business-platform-token',
       orgApp.organizationId,
-      {organizationId: encodedGidFromId(orgApp.organizationId)},
+      {organizationId: encodedGidFromOrganizationId(orgApp.organizationId)},
     )
     const expectedAllowedTemplates = [templateWithoutRules, allowedTemplate]
     expect(gotLabels).toEqual(expectedAllowedTemplates.map((template) => template.name))

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -326,7 +326,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   }
 
   async orgFromId(orgId: string): Promise<Organization | undefined> {
-    const base64Id = encodedGidFromId(orgId)
+    const base64Id = encodedGidFromOrganizationId(orgId)
     const variables = {organizationId: base64Id}
     const organizationResult = await businessPlatformRequestDoc(
       FindOrganizations,
@@ -477,7 +477,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   // partners-client and app-management-client. Since we need transferDisabled and convertableToPartnerTest values
   // from the Partners OrganizationStore schema, we will return this type for now
   async devStoresForOrg(orgId: string, searchTerm?: string): Promise<Paginateable<{stores: OrganizationStore[]}>> {
-    const storesResult = await businessPlatformOrganizationsRequestDoc<ListAppDevStoresQuery>(
+    const storesResult = await businessPlatformOrganizationsRequestDoc(
       ListAppDevStores,
       await this.businessPlatformToken(),
       orgId,
@@ -971,7 +971,9 @@ export class AppManagementClient implements DeveloperPlatformClient {
     organizationId: string,
     allBetaFlags: string[],
   ): Promise<{[flag: (typeof allBetaFlags)[number]]: boolean}> {
-    const variables: OrganizationBetaFlagsQueryVariables = {organizationId: encodedGidFromId(organizationId)}
+    const variables: OrganizationBetaFlagsQueryVariables = {
+      organizationId: encodedGidFromOrganizationId(organizationId),
+    }
     const flagsResult = await businessPlatformOrganizationsRequest<OrganizationBetaFlagsQuerySchema>(
       organizationBetaFlagsQuery(allBetaFlags),
       await this.businessPlatformToken(),
@@ -1046,7 +1048,7 @@ function createAppVars(options: CreateAppOptions, apiVersion?: string): CreateAp
 // just the integer portion of that ID. These functions convert between the two.
 
 // 1234 => gid://organization/Organization/1234 => base64
-export function encodedGidFromId(id: string): string {
+export function encodedGidFromOrganizationId(id: string): string {
   const gid = `gid://organization/Organization/${id}`
   return Buffer.from(gid).toString('base64')
 }

--- a/packages/cli-kit/src/public/node/api/business-platform.ts
+++ b/packages/cli-kit/src/public/node/api/business-platform.ts
@@ -116,13 +116,13 @@ export async function businessPlatformOrganizationsRequest<T>(
  * @param variables - GraphQL variables to pass to the query.
  * @returns The response of the query of generic type <T>.
  */
-export async function businessPlatformOrganizationsRequestDoc<TResult>(
-  query: TypedDocumentNode<TResult, GraphQLVariables> | TypedDocumentNode<TResult, Exact<{[key: string]: never}>>,
+export async function businessPlatformOrganizationsRequestDoc<TResult, TVariables extends Variables>(
+  query: TypedDocumentNode<TResult, TVariables> | TypedDocumentNode<TResult, Exact<{[key: string]: never}>>,
   token: string,
   organizationId: string,
-  variables?: GraphQLVariables,
+  variables?: TVariables,
 ): Promise<TResult> {
-  return graphqlRequestDoc({
+  return graphqlRequestDoc<TResult, TVariables>({
     query,
     ...(await setupOrganizationsRequest(token, organizationId)),
     variables,


### PR DESCRIPTION
### WHY are these changes introduced?

This Refactor/cleanup of the business platform interface allows the addition of new BP calls in the future and makes the existing code clearer.

### WHAT is this pull request doing?

This PR renames the `encodedGidFromId` function to `encodedGidFromOrganizationId` to make its purpose more explicit and to make room for encoding other id types in the future. 

Additionally, it updates the type signature for `businessPlatformOrganizationsRequestDoc` to properly handle generic variables, improving type safety. This makes it consistent with other `*RequestDoc` functions and seems to allow proper usage with mutations.

### How to test your changes?

Run the existing test suite to ensure all tests pass with the renamed function. It was not necessary to add new test. 

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes