### PR TITLE
admin-graphql command

### DIFF
--- a/packages/app/src/cli/commands/app/admin-graphql.ts
+++ b/packages/app/src/cli/commands/app/admin-graphql.ts
@@ -1,0 +1,165 @@
+import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
+import {appFlags} from '../../flags.js'
+import {linkedAppContext} from '../../services/app-context.js'
+import {storeContext} from '../../services/store-context.js'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {Flags} from '@oclif/core'
+import {ensureAuthenticatedAdminAsApp} from '@shopify/cli-kit/node/session'
+import {adminAsAppRequest} from '@shopify/cli-kit/node/api/admin-as-app'
+import {outputContent, outputInfo, outputToken} from '@shopify/cli-kit/node/output'
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+export default class AdminGraphql extends AppCommand {
+  static hidden = true
+
+  static summary = 'Run a GraphQL query through the Admin API against your development store.'
+
+  static descriptionWithMarkdown = `
+  Runs a GraphQL query through the Admin API on behalf of your app, against your development store.
+
+  Query and variables can be provided in two ways:
+  1. Using --query and --variables flags
+  2. Piping JSON to stdin in the format: {"query": "...", "variables": {...}}
+
+  If using the flags, the --variables flag should be a valid JSON string.
+
+  The same scopes defined in your app's configuration file are used by this command.
+  `
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static flags = {
+    ...globalFlags,
+    ...appFlags,
+    ...jsonFlag,
+    'api-version': Flags.string({
+      description: 'API version to use for the Admin API query',
+      default: '2025-04',
+      env: 'SHOPIFY_FLAG_ADMIN_API_VERSION',
+    }),
+    query: Flags.string({
+      description: 'GraphQL query to execute',
+      env: 'SHOPIFY_FLAG_ADMIN_GRAPHQL_QUERY',
+    }),
+    variables: Flags.string({
+      description: 'Variables for the GraphQL query (as JSON string)',
+      env: 'SHOPIFY_FLAG_ADMIN_GRAPHQL_VARIABLES',
+      default: '{}',
+    }),
+  }
+
+  /**
+   * Reads data from stdin and parses it as JSON for query and variables
+   */
+  async readFromStdin(): Promise<{query: string; variables: {[key: string]: unknown}}> {
+    // Check if stdin is connected to a terminal (TTY)
+    if (process.stdin.isTTY) {
+      throw new AbortError(
+        'No query provided. You must either:\n' +
+          '1. Provide --query and --variables flags, or\n' +
+          '2. Pipe in JSON in the format: {"query": "...", "variables": {...}}\n\n' +
+          'Example: echo \'{"query": "query { shop { name } }", "variables": {}}\' | ' +
+          'shopify app admin-graphql',
+      )
+    }
+
+    return new Promise((resolve, reject) => {
+      let data = ''
+
+      process.stdin.on('data', (chunk) => {
+        data += chunk as unknown as string
+      })
+
+      process.stdin.on('end', () => {
+        try {
+          if (!data.trim()) {
+            reject(new Error('No input received from stdin'))
+            return
+          }
+
+          const parsed = JSON.parse(data)
+
+          if (!parsed.query || typeof parsed.query !== 'string') {
+            reject(new Error('Input must contain a "query" property that is a string'))
+            return
+          }
+
+          resolve({
+            query: parsed.query,
+            variables: parsed.variables || {},
+          })
+          // eslint-disable-next-line no-catch-all/no-catch-all
+        } catch (error) {
+          reject(new Error(`Failed to parse stdin as JSON: ${error}`))
+        }
+      })
+
+      process.stdin.on('error', (error) => {
+        reject(new Error(`Error reading from stdin: ${error}`))
+      })
+    })
+  }
+
+  /**
+   * Gets query and variables from either flags or stdin
+   */
+  async getQueryAndVariables(flags: {
+    query?: string
+    variables?: string
+  }): Promise<{query: string; variables: {[key: string]: unknown}}> {
+    // If query flag is provided, we use flags for input
+    if (flags.query) {
+      let variables: {[key: string]: unknown} = {}
+
+      // Parse variables from JSON string
+      try {
+        variables = JSON.parse(flags.variables as unknown as string)
+      } catch (error) {
+        throw new AbortError('Failed to parse variables as JSON. Please provide a valid JSON string for --variables')
+      }
+
+      return {
+        query: flags.query,
+        variables,
+      }
+    }
+
+    // Otherwise, read from stdin
+    return this.readFromStdin()
+  }
+
+  async run(): Promise<AppCommandOutput> {
+    const {flags} = await this.parse(AdminGraphql)
+
+    const appContextResult = await linkedAppContext({
+      directory: flags.path,
+      clientId: undefined,
+      forceRelink: flags.reset,
+      userProvidedConfigName: flags.config,
+    })
+    const store = await storeContext({
+      appContextResult,
+      storeFqdn: undefined,
+      forceReselectStore: flags.reset,
+    })
+
+    const session = await ensureAuthenticatedAdminAsApp(
+      store.shopDomain,
+      appContextResult.remoteApp.apiKey,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      appContextResult.remoteApp.apiSecretKeys[0]!.secret,
+    )
+
+    const {query, variables} = await this.getQueryAndVariables(flags)
+
+    try {
+      const result = await adminAsAppRequest(query, session, flags['api-version'], variables)
+
+      outputInfo(outputContent`${outputToken.json(result)}`)
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      outputInfo(outputContent`${outputToken.json(error)}`)
+    }
+    return {app: appContextResult.app}
+  }
+}

