### PR TITLE
Add CLI token support for app management and BP API

### DIFF
--- a/.changeset/tasty-terms-brake.md
+++ b/.changeset/tasty-terms-brake.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/app': minor
+---
+
+Add support to use App Management API with CLI Tokens.

--- a/packages/app/src/cli/api/graphql/business-platform-destinations/generated/user-info.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-destinations/generated/user-info.ts
@@ -5,7 +5,9 @@ import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/co
 
 export type UserInfoQueryVariables = Types.Exact<{[key: string]: never}>
 
-export type UserInfoQuery = {currentUserAccount?: {uuid: string; email: string} | null}
+export type UserInfoQuery = {
+  currentUserAccount?: {uuid: string; email: string; organizations: {nodes: {name: string}[]}} | null
+}
 
 export const UserInfo = {
   kind: 'Document',
@@ -25,6 +27,30 @@ export const UserInfo = {
               selections: [
                 {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'email'}},
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'organizations'},
+                  arguments: [
+                    {kind: 'Argument', name: {kind: 'Name', value: 'first'}, value: {kind: 'IntValue', value: '2'}},
+                  ],
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'nodes'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
                 {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
               ],
             },

--- a/packages/app/src/cli/api/graphql/business-platform-destinations/queries/user-info.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-destinations/queries/user-info.graphql
@@ -2,5 +2,10 @@ query UserInfo {
   currentUserAccount {
     uuid
     email
+    organizations(first: 2){
+      nodes {
+        name
+      }
+    }
   }
 }

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -60,9 +60,7 @@ import {
   AppLogsSubscribeMutation,
   AppLogsSubscribeMutationVariables,
 } from '../api/graphql/app-management/generated/app-logs-subscribe.js'
-import {isAppManagementDisabled} from '@shopify/cli-kit/node/context/local'
 import {blockPartnersAccess} from '@shopify/cli-kit/node/environment'
-import {AbortError} from '@shopify/cli-kit/node/error'
 
 export enum ClientName {
   AppManagement = 'app-management',
@@ -88,12 +86,8 @@ export function allDeveloperPlatformClients(): DeveloperPlatformClient[] {
   if (!blockPartnersAccess()) {
     clients.push(new PartnersClient())
   }
-  if (!isAppManagementDisabled()) {
-    clients.push(new AppManagementClient())
-  }
-  if (clients.length === 0) {
-    throw new AbortError('Both Partners and App Management APIs are deactivated.')
-  }
+
+  clients.push(new AppManagementClient())
   return clients
 }
 
@@ -133,7 +127,6 @@ export function selectDeveloperPlatformClient({
   configuration,
   organization,
 }: SelectDeveloperPlatformClientOptions = {}): DeveloperPlatformClient {
-  if (isAppManagementDisabled()) return new PartnersClient()
   if (organization) return selectDeveloperPlatformClientByOrg(organization)
   return selectDeveloperPlatformClientByConfig(configuration)
 }

--- a/packages/cli-kit/src/private/node/session/exchange.test.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.test.ts
@@ -1,6 +1,8 @@
 import {
   exchangeAccessForApplicationTokens,
   exchangeCustomPartnerToken,
+  exchangeCliTokenForAppManagementAccessToken,
+  exchangeCliTokenForBusinessPlatformAccessToken,
   InvalidGrantError,
   InvalidRequestError,
   refreshAccessToken,
@@ -9,7 +11,7 @@ import {applicationId, clientId} from './identity.js'
 import {IdentityToken} from './schema.js'
 import {shopifyFetch} from '../../../public/node/http.js'
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
-import {getLastSeenUserIdAfterAuth} from '../session.js'
+import {getLastSeenUserIdAfterAuth, getLastSeenAuthMethod} from '../session.js'
 import {describe, test, expect, vi, afterAll, beforeEach} from 'vitest'
 import {Response} from 'node-fetch'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -197,30 +199,93 @@ describe('refresh access tokens', () => {
   })
 })
 
