### PR TITLE
Temporary CLI change for checkout and customer account templates

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -318,9 +318,10 @@ function getSharedTypeDefinition(fullPath: string, typeFilePath: string, target:
   } catch (_) {
     // Remove the type reference from the source file
     updateTypeReference({fullPath, template, shouldAddTypeReference: false})
-    throw new Error(
-      `Type reference for ${target} could not be found. You might be using the wrong @shopify/ui-extensions version. Fix the error by ensuring you install @shopify/ui-extensions@${apiVersion} in your dependencies.`,
-    )
+    // throw new Error(
+    //   `Type reference for ${target} could not be found. You might be using the wrong @shopify/ui-extensions version. Fix the error by ensuring you install @shopify/ui-extensions@${apiVersion} in your dependencies.`,
+    // )
+    return types
   }
 
   // Update the type reference

--- a/packages/cli-kit/src/public/common/version.ts
+++ b/packages/cli-kit/src/public/common/version.ts
@@ -1,1 +1,1 @@
-export const CLI_KIT_VERSION = '3.77.0'
+export const CLI_KIT_VERSION = '3.78.0'


### PR DESCRIPTION
# 🔥 

~~This is a temporary workaround until we land the [types](https://github.com/Shopify/temp-project-mover-Archetypically-20250512095102/issues/160)~~ They landed in https://github.com/Shopify/ui-extensions/pull/2765

## Patches

- **Temporarily disable thrown error when types are undefined for a target**
- **Pin version for proper templates**
