### PR TITLE
Change http reverse proxy test to await TCP port test individually

### DIFF
--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
@@ -81,11 +81,9 @@ function getTestReverseProxy(protocol: 'http' | 'https') {
   }>({
     // eslint-disable-next-line no-empty-pattern
     ports: async ({}, use) => {
-      const [proxyPort, targetPort1, targetPort2] = await Promise.all([
-        getAvailableTCPPort(),
-        getAvailableTCPPort(),
-        getAvailableTCPPort(),
-      ])
+      const proxyPort = await getAvailableTCPPort()
+      const targetPort1 = await getAvailableTCPPort()
+      const targetPort2 = await getAvailableTCPPort()
       await use({proxyPort, targetPort1, targetPort2})
     },
     servers: async ({ports}, use) => {


### PR DESCRIPTION
### WHY are these changes introduced?

In `http-reverse-proxy.test.ts`, the test setup acquires 3 ports: `proxyPort`, `targetPort1`, and `targetPort2` using `getAvailableTCPPort`. We were previously requesting these ports concurrently using `Promise.all`. This created a small possibility of a race condition where the same available port could be selected by multiple concurrent requests before being bound, potentially leading to test failures.

### WHAT is this pull request doing?

This PR modifies the port acquisition to use sequential `await` calls. Each port request now waits for the previous one to complete, ensuring distinct ports are highly likely to be assigned for the test setup.

### How to test your changes?

- Pull down the branch
- Build the branch
- run `npx vitest run packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts` to directly run the changed test.

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
