### PR TITLE
Enforce upload ordering of layout files before templates

### DIFF
--- a/.changeset/soft-poets-hide.md
+++ b/.changeset/soft-poets-hide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Improved theme upload ordering to ensure layout files are uploaded before templates

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -401,14 +401,16 @@ describe('theme-fs', () => {
         {key: 'assets/sparkle.gif', checksum: '3'},
         {key: 'layout/password.liquid', checksum: '4'},
         {key: 'layout/theme.liquid', checksum: '5'},
+        {key: 'layout/custom.liquid', checksum: '15'},
         {key: 'locales/en.default.json', checksum: '6'},
         {key: 'templates/404.json', checksum: '7'},
         {key: 'config/settings_schema.json', checksum: '8'},
         {key: 'config/settings_data.json', checksum: '9'},
         {key: 'sections/announcement-bar.liquid', checksum: '10'},
         {key: 'snippets/language-localization.liquid', checksum: '11'},
-        {key: 'templates/404.context.uk.json', checksum: '11'},
-        {key: 'blocks/block.liquid', checksum: '12'},
+        {key: 'templates/404.context.uk.json', checksum: '12'},
+        {key: 'templates/404.liquid', checksum: '13'},
+        {key: 'blocks/block.liquid', checksum: '14'},
       ]
       // When
       const {
@@ -420,18 +422,18 @@ describe('theme-fs', () => {
         staticAssetFiles,
         contextualizedJsonFiles,
         blockLiquidFiles,
+        layoutFiles,
       } = partitionThemeFiles(files)
 
       // Then
       expect(sectionLiquidFiles).toEqual([{key: 'sections/announcement-bar.liquid', checksum: '10'}])
       expect(otherLiquidFiles).toEqual([
         {key: 'assets/base.css.liquid', checksum: '2'},
-        {key: 'layout/password.liquid', checksum: '4'},
-        {key: 'layout/theme.liquid', checksum: '5'},
         {key: 'snippets/language-localization.liquid', checksum: '11'},
+        {key: 'templates/404.liquid', checksum: '13'},
       ])
-      expect(templateJsonFiles).toEqual([{key: 'templates/404.json', checksum: '7'}])
       expect(otherJsonFiles).toEqual([{key: 'locales/en.default.json', checksum: '6'}])
+      expect(templateJsonFiles).toEqual([{key: 'templates/404.json', checksum: '7'}])
       expect(configFiles).toEqual([
         {key: 'config/settings_schema.json', checksum: '8'},
         {key: 'config/settings_data.json', checksum: '9'},
@@ -440,8 +442,13 @@ describe('theme-fs', () => {
         {key: 'assets/base.css', checksum: '1'},
         {key: 'assets/sparkle.gif', checksum: '3'},
       ])
-      expect(contextualizedJsonFiles).toEqual([{key: 'templates/404.context.uk.json', checksum: '11'}])
-      expect(blockLiquidFiles).toEqual([{key: 'blocks/block.liquid', checksum: '12'}])
+      expect(contextualizedJsonFiles).toEqual([{key: 'templates/404.context.uk.json', checksum: '12'}])
+      expect(blockLiquidFiles).toEqual([{key: 'blocks/block.liquid', checksum: '14'}])
+      expect(layoutFiles).toEqual([
+        {key: 'layout/password.liquid', checksum: '4'},
+        {key: 'layout/theme.liquid', checksum: '5'},
+        {key: 'layout/custom.liquid', checksum: '15'},
+      ])
     })
 
     test('should handle empty file array', () => {

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -35,6 +35,7 @@ const THEME_DIRECTORY_PATTERNS = [
 ]
 
 const THEME_PARTITION_REGEX = {
+  layoutLiquidRegex: /^layout\/.+\.liquid$/,
   sectionLiquidRegex: /^sections\/.+\.liquid$/,
   blockLiquidRegex: /^blocks\/.+\.liquid$/,
   configRegex: /^config\/(settings_schema|settings_data)\.json$/,
@@ -359,6 +360,7 @@ export function partitionThemeFiles<T extends {key: string}>(files: T[]) {
   const configFiles: T[] = []
   const staticAssetFiles: T[] = []
   const blockLiquidFiles: T[] = []
+  const layoutFiles: T[] = []
 
   files.forEach((file) => {
     const fileKey = file.key
@@ -367,6 +369,8 @@ export function partitionThemeFiles<T extends {key: string}>(files: T[]) {
         sectionLiquidFiles.push(file)
       } else if (THEME_PARTITION_REGEX.blockLiquidRegex.test(fileKey)) {
         blockLiquidFiles.push(file)
+      } else if (THEME_PARTITION_REGEX.layoutLiquidRegex.test(fileKey)) {
+        layoutFiles.push(file)
       } else {
         otherLiquidFiles.push(file)
       }
@@ -397,6 +401,7 @@ export function partitionThemeFiles<T extends {key: string}>(files: T[]) {
     configFiles,
     staticAssetFiles,
     blockLiquidFiles,
+    layoutFiles,
   }
 }
 

--- a/packages/theme/src/cli/utilities/theme-uploader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.test.ts
@@ -253,6 +253,7 @@ describe('theme-uploader', () => {
       {key: 'assets/liquid.liquid', checksum: '5'},
       {key: 'config/settings_data.json', checksum: '6'},
       {key: 'assets/image.png', checksum: '7'},
+      {key: 'layout/custom.liquid', checksum: '8'},
     ]
     const themeFileSystem = fakeThemeFileSystem('tmp', new Map([]))
 
@@ -274,6 +275,7 @@ describe('theme-uploader', () => {
         'templates/product.context.uk.json',
         'templates/product.json',
         'sections/header-group.json',
+        'layout/custom.liquid',
         'templates/index.liquid',
         'assets/liquid.liquid',
         'config/settings_data.json',
@@ -299,6 +301,7 @@ describe('theme-uploader', () => {
         ['assets/image.png', {key: 'assets/image.png', checksum: '7'}],
         ['templates/product.context.uk.json', {key: 'templates/product.context.uk.json', checksum: '8'}],
         ['blocks/block.liquid', {key: 'blocks/block.liquid', checksum: '9'}],
+        ['layout/theme.liquid', {key: 'layout/theme.liquid', checksum: '10'}],
       ]),
     )
 
@@ -313,14 +316,14 @@ describe('theme-uploader', () => {
     await renderThemeSyncProgress()
 
     // Then
-    expect(bulkUploadThemeAssets).toHaveBeenCalledTimes(8)
+    expect(bulkUploadThemeAssets).toHaveBeenCalledTimes(9)
     // Minimum theme files start first
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(1, remoteTheme.id, MINIMUM_THEME_ASSETS, adminSession)
     // Dependent assets start second
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
       2,
       remoteTheme.id,
-      [{key: 'blocks/block.liquid'}],
+      [{key: 'layout/theme.liquid'}],
       adminSession,
     )
     // Independent assets start right after dependent assets start
@@ -344,6 +347,12 @@ describe('theme-uploader', () => {
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
       4,
       remoteTheme.id,
+      [{key: 'blocks/block.liquid'}],
+      adminSession,
+    )
+    expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
+      5,
+      remoteTheme.id,
       [
         {
           key: 'sections/header.liquid',
@@ -353,7 +362,7 @@ describe('theme-uploader', () => {
     )
 
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
-      5,
+      6,
       remoteTheme.id,
       [
         {
@@ -362,8 +371,9 @@ describe('theme-uploader', () => {
       ],
       adminSession,
     )
+
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
-      6,
+      7,
       remoteTheme.id,
       [
         {
@@ -372,8 +382,9 @@ describe('theme-uploader', () => {
       ],
       adminSession,
     )
+
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
-      7,
+      8,
       remoteTheme.id,
       [
         {
@@ -382,8 +393,9 @@ describe('theme-uploader', () => {
       ],
       adminSession,
     )
+
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
-      8,
+      9,
       remoteTheme.id,
       [
         {

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -190,6 +190,7 @@ function orderFilesToBeDeleted(files: Checksum[]): Checksum[] {
     ...fileSets.otherJsonFiles,
     ...fileSets.sectionLiquidFiles,
     ...fileSets.blockLiquidFiles,
+    ...fileSets.layoutFiles,
     ...fileSets.otherLiquidFiles,
     ...fileSets.configFiles,
     ...fileSets.staticAssetFiles,
@@ -289,14 +290,16 @@ function selectUploadableFiles(themeFileSystem: ThemeFileSystem, remoteChecksums
  * We use this 2d array to batch files of the same type together
  * while maintaining the order between file types. The files with
  * dependencies we have are:
- * 1. Liquid sections need to be uploaded first
- * 2. JSON sections need to be uploaded afterward so they can reference Liquid sections
- * 3. JSON templates should be the next ones so they can reference sections
- * 4. Contextualized templates should be uploaded after as they are variations of templates
- * 5. Config files must be the last ones, but we need to upload config/settings_schema.json first, followed by config/settings_data.json
+ * 1. Layout files don't necessarily need to be the first, but they must uploaded before templates.
+ * 2. Liquid blocks need to be uploaded before sections
+ * 3. Liquid sections need to be uploaded afterwards
+ * 4. JSON sections need to be uploaded after sections
+ * 5. JSON templates need to be uploaded after all sections and layouts
+ * 6. Contextualized templates should be uploaded after as they are variations of templates
+ * 7. Config files must be the last ones, but we need to upload config/settings_schema.json first, followed by config/settings_data.json
  *
  * The files with no dependencies we have are:
- * - The other Liquid files (for example, snippets)
+ * - The other Liquid files (for example, snippets, and liquid templates)
  * - The other JSON files (for example, locales)
  * - The static assets
  *
@@ -312,6 +315,7 @@ function orderFilesToBeUploaded(files: ChecksumWithSize[]): {
     independentFiles: [fileSets.otherLiquidFiles, fileSets.otherJsonFiles, fileSets.staticAssetFiles],
     // Follow order of dependencies:
     dependentFiles: [
+      fileSets.layoutFiles,
       fileSets.blockLiquidFiles,
       fileSets.sectionLiquidFiles,
       fileSets.sectionJsonFiles,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5696

Layouts were previously considered independent files, which were[ concurrently uploaded](https://github.com/Shopify/cli/blob/d445f4cd246f964c9fd5835850d0c11ac0b728c9/packages/theme/src/cli/utilities/theme-uploader.ts#L258-L268) with the dependent files

If a user is referencing a custom layout from a template, there is no guarantee that the layout already exists.

### WHAT is this pull request doing?
This change adds `layout` files to the list of dependant files. This allows us to can enforce ordering before templates are uploaded.

- Separately partitions any layout files
- Queues layout files first (this is inspired by the way the backend orders the [copier](https://github.com/shop/world/blob/main/areas/core/shopify/components/online_store/app/models/theme/copier.rb#L256-L297))

### How to test your changes?
Refer to https://github.com/Shopify/cli/issues/5696 

I wasn't able to replicate this locally as I believe this is related to a race condition.


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
