### PR TITLE
Improve type definition support for POLARIS_UNIFIED extensions

### DIFF
--- a/.changeset/big-singers-pump.md
+++ b/.changeset/big-singers-pump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Improve type definition support for POLARIS_UNIFIED extensions

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -2,7 +2,7 @@
 
 import {BaseConfigType, MAX_EXTENSION_HANDLE_LENGTH} from './schemas.js'
 import {FunctionConfigType} from './specifications/function.js'
-import {ExtensionFeature, ExtensionSpecification, SharedType} from './specification.js'
+import {ExtensionFeature, ExtensionSpecification} from './specification.js'
 import {SingleWebhookSubscriptionType} from './specifications/app_config_webhook_schemas/webhooks_schema.js'
 import {AppHomeSpecIdentifier} from './specifications/app_config_app_home.js'
 import {AppAccessSpecIdentifier} from './specifications/app_config_app_access.js'
@@ -437,8 +437,8 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     this.specification.patchWithAppDevURLs(this.configuration, urls)
   }
 
-  async contributeToSharedTypeFile(typeFilePath: string): Promise<SharedType[]> {
-    return this.specification.contributeToSharedTypeFile?.(this, typeFilePath) ?? []
+  async contributeToSharedTypeFile(typeDefinitionsByFile: Map<string, Set<string>>) {
+    await this.specification.contributeToSharedTypeFile?.(this, typeDefinitionsByFile)
   }
 
   private buildHandle() {

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -47,11 +47,6 @@ export interface Asset {
   content: string
 }
 
-export interface SharedType {
-  libraryRoot: string
-  definition: string
-}
-
 /**
  * Extension specification with all the needed properties and methods to load an extension.
  */
@@ -122,8 +117,8 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
 
   contributeToSharedTypeFile?: (
     extension: ExtensionInstance<TConfiguration>,
-    typeFilePath: string,
-  ) => Promise<SharedType[]>
+    typeDefinitionsByFile: Map<string, Set<string>>,
+  ) => Promise<void>
 }
 
 /**

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -984,11 +984,13 @@ Please check the configuration in ${uiExtension.configurationPath}`),
           apiVersion: '2025-07',
         })
 
-        // Add another target sharing the same tsconfig.json
+        // Add another target sharing the same tsconfig.json as the main target
         const otherTarget = 'admin.orders-details.block.render'
         const targetPath = joinPath(nodeModulesPath, otherTarget)
         await mkdir(targetPath)
         await writeFile(joinPath(targetPath, 'index.js'), '// Mock other target')
+        await writeFile(joinPath(tmpDir, 'src', 'another-target-module.jsx'), '// JSX code for other target')
+
         extension.configuration.extension_points.push({
           target: otherTarget,
           module: './src/another-target-module.jsx',

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -4,7 +4,7 @@ import {ExtensionInstance} from '../extension-instance.js'
 import {loadLocalExtensionsSpecifications} from '../load-specifications.js'
 import {placeholderAppConfiguration} from '../../app/app.test-data.js'
 import {AssetIdentifier} from '../specification.js'
-import {inTemporaryDirectory, touchFile, writeFile, readFile, mkdir} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, touchFile, writeFile, mkdir, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {err, ok} from '@shopify/cli-kit/node/result'
 import {zod} from '@shopify/cli-kit/node/schema'
@@ -706,7 +706,7 @@ Please check the configuration in ${uiExtension.configurationPath}`),
           apiVersion: '2025-07',
           extensionPoints: [
             {
-              target: 'admin.product-details.block.render',
+              target: 'admin.product-details.action.render',
               module: './src/ExtensionPointA.js',
               build_manifest: {
                 assets: {
@@ -729,11 +729,11 @@ Please check the configuration in ${uiExtension.configurationPath}`),
 
         // Then
         expect(stdInContent.main).toBe(
-          `import Target_0 from './src/ExtensionPointA.js';shopify.extend('admin.product-details.block.render', (...args) => Target_0(...args));`,
+          `import Target_0 from './src/ExtensionPointA.js';shopify.extend('admin.product-details.action.render', (...args) => Target_0(...args));`,
         )
 
         expect(stdInContent.assets!.find((asset) => asset.identifier === AssetIdentifier.ShouldRender)?.content).toBe(
-          `import shouldRender from './src/condition/should-render.js';shopify.extend('admin.product-details.block.should-render', (...args) => shouldRender(...args));`,
+          `import shouldRender from './src/condition/should-render.js';shopify.extend('admin.product-details.action.should-render', (...args) => shouldRender(...args));`,
         )
       })
     })
@@ -747,7 +747,7 @@ Please check the configuration in ${uiExtension.configurationPath}`),
           apiVersion: '2025-01',
           extensionPoints: [
             {
-              target: 'admin.product-details.block.render',
+              target: 'admin.product-details.action.render',
               module: './src/ExtensionPointA.js',
               build_manifest: {
                 assets: {
@@ -851,7 +851,7 @@ Please check the configuration in ${uiExtension.configurationPath}`),
     fileContent,
     shouldRenderFileContent,
     apiVersion,
-    target = 'admin.product-details.block.render',
+    target = 'admin.product-details.action.render',
   }: {
     tmpDir: string
     fileContent: string
@@ -866,10 +866,6 @@ Please check the configuration in ${uiExtension.configurationPath}`),
 
     await writeFile(filePath, fileContent)
 
-    // Create shopify.d.ts type file
-    const typeFilePath = joinPath(tmpDir, 'shopify.d.ts')
-    await writeFile(typeFilePath, '// Type definitions')
-
     // Create node_modules structure
     const nodeModulesPath = joinPath(tmpDir, 'node_modules', '@shopify', 'ui-extensions')
     await mkdir(nodeModulesPath)
@@ -877,9 +873,6 @@ Please check the configuration in ${uiExtension.configurationPath}`),
     const targetPath = joinPath(nodeModulesPath, target)
     await mkdir(targetPath)
     await writeFile(joinPath(targetPath, 'index.js'), '// Mock UI extension target')
-
-    const libraryPath = joinPath(nodeModulesPath, 'index.js')
-    await writeFile(libraryPath, '// Mock UI extension library')
 
     let shouldRenderFilePath
     if (shouldRenderFileContent) {
@@ -930,82 +923,177 @@ Please check the configuration in ${uiExtension.configurationPath}`),
     })
 
     return {
-      typeFilePath,
       filePath,
-      libraryPath,
       extension,
       shouldRenderFilePath,
+      nodeModulesPath,
     }
   }
 
   describe('contributeToSharedTypeFile', () => {
-    test('updates both main and should-render modules with type reference and returns shared types definition when api version supports Remote DOM', async () => {
+    test('sets the typeDefinitionsByFile map for both main and should-render modules when api version supports Remote DOM', async () => {
+      const typeDefinitionsByFile = new Map<string, Set<string>>()
+
       await inTemporaryDirectory(async (tmpDir) => {
-        const {extension, typeFilePath, filePath, libraryPath, shouldRenderFilePath} =
-          await setupUIExtensionWithNodeModules({
-            tmpDir,
-            fileContent: '// JSX code',
-            shouldRenderFileContent: '// JS code',
-            // Remote DOM supported version
-            apiVersion: '2025-07',
-          })
+        const {extension} = await setupUIExtensionWithNodeModules({
+          tmpDir,
+          fileContent: '// JSX code',
+          shouldRenderFileContent: '// JS code',
+          // Remote DOM supported version
+          apiVersion: '2025-07',
+        })
+        // Create tsconfig.json
+        const tsconfigPath = joinPath(tmpDir, 'tsconfig.json')
+        await writeFile(tsconfigPath, '// TypeScript config')
 
         // When
-        const result = await extension.contributeToSharedTypeFile?.(typeFilePath)
+        await extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)
+
+        const shopifyDtsPath = joinPath(tmpDir, 'shopify.d.ts')
 
         // Then
-        expect(result).toHaveLength(2)
-
-        // Main module types
-        const expectedDefinition = `//@ts-ignore\ndeclare module './src/index.jsx' {
-  const shopify: import('./node_modules/@shopify/ui-extensions/admin.product-details.block.render/index.js').Api;
+        expect(typeDefinitionsByFile).toStrictEqual(
+          new Map([
+            [
+              shopifyDtsPath,
+              new Set([
+                `//@ts-ignore\ndeclare module './src/index.jsx' {
+  const shopify: import('@shopify/ui-extensions/admin.product-details.action.render').Api;
   const globalThis: { shopify: typeof shopify };
-}\n`
-        expect(result[0]?.definition).toBe(expectedDefinition)
-        expect(result[0]?.libraryRoot.replace(/\\/g, '/')).toBe(libraryPath.replace(/\\/g, '/'))
-
-        // Check if the TS file was updated with reference
-        const moduleFileContent = await readFile(filePath)
-        expect(moduleFileContent.toString()).toContain('/// <reference types="../shopify.d.ts" />')
-
-        // Should-render module types
-        const expectedShouldRenderDefinition = `//@ts-ignore\ndeclare module './src/condition/should-render.js' {
-  const shopify: import('./node_modules/@shopify/ui-extensions/admin.product-details.block.should-render/index.js').Api;
+}\n`,
+                `//@ts-ignore\ndeclare module './src/condition/should-render.js' {
+  const shopify: import('@shopify/ui-extensions/admin.product-details.action.should-render').Api;
   const globalThis: { shopify: typeof shopify };
-}\n`
-        expect(result[1]?.definition).toBe(expectedShouldRenderDefinition)
-        expect(result[1]?.libraryRoot.replace(/\\/g, '/')).toBe(libraryPath.replace(/\\/g, '/'))
-
-        const shouldRenderFileContent = await readFile(shouldRenderFilePath!)
-        expect(shouldRenderFileContent.toString()).toContain('/// <reference types="../../shopify.d.ts" />')
+}\n`,
+              ]),
+            ],
+          ]),
+        )
       })
     })
 
-    test('throws error when and remove type reference when api version supports Remote DOM but type reference for target could not be found', async () => {
+    test('supports individual and shared tsconfig.json files when api version supports Remote DOM', async () => {
+      const typeDefinitionsByFile = new Map<string, Set<string>>()
+
       await inTemporaryDirectory(async (tmpDir) => {
-        const {extension, typeFilePath, filePath} = await setupUIExtensionWithNodeModules({
+        const {extension, nodeModulesPath} = await setupUIExtensionWithNodeModules({
           tmpDir,
-          fileContent: '/// <reference types="../shopify.d.ts" />\n// Preact code',
+          fileContent: '// JSX code',
+          shouldRenderFileContent: '// JS code',
+          // Remote DOM supported version
+          apiVersion: '2025-07',
+        })
+
+        // Add another target sharing the same tsconfig.json
+        const otherTarget = 'admin.orders-details.block.render'
+        const targetPath = joinPath(nodeModulesPath, otherTarget)
+        await mkdir(targetPath)
+        await writeFile(joinPath(targetPath, 'index.js'), '// Mock other target')
+        extension.configuration.extension_points.push({
+          target: otherTarget,
+          module: './src/another-target-module.jsx',
+          build_manifest: {
+            assets: {
+              main: {
+                module: './src/another-target-module.jsx',
+              },
+            } as any,
+          },
+        })
+
+        const mainModuleTsConfigPath = joinPath(tmpDir, 'tsconfig.json')
+        await writeFile(mainModuleTsConfigPath, '// TypeScript config')
+
+        const shouldRenderModuleTsConfigPath = joinPath(tmpDir, 'src', 'condition', 'tsconfig.json')
+        await writeFile(shouldRenderModuleTsConfigPath, '// TypeScript config')
+
+        // When
+        await extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)
+
+        // Then
+        expect(typeDefinitionsByFile).toStrictEqual(
+          new Map([
+            [
+              joinPath(tmpDir, 'shopify.d.ts'),
+              new Set([
+                `//@ts-ignore\ndeclare module './src/index.jsx' {
+  const shopify: import('@shopify/ui-extensions/admin.product-details.action.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}\n`,
+                `//@ts-ignore\ndeclare module './src/another-target-module.jsx' {
+  const shopify: import('@shopify/ui-extensions/admin.orders-details.block.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}\n`,
+              ]),
+            ],
+            [
+              joinPath(tmpDir, 'src', 'condition', 'shopify.d.ts'),
+              new Set([
+                `//@ts-ignore\ndeclare module './should-render.js' {
+  const shopify: import('@shopify/ui-extensions/admin.product-details.action.should-render').Api;
+  const globalThis: { shopify: typeof shopify };
+}\n`,
+              ]),
+            ],
+          ]),
+        )
+      })
+    })
+
+    test("throws error when when api version supports Remote DOM and there's a tsconfig.json but type reference for target could not be found", async () => {
+      const typeDefinitionsByFile = new Map<string, Set<string>>()
+
+      await inTemporaryDirectory(async (tmpDir) => {
+        const {extension} = await setupUIExtensionWithNodeModules({
+          tmpDir,
+          fileContent: '// Preact code',
+          // Remote DOM supported version
+          apiVersion: '2025-07',
+        })
+
+        // Create tsconfig.json file for testing
+        const mainModuleTsConfigPath = joinPath(tmpDir, 'tsconfig.json')
+        await writeFile(mainModuleTsConfigPath, '// TypeScript config')
+
+        // Change target to a target that does not exist in the library
+        extension.configuration.extension_points[0]!.target = 'admin.unknown.action.render'
+
+        // When
+        await expect(extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)).rejects.toThrow(
+          'Type reference for admin.unknown.action.render could not be found. You might be using the wrong @shopify/ui-extensions version. Fix the error by ensuring you install @shopify/ui-extensions@2025-07 in your dependencies.',
+        )
+
+        // No shopify.d.ts file should be created
+        expect(fileExistsSync(joinPath(tmpDir, 'shopify.d.ts'))).toBe(false)
+      })
+    })
+
+    test('does not throw error when when api version supports Remote DOM but there is no tsconfig.json', async () => {
+      const typeDefinitionsByFile = new Map<string, Set<string>>()
+
+      await inTemporaryDirectory(async (tmpDir) => {
+        const {extension} = await setupUIExtensionWithNodeModules({
+          tmpDir,
+          fileContent: '// Preact code',
           // Remote DOM supported version
           apiVersion: '2025-07',
         })
 
         // Change target to a target that does not exist in the library
         extension.configuration.extension_points[0]!.target = 'admin.unknown.action.render'
-        // Then
-        await expect(extension.contributeToSharedTypeFile?.(typeFilePath)).rejects.toThrow(
-          'Type reference for admin.unknown.action.render could not be found. You might be using the wrong @shopify/ui-extensions version. Fix the error by ensuring you install @shopify/ui-extensions@2025-07 in your dependencies.',
-        )
 
-        // TSX file should remain unchanged
-        const moduleFileContent = await readFile(filePath)
-        expect(moduleFileContent.toString()).toBe('// Preact code')
+        // When
+        await expect(extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)).resolves.not.toThrow()
+
+        // No shopify.d.ts file should be created
+        expect(fileExistsSync(joinPath(tmpDir, 'shopify.d.ts'))).toBe(false)
       })
     })
 
-    test('returns empty shared types definition and leaves file unchanged when api version does not support Remote DOM', async () => {
+    test('does not set the typeDefinitionsByFile map when api version does not support Remote DOM', async () => {
+      const typeDefinitionsByFile = new Map<string, Set<string>>()
       await inTemporaryDirectory(async (tmpDir) => {
-        const {extension, typeFilePath, filePath} = await setupUIExtensionWithNodeModules({
+        const {extension, filePath} = await setupUIExtensionWithNodeModules({
           tmpDir,
           fileContent: '// TypeScript React code',
           // Non-Remote DOM supported version
@@ -1013,14 +1101,13 @@ Please check the configuration in ${uiExtension.configurationPath}`),
         })
 
         // When
-        const result = await extension.contributeToSharedTypeFile?.(typeFilePath)
+        await extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)
 
         // Then
-        expect(result).toEqual([])
+        expect(typeDefinitionsByFile).toStrictEqual(new Map())
 
-        // TSX file should remain unchanged
-        const moduleFileContent = await readFile(filePath)
-        expect(moduleFileContent.toString()).toBe('// TypeScript React code')
+        // No shopify.d.ts file should be created
+        expect(fileExistsSync(joinPath(tmpDir, 'shopify.d.ts'))).toBe(false)
       })
     })
   })


### PR DESCRIPTION
### WHAT is this pull request doing?

Create a shopify.d.ts for each module that have a `tsconfig` to prevent JSX type collision between extensions.

### How to test your changes?

1. Checkout this branch 
1. Grab the relative path to the directory for an existing app (or create one using `pnpm create-app` if you don't have one)
1. Create a remote dom extension by running `POLARIS_UNIFIED=true pnpm shopify app generate extension --path <your-app-directory>`
1. Select an Admin Block extension
1. Run `pnpm shopify app dev --path <your-app-directory>`
1. Verify that runs successfully.
    NOTE: You will see errors relating to updating the drafts like "Error while updating drafts: "2025-07" is not a valid API version" - this is expected until `2025-07` is publicly available.
1. Open the remote-dom Block extension's TOML file and update the target
1. Verify that after you update the target the `shopify.extension.target` is typed to the new target. 
1. Verify that updating the target to be an `action` extension like `"admin.gift-card-details.action.render"` you get type errors for trying to use the `<s-admin-block>` element. 

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