--- a/packages/app/src/cli/index.ts
+++ b/packages/app/src/cli/index.ts
@@ -26,11 +26,13 @@ import init from './hooks/clear_command_cache.js'
 import gatherPublicMetadata from './hooks/public_metadata.js'
 import gatherSensitiveMetadata from './hooks/sensitive_metadata.js'
 import AppCommand from './utilities/app-command.js'
+import AdminGraphql from './commands/app/admin-graphql.js'
 
 /**
  * All app commands should extend AppCommand.
  */
 export const commands: {[key: string]: typeof AppCommand} = {
+  'app:admin-graphql': AdminGraphql,
   'app:build': Build,
   'app:deploy': Deploy,
   'app:dev': Dev,

--- a/packages/cli-kit/src/public/node/api/admin-as-app.ts
+++ b/packages/cli-kit/src/public/node/api/admin-as-app.ts
@@ -1,0 +1,28 @@
+import {graphqlRequest, GraphQLVariables} from './graphql.js'
+import {AdminSession} from '../session.js'
+
+/**
+ * Executes a GraphQL query against the Admin API on behalf of the app. Uses string queries etc.
+ *
+ * @param query - GraphQL query to execute.
+ * @param session - Admin session.
+ * @param apiVersion - API version, e.g. '2024-07'.
+ * @param variables - GraphQL variables to pass to the query.
+ * @returns The response of the query of generic type <TResult>.
+ */
+export async function adminAsAppRequest<T>(
+  query: string,
+  session: AdminSession,
+  apiVersion: string,
+  variables?: GraphQLVariables,
+): Promise<T> {
+  return graphqlRequest<T>({
+    api: 'Admin',
+    url: `https://${session.storeFqdn}/admin/api/${apiVersion}/graphql.json`,
+    addedHeaders: {
+      'X-Shopify-Access-Token': session.token,
+    },
+    query,
+    variables,
+  })
+}

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -2,6 +2,7 @@ import {normalizeStoreFqdn} from './context/fqdn.js'
 import {BugError} from './error.js'
 import {getPartnersToken} from './environment.js'
 import {nonRandomUUID} from './crypto.js'
+import {shopifyFetch} from './http.js'
 import * as secureStore from '../../private/node/session/store.js'
 import {exchangeCustomPartnerToken} from '../../private/node/session/exchange.js'
 import {outputContent, outputToken, outputDebug} from '../../public/node/output.js'
@@ -16,6 +17,7 @@ import {
   setLastSeenUserIdAfterAuth,
 } from '../../private/node/session.js'
 import {isThemeAccessSession} from '../../private/node/api/rest.js'
+import {encode as queryStringEncode} from 'node:querystring'
 
 /**
  * Session Object to access the Admin API, includes the token and the store FQDN.
@@ -152,6 +154,39 @@ ${outputToken.json(scopes)}
     throw new BugError('No admin token found after ensuring authenticated')
   }
   return tokens.admin
+}
+
+/**
+ * Ensure that we have a valid Admin session for the given store, acting on behalf of the app.
+ *
+ * This will fail if the app has not already been installed.
+ *
+ * @param storeFqdn - Store fqdn to request auth for.
+ * @param apiKey - API key for the app.
+ * @param apiSecret - API secret for the app.
+ * @returns The access token for the Admin API.
+ */
+export async function ensureAuthenticatedAdminAsApp(
+  storeFqdn: string,
+  apiKey: string,
+  apiSecret: string,
+): Promise<AdminSession> {
+  const queryString = queryStringEncode({
+    client_id: apiKey,
+    client_secret: apiSecret,
+    grant_type: 'client_credentials',
+  })
+  const normalised = await normalizeStoreFqdn(storeFqdn)
+  const tokenResponse = await shopifyFetch(`https://${normalised}/admin/oauth/access_token?${queryString}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+  const tokenJson = (await tokenResponse.json()) as {access_token: string}
+  outputDebug(outputContent`Token: ${outputToken.raw(tokenJson.access_token)}`)
+  const token = tokenJson.access_token
+  return {token, storeFqdn: normalised}
 }
 
 /**

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1,5 +1,119 @@
 {
   "commands": {
+    "app:admin-graphql": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "customPluginName": "@shopify/app",
+      "description": "\n  Runs a GraphQL query through the Admin API on behalf of your app, against your development store.\n\n  Query and variables can be provided in two ways:\n  1. Using --query and --variables flags\n  2. Piping JSON to stdin in the format: {\"query\": \"...\", \"variables\": {...}}\n\n  If using the flags, the --variables flag should be a valid JSON string.\n\n  The same scopes defined in your app's configuration file are used by this command.\n  ",
+      "descriptionWithMarkdown": "\n  Runs a GraphQL query through the Admin API on behalf of your app, against your development store.\n\n  Query and variables can be provided in two ways:\n  1. Using --query and --variables flags\n  2. Piping JSON to stdin in the format: {\"query\": \"...\", \"variables\": {...}}\n\n  If using the flags, the --variables flag should be a valid JSON string.\n\n  The same scopes defined in your app's configuration file are used by this command.\n  ",
+      "flags": {
+        "api-version": {
+          "default": "2025-04",
+          "description": "API version to use for the Admin API query",
+          "env": "SHOPIFY_FLAG_ADMIN_API_VERSION",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "api-version",
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "client-id",
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "config",
+          "type": "option"
+        },
+        "json": {
+          "allowNo": false,
+          "char": "j",
+          "description": "Output the result as JSON.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "type": "boolean"
+        },
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "query": {
+          "description": "GraphQL query to execute",
+          "env": "SHOPIFY_FLAG_ADMIN_GRAPHQL_QUERY",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "query",
+          "type": "option"
+        },
+        "reset": {
+          "allowNo": false,
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "type": "boolean"
+        },
+        "variables": {
+          "default": "{}",
+          "description": "Variables for the GraphQL query (as JSON string)",
+          "env": "SHOPIFY_FLAG_ADMIN_GRAPHQL_VARIABLES",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "variables",
+          "type": "option"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [
+      ],
+      "id": "app:admin-graphql",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Run a GraphQL query through the Admin API against your development store."
+    },
     "app:build": {
       "aliases": [
       ],


### PR DESCRIPTION
# [Feature] Add Admin GraphQL command for executing queries against the Admin API

### WHY are these changes introduced?

This PR adds a new command that allows developers to execute GraphQL queries against the Admin API directly from the CLI, making it easier to test and debug Admin API interactions.

### WHAT is this pull request doing?

- Adds a new `shopify app admin-graphql` command that allows running GraphQL queries against the Admin API
- Implements two input methods:
  1. Using `--query` and `--variables` flags
  2. Piping JSON to stdin in the format: `{"query": "...", "variables": {...}}`
- Adds support for API version selection with the `--api-version` flag (defaults to 2025-04)

### How to test your changes?

1. Pipe a query via stdin:
```
echo '{"query": "query { shop { name } }", "variables": {}}' | p shopify app admin-graphql --path=<path to app>
```
