### PR TITLE
[DNM] Generate and store a combined extension schema

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -10,6 +10,15 @@ const MetafieldSchema = zod.object({
   key: zod.string(),
 })
 
+export const MetafieldSchemaAsJson = {
+  type: 'object',
+  properties: {
+    key: {type: 'string'},
+    namespace: {type: 'string'},
+  },
+  required: ['key', 'namespace'],
+}
+
 const CollectBuyerConsentCapabilitySchema = zod.object({
   sms_marketing: zod.boolean().optional(),
   customer_privacy: zod.boolean().optional(),
@@ -59,6 +68,45 @@ const NewExtensionPointSchema = zod.object({
     .optional(),
 })
 
+export const NewExtensionPointsSchemaAsJson = {
+  type: 'object',
+  properties: {
+    target: {type: 'string'},
+    module: {type: 'string'},
+    should_render: {
+      type: 'object',
+      properties: {
+        module: {type: 'string'},
+      },
+      required: ['module'],
+    },
+    metafields: {
+      type: 'array',
+      items: MetafieldSchemaAsJson,
+    },
+    default_placement: {type: 'string'},
+    urls: {
+      type: 'object',
+      properties: {
+        edit: {type: 'string'},
+      },
+    },
+    capabilities: {
+      type: 'object',
+      properties: {
+        allow_direct_linking: {type: 'boolean'},
+      },
+    },
+    preloads: {
+      type: 'object',
+      properties: {
+        chat: {type: 'string'},
+      },
+    },
+  },
+  required: ['target', 'module'],
+}
+
 export const NewExtensionPointsSchema = zod.array(NewExtensionPointSchema)
 const ApiVersionSchema = zod.string()
 
@@ -79,6 +127,30 @@ export const FieldSchema = zod.object({
 const SettingsSchema = zod.object({
   fields: zod.array(FieldSchema).optional(),
 })
+
+export const SettingsSchemaAsJson = {
+  type: 'object',
+  properties: {
+    fields: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          key: {type: 'string'},
+          name: {type: 'string'},
+          description: {type: 'string'},
+          required: {type: 'boolean'},
+          type: {type: 'string'},
+          validations: {type: 'array', items: {type: 'object'}},
+          marketingActivityCreateUrl: {type: 'string'},
+          marketingActivityDeleteUrl: {type: 'string'},
+        },
+        required: ['type'],
+        additionalProperties: true,
+      },
+    },
+  },
+}
 
 const HandleSchema = zod
   .string()
@@ -105,6 +177,46 @@ export const BaseSchema = zod.object({
 export const BaseSchemaWithHandle = BaseSchema.extend({
   handle: HandleSchema,
 })
+
+export const BaseSchemaWithHandleAsJson = {
+  type: 'object',
+  properties: {
+    name: {type: 'string'},
+    extension_points: {type: 'array', items: NewExtensionPointsSchemaAsJson},
+    targeting: {
+      type: 'array',
+      items: NewExtensionPointsSchemaAsJson,
+    },
+    handle: {type: 'string'},
+    uid: {type: 'string'},
+    description: {type: 'string'},
+    capabilities: {
+      type: 'object',
+      properties: {
+        network_access: {type: 'boolean'},
+        block_progress: {type: 'boolean'},
+        api_access: {type: 'boolean'},
+        collect_buyer_consent: {
+          type: 'object',
+          properties: {
+            sms_marketing: {type: 'boolean'},
+            customer_privacy: {type: 'boolean'},
+          },
+        },
+        iframe: {
+          type: 'object',
+          properties: {
+            sources: {type: 'array', items: {type: 'string'}},
+          },
+        },
+      },
+    },
+    metafields: {type: 'array', items: MetafieldSchemaAsJson},
+    settings: SettingsSchemaAsJson,
+  },
+  required: ['name', 'type', 'handle'],
+  additionalProperties: false,
+}
 
 export const UnifiedSchema = zod.object({
   api_version: ApiVersionSchema.optional(),

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -1,5 +1,5 @@
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, BaseSchemaWithHandleAsJson} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -80,6 +80,66 @@ const functionSpec = createExtensionSpecification({
     'pickup_point_delivery_option_generator',
   ],
   schema: FunctionExtensionSchema,
+  hardcodedInputJsonSchema: JSON.stringify({
+    ...BaseSchemaWithHandleAsJson,
+    properties: {
+      ...BaseSchemaWithHandleAsJson.properties,
+      type: {const: 'function'},
+      build: {
+        type: 'object',
+        properties: {
+          command: {type: 'string'},
+          path: {type: 'string'},
+          watch: {
+            type: 'string',
+          },
+          wasm_opt: {type: 'boolean'},
+        },
+      },
+      configuration_ui: {type: 'boolean'},
+      ui: {
+        type: 'object',
+        properties: {
+          enable_create: {type: 'boolean'},
+          paths: {
+            type: 'object',
+            properties: {
+              create: {type: 'string'},
+              details: {type: 'string'},
+            },
+            required: ['create', 'details'],
+          },
+          handle: {type: 'string'},
+        },
+      },
+      input: {
+        type: 'object',
+        properties: {
+          variables: {
+            type: 'object',
+            properties: {
+              namespace: {type: 'string'},
+              key: {type: 'string'},
+            },
+            required: ['namespace', 'key'],
+          },
+        },
+      },
+      targeting: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            target: {type: 'string'},
+            input_query: {type: 'string'},
+            export: {type: 'string'},
+          },
+          required: ['target'],
+        },
+      },
+    },
+    required: [...BaseSchemaWithHandleAsJson.required, 'build'],
+  }),
   appModuleFeatures: (_) => ['function', 'bundling'],
   deployConfig: async (config, directory, apiKey) => {
     let inputQuery: string | undefined

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -1,5 +1,11 @@
 import {Asset, AssetIdentifier, ExtensionFeature, createExtensionSpecification} from '../specification.js'
-import {NewExtensionPointSchemaType, NewExtensionPointsSchema, BaseSchema} from '../schemas.js'
+import {
+  NewExtensionPointSchemaType,
+  NewExtensionPointsSchema,
+  BaseSchema,
+  NewExtensionPointsSchemaAsJson,
+  BaseSchemaWithHandleAsJson,
+} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {getExtensionPointTargetSurface} from '../../../services/dev/extension/utilities.js'
 import {err, ok, Result} from '@shopify/cli-kit/node/result'
@@ -77,6 +83,17 @@ const uiExtensionSpec = createExtensionSpecification({
   identifier: 'ui_extension',
   dependency,
   schema: UIExtensionSchema,
+  hardcodedInputJsonSchema: JSON.stringify({
+    ...BaseSchemaWithHandleAsJson,
+    properties: {
+      ...BaseSchemaWithHandleAsJson.properties,
+      type: {const: 'ui_extension'},
+      targeting: {
+        type: 'array',
+        items: NewExtensionPointsSchemaAsJson,
+      },
+    },
+  }),
   appModuleFeatures: (config) => {
     const basic: ExtensionFeature[] = ['ui_preview', 'bundling', 'esbuild', 'generates_source_maps']
     const needsCart =


### PR DESCRIPTION
As downstack, but for extensions.

This produces a good JSON schema for extensions (it only covers UI extensions & functions right now though). But, the most common LSP for TOML will struggle with this schema as it is oriented around a union/anyOf. So as-is, this is a demonstration of what may be possible, but today isn't.
