### PR TITLE
No action required for scope update

### DIFF
--- a/.changeset/nice-ducks-shop.md
+++ b/.changeset/nice-ducks-shop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Auto grant declared scopes during dev sessions. Replace action required message with information on granted scopes.

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -22,7 +22,7 @@ import {
 import {bundleThemeExtension} from '../../services/extensions/bundle.js'
 import {Identifiers} from '../app/identifiers.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
-import {AppConfigurationWithoutPath, CurrentAppConfiguration} from '../app/app.js'
+import {AppConfigurationWithoutPath} from '../app/app.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
 import {ok} from '@shopify/cli-kit/node/result'
 import {constantize, slugify} from '@shopify/cli-kit/common/string'
@@ -419,12 +419,9 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     }
   }
 
-  async getDevSessionActionUpdateMessage(
-    appConfig: CurrentAppConfiguration,
-    storeFqdn: string,
-  ): Promise<string | undefined> {
-    if (!this.specification.getDevSessionActionUpdateMessage) return undefined
-    return this.specification.getDevSessionActionUpdateMessage(this.configuration, appConfig, storeFqdn)
+  async getDevSessionUpdateMessage(): Promise<string | undefined> {
+    if (!this.specification.getDevSessionUpdateMessage) return undefined
+    return this.specification.getDevSessionUpdateMessage(this.configuration)
   }
 
   /**

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -4,7 +4,7 @@ import {ExtensionInstance} from './extension-instance.js'
 import {blocks} from '../../constants.js'
 
 import {Flag} from '../../utilities/developer-platform-client.js'
-import {AppConfigurationWithoutPath, CurrentAppConfiguration} from '../app/app.js'
+import {AppConfigurationWithoutPath} from '../app/app.js'
 import {loadLocalesConfig} from '../../utilities/extensions/locales-configuration.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
 import {Result} from '@shopify/cli-kit/node/result'
@@ -74,11 +74,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   buildValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   hasExtensionPointTarget?(config: TConfiguration, target: string): boolean
   appModuleFeatures: (config?: TConfiguration) => ExtensionFeature[]
-  getDevSessionActionUpdateMessage?: (
-    config: TConfiguration,
-    appConfig: CurrentAppConfiguration,
-    storeFqdn: string,
-  ) => Promise<string>
+  getDevSessionUpdateMessage?: (config: TConfiguration) => Promise<string>
   patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
 
   /**
@@ -190,7 +186,7 @@ export function createExtensionSpecification<TConfiguration extends BaseConfigTy
     reverseTransform: spec.transformRemoteToLocal,
     experience: spec.experience ?? 'extension',
     uidStrategy: spec.uidStrategy ?? (spec.experience === 'configuration' ? 'single' : 'uuid'),
-    getDevSessionActionUpdateMessage: spec.getDevSessionActionUpdateMessage,
+    getDevSessionUpdateMessage: spec.getDevSessionUpdateMessage,
   }
   const merged = {...defaults, ...spec}
 
@@ -235,11 +231,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
   appModuleFeatures?: (config?: TConfiguration) => ExtensionFeature[]
   transformConfig: TransformationConfig | CustomTransformationConfig
   uidStrategy?: UidStrategy
-  getDevSessionActionUpdateMessage?: (
-    config: TConfiguration,
-    appConfig: CurrentAppConfiguration,
-    storeFqdn: string,
-  ) => Promise<string>
+  getDevSessionUpdateMessage?: (config: TConfiguration) => Promise<string>
   patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
 }): ExtensionSpecification<TConfiguration> {
   const appModuleFeatures = spec.appModuleFeatures ?? (() => [])
@@ -253,7 +245,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
     transformRemoteToLocal: resolveReverseAppConfigTransform(spec.schema, spec.transformConfig),
     experience: 'configuration',
     uidStrategy: spec.uidStrategy ?? 'single',
-    getDevSessionActionUpdateMessage: spec.getDevSessionActionUpdateMessage,
+    getDevSessionUpdateMessage: spec.getDevSessionUpdateMessage,
     patchWithAppDevURLs: spec.patchWithAppDevURLs,
   })
 }

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
@@ -74,4 +74,57 @@ describe('app_config_app_access', () => {
       })
     })
   })
+
+  describe('getDevSessionUpdateMessage', () => {
+    test('should return message with scopes when scopes are provided', async () => {
+      // Given
+      const config = {
+        access_scopes: {
+          scopes: 'read_products,write_products',
+        },
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
+      }
+
+      // When
+      const result = await spec.getDevSessionUpdateMessage!(config)
+
+      // Then
+      expect(result).toBe('Access scopes auto-granted: read_products, write_products')
+    })
+
+    test('should return message with required_scopes when only required_scopes are provided', async () => {
+      // Given
+      const config = {
+        access_scopes: {
+          required_scopes: ['write_orders', 'read_inventory'],
+        },
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
+      }
+
+      // When
+      const result = await spec.getDevSessionUpdateMessage!(config)
+
+      // Then
+      expect(result).toBe('Access scopes auto-granted: write_orders, read_inventory')
+    })
+
+    test('should return default message when no scopes are provided', async () => {
+      // Given
+      const config = {
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
+      }
+
+      // When
+      const result = await spec.getDevSessionUpdateMessage!(config)
+
+      // Then
+      expect(result).toBe('App has been installed')
+    })
+  })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -1,8 +1,6 @@
-import {buildAppURLForWeb} from '../../../utilities/app/app-url.js'
 import {validateUrl} from '../../app/validation/common.js'
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {BaseSchema} from '../schemas.js'
-import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {normalizeDelimitedString} from '@shopify/cli-kit/common/string'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -48,9 +46,15 @@ const appAccessSpec = createConfigExtensionSpecification({
   identifier: AppAccessSpecIdentifier,
   schema: AppAccessSchema,
   transformConfig: AppAccessTransformConfig,
-  getDevSessionActionUpdateMessage: async (_, appConfig, storeFqdn) => {
-    const scopesURL = await buildAppURLForWeb(storeFqdn, appConfig.client_id)
-    return outputContent`Scopes updated. ${outputToken.link('Open app to accept scopes.', scopesURL)}`.value
+  getDevSessionUpdateMessage: async (config) => {
+    const scopesString = config.access_scopes?.scopes
+      ? config.access_scopes.scopes
+          .split(',')
+          .map((scope) => scope.trim())
+          .join(', ')
+      : config.access_scopes?.required_scopes?.join(', ')
+
+    return scopesString ? `Access scopes auto-granted: ${scopesString}` : `App has been installed`
   },
   patchWithAppDevURLs: (config, urls) => {
     if (urls.redirectUrlWhitelist) {

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.test.ts
@@ -164,15 +164,15 @@ describe('DevSessionLogger', () => {
     })
   })
 
-  describe('logActionRequiredMessages', () => {
+  describe('logExtensionUpdateMessages', () => {
     test('does nothing when no event is provided', async () => {
-      await logger.logActionRequiredMessages('test.myshopify.com')
+      await logger.logExtensionUpdateMessages()
       expect(output).toMatchInlineSnapshot(`[]`)
     })
 
-    test('logs warning messages when actions are required', async () => {
+    test('logs messages', async () => {
       const mockExtension = {
-        getDevSessionActionUpdateMessage: vi.fn().mockResolvedValue('Action required message'),
+        getDevSessionUpdateMessage: vi.fn().mockResolvedValue('This has been updated.'),
         entrySourceFilePath: '',
         devUUID: '',
         localIdentifier: '',
@@ -191,11 +191,10 @@ describe('DevSessionLogger', () => {
         startTime: [0, 0],
       }
 
-      await logger.logActionRequiredMessages('test.myshopify.com', event)
+      await logger.logExtensionUpdateMessages(event)
       expect(output).toMatchInlineSnapshot(`
         [
-          "[33m🔄 Action required[39m",
-          "[33m└ Action required message[39m",
+          "└  This has been updated.",
         ]
       `)
     })

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
@@ -180,7 +180,7 @@ describe('pushUpdatesForDevSession', () => {
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Update error'))
   })
 
-  test('handles scope changes and displays action required message', async () => {
+  test('handles scope changes and displays updated message', async () => {
     // Given
     vi.mocked(buildAppURLForWeb).mockResolvedValue('https://test.myshopify.com/admin/apps/test')
     const appAccess = await testAppAccessConfigExtension()
@@ -196,8 +196,10 @@ describe('pushUpdatesForDevSession', () => {
 
     // Then
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated'))
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Action required'))
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Scopes updated'))
+    expect(stdout.write).toHaveBeenCalledWith(
+      expect.stringContaining('Access scopes auto-granted: read_products, write_products'),
+    )
+
     expect(contextSpy).toHaveBeenCalledWith({outputPrefix: 'app-preview', stripAnsi: false}, expect.anything())
     contextSpy.mockRestore()
   })

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
@@ -162,11 +162,12 @@ export class DevSession {
   private async handleDevSessionResult(result: DevSessionResult, event?: AppEvent) {
     if (result.status === 'updated') {
       await this.logger.success(`✅ Updated`)
-      await this.logger.logActionRequiredMessages(this.options.storeFqdn, event)
+      await this.logger.logExtensionUpdateMessages(event)
       await this.setUpdatedStatusMessage()
     } else if (result.status === 'created') {
       this.statusManager.updateStatus({isReady: true})
       await this.logger.success(`✅ Ready, watching for changes in your app `)
+      await this.logger.logExtensionUpdateMessages(event)
       this.statusManager.setMessage('READY')
     } else if (result.status === 'aborted') {
       await this.logger.debug('❌ App preview update aborted (new change detected or error during update)')


### PR DESCRIPTION
### WHY are these changes introduced?

For:
- https://github.com/shop/issues-app-access/issues/715

Depends on PR:
- https://app.graphite.dev/github/pr/shop/world/41406/Support-dev-session-auto-update-ApiPermission-scopes

# Remove "Action required" message for scope updates

| Before | After |
| -- | -- |
|![action-required-for-scope-update.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0ulauwH3MAngKQbIjk2w/4fdf641b-fedf-4b21-9529-148e64332b44.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0ulauwH3MAngKQbIjk2w/58d2ddd8-39fc-4eb9-afea-f2cb1ea3998d.png)|

### WHAT is this pull request doing?

Removes the "Action required" message and link that appears when app scopes are updated during development. 

### How to test your changes?

1. Start a dev session for an app
2. Update the app's scopes in the app TOML in include new scopes
3. See the `action required` message no longer exists

[See video demo in this PR](https://app.graphite.dev/github/pr/shop/world/41406/Support-dev-session-auto-update-ApiPermission-scopes)