### PR TITLE
Remove GQL version from themeCreate API

### DIFF
--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -181,16 +181,11 @@ describe('themeCreate', () => {
     const theme = await themeCreate(params, session)
 
     // Then
-    expect(adminRequestDoc).toHaveBeenCalledWith(
-      ThemeCreate,
-      session,
-      {
-        name: params.name,
-        source: 'https://cdn.shopify.com/static/online-store/theme-skeleton.zip',
-        role: 'UNPUBLISHED',
-      },
-      '2025-04',
-    )
+    expect(adminRequestDoc).toHaveBeenCalledWith(ThemeCreate, session, {
+      name: params.name,
+      source: 'https://cdn.shopify.com/static/online-store/theme-skeleton.zip',
+      role: 'UNPUBLISHED',
+    })
     expect(theme).not.toBeNull()
     expect(theme!.id).toEqual(id)
     expect(theme!.name).toEqual(name)
@@ -215,16 +210,11 @@ describe('themeCreate', () => {
     const theme = await themeCreate({...params, src: 'https://example.com/theme.zip'}, session)
 
     // Then
-    expect(adminRequestDoc).toHaveBeenCalledWith(
-      ThemeCreate,
-      session,
-      {
-        name: params.name,
-        source: 'https://example.com/theme.zip',
-        role: 'UNPUBLISHED',
-      },
-      '2025-04',
-    )
+    expect(adminRequestDoc).toHaveBeenCalledWith(ThemeCreate, session, {
+      name: params.name,
+      source: 'https://example.com/theme.zip',
+      role: 'UNPUBLISHED',
+    })
   })
 })
 

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -93,16 +93,11 @@ export async function fetchThemes(session: AdminSession): Promise<Theme[]> {
 
 export async function themeCreate(params: ThemeParams, session: AdminSession): Promise<Theme | undefined> {
   const themeSource = params.src ?? SkeletonThemeCdn
-  const {themeCreate} = await adminRequestDoc(
-    ThemeCreate,
-    session,
-    {
-      name: params.name ?? '',
-      source: themeSource,
-      role: (params.role ?? DEVELOPMENT_THEME_ROLE).toUpperCase() as ThemeRole,
-    },
-    '2025-04',
-  )
+  const {themeCreate} = await adminRequestDoc(ThemeCreate, session, {
+    name: params.name ?? '',
+    source: themeSource,
+    role: (params.role ?? DEVELOPMENT_THEME_ROLE).toUpperCase() as ThemeRole,
+  })
 
   if (!themeCreate) {
     unexpectedGraphQLError('Failed to create theme')


### PR DESCRIPTION
### WHY are these changes introduced?

Removing the hard coded GraphQL version for the `themeCreate` mutation since the stable release is >= `2025-04` .

Didn't forget 😛 https://github.com/Shopify/cli/pull/5249#discussion_r1949997344

### How to test your changes?

Tests pass and `shopify theme init` action work as is.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
