### PR TITLE
Fix nightly releases when there are no changesets yet

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -12,13 +12,9 @@ if [ "$tag" != "latest" ] && [ "$tag" != "nightly" ] && [ "$tag" != "experimenta
   exit 1
 fi
 
-if [ "$tag" = "experimental" ]; then
-  # Only for experimental releases, force an empty changeset to ensure a build is created
-  echo -e "---\n'"'@shopify/cli'"': patch\n---" > .changeset/force-experimental-build.md
-fi
-
-# Only for nightly and experimental releases, set the snapshot version
+# Only for nightly and experimental releases, force an empty changeset to ensure a build is created and set the snapshot version
 if [ "$tag" = "nightly" ] || [ "$tag" = "experimental" ]; then
+  echo -e "---\n'"'@shopify/cli'"': patch\n---" > .changeset/force-release.md
   pnpm changeset version --snapshot $tag
   ./bin/update-cli-kit-version.js
 fi


### PR DESCRIPTION
### WHY are these changes introduced?

There needs to be at least one changeset for a release to work.

### WHAT is this pull request doing?

Create an empty changeset for nightly/experimental releases to ensure they succeed. 

### How to test your changes?

Nightly should work again

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes