### PR TITLE
Support Remote DOM ui extensions

### DIFF
--- a/.changeset/orange-poems-give.md
+++ b/.changeset/orange-poems-give.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Enable support for Polaris Unified extensions using an experimental environment variable

--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
       "eslint-plugin-react-hooks",
       "@shopify/cli-hydrogen",
       "@shopify/theme-check-node",
-      "@shopify/theme-check-docs-updater"
+      "@shopify/theme-check-docs-updater",
+      "@shopify/ui-extensions"
     ],
     "ignoreWorkspaces": [
       "packages/eslint-plugin-cli"

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -17,7 +17,7 @@ import {patchAppHiddenConfigFile} from '../../services/app/patch-app-configurati
 import {ZodObjectOf, zod} from '@shopify/cli-kit/node/schema'
 import {DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {getDependencies, PackageManager, readAndParsePackageJson} from '@shopify/cli-kit/node/node-package-manager'
-import {fileRealPath, findPathUp} from '@shopify/cli-kit/node/fs'
+import {fileExistsSync, fileRealPath, findPathUp, readFileSync, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {normalizeDelimitedString} from '@shopify/cli-kit/common/string'
@@ -295,6 +295,7 @@ export interface AppInterface<
   removeExtension: (extensionUid: string) => void
   updateHiddenConfig: (values: Partial<AppHiddenConfig>) => Promise<void>
   setDevApplicationURLs: (devApplicationURLs: ApplicationURLs) => void
+  generateExtensionTypes(): Promise<void>
 }
 
 type AppConstructor<
@@ -495,6 +496,35 @@ export class App<
 
   removeExtension(extensionUid: string) {
     this.realExtensions = this.realExtensions.filter((ext) => ext.uid !== extensionUid)
+  }
+
+  async generateExtensionTypes() {
+    const typeFilePath = joinPath(this.directory, 'shopify.d.ts')
+    let firstImport = ''
+    const sharedTypes = await Promise.all(
+      this.allExtensions.map((extension) => extension.contributeToSharedTypeFile(typeFilePath)),
+    )
+    const combinedDefinitions = new Set()
+    sharedTypes.forEach((shared) => {
+      shared.forEach(({libraryRoot, definition}) => {
+        if (!firstImport) {
+          firstImport = `import '${libraryRoot}';\n`
+        }
+        combinedDefinitions.add(definition)
+      })
+    })
+
+    if (combinedDefinitions.size === 0) {
+      return
+    }
+
+    const originalContent = fileExistsSync(typeFilePath) ? readFileSync(typeFilePath).toString() : ''
+    const typeContent = [firstImport, ...Array.from(combinedDefinitions)].join('\n')
+    if (originalContent === typeContent) {
+      return
+    }
+    // Adding a top-level import to the type file allows us to workaround the TS restriction of not allowing declaring modules with relative paths
+    writeFileSync(typeFilePath, [firstImport, ...Array.from(combinedDefinitions)].join('\n'))
   }
 
   get includeConfigOnDeploy() {

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -12,7 +12,7 @@ import {
   reloadApp,
   loadHiddenConfig,
 } from './loader.js'
-import {AppLinkedInterface, LegacyAppSchema, WebConfigurationSchema} from './app.js'
+import {App, AppLinkedInterface, LegacyAppSchema, WebConfigurationSchema} from './app.js'
 import {DEFAULT_CONFIG, buildVersionedAppSchema, getWebhookConfig} from './app.test-data.js'
 import {configurationFileNames, blocks} from '../../constants.js'
 import metadata from '../../metadata.js'
@@ -2375,6 +2375,19 @@ wrong = "property"
     expect(reloadedApp.packageManager).toBe(app.packageManager)
     expect(reloadedApp.nodeDependencies).toEqual(app.nodeDependencies)
     expect(reloadedApp.usesWorkspaces).toBe(app.usesWorkspaces)
+  })
+
+  test('call app.generateExtensionTypes', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+    const generateTypesSpy = vi.spyOn(App.prototype, 'generateExtensionTypes')
+
+    // When
+    await loadTestingApp()
+
+    // Then
+    expect(generateTypesSpy).toHaveBeenCalled()
+    generateTypesSpy.mockRestore()
   })
 
   const runningOnWindows = platformAndArch().platform === 'windows'

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -34,16 +34,7 @@ import {WebhooksSchema} from '../extensions/specifications/app_config_webhook_sc
 import {loadLocalExtensionsSpecifications} from '../extensions/load-specifications.js'
 import {UIExtensionSchemaType} from '../extensions/specifications/ui_extension.js'
 import {patchAppHiddenConfigFile} from '../../services/app/patch-app-configuration-file.js'
