### PR TITLE
Rename dev session to app preview

### DIFF
--- a/packages/app/src/cli/services/dev/processes/app-watcher-process.ts
+++ b/packages/app/src/cli/services/dev/processes/app-watcher-process.ts
@@ -24,7 +24,7 @@ export interface AppWatcherProcess extends BaseProcess<AppWatcherProcessOptions>
 export async function setupAppWatcherProcess(options: AppWatcherProcessOptions): Promise<AppWatcherProcess> {
   return {
     type: 'app-watcher',
-    prefix: `dev-session`,
+    prefix: `app-preview`,
     options,
     function: launchAppWatcher,
   }

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.test.ts
@@ -35,7 +35,6 @@ describe('DevSessionLogger', () => {
 
     test('warning logs message', async () => {
       await logger.warning('test warning')
-      // expect(contextSpy).toHaveBeenCalledWith({outputPrefix: 'dev-session', stripAnsi: false}, expect.anything())
       expect(output).toMatchInlineSnapshot(`
         [
           "[33mtest warning[39m",

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.ts
@@ -45,7 +45,7 @@ export class DevSessionLogger {
       const mappedErrors = errors.map((error) => {
         const on = error.on ? (error.on[0] as {user_identifier: unknown}) : undefined
         const extension = extensions.find((ext) => ext.uid === on?.user_identifier)
-        return {error: error.message, prefix: extension?.handle ?? 'dev-session'}
+        return {error: error.message, prefix: extension?.handle ?? 'app-preview'}
       })
       await this.logMultipleErrors(mappedErrors)
     }
@@ -96,7 +96,7 @@ export class DevSessionLogger {
 
   async logMultipleErrors(errors: {error: string; prefix: string}[]) {
     const header = outputToken.errorText(`❌ Error`)
-    await this.log(outputContent`${header}`.value, 'dev-session')
+    await this.log(outputContent`${header}`.value, 'app-preview')
     const messages = errors.map((error) => {
       const content = outputToken.errorText(`└  ${error.error}`)
       return this.log(outputContent`${content}`.value, error.prefix)
@@ -106,7 +106,7 @@ export class DevSessionLogger {
 
   // Helper function to print to terminal using output context with stripAnsi disabled.
   private async log(message: string, prefix?: string) {
-    await useConcurrentOutputContext({outputPrefix: prefix ?? 'dev-session', stripAnsi: false}, () => {
+    await useConcurrentOutputContext({outputPrefix: prefix ?? 'app-preview', stripAnsi: false}, () => {
       this.stdout.write(message)
     })
   }

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
@@ -48,7 +48,7 @@ describe('setupDevSessionProcess', () => {
     // Then
     expect(process).toEqual({
       type: 'dev-session',
-      prefix: 'dev-session',
+      prefix: 'app-preview',
       function: pushUpdatesForDevSession,
       options: {
         app: options.app,
@@ -158,7 +158,7 @@ describe('pushUpdatesForDevSession', () => {
 
     // Then
     expect(stdout.write).toHaveBeenCalledWith(
-      expect.stringContaining('Change detected, but dev session is not ready yet.'),
+      expect.stringContaining('Change detected, but app preview is not ready yet.'),
     )
     expect(developerPlatformClient.devSessionCreate).not.toHaveBeenCalled()
     expect(developerPlatformClient.devSessionUpdate).not.toHaveBeenCalled()
@@ -199,7 +199,7 @@ describe('pushUpdatesForDevSession', () => {
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated'))
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Action required'))
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Scopes updated'))
-    expect(contextSpy).toHaveBeenCalledWith({outputPrefix: 'dev-session', stripAnsi: false}, expect.anything())
+    expect(contextSpy).toHaveBeenCalledWith({outputPrefix: 'app-preview', stripAnsi: false}, expect.anything())
     contextSpy.mockRestore()
   })
 
@@ -300,7 +300,7 @@ describe('pushUpdatesForDevSession', () => {
 
     // Then - Initial loading state
     expect(devSessionStatusManager.status.statusMessage).toEqual({
-      message: 'Preparing dev session',
+      message: 'Preparing app preview',
       type: 'loading',
     })
 
@@ -365,7 +365,7 @@ describe('pushUpdatesForDevSession', () => {
 
     // Then
     expect(devSessionStatusManager.status.statusMessage).toEqual({
-      message: 'Error updating dev session',
+      message: 'Error updating app preview',
       type: 'error',
     })
   })

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.ts
@@ -31,7 +31,7 @@ export async function setupDevSessionProcess({
 }: Omit<DevSessionProcessOptions, 'extensions'>): Promise<DevSessionProcess | undefined> {
   return {
     type: 'dev-session',
-    prefix: 'dev-session',
+    prefix: 'app-preview',
     function: pushUpdatesForDevSession,
     options: {
       app,

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-status-manager.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-status-manager.test.ts
@@ -120,7 +120,7 @@ describe('DevSessionStatusManager', () => {
       expect(listener).toHaveBeenCalledWith(
         expect.objectContaining({
           statusMessage: {
-            message: 'Preparing dev session',
+            message: 'Preparing app preview',
             type: 'loading',
           },
         }),

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-status-manager.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-status-manager.ts
@@ -6,11 +6,11 @@ export type DevSessionStatusMessageType = 'error' | 'success' | 'loading'
 const DevSessionStaticMessages = {
   BUILD_ERROR: {message: 'Build error. Please review your code and try again', type: 'error'},
   READY: {message: 'Ready, watching for changes in your app', type: 'success'},
-  LOADING: {message: 'Preparing dev session', type: 'loading'},
+  LOADING: {message: 'Preparing app preview', type: 'loading'},
   UPDATED: {message: 'Updated', type: 'success'},
   VALIDATION_ERROR: {message: 'Validation error in your app configuration', type: 'error'},
-  REMOTE_ERROR: {message: 'Error updating dev session', type: 'error'},
-  CHANGE_DETECTED: {message: 'Change detected, updating dev session', type: 'loading'},
+  REMOTE_ERROR: {message: 'Error updating app preview', type: 'error'},
+  CHANGE_DETECTED: {message: 'Change detected, updating app preview', type: 'loading'},
 } as const
 
 export interface DevSessionStatus {

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
@@ -56,7 +56,7 @@ export class DevSession {
   }
 
   private async start() {
-    await this.logger.info('Preparing dev session')
+    await this.logger.info('Preparing app preview')
     this.statusManager.setMessage('LOADING')
 
     this.appWatcher
@@ -93,7 +93,7 @@ export class DevSession {
     const errors = this.parseBuildErrors(event)
     if (errors.length) {
       await this.logger.logMultipleErrors(errors)
-      throw new AbortError('Dev session aborted, build errors detected in extensions.')
+      throw new AbortError('App preview aborted, build errors detected in extensions.')
     }
     const result = await this.bundleExtensionsAndUpload(event)
     await this.handleDevSessionResult(result, event)
@@ -111,7 +111,7 @@ export class DevSession {
    */
   private async validateAppEvent(event: AppEvent): Promise<boolean> {
     if (!this.statusManager.status.isReady) {
-      await this.logger.warning('Change detected, but dev session is not ready yet.')
+      await this.logger.warning('Change detected, but app preview is not ready yet.')
       return false
     }
 
@@ -172,7 +172,7 @@ export class DevSession {
       await this.logger.success(`✅ Ready, watching for changes in your app `)
       this.statusManager.setMessage('READY')
     } else if (result.status === 'aborted') {
-      await this.logger.debug('❌ Session update aborted (new change detected or error in Session Update)')
+      await this.logger.debug('❌ App preview update aborted (new change detected or error during update)')
     } else if (result.status === 'remote-error' || result.status === 'unknown-error') {
       await this.logger.logUserErrors(result.error, event?.app.allExtensions ?? [])
       if (result.error instanceof Error && result.error.cause === 'validation-error') {
@@ -185,7 +185,7 @@ export class DevSession {
     // If we failed to create a session, exit the process. Don't throw an error in tests as it can't be caught due to the
     // async nature of the process.
     if (!this.statusManager.status.isReady && !isUnitTest()) {
-      throw new AbortError('Failed to start dev session.')
+      throw new AbortError('Failed to start app preview.')
     }
   }
 

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -263,7 +263,7 @@ describe('setup-dev-processes', () => {
 
     expect(res.processes[6]).toMatchObject({
       type: 'app-watcher',
-      prefix: 'dev-session',
+      prefix: 'app-preview',
       function: launchAppWatcher,
       options: {
         appWatcher: expect.any(AppEventWatcher),
@@ -348,7 +348,7 @@ describe('setup-dev-processes', () => {
 
     expect(res.processes[3]).toMatchObject({
       type: 'dev-session',
-      prefix: 'dev-session',
+      prefix: 'app-preview',
       function: pushUpdatesForDevSession,
       options: {
         app: localApp,


### PR DESCRIPTION
### WHY are these changes introduced?

We should better say `app preview` externally

### WHAT is this pull request doing?

Renames `dev session` references in logs and prompts to `app preview`

### How to test your changes?

`p shopify app dev` against dev platform

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
