### PR TITLE
Add forceRefresh option to token refresh methods

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -303,7 +303,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   }
 
   async refreshToken(): Promise<string> {
-    const result = await ensureAuthenticatedAppManagementAndBusinessPlatform({noPrompt: true})
+    const result = await ensureAuthenticatedAppManagementAndBusinessPlatform({noPrompt: true, forceRefresh: true})
     const session = await this.session()
     session.token = result.appManagementToken
     session.businessPlatformToken = result.businessPlatformToken

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -262,7 +262,7 @@ export class PartnersClient implements DeveloperPlatformClient {
   }
 
   async refreshToken(): Promise<string> {
-    const {token} = await ensureAuthenticatedPartners([], process.env, {noPrompt: true})
+    const {token} = await ensureAuthenticatedPartners([], process.env, {noPrompt: true, forceRefresh: true})
     const session = await this.session()
     if (token) {
       session.token = token

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -31,6 +31,7 @@ export interface AdminSession {
 
 interface EnsureAuthenticatedAdditionalOptions {
   noPrompt?: boolean
+  forceRefresh?: boolean
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

`refreshToken` should always refresh the token, even if its not expired yet.

### WHAT is this pull request doing?

Adds the `forceRefresh` parameter to token refresh methods in both the AppManagementClient and PartnersClient classes. 

### How to test your changes?

1. Run dev with function logs for a long time.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes