### PR TITLE
Send app ids as numbers on websocket payloads

### DIFF
--- a/packages/app/src/cli/services/dev/extension/payload/store.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.ts
@@ -3,6 +3,7 @@ import {ExtensionDevOptions} from '../../extension.js'
 import {getUIExtensionPayload, isNewExtensionPointsSchema} from '../payload.js'
 import {buildAppURLForMobile, buildAppURLForWeb} from '../../../../utilities/app/app-url.js'
 import {ExtensionInstance} from '../../../../models/extensions/extension-instance.js'
+import {numberFromGid} from '../../../../utilities/developer-platform-client/app-management-client.js'
 import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 import {outputDebug, outputContent} from '@shopify/cli-kit/node/output'
 import {EventEmitter} from 'events'
@@ -26,7 +27,7 @@ export async function getExtensionsPayloadStoreRawPayload(
       url: await buildAppURLForWeb(options.storeFqdn, options.apiKey),
       mobileUrl: await buildAppURLForMobile(options.storeFqdn, options.apiKey),
     },
-    appId: options.id,
+    appId: options.id ? numberFromGid(options.id).toString() : undefined,
     version: options.manifestVersion,
     root: {
       url: new URL('/extensions', options.url).toString(),

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -1094,7 +1094,8 @@ function idFromEncodedGid(gid: string): string {
 }
 
 // gid://organization/Organization/1234 => 1234
-function numberFromGid(gid: string): number {
+export function numberFromGid(gid: string): number {
+  if (Number(gid)) return Number(gid)
   return Number(gid.match(/^gid.*\/(\d+)$/)![1])
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure the app ID is correctly formatted when used in the extensions payload store and DP2.

### WHAT is this pull request doing?

This PR modifies how app IDs are processed in the extensions payload:

1. Exports the `numberFromGid` function from the app-management-client for reuse
2. Adds a check to handle cases where the ID is already a number
3. Updates the extensions payload store to convert GID-formatted app IDs to numeric strings

### How to test your changes?

1. Run consistent dev with a checkout-ui extension that uses the appId to query stuff.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes