### PR TITLE
Benchmarks for @shopify/toml-patch

### DIFF
--- a/packages/app/src/cli/services/app/toml-patch-wasm.bench.ts
+++ b/packages/app/src/cli/services/app/toml-patch-wasm.bench.ts
@@ -1,0 +1,71 @@
+import {replaceArrayStrategy} from './patch-app-configuration-file.js'
+import {updateTomlValues} from './toml-patch-wasm.js'
+import {decodeToml, encodeToml} from '@shopify/cli-kit/node/toml'
+import {deepMergeObjects} from '@shopify/cli-kit/common/object'
+import {describe, bench} from 'vitest'
+
+// Sample TOML content for testing
+const sampleToml = `
+# This is a sample TOML file
+title = "TOML Example"
+
+[owner]
+name = "Test User"
+organization = "Test Org"
+
+[database]
+server = "192.168.1.1"
+ports = [ 8001, 8001, 8002 ] # Comment after array
+enabled = true
+`
+
+function createPatchFromDottedPath(keyPath: string, value: unknown): {[key: string]: unknown} {
+  const keys = keyPath.split('.')
+  if (keys.length === 1) {
+    return {[keyPath]: value}
+  }
+
+  const obj: {[key: string]: unknown} = {}
+  let currentObj = obj
+
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i]
+    if (key) {
+      currentObj[key] = {}
+      currentObj = currentObj[key] as {[key: string]: unknown}
+    }
+  }
+
+  const lastKey = keys[keys.length - 1]
+  if (lastKey) {
+    currentObj[lastKey] = value
+  }
+
+  return obj
+}
+
+describe('WASM TOML Patch Integration', () => {
+  bench('time how long to update TOML, using WASM wrapper', async () => {
+    await updateTomlValues(sampleToml, [
+      [['owner', 'dotted', 'notation'], 123.5],
+      [['database', 'server'], 'changed'],
+      [['top_level'], true],
+    ])
+  })
+
+  bench('time how long to update TOML, using plain JS', async () => {
+    const configValues = [
+      ['owner.dotted.notation', 123.5],
+      ['database.server', 'changed'],
+      ['top_level', true],
+    ] as const
+    const patch = configValues.reduce((acc, [keyPath, value]) => {
+      const valuePatch = createPatchFromDottedPath(keyPath, value)
+      return deepMergeObjects(acc, valuePatch, replaceArrayStrategy)
+    }, {})
+
+    const configuration = decodeToml(sampleToml)
+    const updatedConfig = deepMergeObjects(configuration, patch, replaceArrayStrategy)
+    encodeToml(updatedConfig)
+  })
+})

--- a/packages/eslint-plugin-cli/config.js
+++ b/packages/eslint-plugin-cli/config.js
@@ -194,7 +194,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/*.test.ts', '**/*.test.tsx', '**/*.test-data.ts', '**/testing/*.{ts,tsx}'],
+      files: ['**/*.test.ts', '**/*.test.tsx', '**/*.test-data.ts', '**/testing/*.{ts,tsx}', '**/*.bench.ts'],
       rules: {
         '@typescript-eslint/no-explicit-any': 'off',
         'no-restricted-syntax': 'off',
@@ -213,6 +213,12 @@ module.exports = {
         '@typescript-eslint/non-nullable-type-assertion-style': 'off',
         '@typescript-eslint/prefer-reduce-type-parameter': 'warn',
         'no-restricted-globals': 'off',
+      },
+    },
+    {
+      files: ['**/*.bench.ts'],
+      rules: {
+        'vitest/consistent-test-it': 'off',
       },
     },
   ],


### PR DESCRIPTION
### WHY are these changes introduced?

To benchmark and compare the performance of two different approaches for updating TOML configuration files: a new WASM-based implementation versus the existing JavaScript implementation.

### WHAT is this pull request doing?

- Adds a benchmark file (`toml-patch-wasm.bench.ts`) to measure and compare the performance of TOML patching implementations

### How to test your changes?

Run the benchmark tests with `pnpm vitest bench`. It'll give a comparison between pure JS & WASM based patching. At time of writing they're roughly equivalent.