-describe('exchangeCustomPartnerToken', () => {
-  const token = 'customToken'
+const tokenExchangeMethods = [
+  {
+    tokenExchangeMethod: exchangeCustomPartnerToken,
+    expectedScopes: ['https://api.shopify.com/auth/partners.app.cli.access'],
+    expectedApi: 'partners',
+    expectedErrorName: 'Partners',
+  },
+  {
+    tokenExchangeMethod: exchangeCliTokenForAppManagementAccessToken,
+    expectedScopes: ['https://api.shopify.com/auth/organization.apps.manage'],
+    expectedApi: 'app-management',
+    expectedErrorName: 'App Management',
+  },
+  {
+    tokenExchangeMethod: exchangeCliTokenForBusinessPlatformAccessToken,
+    expectedScopes: ['https://api.shopify.com/auth/destinations.readonly'],
+    expectedApi: 'business-platform',
+    expectedErrorName: 'Business Platform',
+  },
+]
 
-  // Generated from `customToken` using `nonRandomUUID()`
-  const userId = 'eab16ac4-0690-5fed-9d00-71bd202a3c2b37259a8f'
+describe.each(tokenExchangeMethods)(
+  'Token exchange: %s',
+  ({tokenExchangeMethod, expectedScopes, expectedApi, expectedErrorName}) => {
+    const cliToken = 'customToken'
+    // Generated from `customToken` using `nonRandomUUID()`
+    const userId = 'eab16ac4-0690-5fed-9d00-71bd202a3c2b37259a8f'
 
-  test('returns access token and user ID for a valid token', async () => {
-    // Given
-    const data = {
-      access_token: 'access_token',
-      expires_in: 300,
-      scope: 'scope,scope2',
-    }
-    // Given
-    const response = new Response(JSON.stringify(data))
+    const grantType = 'urn:ietf:params:oauth:grant-type:token-exchange'
+    const accessTokenType = 'urn:ietf:params:oauth:token-type:access_token'
 
-    // Need to do it 3 times because a Response can only be used once
-    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    test(`Executing ${tokenExchangeMethod.name} returns access token and user ID for a valid CLI token`, async () => {
+      // Given
+      let capturedUrl = ''
+      vi.mocked(shopifyFetch).mockImplementation(async (url, options) => {
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        capturedUrl = url.toString()
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              access_token: 'expected_access_token',
+              expires_in: 300,
+              scope: 'scope,scope2',
+            }),
+          ),
+        )
+      })
 
-    // When
-    const result = await exchangeCustomPartnerToken(token)
+      // When
+      const result = await tokenExchangeMethod(cliToken)
 
-    // Then
-    expect(result).toEqual({accessToken: 'access_token', userId})
-    await expect(getLastSeenUserIdAfterAuth()).resolves.toBe(userId)
-  })
-})
+      // Then
+      expect(result).toEqual({accessToken: 'expected_access_token', userId})
+      await expect(getLastSeenUserIdAfterAuth()).resolves.toBe(userId)
+      await expect(getLastSeenAuthMethod()).resolves.toBe('partners_token')
+
+      // Assert token exchange parameters are correct
+      const actualUrl = new URL(capturedUrl)
+      expect(actualUrl).toBeDefined()
+      expect(actualUrl.href).toContain('https://fqdn.com/oauth/token')
+
+      const params = actualUrl.searchParams
+      expect(params.get('grant_type')).toBe(grantType)
+      expect(params.get('requested_token_type')).toBe(accessTokenType)
+      expect(params.get('subject_token_type')).toBe(accessTokenType)
+      expect(params.get('client_id')).toBe('clientId')
+      expect(params.get('audience')).toBe(expectedApi)
+      expect(params.get('scope')).toBe(expectedScopes.join(' '))
+      expect(params.get('subject_token')).toBe(cliToken)
+    })
+
+    test(`Executing ${tokenExchangeMethod.name} throws AbortError if an error is caught`, async () => {
+      const expectedErrorMessage = `The custom token provided can't be used for the ${expectedErrorName} API.`
+      vi.mocked(shopifyFetch).mockImplementation(async () => {
+        throw new Error('BAD ERROR')
+      })
+
+      try {
+        await tokenExchangeMethod(cliToken)
+      } catch (error) {
+        if (error instanceof Error) {
+          expect(error).toBeInstanceOf(AbortError)
+          expect(error.message).toBe(expectedErrorMessage)
+        } else {
+          throw error
+        }
+      }
+    })
+  },
+)

