### PR TITLE
Revert global CLI detection change

### DIFF
--- a/.changeset/moody-chairs-divide.md
+++ b/.changeset/moody-chairs-divide.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Improve global CLI detection to avoid showing unnecessary warnings

--- a/packages/cli-kit/src/public/node/is-global.test.ts
+++ b/packages/cli-kit/src/public/node/is-global.test.ts
@@ -1,4 +1,3 @@
-import {isDevelopment} from './context/local.js'
 import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI, installGlobalCLIPrompt} from './is-global.js'
 import {terminalSupportsPrompting} from './system.js'
 import {renderSelectPrompt} from './ui.js'
@@ -9,33 +8,20 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 vi.mock('./system.js')
 vi.mock('./ui.js')
 vi.mock('execa')
-vi.mock('./context/local.js')
 vi.mock('which')
 vi.mock('./version.js')
+
 const globalNPMPath = '/path/to/global/npm'
 const globalYarnPath = '/path/to/global/yarn'
 const globalPNPMPath = '/path/to/global/pnpm'
 const unknownGlobalPath = '/path/to/global/unknown'
-const localProjectPath = '/path/local/node_modules'
+const localProjectPath = '/path/local'
 
 beforeEach(() => {
   ;(vi.mocked(execa.execaSync) as any).mockReturnValue({stdout: localProjectPath})
-  vi.mocked(isDevelopment).mockReturnValue(false)
 })
 
 describe('currentProcessIsGlobal', () => {
-  test('returns false in development', () => {
-    // Given
-    vi.mocked(isDevelopment).mockReturnValue(true)
-    const argv = ['node', localProjectPath, 'shopify']
-
-    // When
-    const got = currentProcessIsGlobal(argv)
-
-    // Then
-    expect(got).toBeFalsy()
-  })
-
   test('returns true if argv point to the global npm path', () => {
     // Given
     const argv = ['node', globalNPMPath, 'shopify']

--- a/packages/cli-kit/src/public/node/is-global.ts
+++ b/packages/cli-kit/src/public/node/is-global.ts
@@ -1,9 +1,13 @@
-import {isDevelopment} from './context/local.js'
 import {PackageManager} from './node-package-manager.js'
 import {outputInfo} from './output.js'
+import {cwd, sniffForPath} from './path.js'
 import {exec, terminalSupportsPrompting} from './system.js'
 import {renderSelectPrompt} from './ui.js'
 import {globalCLIVersion} from './version.js'
+import {isUnitTest} from './context/local.js'
+import {execaSync} from 'execa'
+
+let _isGlobal: boolean | undefined
 
 /**
  * Returns true if the current process is running in a global context.
@@ -12,8 +16,29 @@ import {globalCLIVersion} from './version.js'
  * @returns `true` if the current process is running in a global context.
  */
 export function currentProcessIsGlobal(argv = process.argv): boolean {
-  const currentExecutable = argv[1] ?? ''
-  return !currentExecutable.includes('node_modules') && !isDevelopment()
+  // If we are running tests, we need to disable the cache
+  try {
+    if (_isGlobal !== undefined && !isUnitTest()) return _isGlobal
+
+    // Path where the current project is (app/hydrogen)
+    const path = sniffForPath() ?? cwd()
+
+    // Closest parent directory to contain a package.json file or node_modules directory
+    // https://docs.npmjs.com/cli/v8/commands/npm-prefix#description
+    const npmPrefix = execaSync('npm', ['prefix'], {cwd: path}).stdout.trim()
+
+    // From node docs: "The second element [of the array] will be the path to the JavaScript file being executed"
+    const binDir = argv[1] ?? ''
+
+    // If binDir starts with npmPrefix, then we are running a local CLI
+    const isLocal = binDir.startsWith(npmPrefix.trim())
+
+    _isGlobal = !isLocal
+    return _isGlobal
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (error) {
+    return false
+  }
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Partially reverts https://github.com/Shopify/cli/pull/5704

The default PNPM folder for global packages in Mac is `/pnpm/global/5/node_modules/`, but the previous PR was expecting global installations to not contain `node_modules`.

Also, it's possible to customize the folder, so it's better to avoid this approach.

This is causing `shopify app init` to use NPM when the CLI is installed globally with PNPM.

### WHAT is this pull request doing?

Keeps the logic to detect the global installation based on the project path.

### How to test your changes?

- `pnpm i -g @shopify/cli@0.0.0-snapshot-20250502142317`
- `shopify app init` => it should use pnpm

Global version:
- `npm i -g @shopify/cli/0.0.0-snapshot-20250502142317 --@shopify:registry=https://registry.npmjs.org`
- `shopify cache clear`
- `shopify app info` => nothing
- `npm add @shopify/cli`
- `shopify cache clear`
- `shopify app info` => warning

Without global version:
- `npm rm -g @shopify/cli`
- `npm add @shopify/cli@0.0.0-snapshot-20250502142317`
- `shopify cache clear`
- `npm run shopify app info` => nothing
- `shopify cache clear`
- `npm i -g @shopify/cli`
- `npm run shopify app info` => warning

Also test with pnpm, yarn, bun, windows, linux...

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
