### PR TITLE
Provision user access to stores only when permitted

### DIFF
--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_dev_store_by_domain.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_dev_store_by_domain.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
+/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-duplicate-type-constituents */
 import * as Types from './types.js'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -23,6 +23,7 @@ export type FetchDevStoreByDomainQuery = {
         }
       }[]
     } | null
+    currentUser?: {organizationPermissions: string[]} | {organizationPermissions: string[]} | null
   } | null
 }
 
@@ -114,6 +115,17 @@ export const FetchDevStoreByDomain = {
                           ],
                         },
                       },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'currentUser'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'organizationPermissions'}},
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],
                   },

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/list_app_dev_stores.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/list_app_dev_stores.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
+/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-duplicate-type-constituents */
 import * as Types from './types.js'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -24,6 +24,7 @@ export type ListAppDevStoresQuery = {
       }[]
       pageInfo: {hasNextPage: boolean}
     } | null
+    currentUser?: {organizationPermissions: string[]} | {organizationPermissions: string[]} | null
   } | null
 }
 
@@ -126,6 +127,17 @@ export const ListAppDevStores = {
                           ],
                         },
                       },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'currentUser'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'organizationPermissions'}},
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],
                   },

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/queries/fetch_dev_store_by_domain.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/queries/fetch_dev_store_by_domain.graphql
@@ -14,5 +14,8 @@
           }
         }
       }
+      currentUser {
+        organizationPermissions
+      }
     }
   }

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/queries/list_app_dev_stores.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/queries/list_app_dev_stores.graphql
@@ -17,5 +17,8 @@ query ListAppDevStores($searchTerm: String) {
         hasNextPage
       }
     }
+    currentUser {
+      organizationPermissions
+    }
   }
 }

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -668,6 +668,7 @@ export function testOrganizationStore({shopId, shopDomain}: {shopId?: string; sh
     shopName: 'store1',
     transferDisabled: false,
     convertableToPartnerTest: false,
+    provisionable: true,
   }
 }
 
@@ -1436,7 +1437,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     createApp: (_organization: Organization, _options: CreateAppOptions) => Promise.resolve(testOrganizationApp()),
     devStoresForOrg: (_organizationId: string) => Promise.resolve({stores: [], hasMorePages: false}),
     storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve(undefined),