-import {
-  fileExists,
-  readFile,
-  glob,
-  findPathUp,
-  fileExistsSync,
-  writeFile,
-  writeFileSync,
-  mkdir,
-} from '@shopify/cli-kit/node/fs'
+import {fileExists, readFile, glob, findPathUp, fileExistsSync, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {
@@ -398,6 +389,8 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
       usedCustomLayoutForExtensions: configuration.extension_directories !== undefined,
     })
 
+    await appClass.generateExtensionTypes()
+
     return appClass
   }
 
@@ -554,8 +547,6 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
     // Temporary code to validate that there is a single print action extension per target in an app.
     // Should be replaced by core validation.
     this.validatePrintActionExtensionsUniqueness(allExtensions)
-
-    await this.generateExtensionTypes(allExtensions)
 
     return allExtensions
   }
@@ -763,15 +754,6 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
           }
         })
       })
-  }
-
-  private async generateExtensionTypes(allExtensions: ExtensionInstance[]) {
-    const typeFilePath = joinPath(this.loadedConfiguration.directory, 'shopify.d.ts')
-    const definitions = await Promise.all(
-      allExtensions.map((extension) => extension.contributeToSharedTypeFile(typeFilePath)),
-    )
-    const combinedDefinitions = new Set(definitions.flatMap((definition) => definition))
-    writeFileSync(typeFilePath, [`import '@shopify/ui-extensions';`, ...Array.from(combinedDefinitions)].join('\n'))
   }
 }
 

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -437,6 +437,10 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     this.specification.patchWithAppDevURLs(this.configuration, urls)
   }
 
