### PR TITLE
fix Shell command built from environment values

### DIFF
--- a/bin/pin-github-actions.js
+++ b/bin/pin-github-actions.js
@@ -4,9 +4,9 @@ import glob from 'fast-glob'
 import {fileURLToPath} from 'url'
 import path from 'node:path'
 import utils from 'util'
-import {exec} from 'child_process'
+import {execFile} from 'child_process'
 
-export const execute = utils.promisify(exec)
+export const execute = utils.promisify(execFile)
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -28,9 +28,13 @@ async function doIt() {
   const githubYmls = glob.sync(`${__dirname}/../.github/{actions,workflows}/**/*.yml`)
   const pinGithubAction = `${__dirname}/../node_modules/.bin/pin-github-action`
   for (const githubYml of githubYmls) {
-    await execute(
-      `GH_ADMIN_TOKEN=${githubAccessToken} ${pinGithubAction} ${githubYml} --allow="actions/*" --allow-empty`,
-    )
+    await execute(pinGithubAction, [
+      githubYml,
+      '--allow=actions/*',
+      '--allow-empty',
+    ], {
+      env: { ...process.env, GH_ADMIN_TOKEN: githubAccessToken },
+    })
     process.stdout.write('.')
   }
   console.log(' Done!')


### PR DESCRIPTION
https://github.com/Shopify/cli/blob/fe5568a39f42c252adf9fc204d5ce3d6947a933c/bin/pin-github-actions.js#L32-L32

fix the issue replace the use of `exec` with `execFile`, which allows us to pass arguments to the command as an array, avoiding the need to construct a shell command string. This approach ensures that special characters in filenames or other inputs are properly escaped and do not alter the behavior of the command.

Specifically:
1. Replace the dynamic shell command string on line 32 with a call to `execFile`.
2. Pass the `GH_ADMIN_TOKEN` environment variable explicitly using the `env` option of `execFile`.
3. Pass the remaining arguments (`pinGithubAction`, `githubYml`, and flags) as an array to `execFile`.

## References
[Command Injection](https://www.owasp.org/index.php/Command_Injection)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
