### PR TITLE
[ShopifyVM] shopify app dev - start polling when empty app adds function

### DIFF
--- a/packages/app/src/cli/services/dev/processes/function-watcher-process.ts
+++ b/packages/app/src/cli/services/dev/processes/function-watcher-process.ts
@@ -1,0 +1,77 @@
+import {BaseProcess, DevProcessFunction} from './types.js'
+import {AppEventWatcher} from '../app-events/app-event-watcher.js'
+import {subscribeAndStartPolling} from './app-logs-polling.js'
+import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {AppLogsSubscribeMutationVariables} from '../../../api/graphql/app-management/generated/app-logs-subscribe.js'
+import {outputDebug, outputInfo} from '@shopify/cli-kit/node/output'
+
+interface FunctionWatcherProcessOptions {
+  appWatcher: AppEventWatcher
+  developerPlatformClient: DeveloperPlatformClient
+  appLogsSubscribeVariables: AppLogsSubscribeMutationVariables
+  storeName: string
+  organizationId: string
+  logsActive: boolean
+}
+
+export interface FunctionWatcherProcess extends BaseProcess<FunctionWatcherProcessOptions> {
+  type: 'function-watcher'
+}
+
+/**
+ * Sets up a function extension watcher process.
+ * This process watches for function extension creation and starts log polling when one is detected.
+ *
+ * @param options - The options for the function watcher process.
+ * @returns The function watcher process.
+ */
+export async function setupFunctionWatcherProcess(options: FunctionWatcherProcessOptions): Promise<FunctionWatcherProcess> {
+  return {
+    type: 'function-watcher',
+    prefix: `function-logs-watcher`,
+    options,
+    function: launchFunctionWatcher,
+  }
+}
+
+export const launchFunctionWatcher: DevProcessFunction<FunctionWatcherProcessOptions> = async (
+  {stdout, stderr, abortSignal},
+  options: FunctionWatcherProcessOptions,
+) => {
+  const {appWatcher, logsActive, developerPlatformClient, appLogsSubscribeVariables, storeName, organizationId} = options
+  
+  // If logs are already active, we don't need to do anything
+  if (logsActive) {
+    outputDebug('Function logs already active, skipping function watcher', stdout)
+    return
+  }
+
+  let logPollingStarted = false
+  
+  appWatcher.onEvent(async (appEvent) => {
+    // Skip if logs polling already started
+    if (logPollingStarted) return
+    
+    // Check if any function extension was created
+    const hasFunctionExtension = appEvent.extensionEvents.some(
+      (event) => 
+        (event.type === 'created' || event.type === 'changed') && 
+        event.extension.isFunctionExtension
+    )
+    
+    if (hasFunctionExtension && !logPollingStarted) {
+      logPollingStarted = true
+      outputInfo('Function extension detected - starting logs polling', stdout)
+      
+      // Start logs polling
+      try {
+        await subscribeAndStartPolling(
+          {stdout, stderr, abortSignal}, 
+          {developerPlatformClient, appLogsSubscribeVariables, storeName, organizationId}
+        )
+      } catch (error) {
+        outputDebug(`Failed to start function logs: ${error}`, stderr)
+      }
+    }
+  })
+}

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -8,6 +8,7 @@ import {pushUpdatesForDraftableExtensions} from './draftable-extension.js'
 import {pushUpdatesForDevSession} from './dev-session/dev-session-process.js'
 import {runThemeAppExtensionsServer} from './theme-app-extension.js'
 import {launchAppWatcher} from './app-watcher-process.js'
+import {launchFunctionWatcher} from './function-watcher-process.js'
 import {
   testAppAccessConfigExtension,
   testAppConfigExtensions,
@@ -270,12 +271,22 @@ describe('setup-dev-processes', () => {
       },
     })
 
+    expect(res.processes[7]).toMatchObject({
+      type: 'function-watcher',
+      prefix: 'function-logs-watcher',
+      function: launchFunctionWatcher,
+      options: {
+        appWatcher: expect.any(AppEventWatcher),
+        logsActive: false,
+      },
+    })
+
     // Check the ports & rule mapping
     const webPort = (res.processes[0] as WebProcess).options.port
     const hmrPort = (res.processes[0] as WebProcess).options.hmrServerOptions?.port
     const previewExtensionPort = (res.processes[2] as PreviewableExtensionProcess).options.port
 
-    expect(res.processes[7]).toMatchObject({
+    expect(res.processes[8]).toMatchObject({
       type: 'proxy-server',
       prefix: 'proxy',
       function: startProxyServer,
@@ -452,6 +463,25 @@ describe('setup-dev-processes', () => {
           shopIds: [123456789],
           apiKey: 'api-key',
         },
+      },
+    })
+
+    expect(res.processes[7]).toMatchObject({
+      type: 'app-watcher',
+      prefix: 'app-preview',
+      function: launchAppWatcher,
+      options: {
+        appWatcher: expect.any(AppEventWatcher),
+      },
+    })
+
+    expect(res.processes[8]).toMatchObject({
+      type: 'function-watcher',
+      prefix: 'function-logs-watcher',
+      function: launchFunctionWatcher,
+      options: {
+        appWatcher: expect.any(AppEventWatcher),
+        logsActive: true,
       },
     })
   })


### PR DESCRIPTION
WIP

Address: https://github.com/shop/issues-shopifyvm/issues/261

### WHY are these changes introduced?
  When running shopify app dev, function logs weren't automatically streamed if a function extension wa added during an active dev session. The logs polling mechanism only initialized at CLI startup, not when extensions were dynamically added.

### WHAT is this pull request doing?

-  created a dedicated FunctionWatcherProcess that monitors for function extension creation
- When a function extension is detected during a dev session, it automatically starts the logs polling
- The solution preserves the original behavior of starting logs polling at startup if function extensions already exist
Other solution explored
- Using some sort for delay mechanism instead for process, where we would pass the process, but not start it, until a function extension was added. This require big refactor on process.

### How to test your changes?

Test against production developer dashboard shop. 

  1. Start a dev session without any function extensions: `pnpm run shopify app dev --path=xyz`
  2. In another terminal, create a new function extension: `shopify app generate extension`
  3. Observe that function logs start streaming automatically in the dev output
  4. Verify the logs appear correctly after triggering the function


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
