### PR TITLE
Add BP mutation to ensure access to a dev store + Ensure user access to selected dev stores

### DIFF
--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/provision_shop_access.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/provision_shop_access.ts
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type ProvisionShopAccessMutationVariables = Types.Exact<{
+  input: Types.OrganizationUserProvisionShopAccessInput
+}>
+
+export type ProvisionShopAccessMutation = {
+  organizationUserProvisionShopAccess: {success?: boolean | null; userErrors?: {message: string}[] | null}
+}
+
+export const ProvisionShopAccess = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'ProvisionShopAccess'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'input'}},
+          type: {
+            kind: 'NonNullType',
+            type: {kind: 'NamedType', name: {kind: 'Name', value: 'OrganizationUserProvisionShopAccessInput'}},
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'organizationUserProvisionShopAccess'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'organizationUserProvisionShopAccessInput'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'input'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {kind: 'Field', name: {kind: 'Name', value: 'success'}},
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'userErrors'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ProvisionShopAccessMutation, ProvisionShopAccessMutationVariables>

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -69,4 +69,9 @@ export type Scalars = {
   URL: {input: string; output: string}
 }
 
+export type OrganizationUserProvisionShopAccessInput = {
+  /** The shop to provision the requester on. */
+  shopifyShopId: Scalars['PropertyPublicID']['input']
+}
+
 export type Store = 'APP_DEVELOPMENT' | 'DEVELOPMENT' | 'DEVELOPMENT_SUPERSET' | 'PRODUCTION'

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/queries/provision_shop_access.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/queries/provision_shop_access.graphql
@@ -1,0 +1,8 @@
+mutation ProvisionShopAccess($input: OrganizationUserProvisionShopAccessInput!) {
+  organizationUserProvisionShopAccess(organizationUserProvisionShopAccessInput: $input) {
+    success,
+    userErrors {
+      message
+    }
+  }
+}

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1436,6 +1436,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     createApp: (_organization: Organization, _options: CreateAppOptions) => Promise.resolve(testOrganizationApp()),
     devStoresForOrg: (_organizationId: string) => Promise.resolve({stores: [], hasMorePages: false}),
     storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve({organizations: {nodes: []}}),
+    ensureUserAccessToStore: (_orgId: string, _shopId: string) => Promise.resolve(),
     appExtensionRegistrations: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppExtensionRegistrations),
     appVersions: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppVersions),
     activeAppVersion: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyActiveAppVersion),

--- a/packages/app/src/cli/services/store-context.test.ts
+++ b/packages/app/src/cli/services/store-context.test.ts
@@ -200,6 +200,20 @@ describe('storeContext', () => {
       expect(hiddenConfig).toEqual('{\n  "client_id": {\n    "dev_store_url": "test-store.myshopify.com"\n  }\n}')
     })
   })
