### PR TITLE
Exclude map files from the app bundle

### DIFF
--- a/packages/app/src/cli/services/bundle.test.ts
+++ b/packages/app/src/cli/services/bundle.test.ts
@@ -44,4 +44,23 @@ describe('compressBundle', () => {
       expect(zipExists).toBe(true)
     })
   })
+
+  test('excludes .js.map files from the zip', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const inputDir = joinPath(tmpDir, 'input')
+      const outputZip = joinPath(tmpDir, 'output.zip')
+      await mkdir(inputDir)
+      await writeFile(joinPath(inputDir, 'test.txt'), 'test content')
+      await writeFile(joinPath(inputDir, 'test.js.map'), 'test content')
+
+      // When
+      await compressBundle(inputDir, outputZip)
+
+      // Then
+      const zipContent = await readFile(outputZip)
+      // We are reading the zip as a binary because we don't have a library to unzip, but we can still check for the presence of the file name
+      expect(zipContent).not.toContain('test.js.map')
+    })
+  })
 })

--- a/packages/app/src/cli/services/bundle.ts
+++ b/packages/app/src/cli/services/bundle.ts
@@ -19,6 +19,7 @@ export async function compressBundle(inputPath: string, outputPath: string) {
   await zip({
     inputDirectory: inputPath,
     outputZipPath: outputPath,
+    matchFilePattern: ['**/*', '!**/*.js.map'],
   })
 }
 

--- a/packages/cli-kit/src/public/node/archiver.ts
+++ b/packages/cli-kit/src/public/node/archiver.ts
@@ -16,9 +16,9 @@ interface ZipOptions {
   outputZipPath: string
 
   /**
-   * Pattern to match when adding files to zip, uses glob expressions.
+   * Pattern(s) to match when adding files to zip, uses glob expressions.
    */
-  matchFilePattern?: string
+  matchFilePattern?: string | string[]
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-outer-loop/issues/1453



### WHAT is this pull request doing?

Removes the unrequired *.js.map files from the zip bundle for both dev and deploy

### How to test your changes?

Dev and deploy with UI extensions

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
