### PR TITLE
Add build logging to app watcher for esbuild-based extensions

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -237,7 +237,9 @@ export class AppEventWatcher extends EventEmitter {
       return useConcurrentOutputContext({outputPrefix: ext.handle, stripAnsi: false}, async () => {
         try {
           if (this.esbuildManager.contexts?.[ext.uid]?.length) {
+            this.options.stdout.write(`Building extension ${ext.handle}...`)
             await this.esbuildManager.rebuildContext(ext)
+            this.options.stdout.write(`Done!`)
           } else {
             await this.buildExtension(ext)
           }

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -237,9 +237,8 @@ export class AppEventWatcher extends EventEmitter {
       return useConcurrentOutputContext({outputPrefix: ext.handle, stripAnsi: false}, async () => {
         try {
           if (this.esbuildManager.contexts?.[ext.uid]?.length) {
-            this.options.stdout.write(`Building extension ${ext.handle}...`)
             await this.esbuildManager.rebuildContext(ext)
-            this.options.stdout.write(`Done!`)
+            this.options.stdout.write(`Build successful`)
           } else {
             await this.buildExtension(ext)
           }


### PR DESCRIPTION
### WHY are these changes introduced?

UI extensions currently don't output any logging for successful builds, unlike Functions.

### WHAT is this pull request doing?

Adds logging for esbuild-managed builds to the app watcher.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OrzNT0QONlj24wp8r92T/0e718d51-03c0-4503-97ac-bdb23c2ce372.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OrzNT0QONlj24wp8r92T/f045824a-9eb9-4ba9-80d8-2eb2902b7ae4.png)

### How to test your changes?

Add a UI extension and `pnpm shopify app dev --path <your app>`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
