### PR TITLE
Remember randomly selected ports, and don't reuse them

### DIFF
--- a/packages/cli-kit/src/public/node/tcp.test.ts
+++ b/packages/cli-kit/src/public/node/tcp.test.ts
@@ -56,4 +56,15 @@ describe('getAvailableTCPPort', () => {
     // Then
     expect(got).toBe(5)
   })
+
+  test('reserves random ports and does not reuse them', async () => {
+    vi.mocked(port.checkPort).mockResolvedValue(false)
+    vi.mocked(port.getRandomPort).mockResolvedValueOnce(55).mockResolvedValueOnce(55).mockResolvedValueOnce(66)
+
+    let got = await getAvailableTCPPort(123)
+    expect(got).toBe(55)
+
+    got = await getAvailableTCPPort(123)
+    expect(got).toBe(66)
+  })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

To prevent port conflicts when multiple processes request random TCP ports in quick succession. If a caller doesn't use a port immediately, a duplicate random port can be chosen.

### WHAT is this pull request doing?

Enhances the `getAvailableTCPPort` function to track previously obtained random ports and ensure they aren't reused within the same process. This is accomplished by:

1. Adding a `obtainedRandomPorts` Set to keep track of ports that have been assigned
2. Adding logic to check if a random port has already been obtained and retry if necessary
3. Adding the obtained port to the tracking Set before returning it

Added a test case to verify that random ports are not reused.