-    ensureUserAccessToStore: (_orgId: string, _shopId: string) => Promise.resolve(),
+    ensureUserAccessToStore: (_orgId: string, _store: OrganizationStore) => Promise.resolve(),
     appExtensionRegistrations: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppExtensionRegistrations),
     appVersions: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppVersions),
     activeAppVersion: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyActiveAppVersion),

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -62,4 +62,5 @@ export interface OrganizationStore {
   shopName: string
   transferDisabled: boolean
   convertableToPartnerTest: boolean
+  provisionable: boolean
 }

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -48,6 +48,7 @@ const STORE1: OrganizationStore = {
   shopName: 'store1',
   transferDisabled: false,
   convertableToPartnerTest: false,
+  provisionable: true,
 }
 const STORE2: OrganizationStore = {
   shopId: '2',
@@ -56,6 +57,7 @@ const STORE2: OrganizationStore = {
   shopName: 'store2',
   transferDisabled: false,
   convertableToPartnerTest: false,
+  provisionable: true,
 }
 const STORE3: OrganizationStore = {
   shopId: '3',
@@ -64,6 +66,7 @@ const STORE3: OrganizationStore = {
   shopName: 'store3',
   transferDisabled: false,
   convertableToPartnerTest: false,
+  provisionable: true,
 }
 
 beforeEach(() => {

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -70,6 +70,7 @@ const STORE1: OrganizationStore = {
   shopName: 'store1',
   transferDisabled: true,
   convertableToPartnerTest: true,
+  provisionable: true,
 }
 
 const state: AppConfigurationStateLinked = {

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -30,6 +30,7 @@ const STORE1: OrganizationStore = {
   shopName: 'store1',
   transferDisabled: false,
   convertableToPartnerTest: false,
+  provisionable: true,
 }
 
 vi.mock('@shopify/cli-kit/node/api/partners')

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -29,6 +29,7 @@ const STORE1: OrganizationStore = {
   shopName: 'store1',
   transferDisabled: true,
   convertableToPartnerTest: true,
+  provisionable: true,
 }
 
 const STORE2: OrganizationStore = {
@@ -38,6 +39,7 @@ const STORE2: OrganizationStore = {
   shopName: 'store2',
   transferDisabled: false,
   convertableToPartnerTest: true,
+  provisionable: true,
 }
 
 const STORE3: OrganizationStore = {
@@ -47,6 +49,7 @@ const STORE3: OrganizationStore = {
   shopName: 'store3',
   transferDisabled: false,
   convertableToPartnerTest: false,
+  provisionable: true,
 }
 
 const defaultShowDomainOnPrompt = false

--- a/packages/app/src/cli/services/store-context.test.ts
+++ b/packages/app/src/cli/services/store-context.test.ts
@@ -208,10 +208,7 @@ describe('storeContext', () => {
 
       await storeContext({appContextResult, forceReselectStore: false})
 
-      expect(mockDeveloperPlatformClient.ensureUserAccessToStore).toHaveBeenCalledWith(
-        mockOrganization.id,
-        mockStore.shopId,
-      )
+      expect(mockDeveloperPlatformClient.ensureUserAccessToStore).toHaveBeenCalledWith(mockOrganization.id, mockStore)
     })
   })
 })

--- a/packages/app/src/cli/services/store-context.ts
+++ b/packages/app/src/cli/services/store-context.ts
@@ -64,7 +64,7 @@ export async function storeContext({
   }
 
   // Ensure that the user is able to login to the store and install apps
-  await developerPlatformClient.ensureUserAccessToStore(organization.id, selectedStore.shopId)
+  await developerPlatformClient.ensureUserAccessToStore(organization.id, selectedStore)
 
   return selectedStore
 }

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -273,7 +273,7 @@ export interface DeveloperPlatformClient {
   createApp: (org: Organization, options: CreateAppOptions) => Promise<OrganizationApp>
   devStoresForOrg: (orgId: string, searchTerm?: string) => Promise<Paginateable<{stores: OrganizationStore[]}>>
   storeByDomain: (orgId: string, shopDomain: string) => Promise<OrganizationStore | undefined>
-  ensureUserAccessToStore: (orgId: string, shopId: string) => Promise<void>
+  ensureUserAccessToStore: (orgId: string, store: OrganizationStore) => Promise<void>
   appExtensionRegistrations: (
     app: MinimalAppIdentifiers,
     activeAppVersion?: AppVersion,

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -526,8 +526,9 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
 
     const shopArray = organization.accessibleShops?.edges.map((value) => value.node) ?? []
+    const provisionable = isStoreProvisionable(organization.currentUser?.organizationPermissions ?? [])
     return {
-      stores: mapBusinessPlatformStoresToOrganizationStores(shopArray),
+      stores: mapBusinessPlatformStoresToOrganizationStores(shopArray, provisionable),
       hasMorePages: storesResult.organization?.accessibleShops?.pageInfo.hasNextPage ?? false,
     }
   }
@@ -829,12 +830,16 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
 
     const bpStoresArray = organization.accessibleShops?.edges.map((value) => value.node) ?? []
-    const storesArray = mapBusinessPlatformStoresToOrganizationStores(bpStoresArray)
+    const provisionable = isStoreProvisionable(organization.currentUser?.organizationPermissions ?? [])
+    const storesArray = mapBusinessPlatformStoresToOrganizationStores(bpStoresArray, provisionable)
     return storesArray[0]
   }
 
-  async ensureUserAccessToStore(orgId: string, shopId: string): Promise<void> {
-    const encodedShopId = encodedGidFromShopId(shopId)
+  async ensureUserAccessToStore(orgId: string, store: OrganizationStore): Promise<void> {
+    if (!store.provisionable) {
+      return
+    }
+    const encodedShopId = encodedGidFromShopId(store.shopId)
     const variables: ProvisionShopAccessMutationVariables = {
       input: {shopifyShopId: encodedShopId},
     }
@@ -1196,7 +1201,10 @@ function experience(identifier: string): 'configuration' | 'extension' {
   return CONFIG_EXTENSION_IDS.includes(identifier) ? 'configuration' : 'extension'
 }
 
-function mapBusinessPlatformStoresToOrganizationStores(storesArray: ShopNode[]): OrganizationStore[] {
+function mapBusinessPlatformStoresToOrganizationStores(
+  storesArray: ShopNode[],
+  provisionable: boolean,
+): OrganizationStore[] {
   return storesArray.map((store: ShopNode) => {
     const {externalId, primaryDomain, name} = store
     return {
@@ -1206,6 +1214,7 @@ function mapBusinessPlatformStoresToOrganizationStores(storesArray: ShopNode[]):
       shopName: name,
       transferDisabled: true,
       convertableToPartnerTest: true,
+      provisionable,
     } as OrganizationStore
   })
 }
@@ -1258,4 +1267,8 @@ function toUserError(err: CreateAppVersionMutation['appVersionCreate']['userErro
     details.push({extension_id: extensionId})
   }
   return {...err, details}
+}
+
+function isStoreProvisionable(permissions: string[]) {
+  return permissions.includes('ondemand_access_to_stores')
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
@@ -58,6 +58,7 @@ const STORE1: OrganizationStore = {
   shopName: 'store1',
   transferDisabled: false,
   convertableToPartnerTest: false,
+  provisionable: true,
 }
 
 const FETCH_ORG_RESPONSE_VALUE = {

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -481,10 +481,17 @@ export class PartnersClient implements DeveloperPlatformClient {
     const variables: FindStoreByDomainQueryVariables = {orgId, shopDomain}
     const result: FindStoreByDomainSchema = await this.request(FindStoreByDomainQuery, variables)
 
-    return result.organizations.nodes[0]?.stores.nodes[0]
+    const node = result.organizations.nodes[0]?.stores.nodes[0]
+    if (!node) {
+      return undefined
+    }
+    return {
+      ...node,
+      provisionable: false,
+    }
   }
 
-  async ensureUserAccessToStore(_orgId: string, _shopId: string): Promise<void> {
+  async ensureUserAccessToStore(_orgId: string, _store: OrganizationStore): Promise<void> {
     // This is a no-op for partners
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Modifies the fix for https://github.com/Shopify/core-issues/issues/88829 to limit calls the BP provisioning mutation to organization owners and administrators.

### WHAT is this pull request doing?

The mutation is available only to holders of the `ondemand_access_to_stores` permission.  Other users should always be provisioned for access to a store and do not need the mutation called. 

To avoid a separate GraphQL query to fetch user permissions, they are instead added to existing to store fetch calls by including 

```
currentUser {
  organizationPermissions
}
```

in the existing query.

The additional information is added to `OrganizationStore` class so that is available when needed. 

Ideally we would not be storing user-level information in a store object, but to avoid that, we'd need to
- Add yet another GraphQL call to the `app dev` flow, or
- Gather permission info more centrally for an authenticated user. This would require some refactoring and probably moving from destinations API to organizations API to gather some user info (beyond the scope of this PR)

### How to test your changes?

Tophatting requires local dev and the following painful steps (sorry)

Add the user management scope to the CLI application.
- Visit https://identity.shop.dev/services/applications
- Search for shopify-cli 
- Click Edit
- Under "scopes that may be requested", select the checkbox for the BP user-management checkbox (`https://api.shopify.com/auth/organization.user-management`)
- Save the changes. Ignore the error message.

Run BP using the `rz-accessible-shops` branch, rebasing from `main` as necessary.

Update `shop/world`
- Ensure that your local repo is recent enough to include this [PR](https://github.com/shop/world/pull/24953/)
- Add potentiaal dev shops to `extra_server_names` ([details](https://shopify.slack.com/archives/C06MNN3NE9Z/p1742473401553979?thread_ts=1742407962.376999&cid=C06MNN3NE9Z))

Ensure that `dev@shopify.com` has created a development store as described in the [local dev doc](https://docs.google.com/document/d/1_fs9oHyxt4xqKnLk3WpMVIAU2gSaPUBHIVsFzcUMSlk/edit?tab=t.0#heading=h.gw4jjh9a3jih)

Log in to the dev store and add an admin user for the store.
- Navigate to Settings -> Users and click add user. 
- Enter an email for one of the existing test users (e.g. `alice@example.com`).
- Assign the user to an organization administrator role
- At this point the user has been invited. To accept the invitation, follow the instructions [here](https://github.com/Shopify/core-issues/issues/88829) (run the commands via `bin/rails c` from the BP repo)

Create a store as the admin user
- Log in to dev dash as the admin user invited above (incognito)
- Create a store 

Exercise the alternative methods of listing/selecting stores from the CLI. Both stores should be visible and selectable, and `app dev` should start up and auto-install the app on the selected store if necessary.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
