### PR TITLE
Add dependency on @shopify/toml-patch

### DIFF
--- a/.changeset/seven-jeans-run.md
+++ b/.changeset/seven-jeans-run.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': patch
+'@shopify/cli': patch
+---
+
+Added formatting and comment preserving TOML support via @shopify/toml-patch; opt-in by setting "SHOPIFY_CLI_USE_WASM_TOML_PATCH"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -59,6 +59,7 @@
     "@shopify/polaris-icons": "8.11.1",
     "@shopify/theme": "3.78.0",
     "@shopify/theme-check-node": "3.15.1",
+    "@shopify/toml-patch": "0.3.0",
     "body-parser": "1.20.3",
     "camelcase-keys": "9.1.3",
     "chokidar": "3.6.0",

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -5,6 +5,7 @@ export const environmentVariableNames = {
   enableAppLogPolling: 'SHOPIFY_CLI_ENABLE_APP_LOG_POLLING',
   templatesJsonPath: 'SHOPIFY_CLI_APP_TEMPLATES_JSON_PATH',
   mkcertBinaryPath: 'SHOPIFY_CLI_MKCERT_BINARY',
+  useWasmTomlPatch: 'SHOPIFY_CLI_USE_WASM_TOML_PATCH',
 }
 
 export const configurationFileNames = {

--- a/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
+++ b/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
@@ -6,9 +6,10 @@ import {
 } from './patch-app-configuration-file.js'
 import {getAppVersionedSchema} from '../../models/app/app.js'
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import {environmentVariableNames} from '../../constants.js'
 import {readFile, writeFileSync, inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {describe, expect, test} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 const defaultToml = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 client_id = "12345"
@@ -119,7 +120,15 @@ describe('patchAppHiddenConfigFile', () => {
   })
 })
 
