### PR TITLE
Build UID using uidStrategy

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -407,7 +407,7 @@ describe('allExtensions', () => {
 
     const webhookConfig = app.allExtensions.find((ext) => ext.handle === 'webhooks')!
       .configuration as unknown as WebhookTestConfig
-    const privacyConfig = app.allExtensions.find((ext) => ext.handle === 'privacy-compliance-webhooks')!
+    const privacyConfig = app.allExtensions.find((ext) => ext.handle === 'privacy_compliance_webhooks')!
       .configuration as unknown as WebhookTestConfig
 
     expect(webhookConfig.webhooks.subscriptions!.length).not.toStrictEqual(0)
@@ -497,7 +497,7 @@ describe('manifest', () => {
       modules: [
         {
           type: 'app_access_external',
-          handle: 'app-access',
+          handle: 'app_access',
           uid: appAccessModule.uid,
           assets: appAccessModule.uid,
           target: appAccessModule.contextValue,
@@ -545,7 +545,7 @@ describe('manifest', () => {
       modules: [
         {
           type: 'app_home_external',
-          handle: 'app-home',
+          handle: 'app_home',
           uid: appHome.uid,
           assets: appHome.uid,
           target: appHome.contextValue,
@@ -555,7 +555,7 @@ describe('manifest', () => {
         },
         {
           type: 'app_proxy_external',
-          handle: 'app-proxy',
+          handle: 'app_proxy',
           uid: appProxy.uid,
           assets: appProxy.uid,
           target: appProxy.contextValue,
@@ -567,7 +567,7 @@ describe('manifest', () => {
         },
         {
           type: 'app_access_external',
-          handle: 'app-access',
+          handle: 'app_access',
           uid: appAccess.uid,
           assets: appAccess.uid,
           target: appAccess.contextValue,
@@ -603,7 +603,7 @@ describe('manifest', () => {
       modules: [
         {
           type: 'app_home_external',
-          handle: 'app-home',
+          handle: 'app_home',
           uid: appHome.uid,
           assets: appHome.uid,
           target: appHome.contextValue,

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -924,8 +924,8 @@ describe('deployConfirmed: handle non existent uuid managed extensions', () => {
     expect(developerPlatformClient.createExtension).not.toBeCalled()
     expect(got).toEqual({
       extensions: {},
-      extensionIds: {'point-of-sale': 'C_A'},
-      extensionsNonUuidManaged: {'point-of-sale': 'UUID_C_A'},
+      extensionIds: {point_of_sale: 'C_A'},
+      extensionsNonUuidManaged: {point_of_sale: 'UUID_C_A'},
     })
   })
   test('when the include config on deploy flag is disabled configuration extensions are not created', async () => {
@@ -978,8 +978,8 @@ describe('deployConfirmed: handle non existent uuid managed extensions', () => {
     expect(developerPlatformClient.createExtension).toBeCalledTimes(1)
     expect(got).toEqual({
       extensions: {},
-      extensionIds: {'app-access': 'C_A'},
-      extensionsNonUuidManaged: {'app-access': 'UUID_C_A'},
+      extensionIds: {app_access: 'C_A'},
+      extensionsNonUuidManaged: {app_access: 'UUID_C_A'},
     })
   })
   test('when the include config on deploy flag is disabled but draft extensions should be used configuration extensions are created with context', async () => {
@@ -1044,8 +1044,8 @@ describe('deployConfirmed: handle existent uuid managed extensions', () => {
     expect(developerPlatformClient.createExtension).not.toHaveBeenCalled()
     expect(got).toEqual({
       extensions: {},
-      extensionIds: {'point-of-sale': 'C_A'},
-      extensionsNonUuidManaged: {'point-of-sale': 'UUID_C_A'},
+      extensionIds: {point_of_sale: 'C_A'},
+      extensionsNonUuidManaged: {point_of_sale: 'UUID_C_A'},
     })
   })
 })
@@ -1080,8 +1080,8 @@ describe('deployConfirmed: extensions that should be managed in the TOML', () =>
     expect(developerPlatformClient.createExtension).not.toHaveBeenCalled()
     expect(got).toEqual({
       extensions: {},
-      extensionIds: {'point-of-sale': 'C_A'},
-      extensionsNonUuidManaged: {'point-of-sale': 'UUID_C_A'},
+      extensionIds: {point_of_sale: 'C_A'},
+      extensionsNonUuidManaged: {point_of_sale: 'UUID_C_A'},
     })
   })
 })

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -17,6 +17,7 @@ import {updateAppIdentifiers} from '../models/app/identifiers.js'
 import {AppInterface, AppLinkedInterface} from '../models/app/app.js'
 import {OrganizationApp} from '../models/organization.js'
 import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
+import {PosSpecIdentifier} from '../models/extensions/specifications/app_config_point_of_sale.js'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
 import {useThemebundling} from '@shopify/cli-kit/node/context/local'
 import {renderInfo, renderSuccess, renderTasks, renderTextPrompt, Task} from '@shopify/cli-kit/node/ui'
@@ -343,7 +344,7 @@ describe('deploy', () => {
           context: '',
           handle: extensionNonUuidManaged.handle,
           specificationIdentifier: undefined,
-          uid: 'point-of-sale',
+          uid: PosSpecIdentifier,
         },
       ],
       developerPlatformClient,

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
@@ -12,12 +12,13 @@ import {
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
 import {loadApp, reloadApp} from '../../../models/app/loader.js'
 import {AppLinkedInterface} from '../../../models/app/app.js'
+import {AppAccessSpecIdentifier} from '../../../models/extensions/specifications/app_config_app_access.js'
+import {PosSpecIdentifier} from '../../../models/extensions/specifications/app_config_point_of_sale.js'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 import {AbortSignal, AbortController} from '@shopify/cli-kit/node/abort'
 import {flushPromises} from '@shopify/cli-kit/node/promises'
 import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {nonRandomUUID} from '@shopify/cli-kit/node/crypto'
 import {Writable} from 'stream'
 
 vi.mock('../../../models/app/loader.js')
@@ -216,13 +217,13 @@ const testCases: TestCase[] = [
       {
         type: EventType.Updated,
         extension: posExtensionUpdated,
-        buildResult: {status: 'ok', uid: nonRandomUUID('point-of-sale')},
+        buildResult: {status: 'ok', uid: PosSpecIdentifier},
       },
       {type: EventType.Deleted, extension: webhookExtension},
       {
         type: EventType.Created,
         extension: appAccessExtension,
-        buildResult: {status: 'ok', uid: nonRandomUUID('app-access')},
+        buildResult: {status: 'ok', uid: AppAccessSpecIdentifier},
       },
     ],
     needsAppReload: true,


### PR DESCRIPTION
### WHY are these changes introduced?

We need to follow `uidStrategy` when building the `uid`. Specifically we need to fix it for the `single` case and use the spec identifier in that case.

### WHAT is this pull request doing?

Refactors the extension instance UID generation by:
- Creating a dedicated `buildUIDFromStrategy` method to handle UID generation based on the extension's strategy

### How to test your changes?

1. This doesn't imply any change in functionality. You can try deploying an app with different types of extensions

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes