### PR TITLE
show warning message when installing mkcert in WSL

### DIFF
--- a/packages/app/src/cli/utilities/mkcert.ts
+++ b/packages/app/src/cli/utilities/mkcert.ts
@@ -186,21 +186,21 @@ export async function generateCertificate({
   outputInfo(outputContent`${outputToken.successIcon()} Certificate generated at ${relativeCertPath}\n`)
 
   const wsl = await isWsl()
-  if (!wsl) {
+  if (wsl) {
     renderWarning({
-      headline:
-        "We've detected that you are running Shopify CLI under WSL. Additional steps are required to configure certificate trust in Windows.",
-      body: [
-        'This is only needed the first time you run an app with',
-        {command: '--use-localhost'},
-        'If needed, we recommend following these steps before proceeding. Press enter to continue',
-      ],
+      headline: "It looks like you're using WSL.",
+      body: ['Additional steps are required to configure certificate trust in Windows.'],
       link: {
-        label: 'See Shopify CLI documentation for details',
+        label: 'See Shopify CLI documentation',
         url: 'https://shopify.dev/docs/apps/build/cli-for-apps/networking-options#localhost-based-development-with-windows-subsystem-for-linux-wsl',
       },
     })
+
+    outputInfo('👉 Press any key to continue')
+
     await keypress()
+    // Empty line so that the keypress feels more responsive.
+    outputInfo('')
   }
 
   return {


### PR DESCRIPTION
### WHY are these changes introduced?

Provide guidance on certificate trust configuration for windows users under WSL.

### WHAT is this pull request doing?

When a user is running the CLI in WSL, they'll now see a warning explaining that additional steps are required to configure certificate trust in Windows, along with a link to documentation that provides detailed instructions.

The PR also:
- Adds a pause (keypress prompt) after the warning to ensure users see the message
- Updates tests to cover the new WSL detection and warning functionality

### How to test your changes?

1. Run the CLI in a WSL environment
2. Generate a certificate using the CLI
3. Verify that the WSL warning appears with a link to documentation
4. Verify that the CLI pauses for user input after displaying the warning

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes