### PR TITLE
Add actual "errors" to `shopify theme push --json` output

### DIFF
--- a/.changeset/twenty-lamps-behave.md
+++ b/.changeset/twenty-lamps-behave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Add the actual "errors" during theme upload to the JSON output from `shopify theme push --json`


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

I need to show the errors from a theme preview GitHub Action that we have for Horizon.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Adds the upload `"errors"` to the JSON output from `shopify theme push --json`.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

I added a unit test. If you want to test it manually, run `shopify theme push --json` with an invalid theme (but NOT theme check invalid! upload invalid.)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