--- a/packages/cli-kit/src/private/node/session/scopes.test.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.test.ts
@@ -1,4 +1,4 @@
-import {allDefaultScopes, apiScopes} from './scopes.js'
+import {allDefaultScopes, apiScopes, tokenExchangeScopes} from './scopes.js'
 import {describe, expect, test} from 'vitest'
 
 describe('allDefaultScopes', () => {
@@ -60,5 +60,39 @@ describe('apiScopes', () => {
       'https://api.shopify.com/auth/partners.collaborator-relationships.readonly',
       ...customScopes,
     ])
+  })
+})
+
+describe('tokenExchangeScopes', () => {
+  test('returns transformed scopes for partners API', () => {
+    // When
+    const got = tokenExchangeScopes('partners')
+
+    // Then
+    expect(got).toEqual(['https://api.shopify.com/auth/partners.app.cli.access'])
+  })
+
+  test('returns transformed scopes for app-management API', () => {
+    // When
+    const got = tokenExchangeScopes('app-management')
+
+    // Then
+    expect(got).toEqual(['https://api.shopify.com/auth/organization.apps.manage'])
+  })
+
+  test('returns transformed scopes for business-platform API', () => {
+    // When
+    const got = tokenExchangeScopes('business-platform')
+
+    // Then
+    expect(got).toEqual(['https://api.shopify.com/auth/destinations.readonly'])
+  })
+
+  test('throws an error for unsupported APIs', () => {
+    // When/Then
+    expect(() => tokenExchangeScopes('admin')).toThrow('API not supported for token exchange: admin')
+    expect(() => tokenExchangeScopes('storefront-renderer')).toThrow(
+      'API not supported for token exchange: storefront-renderer',
+    )
   })
 })

--- a/packages/cli-kit/src/private/node/session/scopes.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.ts
@@ -25,6 +25,24 @@ export function apiScopes(api: API, extraScopes: string[] = []): string[] {
   return Array.from(new Set(scopes))
 }
 
