### PR TITLE
Generate and store a combined config schema

### DIFF
--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -113,6 +113,11 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
    * Parse some provided configuration into a valid configuration object for this extension.
    */
   parseConfigurationObject: (configurationObject: object) => ParseConfigurationResult<TConfiguration>
+
+  /**
+   * The JSON schema for the extension, where no contract yet exists. Only used for in-editor validation.
+   */
+  hardcodedInputJsonSchema?: string
 }
 
 /**
@@ -235,6 +240,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
     storeFqdn: string,
   ) => Promise<string>
   patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
+  hardcodedInputJsonSchema?: string
 }): ExtensionSpecification<TConfiguration> {
   const appModuleFeatures = spec.appModuleFeatures ?? (() => [])
   return createExtensionSpecification({
@@ -249,6 +255,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
     uidStrategy: spec.uidStrategy ?? 'single',
     getDevSessionActionUpdateMessage: spec.getDevSessionActionUpdateMessage,
     patchWithAppDevURLs: spec.patchWithAppDevURLs,
+    hardcodedInputJsonSchema: spec.hardcodedInputJsonSchema,
   })
 }
 

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -67,6 +67,8 @@ async function mergeLocalAndRemoteSpecs(
     let localSpec = local.find((local) => local.identifier === remoteSpec.identifier)
     if (!localSpec && remoteSpec.validationSchema?.jsonSchema) {
       const normalisedSchema = await normaliseJsonSchema(remoteSpec.validationSchema.jsonSchema)
+      // eslint-disable-next-line require-atomic-updates
+      remoteSpec.validationSchema.jsonSchema = JSON.stringify(normalisedSchema)
       const hasLocalization = normalisedSchema.properties?.localization !== undefined
       localSpec = createContractBasedModuleSpecification(remoteSpec.identifier, hasLocalization ? ['localization'] : [])
       localSpec.uidStrategy = remoteSpec.options.uidIsClientProvided ? 'uuid' : 'single'


### PR DESCRIPTION
# Add JSON schema support for app configuration validation

### WHY are these changes introduced?

This PR generates a JSON schema for the app configuration file, which will enable better editor integration and validation for developers working with Shopify app configurations.

### WHAT is this pull request doing?

Schema is a combination of locally specified schemas -- i.e. because the input format !== the submission format -- and JSON schema contracts.

- Adds a `hardcodedInputJsonSchema` property to extension specifications to support schema validation
- Implements schema bank generation that creates pretty-printed JSON schema files in the `.shopify/schemas` directory
- Generates a combined app configuration schema that merges properties from all config modules
- Prioritizes hardcoded schemas over validation schemas when both are present
- Ensures schemas are properly formatted with consistent indentation for better readability
- Cleans up old schema files that are no longer needed

### How to test your changes?

Run at least one CLI command. Add `#: schema ./.shopify/schemas/app.schema.json` to the top of your app.toml file. See validation and autocomplete magic.
