### PR TITLE
Do not throw errors when Bugsnag fails

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.test.ts
+++ b/packages/cli-kit/src/public/node/error-handler.test.ts
@@ -142,4 +142,21 @@ describe('send to Bugsnag', () => {
     expect(res.reported).toEqual(false)
     expect(onNotify).not.toHaveBeenCalled()
   })
+
+  test('do not throw an error if Bugsnag fails, but just log it', async () => {
+    // Given
+    onNotify.mockImplementationOnce(() => {
+      throw new Error('Bugsnag is down')
+    })
+    const toThrow = new Error('In test')
+    const mockOutput = mockAndCaptureOutput()
+
+    // When
+    const res = await sendErrorToBugsnag(toThrow, 'unexpected_error')
+
+    // Then
+    expect(res.reported).toEqual(false)
+    expect(res.error).toEqual(toThrow)
+    expect(mockOutput.debug()).toMatch('Error reporting to Bugsnag: Error: Bugsnag is down')
+  })
 })

--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -140,8 +140,8 @@ export async function sendErrorToBugsnag(
     }
     return {error: reportableError, reported: report, unhandled}
     // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch (error) {
-    outputDebug(`Error reporting to Bugsnag: ${error}`)
+  } catch (err) {
+    outputDebug(`Error reporting to Bugsnag: ${err}`)
     return {error, reported: false, unhandled: undefined}
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

If a report to Bugsnag fails, it throws an error that finishes the current command

### WHAT is this pull request doing?

Adds a try/catch to log the error without stopping the command

### How to test your changes?

- Modify `packages/cli/src/cli/commands/version.ts`: replace `await versionService()` with `throw new Error('Boom')`. That way, `shopify version` will throw an error.
- Modify `packages/cli-kit/src/public/node/error-handler.ts`: replace `Bugsnag.notify(reportableError, eventHandler, errorHandler)` with `throw new Error('Bugsnag is down')`. That way, the function that reports to Bugsnag will throw an error.
- Run `SHOPIFY_CLI_ENV=production p shopify version --verbose`: no error should be reported to Bugsnag, and the log should show `Error reporting to Bugsnag: Error: Busgnag is down`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