+/**
+ * Returns specific scopes required for token exchange with the given API.
+ * @param api - API to get the scopes for
+ * @returns Array of transformed scopes
+ */
+export function tokenExchangeScopes(api: API): string[] {
+  switch (api) {
+    case 'partners':
+      return [scopeTransform('cli')]
+    case 'app-management':
+      return [scopeTransform('app-management')]
+    case 'business-platform':
+      return [scopeTransform('destinations')]
+    default:
+      throw new BugError(`API not supported for token exchange: ${api}`)
+  }
+}
+
 function defaultApiScopes(api: API): string[] {
   switch (api) {
     case 'admin':

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -7,11 +7,9 @@ import {
   analyticsDisabled,
   cloudEnvironment,
   macAddress,
-  isAppManagementDisabled,
   getThemeKitAccessDomain,
   opentelemetryDomain,
 } from './local.js'
-import {getPartnersToken} from '../environment.js'
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
 import {expect, describe, vi, test} from 'vitest'
@@ -101,30 +99,6 @@ describe('hasGit', () => {
 
     // Then
     expect(got).toBeTruthy()
-  })
-})
-
-describe('isAppManagementDisabled', () => {
-  test('returns true when a Partners token is present', () => {
-    // Given
-    vi.mocked(getPartnersToken).mockReturnValue('token')
-
-    // When
-    const got = isAppManagementDisabled()
-
-    // Then
-    expect(got).toBe(true)
-  })
-
-  test('returns false when a Partners token is not present', () => {
-    // Given
-    vi.mocked(getPartnersToken).mockReturnValue(undefined)
-
-    // When
-    const got = isAppManagementDisabled()
-
-    // Then
-    expect(got).toBe(false)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -4,7 +4,6 @@ import {getCIMetadata, isSet, Metadata} from '../../../private/node/context/util
 import {defaultThemeKitAccessDomain, environmentVariables, pathConstants} from '../../../private/node/constants.js'
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
-import {getPartnersToken} from '../environment.js'
 import isInteractive from 'is-interactive'
 import macaddress from 'macaddress'
 import {homedir} from 'os'
@@ -45,16 +44,6 @@ export function isDevelopment(env = process.env): boolean {
  */
 export function isVerbose(env = process.env): boolean {
   return isTruthy(env[environmentVariables.verbose]) || process.argv.includes('--verbose')
-}
-
-/**
- * It returns true if the App Management API is disabled.
- * This should only be relevant when using a Partners token.
- *
- * @returns True if the App Management API is disabled.
- */
-export function isAppManagementDisabled(): boolean {
-  return Boolean(getPartnersToken())
 }
 
 /**

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -3,7 +3,11 @@ import {BugError} from './error.js'
 import {getPartnersToken} from './environment.js'
 import {nonRandomUUID} from './crypto.js'
 import * as secureStore from '../../private/node/session/store.js'
-import {exchangeCustomPartnerToken} from '../../private/node/session/exchange.js'
+import {
+  exchangeCustomPartnerToken,
+  exchangeCliTokenForAppManagementAccessToken,
+  exchangeCliTokenForBusinessPlatformAccessToken,
+} from '../../private/node/session/exchange.js'
 import {outputContent, outputToken, outputDebug} from '../../public/node/output.js'
 import {
   AdminAPIScope,
@@ -77,6 +81,19 @@ export async function ensureAuthenticatedAppManagementAndBusinessPlatform(
   outputDebug(outputContent`Ensuring that the user is authenticated with the App Management API with the following scopes:
 ${outputToken.json(appManagementScopes)}
 `)
+
+  const envToken = getPartnersToken()
+  if (envToken) {
+    const appManagmentToken = await exchangeCliTokenForAppManagementAccessToken(envToken)
+    const businessPlatformToken = await exchangeCliTokenForBusinessPlatformAccessToken(envToken)
+
+    return {
+      appManagementToken: appManagmentToken.accessToken,
+      userId: appManagmentToken.userId,
+      businessPlatformToken: businessPlatformToken.accessToken,
+    }
+  }
+
   const tokens = await ensureAuthenticated(
     {appManagementApi: {scopes: appManagementScopes}, businessPlatformApi: {scopes: businessPlatformScopes}},
     env,


### PR DESCRIPTION
### WHY are these changes introduced?
Closes 
- https://github.com/shop/issues-app-access/issues/689

### WHAT is this pull request doing?
Add support to use the CLI token for app management API
  - Remove `isAppManagementDisabled()` function that disables App Management API if a CLI Token is provided
  - Perform token exchange with **AppMangement API** and **BusinessPlatform API** if a CLI token is provided when creating a session for **AppManagmentClient**, and assign those access token as a `ServiceAccount` user
  - Extend `UserInfo` query to get the first 2 organizations the user/CLI token service account belongs to
    - This assumes the CLI Token will always only belong to a single organization and raise an exception if the CLI Token belong in multiple orgs
  - ⚠️ With this change, CLI Tokens will be used to exchange for `Partners API`, `BP API` and `App Management API`, the token exchange requests will fail if the CLI token does not contain enough scopes. 
    - ‼️**This will break existing CLI Tokens unless this scope backfill is complete** ‼️
    - https://github.com/shop/issues-app-access/issues/703
    - ![image](https://github.com/user-attachments/assets/b5a11234-75ff-4f57-9572-cafc2c3a4e88)

### How to test your changes?
-  ➡️ [Demo Video](https://share.descript.com/view/ekNl3JSBrbT)

#### Steps
1. Ensure Partners org permission is synced to Dev Dash ([steps](https://docs.google.com/document/d/1_wS3BESWSTZhQexQ7jWnhfWaUQa1uiKERjQxYgbkyBY/edit?tab=t.yiz46egvghtx))
2. Enable beta  **_"Add app management scope to CLI token"_** for your org in Partners internal
3. Create a new CLI Token for your org
4. Use the CLI token for apps within your partner and dev dash org with the [CLI snapshot version `20250414215916`](https://github.com/Shopify/cli/pull/5622#issuecomment-2803134002)
  `npm i -g @shopify/cli@0.0.0-snapshot-20250414215916 --@shopify:registry=https://registry.npmjs.org`

#### Tested flows
- ✅ With CLI Token, `shopify app config link` a Partners app
- ✅ With CLI Token, `shopify app config link` a dev dash app
- ✅ With CLI Token, `shopify app deploy` a dev dash app
- ✅ With CLI Token, `shopify app deploy` a Partners app
- ✅ With a user session, `shopify app config link` a Partners app
- ✅ With a user session, `shopify app config link` a dev dash app
- ✅ With a user session, `shopify app deploy` a dev dash app
- ✅ With a user session, `shopify app deploy` a Partners app
- ✅ With CLI token, `shopify app info` to display a Partners app 
![image](https://github.com/user-attachments/assets/3b7bdc52-5f17-48e5-8a27-18bc7afbccf7)

- ✅ With CLI token, `shopify app info` to display a dev dash app
![image](https://github.com/user-attachments/assets/b69da68f-67bf-45b0-88a3-afc9afa1558b)


### Post-release steps
‼️**This will break existing CLI Tokens unless this scope backfill is complete** ‼️
  - https://github.com/shop/issues-app-access/issues/703

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