+
+  test('ensures user access to store', async () => {
+    await inTemporaryDirectory(async (dir) => {
+      await prepareAppFolder(mockApp, dir)
+      vi.mocked(fetchStore).mockResolvedValue(mockStore)
+
+      await storeContext({appContextResult, forceReselectStore: false})
+
+      expect(mockDeveloperPlatformClient.ensureUserAccessToStore).toHaveBeenCalledWith(
+        mockOrganization.id,
+        mockStore.shopId,
+      )
+    })
+  })
 })
 
 async function prepareAppFolder(app: AppLinkedInterface, directory: string) {

--- a/packages/app/src/cli/services/store-context.ts
+++ b/packages/app/src/cli/services/store-context.ts
@@ -63,6 +63,9 @@ export async function storeContext({
     await app.updateHiddenConfig({dev_store_url: selectedStore.shopDomain})
   }
 
+  // Ensure that the user is able to login to the store and install apps
+  await developerPlatformClient.ensureUserAccessToStore(organization.id, selectedStore.shopId)
+
   return selectedStore
 }
 

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -274,6 +274,7 @@ export interface DeveloperPlatformClient {
   createApp: (org: Organization, options: CreateAppOptions) => Promise<OrganizationApp>
   devStoresForOrg: (orgId: string, searchTerm?: string) => Promise<Paginateable<{stores: OrganizationStore[]}>>
   storeByDomain: (orgId: string, shopDomain: string) => Promise<FindStoreByDomainSchema>
+  ensureUserAccessToStore: (orgId: string, shopId: string) => Promise<void>
   appExtensionRegistrations: (
     app: MinimalAppIdentifiers,
     activeAppVersion?: AppVersion,

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -4,6 +4,7 @@ import {
   allowedTemplates,
   diffAppModules,
   encodedGidFromOrganizationId,
+  encodedGidFromShopId,
   versionDeepLink,
 } from './app-management-client.js'
 import {OrganizationBetaFlagsQuerySchema} from './app-management-client/graphql/organization_beta_flags.js'
@@ -29,7 +30,10 @@ import {SourceExtension} from '../../api/graphql/app-management/generated/types.
 import {describe, expect, test, vi} from 'vitest'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 import {fetch} from '@shopify/cli-kit/node/http'
-import {businessPlatformOrganizationsRequest} from '@shopify/cli-kit/node/api/business-platform'
+import {
+  businessPlatformOrganizationsRequest,
+  businessPlatformOrganizationsRequestDoc,
+} from '@shopify/cli-kit/node/api/business-platform'
 import {appManagementRequestDoc} from '@shopify/cli-kit/node/api/app-management'
 import {BugError} from '@shopify/cli-kit/node/error'
 import {randomUUID} from '@shopify/cli-kit/node/crypto'
@@ -1187,5 +1191,50 @@ describe('AppManagementClient', () => {
       // Then
       expect(client.bundleFormat).toBe('br')
     })
+  })
+})
+
+describe('ensureUserAccessToStore', () => {
+  test('ensures user access to store', async () => {
+    // Given
+    const orgId = '123'
+    const shopId = '456'
+    const token = 'business-platform-token'
+
+    const client = new AppManagementClient()
+    client.businessPlatformToken = () => Promise.resolve(token)
+
+    const mockResponse = {
+      organizationUserProvisionShopAccess: {
+        success: true,
+        userErrors: [],
+      },
+    }
+    vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce(mockResponse)
+
+    // When
+    await client.ensureUserAccessToStore(orgId, shopId)
+
+    // Then
+    expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(expect.anything(), token, orgId, {
+      input: {shopifyShopId: encodedGidFromShopId(shopId)},
+    })
+  })
+
+  test('handles failure', async () => {
+    const client = new AppManagementClient()
+    client.businessPlatformToken = () => Promise.resolve('business-platform-token')
+
+    const mockResponse = {
+      organizationUserProvisionShopAccess: {
+        success: false,
+        userErrors: [{message: 'error1'}, {message: 'error2'}],
+      },
+    }
+    vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce(mockResponse)
+
+    await expect(client.ensureUserAccessToStore('123', '456')).rejects.toThrowError(
+      'Failed to provision user access to store: error1, error2',
+    )
   })
 })

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -97,6 +97,10 @@ import {
   ListAppDevStoresQuery,
 } from '../../api/graphql/business-platform-organizations/generated/list_app_dev_stores.js'
 import {
+  ProvisionShopAccess,
+  ProvisionShopAccessMutationVariables,
+} from '../../api/graphql/business-platform-organizations/generated/provision_shop_access.js'
+import {
   ActiveAppReleaseQuery,
   ReleasedAppModuleFragment,
 } from '../../api/graphql/app-management/generated/active-app-release.js'
@@ -846,6 +850,25 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
   }
 
+  async ensureUserAccessToStore(orgId: string, shopId: string): Promise<void> {
+    const encodedShopId = encodedGidFromShopId(shopId)
+    const variables: ProvisionShopAccessMutationVariables = {
+      input: {shopifyShopId: encodedShopId},
+    }
+
+    const fullResult = await businessPlatformOrganizationsRequestDoc(
+      ProvisionShopAccess,
+      await this.businessPlatformToken(),
+      orgId,
+      variables,
+    )
+    const provisionResult = fullResult.organizationUserProvisionShopAccess
+    if (!provisionResult.success) {
+      const errorMessages = provisionResult.userErrors?.map((error) => error.message).join(', ') ?? ''
+      throw new BugError(`Failed to provision user access to store: ${errorMessages}`)
+    }
+  }
+
   async createExtension(_input: ExtensionCreateVariables): Promise<ExtensionCreateSchema> {
     throw new BugError('Not implemented: createExtension')
   }
