### PR TITLE
Don't use cached config name when using `--reset`

### DIFF
--- a/.changeset/thirty-kings-add.md
+++ b/.changeset/thirty-kings-add.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix issue when using `--reset` not creating a new config toml file

--- a/packages/app/src/cli/services/app-context.test.ts
+++ b/packages/app/src/cli/services/app-context.test.ts
@@ -220,7 +220,7 @@ describe('linkedAppContext', () => {
       })
 
       // Then
-      expect(link).toHaveBeenCalledWith({directory: tmp, apiKey: undefined, configName: 'shopify.app.toml'})
+      expect(link).toHaveBeenCalledWith({directory: tmp, apiKey: undefined, configName: undefined})
     })
   })
 

--- a/packages/app/src/cli/services/app-context.ts
+++ b/packages/app/src/cli/services/app-context.ts
@@ -59,7 +59,9 @@ export async function linkedAppContext({
 
   // If the app is not linked, force a link.
   if (configState.state === 'template-only' || forceRelink) {
-    const result = await link({directory, apiKey: clientId, configName: configState.configurationFileName})
+    // If forceRelink is true, we don't want to use the cached config name and instead prompt the user for a new one.
+    const configName = forceRelink ? undefined : configState.configurationFileName
+    const result = await link({directory, apiKey: clientId, configName})
     remoteApp = result.remoteApp
     configState = result.state
   }


### PR DESCRIPTION
### WHY are these changes introduced?

When forcing a relink of an app, the system was still using the cached configuration file name, which made the overwrite the existing config.

Fixes https://github.com/Shopify/cli/issues/5653

### WHAT is this pull request doing?

Modifies the `linkedAppContext` function to set the `configName` to `undefined` when `forceRelink` is true, allowing users to be prompted for a new configuration file name instead of using the cached one.

### How to test your changes?

1. Run a command with `--reset`
2. Verify that you are prompted to select a configuration file name
3. Confirm that the new configuration file is used after relinking

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes