### PR TITLE
Recrate ui-extension ESBuild contexts when updating the toml

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.test.ts
@@ -117,6 +117,28 @@ describe('app-watcher-esbuild', () => {
     expect(manager.contexts).not.toHaveProperty('uid2')
   })
 
+  test('updating contexts with an app event when the app was reloaded', async () => {
+    // Given
+    const manager = new ESBuildContextManager(options)
+    await manager.createContexts([extension1])
+    const originalContext = manager.contexts.uid1![0]!
+    const appEvent: AppEvent = {
+      app: testAppLinked(),
+      path: '',
+      startTime: [0, 0],
+      extensionEvents: [{type: EventType.Updated, extension: extension1}],
+      appWasReloaded: true,
+    }
+
+    // When
+    await manager.updateContexts(appEvent)
+
+    // Then
+    expect(manager.contexts).toHaveProperty('uid1')
+    expect(manager.contexts.uid1!.length).toBe(1)
+    expect(manager.contexts.uid1![0]).not.toBe(originalContext)
+  })
+
   test('rebuilding contexts', async () => {
     // Given
     const manager = new ESBuildContextManager(options)

--- a/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.ts
@@ -88,10 +88,17 @@ export class ESBuildContextManager {
     await copyFile(outputPath, copyPath)
   }
 
+  /**
+   * New contexts are created for new extensions that were added during a dev session.
+   * We also need to recreate contexts for UI extensions whose TOML files were updated.
+   * This is because some changes in the TOML invalidate the current context (changing targets or handle for example)
+   */
   async updateContexts(appEvent: AppEvent) {
     this.dotEnvVariables = appEvent.app.dotenv?.variables ?? {}
+
     const createdEsBuild = appEvent.extensionEvents
-      .filter((extEvent) => extEvent.type === EventType.Created && extEvent.extension.isESBuildExtension)
+      .filter((extEvent) => extEvent.extension.isESBuildExtension)
+      .filter((extEvent) => extEvent.type === 'created' || (extEvent.type === 'changed' && appEvent.appWasReloaded))
       .map((extEvent) => extEvent.extension)
     await this.createContexts(createdEsBuild)
 


### PR DESCRIPTION
### WHY are these changes introduced?

When an app is reloaded, the ESBuild contexts need to be recreated for updated ui-extensions because the toml could have been updated with relevant changes.

Fixes https://github.com/Shopify/develop-app-outer-loop/issues/1282

### WHAT is this pull request doing?

Update the filter condition in `updateContexts()` to also handle updated extensions when `appWasReloaded` is true

### How to test your changes?

1. Run a dev-session with an app that uses ui-extensions
2. Change the handle of the extension during dev
3. See that the session is updated correctly.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes