### PR TITLE
Enable multi-memory with wasm-opt

### DIFF
--- a/.changeset/nice-dolls-pay.md
+++ b/.changeset/nice-dolls-pay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Enable multi-memory with wasm-opt

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -221,7 +221,16 @@ describe('runWasmOpt', () => {
     await expect(got).resolves.toBeUndefined()
     expect(exec).toHaveBeenCalledWith(
       'node',
-      [wasmOptBinary().name, modulePath, '-Oz', '--enable-bulk-memory', '--strip-debug', '-o', modulePath],
+      [
+        wasmOptBinary().name,
+        modulePath,
+        '-Oz',
+        '--enable-bulk-memory',
+        '--enable-multimemory',
+        '--strip-debug',
+        '-o',
+        modulePath,
+      ],
       {
         cwd: dirname(wasmOptBinary().path),
       },

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -230,6 +230,7 @@ export async function runWasmOpt(modulePath: string) {
     // pass these options to wasm-opt
     '-Oz',
     '--enable-bulk-memory',
+    '--enable-multimemory',
     '--strip-debug',
     // overwrite our existing module with the optimized version
     '-o',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-shopifyvm/issues/232

### WHAT is this pull request doing?

This PR enables multi-memory when running the `wasm-opt` command.

### How to test your changes?

- Build a JS function (not using multi-memory)
- Build a Rust function (not using multi-memory)
- Deploy app, verify that functions run as expected in Checkout

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
