### PR TITLE
Automatically retry partners requests that fail with 401

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
@@ -102,7 +102,7 @@ describe('createApp', () => {
 
     // Then
     expect(got).toEqual({...APP1, newApp: true, developerPlatformClient: partnersClient})
-    expect(partnersRequest).toHaveBeenCalledWith(CreateAppQuery, 'token', variables, undefined)
+    expect(partnersRequest).toHaveBeenCalledWith(CreateAppQuery, 'token', variables, undefined, expect.any(Function))
   })
 
   test('creates an app with non-launchable defaults', async () => {
@@ -131,7 +131,7 @@ describe('createApp', () => {
 
     // Then
     expect(got).toEqual({...APP1, newApp: true, developerPlatformClient: partnersClient})
-    expect(partnersRequest).toHaveBeenCalledWith(CreateAppQuery, 'token', variables, undefined)
+    expect(partnersRequest).toHaveBeenCalledWith(CreateAppQuery, 'token', variables, undefined, expect.any(Function))
   })
 
   test('throws error if requests has a user error', async () => {
@@ -162,7 +162,13 @@ describe('fetchApp', async () => {
 
     // Then
     expect(got).toEqual({organization: partnerMarkedOrg, apps: [APP1, APP2], hasMorePages: false})
-    expect(partnersRequest).toHaveBeenCalledWith(FindOrganizationQuery, 'token', {id: ORG1.id}, undefined)
+    expect(partnersRequest).toHaveBeenCalledWith(
+      FindOrganizationQuery,
+      'token',
+      {id: ORG1.id},
+      undefined,
+      expect.any(Function),
+    )
   })
 
   test('throws if there are no organizations', async () => {
@@ -175,6 +181,12 @@ describe('fetchApp', async () => {
 
     // Then
     await expect(got).rejects.toThrowError(new NoOrgError(testPartnersUserSession.accountInfo))
-    expect(partnersRequest).toHaveBeenCalledWith(FindOrganizationQuery, 'token', {id: ORG1.id}, undefined)
+    expect(partnersRequest).toHaveBeenCalledWith(
+      FindOrganizationQuery,
+      'token',
+      {id: ORG1.id},
+      undefined,
+      expect.any(Function),
+    )
   })
 })

--- a/packages/cli-kit/src/public/node/api/admin.ts
+++ b/packages/cli-kit/src/public/node/api/admin.ts
@@ -65,7 +65,7 @@ export async function adminRequestDoc<TResult, TVariables extends Variables>(
   }
   let unauthorizedHandler
   if ('refresh' in session) {
-    unauthorizedHandler = session.refresh as () => Promise<void>
+    unauthorizedHandler = session.refresh as () => Promise<undefined>
   }
   const result = graphqlRequestDoc<TResult, TVariables>({
     ...opts,

--- a/packages/cli-kit/src/public/node/api/partners.ts
+++ b/packages/cli-kit/src/public/node/api/partners.ts
@@ -1,4 +1,11 @@
-import {graphqlRequest, GraphQLVariables, GraphQLResponse, graphqlRequestDoc, CacheOptions} from './graphql.js'
+import {
+  graphqlRequest,
+  GraphQLVariables,
+  GraphQLResponse,
+  graphqlRequestDoc,
+  CacheOptions,
+  RefreshTokenOnAuthorizedResponse,
+} from './graphql.js'
 import {addCursorAndFiltersToAppLogsUrl} from './utilities.js'
 import {partnersFqdn} from '../context/fqdn.js'
 import {setNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
@@ -42,6 +49,7 @@ async function setupRequest(token: string) {
  * @param token - Partners token.
  * @param variables - GraphQL variables to pass to the query.
  * @param cacheOptions - Cache options.
+ * @param refreshTokenOnAuthorizedResponse - Optional handler for unauthorized requests.
  * @returns The response of the query of generic type <T>.
  */
 export async function partnersRequest<T>(
@@ -49,6 +57,7 @@ export async function partnersRequest<T>(
   token: string,
   variables?: GraphQLVariables,
   cacheOptions?: CacheOptions,
+  refreshTokenOnAuthorizedResponse?: () => RefreshTokenOnAuthorizedResponse,
 ): Promise<T> {
   const opts = await setupRequest(token)
   const result = limiter.schedule(() =>
@@ -57,6 +66,7 @@ export async function partnersRequest<T>(
       query,
       variables,
       cacheOptions,
+      refreshTokenOnAuthorizedResponse,
     }),
   )
 
@@ -81,12 +91,14 @@ export const generateFetchAppLogUrl = async (
  * @param query - GraphQL query to execute.
  * @param token - Partners token.
  * @param variables - GraphQL variables to pass to the query.
+ * @param refreshTokenOnAuthorizedResponse - Optional handler for unauthorized requests.
  * @returns The response of the query of generic type <TResult>.
  */
 export async function partnersRequestDoc<TResult, TVariables extends Variables>(
   query: TypedDocumentNode<TResult, TVariables>,
   token: string,
   variables?: TVariables,
+  refreshTokenOnAuthorizedResponse?: () => RefreshTokenOnAuthorizedResponse,
 ): Promise<TResult> {
   try {
     const opts = await setupRequest(token)
@@ -95,6 +107,7 @@ export async function partnersRequestDoc<TResult, TVariables extends Variables>(
         ...opts,
         query,
         variables,
+        refreshTokenOnAuthorizedResponse,
       }),
     )
 


### PR DESCRIPTION
### WHY are these changes introduced?

To improve error handling in the Partners API client by adding support for token refresh when unauthorized responses are received.

### WHAT is this pull request doing?

Adds an unauthorized handler to the Partners API client that automatically refreshes the token when an unauthorized response is received. This prevents API requests from failing due to expired tokens by:

1. Adding an optional `unauthorizedHandler` parameter to `partnersRequest` and `partnersRequestDoc` functions
2. Creating a handler in the `PartnersClient` class that refreshes the token when needed
3. Updating tests to expect the new handler parameter

### Measuring impact

We should see an improvement in our internal command success metrics.

### Look out for

Do we need to increase the scope of this? Other services and such.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes