### PR TITLE
Fix extension collection validation running immediately on generate

### DIFF
--- a/.changeset/calm-cooks-doubt.md
+++ b/.changeset/calm-cooks-doubt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fixes editor extension collection validation being run on generate

--- a/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.test.ts
@@ -5,7 +5,6 @@ import {placeholderAppConfiguration} from '../../app/app.test-data.js'
 import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {describe, expect, test, vi} from 'vitest'
-import {err, ok} from '@shopify/cli-kit/node/result'
 
 describe('editor_extension_collection', async () => {
   interface EditorExtensionCollectionProps {
@@ -143,69 +142,6 @@ describe('editor_extension_collection', async () => {
           in_collection: [{handle: 'handle1'}],
           localization,
         })
-      })
-    })
-  })
-
-  describe('validate()', () => {
-    test('returns ok({}) if there are no errors', async () => {
-      await inTemporaryDirectory(async (tmpDir) => {
-        const localization = {
-          default_locale: 'en',
-          translations: {title: 'Hola!'},
-        }
-        vi.spyOn(loadLocales, 'loadLocalesConfig').mockResolvedValue(localization)
-        const configuration = {
-          name: 'Order summary',
-          handle: 'order-summary-collection',
-          include: [
-            {
-              handle: 'handle1',
-            },
-            {
-              handle: 'handle2',
-            },
-          ],
-        }
-        const extensionCollection = await getTestEditorExtensionCollection({
-          directory: tmpDir,
-          configuration,
-        })
-
-        const result = await extensionCollection.validate()
-
-        expect(result).toStrictEqual(ok({}))
-      })
-    })
-
-    test('returns error if there are less than 2 extensions in a collection', async () => {
-      await inTemporaryDirectory(async (tmpDir) => {
-        const localization = {
-          default_locale: 'en',
-          translations: {title: 'Hola!'},
-        }
-        vi.spyOn(loadLocales, 'loadLocalesConfig').mockResolvedValue(localization)
-        const configuration = {
-          name: 'Order summary',
-          handle: 'order-summary-collection',
-          include: [
-            {
-              handle: 'handle1',
-            },
-          ],
-        }
-        const extensionCollection = await getTestEditorExtensionCollection({
-          directory: tmpDir,
-          configuration,
-        })
-
-        const result = await extensionCollection.validate()
-
-        expect(result).toStrictEqual(
-          err(
-            `${configuration.handle}: This editor extension collection must include at least 2 extensions\n\nPlease check the configuration in ${extensionCollection.configurationPath}`,
-          ),
-        )
       })
     })
   })

--- a/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.ts
+++ b/packages/app/src/cli/models/extensions/specifications/editor_extension_collection.ts
@@ -1,7 +1,6 @@
 import {loadLocalesConfig} from '../../../utilities/extensions/locales-configuration.js'
 import {BaseSchema, MetafieldSchema} from '../schemas.js'
 import {createExtensionSpecification} from '../specification.js'
-import {err, ok} from '@shopify/cli-kit/node/result'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 interface IncludeSchema {
@@ -36,20 +35,6 @@ const editorExtensionCollectionSpecification = createExtensionSpecification({
   identifier: 'editor_extension_collection',
   schema: EditorExtensionCollectionSchema,
   appModuleFeatures: (_) => [],
-  validate: async (config, path) => {
-    const errors: string[] = []
-
-    if (config.inCollection.length < 2) {
-      errors.push(`${config.handle}: This editor extension collection must include at least 2 extensions`)
-    }
-
-    if (errors.length > 0) {
-      errors.push(`Please check the configuration in ${path}`)
-      return err(errors.join('\n\n'))
-    }
-
-    return ok({})
-  },
   deployConfig: async (config, directory) => {
     return {
       name: config.name,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a bug with validation running immediately an editor extension collection is generated. Since we have backend validation there is no need for the frontend validation here.

### WHAT is this pull request doing?

Fixes validation running immediately when you generate editor extension collection. This makes it impossible since editor extension collection cannot start in a valid state.

### How to test your changes?

1. `POLARIS_UNIFIED=true pnpm shopify app generate extension  --path pathToApp`
2. Select `Editor Extension Collection` under admin
3. It should generate it successfully

<img width="1497" alt="Screenshot 2025-05-07 at 12 23 38 PM" src="https://github.com/user-attachments/assets/5c865508-a959-4bbe-981b-7d3ffb867155" />


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
