### PR TITLE
Fix template filter for nightly versions

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -229,6 +229,26 @@ describe('allowedTemplates', () => {
     expect(got.length).toEqual(2)
     expect(got).toEqual([templateWithoutRules, allowedTemplate])
   })
+
+  test('allows newer templates for any version if the CLI is nightly, but not deprecated ones', async () => {
+    // Given
+    const templates: GatedExtensionTemplate[] = [
+      allowedTemplate,
+      templateDisallowedByMinimumCliVersion,
+      templateDisallowedByDeprecatedFromCliVersion,
+    ]
+
+    // When
+    const got = await allowedTemplates(
+      templates,
+      () => Promise.resolve({allowedFlag: true, notAllowedFlag: false}),
+      '0.0.0-nightly',
+    )
+
+    // Then
+    expect(got.length).toEqual(2)
+    expect(got).toEqual([allowedTemplate, templateDisallowedByMinimumCliVersion])
+  })
 })
 
 describe('versionDeepLink', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

To allow nightly CLI versions to access newer templates that would otherwise be restricted by minimum CLI version requirements, while still respecting deprecation rules.

### WHAT is this pull request doing?

Modifies the `allowedTemplates` function to:
- Inject a version parameter (defaulting to CLI_KIT_VERSION)
- Add special handling for nightly versions (those starting with "0.0.0")
- Allow nightly versions to access templates regardless of minimum CLI version requirements
- Still respect deprecation rules even for nightly versions

### How to test your changes?

1. Run the CLI with a nightly version
2. Verify that templates with minimum CLI version requirements higher than the current stable release are accessible
3. Confirm that deprecated templates remain inaccessible even with nightly versions

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes