### PR TITLE
Remove empty brackets and path from human readable zod error message

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -53,7 +53,7 @@ export const LegacyAppSchema = zod
       })
       .optional(),
   })
-  .strict()
+  .strict({message: 'You may be missing client_id, or your TOML is malformed'})
 
 function removeTrailingPathSeparator(value: string[] | undefined) {
   // eslint-disable-next-line no-useless-escape

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -122,8 +122,8 @@ export async function parseConfigurationFile<TSchema extends zod.ZodType>(
 export function parseHumanReadableError(issues: Pick<zod.ZodIssueBase, 'path' | 'message'>[]) {
   let humanReadableError = ''
   issues.forEach((issue) => {
-    const path = issue.path ? issue?.path.join('.') : 'n/a'
-    humanReadableError += `• [${path}]: ${issue.message}\n`
+    const path = issue.path?.length ? `[${issue.path.join('.')}]: ` : ''
+    humanReadableError += `• ${path}${issue.message}\n`
   })
   return humanReadableError
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2237

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR looks at the path that zod provides when parsing the schema. When error occurs in the 'root' of the schema, the path is an empty array. This passes `parseHumanReadableError` an empty string and causing the error to look like this:
![image](https://github.com/user-attachments/assets/521e2fd5-85ad-46dc-a800-4008c7ab7e06)

After these changes, and providing a specific error message for mismatching the `LegacyAppSchema` 
<img width="1228" alt="Screenshot 2025-03-20 at 4 11 55 PM" src="https://github.com/user-attachments/assets/e29db4e3-2589-4191-a10a-af948c8efff3" />

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

- Create an app
- Remove `client_id` or provide incorrect types for any of the types provided in `AppSchema` or `LegacyAppSchema`
- View the error message provided  

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