+  contributeToSharedTypeFile(typeFilePath: string) {
+    return this.specification.contributeToSharedTypeFile?.(this, typeFilePath) ?? []
+  }
+
   private buildHandle() {
     switch (this.specification.uidStrategy) {
       case 'single':

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -2,7 +2,7 @@
 
 import {BaseConfigType, MAX_EXTENSION_HANDLE_LENGTH} from './schemas.js'
 import {FunctionConfigType} from './specifications/function.js'
-import {ExtensionFeature, ExtensionSpecification} from './specification.js'
+import {ExtensionFeature, ExtensionSpecification, SharedType} from './specification.js'
 import {SingleWebhookSubscriptionType} from './specifications/app_config_webhook_schemas/webhooks_schema.js'
 import {AppHomeSpecIdentifier} from './specifications/app_config_app_home.js'
 import {AppAccessSpecIdentifier} from './specifications/app_config_app_access.js'
@@ -264,7 +264,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   hasExtensionPointTarget(target: string): boolean {
-    return this.specification.hasExtensionPointTarget?.(this.configuration, target) || false
+    return this.specification.hasExtensionPointTarget?.(this.configuration, target) ?? false
   }
 
   // Functions specific properties
@@ -437,7 +437,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     this.specification.patchWithAppDevURLs(this.configuration, urls)
   }
 
-  contributeToSharedTypeFile(typeFilePath: string) {
+  async contributeToSharedTypeFile(typeFilePath: string): Promise<SharedType[]> {
     return this.specification.contributeToSharedTypeFile?.(this, typeFilePath) ?? []
   }
 

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -46,6 +46,12 @@ export interface Asset {
   outputFileName: string
   content: string
 }
+
+export interface SharedType {
+  libraryRoot: string
+  definition: string
+}
+
 /**
  * Extension specification with all the needed properties and methods to load an extension.
  */
@@ -114,7 +120,10 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
    */
   parseConfigurationObject: (configurationObject: object) => ParseConfigurationResult<TConfiguration>
 
-  contributeToSharedTypeFile?: (extension: ExtensionInstance<TConfiguration>, typeFilePath: string) => Promise<string[]>
+  contributeToSharedTypeFile?: (
+    extension: ExtensionInstance<TConfiguration>,
+    typeFilePath: string,
+  ) => Promise<SharedType[]>
 }
 
 /**

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -113,6 +113,8 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
    * Parse some provided configuration into a valid configuration object for this extension.
    */
   parseConfigurationObject: (configurationObject: object) => ParseConfigurationResult<TConfiguration>
+
+  contributeToSharedTypeFile?: (extension: ExtensionInstance<TConfiguration>, typeFilePath: string) => Promise<string[]>
 }
 
 /**

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -1,12 +1,16 @@
-import {Asset, AssetIdentifier, ExtensionFeature, createExtensionSpecification} from '../specification.js'
+import {Asset, AssetIdentifier, ExtensionFeature, SharedType, createExtensionSpecification} from '../specification.js'
 import {NewExtensionPointSchemaType, NewExtensionPointsSchema, BaseSchema} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {getExtensionPointTargetSurface} from '../../../services/dev/extension/utilities.js'
+import {ExtensionInstance} from '../extension-instance.js'
 import {err, ok, Result} from '@shopify/cli-kit/node/result'
-import {fileExists} from '@shopify/cli-kit/node/fs'
-import {joinPath, relativePath} from '@shopify/cli-kit/node/path'
+import {fileExists, readFileSync, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {dirname, joinPath, relativePath, relativizePath} from '@shopify/cli-kit/node/path'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {zod} from '@shopify/cli-kit/node/schema'
+import {createRequire} from 'module'
+
+const require = createRequire(import.meta.url)
 
 const dependency = '@shopify/checkout-ui-extensions'
 
@@ -102,9 +106,13 @@ const uiExtensionSpec = createExtensionSpecification({
     }
   },
   getBundleExtensionStdinContent: (config) => {
+    const shouldIncludeShopifyExtend = isRemoteDomExtension(config)
     const main = config.extension_points
-      .map(({module}) => {
-        return `import '${module}'; `
+      .map(({target, module}, index) => {
+        if (shouldIncludeShopifyExtend) {
+          return `import Target_${index} from '${module}';shopify.extend('${target}', (...args) => Target_${index}(...args));`
+        }
+        return `import '${module}';`
       })
       .join('\n')
 
@@ -119,7 +127,11 @@ const uiExtensionSpec = createExtensionSpecification({
         assets[identifier] = {
           identifier: identifier as AssetIdentifier,
           outputFileName: asset.filepath,
-          content: `import '${asset.module}'`,
+          content: shouldIncludeShopifyExtend
+            ? `import shouldRender from '${asset.module}';shopify.extend('${getShouldRenderTarget(
+                extensionPoint.target,
+              )}', (...args) => shouldRender(...args));`
+            : `import '${asset.module}'`,
         }
       })
     })
@@ -138,41 +150,46 @@ const uiExtensionSpec = createExtensionSpecification({
     )
   },
   contributeToSharedTypeFile: async (extension, typeFilePath) => {
-    const definition: string[] = []
-    for await (const {module, target} of extension.configuration.extension_points) {
-      const fullPath = joinPath(extension.directory, module)
-      const exists = await fileExists(fullPath)
+    const sharedTypes: SharedType[] = []
+    if (!isRemoteDomExtension(extension.configuration)) {
+      return sharedTypes
+    }
 
-      if (!exists || extension.configuration.api_version !== '2025-04') {
+    const {configuration} = extension
+    for await (const extensionPoint of configuration.extension_points) {
+      const fullPath = joinPath(extension.directory, extensionPoint.module)
+      const fileParts = fullPath.split('.')
+      const fileExtension = fileParts.pop()
+      const exists = await fileExists(fullPath)
+      if (!fileExtension || !exists) {
         continue
       }
 
-      // eslint-disable-next-line no-useless-escape
-      const typeRefRegex = /\/\/\/ <reference types="([.\/]*)shopify\.d\.ts" \/>/
-      const template = `/// <reference types="${relativePath(fullPath, typeFilePath)}" />`
-
-      let fileContent = readFileSync(fullPath).toString()
-      let match
-      if ((match = fileContent.match(typeRefRegex)) && match[1]) {
-        fileContent = fileContent.replace(match[0], template)
-      } else {
-        fileContent = `${template}\n`.concat(fileContent)
+      const mainTypes = getSharedTypeDefinition(
+        fullPath,
+        typeFilePath,
+        extensionPoint.target,
+        configuration.api_version,
+      )
+      if (mainTypes) {
+        sharedTypes.push(mainTypes)
       }
-      writeFileSync(fullPath, fileContent)
 
-      const surface = target.split('.')?.[0]
-      // @todo: update to work for non-admin
-      const importName = `${surface?.slice(0, 1).toUpperCase().concat(surface.slice(1))}ExtensionTargets`
-      if (importName) {
-        definition.push(
-          `declare module './${relativePath(typeFilePath, fullPath)}' {
-  const globalThis: typeof import('@shopify/ui-extensions/${target}');
-  const shopify: import('@shopify/ui-extensions/${target}').Api;
-}`,
+      if (extensionPoint.build_manifest.assets[AssetIdentifier.ShouldRender]?.module) {
+        const shouldRenderTypes = getSharedTypeDefinition(
+          joinPath(extension.directory, extensionPoint.build_manifest.assets[AssetIdentifier.ShouldRender].module),
+          typeFilePath,
+          getShouldRenderTarget(extensionPoint.target),
+
+          configuration.api_version,
         )
+        if (shouldRenderTypes) {
+          sharedTypes.push(shouldRenderTypes)
+        }
       }
     }
-    return definition
+
+    return sharedTypes
   },
 })
 
@@ -236,6 +253,79 @@ Please check the module path for ${target}`.value,
     return err(errors.join('\n\n'))
   }
   return ok({})
+}
+
+function isRemoteDomExtension(
+  config: ExtensionInstance['configuration'],
+): config is ExtensionInstance<{api_version: string}>['configuration'] {
+  const apiVersion = config.api_version
+  const [year, month] = apiVersion?.split('-').map((part: string) => parseInt(part, 10)) ?? []
+  if (!year || !month) {
+    return false
+  }
+
+  return year > 2025 || (year === 2025 && month >= 7)
+}
+
+// eslint-disable-next-line no-useless-escape
+const TYPE_REF_REGEX = /^\/\/\/ <reference types="(?:[.\/]*)shopify\.d\.ts" \/>\n/
+
+function updateTypeReference({
+  fullPath,
+  template,
+  shouldAddTypeReference,
+}: {
+  fullPath: string
+  template: string
+  shouldAddTypeReference: boolean
+}) {
+  const originalContent = readFileSync(fullPath).toString()
+  let fileContent = originalContent
+  let match
+  while ((match = TYPE_REF_REGEX.exec(fileContent))) {
+    fileContent = fileContent.replace(match[0], '')
+  }
+
+  if (shouldAddTypeReference) {
+    fileContent = template.concat(fileContent)
+  }
+
+  if (originalContent !== fileContent) {
+    writeFileSync(fullPath, fileContent)
+  }
+}
+
+export function getShouldRenderTarget(target: string) {
+  return target.replace(/\.render$/, '.should-render')
+}
+
+function getSharedTypeDefinition(fullPath: string, typeFilePath: string, target: string, apiVersion: string) {
+  const template = `/// <reference types="${relativePath(dirname(fullPath), typeFilePath)}" />\n`
+  let types
+  try {
+    // We try to resolve from the module's path first with the app root as the fallback in case dependencies are hoisted to the shared workspace
+    const fullTypePath = require.resolve(`@shopify/ui-extensions/${target}`, {paths: [fullPath, typeFilePath]})
+    const libraryRoot = require.resolve('@shopify/ui-extensions', {paths: [fullPath, typeFilePath]})
+    const importPath = `./${relativizePath(fullTypePath, dirname(typeFilePath))}`
+
+    types = {
+      libraryRoot,
+      definition: `//@ts-ignore\ndeclare module './${relativizePath(fullPath, dirname(typeFilePath))}' {
+  const globalThis: typeof import('${importPath}');
+  const shopify: import('${importPath}').Api;
+}\n`,
+    }
+  } catch (_) {
+    // Remove the type reference from the source file
+    updateTypeReference({fullPath, template, shouldAddTypeReference: false})
+    throw new Error(
+      `Type reference for ${target} could not be found. You might be using the wrong @shopify/ui-extensions version. Fix the error by ensuring you install @shopify/ui-extensions@${apiVersion} in your dependencies.`,
+    )
+  }
+
+  // Update the type reference
+  updateTypeReference({fullPath, template, shouldAddTypeReference: true})
+  return types
 }
 
 export default uiExtensionSpec

--- a/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.ts
@@ -95,7 +95,6 @@ export class ESBuildContextManager {
    */
   async updateContexts(appEvent: AppEvent) {
     this.dotEnvVariables = appEvent.app.dotenv?.variables ?? {}
-
     const createdEsBuild = appEvent.extensionEvents
       .filter((extEvent) => extEvent.extension.isESBuildExtension)
       .filter((extEvent) => extEvent.type === 'created' || (extEvent.type === 'changed' && appEvent.appWasReloaded))

--- a/packages/app/src/cli/services/generate.ts
+++ b/packages/app/src/cli/services/generate.ts
@@ -106,7 +106,7 @@ async function saveAnalyticsMetadata(promptAnswers: GenerateExtensionPromptOutpu
 
 function buildGenerateOptions(
   promptAnswers: GenerateExtensionPromptOutput,
-  app: AppInterface,
+  app: AppLinkedInterface,
   options: GenerateOptions,
   developerPlatformClient: DeveloperPlatformClient,
 ): GenerateExtensionTemplateOptions {

--- a/packages/app/src/cli/services/generate/fetch-template-specifications.test.ts
+++ b/packages/app/src/cli/services/generate/fetch-template-specifications.test.ts
@@ -1,7 +1,13 @@
 import {fetchExtensionTemplates} from './fetch-template-specifications.js'
+import {ExtensionFlavorValue} from './extension.js'
 import {testDeveloperPlatformClient, testOrganizationApp} from '../../models/app/app.test-data.js'
-import {ExtensionTemplate} from '../../models/app/template.js'
-import {describe, expect, test} from 'vitest'
+import {ExtensionTemplate, ExtensionFlavor} from '../../models/app/template.js'
+import {describe, expect, test, vi} from 'vitest'
+import * as experimentModule from '@shopify/cli-kit/node/is-polaris-unified-enabled'
+
+vi.mock('@shopify/cli-kit/node/is-polaris-unified-enabled', () => ({
+  isPolarisUnifiedEnabled: vi.fn().mockReturnValue(false),
+}))
 
 describe('fetchTemplateSpecifications', () => {
   test('returns the remote specs', async () => {
@@ -25,5 +31,136 @@ describe('fetchTemplateSpecifications', () => {
 
     // Since the ui_extension specification is not enabled, this template should not be included.
     expect(identifiers).not.toContain('ui_extension')
+  })
+
+  describe('ui_extension', () => {
+    const preactFlavor: ExtensionFlavor = {
+      name: 'Preact',
+      value: 'preact' as ExtensionFlavorValue,
+    }
+
+    const oldFlavors = [
+      {
+        name: 'JavaScript React',
+        value: 'react' as ExtensionFlavorValue,
+        path: 'admin-action',
+      },
+      {
+        name: 'JavaScript',
+        value: 'vanilla-js' as ExtensionFlavorValue,
+        path: 'admin-action',
+      },
+      {
+        name: 'TypeScript React',
+        value: 'typescript-react' as ExtensionFlavorValue,
+        path: 'admin-action',
+      },
+      {
+        name: 'TypeScript',
+        value: 'typescript' as ExtensionFlavorValue,
+        path: 'admin-action',
+      },
+    ]
+    const allFlavors = [...oldFlavors, preactFlavor]
+
+    async function getTemplates() {
+      const templates: ExtensionTemplate[] = await fetchExtensionTemplates(
+        testDeveloperPlatformClient({
+          templateSpecifications: () =>
+            Promise.resolve([
+              {
+                identifier: 'ui_extension',
+                name: 'UI Extension',
+                defaultName: 'ui-extension',
+                group: 'Merchant Admin',
+                supportLinks: [],
+                type: 'ui_extension',
+                url: 'https://github.com/Shopify/extensions-templates',
+                extensionPoints: [],
+                supportedFlavors: allFlavors,
+              },
+            ]),
+        }),
+        testOrganizationApp(),
+        ['ui_extension'],
+      )
+      return templates
+    }
+
+    test('returns only the preact flavor when POLARIS_UNIFIED is enabled', async () => {
+      // Given
+      vi.spyOn(experimentModule, 'isPolarisUnifiedEnabled').mockReturnValueOnce(true)
+
+      // When
+      const templates = await getTemplates()
+
+      // Then
+      expect(templates[0]!.supportedFlavors).toEqual([preactFlavor])
+    })
+
+    test('excludes the preact flavor by default', async () => {
+      // When
+      const templates = await getTemplates()
+
+      // Then
+      expect(templates[0]!.supportedFlavors).toEqual(oldFlavors)
+    })
+
+    test('filter out templates that have no flavors available by default', async () => {
+      // When
+      const templates: ExtensionTemplate[] = await fetchExtensionTemplates(
+        testDeveloperPlatformClient({
+          templateSpecifications: () =>
+            Promise.resolve([
+              {
+                identifier: 'ui_extension',
+                name: 'UI Extension',
+                defaultName: 'ui-extension',
+                group: 'Merchant Admin',
+                supportLinks: [],
+                type: 'ui_extension',
+                url: 'https://github.com/Shopify/extensions-templates',
+                extensionPoints: [],
+                supportedFlavors: [preactFlavor],
+              },
+            ]),
+        }),
+        testOrganizationApp(),
+        ['ui_extension'],
+      )
+
+      // Then
+      expect(templates).toEqual([])
+    })
+
+    test('filter out templates that have no flavors available POLARIS_UNIFIED is enabled', async () => {
+      // Given
+      vi.spyOn(experimentModule, 'isPolarisUnifiedEnabled').mockReturnValueOnce(true)
+
+      // When
+      const templates: ExtensionTemplate[] = await fetchExtensionTemplates(
+        testDeveloperPlatformClient({
+          templateSpecifications: () =>
+            Promise.resolve([
+              {
+                identifier: 'ui_extension',
+                name: 'UI Extension',
+                defaultName: 'ui-extension',
+                group: 'Merchant Admin',
+                supportLinks: [],
+                type: 'ui_extension',
+                url: 'https://github.com/Shopify/extensions-templates',
+                extensionPoints: [],
+                supportedFlavors: oldFlavors,
+              },
+            ]),
+        }),
+        testOrganizationApp(),
+        ['ui_extension'],
+      )
+
+      // Then
+      expect(templates).toEqual([])
+    })
   })
 })

--- a/packages/cli-kit/src/public/node/is-polaris-unified-enabled.test.ts
+++ b/packages/cli-kit/src/public/node/is-polaris-unified-enabled.test.ts
@@ -1,0 +1,18 @@
+import {isPolarisUnifiedEnabled} from './is-polaris-unified-enabled.js'
+import {describe, test, expect, vi} from 'vitest'
+
+describe('isPolarisUnifiedEnabled', () => {
+  test('returns true when POLARIS_UNIFIED is set to truthy value', () => {
+    vi.stubEnv('POLARIS_UNIFIED', 'true')
+    expect(isPolarisUnifiedEnabled()).toBe(true)
+  })
+
+  test('returns false when POLARIS_UNIFIED is set to falsy value', () => {
+    vi.stubEnv('POLARIS_UNIFIED', 'false')
+    expect(isPolarisUnifiedEnabled()).toBe(false)
+  })
+
+  test('returns false when POLARIS_UNIFIED is not set', () => {
+    expect(isPolarisUnifiedEnabled()).toBe(false)
+  })
+})

--- a/packages/cli-kit/src/public/node/is-polaris-unified-enabled.ts
+++ b/packages/cli-kit/src/public/node/is-polaris-unified-enabled.ts
@@ -1,0 +1,10 @@
+import {isTruthy} from './context/utilities.js'
+
+/**
+ * Returns true if the POLARIS_UNIFIED environment variable is set to true.
+ *
+ * @returns `true` if the POLARIS_UNIFIED environment variable is set to true.
+ */
+export function isPolarisUnifiedEnabled(): boolean {
+  return isTruthy(process.env.POLARIS_UNIFIED)
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/app-ui/issues/2158

### WHAT is this pull request doing?
Enables support for Remote DOM UI extensions when using the `REMOTE_DOM_EXPERIMENT` environment variable.

### How to test your changes?

1. Checkout this branch and set your `CLI_KIT_VERSION` to `3.78.0`
1. Grab the relative path to the directory for an existing app (or create one using `pnpm create-app` if you don't have one)
1. Create a remote ui extension by running `pnpm shopify app generate --path <app-directory>`
1. Select an Admin Block extension and chose the Typescript React template
1. Verify that it successfully creates the remote-ui block extension
1. Select a Checkout UI extension and chose the Typescript React template
1. Verify that it successfully creates the checkout-ui extension
1. Create a remote dom extension by running `REMOTE_DOM_EXPERIMENT=true pnpm shopify app generate REMOTE_DOM_EXPERIMENT=true pnpm shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#2025-07 --path <app-directory>`
1. Select an Admin Block extension and chose the Typescript React template
1. Verify that it successfully creates the remote-dom block extension
1. Run `REMOTE_DOM_EXPERIMENT=true pnpm shopify app dev --path ../../../apps/remote-dom-feb-2025`
1. Verify that runs successfully.
    NOTE: You will see errors relating to updating the drafts like "Error while updating drafts: "2025-07" is not a valid API version" - this is expected until `2025-07` is publicly available.
1. Open the remote-dom Block extension's TOML file and update the target
1. Verify that after you update the target the `shopify.extension.target` is typed to the new target. 
1. Verify that updating the target to be an `action` extension like `"admin.gift-card-details.action.render"` you get type errors for trying to use the `<s-admin-block>` element.
1. Verify that the remote-ui extension still works the same as before:
- changing its target should not impact the shared type file
- no type reference comment is added

Uploading Screen Recording 2025-03-27 at 3.21.21 PM.mov…



### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