-describe('setAppConfigValue', () => {
+describe.each([false, true])('unsetAppConfigValue (useWasmTomlPatch: %s)', (useWasmTomlPatch) => {
+  beforeEach(() => {
+    vi.stubEnv(environmentVariableNames.useWasmTomlPatch, useWasmTomlPatch.toString())
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   test('sets a top-level value in the configuration', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       const configPath = writeDefaulToml(tmpDir)
@@ -156,7 +165,15 @@ describe('setAppConfigValue', () => {
   })
 })
 
-describe('unsetAppConfigValue', () => {
+describe.each([false, true])('unsetAppConfigValue (useWasmTomlPatch: %s)', (useWasmTomlPatch) => {
+  beforeEach(() => {
+    vi.stubEnv(environmentVariableNames.useWasmTomlPatch, useWasmTomlPatch.toString())
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   test('unsets a top-level value in the configuration', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       const configPath = writeDefaulToml(tmpDir)
@@ -185,7 +202,15 @@ describe('unsetAppConfigValue', () => {
   })
 })
 
-describe('setManyAppConfigValues', () => {
+describe.each([false, true])('setManyAppConfigValues (useWasmTomlPatch: %s)', (useWasmTomlPatch) => {
+  beforeEach(() => {
+    vi.stubEnv(environmentVariableNames.useWasmTomlPatch, useWasmTomlPatch.toString())
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   test('sets multiple top-level values in the configuration', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       const configPath = writeDefaulToml(tmpDir)
@@ -194,14 +219,14 @@ describe('setManyAppConfigValues', () => {
         configPath,
         [
           {keyPath: 'name', value: 'Updated App Name'},
-          {keyPath: 'client_id', value: '67890'},
+          {keyPath: 'client_id', value: 'abcdef'},
         ],
         schema,
       )
 
       const updatedTomlFile = await readFile(configPath)
       expect(updatedTomlFile).toContain('name = "Updated App Name"')
-      expect(updatedTomlFile).toContain('client_id = "67890"')
+      expect(updatedTomlFile).toContain('client_id = "abcdef"')
     })
   })
 

--- a/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
+++ b/packages/app/src/cli/services/app/patch-app-configuration-file.test.ts
@@ -219,14 +219,14 @@ describe.each([false, true])('setManyAppConfigValues (useWasmTomlPatch: %s)', (u
         configPath,
         [
           {keyPath: 'name', value: 'Updated App Name'},
-          {keyPath: 'client_id', value: 'abcdef'},
+          {keyPath: 'client_id', value: '67890'},
         ],
         schema,
       )
 
       const updatedTomlFile = await readFile(configPath)
       expect(updatedTomlFile).toContain('name = "Updated App Name"')
-      expect(updatedTomlFile).toContain('client_id = "abcdef"')
+      expect(updatedTomlFile).toContain('client_id = "67890"')
     })
   })
 

--- a/packages/app/src/cli/services/app/patch-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/patch-app-configuration-file.ts
@@ -124,6 +124,9 @@ export async function setManyAppConfigValues(
  * @param schema - The schema to validate the patch against. If not provided, the toml will not be validated.
  */
 export async function unsetAppConfigValue(path: string, keyPath: string, schema?: zod.AnyZodObject) {
+  if (shouldUseWasmTomlPatch()) {
+    return patchAppConfigurationFileWithWasm(path, [{keyPath, value: undefined}])
+  }
   const patch = createPatchFromDottedPath(keyPath, undefined)
   await patchAppConfigurationFile({path, patch, schema})
 }

--- a/packages/app/src/cli/services/app/patch-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/patch-app-configuration-file.ts
@@ -1,14 +1,22 @@
 import {addDefaultCommentsToToml} from './write-app-configuration-file.js'
 import {AppHiddenConfig} from '../../models/app/app.js'
+import {environmentVariableNames} from '../../constants.js'
 import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 import {readFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {decodeToml, encodeToml} from '@shopify/cli-kit/node/toml'
+import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 
 export interface PatchTomlOptions {
   path: string
   patch: {[key: string]: unknown}
   schema?: zod.AnyZodObject
+}
+
+type TomlPatchValue = string | number | boolean | undefined | string[]
+
+function shouldUseWasmTomlPatch(env = process.env): boolean {
+  return isTruthy(env[environmentVariableNames.useWasmTomlPatch])
 }
 
 /**
@@ -42,6 +50,20 @@ async function patchAppConfigurationFile({path, patch, schema}: PatchTomlOptions
   await writeFile(path, encodedString)
 }
 
+async function patchAppConfigurationFileWithWasm(
+  path: string,
+  configValues: {keyPath: string; value: TomlPatchValue}[],
+) {
+  // Don't import WASM unless we are really using it.
+  const {updateTomlValues} = await import('./toml-patch-wasm.js')
+  const tomlContents = await readFile(path)
+  const updatedConfig = await updateTomlValues(
+    tomlContents,
+    configValues.map(({keyPath, value}) => [keyPath.split('.'), value]),
+  )
+  await writeFile(path, updatedConfig)
+}
+
 /**
  * Sets a single value in the app configuration file based on a dotted key path.
  *
@@ -50,7 +72,15 @@ async function patchAppConfigurationFile({path, patch, schema}: PatchTomlOptions
  * @param value - The value to set
  * @param schema - The schema to validate the patch against. If not provided, the toml will not be validated.
  */
-export async function setAppConfigValue(path: string, keyPath: string, value: unknown, schema?: zod.AnyZodObject) {
+export async function setAppConfigValue(
+  path: string,
+  keyPath: string,
+  value: TomlPatchValue,
+  schema?: zod.AnyZodObject,
+) {
+  if (shouldUseWasmTomlPatch()) {
+    return patchAppConfigurationFileWithWasm(path, [{keyPath, value}])
+  }
   const patch = createPatchFromDottedPath(keyPath, value)
   await patchAppConfigurationFile({path, patch, schema})
 }
@@ -72,9 +102,12 @@ export async function setAppConfigValue(path: string, keyPath: string, value: un
  */
 export async function setManyAppConfigValues(
   path: string,
-  configValues: {keyPath: string; value: unknown}[],
+  configValues: {keyPath: string; value: TomlPatchValue}[],
   schema?: zod.AnyZodObject,
 ) {
+  if (shouldUseWasmTomlPatch()) {
+    return patchAppConfigurationFileWithWasm(path, configValues)
+  }
   const patch = configValues.reduce((acc, {keyPath, value}) => {
     const valuePatch = createPatchFromDottedPath(keyPath, value)
     return deepMergeObjects(acc, valuePatch, replaceArrayStrategy)

--- a/packages/app/src/cli/services/app/toml-patch-wasm.test.ts
+++ b/packages/app/src/cli/services/app/toml-patch-wasm.test.ts
@@ -1,0 +1,50 @@
+import {updateTomlValues} from './toml-patch-wasm.js'
+import {describe, expect, test} from 'vitest'
+
+// Sample TOML content for testing
+const sampleToml = `
+# This is a sample TOML file
+title = "TOML Example"
+
+[owner]
+name = "Test User"
+organization = "Test Org"
+
+[database]
+server = "192.168.1.1"
+ports = [ 8001, 8001, 8002 ] # Comment after array
+enabled = true
+`
+
+describe('WASM TOML Patch Integration', () => {
+  test('updating TOML makes minimal changes and preserves as much as possible', async () => {
+    const output = await updateTomlValues(sampleToml, [
+      [['owner', 'dotted', 'notation'], 123.5],
+      [['database', 'server'], 'changed'],
+      [['top_level'], true],
+      [['owner', 'organization'], undefined],
+      [
+        ['database', 'backup_ports'],
+        [8003, 8004],
+      ],
+    ])
+
+    const expected = `
+# This is a sample TOML file
+title = "TOML Example"
+top_level = true
+
+[owner]
+name = "Test User"
+dotted.notation = 123.5
+
+[database]
+server = "changed"
+ports = [ 8001, 8001, 8002 ] # Comment after array
+enabled = true
+backup_ports = [8003, 8004]
+`
+
+    expect(output).toBe(expected)
+  })
+})

--- a/packages/app/src/cli/services/app/toml-patch-wasm.ts
+++ b/packages/app/src/cli/services/app/toml-patch-wasm.ts
@@ -1,0 +1,27 @@
+import * as tomlPatch from '@shopify/toml-patch'
+
+type TomlSingleValue = string | number | boolean | undefined
+
+function forPatch(value: TomlSingleValue): string {
+  return value?.toString() ?? '$undefined'
+}
+
+type TomlPatchValue = TomlSingleValue | TomlSingleValue[]
+
+/**
+ * Update the TOML content using the WASM module
+ * @param tomlContent - The TOML content to update
+ * @param patches - An array of tuples, each containing a dotted path and a value
+ * @returns The updated TOML content
+ */
+export async function updateTomlValues(tomlContent: string, patches: [string[], TomlPatchValue][]): Promise<string> {
+  const preparedPatches = patches.map(([path, value]) => {
+    if (Array.isArray(value)) {
+      return tomlPatch.patchArrayValues(path, value.map(forPatch))
+    } else {
+      return tomlPatch.patchSingleValue(path, forPatch(value))
+    }
+  })
+
+  return tomlPatch.updateTomlValues(tomlContent, preparedPatches)
+}

--- a/packages/app/src/cli/services/app/toml-patch-wasm.ts
+++ b/packages/app/src/cli/services/app/toml-patch-wasm.ts
@@ -1,12 +1,8 @@
 import * as tomlPatch from '@shopify/toml-patch'
 
-type TomlSingleValue = string | number | boolean | undefined
+type TomlSingleValue = string | number | boolean
 
-function forPatch(value: TomlSingleValue): string {
-  return value?.toString() ?? '$undefined'
-}
-
-type TomlPatchValue = TomlSingleValue | TomlSingleValue[]
+type TomlPatchValue = TomlSingleValue | TomlSingleValue[] | undefined
 
 /**
  * Update the TOML content using the WASM module
@@ -15,13 +11,5 @@ type TomlPatchValue = TomlSingleValue | TomlSingleValue[]
  * @returns The updated TOML content
  */
 export async function updateTomlValues(tomlContent: string, patches: [string[], TomlPatchValue][]): Promise<string> {
-  const preparedPatches = patches.map(([path, value]) => {
-    if (Array.isArray(value)) {
-      return tomlPatch.patchArrayValues(path, value.map(forPatch))
-    } else {
-      return tomlPatch.patchSingleValue(path, forPatch(value))
-    }
-  })
-
-  return tomlPatch.updateTomlValues(tomlContent, preparedPatches)
+  return tomlPatch.updateTomlValues(tomlContent, patches)
 }

--- a/packages/cli/bin/bundle.js
+++ b/packages/cli/bin/bundle.js
@@ -24,6 +24,8 @@ const external = [
 // yoga wasm file is not bundled by esbuild, so we need to copy it manually
 const yogafile = glob.sync('../../node_modules/.pnpm/**/yoga.wasm')[0]
 
+const wasmTomlPatchFile = glob.sync('../../node_modules/.pnpm/**/toml_patch_bg.wasm')[0]
+
 // Find theme-check-node's config yml files
 const themePath = require.resolve('@shopify/theme-check-node')
 const configYmlPath = joinPath(themePath, '..', '..', 'configs/*.yml')
@@ -89,6 +91,10 @@ esBuild({
         },
         {
           from: [yogafile],
+          to: ['./dist/'],
+        },
+        {
+          from: [wasmTomlPatchFile],
           to: ['./dist/'],
         },
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6635,8 +6635,8 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/toml-patch@0.2.0:
-    resolution: {integrity: sha512-k/5+ymXTu4WkAGkw8V5XYmRIgYCi2FjRjqFDPkH5KqqObKeQhhNFw43iySq9Del0fXQtVendNfFlzFKzCbI/Ag==}
+  /@shopify/toml-patch@0.3.0:
+    resolution: {integrity: sha512-ruv2FT17FW3CfWx8jXEyfx3xZDdo22PDaFQ9R7QYOovXQbgQCIKY+5QjGVBA7jsyLm+Wa2ngVANmt7MS0M/g+w==}
     dev: false
 
   /@shopify/useful-types@4.0.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@shopify/theme-check-node':
         specifier: 3.15.1
         version: 3.15.1
+      '@shopify/toml-patch':
+        specifier: 0.3.0
+        version: 0.3.0
       body-parser:
         specifier: 1.20.3
         version: 1.20.3
@@ -6630,6 +6633,10 @@ packages:
       vscode-uri: 3.0.8
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /@shopify/toml-patch@0.2.0:
+    resolution: {integrity: sha512-k/5+ymXTu4WkAGkw8V5XYmRIgYCi2FjRjqFDPkH5KqqObKeQhhNFw43iySq9Del0fXQtVendNfFlzFKzCbI/Ag==}
     dev: false
 
   /@shopify/useful-types@4.0.3:


### PR DESCRIPTION
### WHY are these changes introduced?

To improve TOML file manipulation by adding a WASM-based implementation for patching app configuration files.

### WHAT is this pull request doing?

- Adds `@shopify/toml-patch` dependency (v0.2.0) to handle TOML file modifications
- Adds a feature flag `SHOPIFY_CLI_USE_WASM_TOML_PATCH` to toggle between implementations. Off by default.

### How to test your changes?

1. Set the environment variable `SHOPIFY_CLI_USE_WASM_TOML_PATCH=true`
2. Make a new DP2 app
3. Edit the TOML file to put some formatting/comments in
4. Run `shopify app dev`
5. See that `automatically_update_urls_on_dev` is set -- i.e. the file is written to -- but your formatting is not broken
