### PR TITLE
Refactor store fetch, remove dead code

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1435,7 +1435,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
       Promise.resolve({organization: testOrganization(), apps: [testOrganizationApp()], hasMorePages: false}),
     createApp: (_organization: Organization, _options: CreateAppOptions) => Promise.resolve(testOrganizationApp()),
     devStoresForOrg: (_organizationId: string) => Promise.resolve({stores: [], hasMorePages: false}),
-    storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve({organizations: {nodes: []}}),
+    storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve(undefined),
     ensureUserAccessToStore: (_orgId: string, _shopId: string) => Promise.resolve(),
     appExtensionRegistrations: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppExtensionRegistrations),
     appVersions: (_app: MinimalAppIdentifiers) => Promise.resolve(emptyAppVersions),

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -1,6 +1,5 @@
-import {fetchOrganizations, fetchStore, fetchStoreByDomain, NoOrgError} from './fetch.js'
+import {fetchOrganizations, fetchStore, NoOrgError} from './fetch.js'
 import {Organization, OrganizationSource, OrganizationStore} from '../../models/organization.js'
-import {FindStoreByDomainSchema} from '../../api/graphql/find_store_by_domain.js'
 import {
   testPartnersServiceSession,
   testPartnersUserSession,
@@ -31,17 +30,6 @@ const STORE1: OrganizationStore = {
   shopName: 'store1',
   transferDisabled: false,
   convertableToPartnerTest: false,
-}
-const FETCH_STORE_RESPONSE_VALUE: FindStoreByDomainSchema = {
-  organizations: {
-    nodes: [
-      {
-        id: ORG1.id,
-        businessName: ORG1.businessName,
-        stores: {nodes: [STORE1]},
-      },
-    ],
-  },
 }
 
 vi.mock('@shopify/cli-kit/node/api/partners')
@@ -95,27 +83,11 @@ describe('fetchOrganizations', async () => {
   })
 })
 
-describe('fetchStoreByDomain', async () => {
-  test('returns fetched store and organization', async () => {
-    // Given
-    const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
-      storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve(FETCH_STORE_RESPONSE_VALUE),
-    })
-
-    // When
-    const got = await fetchStoreByDomain(ORG1.id, 'domain1', developerPlatformClient)
-
-    // Then
-    expect(got).toEqual({organization: ORG1, store: STORE1})
-    expect(developerPlatformClient.storeByDomain).toHaveBeenCalledWith(ORG1.id, 'domain1')
-  })
-})
-
 describe('fetchStore', () => {
   test('returns fetched store', async () => {
     // Given
     const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
-      storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve(FETCH_STORE_RESPONSE_VALUE),
+      storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve(STORE1),
     })
 
     // When
@@ -129,7 +101,7 @@ describe('fetchStore', () => {
   test('throws error if store not found', async () => {
     // Given
     const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({
-      storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve({organizations: {nodes: []}}),
+      storeByDomain: (_orgId: string, _shopDomain: string) => Promise.resolve(undefined),
     })
 
     // When

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -18,7 +18,6 @@ import {
   ConvertDevToTransferDisabledSchema,
   ConvertDevToTransferDisabledStoreVariables,
 } from '../api/graphql/convert_dev_to_transfer_disabled_store.js'
-import {FindStoreByDomainSchema} from '../api/graphql/find_store_by_domain.js'
 import {AppVersionsQuerySchema} from '../api/graphql/get_versions_list.js'
 import {
   DevelopmentStorePreviewUpdateInput,
@@ -273,7 +272,7 @@ export interface DeveloperPlatformClient {
   templateSpecifications: (app: MinimalAppIdentifiers) => Promise<ExtensionTemplate[]>
   createApp: (org: Organization, options: CreateAppOptions) => Promise<OrganizationApp>
   devStoresForOrg: (orgId: string, searchTerm?: string) => Promise<Paginateable<{stores: OrganizationStore[]}>>
-  storeByDomain: (orgId: string, shopDomain: string) => Promise<FindStoreByDomainSchema>
+  storeByDomain: (orgId: string, shopDomain: string) => Promise<OrganizationStore | undefined>
   ensureUserAccessToStore: (orgId: string, shopId: string) => Promise<void>
   appExtensionRegistrations: (
     app: MinimalAppIdentifiers,

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -39,7 +39,6 @@ import {
   ExtensionRegistration,
 } from '../../api/graphql/all_app_extension_registrations.js'
 import {AppDeploySchema} from '../../api/graphql/app_deploy.js'
-import {FindStoreByDomainSchema} from '../../api/graphql/find_store_by_domain.js'
 import {AppVersionsQuerySchema as AppVersionsQuerySchemaInterface} from '../../api/graphql/get_versions_list.js'
 import {ExtensionCreateSchema, ExtensionCreateVariables} from '../../api/graphql/extension_create.js'
 import {
@@ -814,10 +813,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
   }
 
-  // we are using FindStoreByDomainSchema type here because we want to keep types consistent btwn
-  // partners-client and app-management-client. Since we need transferDisabled and convertableToPartnerTest values
-  // from the Partners FindByStoreDomainSchema, we will return this type for now
-  async storeByDomain(orgId: string, shopDomain: string): Promise<FindStoreByDomainSchema> {
+  async storeByDomain(orgId: string, shopDomain: string): Promise<OrganizationStore | undefined> {
     const queryVariables: FetchDevStoreByDomainQueryVariables = {domain: shopDomain}
     const storesResult = await businessPlatformOrganizationsRequestDoc(
       FetchDevStoreByDomain,
@@ -834,20 +830,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
     const bpStoresArray = organization.accessibleShops?.edges.map((value) => value.node) ?? []
     const storesArray = mapBusinessPlatformStoresToOrganizationStores(bpStoresArray)
-
-    return {
-      organizations: {
-        nodes: [
-          {
-            id: organization.id,
-            businessName: organization.name,
-            stores: {
-              nodes: storesArray,
-            },
-          },
-        ],
-      },
-    }
+    return storesArray[0]
   }
 
   async ensureUserAccessToStore(orgId: string, shopId: string): Promise<void> {

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -477,9 +477,11 @@ export class PartnersClient implements DeveloperPlatformClient {
     return this.request(ConvertDevToTransferDisabledStoreQuery, input)
   }
 
-  async storeByDomain(orgId: string, shopDomain: string): Promise<FindStoreByDomainSchema> {
+  async storeByDomain(orgId: string, shopDomain: string): Promise<OrganizationStore | undefined> {
     const variables: FindStoreByDomainQueryVariables = {orgId, shopDomain}
-    return this.request(FindStoreByDomainQuery, variables)
+    const result: FindStoreByDomainSchema = await this.request(FindStoreByDomainQuery, variables)
+
+    return result.organizations.nodes[0]?.stores.nodes[0]
   }
 
   async ensureUserAccessToStore(_orgId: string, _shopId: string): Promise<void> {


### PR DESCRIPTION
### WHY are these changes introduced?

Refactors store fetching code and removes dead code to simplify future changes. 

### WHAT is this pull request doing?

`fetchStoreByDomain` is no longer used and is removed in this PR. 

This also allows the developer platform client interface to be simplified. Its `storeByDomain` method can then return an `OrganizationStore` instead of a GraphQL result. 

This change paves the way for changes to `OrganizationStore` that are not coupled to underlying GraphQL. 

### How to test your changes?

Unit tests are sufficient here. The entire PR stack can be tophatted using the instructions [here](https://github.com/Shopify/cli/pull/5596). 

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
