### PR TITLE
Specific methods for patch app configuration file scenarios

### DIFF
--- a/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
+++ b/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
@@ -1,4 +1,9 @@
-import {patchAppConfigurationFile, patchAppHiddenConfigFile} from './patch-app-configuration-file.js'
+import {
+  patchAppHiddenConfigFile,
+  setAppConfigValue,
+  unsetAppConfigValue,
+  setManyAppConfigValues,
+} from './patch-app-configuration-file.js'
 import {getAppVersionedSchema} from '../../models/app/app.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
 import {readFile, writeFileSync, inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
@@ -32,150 +37,6 @@ function writeDefaulToml(tmpDir: string) {
   writeFileSync(configPath, defaultToml)
   return configPath
 }
-
-describe('patchAppConfigurationFile', () => {
-  test('updates existing configuration with new values and adds new top-levelfields, replaces arrays', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      const configPath = writeDefaulToml(tmpDir)
-      const patch = {
-        name: 'Updated App Name',
-        application_url: 'https://example.com',
-        access_scopes: {
-          use_legacy_install_flow: false,
-        },
-        auth: {
-          redirect_urls: ['https://example.com/redirect3', 'https://example.com/redirect4'],
-        },
-      }
-
-      await patchAppConfigurationFile({path: configPath, patch, schema})
-
-      const updatedTomlFile = await readFile(configPath)
-      expect(updatedTomlFile)
-        .toEqual(`# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
-
-client_id = "12345"
-name = "Updated App Name"
-application_url = "https://example.com"
-embedded = true
-
-[access_scopes]
-# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-use_legacy_install_flow = false
-
-[auth]
-redirect_urls = [
-  "https://example.com/redirect3",
-  "https://example.com/redirect4"
-]
-
-[webhooks]
-api_version = "2023-04"
-`)
-    })
-  })
-
-  test('Adds new table to the toml file', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      const configPath = writeDefaulToml(tmpDir)
-      const patch = {
-        application_url: 'https://example.com',
-        build: {
-          dev_store_url: 'example.myshopify.com',
-        },
-      }
-
-      await patchAppConfigurationFile({path: configPath, patch, schema})
-
-      const updatedTomlFile = await readFile(configPath)
-      expect(updatedTomlFile)
-        .toEqual(`# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
-
-client_id = "12345"
-name = "app1"
-application_url = "https://example.com"
-embedded = true
-
-[access_scopes]
-# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-use_legacy_install_flow = true
-
-[auth]
-redirect_urls = [
-  "https://example.com/redirect",
-  "https://example.com/redirect2"
-]
-
-[webhooks]
-api_version = "2023-04"
-
-[build]
-dev_store_url = "example.myshopify.com"
-`)
-    })
-  })
-
-  test('Adds a new field to a toml table, merging with exsisting values', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      const configPath = writeDefaulToml(tmpDir)
-      const patch = {
-        application_url: 'https://example.com',
-        access_scopes: {
-          scopes: 'read_products',
-        },
-      }
-
-      await patchAppConfigurationFile({path: configPath, patch, schema})
-
-      const updatedTomlFile = await readFile(configPath)
-      expect(updatedTomlFile)
-        .toEqual(`# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
-
-client_id = "12345"
-name = "app1"
-application_url = "https://example.com"
-embedded = true
-
-[access_scopes]
-# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-use_legacy_install_flow = true
-scopes = "read_products"
-
-[auth]
-redirect_urls = [
-  "https://example.com/redirect",
-  "https://example.com/redirect2"
-]
-
-[webhooks]
-api_version = "2023-04"
-`)
-    })
-  })
-
-  test('does not validate the toml if no schema is provided', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      const configPath = joinPath(tmpDir, 'shopify.app.toml')
-      writeFileSync(
-        configPath,
-        `
-random_toml_field = "random_value"
-`,
-      )
-      const patch = {name: 123}
-
-      await patchAppConfigurationFile({path: configPath, patch, schema: undefined})
-
-      const updatedTomlFile = await readFile(configPath)
-      expect(updatedTomlFile)
-        .toEqual(`# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
-
-random_toml_field = "random_value"
-name = 123
-`)
-    })
-  })
-})
 
 describe('patchAppHiddenConfigFile', () => {
   test('creates a new hidden config file when it does not exist', async () => {
@@ -254,6 +115,179 @@ describe('patchAppHiddenConfigFile', () => {
           dev_store_url: 'store-2.myshopify.com',
         },
       })
+    })
+  })
+})
+
+describe('setAppConfigValue', () => {
+  test('sets a top-level value in the configuration', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      await setAppConfigValue(configPath, 'name', 'Updated App Name', schema)
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).toContain('name = "Updated App Name"')
+    })
+  })
+
+  test('sets a nested value in the configuration', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      await setAppConfigValue(configPath, 'build.dev_store_url', 'example.myshopify.com', schema)
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).toContain('[build]')
+      expect(updatedTomlFile).toContain('dev_store_url = "example.myshopify.com"')
+    })
+  })
+
+  test('sets a deeply nested value in the configuration', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      await setAppConfigValue(configPath, 'build.auth.settings', true, schema)
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).toContain('[build.auth]')
+      expect(updatedTomlFile).toContain('settings = true')
+    })
+  })
+})
+
+describe('unsetAppConfigValue', () => {
+  test('unsets a top-level value in the configuration', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      await unsetAppConfigValue(configPath, 'name', schema)
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).not.toContain('name = "app1"')
+    })
+  })
+
+  test('unsets a nested value in existing table in the configuration', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      // Add a value first
+      await setAppConfigValue(configPath, 'build.dev_store_url', 'example.myshopify.com', schema)
+
+      // Now unset it
+      await unsetAppConfigValue(configPath, 'build.dev_store_url', schema)
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).toContain('[build]')
+      expect(updatedTomlFile).not.toContain('dev_store_url = "example.myshopify.com"')
+    })
+  })
+})
+
+describe('setManyAppConfigValues', () => {
+  test('sets multiple top-level values in the configuration', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      await setManyAppConfigValues(
+        configPath,
+        [
+          {keyPath: 'name', value: 'Updated App Name'},
+          {keyPath: 'client_id', value: '67890'},
+        ],
+        schema,
+      )
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).toContain('name = "Updated App Name"')
+      expect(updatedTomlFile).toContain('client_id = "67890"')
+    })
+  })
+
+  test('sets a mix of top-level and nested values in the configuration', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      await setManyAppConfigValues(
+        configPath,
+        [
+          {keyPath: 'name', value: 'Updated App Name'},
+          {keyPath: 'build.dev_store_url', value: 'example.myshopify.com'},
+        ],
+        schema,
+      )
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).toContain('name = "Updated App Name"')
+      expect(updatedTomlFile).toContain('[build]')
+      expect(updatedTomlFile).toContain('dev_store_url = "example.myshopify.com"')
+    })
+  })
+
+  test('properly handles array values in the configuration', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      await setManyAppConfigValues(
+        configPath,
+        [{keyPath: 'auth.redirect_urls', value: ['https://example.com/redirect3', 'https://example.com/redirect4']}],
+        schema,
+      )
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).toContain('[auth]')
+      expect(updatedTomlFile).toContain('redirect_urls = [')
+      expect(updatedTomlFile).toContain('"https://example.com/redirect3"')
+      expect(updatedTomlFile).toContain('"https://example.com/redirect4"')
+      expect(updatedTomlFile).not.toContain('"https://example.com/redirect"')
+      expect(updatedTomlFile).not.toContain('"https://example.com/redirect2"')
+    })
+  })
+
+  test('combines multiple nested keys into a single object structure', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      await setManyAppConfigValues(
+        configPath,
+        [
+          {keyPath: 'build.dev_store_url', value: 'example.myshopify.com'},
+          {keyPath: 'build.automatically_update_urls_on_dev', value: true},
+        ],
+        schema,
+      )
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).toContain('[build]')
+      expect(updatedTomlFile).toContain('dev_store_url = "example.myshopify.com"')
+      expect(updatedTomlFile).toContain('automatically_update_urls_on_dev = true')
+    })
+  })
+
+  test('updates existing configuration with new values and replaces arrays', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configPath = writeDefaulToml(tmpDir)
+
+      await setManyAppConfigValues(
+        configPath,
+        [
+          {keyPath: 'name', value: 'Updated App Name'},
+          {keyPath: 'application_url', value: 'https://example.com'},
+          {keyPath: 'access_scopes.use_legacy_install_flow', value: false},
+          {keyPath: 'auth.redirect_urls', value: ['https://example.com/redirect3', 'https://example.com/redirect4']},
+        ],
+        schema,
+      )
+
+      const updatedTomlFile = await readFile(configPath)
+      expect(updatedTomlFile).toContain('name = "Updated App Name"')
+      expect(updatedTomlFile).toContain('application_url = "https://example.com"')
+      expect(updatedTomlFile).toContain('use_legacy_install_flow = false')
+      expect(updatedTomlFile).toContain('redirect_urls = [')
+      expect(updatedTomlFile).toContain('"https://example.com/redirect3"')
+      expect(updatedTomlFile).toContain('"https://example.com/redirect4"')
+      expect(updatedTomlFile).not.toContain('"https://example.com/redirect"')
     })
   })
 })

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -3,7 +3,7 @@ import {fetchOrganizations} from './dev/fetch.js'
 import {ensureDeploymentIdsPresence} from './context/identifiers.js'
 import {createExtension} from './dev/create-extension.js'
 import {CachedAppInfo} from './local-storage.js'
-import {patchAppConfigurationFile} from './app/patch-app-configuration-file.js'
+import {setAppConfigValue, unsetAppConfigValue} from './app/patch-app-configuration-file.js'
 import {DeployOptions} from './deploy.js'
 import {isServiceAccount, isUserAccount} from './context/partner-account-info.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
@@ -212,8 +212,7 @@ async function removeIncludeConfigOnDeployField(localApp: AppInterface) {
   const includeConfigOnDeploy = configuration.build?.include_config_on_deploy
   if (includeConfigOnDeploy === undefined) return
 
-  const patch = {build: {include_config_on_deploy: undefined}}
-  await patchAppConfigurationFile({path: localApp.configuration.path, patch, schema: localApp.configSchema})
+  await unsetAppConfigValue(localApp.configuration.path, 'build.include_config_on_deploy', localApp.configSchema)
 
   includeConfigOnDeploy ? renderInfoAboutIncludeConfigOnDeploy() : renderWarningAboutIncludeConfigOnDeploy()
 }
@@ -251,8 +250,12 @@ async function promptIncludeConfigOnDeploy(options: ShouldOrPromptIncludeConfigD
     ...localConfiguration.build,
     include_config_on_deploy: shouldIncludeConfigDeploy,
   }
-  const patch = {build: {include_config_on_deploy: shouldIncludeConfigDeploy}}
-  await patchAppConfigurationFile({path: localConfiguration.path, patch, schema: options.localApp.configSchema})
+  await setAppConfigValue(
+    localConfiguration.path,
+    'build.include_config_on_deploy',
+    shouldIncludeConfigDeploy,
+    options.localApp.configSchema,
+  )
   await metadata.addPublicMetadata(() => ({cmd_deploy_confirm_include_config_used: shouldIncludeConfigDeploy}))
 }
 

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -24,7 +24,7 @@ import {DevProcessFunction} from './dev/processes/types.js'
 import {getCachedAppInfo, setCachedAppInfo} from './local-storage.js'
 import {canEnablePreviewMode} from './extensions/common.js'
 import {fetchAppRemoteConfiguration} from './app/select-app.js'
