### PR TITLE
Add a warning about changesets for private features

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -14,5 +14,10 @@ jobs:
         with:
           changelogRegex: \.changeset
           message: |
-            We detected some changes at packages/*/src and there are no updates in the .changeset.
-            If the changes are user-facing, run "pnpm changeset add" to track your changes and include them in the next release CHANGELOG.
+            We detected some changes at `packages/*/src` and there are no updates in the `.changeset`.
+            If the changes are user-facing, run `pnpm changeset add` to track your changes and include them in the next release CHANGELOG.
+
+            > [!CAUTION]
+
+            > DO NOT create changesets for features which you do not wish to be included in the public changelog of the next CLI release.
+


### PR DESCRIPTION
### WHY are these changes introduced?

We are adding changesets in PRs about features that are not ready to be published

### WHAT is this pull request doing?

Adds a warning to the changelog reminder included in every PR

### How to test your changes?

See below?

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
