### PR TITLE
When the Cloudflare tunnel fails to start, link the user to our docum…

### DIFF
--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -155,15 +155,14 @@ class TunnelClientInstance implements TunnelClient {
 
 function whatToTry() {
   return [
-    'What to try:',
+    'Run the command again or',
     {
-      list: {
-        items: [
-          ['Run the command again'],
-          ['Add the flag', {command: '--tunnel-url {URL}'}, 'to use a custom tunnel URL'],
-        ],
+      link: {
+        label: 'Read the documentation',
+        url: 'https://shopify.dev/docs/apps/build/cli-for-apps/networking-options',
       },
     },
+    'for more options.',
   ]
 }
 

--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -158,7 +158,7 @@ function whatToTry() {
     'Run the command again or',
     {
       link: {
-        label: 'Read the documentation',
+        label: 'see Shopify CLI documentation',
         url: 'https://shopify.dev/docs/apps/build/cli-for-apps/networking-options',
       },
     },


### PR DESCRIPTION
### WHY are these changes introduced?

To steer users towards our documentation, which is better since we release the `--use-localhost` flag:

### WHAT is this pull request doing?

When the Cloudflare tunnel fails to start previously we would show a list of possible remedies.  Now we just link to the docs:

<img width="1054" alt="Screenshot 2025-04-04 at 4 21 47 PM" src="https://github.com/user-attachments/assets/1fabd87f-0558-4195-8e8e-b765a3651a3e" />

### How to test your changes?

To force a failure, change this line 

```
exec(getBinPathTarget(), args, {
```

to 

```
exec(`${getBinPathTarget()}/123`, args, {
```

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
