### PR TITLE
Increase default request timeout to 30s

### DIFF
--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -119,6 +119,6 @@ export function maxRequestTimeForNetworkCallsMs(environment = getEnvironmentVari
   if (maxRequestTime && !isNaN(Number(maxRequestTime))) {
     return Number(maxRequestTime)
   }
-  // 15 seconds is the default
-  return 15 * 1000
+  // 30 seconds is the default
+  return 30 * 1000
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The default timeout for network calls is too short, causing unnecessary timeouts in some cases.

### WHAT is this pull request doing?

Increases the default timeout for network calls from 15 seconds to 30 seconds in the `maxRequestTimeForNetworkCallsMs` function.

### How to test your changes?

1. Make a deploy with 50+ functions, see that it doesn't timeout
2. If it does, verify that requests now timeout after 30 seconds instead of 15 seconds with --verbose

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes