### PR TITLE
Remove SHOPIFY_CLI_DISABLE_WASM_TOML_PATCH opt-out

### DIFF
--- a/.changeset/grumpy-doors-march.md
+++ b/.changeset/grumpy-doors-march.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Remove opt-out of TOML patching with SHOPIFY_CLI_DISABLE_WASM_TOML_PATCH

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -8,7 +8,6 @@ export const environmentVariableNames = {
   enableUnsupportedConfigPropertyChecks: 'SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS',
   disableUnsupportedConfigPropertyChecks: 'SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS',
   disableMinificationOnDev: 'SHOPIFY_CLI_DISABLE_MINIFICATION_ON_DEV',
-  disableWasmTomlPatch: 'SHOPIFY_CLI_DISABLE_WASM_TOML_PATCH',
 }
 
 export const configurationFileNames = {

--- a/packages/app/src/cli/services/app/patch-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/patch-app-configuration-file.ts
@@ -1,11 +1,7 @@
-import {addDefaultCommentsToToml} from './write-app-configuration-file.js'
 import {AppHiddenConfig} from '../../models/app/app.js'
-import {environmentVariableNames} from '../../constants.js'
 import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 import {readFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {zod} from '@shopify/cli-kit/node/schema'
-import {decodeToml, encodeToml} from '@shopify/cli-kit/node/toml'
-import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {updateTomlValues} from '@shopify/toml-patch'
 
 export interface PatchTomlOptions {
@@ -15,41 +11,6 @@ export interface PatchTomlOptions {
 }
 
 type TomlPatchValue = string | number | boolean | undefined | string[]
-
-function shouldUseWasmTomlPatch(env = process.env): boolean {
-  return !isTruthy(env[environmentVariableNames.disableWasmTomlPatch])
-}
-
-/**
- * Updates an app configuration file with the given patch.
- *
- * Only updates the given fields in the patch and leaves the rest of the file unchanged.
- * Keeps the same order of the keys as the original file.
- *
- * New keys are always added at the end of the file.
- *
- * @param path - The path to the app configuration file.
- * @param patch - The patch to apply to the app configuration file.
- * @param schema - The schema to validate the patch against. If not provided, the toml will not be validated.
- * @internal Internal function, use setAppConfigValue, unsetAppConfigValue, or setManyAppConfigValues instead
- */
-async function patchAppConfigurationFile({path, patch, schema}: PatchTomlOptions) {
-  const tomlContents = await readFile(path)
-  const configuration = decodeToml(tomlContents)
-
-  // Deep merge the configuration with the patch.
-  // Use replaceArrayStrategy to replace the destination array with the source array. (Arrays are not merged)
-  const updatedConfig = deepMergeObjects(configuration, patch, replaceArrayStrategy)
-
-  // Re-parse the config with the schema to validate the patch
-  // Make every field optional to not crash on tomls that are missing fields.
-  const validSchema = schema ?? zod.object({}).passthrough()
-  validSchema.partial().parse(updatedConfig)
-
-  let encodedString = encodeToml(updatedConfig)
-  encodedString = addDefaultCommentsToToml(encodedString)
-  await writeFile(path, encodedString)
-}
 
 async function patchAppConfigurationFileWithWasm(
   path: string,
@@ -69,19 +30,9 @@ async function patchAppConfigurationFileWithWasm(
  * @param path - The path to the app configuration file.
  * @param keyPath - The dotted key path to set the value at (e.g. 'build.dev_store_url')
  * @param value - The value to set
- * @param schema - The schema to validate the patch against. If not provided, the toml will not be validated.
  */
-export async function setAppConfigValue(
-  path: string,
-  keyPath: string,
-  value: TomlPatchValue,
-  schema?: zod.AnyZodObject,
-) {
-  if (shouldUseWasmTomlPatch()) {
-    return patchAppConfigurationFileWithWasm(path, [{keyPath, value}])
-  }
-  const patch = createPatchFromDottedPath(keyPath, value)
-  await patchAppConfigurationFile({path, patch, schema})
+export async function setAppConfigValue(path: string, keyPath: string, value: TomlPatchValue) {
+  return patchAppConfigurationFileWithWasm(path, [{keyPath, value}])
 }
 
 /**
@@ -89,30 +40,17 @@ export async function setAppConfigValue(
  *
  * @param path - The path to the app configuration file
  * @param configValues - Array of keyPath and value pairs to set
- * @param schema - The schema to validate the patch against. If not provided, the toml will not be validated.
  *
  * @example
  * ```ts
  * await setManyAppConfigValues('shopify.app.toml', [
  *   { keyPath: 'application_url', value: 'https://example.com' },
  *   { keyPath: 'auth.redirect_urls', value: ['https://example.com/callback'] }
- * ], schema)
+ * ])
  * ```
  */
-export async function setManyAppConfigValues(
-  path: string,
-  configValues: {keyPath: string; value: TomlPatchValue}[],
-  schema?: zod.AnyZodObject,
-) {
-  if (shouldUseWasmTomlPatch()) {
-    return patchAppConfigurationFileWithWasm(path, configValues)
-  }
-  const patch = configValues.reduce((acc, {keyPath, value}) => {
-    const valuePatch = createPatchFromDottedPath(keyPath, value)
-    return deepMergeObjects(acc, valuePatch, replaceArrayStrategy)
-  }, {})
-
-  await patchAppConfigurationFile({path, patch, schema})
+export async function setManyAppConfigValues(path: string, configValues: {keyPath: string; value: TomlPatchValue}[]) {
+  return patchAppConfigurationFileWithWasm(path, configValues)
 }
 
 /**
@@ -120,47 +58,12 @@ export async function setManyAppConfigValues(
  *
  * @param path - The path to the app configuration file.
  * @param keyPath - The dotted key path to unset (e.g. 'build.include_config_on_deploy')
- * @param schema - The schema to validate the patch against. If not provided, the toml will not be validated.
  */
-export async function unsetAppConfigValue(path: string, keyPath: string, schema?: zod.AnyZodObject) {
-  if (shouldUseWasmTomlPatch()) {
-    return patchAppConfigurationFileWithWasm(path, [{keyPath, value: undefined}])
-  }
-  const patch = createPatchFromDottedPath(keyPath, undefined)
-  await patchAppConfigurationFile({path, patch, schema})
+export async function unsetAppConfigValue(path: string, keyPath: string) {
+  return patchAppConfigurationFileWithWasm(path, [{keyPath, value: undefined}])
 }
 
-/**
- * Creates a patch object from a dotted key path and a value
- * For example, 'build.dev_store_url' with value 'example.myshopify.com'
- * will create \{ build: \{ dev_store_url: 'example.myshopify.com' \} \}
- */
-function createPatchFromDottedPath(keyPath: string, value: unknown): {[key: string]: unknown} {
-  const keys = keyPath.split('.')
-  if (keys.length === 1) {
-    return {[keyPath]: value}
-  }
-
-  const obj: {[key: string]: unknown} = {}
-  let currentObj = obj
-
-  for (let i = 0; i < keys.length - 1; i++) {
-    const key = keys[i]
-    if (key) {
-      currentObj[key] = {}
-      currentObj = currentObj[key] as {[key: string]: unknown}
-    }
-  }
-
-  const lastKey = keys[keys.length - 1]
-  if (lastKey) {
-    currentObj[lastKey] = value
-  }
-
-  return obj
-}
-
-export function replaceArrayStrategy(_: unknown[], newArray: unknown[]): unknown[] {
+function replaceArrayStrategy(_: unknown[], newArray: unknown[]): unknown[] {
   return newArray
 }
 

--- a/packages/app/src/cli/services/app/write-app-configuration-file.ts
+++ b/packages/app/src/cli/services/app/write-app-configuration-file.ts
@@ -68,7 +68,7 @@ export const rewriteConfiguration = <T extends zod.ZodTypeAny>(schema: T, config
   return config
 }
 
-export function addDefaultCommentsToToml(fileString: string) {
+function addDefaultCommentsToToml(fileString: string) {
   const appTomlInitialComment = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration\n`
   const appTomlScopesComment = `\n# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes`
 

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -209,12 +209,7 @@ describe('ensureDeployContext', () => {
     expect(metadataSpyOn.mock.calls[0]![0]()).toEqual({cmd_deploy_confirm_include_config_used: true})
 
     expect(renderConfirmationPrompt).toHaveBeenCalled()
-    expect(setAppConfigValueSpy).toHaveBeenCalledWith(
-      app.configuration.path,
-      'build.include_config_on_deploy',
-      true,
-      expect.any(Object),
-    )
+    expect(setAppConfigValueSpy).toHaveBeenCalledWith(app.configuration.path, 'build.include_config_on_deploy', true)
     expect(renderInfo).toHaveBeenCalledWith({
       body: [
         {
@@ -253,12 +248,7 @@ describe('ensureDeployContext', () => {
 
     // Then
     expect(renderConfirmationPrompt).toHaveBeenCalled()
-    expect(setAppConfigValueSpy).toHaveBeenCalledWith(
-      app.configuration.path,
-      'build.include_config_on_deploy',
-      false,
-      expect.any(Object),
-    )
+    expect(setAppConfigValueSpy).toHaveBeenCalledWith(app.configuration.path, 'build.include_config_on_deploy', false)
     expect(renderInfo).toHaveBeenCalledWith({
       body: [
         {
@@ -399,12 +389,7 @@ describe('ensureDeployContext', () => {
     expect(metadataSpyOn.mock.calls[0]![0]()).toEqual({cmd_deploy_confirm_include_config_used: false})
 
     expect(renderConfirmationPrompt).toHaveBeenCalled()
-    expect(setAppConfigValueSpy).toHaveBeenCalledWith(
-      app.configuration.path,
-      'build.include_config_on_deploy',
-      false,
-      expect.any(Object),
-    )
+    expect(setAppConfigValueSpy).toHaveBeenCalledWith(app.configuration.path, 'build.include_config_on_deploy', false)
 
     expect(renderInfo).toHaveBeenCalledWith({
       body: [
@@ -533,11 +518,7 @@ describe('ensureDeployContext', () => {
 
     // Then
     expect(renderConfirmationPrompt).not.toHaveBeenCalled()
-    expect(unsetAppConfigValueSpy).toHaveBeenCalledWith(
-      app.configuration.path,
-      'build.include_config_on_deploy',
-      expect.any(Object),
-    )
+    expect(unsetAppConfigValueSpy).toHaveBeenCalledWith(app.configuration.path, 'build.include_config_on_deploy')
     expect(renderInfo).toHaveBeenCalledWith({
       body: [
         'The `include_config_on_deploy` field is no longer supported, since all apps must now include configuration on deploy. It has been removed from your configuration file.',
@@ -578,11 +559,7 @@ describe('ensureDeployContext', () => {
 
     // Then
     expect(renderConfirmationPrompt).not.toHaveBeenCalled()
-    expect(unsetAppConfigValueSpy).toHaveBeenCalledWith(
-      app.configuration.path,
-      'build.include_config_on_deploy',
-      expect.any(Object),
-    )
+    expect(unsetAppConfigValueSpy).toHaveBeenCalledWith(app.configuration.path, 'build.include_config_on_deploy')
     expect(renderWarning).toHaveBeenCalledWith({
       body: [
         "The `include_config_on_deploy` field is no longer supported and has been removed from your configuration file. Review this file to ensure it's up to date with the correct configuration.",

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -213,7 +213,7 @@ async function removeIncludeConfigOnDeployField(localApp: AppInterface) {
   const includeConfigOnDeploy = configuration.build?.include_config_on_deploy
   if (includeConfigOnDeploy === undefined) return
 
-  await unsetAppConfigValue(localApp.configuration.path, 'build.include_config_on_deploy', localApp.configSchema)
+  await unsetAppConfigValue(localApp.configuration.path, 'build.include_config_on_deploy')
 
   includeConfigOnDeploy ? renderInfoAboutIncludeConfigOnDeploy() : renderWarningAboutIncludeConfigOnDeploy()
 }
@@ -251,12 +251,7 @@ async function promptIncludeConfigOnDeploy(options: ShouldOrPromptIncludeConfigD
     ...localConfiguration.build,
     include_config_on_deploy: shouldIncludeConfigDeploy,
   }
-  await setAppConfigValue(
-    localConfiguration.path,
-    'build.include_config_on_deploy',
-    shouldIncludeConfigDeploy,
-    options.localApp.configSchema,
-  )
+  await setAppConfigValue(localConfiguration.path, 'build.include_config_on_deploy', shouldIncludeConfigDeploy)
   await metadata.addPublicMetadata(() => ({cmd_deploy_confirm_include_config_used: shouldIncludeConfigDeploy}))
 }
 

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -113,7 +113,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
       ...app.configuration.build,
       dev_store_url: store.shopDomain,
     }
-    await setAppConfigValue(app.configuration.path, 'build.dev_store_url', store.shopDomain, app.configSchema)
+    await setAppConfigValue(app.configuration.path, 'build.dev_store_url', store.shopDomain)
   }
 
   if (!commandOptions.skipDependenciesInstallation && !app.usesWorkspaces) {

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -96,21 +96,17 @@ describe('updateURLs', () => {
     await updateURLs(urls, apiKey, testDeveloperPlatformClient(), appWithConfig)
 
     // Then
-    expect(setManyAppConfigValues).toHaveBeenCalledWith(
-      appWithConfig.configuration.path,
-      [
-        {keyPath: 'application_url', value: 'https://example.com'},
-        {
-          keyPath: 'auth.redirect_urls',
-          value: [
-            'https://example.com/auth/callback',
-            'https://example.com/auth/shopify/callback',
-            'https://example.com/api/auth/callback',
-          ],
-        },
-      ],
-      expect.any(Object),
-    )
+    expect(setManyAppConfigValues).toHaveBeenCalledWith(appWithConfig.configuration.path, [
+      {keyPath: 'application_url', value: 'https://example.com'},
+      {
+        keyPath: 'auth.redirect_urls',
+        value: [
+          'https://example.com/auth/callback',
+          'https://example.com/auth/shopify/callback',
+          'https://example.com/api/auth/callback',
+        ],
+      },
+    ])
   })
 
   test('throws an error if requests has a user error', async () => {
@@ -183,24 +179,20 @@ describe('updateURLs', () => {
     await updateURLs(urls, apiKey, testDeveloperPlatformClient(), appWithConfig)
 
     // Then
-    expect(setManyAppConfigValues).toHaveBeenCalledWith(
-      appWithConfig.configuration.path,
-      [
-        {keyPath: 'application_url', value: 'https://example.com'},
-        {
-          keyPath: 'auth.redirect_urls',
-          value: [
-            'https://example.com/auth/callback',
-            'https://example.com/auth/shopify/callback',
-            'https://example.com/api/auth/callback',
-          ],
-        },
-        {keyPath: 'app_proxy.url', value: 'https://example.com'},
-        {keyPath: 'app_proxy.subpath', value: 'subpath'},
-        {keyPath: 'app_proxy.prefix', value: 'prefix'},
-      ],
-      expect.any(Object),
-    )
+    expect(setManyAppConfigValues).toHaveBeenCalledWith(appWithConfig.configuration.path, [
+      {keyPath: 'application_url', value: 'https://example.com'},
+      {
+        keyPath: 'auth.redirect_urls',
+        value: [
+          'https://example.com/auth/callback',
+          'https://example.com/auth/shopify/callback',
+          'https://example.com/api/auth/callback',
+        ],
+      },
+      {keyPath: 'app_proxy.url', value: 'https://example.com'},
+      {keyPath: 'app_proxy.subpath', value: 'subpath'},
+      {keyPath: 'app_proxy.prefix', value: 'prefix'},
+    ])
   })
 })
 
@@ -385,11 +377,9 @@ describe('shouldOrPromptUpdateURLs', () => {
     // Then
     expect(result).toBe(true)
     expect(setCachedAppInfo).not.toHaveBeenCalled()
-    expect(setManyAppConfigValues).toHaveBeenCalledWith(
-      localApp.configuration.path,
-      [{keyPath: 'build.automatically_update_urls_on_dev', value: true}],
-      localApp.configSchema,
-    )
+    expect(setManyAppConfigValues).toHaveBeenCalledWith(localApp.configuration.path, [
+      {keyPath: 'build.automatically_update_urls_on_dev', value: true},
+    ])
   })
 })
 

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -221,7 +221,7 @@ export async function updateURLs(
       )
     }
 
-    await setManyAppConfigValues(localApp.configuration.path, configValues, localApp.configSchema)
+    await setManyAppConfigValues(localApp.configuration.path, configValues)
   }
 }
 
@@ -271,11 +271,7 @@ export async function shouldOrPromptUpdateURLs(options: ShouldOrPromptUpdateURLs
         automatically_update_urls_on_dev: shouldUpdateURLs,
       }
       const path = options.localApp.configuration.path
-      await setManyAppConfigValues(
-        path,
-        [{keyPath: 'build.automatically_update_urls_on_dev', value: shouldUpdateURLs}],
-        options.localApp.configSchema,
-      )
+      await setManyAppConfigValues(path, [{keyPath: 'build.automatically_update_urls_on_dev', value: shouldUpdateURLs}])
     } else {
       setCachedAppInfo({directory: options.appDirectory, updateURLs: shouldUpdateURLs})
     }


### PR DESCRIPTION
🚨 BLOCKED: downstack PR must be released first and have a period to run and shake out any issues.

### WHY are these changes introduced?

This PR removes the ability to opt-out of WASM TOML patching by removing the `SHOPIFY_CLI_DISABLE_WASM_TOML_PATCH` environment variable. This completes the migration to format-preserving TOML updates.
