### PR TITLE
Add `unsetPathValue` to `cli-kit`

### DIFF
--- a/.changeset/twenty-penguins-allow.md
+++ b/.changeset/twenty-penguins-allow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Add new `unsetPathValue` function which wraps the `unset` function from lodash

--- a/packages/cli-kit/src/public/common/object.test.ts
+++ b/packages/cli-kit/src/public/common/object.test.ts
@@ -7,6 +7,7 @@ import {
   mapValues,
   pickBy,
   setPathValue,
+  unsetPathValue,
 } from './object.js'
 import {describe, expect, test} from 'vitest'
 
@@ -273,5 +274,88 @@ describe('compact', () => {
 
     // Then
     expect(result).toEqual({})
+  })
+})
+
+describe('unsetPathValue', () => {
+  test('removes the path value at the top level if it exists', () => {
+    // Given
+    const obj: object = {
+      key1: '1',
+      key2: '2',
+    }
+
+    // When
+    const result = unsetPathValue(obj, 'key1')
+
+    // Then
+    expect(result).toBeTruthy()
+    expect(obj).toEqual({key2: '2'})
+  })
+
+  test('removes the path value inside a nested object if it exists', () => {
+    // Given
+    const obj: object = {
+      key1: {
+        key11: 2,
+        key12: 3,
+      },
+    }
+
+    // When
+    const result = unsetPathValue(obj, 'key1.key11')
+
+    // Then
+    expect(result).toBeTruthy()
+    expect(obj).toEqual({key1: {key12: 3}})
+  })
+
+  test('returns true and does not modify the object if the specific path does not exist', () => {
+    // Given
+    const obj: object = {
+      key1: {
+        key11: 3,
+      },
+    }
+
+    // When
+    const result = unsetPathValue(obj, 'key1.key21')
+
+    // Then
+    expect(result).toBeTruthy()
+    expect(obj).toEqual({key1: {key11: 3}})
+  })
+
+  test('returns false when trying to remove a property from a frozen object', () => {
+    // Given
+    const obj: object = {
+      key1: '1',
+      key2: '2',
+    }
+    Object.freeze(obj)
+
+    // When
+    const result = unsetPathValue(obj, 'key1')
+
+    // Then
+    expect(result).toBeFalsy()
+    expect(obj).toEqual({key1: '1', key2: '2'})
+  })
+
+  test('returns false when trying to remove a non-configurable property', () => {
+    // Given
+    const obj: object = {}
+    Object.defineProperty(obj, 'key1', {
+      value: '1',
+      configurable: false,
+      enumerable: true,
+    })
+
+    // When
+    const result = unsetPathValue(obj, 'key1')
+
+    // Then
+    expect(result).toBeFalsy()
+    expect(Object.prototype.hasOwnProperty.call(obj, 'key1')).toBeTruthy()
   })
 })

--- a/packages/cli-kit/src/public/common/object.ts
+++ b/packages/cli-kit/src/public/common/object.ts
@@ -9,6 +9,7 @@ import fromPairs from 'lodash/fromPairs.js'
 import toPairs from 'lodash/toPairs.js'
 import get from 'lodash/get.js'
 import set from 'lodash/set.js'
+import unset from 'lodash/unset.js'
 import lodashIsEmpty from 'lodash/isEmpty.js'
 
 /**
@@ -101,6 +102,17 @@ export function getPathValue<T = object>(object: object, path: string): T | unde
  */
 export function setPathValue(object: object, path: string, value?: unknown): object {
   return set(object, path, value)
+}
+
+/**
+ * Removes the property at path of object.
+ *
+ * @param object - The object to modify.
+ * @param path - The path of the property to unset.
+ * @returns - Returns true if the property is deleted or not found, else false.
+ */
+export function unsetPathValue(object: object, path: string): boolean {
+  return unset(object, path)
 }
 
 /**


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

The CLI kit package currently provides utilities like `getPathValue` and `setPathValue` for working with object paths, but lacks a corresponding function to remove properties at a specific path. This change adds an `unsetPathValue` utility to complete the set of object path manipulation functions.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR:

- Adds a new `unsetPathValue` function to `@shopify/cli-kit` which wraps `lodash`'s `unset` function
- Provides tests that verify the function's behaviour with different scenarios (top-level paths, nested paths, and non-existent paths)
- Adds a changeset that marks this as a minor version change for `@shopify/cli-kit`

The implementation follows the same pattern as existing path-related functions like `getPathValue` and `setPathValue`, maintaining consistency in the codebase.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
