### PR TITLE
Add app:dev:clean command to stop app previews

### DIFF
--- a/packages/app/src/cli/commands/app/dev/clean.ts
+++ b/packages/app/src/cli/commands/app/dev/clean.ts
@@ -12,7 +12,7 @@ export default class DevClean extends AppCommand {
 
   static descriptionWithMarkdown = `Stop the app preview that was started with \`shopify app dev\`.
 
-  It restores the app active version to the selected development store.
+  It restores the app's active version to the selected development store.
   `
 
   static description = this.descriptionWithoutMarkdown()

--- a/packages/app/src/cli/commands/app/dev/clean.ts
+++ b/packages/app/src/cli/commands/app/dev/clean.ts
@@ -25,7 +25,7 @@ export default class DevClean extends AppCommand {
     store: Flags.string({
       hidden: false,
       char: 's',
-      description: 'Store URL. Must be an existing development or Shopify Plus sandbox store.',
+      description: 'Store URL. Must be an existing development store.',
       env: 'SHOPIFY_FLAG_STORE',
       parse: async (input) => normalizeStoreFqdn(input),
     }),
@@ -53,7 +53,7 @@ export default class DevClean extends AppCommand {
     renderSuccess({
       headline: 'App preview stopped.',
       body: [
-        `The app preview has been stopped on "${store.shopDomain}" and the app active version has been restored.`,
+        `The app preview has been stopped on "${store.shopDomain}" and the app's active version has been restored.`,
         'You can start it again with `shopify app dev`.',
       ],
     })

--- a/packages/app/src/cli/commands/app/dev/clean.ts
+++ b/packages/app/src/cli/commands/app/dev/clean.ts
@@ -17,6 +17,8 @@ export default class DevClean extends AppCommand {
 
   static description = this.descriptionWithoutMarkdown()
 
+  static hidden = true
+
   static flags = {
     ...globalFlags,
     ...appFlags,

--- a/packages/app/src/cli/commands/app/dev/clean.ts
+++ b/packages/app/src/cli/commands/app/dev/clean.ts
@@ -1,0 +1,61 @@
+import {linkedAppContext} from '../../../services/app-context.js'
+import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
+import {appFlags} from '../../../flags.js'
+import {storeContext} from '../../../services/store-context.js'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {Flags} from '@oclif/core'
+import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {renderSuccess} from '@shopify/cli-kit/node/ui'
+
+export default class DevClean extends AppCommand {
+  static summary = 'Cleans up the app preview from the selected store.'
+
+  static descriptionWithMarkdown = `Stop the app preview that was started with \`shopify app dev\`.
+
+  It restores the app active version to the selected development store.
+  `
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static flags = {
+    ...globalFlags,
+    ...appFlags,
+    store: Flags.string({
+      hidden: false,
+      char: 's',
+      description: 'Store URL. Must be an existing development or Shopify Plus sandbox store.',
+      env: 'SHOPIFY_FLAG_STORE',
+      parse: async (input) => normalizeStoreFqdn(input),
+    }),
+  }
+
+  public async run(): Promise<AppCommandOutput> {
+    const {flags} = await this.parse(DevClean)
+
+    const appContextResult = await linkedAppContext({
+      directory: flags.path,
+      clientId: flags['client-id'],
+      forceRelink: flags.reset,
+      userProvidedConfigName: flags.config,
+    })
+
+    const store = await storeContext({
+      appContextResult,
+      storeFqdn: flags.store,
+      forceReselectStore: flags.reset,
+    })
+
+    const client = appContextResult.developerPlatformClient
+    await client.devSessionDelete({shopFqdn: store.shopDomain, appId: appContextResult.remoteApp.id})
+
+    renderSuccess({
+      headline: 'App preview stopped.',
+      body: [
+        `The app preview has been stopped on "${store.shopDomain}" and the app active version has been restored.`,
+        'You can start it again with `shopify app dev`.',
+      ],
+    })
+
+    return {app: appContextResult.app}
+  }
+}

--- a/packages/app/src/cli/index.ts
+++ b/packages/app/src/cli/index.ts
@@ -26,6 +26,7 @@ import init from './hooks/clear_command_cache.js'
 import gatherPublicMetadata from './hooks/public_metadata.js'
 import gatherSensitiveMetadata from './hooks/sensitive_metadata.js'
 import AppCommand from './utilities/app-command.js'
+import DevClean from './commands/app/dev/clean.js'
 
 /**
  * All app commands should extend AppCommand.
@@ -34,6 +35,7 @@ export const commands: {[key: string]: typeof AppCommand} = {
   'app:build': Build,
   'app:deploy': Deploy,
   'app:dev': Dev,
+  'app:dev:clean': DevClean,
   'app:logs': Logs,
   'app:logs:sources': Sources,
   'app:import-extensions': ImportExtensions,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,6 +5,7 @@
 * [`shopify app config use [config] [flags]`](#shopify-app-config-use-config-flags)
 * [`shopify app deploy`](#shopify-app-deploy)
 * [`shopify app dev`](#shopify-app-dev)
+* [`shopify app dev clean`](#shopify-app-dev-clean)
 * [`shopify app env pull`](#shopify-app-env-pull)
 * [`shopify app env show`](#shopify-app-env-show)
 * [`shopify app function build`](#shopify-app-function-build)
@@ -272,6 +273,32 @@ DESCRIPTION
   a "staff account" (https://help.shopify.com/manual/your-account/staff-accounts) on the store. Staff accounts are
   created automatically the first time you access a development store with your Partner staff account through the
   Partner Dashboard.
+```
+
+## `shopify app dev clean`
+
+Stop the app.
+
+```
+USAGE
+  $ shopify app dev clean [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ] [-s
+    <value>] [--verbose]
+
+FLAGS
+  -c, --config=<value>     The name of the app configuration.
+  -s, --store=<value>      Store URL. Must be an existing development or Shopify Plus sandbox store.
+      --client-id=<value>  The Client ID of your app.
+      --no-color           Disable color output.
+      --path=<value>       The path to your app directory.
+      --reset              Reset all your settings.
+      --verbose            Increase the verbosity of the output.
+
+DESCRIPTION
+  Stop the app.
+
+  Stop the app preview that was started with `shopify app dev`.
+
+  It restores the app active version to the selected development store.
 ```
 
 ## `shopify app env pull`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,7 +5,6 @@
 * [`shopify app config use [config] [flags]`](#shopify-app-config-use-config-flags)
 * [`shopify app deploy`](#shopify-app-deploy)
 * [`shopify app dev`](#shopify-app-dev)
-* [`shopify app dev clean`](#shopify-app-dev-clean)
 * [`shopify app env pull`](#shopify-app-env-pull)
 * [`shopify app env show`](#shopify-app-env-show)
 * [`shopify app function build`](#shopify-app-function-build)
@@ -273,32 +272,6 @@ DESCRIPTION
   a "staff account" (https://help.shopify.com/manual/your-account/staff-accounts) on the store. Staff accounts are
   created automatically the first time you access a development store with your Partner staff account through the
   Partner Dashboard.
-```
-
-## `shopify app dev clean`
-
-Stop the app.
-
-```
-USAGE
-  $ shopify app dev clean [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ] [-s
-    <value>] [--verbose]
-
-FLAGS
-  -c, --config=<value>     The name of the app configuration.
-  -s, --store=<value>      Store URL. Must be an existing development or Shopify Plus sandbox store.
-      --client-id=<value>  The Client ID of your app.
-      --no-color           Disable color output.
-      --path=<value>       The path to your app directory.
-      --reset              Reset all your settings.
-      --verbose            Increase the verbosity of the output.
-
-DESCRIPTION
-  Stop the app.
-
-  Stop the app preview that was started with `shopify app dev`.
-
-  It restores the app active version to the selected development store.
 ```
 
 ## `shopify app env pull`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -600,8 +600,8 @@
       "args": {
       },
       "customPluginName": "@shopify/app",
-      "description": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app active version to the selected development store.\n  ",
-      "descriptionWithMarkdown": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app active version to the selected development store.\n  ",
+      "description": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
+      "descriptionWithMarkdown": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
       "flags": {
         "client-id": {
           "description": "The Client ID of your app.",
@@ -655,7 +655,7 @@
         },
         "store": {
           "char": "s",
-          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
+          "description": "Store URL. Must be an existing development store.",
           "env": "SHOPIFY_FLAG_STORE",
           "hasDynamicHelp": false,
           "hidden": false,

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -594,6 +594,94 @@
       "strict": true,
       "summary": "Run the app."
     },
+    "app:dev:clean": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "customPluginName": "@shopify/app",
+      "description": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app active version to the selected development store.\n  ",
+      "descriptionWithMarkdown": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app active version to the selected development store.\n  ",
+      "flags": {
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "client-id",
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "config",
+          "type": "option"
+        },
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "reset": {
+          "allowNo": false,
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "type": "boolean"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "store",
+          "type": "option"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [
+      ],
+      "id": "app:dev:clean",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Stop the app."
+    },
     "app:env:pull": {
       "aliases": [
       ],

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -673,6 +673,7 @@
         }
       },
       "hasDynamicHelp": false,
+      "hidden": true,
       "hiddenAliases": [
       ],
       "id": "app:dev:clean",
@@ -680,7 +681,7 @@
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Stop the app."
+      "summary": "Cleans up the app preview from the selected store."
     },
     "app:env:pull": {
       "aliases": [


### PR DESCRIPTION
### WHY are these changes introduced?

Add a new commend `app dev clean` to clean up app previews.

### WHAT is this pull request doing?

Adds a new hidden command `shopify app dev clean` that:
- Stops the app preview that was started with `shopify app dev`
- Restores the app active version to the selected development store

The command accepts the same flags as other app commands, including `--store` to specify which store to clean up from.

### How to test your changes?

1. Start an app preview with `shopify app dev`
2. Run `shopify app dev clean` to stop the preview
3. Verify that the success message appears and the app active version is restored

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes