### PR TITLE
Extract `dev clean` logic to a service file

### DIFF
--- a/packages/app/src/cli/commands/app/dev/clean.ts
+++ b/packages/app/src/cli/commands/app/dev/clean.ts
@@ -2,10 +2,10 @@ import {linkedAppContext} from '../../../services/app-context.js'
 import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
 import {appFlags} from '../../../flags.js'
 import {storeContext} from '../../../services/store-context.js'
+import {devClean} from '../../../services/dev-clean.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {renderSuccess} from '@shopify/cli-kit/node/ui'
 
 export default class DevClean extends AppCommand {
   static summary = 'Cleans up the app preview from the selected store.'
@@ -47,16 +47,7 @@ export default class DevClean extends AppCommand {
       forceReselectStore: flags.reset,
     })
 
-    const client = appContextResult.developerPlatformClient
-    await client.devSessionDelete({shopFqdn: store.shopDomain, appId: appContextResult.remoteApp.id})
-
-    renderSuccess({
-      headline: 'App preview stopped.',
-      body: [
-        `The app preview has been stopped on "${store.shopDomain}" and the app's active version has been restored.`,
-        'You can start it again with `shopify app dev`.',
-      ],
-    })
+    await devClean({appContextResult, store})
 
     return {app: appContextResult.app}
   }

--- a/packages/app/src/cli/services/dev-clean.test.ts
+++ b/packages/app/src/cli/services/dev-clean.test.ts
@@ -1,0 +1,66 @@
+import {devClean} from './dev-clean.js'
+import {LoadedAppContextOutput} from './app-context.js'
+import {testDeveloperPlatformClient, testOrganizationStore} from '../models/app/app.test-data.js'
+import {renderSuccess} from '@shopify/cli-kit/node/ui'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/ui')
+
+const shopDomain = 'test-store.myshopify.com'
+const mockStore = testOrganizationStore({shopDomain})
+
+const mockOptions = {
+  appContextResult: {
+    developerPlatformClient: testDeveloperPlatformClient(),
+    remoteApp: {id: 'app-id-1', title: 'Test App', apiKey: 'api-key-1'},
+  } as unknown as LoadedAppContextOutput,
+  store: mockStore,
+}
+
+describe('devClean', () => {
+  test('successfully stops app preview and renders success message', async () => {
+    // Given
+    mockOptions.appContextResult.developerPlatformClient = customDevPlatformClient()
+
+    // When
+    await devClean(mockOptions)
+
+    // Then
+    expect(renderSuccess).toHaveBeenCalledWith({
+      headline: 'App preview stopped.',
+      body: [
+        `The app preview has been stopped on ${mockStore.shopDomain} and the app's active version has been restored.`,
+        'You can start it again with',
+        {command: 'shopify app dev'},
+      ],
+    })
+  })
+
+  test('throws AbortError when devSessionDelete returns user errors', async () => {
+    // Given
+    const errorMessage = 'Failed to stop app preview'
+    mockOptions.appContextResult.developerPlatformClient = customDevPlatformClient(errorMessage)
+
+    // When/Then
+    await expect(devClean(mockOptions)).rejects.toThrow(`Failed to stop the app preview: ${errorMessage}`)
+  })
+
+  test('throws AbortError when devSessions are not supported', async () => {
+    // Given
+    mockOptions.appContextResult.developerPlatformClient = customDevPlatformClient(undefined, false)
+
+    // When/Then
+    await expect(devClean(mockOptions)).rejects.toThrow('App preview is not supported for this app.')
+  })
+})
+
+function customDevPlatformClient(devSessionDeleteError?: string, supportsDevSessions = true) {
+  return testDeveloperPlatformClient({
+    supportsDevSessions,
+    devSessionDelete: vi.fn().mockResolvedValue({
+      devSessionDelete: {
+        userErrors: devSessionDeleteError ? [{message: devSessionDeleteError}] : [],
+      },
+    }),
+  })
+}

--- a/packages/app/src/cli/services/dev-clean.ts
+++ b/packages/app/src/cli/services/dev-clean.ts
@@ -1,0 +1,34 @@
+import {LoadedAppContextOutput} from './app-context.js'
+import {OrganizationStore} from '../models/organization.js'
+import {renderSuccess} from '@shopify/cli-kit/node/ui'
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+interface DevCleanOptions {
+  appContextResult: LoadedAppContextOutput
+  store: OrganizationStore
+}
+
+export async function devClean(options: DevCleanOptions) {
+  const client = options.appContextResult.developerPlatformClient
+  const remoteApp = options.appContextResult.remoteApp
+
+  if (!client.supportsDevSessions) {
+    throw new AbortError(`App preview is not supported for this app.`)
+  }
+
+  const result = await client.devSessionDelete({shopFqdn: options.store.shopDomain, appId: remoteApp.id})
+
+  if (result.devSessionDelete?.userErrors.length) {
+    const errors = result.devSessionDelete.userErrors.map((error) => error.message).join('\n')
+    throw new AbortError(`Failed to stop the app preview: ${errors}`)
+  }
+
+  renderSuccess({
+    headline: 'App preview stopped.',
+    body: [
+      `The app preview has been stopped on ${options.store.shopDomain} and the app's active version has been restored.`,
+      'You can start it again with',
+      {command: 'shopify app dev'},
+    ],
+  })
+}


### PR DESCRIPTION
### WHY are these changes introduced?

To improve error handling when stopping app previews and to refactor the dev clean functionality into a service.

### WHAT is this pull request doing?

- Extracts the app preview cleanup logic from the `DevClean` command into a new service function `devClean`
- Adds proper error handling for the `devSessionDelete` API call
- Improves the success message formatting with proper command styling

### How to test your changes?

1. Create an app preview with `shopify app dev`
2. Run `shopify app dev clean` to stop the preview
3. Verify that the success message is properly formatted
4. Try to reproduce an error scenario (if possible) to verify the error handling works correctly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes