### PR TITLE
Use `PropertyPath` in path value methods

### DIFF
--- a/.changeset/funny-pots-visit.md
+++ b/.changeset/funny-pots-visit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Update `getPathValue`, `setPathValue`, and `unsetPathValue` to support the lodash `PropertyPath` type

--- a/packages/cli-kit/src/public/common/object.test.ts
+++ b/packages/cli-kit/src/public/common/object.test.ts
@@ -184,6 +184,17 @@ describe('getPathValue', () => {
     // Then
     expect(result).toBeUndefined()
   })
+
+  test('gets a property whose name contains dots using array notation', () => {
+    // Given
+    const obj: object = {'key1.with.dots': 'value'}
+
+    // When
+    const result = getPathValue(obj, ['key1.with.dots'])
+
+    // Then
+    expect(result).toEqual('value')
+  })
 })
 
 describe('setPathValue', () => {
@@ -241,6 +252,47 @@ describe('setPathValue', () => {
 
     // Then
     expect(getPathValue(result, 'key1')).toEqual({key11: 2})
+  })
+
+  test('set the path value using an array path notation', () => {
+    // Given
+    const obj: object = {
+      key1: {
+        key11: 3,
+      },
+    }
+
+    // When
+    const result = setPathValue(obj, ['key1', 'key11'], 4)
+
+    // Then
+    expect(getPathValue(result, 'key1.key11')).toEqual(4)
+  })
+
+  test('set a property whose name contains dots using array notation', () => {
+    // Given
+    const obj: object = {}
+
+    // When
+    const result = setPathValue(obj, ['key1.with.dots'], 'value')
+
+    // Then
+    expect(result).toEqual({'key1.with.dots': 'value'})
+    // Should NOT create a nested structure
+    expect(getPathValue(result, ['key1.with.dots'])).toEqual('value')
+    // Should be accessible as a top-level property
+    expect((result as {[key: string]: string})['key1.with.dots']).toEqual('value')
+  })
+
+  test('set nested property under a key that contains dots', () => {
+    // Given
+    const obj: object = {'key1.with.dots': {}}
+
+    // When
+    const result = setPathValue(obj, ['key1.with.dots', 'nested'], 'value')
+
+    // Then
+    expect(result).toEqual({'key1.with.dots': {nested: 'value'}})
   })
 })
 
@@ -357,5 +409,34 @@ describe('unsetPathValue', () => {
     // Then
     expect(result).toBeFalsy()
     expect(Object.prototype.hasOwnProperty.call(obj, 'key1')).toBeTruthy()
+  })
+
+  test('removes the path value using array path notation', () => {
+    // Given
+    const obj: object = {
+      key1: {
+        key11: 2,
+        key12: 3,
+      },
+    }
+
+    // When
+    const result = unsetPathValue(obj, ['key1', 'key11'])
+
+    // Then
+    expect(result).toBeTruthy()
+    expect(obj).toEqual({key1: {key12: 3}})
+  })
+
+  test('removes a property whose name contains dots using array notation', () => {
+    // Given
+    const obj: object = {'key1.with.dots': 'value', regular: 'value2'}
+
+    // When
+    const result = unsetPathValue(obj, ['key1.with.dots'])
+
+    // Then
+    expect(result).toBeTruthy()
+    expect(obj).toEqual({regular: 'value2'})
   })
 })

--- a/packages/cli-kit/src/public/common/object.ts
+++ b/packages/cli-kit/src/public/common/object.ts
@@ -1,6 +1,6 @@
 import {unionArrayStrategy} from '../../private/common/array.js'
 import deepMerge from 'deepmerge'
-import {Dictionary, ObjectIterator, ValueKeyIteratee} from 'lodash'
+import {Dictionary, ObjectIterator, PropertyPath, ValueKeyIteratee} from 'lodash'
 import lodashPickBy from 'lodash/pickBy.js'
 import lodashMapValues from 'lodash/mapValues.js'
 import lodashIsEqual from 'lodash/isEqual.js'
@@ -88,7 +88,7 @@ export function deepDifference(one: object, two: object): [object, object] {
  * @param path - The path of the property to get.
  * @returns - Returns the resolved value.
  */
-export function getPathValue<T = object>(object: object, path: string): T | undefined {
+export function getPathValue<T = object>(object: object, path: PropertyPath): T | undefined {
   return get(object, path) === undefined ? undefined : (get(object, path) as T)
 }
 
@@ -100,7 +100,7 @@ export function getPathValue<T = object>(object: object, path: string): T | unde
  * @param value - The value to set.
  * @returns - Returns object.
  */
-export function setPathValue(object: object, path: string, value?: unknown): object {
+export function setPathValue(object: object, path: PropertyPath, value?: unknown): object {
   return set(object, path, value)
 }
 
@@ -111,7 +111,7 @@ export function setPathValue(object: object, path: string, value?: unknown): obj
  * @param path - The path of the property to unset.
  * @returns - Returns true if the property is deleted or not found, else false.
  */
-export function unsetPathValue(object: object, path: string): boolean {
+export function unsetPathValue(object: object, path: PropertyPath): boolean {
   return unset(object, path)
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

The current implementation of path-based operations (`getPathValue`, `setPathValue`, `unsetPathValue`) doesn't support property names that contain dots. When using string paths, lodash interprets dots as path separators for nested objects, making it impossible to directly access properties whose names contain dots.

For example, attempting to access a property named `"some.property"` would be interpreted as trying to access `property` inside the `some` object, rather than accessing the property literally named `"some.property"`.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR updates the parameter types for `getPathValue`, `setPathValue`, and `unsetPathValue` to use lodash's `PropertyPath` type instead of just `string`. This enables using array notation (`['some.property']`) to access properties with dots in their names.

The changes include:
- Importing the `PropertyPath` type from lodash
- Updating the type signatures of the three affected functions
- Adding tests demonstrating how to work with property names containing dots

This approach maintains compatibility with the existing API while adding support for a previously unsupported use case.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
