### PR TITLE
Github releases and Cloudlared should be downloaded on the slow pathway

### DIFF
--- a/.changeset/plenty-bananas-fly.md
+++ b/.changeset/plenty-bananas-fly.md
@@ -1,0 +1,6 @@
+---
+'@shopify/plugin-cloudflare': patch
+'@shopify/cli-kit': patch
+---
+
+Fix a bug with binary downloads timing out

--- a/packages/cli-kit/src/public/node/github.test.ts
+++ b/packages/cli-kit/src/public/node/github.test.ts
@@ -190,7 +190,11 @@ describe('downloadGitHubRelease', () => {
 
     await downloadGitHubRelease(repo, version, asset, targetPath)
 
-    expect(fetch).toHaveBeenCalledWith(`https://github.com/${repo}/releases/download/${version}/${asset}`)
+    expect(fetch).toHaveBeenCalledWith(
+      `https://github.com/${repo}/releases/download/${version}/${asset}`,
+      undefined,
+      'slow-request',
+    )
 
     const downloadedContent = await readFile(targetPath)
     expect(downloadedContent).toEqual('hello')

--- a/packages/cli-kit/src/public/node/github.ts
+++ b/packages/cli-kit/src/public/node/github.ts
@@ -143,7 +143,7 @@ export async function downloadGitHubRelease(
       const tempPath = joinPath(tmpDir, assetName)
       let response: Response
       try {
-        response = await fetch(url)
+        response = await fetch(url, undefined, 'slow-request')
         if (!response.ok) {
           throw new AbortError(`Failed to download ${assetName}: ${response.statusText}`)
         }

--- a/packages/plugin-cloudflare/src/install-cloudflared.test.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.test.ts
@@ -44,6 +44,7 @@ describe('install-cloudflare', () => {
     expect(http.fetch).toHaveBeenCalledWith(
       'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-darwin-amd64.tgz',
       expect.anything(),
+      'slow-request',
     )
   })
 
@@ -58,6 +59,7 @@ describe('install-cloudflare', () => {
     expect(http.fetch).toHaveBeenCalledWith(
       'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-darwin-arm64.tgz',
       expect.anything(),
+      'slow-request',
     )
   })
 
@@ -72,6 +74,7 @@ describe('install-cloudflare', () => {
     expect(http.fetch).toHaveBeenCalledWith(
       'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-linux-amd64',
       expect.anything(),
+      'slow-request',
     )
   })
 
@@ -86,6 +89,7 @@ describe('install-cloudflare', () => {
     expect(http.fetch).toHaveBeenCalledWith(
       'https://github.com/cloudflare/cloudflared/releases/download/2024.8.2/cloudflared-windows-amd64.exe',
       expect.anything(),
+      'slow-request',
     )
   })
 

--- a/packages/plugin-cloudflare/src/install-cloudflared.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.ts
@@ -143,7 +143,7 @@ async function downloadFile(url: string, to: string) {
     mkdirSync(dirname(to))
   }
   const streamPipeline = util.promisify(pipeline)
-  const response = await fetch(url, {redirect: 'follow'})
+  const response = await fetch(url, {redirect: 'follow'}, 'slow-request')
   if (!response.ok || !response.body)
     throw new Error(`Couldn't download file ${url} (${response.status} ${response.statusText})`)
   const fileObject = createFileWriteStream(to)


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the handling of slow network requests when downloading GitHub releases and Cloudflare files. These should never time out.