-import {patchAppConfigurationFile} from './app/patch-app-configuration-file.js'
+import {setAppConfigValue} from './app/patch-app-configuration-file.js'
 import {DevSessionStatusManager} from './dev/processes/dev-session/dev-session-status-manager.js'
 import {TunnelMode} from './dev/tunnel-mode.js'
 import {PortDetail, renderPortWarnings} from './dev/port-warnings.js'
@@ -112,8 +112,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
       ...app.configuration.build,
       dev_store_url: store.shopDomain,
     }
-    const patch = {build: {dev_store_url: store.shopDomain}}
-    await patchAppConfigurationFile({path: app.configuration.path, patch, schema: app.configSchema})
+    await setAppConfigValue(app.configuration.path, 'build.dev_store_url', store.shopDomain, app.configSchema)
   }
 
   if (!commandOptions.skipDependenciesInstallation && !app.usesWorkspaces) {
@@ -237,7 +236,7 @@ export async function warnIfScopesDifferBeforeDev({
 }
 
 async function actionsBeforeLaunchingDevProcesses(config: DevConfig) {
-  setPreviousAppId(config.commandOptions.directory, config.remoteApp.apiKey)
+  setCachedAppInfo({directory: config.commandOptions.directory, previousAppId: config.remoteApp.apiKey})
 
   await logMetadataForDev({
     devOptions: config.commandOptions,
@@ -519,8 +518,4 @@ async function validateCustomPorts(webConfigs: Web[], graphiqlPort: number) {
       }
     })(),
   ])
-}
-
-function setPreviousAppId(directory: string, apiKey: string) {
-  setCachedAppInfo({directory, previousAppId: apiKey})
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The current implementation of `patchAppConfigurationFile` is too broad, and we'll need something more specific if we want to switch out for a format preserving patcher.

### WHAT is this pull request doing?

This PR introduces three new, more intuitive functions for modifying app configuration:

1. `setAppConfigValue` - Sets a single value in the app configuration using a dotted path notation
2. `unsetAppConfigValue` - Removes a value from the app configuration
3. `setManyAppConfigValues` - Sets multiple values at once in the app configuration

The original `patchAppConfigurationFile` function is now marked as internal, and all existing usages have been updated to use the new functions. This provides a more declarative API for modifying configuration values.

### How to test your changes?

1. Run the test suite to verify all tests pass
2. Try using the CLI to modify app configuration values (e.g., `dev` command that updates URLs)
3. Verify that the TOML file is correctly updated with the expected values

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes