### PR TITLE
[Fix][Themes] Remove asset upload errors for files that are renamed / deleted

### DIFF
--- a/.changeset/sweet-colts-film.md
+++ b/.changeset/sweet-colts-film.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix: Clear asset upload error overlay for deleted / renamed files

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -112,7 +112,7 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
           case 'change':
             return handleFileUpdate(eventName, themeId, adminSession, fileKey)
           case 'unlink':
-            return handleFileDelete(themeId, adminSession, fileKey)
+            return handleFileDelete(themeId, adminSession, fileKey, uploadErrors)
         }
       })
       .catch((error) => {
@@ -176,10 +176,16 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
     })
   }
 
-  const handleFileDelete = (themeId: string, adminSession: AdminSession, fileKey: string) => {
+  const handleFileDelete = (
+    themeId: string,
+    adminSession: AdminSession,
+    fileKey: string,
+    uploadErrors: Map<string, string[]>,
+  ) => {
     if (isFileIgnored(fileKey)) return
 
     // Optimistically delete the file from the local file system.
+    uploadErrors.delete(fileKey)
     files.delete(fileKey)
     unsyncedFileKeys.add(fileKey)
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5640

### WHAT is this pull request doing?
- On deletion or renaming of a theme file, clear any associated asset upload errors to prevent this overlay from persisting for the whole session

https://github.com/user-attachments/assets/90e7681c-b7ec-4f97-9988-8b1613aa3470

### How to test your changes?
1) Run `shopify-dev theme dev`
2) Rename template to something invalid (i.e.`404.json` -> `404 copy.json`)
3) Verify that the asset upload errors page is rendered
4) Rename the template to a valid name (i.e.`404 copy.json` -> `404.json`)
5) Verify that the asset upload error page disappears

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
