### PR TITLE
Show multiple CLI installation warning once a day

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -37,7 +37,7 @@ import {platformAndArch} from '@shopify/cli-kit/node/os'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {zod} from '@shopify/cli-kit/node/schema'
 import colors from '@shopify/cli-kit/node/colors'
-import {showMultipleCLIWarningIfNeeded} from '@shopify/cli-kit/node/cli'
+import {showMultipleCLIWarningIfNeeded} from '@shopify/cli-kit/node/multiple-installation-warning'
 
 vi.mock('../../services/local-storage.js')
 vi.mock('../../services/app/config/use.js')
@@ -48,7 +48,8 @@ vi.mock('@shopify/cli-kit/node/node-package-manager', async () => ({
   globalCLIVersion: vi.fn(),
 }))
 vi.mock('@shopify/cli-kit/node/version')
-vi.mock('@shopify/cli-kit/node/cli')
+vi.mock('@shopify/cli-kit/node/multiple-installation-warning')
+
 describe('load', () => {
   let specifications: ExtensionSpecification[] = []
 

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -33,7 +33,7 @@ import {loadLocalExtensionsSpecifications} from '../extensions/load-specificatio
 import {UIExtensionSchemaType} from '../extensions/specifications/ui_extension.js'
 import {patchAppHiddenConfigFile} from '../../services/app/patch-app-configuration-file.js'
 import {getOrCreateAppConfigHiddenPath} from '../../utilities/app/config/hidden-app-config.js'
-import {showMultipleCLIWarningIfNeeded} from '@shopify/cli-kit/node/cli'
+import {showMultipleCLIWarningIfNeeded} from '@shopify/cli-kit/node/multiple-installation-warning'
 import {fileExists, readFile, glob, findPathUp, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
@@ -351,7 +351,9 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
 
     const hiddenConfig = await loadHiddenConfig(directory, configuration)
 
-    await showMultipleCLIWarningIfNeeded(directory, nodeDependencies)
+    if (!this.previousApp) {
+      await showMultipleCLIWarningIfNeeded(directory, nodeDependencies)
+    }
 
     const {webs, usedCustomLayout: usedCustomLayoutForWeb} = await this.loadWebs(
       directory,

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -92,12 +92,7 @@
                 "../../private/node/conf-store.js",
                 "../../private/node/constants.js",
                 "url",
-                "./cli-launcher.js",
-                "./is-global.js",
-                "./ui.js",
-                "./version.js",
-                "../common/version.js",
-                "./environment.js"
+                "./cli-launcher.js"
               ]
             }
           ]

--- a/packages/cli-kit/src/public/node/cli.test.ts
+++ b/packages/cli-kit/src/public/node/cli.test.ts
@@ -1,15 +1,10 @@
-import {clearCache, runCLI, runCreateCLI, showMultipleCLIWarningIfNeeded} from './cli.js'
+import {clearCache, runCLI, runCreateCLI} from './cli.js'
 import {findUpAndReadPackageJson} from './node-package-manager.js'
 import {mockAndCaptureOutput} from './testing/output.js'
-import {globalCLIVersion, localCLIVersion} from './version.js'
-import {currentProcessIsGlobal} from './is-global.js'
 import * as confStore from '../../private/node/conf-store.js'
-import {CLI_KIT_VERSION} from '../common/version.js'
-import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
 
 vi.mock('./node-package-manager.js')
-vi.mock('./version.js')
-vi.mock('./is-global.js')
 
 describe('cli', () => {
   test('prepares to run the CLI', async () => {
@@ -117,137 +112,5 @@ describe('clearCache', () => {
     clearCache()
     expect(spy).toHaveBeenCalled()
     spy.mockRestore()
-  })
-})
-
-describe('showMultipleCLIWarningIfNeeded', () => {
-  beforeEach(() => {
-    clearCache()
-  })
-
-  test('shows warning if using global CLI but app has local dependency', async () => {
-    // Given
-    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
-    vi.mocked(globalCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
-    vi.mocked(localCLIVersion).mockResolvedValue('3.70.0')
-    const mockOutput = mockAndCaptureOutput()
-
-    // When
-    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': '3.70.0'})
-
-    // Then
-    expect(mockOutput.info()).toMatchInlineSnapshot(`
-      "╭─ info ───────────────────────────────────────────────────────────────────────╮
-      │                                                                              │
-      │  Two Shopify CLI installations found – using global installation             │
-      │                                                                              │
-      │  A global installation (v${CLI_KIT_VERSION}) and a local dependency (v3.70.0) were       │
-      │  detected.                                                                   │
-      │  We recommend removing the @shopify/cli and @shopify/app dependencies from   │
-      │  your package.json, unless you want to use different versions across         │
-      │  multiple apps.                                                              │
-      │                                                                              │
-      │  See Shopify CLI documentation. [1]                                          │
-      │                                                                              │
-      ╰──────────────────────────────────────────────────────────────────────────────╯
-      [1] https://shopify.dev/docs/apps/build/cli-for-apps#switch-to-a-global-executab
-      le-or-local-dependency
-      "
-    `)
-    mockOutput.clear()
-  })
-
-  test('shows warning if using local CLI but app has global dependency', async () => {
-    // Given
-    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
-    vi.mocked(globalCLIVersion).mockResolvedValue('3.70.0')
-    vi.mocked(localCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
-    const mockOutput = mockAndCaptureOutput()
-
-    // When
-    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': CLI_KIT_VERSION})
-
-    // Then
-    expect(mockOutput.info()).toMatchInlineSnapshot(`
-      "╭─ info ───────────────────────────────────────────────────────────────────────╮
-      │                                                                              │
-      │  Two Shopify CLI installations found – using local dependency                │
-      │                                                                              │
-      │  A global installation (v3.70.0) and a local dependency (v${CLI_KIT_VERSION}) were       │
-      │  detected.                                                                   │
-      │  We recommend removing the @shopify/cli and @shopify/app dependencies from   │
-      │  your package.json, unless you want to use different versions across         │
-      │  multiple apps.                                                              │
-      │                                                                              │
-      │  See Shopify CLI documentation. [1]                                          │
-      │                                                                              │
-      ╰──────────────────────────────────────────────────────────────────────────────╯
-      [1] https://shopify.dev/docs/apps/build/cli-for-apps#switch-to-a-global-executab
-      le-or-local-dependency
-      "
-    `)
-    mockOutput.clear()
-  })
-
-  test('does not show two consecutive warnings', async () => {
-    // Given
-    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
-    vi.mocked(globalCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
-    vi.mocked(localCLIVersion).mockResolvedValue('3.70.0')
-    const mockOutput = mockAndCaptureOutput()
-
-    // When
-    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': '3.70.0'})
-    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': '3.70.0'})
-
-    // Then
-    expect(mockOutput.info()).toMatchInlineSnapshot(`
-      "╭─ info ───────────────────────────────────────────────────────────────────────╮
-      │                                                                              │
-      │  Two Shopify CLI installations found – using global installation             │
-      │                                                                              │
-      │  A global installation (v${CLI_KIT_VERSION}) and a local dependency (v3.70.0) were       │
-      │  detected.                                                                   │
-      │  We recommend removing the @shopify/cli and @shopify/app dependencies from   │
-      │  your package.json, unless you want to use different versions across         │
-      │  multiple apps.                                                              │
-      │                                                                              │
-      │  See Shopify CLI documentation. [1]                                          │
-      │                                                                              │
-      ╰──────────────────────────────────────────────────────────────────────────────╯
-      [1] https://shopify.dev/docs/apps/build/cli-for-apps#switch-to-a-global-executab
-      le-or-local-dependency
-      "
-    `)
-  })
-
-  test('does not show a warning if there is no local dependency', async () => {
-    // Given
-    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
-    vi.mocked(globalCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
-    vi.mocked(localCLIVersion).mockResolvedValue(undefined)
-    const mockOutput = mockAndCaptureOutput()
-
-    // When
-    await showMultipleCLIWarningIfNeeded('path', {})
-
-    // Then
-    expect(mockOutput.warn()).toBe('')
-    mockOutput.clear()
-  })
-
-  test('does not show a warning if there is no global dependency', async () => {
-    // Given
-    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
-    vi.mocked(globalCLIVersion).mockResolvedValue(undefined)
-    vi.mocked(localCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
-    const mockOutput = mockAndCaptureOutput()
-
-    // When
-    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': CLI_KIT_VERSION})
-
-    // Then
-    expect(mockOutput.warn()).toBe('')
-    mockOutput.clear()
   })
 })

--- a/packages/cli-kit/src/public/node/cli.ts
+++ b/packages/cli-kit/src/public/node/cli.ts
@@ -1,12 +1,7 @@
 import {isTruthy} from './context/utilities.js'
 import {launchCLI as defaultLaunchCli} from './cli-launcher.js'
-import {renderInfo} from './ui.js'
-import {currentProcessIsGlobal} from './is-global.js'
-import {globalCLIVersion, localCLIVersion} from './version.js'
-import {jsonOutputEnabled} from './environment.js'
-import {cacheClear, runAtMinimumInterval} from '../../private/node/conf-store.js'
+import {cacheClear} from '../../private/node/conf-store.js'
 import {environmentVariables} from '../../private/node/constants.js'
-import {CLI_KIT_VERSION} from '../common/version.js'
 import {Flags} from '@oclif/core'
 
 /**
@@ -158,48 +153,4 @@ export const jsonFlag = {
  */
 export function clearCache(): void {
   cacheClear()
-}
-
-/**
- * Shows a warning if there are two Shopify CLI installations found (global and local).
- * Won't show anything if the user included the --json flag.
- *
- * @param directory - The directory of the project.
- * @param dependencies - The dependencies of the project.
- */
-export async function showMultipleCLIWarningIfNeeded(
-  directory: string,
-  dependencies: {[key: string]: string},
-): Promise<void> {
-  // Show the warning only once per day
-  await runAtMinimumInterval('warn-on-multiple-versions', {days: 1}, async () => {
-    if (!dependencies['@shopify/cli'] || jsonOutputEnabled()) return
-
-    const isGlobal = currentProcessIsGlobal()
-
-    // If running globally, use the current CLI version, otherwise fetch the global CLI version
-    // Exit early if we can't get the global version
-    const globalVersion = isGlobal ? CLI_KIT_VERSION : await globalCLIVersion()
-    if (!globalVersion) return
-
-    // If running globally, fetch the local version from npm list, otherwise use current CLI version
-    // Exit early if we can't get the local version
-    const localVersion = isGlobal ? await localCLIVersion(directory) : CLI_KIT_VERSION
-    if (!localVersion) return
-
-    const currentInstallation = isGlobal ? 'global installation' : 'local dependency'
-
-    const warningContent = {
-      headline: `Two Shopify CLI installations found – using ${currentInstallation}`,
-      body: [
-        `A global installation (v${globalVersion}) and a local dependency (v${localVersion}) were detected.
-We recommend removing the @shopify/cli and @shopify/app dependencies from your package.json, unless you want to use different versions across multiple apps.`,
-      ],
-      link: {
-        label: 'See Shopify CLI documentation.',
-        url: 'https://shopify.dev/docs/apps/build/cli-for-apps#switch-to-a-global-executable-or-local-dependency',
-      },
-    }
-    renderInfo(warningContent)
-  })
 }

--- a/packages/cli-kit/src/public/node/multiple-installation-warning.ts
+++ b/packages/cli-kit/src/public/node/multiple-installation-warning.ts
@@ -1,0 +1,50 @@
+import {jsonOutputEnabled} from './environment.js'
+import {currentProcessIsGlobal} from './is-global.js'
+import {renderInfo} from './ui.js'
+import {globalCLIVersion, localCLIVersion} from './version.js'
+import {CLI_KIT_VERSION} from '../common/version.js'
+import {runAtMinimumInterval} from '../../private/node/conf-store.js'
+
+/**
+ * Shows a warning if there are two Shopify CLI installations found (global and local).
+ * Won't show anything if the user included the --json flag.
+ *
+ * @param directory - The directory of the project.
+ * @param dependencies - The dependencies of the project.
+ */
+export async function showMultipleCLIWarningIfNeeded(
+  directory: string,
+  dependencies: {[key: string]: string},
+): Promise<void> {
+  // Show the warning only once per day
+  await runAtMinimumInterval('warn-on-multiple-versions', {days: 1}, async () => {
+    if (!dependencies['@shopify/cli'] || jsonOutputEnabled()) return
+
+    const isGlobal = currentProcessIsGlobal()
+
+    // If running globally, use the current CLI version, otherwise fetch the global CLI version
+    // Exit early if we can't get the global version
+    const globalVersion = isGlobal ? CLI_KIT_VERSION : await globalCLIVersion()
+    if (!globalVersion) return
+
+    // If running globally, fetch the local version from npm list, otherwise use current CLI version
+    // Exit early if we can't get the local version
+    const localVersion = isGlobal ? await localCLIVersion(directory) : CLI_KIT_VERSION
+    if (!localVersion) return
+
+    const currentInstallation = isGlobal ? 'global installation' : 'local dependency'
+
+    const warningContent = {
+      headline: `Two Shopify CLI installations found – using ${currentInstallation}`,
+      body: [
+        `A global installation (v${globalVersion}) and a local dependency (v${localVersion}) were detected.
+We recommend removing the @shopify/cli and @shopify/app dependencies from your package.json, unless you want to use different versions across multiple apps.`,
+      ],
+      link: {
+        label: 'See Shopify CLI documentation.',
+        url: 'https://shopify.dev/docs/apps/build/cli-for-apps#switch-to-a-global-executable-or-local-dependency',
+      },
+    }
+    renderInfo(warningContent)
+  })
+}

--- a/packages/cli-kit/src/public/node/plugins/multiple-installation-warning.test.ts
+++ b/packages/cli-kit/src/public/node/plugins/multiple-installation-warning.test.ts
@@ -1,0 +1,142 @@
+import {clearCache} from '../cli.js'
+import {currentProcessIsGlobal} from '../is-global.js'
+import {showMultipleCLIWarningIfNeeded} from '../multiple-installation-warning.js'
+import {mockAndCaptureOutput} from '../testing/output.js'
+import {globalCLIVersion, localCLIVersion} from '../version.js'
+import {describe, beforeEach, test, vi, expect} from 'vitest'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
+
+vi.mock('../version.js')
+vi.mock('../is-global.js')
+
+describe('showMultipleCLIWarningIfNeeded', () => {
+  beforeEach(() => {
+    clearCache()
+  })
+
+  test('shows warning if using global CLI but app has local dependency', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(globalCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
+    vi.mocked(localCLIVersion).mockResolvedValue('3.70.0')
+    const mockOutput = mockAndCaptureOutput()
+
+    // When
+    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': '3.70.0'})
+
+    // Then
+    expect(mockOutput.info()).toMatchInlineSnapshot(`
+        "╭─ info ───────────────────────────────────────────────────────────────────────╮
+        │                                                                              │
+        │  Two Shopify CLI installations found – using global installation             │
+        │                                                                              │
+        │  A global installation (v${CLI_KIT_VERSION}) and a local dependency (v3.70.0) were       │
+        │  detected.                                                                   │
+        │  We recommend removing the @shopify/cli and @shopify/app dependencies from   │
+        │  your package.json, unless you want to use different versions across         │
+        │  multiple apps.                                                              │
+        │                                                                              │
+        │  See Shopify CLI documentation. [1]                                          │
+        │                                                                              │
+        ╰──────────────────────────────────────────────────────────────────────────────╯
+        [1] https://shopify.dev/docs/apps/build/cli-for-apps#switch-to-a-global-executab
+        le-or-local-dependency
+        "
+      `)
+    mockOutput.clear()
+  })
+
+  test('shows warning if using local CLI but app has global dependency', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
+    vi.mocked(globalCLIVersion).mockResolvedValue('3.70.0')
+    vi.mocked(localCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
+    const mockOutput = mockAndCaptureOutput()
+
+    // When
+    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': CLI_KIT_VERSION})
+
+    // Then
+    expect(mockOutput.info()).toMatchInlineSnapshot(`
+        "╭─ info ───────────────────────────────────────────────────────────────────────╮
+        │                                                                              │
+        │  Two Shopify CLI installations found – using local dependency                │
+        │                                                                              │
+        │  A global installation (v3.70.0) and a local dependency (v${CLI_KIT_VERSION}) were       │
+        │  detected.                                                                   │
+        │  We recommend removing the @shopify/cli and @shopify/app dependencies from   │
+        │  your package.json, unless you want to use different versions across         │
+        │  multiple apps.                                                              │
+        │                                                                              │
+        │  See Shopify CLI documentation. [1]                                          │
+        │                                                                              │
+        ╰──────────────────────────────────────────────────────────────────────────────╯
+        [1] https://shopify.dev/docs/apps/build/cli-for-apps#switch-to-a-global-executab
+        le-or-local-dependency
+        "
+      `)
+    mockOutput.clear()
+  })
+
+  test('does not show two consecutive warnings', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(globalCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
+    vi.mocked(localCLIVersion).mockResolvedValue('3.70.0')
+    const mockOutput = mockAndCaptureOutput()
+
+    // When
+    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': '3.70.0'})
+    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': '3.70.0'})
+
+    // Then
+    expect(mockOutput.info()).toMatchInlineSnapshot(`
+        "╭─ info ───────────────────────────────────────────────────────────────────────╮
+        │                                                                              │
+        │  Two Shopify CLI installations found – using global installation             │
+        │                                                                              │
+        │  A global installation (v${CLI_KIT_VERSION}) and a local dependency (v3.70.0) were       │
+        │  detected.                                                                   │
+        │  We recommend removing the @shopify/cli and @shopify/app dependencies from   │
+        │  your package.json, unless you want to use different versions across         │
+        │  multiple apps.                                                              │
+        │                                                                              │
+        │  See Shopify CLI documentation. [1]                                          │
+        │                                                                              │
+        ╰──────────────────────────────────────────────────────────────────────────────╯
+        [1] https://shopify.dev/docs/apps/build/cli-for-apps#switch-to-a-global-executab
+        le-or-local-dependency
+        "
+      `)
+  })
+
+  test('does not show a warning if there is no local dependency', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(globalCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
+    vi.mocked(localCLIVersion).mockResolvedValue(undefined)
+    const mockOutput = mockAndCaptureOutput()
+
+    // When
+    await showMultipleCLIWarningIfNeeded('path', {})
+
+    // Then
+    expect(mockOutput.warn()).toBe('')
+    mockOutput.clear()
+  })
+
+  test('does not show a warning if there is no global dependency', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
+    vi.mocked(globalCLIVersion).mockResolvedValue(undefined)
+    vi.mocked(localCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
+    const mockOutput = mockAndCaptureOutput()
+
+    // When
+    await showMultipleCLIWarningIfNeeded('path', {'@shopify/cli': CLI_KIT_VERSION})
+
+    // Then
+    expect(mockOutput.warn()).toBe('')
+    mockOutput.clear()
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5600

There are some situations where the "Two CLI installations found" message appeared two times in a single command execution (like on `shopify app dev --reset` with the global version).

Also, some users that intentionally have two installations find this message a bother because it's shown on every command.

### WHAT is this pull request doing?

Adds a cache mechanism to only show the warning once a day

### How to test your changes?

- `npm i -g @shopify/cli@0.0.0-snapshot-20250502113135 --@shopify:registry=https://registry.npmjs.org`
- Inside an app project: `npm i @shopify/cli`
- `shopify app dev --reset`
- `shopify app dev --reset`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
