### PR TITLE
[DNM] Hard-coded schemas for config modules

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -44,6 +44,8 @@ const AppAccessTransformConfig: TransformationConfig = {
   redirect_url_allowlist: 'auth.redirect_urls',
 }
 
+const allTheScopes = ['read_products', 'write_products', 'read_orders', 'write_orders', 'read_customers']
+
 const appAccessSpec = createConfigExtensionSpecification({
   identifier: AppAccessSpecIdentifier,
   schema: AppAccessSchema,
@@ -57,6 +59,27 @@ const appAccessSpec = createConfigExtensionSpecification({
       config.auth = {redirect_urls: urls.redirectUrlWhitelist}
     }
   },
+  hardcodedInputJsonSchema: JSON.stringify({
+    type: 'object',
+    properties: {
+      access_scopes: {
+        type: 'object',
+        properties: {
+          scopes: {type: 'string'},
+          required_scopes: {type: 'array', items: {type: 'string', enum: allTheScopes}},
+          optional_scopes: {type: 'array', items: {type: 'string', enum: allTheScopes}},
+          use_legacy_install_flow: {type: 'boolean'},
+        },
+      },
+      auth: {
+        type: 'object',
+        properties: {
+          redirect_urls: {type: 'array', items: {type: 'string', format: 'uri'}},
+        },
+      },
+    },
+    required: ['access_scopes', 'auth'],
+  }),
 })
 
 export default appAccessSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
@@ -28,6 +28,21 @@ const appHomeSpec = createConfigExtensionSpecification({
   patchWithAppDevURLs: (config, urls) => {
     config.application_url = urls.applicationUrl
   },
+  hardcodedInputJsonSchema: JSON.stringify({
+    type: 'object',
+    properties: {
+      application_url: {type: 'string'},
+      embedded: {type: 'boolean'},
+      app_preferences: {
+        type: 'object',
+        properties: {
+          url: {type: 'string'},
+        },
+        required: ['url'],
+      },
+    },
+    required: ['application_url', 'embedded'],
+  }),
 })
 
 export default appHomeSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
@@ -24,6 +24,21 @@ const appBrandingSpec = createConfigExtensionSpecification({
   identifier: BrandingSpecIdentifier,
   schema: BrandingSchema,
   transformConfig: BrandingTransformConfig,
+  hardcodedInputJsonSchema: JSON.stringify({
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        maxLength: 30,
+      },
+      handle: {
+        type: 'string',
+        maxLength: 256,
+        pattern: '^[a-zA-Z0-9_-]+$',
+      },
+    },
+    required: ['name'],
+  }),
 })
 
 export default appBrandingSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook.ts
@@ -1,5 +1,6 @@
 import {WebhooksSchema} from './app_config_webhook_schemas/webhooks_schema.js'
 import {transformToWebhookConfig, transformFromWebhookConfig} from './transform/app_config_webhook.js'
+import {ComplianceTopic} from './app_config_webhook_schemas/webhook_subscription_schema.js'
 import {CustomTransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 
 export const WebhooksSpecIdentifier = 'webhooks'
@@ -13,6 +14,42 @@ const appWebhooksSpec = createConfigExtensionSpecification({
   identifier: WebhooksSpecIdentifier,
   schema: WebhooksSchema,
   transformConfig: WebhookTransformConfig,
+  hardcodedInputJsonSchema: JSON.stringify({
+    type: 'object',
+    properties: {
+      webhooks: {
+        type: 'object',
+        properties: {
+          api_version: {type: 'string'},
+          subscriptions: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                topics: {type: 'array', items: {type: 'string'}},
+                uri: {type: 'string', format: 'uri-reference'},
+                include_fields: {type: 'array', items: {type: 'string'}},
+                filter: {type: 'string'},
+                compliance_topics: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                    enum: [
+                      ComplianceTopic.CustomersRedact,
+                      ComplianceTopic.CustomersDataRequest,
+                      ComplianceTopic.ShopRedact,
+                    ],
+                  },
+                },
+              },
+              required: ['uri'],
+            },
+          },
+        },
+        required: ['api_version'],
+      },
+    },
+  }),
 })
 
 export default appWebhooksSpec

--- a/packages/app/src/cli/services/app-context.ts
+++ b/packages/app/src/cli/services/app-context.ts
@@ -123,7 +123,7 @@ function generateCombinedConfigSchema(specifications: RemoteAwareExtensionSpecif
       build: {type: 'object', additionalProperties: true},
     },
     required: ['client_id'],
-    additionalProperties: true,
+    additionalProperties: false,
   }
 
   for (const spec of configModules) {


### PR DESCRIPTION
### WHY are these changes introduced?

Adds hard-coded schemas for config modules to be merged with those that have contract support.

It also outputs the combined app schema into a unique-per-execution file. This is useful as some tooling tries to cache JSON schema files. You can use this file instead for easier cache busting.