### PR TITLE
Fix error handling for misconfigured multi-extension config

### DIFF
--- a/.changeset/metal-worms-check.md
+++ b/.changeset/metal-worms-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Bug-fix: Handling mis-configured extension TOML files

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -38,6 +38,7 @@ import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {zod} from '@shopify/cli-kit/node/schema'
 import colors from '@shopify/cli-kit/node/colors'
 import {showMultipleCLIWarningIfNeeded} from '@shopify/cli-kit/node/multiple-installation-warning'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 vi.mock('../../services/local-storage.js')
 vi.mock('../../services/app/config/use.js')
@@ -2456,6 +2457,29 @@ wrong = "property"
         cmd_app_linked_config_git_tracked: true,
       }),
     )
+  })
+
+  test('throws the correct error when multi-extension configuration is invalid', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      api_version = "2022-07"
+      description = "global description"
+
+      [extensions]
+      type = "checkout_post_purchase"
+      name = "my_extension_1"
+      handle = "checkout-ext"
+      description = "custom description"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my_extension_1',
+    })
+    await writeFile(joinPath(blockPath('my_extension_1'), 'index.js'), '')
+
+    await expect(loadTestingApp()).rejects.toThrow(AbortError)
   })
 })
 

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -560,7 +560,16 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
     return configPaths.map(async (configurationPath) => {
       const directory = dirname(configurationPath)
       const obj = await loadConfigurationFileContent(configurationPath)
-      const {extensions, type} = ExtensionsArraySchema.parse(obj)
+      const parseResult = ExtensionsArraySchema.safeParse(obj)
+      if (!parseResult.success) {
+        this.abortOrReport(
+          outputContent`Invalid extension configuration at ${relativePath(appDirectory, configurationPath)}`,
+          undefined,
+          configurationPath,
+        )
+        return []
+      }
+      const {extensions, type} = parseResult.data
 
       if (extensions) {
         // If the extension is an array, it's a unified toml file.


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes bugsnag error 678f6e234714603e798bf36a

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Instead of using `parse`, which can throw, use `safeParse` and the existing `abortOrReport` mechanism when loading extension config.
