### PR TITLE
Refactor dev session status messages into static constants

### DIFF
--- a/packages/app/src/cli/services/dev/processes/dev-session-status-manager.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session-status-manager.test.ts
@@ -91,4 +91,52 @@ describe('DevSessionStatusManager', () => {
       previewURL: undefined,
     })
   })
+
+  describe('setMessage', () => {
+    test('updates status with BUILD_ERROR message', () => {
+      devSessionStatusManager.setMessage('BUILD_ERROR')
+
+      expect(devSessionStatusManager.status.statusMessage).toEqual({
+        message: 'Build error. Please review your code and try again',
+        type: 'error',
+      })
+    })
+
+    test('updates status with READY message', () => {
+      devSessionStatusManager.setMessage('READY')
+
+      expect(devSessionStatusManager.status.statusMessage).toEqual({
+        message: 'Ready, watching for changes in your app',
+        type: 'success',
+      })
+    })
+
+    test('emits event when message changes', () => {
+      const listener = vi.fn()
+      devSessionStatusManager.on('dev-session-update', listener)
+
+      devSessionStatusManager.setMessage('LOADING')
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusMessage: {
+            message: 'Preparing dev session',
+            type: 'loading',
+          },
+        }),
+      )
+    })
+
+    test('does not emit event when setting same message twice', () => {
+      const listener = vi.fn()
+      devSessionStatusManager.on('dev-session-update', listener)
+
+      devSessionStatusManager.setMessage('READY')
+      listener.mockClear()
+
+      devSessionStatusManager.setMessage('READY')
+
+      expect(listener).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/app/src/cli/services/dev/processes/dev-session-status-manager.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session-status-manager.ts
@@ -3,6 +3,16 @@ import {EventEmitter} from 'events'
 
 export type DevSessionStatusMessageType = 'error' | 'success' | 'loading'
 
+const DevSessionStaticMessages = {
+  BUILD_ERROR: {message: 'Build error. Please review your code and try again', type: 'error'},
+  READY: {message: 'Ready, watching for changes in your app', type: 'success'},
+  LOADING: {message: 'Preparing dev session', type: 'loading'},
+  UPDATED: {message: 'Updated', type: 'success'},
+  VALIDATION_ERROR: {message: 'Validation error in your app configuration', type: 'error'},
+  REMOTE_ERROR: {message: 'Error updating dev session', type: 'error'},
+  CHANGE_DETECTED: {message: 'Change detected, updating dev session', type: 'loading'},
+} as const
+
 export interface DevSessionStatus {
   isReady: boolean
   previewURL?: string
@@ -30,6 +40,10 @@ export class DevSessionStatusManager extends EventEmitter {
     if (statusIsEqual) return
     this.currentStatus = newStatus
     this.emit('dev-session-update', newStatus)
+  }
+
+  setMessage(message: keyof typeof DevSessionStaticMessages) {
+    this.updateStatus({statusMessage: DevSessionStaticMessages[message]})
   }
 
   get status(): DevSessionStatus {


### PR DESCRIPTION
# Refactor Dev Session Status Messages for Better Maintainability

### WHY are these changes introduced?

Simplify dev session status messages

### WHAT is this pull request doing?

- Creates a new `DevSessionStaticMessages` constant that centralizes all status messages in one place
- Replaces all individual status message setting functions with calls to the new `setMessage` method
- Simplifies code by removing redundant status message functions

### How to test your changes?

Functionality hasn't changed, verify dev-sessions work as expected.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes