### PR TITLE
Add automatically_update_urls_on_dev for new apps with dev sessions

### DIFF
--- a/packages/app/src/cli/services/app/config/link-service.test.ts
+++ b/packages/app/src/cli/services/app/config/link-service.test.ts
@@ -18,6 +18,7 @@ beforeEach(async () => {})
 
 function buildDeveloperPlatformClient(): DeveloperPlatformClient {
   return testDeveloperPlatformClient({
+    supportsDevSessions: true,
     async appFromIdentifiers({apiKey}: AppApiKeyAndOrgId): Promise<OrganizationApp | undefined> {
       switch (apiKey) {
         case 'api-key':
@@ -37,6 +38,7 @@ function buildDeveloperPlatformClient(): DeveloperPlatformClient {
       return testOrganizationApp({
         requestedAccessScopes: options?.scopesArray,
         developerPlatformClient: this as DeveloperPlatformClient,
+        newApp: true,
       })
     },
   })
@@ -82,6 +84,10 @@ name = "app1"
 application_url = ""
 embedded = true
 
+[build]
+automatically_update_urls_on_dev = true
+include_config_on_deploy = true
+
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "write_something_unusual"
@@ -102,6 +108,10 @@ embedded = false
         embedded: true,
         access_scopes: {
           scopes: 'write_something_unusual',
+        },
+        build: {
+          automatically_update_urls_on_dev: true,
+          include_config_on_deploy: true,
         },
         auth: {
           redirect_urls: [],

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -398,6 +398,7 @@ async function overwriteLocalConfigFileWithRemoteAppConfiguration(options: {
       existingBuildOptions: localAppOptions.existingBuildOptions,
       linkedAppAndClientIdFromFileAreInSync: localAppOptions.localAppIdMatchedRemote,
       linkedAppWasNewlyCreated: Boolean(remoteApp.newApp),
+      defaultToUpdateUrlsOnDev: developerPlatformClient.supportsDevSessions,
     }),
   }
 
@@ -422,10 +423,17 @@ function buildOptionsForGeneratedConfigFile(options: {
   existingBuildOptions: CliBuildPreferences
   linkedAppAndClientIdFromFileAreInSync: boolean
   linkedAppWasNewlyCreated: boolean
+  defaultToUpdateUrlsOnDev: boolean
 }): CliBuildPreferences {
-  const {existingBuildOptions, linkedAppAndClientIdFromFileAreInSync, linkedAppWasNewlyCreated} = options
+  const {
+    existingBuildOptions,
+    linkedAppAndClientIdFromFileAreInSync,
+    linkedAppWasNewlyCreated,
+    defaultToUpdateUrlsOnDev,
+  } = options
   const buildOptions = {
     ...(linkedAppWasNewlyCreated ? {include_config_on_deploy: true} : {}),
+    ...(defaultToUpdateUrlsOnDev && linkedAppWasNewlyCreated ? {automatically_update_urls_on_dev: true} : {}),
     ...(linkedAppAndClientIdFromFileAreInSync ? existingBuildOptions : {}),
   }
   if (isEmpty(buildOptions)) {


### PR DESCRIPTION
### WHY are these changes introduced?

Improve developer experience by setting `automatically_update_urls_on_dev` to `true` automatically for apps created in the app management API.

### WHAT is this pull request doing?

This PR adds automatic configuration of `automatically_update_urls_on_dev = true` in the `build` section of the `shopify.app.toml` file when linking a newly created app that supports dev sessions. 

Specifically:
- Updates the `buildOptionsForGeneratedConfigFile` function to include the `automatically_update_urls_on_dev` setting when appropriate

### How to test your changes?

CASE A:
1. Create a new app using the CLI (with DP2)
2. Verify that the generated `shopify.app.toml` file includes `automatically_update_urls_on_dev = true` in the `build` section
3. Run a dev session and confirm URLs are automatically updated

CASE B:
1. Create a new app using Partners
2. Verify the app.toml doesn't include `automatically_update_urls_on_dev`

CASE C:
1. Create a new app with DP2 (or use an existing one).
2. Remove `automatically_update_urls_on_dev` if present
3. Verify that linking to an existing app (important, no creating a new one) doesn't add `automatically_update_urls_on_dev` to the toml.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes