### PR TITLE
[ShopifyVM] use AppEventWatcher to trigger polling logs

### DIFF
--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.ts
@@ -28,6 +28,7 @@ export const pollAppLogs = async ({
   resubscribeCallback,
   storeName,
   organizationId,
+  abortSignal,
 }: {
   stdout: Writable
   appLogsFetchInput: AppLogsOptions
@@ -36,7 +37,12 @@ export const pollAppLogs = async ({
   resubscribeCallback: () => Promise<string>
   storeName: string
   organizationId: string
+  abortSignal?: AbortSignal
 }) => {
+  if (abortSignal?.aborted) {
+    return
+  }
+
   try {
     let nextJwtToken = jwtToken
     let retryIntervalMs = POLLING_INTERVAL_MS
@@ -116,6 +122,7 @@ export const pollAppLogs = async ({
         resubscribeCallback,
         storeName,
         organizationId,
+        abortSignal,
       }).catch((error) => {
         outputDebug(`Unexpected error during polling: ${error}}\n`)
       })
@@ -138,6 +145,7 @@ export const pollAppLogs = async ({
         resubscribeCallback,
         storeName,
         organizationId,
+        abortSignal,
       }).catch((error) => {
         outputDebug(`Unexpected error during polling: ${error}}\n`)
       })

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
@@ -1,11 +1,17 @@
 import {setupAppLogsPollingProcess, subscribeAndStartPolling} from './app-logs-polling.js'
-import {testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
+import {
+  testDeveloperPlatformClient,
+  testAppWithConfig,
+  testFunctionExtension,
+} from '../../../models/app/app.test-data.js'
 import {pollAppLogs} from '../../app-logs/dev/poll-app-logs.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import * as appLogsUtils from '../../app-logs/utils.js'
+import {AppEventWatcher} from '../app-events/app-event-watcher.js'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {createLogsDir} from '@shopify/cli-kit/node/logs'
+import {outputDebug} from '@shopify/cli-kit/node/output'
 import {describe, expect, vi, Mock, beforeEach, test} from 'vitest'
-import {outputWarn} from '@shopify/cli-kit/node/output'
 
 vi.mock('@shopify/cli-kit/node/logs')
 vi.mock('@shopify/cli-kit/node/output')
@@ -15,6 +21,13 @@ const SHOP_IDS = [1, 2]
 const API_KEY = 'API_KEY'
 const TOKEN = 'token'
 const JWT_TOKEN = 'JWT'
+const DEFAULT_FUNCTION_CONFIG = {
+  name: 'test-function',
+  type: 'function',
+  api_version: '2023-01',
+  configuration_ui: true,
+  build: {wasm_opt: true},
+}
 
 describe('app-logs-polling', () => {
   describe('setupAppLogsPollingProcess', () => {
@@ -22,6 +35,8 @@ describe('app-logs-polling', () => {
       // Given
       const developerPlatformClient = testDeveloperPlatformClient()
       const session = await developerPlatformClient.session()
+      const localApp = testAppWithConfig()
+      const appWatcher = new AppEventWatcher(localApp)
 
       // When
       const result = await setupAppLogsPollingProcess({
@@ -29,6 +44,8 @@ describe('app-logs-polling', () => {
         subscription: {shopIds: SHOP_IDS, apiKey: API_KEY},
         storeName: 'storeName',
         organizationId: 'organizationId',
+        localApp,
+        appWatcher,
       })
 
       // Then
@@ -42,6 +59,8 @@ describe('app-logs-polling', () => {
             shopIds: SHOP_IDS,
             apiKey: API_KEY,
           },
+          localApp,
+          appWatcher,
         },
       })
     })
@@ -59,16 +78,33 @@ describe('app-logs-polling', () => {
     let stdout: any
     let stderr: any
     let abortSignal: AbortSignal
+    let localApp: any
+    let appWatcher: any
 
-    beforeEach(() => {
+    beforeEach(async () => {
       stdout = {write: vi.fn()}
       stderr = {write: vi.fn()}
       abortSignal = new AbortSignal()
       subscribeToAppLogs = vi.fn()
+
+      // Create function extension
+      localApp = testAppWithConfig({
+        config: {},
+        app: {
+          allExtensions: [await testFunctionExtension({config: DEFAULT_FUNCTION_CONFIG})],
+        },
+      })
+
+      appWatcher = {
+        onEvent: vi.fn().mockReturnThis(),
+        onStart: vi.fn().mockReturnThis(),
+      }
+
       developerPlatformClient = testDeveloperPlatformClient({subscribeToAppLogs})
 
       vi.mocked(createLogsDir).mockResolvedValue()
       vi.mocked(pollAppLogs).mockResolvedValue()
+      vi.spyOn(appLogsUtils, 'subscribeToAppLogs').mockResolvedValue(JWT_TOKEN)
     })
 
     test('sets up app log polling', async () => {
@@ -83,12 +119,30 @@ describe('app-logs-polling', () => {
           appLogsSubscribeVariables,
           storeName: 'storeName',
           organizationId: 'organizationId',
+          localApp,
+          appWatcher,
         },
       )
 
+      expect(appWatcher.onStart).toHaveBeenCalledOnce()
+      expect(appWatcher.onEvent).toHaveBeenCalledOnce()
+
+      const startCallback = appWatcher.onStart.mock.calls[0][0]
+      const appEvent = {
+        app: localApp,
+        extensionEvents: [],
+        startTime: [0, 0],
+        path: '',
+      }
+      await startCallback(appEvent)
+
       // Then
-      expect(developerPlatformClient.refreshToken).toHaveBeenCalledOnce()
-      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables, 'organizationId')
+      expect(outputDebug).toHaveBeenCalledWith('Function extensions detected, starting logs polling')
+      expect(appLogsUtils.subscribeToAppLogs).toHaveBeenCalledWith(
+        developerPlatformClient,
+        appLogsSubscribeVariables,
+        'organizationId',
+      )
       expect(createLogsDir).toHaveBeenCalledWith(API_KEY)
       expect(pollAppLogs).toHaveBeenCalledOnce()
       expect(vi.mocked(pollAppLogs).mock.calls[0]?.[0]).toMatchObject({
@@ -96,12 +150,15 @@ describe('app-logs-polling', () => {
         appLogsFetchInput: {jwtToken: JWT_TOKEN},
         apiKey: API_KEY,
       })
+
+      const eventCallback = appWatcher.onEvent.mock.calls[0][0]
+      expect(startCallback).toBe(eventCallback)
     })
 
     test('prints error and returns on query errors', async () => {
       // Given
-      subscribeToAppLogs.mockResolvedValue({
-        appLogsSubscribe: {success: false, errors: ['uh oh', 'another error'], jwtToken: null},
+      vi.spyOn(appLogsUtils, 'subscribeToAppLogs').mockImplementation(() => {
+        throw new Error('uh oh, another error')
       })
 
       // When
@@ -112,14 +169,30 @@ describe('app-logs-polling', () => {
           appLogsSubscribeVariables,
           storeName: 'storeName',
           organizationId: 'organizationId',
+          localApp,
+          appWatcher,
         },
       )
 
+      expect(appWatcher.onStart).toHaveBeenCalledOnce()
+      expect(appWatcher.onEvent).toHaveBeenCalledOnce()
+
+      const startCallback = appWatcher.onStart.mock.calls[0][0]
+      const appEvent = {
+        app: localApp,
+        extensionEvents: [],
+        startTime: [0, 0],
+        path: '',
+      }
+      await startCallback(appEvent)
+
       // Then
-      expect(subscribeToAppLogs).toHaveBeenCalledWith(appLogsSubscribeVariables, 'organizationId')
-      expect(outputWarn).toHaveBeenCalledWith(`Errors subscribing to app logs: uh oh, another error`)
-      expect(outputWarn).toHaveBeenCalledWith(`App log streaming is not available in this session.`)
-      expect(createLogsDir).not.toHaveBeenCalled()
+      expect(appLogsUtils.subscribeToAppLogs).toHaveBeenCalledWith(
+        developerPlatformClient,
+        appLogsSubscribeVariables,
+        'organizationId',
+      )
+      expect(outputDebug).toHaveBeenCalledWith('Failed to start function logs: Error: uh oh, another error', stderr)
       expect(pollAppLogs).not.toHaveBeenCalled()
     })
   })

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
@@ -3,14 +3,23 @@ import {pollAppLogs} from '../../app-logs/dev/poll-app-logs.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {AppLogsSubscribeMutationVariables} from '../../../api/graphql/app-management/generated/app-logs-subscribe.js'
 import {subscribeToAppLogs} from '../../app-logs/utils.js'
+import {AppLinkedInterface} from '../../../models/app/app.js'
+import {AppEventWatcher, AppEvent} from '../app-events/app-event-watcher.js'
 
 import {createLogsDir} from '@shopify/cli-kit/node/logs'
+import {outputDebug} from '@shopify/cli-kit/node/output'
+
+function hasFunctionExtensions(app: AppLinkedInterface): boolean {
+  return app.allExtensions.some((extension) => extension.isFunctionExtension)
+}
 
 interface SubscribeAndStartPollingOptions {
   developerPlatformClient: DeveloperPlatformClient
   appLogsSubscribeVariables: AppLogsSubscribeMutationVariables
   storeName: string
   organizationId: string
+  appWatcher: AppEventWatcher
+  localApp: AppLinkedInterface
 }
 
 export interface AppLogsSubscribeProcess extends BaseProcess<SubscribeAndStartPollingOptions> {
@@ -25,6 +34,8 @@ interface Props {
   }
   storeName: string
   organizationId: string
+  appWatcher: AppEventWatcher
+  localApp: AppLinkedInterface
 }
 
 export async function setupAppLogsPollingProcess({
@@ -32,6 +43,8 @@ export async function setupAppLogsPollingProcess({
   subscription: {shopIds, apiKey},
   storeName,
   organizationId,
+  appWatcher,
+  localApp,
 }: Props): Promise<AppLogsSubscribeProcess> {
   return {
     type: 'app-logs-subscribe',
@@ -45,15 +58,17 @@ export async function setupAppLogsPollingProcess({
       },
       storeName,
       organizationId,
+      appWatcher,
+      localApp,
     },
   }
 }
 
 export const subscribeAndStartPolling: DevProcessFunction<SubscribeAndStartPollingOptions> = async (
   {stdout, stderr: _stderr, abortSignal: _abortSignal},
-  {developerPlatformClient, appLogsSubscribeVariables, storeName, organizationId},
+  {developerPlatformClient, appLogsSubscribeVariables, storeName, organizationId, appWatcher, localApp: _localApp},
 ) => {
-  try {
+  async function startPolling(abortSignal?: AbortSignal) {
     const jwtToken = await subscribeToAppLogs(developerPlatformClient, appLogsSubscribeVariables, organizationId)
 
     const apiKey = appLogsSubscribeVariables.apiKey
@@ -69,7 +84,37 @@ export const subscribeAndStartPolling: DevProcessFunction<SubscribeAndStartPolli
       developerPlatformClient,
       storeName,
       organizationId,
+      abortSignal,
     })
+  }
+
+  try {
+    let logsStarted = false
+    let pollingAbortController: AbortController | undefined
+
+    const startPollingIfNeeded = async (appEvent: AppEvent) => {
+      const hasFunctions = hasFunctionExtensions(appEvent.app)
+
+      if (hasFunctions && !logsStarted) {
+        outputDebug('Function extensions detected, starting logs polling')
+        logsStarted = true
+        pollingAbortController = new AbortController()
+
+        try {
+          await startPolling(pollingAbortController.signal)
+          // eslint-disable-next-line no-catch-all/no-catch-all
+        } catch (error) {
+          outputDebug(`Failed to start function logs: ${error}`, _stderr)
+        }
+      } else if (!hasFunctions && logsStarted) {
+        outputDebug('No function extensions detected, stopping logs polling')
+        logsStarted = false
+        pollingAbortController?.abort()
+        pollingAbortController = undefined
+      }
+    }
+
+    appWatcher.onStart(startPollingIfNeeded).onEvent(startPollingIfNeeded)
     // eslint-disable-next-line no-catch-all/no-catch-all,no-empty
   } catch (error) {}
 }

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -261,7 +261,8 @@ describe('setup-dev-processes', () => {
       },
     })
 
-    expect(res.processes[6]).toMatchObject({
+    const appWatcherProcess = res.processes.find((process) => process.type === 'app-watcher')
+    expect(appWatcherProcess).toMatchObject({
       type: 'app-watcher',
       prefix: 'app-preview',
       function: launchAppWatcher,
@@ -275,7 +276,8 @@ describe('setup-dev-processes', () => {
     const hmrPort = (res.processes[0] as WebProcess).options.hmrServerOptions?.port
     const previewExtensionPort = (res.processes[2] as PreviewableExtensionProcess).options.port
 
-    expect(res.processes[7]).toMatchObject({
+    const proxyServerProcess = res.processes.find((process) => process.type === 'proxy-server')
+    expect(proxyServerProcess).toMatchObject({
       type: 'proxy-server',
       prefix: 'proxy',
       function: startProxyServer,
@@ -452,6 +454,7 @@ describe('setup-dev-processes', () => {
           shopIds: [123456789],
           apiKey: 'api-key',
         },
+        appWatcher: expect.any(AppEventWatcher),
       },
     })
   })
@@ -537,9 +540,10 @@ describe('setup-dev-processes', () => {
       graphiqlKey,
     })
 
-    res.processes.forEach((process) => {
-      expect(process.type).not.toBe('app-logs-subscribe')
-    })
+    const logsProcess = res.processes.find((process) => process.type === 'app-logs-subscribe')
+    expect(logsProcess).not.toBeUndefined()
+    expect(logsProcess?.options).toHaveProperty('localApp')
+    expect(logsProcess?.options).toHaveProperty('appWatcher')
   })
 
   test('pushUpdatesForDraftableExtensions does not include config extensions except app_access', async () => {

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -93,7 +93,6 @@ export async function setupDevProcesses({
   const appPreviewUrl = await buildAppURLForWeb(storeFqdn, apiKey)
   const env = getEnvironmentVariables()
   const shouldRenderGraphiQL = !isTruthy(env[environmentVariableNames.disableGraphiQLExplorer])
-  const shouldPerformAppLogPolling = localApp.allExtensions.some((extension) => extension.isFunctionExtension)
 
   // At this point, the toml file has changed, we need to reload the app before actually starting dev
   const reloadedApp = await reloadApp(localApp)
@@ -185,17 +184,17 @@ export async function setupDevProcesses({
       apiSecret,
       remoteAppUpdated,
     }),
-    shouldPerformAppLogPolling
-      ? await setupAppLogsPollingProcess({
-          developerPlatformClient,
-          subscription: {
-            shopIds: [Number(storeId)],
-            apiKey,
-          },
-          storeName: storeFqdn,
-          organizationId: remoteApp.organizationId,
-        })
-      : undefined,
+    await setupAppLogsPollingProcess({
+      developerPlatformClient,
+      subscription: {
+        shopIds: [Number(storeId)],
+        apiKey,
+      },
+      storeName: storeFqdn,
+      organizationId: remoteApp.organizationId,
+      localApp,
+      appWatcher,
+    }),
     await setupAppWatcherProcess({
       appWatcher,
     }),


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-shopifyvm/issues/261

The app logs polling process needed to be aware of function extensions being added to the app. Previously, it only checked for function extensions at startup, but not when they were added later.


### WHAT is this pull request doing?

- Updates the app logs polling process to use the app watcher to detect when function extensions are added
- Checks extensions by looking at `app.allExtensions`, using `extension.isFunctionExtension` to determine when to poll
- Initially if function exists, we will poll as normal
- Now, when function extension is added, and we are NOT polling, this will trigger the poll to start
- Fixes test setup to properly create function extensions using `testFunctionExtension`
- Added a helper function for function extension check to make the code cleaner and more maintainable

The approach injects the app watcher into the existing polling process without major changes so we can be ready for convergence on thursday..


### How to test your changes?

1. Start a dev server **without** a function extension
2. Add a new function extension in another terminal 
3. Verify logs for the new extension start being polled by running a function

Production (from you local app):
```
shopify app dev
```

CLI on this Branch
```
pnpm run shopify app dev --path=local-app
```

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
