### PR TITLE
Improve global CLI detection

### DIFF
--- a/.changeset/moody-chairs-divide.md
+++ b/.changeset/moody-chairs-divide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Improve global CLI detection to avoid showing unnecessary warnings

--- a/packages/cli-kit/src/public/node/is-global.test.ts
+++ b/packages/cli-kit/src/public/node/is-global.test.ts
@@ -17,7 +17,7 @@ const globalNPMPath = '/path/to/global/npm'
 const globalYarnPath = '/path/to/global/yarn'
 const globalPNPMPath = '/path/to/global/pnpm'
 const unknownGlobalPath = '/path/to/global/unknown'
-const localProjectPath = '/path/local'
+const localProjectPath = '/path/local/node_modules'
 
 beforeEach(() => {
   ;(vi.mocked(execa.execaSync) as any).mockReturnValue({stdout: localProjectPath})
@@ -53,7 +53,7 @@ describe('inferPackageManagerForGlobalCLI', () => {
     const argv = ['node', globalYarnPath, 'shopify']
 
     // When
-    const got = await inferPackageManagerForGlobalCLI(argv)
+    const got = inferPackageManagerForGlobalCLI(argv)
 
     // Then
     expect(got).toBe('yarn')
@@ -64,7 +64,7 @@ describe('inferPackageManagerForGlobalCLI', () => {
     const argv = ['node', globalPNPMPath, 'shopify']
 
     // When
-    const got = await inferPackageManagerForGlobalCLI(argv)
+    const got = inferPackageManagerForGlobalCLI(argv)
 
     // Then
     expect(got).toBe('pnpm')
@@ -75,7 +75,7 @@ describe('inferPackageManagerForGlobalCLI', () => {
     const argv = ['node', unknownGlobalPath, 'shopify']
 
     // When
-    const got = await inferPackageManagerForGlobalCLI(argv)
+    const got = inferPackageManagerForGlobalCLI(argv)
 
     // Then
     expect(got).toBe('npm')
@@ -86,7 +86,7 @@ describe('inferPackageManagerForGlobalCLI', () => {
     const argv = ['node', localProjectPath, 'shopify']
 
     // When
-    const got = await inferPackageManagerForGlobalCLI(argv)
+    const got = inferPackageManagerForGlobalCLI(argv)
 
     // Then
     expect(got).toBe('unknown')

--- a/packages/cli-kit/src/public/node/is-global.test.ts
+++ b/packages/cli-kit/src/public/node/is-global.test.ts
@@ -1,12 +1,8 @@
 import {isDevelopment} from './context/local.js'
-import {
-  currentProcessIsGlobal,
-  inferPackageManagerForGlobalCLI,
-  installGlobalCLIPrompt,
-  isGlobalCLIInstalled,
-} from './is-global.js'
-import {captureOutput, terminalSupportsPrompting} from './system.js'
+import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI, installGlobalCLIPrompt} from './is-global.js'
+import {terminalSupportsPrompting} from './system.js'
 import {renderSelectPrompt} from './ui.js'
+import {globalCLIVersion} from './version.js'
 import * as execa from 'execa'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -14,7 +10,8 @@ vi.mock('./system.js')
 vi.mock('./ui.js')
 vi.mock('execa')
 vi.mock('./context/local.js')
-
+vi.mock('which')
+vi.mock('./version.js')
 const globalNPMPath = '/path/to/global/npm'
 const globalYarnPath = '/path/to/global/yarn'
 const globalPNPMPath = '/path/to/global/pnpm'
@@ -108,48 +105,10 @@ describe('inferPackageManagerForGlobalCLI', () => {
   })
 })
 
-describe('isGlobalCLIInstalled', () => {
-  test('returns true if the global CLI is installed', async () => {
-    // Given
-    vi.mocked(captureOutput).mockImplementationOnce(() => Promise.resolve('app help includes the `app dev` command'))
-
-    // When
-    const got = await isGlobalCLIInstalled()
-
-    // Then
-    expect(got).toBeTruthy()
-  })
-
-  test('returns false if the global CLI is not installed', async () => {
-    // Given
-    vi.mocked(captureOutput).mockImplementationOnce(() => {
-      throw new Error('')
-    })
-
-    // When
-    const got = await isGlobalCLIInstalled()
-
-    // Then
-    expect(got).toBeFalsy()
-  })
-
-  test('returns false if the global CLI is installed but doesnt have app dev command', async () => {
-    // Given
-    vi.mocked(captureOutput).mockImplementationOnce(() => Promise.resolve('app help that includes something else'))
-
-    // When
-    const got = await isGlobalCLIInstalled()
-
-    // Then
-    expect(got).toBeFalsy()
-  })
-})
-
 describe('installGlobalCLIPrompt', () => {
-  test('if global CLI is already installed', async () => {
+  test('does not prompt if global CLI is already installed', async () => {
     // Given
-    // Global CLI is already installed
-    vi.mocked(captureOutput).mockImplementationOnce(() => Promise.resolve('app dev'))
+    vi.mocked(globalCLIVersion).mockImplementationOnce(() => Promise.resolve('3.78.0'))
     vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
 
     // When
@@ -162,10 +121,7 @@ describe('installGlobalCLIPrompt', () => {
 
   test('returns true if the user installs the global CLI', async () => {
     // Given
-    // Global CLI is not installed yet
-    vi.mocked(captureOutput).mockImplementationOnce(() => {
-      throw new Error('')
-    })
+    vi.mocked(globalCLIVersion).mockImplementationOnce(() => Promise.resolve(undefined))
     vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
     vi.mocked(renderSelectPrompt).mockImplementationOnce(() => Promise.resolve('yes'))
 
@@ -178,10 +134,7 @@ describe('installGlobalCLIPrompt', () => {
 
   test('returns false if the user does not install the global CLI', async () => {
     // Given
-    // Global CLI is not installed yet
-    vi.mocked(captureOutput).mockImplementationOnce(() => {
-      throw new Error('')
-    })
+    vi.mocked(globalCLIVersion).mockImplementationOnce(() => Promise.resolve(undefined))
     vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
     vi.mocked(renderSelectPrompt).mockImplementationOnce(() => Promise.resolve('no'))
 

--- a/packages/cli-kit/src/public/node/is-global.test.ts
+++ b/packages/cli-kit/src/public/node/is-global.test.ts
@@ -1,3 +1,4 @@
+import {isDevelopment} from './context/local.js'
 import {
   currentProcessIsGlobal,
   inferPackageManagerForGlobalCLI,
@@ -12,6 +13,7 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 vi.mock('./system.js')
 vi.mock('./ui.js')
 vi.mock('execa')
+vi.mock('./context/local.js')
 
 const globalNPMPath = '/path/to/global/npm'
 const globalYarnPath = '/path/to/global/yarn'
@@ -21,9 +23,22 @@ const localProjectPath = '/path/local/node_modules'
 
 beforeEach(() => {
   ;(vi.mocked(execa.execaSync) as any).mockReturnValue({stdout: localProjectPath})
+  vi.mocked(isDevelopment).mockReturnValue(false)
 })
 
 describe('currentProcessIsGlobal', () => {
+  test('returns false in development', () => {
+    // Given
+    vi.mocked(isDevelopment).mockReturnValue(true)
+    const argv = ['node', localProjectPath, 'shopify']
+
+    // When
+    const got = currentProcessIsGlobal(argv)
+
+    // Then
+    expect(got).toBeFalsy()
+  })
+
   test('returns true if argv point to the global npm path', () => {
     // Given
     const argv = ['node', globalNPMPath, 'shopify']

--- a/packages/cli-kit/src/public/node/is-global.ts
+++ b/packages/cli-kit/src/public/node/is-global.ts
@@ -1,3 +1,4 @@
+import {isDevelopment} from './context/local.js'
 import {PackageManager} from './node-package-manager.js'
 import {outputInfo} from './output.js'
 import {captureOutput, exec, terminalSupportsPrompting} from './system.js'
@@ -11,7 +12,7 @@ import {renderSelectPrompt} from './ui.js'
  */
 export function currentProcessIsGlobal(argv = process.argv): boolean {
   const currentExecutable = argv[1] ?? ''
-  return !currentExecutable.includes('node_modules')
+  return !currentExecutable.includes('node_modules') && !isDevelopment()
 }
 
 /**

--- a/packages/cli-kit/src/public/node/is-global.ts
+++ b/packages/cli-kit/src/public/node/is-global.ts
@@ -3,6 +3,7 @@ import {PackageManager} from './node-package-manager.js'
 import {outputInfo} from './output.js'
 import {captureOutput, exec, terminalSupportsPrompting} from './system.js'
 import {renderSelectPrompt} from './ui.js'
+import which from 'which'
 
 /**
  * Returns true if the current process is running in a global context.
@@ -22,6 +23,8 @@ export function currentProcessIsGlobal(argv = process.argv): boolean {
  */
 export async function isGlobalCLIInstalled(): Promise<boolean> {
   try {
+    // This raises an error if the command is not found. We need it because execa runs the project dependency when the global version does not exist.
+    which.sync('shopify')
     const env = {...process.env, SHOPIFY_CLI_NO_ANALYTICS: '1'}
     const output = await captureOutput('shopify', ['app'], {env})
     // Installed if `app dev` is available globally

--- a/packages/cli-kit/src/public/node/is-global.ts
+++ b/packages/cli-kit/src/public/node/is-global.ts
@@ -1,12 +1,7 @@
-import {isUnitTest} from './context/local.js'
 import {PackageManager} from './node-package-manager.js'
 import {outputInfo} from './output.js'
-import {cwd, sniffForPath} from './path.js'
 import {captureOutput, exec, terminalSupportsPrompting} from './system.js'
 import {renderSelectPrompt} from './ui.js'
-import {execaSync} from 'execa'
-
-let _isGlobal: boolean | undefined
 
 /**
  * Returns true if the current process is running in a global context.
@@ -15,29 +10,8 @@ let _isGlobal: boolean | undefined
  * @returns `true` if the current process is running in a global context.
  */
 export function currentProcessIsGlobal(argv = process.argv): boolean {
-  // If we are running tests, we need to disable the cache
-  try {
-    if (_isGlobal !== undefined && !isUnitTest()) return _isGlobal
-
-    // Path where the current project is (app/hydrogen)
-    const path = sniffForPath() ?? cwd()
-
-    // Closest parent directory to contain a package.json file or node_modules directory
-    // https://docs.npmjs.com/cli/v8/commands/npm-prefix#description
-    const npmPrefix = execaSync('npm', ['prefix'], {cwd: path}).stdout.trim()
-
-    // From node docs: "The second element [of the array] will be the path to the JavaScript file being executed"
-    const binDir = argv[1] ?? ''
-
-    // If binDir starts with npmPrefix, then we are running a local CLI
-    const isLocal = binDir.startsWith(npmPrefix.trim())
-
-    _isGlobal = !isLocal
-    return _isGlobal
-    // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch (error) {
-    return false
-  }
+  const currentExecutable = argv[1] ?? ''
+  return !currentExecutable.includes('node_modules')
 }
 
 /**

--- a/packages/cli-kit/src/public/node/version.test.ts
+++ b/packages/cli-kit/src/public/node/version.test.ts
@@ -40,7 +40,9 @@ describe('localCLIVersion', () => {
 describe('globalCLIVersion', () => {
   test('returns the version when a recent CLI is installed globally', async () => {
     // Given
-    vi.mocked(captureOutput).mockImplementationOnce(() => Promise.resolve('3.65.0'))
+    // TS is not detecting the return type correctly, so we need to cast it
+    vi.mocked(which.sync).mockReturnValue(['path/to/shopify'] as unknown as string)
+    vi.mocked(captureOutput).mockResolvedValueOnce('@shopify/cli/3.65.0')
 
     // When
     const got = await globalCLIVersion()
@@ -51,7 +53,9 @@ describe('globalCLIVersion', () => {
 
   test('returns undefined when the global version is older than 3.59', async () => {
     // Given
-    vi.mocked(captureOutput).mockImplementationOnce(() => Promise.resolve('3.55.0'))
+    // TS is not detecting the return type correctly, so we need to cast it
+    vi.mocked(which.sync).mockReturnValue(['path/to/shopify'] as unknown as string)
+    vi.mocked(captureOutput).mockImplementationOnce(() => Promise.resolve('@shopify/cli/3.50.0'))
 
     // When
     const got = await globalCLIVersion()
@@ -62,7 +66,7 @@ describe('globalCLIVersion', () => {
 
   test('returns undefined when the global version is not installed', async () => {
     // Given
-    vi.mocked(which).mockImplementationOnce(() => Promise.resolve('command not found: shopify'))
+    vi.mocked(which.sync).mockReturnValue(['node_modules/bin/shopify'] as unknown as string)
 
     // When
     const got = await globalCLIVersion()

--- a/packages/cli-kit/src/public/node/version.test.ts
+++ b/packages/cli-kit/src/public/node/version.test.ts
@@ -2,8 +2,10 @@ import {localCLIVersion, globalCLIVersion} from './version.js'
 import {inTemporaryDirectory} from '../node/fs.js'
 import {captureOutput} from '../node/system.js'
 import {describe, expect, test, vi} from 'vitest'
+import which from 'which'
 
 vi.mock('../node/system.js')
+vi.mock('which')
 
 describe('localCLIVersion', () => {
   test('returns the version of the local CLI', async () => {
@@ -60,7 +62,7 @@ describe('globalCLIVersion', () => {
 
   test('returns undefined when the global version is not installed', async () => {
     // Given
-    vi.mocked(captureOutput).mockImplementationOnce(() => Promise.resolve('command not found: shopify'))
+    vi.mocked(which).mockImplementationOnce(() => Promise.resolve('command not found: shopify'))
 
     // When
     const got = await globalCLIVersion()

--- a/packages/cli-kit/src/public/node/version.test.ts
+++ b/packages/cli-kit/src/public/node/version.test.ts
@@ -49,6 +49,7 @@ describe('globalCLIVersion', () => {
 
     // Then
     expect(got).toBe('3.65.0')
+    expect(captureOutput).toHaveBeenCalledWith('path/to/shopify', [], {env: expect.any(Object)})
   })
 
   test('returns undefined when the global version is older than 3.59', async () => {
@@ -62,6 +63,7 @@ describe('globalCLIVersion', () => {
 
     // Then
     expect(got).toBeUndefined()
+    expect(captureOutput).toHaveBeenCalledWith('path/to/shopify', [], {env: expect.any(Object)})
   })
 
   test('returns undefined when the global version is not installed', async () => {
@@ -73,5 +75,6 @@ describe('globalCLIVersion', () => {
 
     // Then
     expect(got).toBeUndefined()
+    expect(captureOutput).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli-kit/src/public/node/version.ts
+++ b/packages/cli-kit/src/public/node/version.ts
@@ -28,12 +28,12 @@ export async function globalCLIVersion(): Promise<string | undefined> {
     const env = {...process.env, SHOPIFY_CLI_NO_ANALYTICS: '1'}
     // Both execa and which find the project dependency. We need to exclude it.
     const shopifyBinaries = which.sync('shopify', {all: true}).filter((path) => !path.includes('node_modules'))
-    if (shopifyBinaries.length === 0) return undefined
-    const output = await captureOutput('shopify', [], {env})
+    if (!shopifyBinaries[0]) return undefined
+    const output = await captureOutput(shopifyBinaries[0], [], {env})
     const versionMatch = output.match(/@shopify\/cli\/([^\s]+)/)
     if (versionMatch && versionMatch[1]) {
       const version = versionMatch[1]
-      if (satisfies(version, `>=3.59.0`)) {
+      if (satisfies(version, `>=3.59.0`) || version.startsWith('0.0.0')) {
         return version
       }
     }

--- a/packages/cli-kit/src/public/node/version.ts
+++ b/packages/cli-kit/src/public/node/version.ts
@@ -1,5 +1,6 @@
 import {versionSatisfies} from '../node/node-package-manager.js'
 import {captureOutput} from '../node/system.js'
+import which from 'which'
 
 /**
  * Returns the version of the local dependency of the CLI if it's installed in the provided directory.
@@ -25,6 +26,8 @@ export async function localCLIVersion(directory: string): Promise<string | undef
 export async function globalCLIVersion(): Promise<string | undefined> {
   try {
     const env = {...process.env, SHOPIFY_CLI_NO_ANALYTICS: '1'}
+    // This raises an error if the command is not found. We need it because execa runs the project dependency when the global version does not exist.
+    which.sync('shopify')
     const version = await captureOutput('shopify', ['version'], {env})
     if (versionSatisfies(version, `>=3.59.0`)) {
       return version

--- a/packages/cli-kit/src/public/node/version.ts
+++ b/packages/cli-kit/src/public/node/version.ts
@@ -1,6 +1,6 @@
-import {versionSatisfies} from '../node/node-package-manager.js'
 import {captureOutput} from '../node/system.js'
 import which from 'which'
+import {satisfies} from 'semver'
 
 /**
  * Returns the version of the local dependency of the CLI if it's installed in the provided directory.
@@ -26,11 +26,16 @@ export async function localCLIVersion(directory: string): Promise<string | undef
 export async function globalCLIVersion(): Promise<string | undefined> {
   try {
     const env = {...process.env, SHOPIFY_CLI_NO_ANALYTICS: '1'}
-    // This raises an error if the command is not found. We need it because execa runs the project dependency when the global version does not exist.
-    which.sync('shopify')
-    const version = await captureOutput('shopify', ['version'], {env})
-    if (versionSatisfies(version, `>=3.59.0`)) {
-      return version
+    // Both execa and which find the project dependency. We need to exclude it.
+    const shopifyBinaries = which.sync('shopify', {all: true}).filter((path) => !path.includes('node_modules'))
+    if (shopifyBinaries.length === 0) return undefined
+    const output = await captureOutput('shopify', [], {env})
+    const versionMatch = output.match(/@shopify\/cli\/([^\s]+)/)
+    if (versionMatch && versionMatch[1]) {
+      const version = versionMatch[1]
+      if (satisfies(version, `>=3.59.0`)) {
+        return version
+      }
     }
     return undefined
     // eslint-disable-next-line no-catch-all/no-catch-all


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/issues/5600#issuecomment-2807041478

In some cases, the two installations warning is not working as expected, showing the message when there is no global version.

Until now, we basically ran the `shopify` command internally to see if there is a global version. But it turns out that execa, the library we use to run external binaries, is actually running the local dependency sometimes, giving false positives.

### WHAT is this pull request doing?

- Before running `shopify`, check the path of the `shopify` binaries found with the `which` library and discard the local ones (including`node_modules`)
- Unify the methods to check the global version: we were running `shopify version` in one place and `shopify app dev` in another, because it's faster. Now we just use `shopify` in both, which is fast and includes the version.

### How to test your changes?

Global version:
- `npm i -g @shopify/cli/0.0.0-snapshot-20250429110410 --@shopify:registry=https://registry.npmjs.org`
- `shopify app info` => nothing
- `npm add @shopify/cli`
- `shopify app info` => warning

Without global version:
- `npm rm -g @shopify/cli`
- `npm add @shopify/cli@0.0.0-snapshot-20250429110410`
- `npm run shopify app info` => nothing
- `npm i -g @shopify/cli`
- `npm run shopify app info` => warning

Also test with pnpm, yarn, bun, windows, linux...

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
