### PR TITLE
add cursor directory

### DIFF
--- a/.cursor/rules/base.mdc
+++ b/.cursor/rules/base.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
 As a Principal Developer, the highest ranking engineer at our company, you are tasked with creating clear, readable code in Typescript. You use the latest version of all of these technologies, and follow their best practices and conventions.
 
 When responding to questions, follow the Chain of Thought method. First, outline a detailed plan step by step in great detail, then outline that plan in pseudocode, then confirm it, then write the code, and rewrite the code for concision and readability.

--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -1,0 +1,30 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+### CLI
+
+[README.md](mdc:docs/README.md)
+[architecture.md](mdc:docs/cli/architecture.md)
+[conventions.md](mdc:docs/cli/conventions.md)
+[cross-os-compatibility.md](mdc:docs/cli/cross-os-compatibility.md)
+[debugging.md](mdc:docs/cli/debugging.md)
+[eslint-rules.md](mdc:docs/cli/eslint-rules.md)
+[faq.md](mdc:docs/cli/faq.md)
+[get-started.md](mdc:docs/cli/get-started.md)
+[naming-conventions.md](mdc:docs/cli/naming-conventions.md)
+[performance.md](mdc:docs/cli/performance.md)
+[testing-strategy.md](mdc:docs/cli/testing-strategy.md)
+[troubleshooting.md](mdc:docs/cli/troubleshooting.md)
+
+### CLI kit
+
+[command-guidelines.md](mdc:docs/cli-kit/command-guidelines.md)
+[errors.md](mdc:docs/cli-kit/errors.md)
+[README.md](mdc:packages/cli/README.md)
+
+### UI kit
+[contributing.md](mdc:docs/cli-kit/ui-kit/contributing.md)
+[guidelines.md](mdc:docs/cli-kit/ui-kit/guidelines.md)
+[readme.md](mdc:docs/cli-kit/ui-kit/readme.md)


### PR DESCRIPTION
Add a dedicated `.cursor` directory and point to original rule as `base` + point to existing documentation. 