### PR TITLE
Move metafields out of the BaseSchema

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -207,7 +207,7 @@ export const placeholderAppConfiguration: AppConfigurationWithoutPath = {scopes:
 
 export async function testUIExtension(
   uiExtension: Omit<Partial<ExtensionInstance>, 'configuration'> & {
-    configuration?: Partial<BaseConfigType> & {path?: string}
+    configuration?: Partial<BaseConfigType> & {path?: string} & {metafields?: {namespace: string; key: string}[]}
   } = {},
 ): Promise<ExtensionInstance> {
   const directory = uiExtension?.directory ?? '/tmp/project/extensions/test-ui-extension'
@@ -565,7 +565,6 @@ function defaultFunctionConfiguration(): FunctionConfigType {
     },
     api_version: '2022-07',
     configuration_ui: true,
-    metafields: [],
   }
 }
 

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -5,7 +5,7 @@ export const MAX_EXTENSION_HANDLE_LENGTH = 50
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ZodSchemaType<T> = zod.ZodType<T, any, any>
 
-const MetafieldSchema = zod.object({
+export const MetafieldSchema = zod.object({
   namespace: zod.string(),
   key: zod.string(),
 })
@@ -98,7 +98,6 @@ export const BaseSchema = zod.object({
   api_version: ApiVersionSchema.optional(),
   extension_points: zod.any().optional(),
   capabilities: CapabilitiesSchema.optional(),
-  metafields: zod.array(MetafieldSchema).optional(),
   settings: SettingsSchema.optional(),
 })
 

--- a/packages/app/src/cli/models/extensions/specifications/checkout_post_purchase.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_post_purchase.ts
@@ -1,13 +1,18 @@
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {createExtensionSpecification} from '../specification.js'
+import {zod} from '@shopify/cli-kit/node/schema'
 
 const dependency = '@shopify/post-purchase-ui-extensions'
+
+const CheckoutPostPurchaseSchema = BaseSchema.extend({
+  metafields: zod.array(MetafieldSchema).optional(),
+})
 
 const checkoutPostPurchaseSpec = createExtensionSpecification({
   identifier: 'checkout_post_purchase',
   dependency,
   partnersWebIdentifier: 'post_purchase',
-  schema: BaseSchema,
+  schema: CheckoutPostPurchaseSchema,
   appModuleFeatures: (_) => ['ui_preview', 'bundling', 'cart_url', 'esbuild', 'single_js_entry_path'],
   deployConfig: async (config, _) => {
     return {metafields: config.metafields ?? []}

--- a/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
@@ -1,5 +1,5 @@
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -8,6 +8,7 @@ const dependency = '@shopify/checkout-ui-extensions'
 const CheckoutSchema = BaseSchema.extend({
   name: zod.string(),
   extension_points: zod.array(zod.string()).optional(),
+  metafields: zod.array(MetafieldSchema).optional(),
   settings: zod
     .object({
       fields: zod.any().optional(),

--- a/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.ts
+++ b/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.ts
@@ -1,5 +1,5 @@
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {createExtensionSpecification} from '../specification.js'
 import {err, ok} from '@shopify/cli-kit/node/result'
 import {zod} from '@shopify/cli-kit/node/schema'
@@ -16,6 +16,7 @@ const EditorExtensionCollectionSchema = BaseSchema.extend({
   name: zod.string(),
   include: zod.array(IncludeSchema).optional(),
   includes: zod.array(zod.string()).optional(),
+  metafields: zod.array(MetafieldSchema).optional(),
   type: zod.literal('editor_extension_collection'),
 }).transform((data) => {
   const includes =

--- a/packages/app/src/cli/models/extensions/specifications/flow_action.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_action.ts
@@ -1,4 +1,4 @@
-import {BaseSchemaWithHandle} from '../schemas.js'
+import {BaseSchemaWithHandle, MetafieldSchema} from '../schemas.js'
 import {createExtensionSpecification} from '../specification.js'
 import {
   validateFieldShape,
@@ -19,6 +19,7 @@ const FlowActionExtensionSchema = BaseSchemaWithHandle.extend({
   config_page_preview_url: zod.string().url().refine(startsWithHttps).optional(),
   schema: zod.string().optional(),
   return_type_ref: zod.string().optional(),
+  metafields: zod.array(MetafieldSchema).optional(),
 }).refine((config) => {
   const configurationPageIsValid = validateCustomConfigurationPageConfig(
     config.config_page_url,

--- a/packages/app/src/cli/models/extensions/specifications/flow_template.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_template.ts
@@ -1,4 +1,4 @@
-import {BaseSchemaWithHandle} from '../schemas.js'
+import {BaseSchemaWithHandle, MetafieldSchema} from '../schemas.js'
 import {createExtensionSpecification} from '../specification.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -42,6 +42,7 @@ const FlowTemplateExtensionSchema = BaseSchemaWithHandle.extend({
     discoverable: zod.boolean().optional(),
     allow_one_click_activate: zod.boolean().optional(),
     enabled: zod.boolean().optional(),
+    metafields: zod.array(MetafieldSchema).optional(),
   }),
 })
 

--- a/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
@@ -1,5 +1,5 @@
 import {loadSchemaFromPath} from '../../../services/flow/utils.js'
-import {BaseSchemaWithHandle, FieldSchema} from '../schemas.js'
+import {BaseSchemaWithHandle, FieldSchema, MetafieldSchema} from '../schemas.js'
 import {createExtensionSpecification} from '../specification.js'
 import {validateFieldShape, validateTriggerSchemaPresence} from '../../../services/flow/validation.js'
 import {serializeFields} from '../../../services/flow/serialize-fields.js'
@@ -18,6 +18,7 @@ const FlowTriggerExtensionSchema = BaseSchemaWithHandle.extend({
   type: zod.literal('flow_trigger'),
   name: zod.string(),
   schema: zod.string().optional(),
+  metafields: zod.array(MetafieldSchema).optional(),
   settings: zod
     .object({
       fields: zod.array(FlowTriggerSettingsSchema).optional(),

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -1,5 +1,5 @@
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -30,6 +30,7 @@ const FunctionExtensionSchema = BaseSchema.extend({
   name: zod.string(),
   type: zod.string(),
   configuration_ui: zod.boolean().optional().default(true),
+  metafields: zod.array(MetafieldSchema).optional(),
   ui: zod
     .object({
       enable_create: zod.boolean().optional(),

--- a/packages/app/src/cli/models/extensions/specifications/marketing_activity_schemas/marketing_activity_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/marketing_activity_schemas/marketing_activity_schema.ts
@@ -1,4 +1,4 @@
-import {BaseSchema} from '../../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const BaseFieldSchema = zod.object({
@@ -122,6 +122,7 @@ export const MarketingActivityExtensionSchema = BaseSchema.extend({
   title: zod.string().min(1),
   description: zod.string().min(1),
   api_path: zod.string(),
+  metafields: zod.array(MetafieldSchema).optional(),
   tactic: zod.enum([
     'ad',
     'retargeting',

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
@@ -1,4 +1,4 @@
-import {BaseSchema} from '../../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const MAX_LABEL_SIZE = 50
@@ -28,7 +28,7 @@ export const BasePaymentsAppExtensionSchema = BaseSchema.extend({
   supported_payment_methods: zod.array(zod.string()),
 
   test_mode_available: zod.boolean(),
-
+  metafields: zod.array(MetafieldSchema).optional(),
   merchant_label: zod.string().max(MAX_LABEL_SIZE),
 
   input: zod

--- a/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
@@ -1,6 +1,6 @@
 import {getDependencyVersion} from '../../app/app.js'
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {BugError} from '@shopify/cli-kit/node/error'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -9,7 +9,10 @@ const dependency = '@shopify/retail-ui-extensions'
 const posUISpec = createExtensionSpecification({
   identifier: 'pos_ui_extension',
   dependency,
-  schema: BaseSchema.extend({name: zod.string()}),
+  schema: BaseSchema.extend({
+    name: zod.string(),
+    metafields: zod.array(MetafieldSchema).optional(),
+  }),
   appModuleFeatures: (_) => ['ui_preview', 'bundling', 'esbuild', 'single_js_entry_path'],
   deployConfig: async (config, directory) => {
     const result = await getDependencyVersion(dependency, directory)

--- a/packages/app/src/cli/models/extensions/specifications/product_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/product_subscription.ts
@@ -1,7 +1,8 @@
 import {getDependencyVersion} from '../../app/app.js'
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {BugError} from '@shopify/cli-kit/node/error'
+import {zod} from '@shopify/cli-kit/node/schema'
 
 const dependency = '@shopify/admin-ui-extensions'
 
@@ -10,7 +11,9 @@ const productSubscriptionSpec = createExtensionSpecification({
   additionalIdentifiers: ['subscription_management'],
   dependency,
   graphQLType: 'subscription_management',
-  schema: BaseSchema,
+  schema: BaseSchema.extend({
+    metafields: zod.array(MetafieldSchema).optional(),
+  }),
   appModuleFeatures: (_) => ['ui_preview', 'bundling', 'esbuild', 'single_js_entry_path'],
   deployConfig: async (_, directory) => {
     const result = await getDependencyVersion(dependency, directory)

--- a/packages/app/src/cli/models/extensions/specifications/tax_calculation.ts
+++ b/packages/app/src/cli/models/extensions/specifications/tax_calculation.ts
@@ -1,5 +1,5 @@
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const TaxCalculationsSchema = BaseSchema.extend({
@@ -16,6 +16,7 @@ const TaxCalculationsSchema = BaseSchema.extend({
         .optional(),
     })
     .optional(),
+  metafields: zod.array(MetafieldSchema).optional(),
 })
 
 const spec = createExtensionSpecification({

--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -1,5 +1,5 @@
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {themeExtensionFiles} from '../../../utilities/extensions/theme.js'
 import {ExtensionInstance} from '../extension-instance.js'
 import {useThemebundling} from '@shopify/cli-kit/node/context/local'
@@ -7,10 +7,13 @@ import {fileSize} from '@shopify/cli-kit/node/fs'
 import {dirname, relativePath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
+import {zod} from '@shopify/cli-kit/node/schema'
 
 const themeSpec = createExtensionSpecification({
   identifier: 'theme',
-  schema: BaseSchema,
+  schema: BaseSchema.extend({
+    metafields: zod.array(MetafieldSchema).optional(),
+  }),
   partnersWebIdentifier: 'theme_app_extension',
   graphQLType: 'theme_app_extension',
   appModuleFeatures: (_) => {

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -1,5 +1,5 @@
 import {Asset, AssetIdentifier, ExtensionFeature, createExtensionSpecification} from '../specification.js'
-import {NewExtensionPointSchemaType, NewExtensionPointsSchema, BaseSchema} from '../schemas.js'
+import {NewExtensionPointSchemaType, NewExtensionPointsSchema, BaseSchema, MetafieldSchema} from '../schemas.js'
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {getExtensionPointTargetSurface} from '../../../services/dev/extension/utilities.js'
 import {ExtensionInstance} from '../extension-instance.js'
@@ -42,6 +42,7 @@ export const UIExtensionSchema = BaseSchema.extend({
   type: zod.literal('ui_extension'),
   extension_points: NewExtensionPointsSchema.optional(),
   targeting: NewExtensionPointsSchema.optional(),
+  metafields: zod.array(MetafieldSchema).optional(),
 })
   .refine((config) => validatePoints(config), missingExtensionPointsMessage)
   .transform((config) => {

--- a/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
@@ -1,5 +1,5 @@
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {fileSize} from '@shopify/cli-kit/node/fs'
@@ -14,6 +14,7 @@ const WebPixelSchema = BaseSchema.extend({
   runtime_context: zod.string(),
   version: zod.string().optional(),
   configuration: zod.any(),
+  metafields: zod.array(MetafieldSchema).optional(),
   customer_privacy: zod
     .object({
       analytics: zod.boolean(),

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -27,6 +27,15 @@ export async function getUIExtensionPayload(
     const renderer = await getUIExtensionRendererVersion(extension)
     const extensionPoints = await getExtensionPoints(extension, url)
 
+    let metafields: {namespace: string; key: string}[] | null = null
+    if (
+      'metafields' in extension.configuration &&
+      Array.isArray(extension.configuration.metafields) &&
+      extension.configuration.metafields.length > 0
+    ) {
+      metafields = extension.configuration.metafields
+    }
+
     const defaultConfig = {
       assets: {
         main: {
@@ -60,7 +69,7 @@ export async function getUIExtensionPayload(
       },
       extensionPoints,
       localization: localization ?? null,
-      metafields: extension.configuration.metafields?.length === 0 ? null : extension.configuration.metafields,
+      metafields,
       type: extension.type,
 
       externalType: extension.externalType,

--- a/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.test.ts
@@ -117,7 +117,7 @@ describe('getExtensionPointRedirectUrl()', () => {
       devUUID: '123abc',
       localIdentifier: 'post-purchase-extension',
       configuration: {metafields: [{namespace: 'test', key: 'test'}]},
-    } as ExtensionInstance
+    } as unknown as ExtensionInstance
 
     const options = {
       storeFqdn: 'example.myshopify.com',

--- a/packages/app/src/cli/services/dev/extension/server/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/server/utilities.ts
@@ -58,7 +58,7 @@ export function getExtensionPointRedirectUrl(
         rawUrl.searchParams.set('socket_url', options.websocketURL)
       }
 
-      if (extension.configuration.metafields) {
+      if ('metafields' in extension.configuration) {
         const config = {config: {metafields: extension.configuration.metafields}}
         rawUrl.searchParams.set('config', JSON.stringify(config))
       }

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -243,7 +243,7 @@ class AppInfo {
       [`📂 ${extension.handle || NOT_LOADED_TEXT}`, {filePath: relativePath(this.app.directory, extension.directory)}],
       ['     config file', {filePath: relativePath(extension.directory, extension.configurationPath)}],
     ]
-    if (config && config.metafields?.length) {
+    if (config && 'metafields' in config && Array.isArray(config.metafields) && config.metafields.length > 0) {
       details.push(['     metafields', `${config.metafields.length}`])
     }
     const error = this.app.errors?.getError(extension.configurationPath)


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds support for metafields in various extension types by moving the metafields schema from the base schema to individual extension schemas.

### WHAT is this pull request doing?

- Moves the `metafields` field from `BaseSchema` to individual extension type schemas
- Exports `MetafieldSchema` to allow reuse across extension specifications
- Updates UI extension payload generation to properly handle metafields

### How to test your changes?

1. Create extensions of the supported types with metafields configuration
2. Verify that metafields are properly included in the extension payload

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes