### PR TITLE
[DNM] Use Javy Plugin v2

### DIFF
--- a/packages/app/src/cli/services/function/binaries.test.ts
+++ b/packages/app/src/cli/services/function/binaries.test.ts
@@ -135,9 +135,9 @@ describe('javy', () => {
 
 describe('javy-plugin', () => {
   test('properties are set correctly', () => {
-    expect(javyPlugin.name).toBe('shopify_functions_javy_v1')
+    expect(javyPlugin.name).toBe(`shopify_functions_javy_v2`)
     expect(javyPlugin.version).match(/^v\d+$/)
-    expect(javyPlugin.path).toMatch(/(\/|\\)shopify_functions_javy_v1.wasm$/)
+    expect(javyPlugin.path).toMatch(/(\/|\\)shopify_functions_javy_v2.wasm$/)
   })
 
   test('downloadUrl returns the correct URL', () => {

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs'
 import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
-const FUNCTION_RUNNER_VERSION = 'v7.0.1'
+const FUNCTION_RUNNER_VERSION = 'v8.0.0'
 const JAVY_VERSION = 'v4.0.0'
 // The Javy plugin version should match the plugin version used in the
 // function-runner version specified above.

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -14,7 +14,7 @@ const FUNCTION_RUNNER_VERSION = 'v7.0.1'
 const JAVY_VERSION = 'v4.0.0'
 // The Javy plugin version should match the plugin version used in the
 // function-runner version specified above.
-const JAVY_PLUGIN_VERSION = 'v1'
+const JAVY_PLUGIN_VERSION = 'v2'
 
 const BINARYEN_VERSION = '123.0.0'
 

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -1,4 +1,12 @@
-import {buildGraphqlTypes, bundleExtension, runJavy, ExportJavyBuilder, jsExports, runWasmOpt} from './build.js'
+import {
+  buildGraphqlTypes,
+  bundleExtension,
+  runJavy,
+  ExportJavyBuilder,
+  jsExports,
+  runWasmOpt,
+  PREFERRED_FUNCTION_NPM_PACKAGE_MAJOR_VERSION,
+} from './build.js'
 import {javyBinary, javyPluginBinary, wasmOptBinary} from './binaries.js'
 import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
@@ -68,7 +76,7 @@ async function installShopifyLibrary(tmpDir: string) {
   await writeFile(runModule, '')
 
   const packageJson = joinPath(shopifyFunctionDir, 'package.json')
-  await writeFile(packageJson, JSON.stringify({version: '1.0.0'}))
+  await writeFile(packageJson, JSON.stringify({version: `${PREFERRED_FUNCTION_NPM_PACKAGE_MAJOR_VERSION}.0.0`}))
 
   return shopifyFunction
 }
@@ -142,7 +150,7 @@ describe('bundleExtension', () => {
   test('errors if shopify library is not on a compatible version', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
-      const incompatibleVersion = '999.0.0'
+      const incompatibleVersion = '1.0.0'
       const ourFunction = await testFunctionExtension({dir: tmpDir})
       ourFunction.entrySourceFilePath = joinPath(tmpDir, 'src/index.ts')
       await installShopifyLibrary(tmpDir)

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -17,8 +17,8 @@ import {runWithTimer} from '@shopify/cli-kit/node/metadata'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {Writable} from 'stream'
 
-const ALLOWED_FUNCTION_NPM_PACKAGE_MAJOR_VERSIONS = ['0', '1']
-export const PREFERRED_FUNCTION_NPM_PACKAGE_MAJOR_VERSION = '1'
+const ALLOWED_FUNCTION_NPM_PACKAGE_MAJOR_VERSIONS = ['2']
+export const PREFERRED_FUNCTION_NPM_PACKAGE_MAJOR_VERSION = '2'
 
 class InvalidShopifyFunctionPackageError extends AbortError {
   constructor(message: string) {


### PR DESCRIPTION
We need to release the functions JS package before we merge this. 

### WHY are these changes introduced?

Part of https://github.com/shop/issues-shopifyvm/issues/29

### WHAT is this pull request doing?

Uses the new version of the javy plugin, as well as updating the related npm package accepted versions.

### How to test your changes?

Without this branch, create a function extension from a javascript template.
Repeat the same with this branch.
Make sure to `npm install` both.

With this branch, attempt to build the two functions.
```
pnpm shopify app function build --path /path/to/javascript/extension
```

On the first extension, it should fail, because it's `package.json` depends on `"@shopify/shopify_function": "~1.0.0"` which no longer matches our minimum accepted version.

On the second extension, it should succeed, because it's `package.json` depends on `"@shopify/shopify_function": "~2.0.0"`.

You can check out main and attempt the build commands again to see the inverse behaviour.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
