### PR TITLE
Enforce in-house fetch function

### DIFF
--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -448,6 +448,7 @@ export async function parseThemeFileContent(
       return {attachment: body.contentBase64}
     case 'OnlineStoreThemeFileBodyUrl':
       try {
+        // eslint-disable-next-line no-restricted-globals
         const response = await fetch(body.url)
 
         const arrayBuffer = await response.arrayBuffer()

--- a/packages/eslint-plugin-cli/config.js
+++ b/packages/eslint-plugin-cli/config.js
@@ -183,6 +183,14 @@ module.exports = {
     '@babel/no-unused-expressions': 'off',
     'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions': ['error', {allowTernary: true}],
+    'no-restricted-globals': [
+      'error',
+      {
+        name: 'fetch',
+        message:
+          'Please use our alternative fetch implementation in @shopify/cli-kit/node/http instead of Node.js built-in fetch. Built-in fetch does not support HTTP proxies.',
+      },
+    ],
   },
   overrides: [
     {
@@ -204,6 +212,7 @@ module.exports = {
         '@typescript-eslint/restrict-plus-operands': 'off',
         '@typescript-eslint/non-nullable-type-assertion-style': 'off',
         '@typescript-eslint/prefer-reduce-type-parameter': 'warn',
+        'no-restricted-globals': 'off',
       },
     },
   ],

--- a/packages/plugin-cloudflare/src/install-cloudflared.test.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.test.ts
@@ -1,14 +1,11 @@
 import install, {CURRENT_CLOUDFLARE_VERSION, versionIsGreaterThan} from './install-cloudflared.js'
 import * as fsActions from '@shopify/cli-kit/node/fs'
+import * as http from '@shopify/cli-kit/node/http'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import util from 'util'
 import {WriteStream} from 'fs'
 // eslint-disable-next-line no-restricted-imports
 import * as childProcess from 'child_process'
-
-global.fetch = vi.fn((aa, bb) => {
-  return Promise.resolve({ok: true} as Response)
-})
 
 vi.mock('child_process')
 vi.mock('stream')
@@ -16,7 +13,7 @@ vi.mock('stream')
 describe('install-cloudflare', () => {
   beforeEach(() => {
     vi.spyOn(util, 'promisify').mockReturnValue(vi.fn().mockReturnValue(Promise.resolve()))
-    vi.spyOn(global, 'fetch').mockReturnValue(Promise.resolve({ok: true, body: {pipe: vi.fn()}} as unknown as Response))
+    vi.spyOn(http, 'fetch').mockReturnValue(Promise.resolve({ok: true, body: {pipe: vi.fn()}} as any))
     vi.spyOn(fsActions, 'fileExistsSync').mockReturnValueOnce(false)
     vi.spyOn(fsActions, 'mkdirSync').mockImplementation(() => vi.fn())
     vi.spyOn(fsActions, 'unlinkFileSync').mockImplementation(() => vi.fn())
@@ -33,7 +30,7 @@ describe('install-cloudflare', () => {
     await install(env)
 
     // Then
-    expect(global.fetch).not.toHaveBeenCalled()
+    expect(http.fetch).not.toHaveBeenCalled()
   })
 
   test('install works when system is mac and x64', async () => {
@@ -44,8 +41,7 @@ describe('install-cloudflare', () => {
     await install(env, 'darwin', 'x64')
 
     // Then
-    // expect(global.fetch).not.toHaveBeenCalled()
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(http.fetch).toHaveBeenCalledWith(
       'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-darwin-amd64.tgz',
       expect.anything(),
     )
@@ -59,8 +55,7 @@ describe('install-cloudflare', () => {
     await install(env, 'darwin', 'arm64')
 
     // Then
-    // expect(global.fetch).not.toHaveBeenCalled()
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(http.fetch).toHaveBeenCalledWith(
       'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-darwin-arm64.tgz',
       expect.anything(),
     )
@@ -74,8 +69,7 @@ describe('install-cloudflare', () => {
     await install(env, 'linux', 'x64')
 
     // Then
-    // expect(global.fetch).not.toHaveBeenCalled()
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(http.fetch).toHaveBeenCalledWith(
       'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-linux-amd64',
       expect.anything(),
     )
@@ -89,7 +83,7 @@ describe('install-cloudflare', () => {
     await install(env, 'win32', 'x64')
 
     // Then
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(http.fetch).toHaveBeenCalledWith(
       'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-windows-amd64.exe',
       expect.anything(),
     )
@@ -107,7 +101,7 @@ describe('install-cloudflare', () => {
     await install(env, 'win32', 'x64')
 
     // Then
-    expect(global.fetch).not.toHaveBeenCalled()
+    expect(http.fetch).not.toHaveBeenCalled()
   })
 
   test('install works if bin exists and current version is not up to date', async () => {
@@ -120,7 +114,7 @@ describe('install-cloudflare', () => {
     await install(env, 'darwin', 'x64')
 
     // Then
-    expect(global.fetch).toHaveBeenCalled()
+    expect(http.fetch).toHaveBeenCalled()
   })
 
   test('install fails if unsupported platform', async () => {

--- a/packages/plugin-cloudflare/src/install-cloudflared.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.ts
@@ -2,6 +2,7 @@
 // Install script for cloudflared, derived from https://github.com/JacobLinCool/node-cloudflared
 import {basename, dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
+import {fetch} from '@shopify/cli-kit/node/http'
 import {
   chmod,
   fileExistsSync,

--- a/packages/theme/src/cli/utilities/notifier.ts
+++ b/packages/theme/src/cli/utilities/notifier.ts
@@ -40,6 +40,7 @@ export class Notifier {
   }
 
   private async notifyUrl(fileName: string): Promise<void> {
+    // eslint-disable-next-line no-restricted-globals
     const response = await fetch(this.notifyPath, {
       method: 'POST',
       body: JSON.stringify({files: [fileName]}),

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -280,6 +280,7 @@ export function proxyStorefrontRequest(event: H3Event, ctx: DevServerContext): P
   const headers = getProxyStorefrontHeaders(event)
   const body = getRequestWebStream(event)
 
+  // eslint-disable-next-line no-restricted-globals
   return fetch(url, {
     method: event.method,
     body,

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
@@ -18,6 +18,7 @@ export async function render(session: DevServerSession, context: DevServerRender
 
     const bodyParams = storefrontReplaceTemplatesParams(context)
 
+    // eslint-disable-next-line no-restricted-globals
     response = await fetch(url, {
       method: 'POST',
       body: bodyParams,
@@ -31,6 +32,7 @@ export async function render(session: DevServerSession, context: DevServerRender
   } else {
     outputDebug(`→ Rendering ${url}...`)
 
+    // eslint-disable-next-line no-restricted-globals
     response = await fetch(url, {
       method: context.method,
       headers: {


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure that HTTP proxy support is maintained across the CLI by enforcing the use of our custom fetch implementation instead of Node.js built-in fetch.

### WHAT is this pull request doing?

Adds an ESLint rule to restrict the use of the global `fetch` function, requiring developers to use our custom implementation from `@shopify/cli-kit/node/http` instead. The built-in Node.js fetch doesn't support HTTP proxies, which can cause issues for users behind corporate proxies.

The PR:
- Adds a new ESLint rule `no-restricted-globals` to flag usage of the global fetch
- Adds appropriate `eslint-disable-next-line` comments to existing fetch usages that are exceptions