@@ -1114,6 +1137,12 @@ function createAppVars(options: CreateAppOptions, apiVersion?: string): CreateAp
 // 1234 => gid://organization/Organization/1234 => base64
 export function encodedGidFromOrganizationId(id: string): string {
   const gid = `gid://organization/Organization/${id}`
+  return Buffer.from(gid).toString('base64')
+}
+
+// 1234 => gid://organization/ShopifyShop/1234 => base64
+export function encodedGidFromShopId(id: string): string {
+  const gid = `gid://organization/ShopifyShop/${id}`
   return Buffer.from(gid).toString('base64')
 }
 

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -482,6 +482,10 @@ export class PartnersClient implements DeveloperPlatformClient {
     return this.request(FindStoreByDomainQuery, variables)
   }
 
+  async ensureUserAccessToStore(_orgId: string, _shopId: string): Promise<void> {
+    // This is a no-op for partners
+  }
+
   async updateDeveloperPreview(
     input: DevelopmentStorePreviewUpdateInput,
   ): Promise<DevelopmentStorePreviewUpdateSchema> {

--- a/packages/cli-kit/src/private/node/session/scopes.test.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.test.ts
@@ -20,6 +20,7 @@ describe('allDefaultScopes', () => {
       'https://api.shopify.com/auth/partners.app.cli.access',
       'https://api.shopify.com/auth/destinations.readonly',
       'https://api.shopify.com/auth/organization.store-management',
+      'https://api.shopify.com/auth/organization.on-demand-user-access',
       'https://api.shopify.com/auth/organization.apps.manage',
       ...customScopes,
     ])
@@ -39,6 +40,7 @@ describe('allDefaultScopes', () => {
       'https://api.shopify.com/auth/partners.app.cli.access',
       'https://api.shopify.com/auth/destinations.readonly',
       'https://api.shopify.com/auth/organization.store-management',
+      'https://api.shopify.com/auth/organization.on-demand-user-access',
       'https://api.shopify.com/auth/organization.apps.manage',
     ])
   })

--- a/packages/cli-kit/src/private/node/session/scopes.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.ts
@@ -52,7 +52,7 @@ function defaultApiScopes(api: API): string[] {
     case 'partners':
       return ['cli']
     case 'business-platform':
-      return ['destinations', 'store-management']
+      return ['destinations', 'store-management', 'on-demand-user-access']
     case 'app-management':
       return ['app-management']
     default:
@@ -76,6 +76,8 @@ function scopeTransform(scope: string): string {
       return 'https://api.shopify.com/auth/destinations.readonly'
     case 'store-management':
       return 'https://api.shopify.com/auth/organization.store-management'
+    case 'on-demand-user-access':
+      return 'https://api.shopify.com/auth/organization.on-demand-user-access'
     case 'app-management':
       return 'https://api.shopify.com/auth/organization.apps.manage'
     default:


### PR DESCRIPTION
This also contains the following PR which was merged into this one:
- https://github.com/Shopify/cli/pull/5531
Merging that one into this one wasn't the plan but I think we can roll with it to avoid having to recreate and re-review PRs. - @rmcnews

### WHY are these changes introduced?

Support the provisioning of user access to stores through fbusiness platform. 

### WHAT is this pull request doing?

Adds the graphql and generated code for the BP `organizationUserProvisionShopAccess` mutation. 

Because it requires the new scope (`organization.on-demand-user-access`) that scope is added to the the list of requested scopes for BP API calls.

Before merging, we'll need to add the new scope to the allowed scopes for the `shopify-cli` oauth app in identity. 
- For [release](https://accounts.shopify.com/services/applications)
- For [dev](https://github.com/Shopify/identity/blob/1b5aea44cdd721b87536e7060d44e99418de7d6f/config/seed/oauth_applications.yml#L590)

### How to test your changes?

Best tested via gthe entire PR stack using the instructions [here](https://github.com/Shopify/cli/pull/5596). 

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
