### PR TITLE
Fix an issue with hot-reloading the compiled assets (scripts.js, block-scripts.js, etc)

### DIFF
--- a/.changeset/orange-bugs-retire.md
+++ b/.changeset/orange-bugs-retire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix an issue with hot-reloading the compiled assets (scripts.js, block-scripts.js, etc)

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -51,7 +51,7 @@
     "yaml": "2.7.0"
   },
   "devDependencies": {
-    "@shopify/theme-hot-reload": "^0.0.11",
+    "@shopify/theme-hot-reload": "^0.0.18",
     "@vitest/coverage-istanbul": "^1.6.0",
     "node-stream-zip": "^1.15.0"
   },

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
@@ -91,7 +91,7 @@ describe('Hot Reload', () => {
 
       const expectedSectionEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${testSectionFileKey}","payload":{"sectionNames":["first","second"],"replaceTemplates":${JSON.stringify(
         getInMemoryTemplates(ctx),
-      )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
+      )},"updatedFileParts":{"stylesheetTag":false,"javascriptTag":false}},"version":"${HOT_RELOAD_VERSION}"}`
 
       // Verify local sync event
       expect(hotReloadEvents.at(-1)).toMatch(expectedSectionEvent)
@@ -142,7 +142,7 @@ describe('Hot Reload', () => {
       // Since this is a template, sectionNames will be empty (no sections to reload)
       const expectedTemplateEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${templateKey}","payload":{"sectionNames":[],"replaceTemplates":${JSON.stringify(
         getInMemoryTemplates(ctx),
-      )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
+      )},"updatedFileParts":{"stylesheetTag":false,"javascriptTag":false}},"version":"${HOT_RELOAD_VERSION}"}`
 
       // Verify local sync event for JSON update
       expect(hotReloadEvents.at(-1)).toMatch(expectedTemplateEvent)
@@ -163,7 +163,7 @@ describe('Hot Reload', () => {
       // Since this is a section group, sectionNames will contain all the section names
       const expectedSectionGroupEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${sectionGroupKey}","payload":{"sectionNames":["first","second"],"replaceTemplates":${JSON.stringify(
         getInMemoryTemplates(ctx),
-      )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
+      )},"updatedFileParts":{"stylesheetTag":false,"javascriptTag":false}},"version":"${HOT_RELOAD_VERSION}"}`
 
       // Verify local sync event for JSON update
       expect(hotReloadEvents.at(-1)).toMatch(expectedSectionGroupEvent)
@@ -178,7 +178,7 @@ describe('Hot Reload', () => {
       expect(hotReloadEvents.at(-1)).toMatch(
         `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${anotherSectionKey}","payload":{"sectionNames":["first","second"],"replaceTemplates":${JSON.stringify(
           getInMemoryTemplates(ctx),
-        )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`,
+        )},"updatedFileParts":{"stylesheetTag":false,"javascriptTag":false}},"version":"${HOT_RELOAD_VERSION}"}`,
       )
       // Wait for remote sync
       await nextTick()
@@ -197,7 +197,7 @@ describe('Hot Reload', () => {
       expect(getInMemoryTemplates(ctx)).toEqual({[anotherSectionKey]: 'default-value'})
       const expectedUnreferencedSectionEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${anotherSectionKey}","payload":{"sectionNames":[],"replaceTemplates":${JSON.stringify(
         getInMemoryTemplates(ctx),
-      )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
+      )},"updatedFileParts":{"stylesheetTag":false,"javascriptTag":false}},"version":"${HOT_RELOAD_VERSION}"}`
       expect(hotReloadEvents.at(-1)).toMatch(expectedUnreferencedSectionEvent)
       await nextTick()
       expect(hotReloadEvents.at(-1)).toMatch(expectedUnreferencedSectionEvent.replace('local', 'remote'))
@@ -207,7 +207,7 @@ describe('Hot Reload', () => {
       await triggerFileEvent('add', cssFileKey)
       // It does not add assets to the in-memory templates:
       expect(getInMemoryTemplates(ctx)).toEqual({})
-      const expectedCssEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${cssFileKey}","payload":{"sectionNames":[],"replaceTemplates":{},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
+      const expectedCssEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${cssFileKey}","payload":{"sectionNames":[],"replaceTemplates":{},"updatedFileParts":{"stylesheetTag":false,"javascriptTag":false}},"version":"${HOT_RELOAD_VERSION}"}`
       expect(hotReloadEvents.at(-1)).toMatch(expectedCssEvent)
       // Wait for remote sync
       await nextTick()
@@ -218,7 +218,7 @@ describe('Hot Reload', () => {
       await triggerFileEvent('add', cssLiquidFileKey)
       // It does not add assets to the in-memory templates:
       expect(getInMemoryTemplates(ctx)).toEqual({})
-      const expectedCssLiquidEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${cssLiquidFileKey}","payload":{"sectionNames":[],"replaceTemplates":{},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
+      const expectedCssLiquidEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${cssLiquidFileKey}","payload":{"sectionNames":[],"replaceTemplates":{},"updatedFileParts":{"stylesheetTag":false,"javascriptTag":false}},"version":"${HOT_RELOAD_VERSION}"}`
       expect(hotReloadEvents.at(-1)).toMatch(expectedCssLiquidEvent)
       // Wait for remote sync
       await nextTick()
@@ -227,7 +227,7 @@ describe('Hot Reload', () => {
       // -- Test other file types (e.g. JS) --
       const jsFileKey = 'assets/something.js'
       await triggerFileEvent('add', jsFileKey)
-      const expectedJsEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${jsFileKey}","payload":{"sectionNames":[],"replaceTemplates":{},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
+      const expectedJsEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${jsFileKey}","payload":{"sectionNames":[],"replaceTemplates":{},"updatedFileParts":{"stylesheetTag":false,"javascriptTag":false}},"version":"${HOT_RELOAD_VERSION}"}`
       expect(hotReloadEvents.at(-1)).toMatch(expectedJsEvent)
       // Wait for remote sync
       await nextTick()

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
@@ -91,7 +91,7 @@ describe('Hot Reload', () => {
 
       const expectedSectionEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${testSectionFileKey}","payload":{"sectionNames":["first","second"],"replaceTemplates":${JSON.stringify(
         getInMemoryTemplates(ctx),
-      )}},"version":"${HOT_RELOAD_VERSION}"}`
+      )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
 
       // Verify local sync event
       expect(hotReloadEvents.at(-1)).toMatch(expectedSectionEvent)
@@ -142,7 +142,7 @@ describe('Hot Reload', () => {
       // Since this is a template, sectionNames will be empty (no sections to reload)
       const expectedTemplateEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${templateKey}","payload":{"sectionNames":[],"replaceTemplates":${JSON.stringify(
         getInMemoryTemplates(ctx),
-      )}},"version":"${HOT_RELOAD_VERSION}"}`
+      )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
 
       // Verify local sync event for JSON update
       expect(hotReloadEvents.at(-1)).toMatch(expectedTemplateEvent)
@@ -163,7 +163,7 @@ describe('Hot Reload', () => {
       // Since this is a section group, sectionNames will contain all the section names
       const expectedSectionGroupEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${sectionGroupKey}","payload":{"sectionNames":["first","second"],"replaceTemplates":${JSON.stringify(
         getInMemoryTemplates(ctx),
-      )}},"version":"${HOT_RELOAD_VERSION}"}`
+      )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
 
       // Verify local sync event for JSON update
       expect(hotReloadEvents.at(-1)).toMatch(expectedSectionGroupEvent)
@@ -178,7 +178,7 @@ describe('Hot Reload', () => {
       expect(hotReloadEvents.at(-1)).toMatch(
         `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${anotherSectionKey}","payload":{"sectionNames":["first","second"],"replaceTemplates":${JSON.stringify(
           getInMemoryTemplates(ctx),
-        )}},"version":"${HOT_RELOAD_VERSION}"}`,
+        )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`,
       )
       // Wait for remote sync
       await nextTick()
@@ -197,7 +197,7 @@ describe('Hot Reload', () => {
       expect(getInMemoryTemplates(ctx)).toEqual({[anotherSectionKey]: 'default-value'})
       const expectedUnreferencedSectionEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${anotherSectionKey}","payload":{"sectionNames":[],"replaceTemplates":${JSON.stringify(
         getInMemoryTemplates(ctx),
-      )}},"version":"${HOT_RELOAD_VERSION}"}`
+      )},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
       expect(hotReloadEvents.at(-1)).toMatch(expectedUnreferencedSectionEvent)
       await nextTick()
       expect(hotReloadEvents.at(-1)).toMatch(expectedUnreferencedSectionEvent.replace('local', 'remote'))
@@ -207,7 +207,7 @@ describe('Hot Reload', () => {
       await triggerFileEvent('add', cssFileKey)
       // It does not add assets to the in-memory templates:
       expect(getInMemoryTemplates(ctx)).toEqual({})
-      const expectedCssEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${cssFileKey}","payload":{"sectionNames":[],"replaceTemplates":{}},"version":"${HOT_RELOAD_VERSION}"}`
+      const expectedCssEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${cssFileKey}","payload":{"sectionNames":[],"replaceTemplates":{},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
       expect(hotReloadEvents.at(-1)).toMatch(expectedCssEvent)
       // Wait for remote sync
       await nextTick()
@@ -218,7 +218,7 @@ describe('Hot Reload', () => {
       await triggerFileEvent('add', cssLiquidFileKey)
       // It does not add assets to the in-memory templates:
       expect(getInMemoryTemplates(ctx)).toEqual({})
-      const expectedCssLiquidEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${cssLiquidFileKey}","payload":{"sectionNames":[],"replaceTemplates":{}},"version":"${HOT_RELOAD_VERSION}"}`
+      const expectedCssLiquidEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${cssLiquidFileKey}","payload":{"sectionNames":[],"replaceTemplates":{},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
       expect(hotReloadEvents.at(-1)).toMatch(expectedCssLiquidEvent)
       // Wait for remote sync
       await nextTick()
@@ -227,7 +227,7 @@ describe('Hot Reload', () => {
       // -- Test other file types (e.g. JS) --
       const jsFileKey = 'assets/something.js'
       await triggerFileEvent('add', jsFileKey)
-      const expectedJsEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${jsFileKey}","payload":{"sectionNames":[],"replaceTemplates":{}},"version":"${HOT_RELOAD_VERSION}"}`
+      const expectedJsEvent = `data: {"sync":"local","themeId":"${THEME_ID}","type":"update","key":"${jsFileKey}","payload":{"sectionNames":[],"replaceTemplates":{},"liquidTagsModified":{"stylesheet":false,"javascript":false}},"version":"${HOT_RELOAD_VERSION}"}`
       expect(hotReloadEvents.at(-1)).toMatch(expectedJsEvent)
       // Wait for remote sync
       await nextTick()

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
@@ -362,7 +362,7 @@ function collectReloadInfoForFile(key: string, ctx: DevServerContext) {
   return {
     sectionNames: type === 'sections' ? findSectionNamesToReload(key, ctx) : [],
     replaceTemplates: needsTemplateUpdate(key) ? getInMemoryTemplates(ctx) : {},
-    liquidTagsModified: getLiquidTagsModified(key, ctx),
+    updatedFileParts: getUpdatedFileParts(key, ctx),
   }
 }
 
@@ -404,20 +404,20 @@ function isAsset(key: string) {
   return key.startsWith('assets/')
 }
 
-function getLiquidTagsModified(key: string, ctx: DevServerContext): {stylesheet: boolean; javascript: boolean} {
+function getUpdatedFileParts(key: string, ctx: DevServerContext): {stylesheetTag: boolean; javascriptTag: boolean} {
   const file = ctx.localThemeFileSystem.files.get(key)
   const validPrefixes = ['sections/', 'snippets/', 'blocks/']
   const isValidFileType = validPrefixes.some((prefix) => key.startsWith(prefix)) && key.endsWith('.liquid')
 
   if (!file || !isValidFileType) {
-    return {stylesheet: false, javascript: false}
+    return {stylesheetTag: false, javascriptTag: false}
   }
 
   const tagContents = getTagContents(file)
 
   return {
-    stylesheet: tagContents.stylesheet.changed,
-    javascript: tagContents.javascript.changed,
+    stylesheetTag: tagContents.stylesheet.changed,
+    javascriptTag: tagContents.javascript.changed,
   }
 }
 

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.ts
@@ -17,6 +17,7 @@ import {renderError, renderInfo, renderWarning} from '@shopify/cli-kit/node/ui'
 import {extname, joinPath} from '@shopify/cli-kit/node/path'
 import {parseJSON} from '@shopify/theme-check-node'
 import {readFile} from '@shopify/cli-kit/node/fs'
+import {NodeTypes, toLiquidHtmlAST, walk} from '@shopify/liquid-html-parser'
 import EventEmitter from 'node:events'
 import type {
   HotReloadEvent,
@@ -24,8 +25,17 @@ import type {
   HotReloadOpenEvent,
   HotReloadFullEvent,
 } from '@shopify/theme-hot-reload'
-import type {Theme, ThemeFSEventPayload} from '@shopify/cli-kit/node/themes/types'
+import type {Theme, ThemeAsset, ThemeFSEventPayload} from '@shopify/cli-kit/node/themes/types'
 import type {DevServerContext} from '../types.js'
+
+// --- Section tag content cache ---
+
+interface TagContent {
+  content: string
+  changed: boolean
+}
+
+const tagContentCache = new Map<string, {checksum: string; stylesheet: TagContent; javascript: TagContent}>()
 
 // --- Template Replacers ---
 
@@ -352,6 +362,7 @@ function collectReloadInfoForFile(key: string, ctx: DevServerContext) {
   return {
     sectionNames: type === 'sections' ? findSectionNamesToReload(key, ctx) : [],
     replaceTemplates: needsTemplateUpdate(key) ? getInMemoryTemplates(ctx) : {},
+    liquidTagsModified: getLiquidTagsModified(key, ctx),
   }
 }
 
@@ -391,4 +402,53 @@ export function handleHotReloadScriptInjection(html: string, ctx: DevServerConte
 
 function isAsset(key: string) {
   return key.startsWith('assets/')
+}
+
+function getLiquidTagsModified(key: string, ctx: DevServerContext): {stylesheet: boolean; javascript: boolean} {
+  const file = ctx.localThemeFileSystem.files.get(key)
+  const validPrefixes = ['sections/', 'snippets/', 'blocks/']
+  const isValidFileType = validPrefixes.some((prefix) => key.startsWith(prefix)) && key.endsWith('.liquid')
+
+  if (!file || !isValidFileType) {
+    return {stylesheet: false, javascript: false}
+  }
+
+  const tagContents = getTagContents(file)
+
+  return {
+    stylesheet: tagContents.stylesheet.changed,
+    javascript: tagContents.javascript.changed,
+  }
+}
+
+function getTagContents(file: ThemeAsset) {
+  const cached = tagContentCache.get(file.key)
+  const cacheEntry = {
+    checksum: file.checksum,
+    stylesheet: {content: '', changed: false},
+    javascript: {content: '', changed: false},
+  }
+
+  if (cached?.checksum === file.checksum) {
+    return cached
+  }
+
+  tagContentCache.delete(file.key)
+
+  if (!file.value) return cacheEntry
+
+  walk(toLiquidHtmlAST(file.value), (node) => {
+    if (node.type !== NodeTypes.LiquidRawTag) return
+
+    if (node.name === 'stylesheet' || node.name === 'javascript') {
+      const content = node.body.value
+      const changed = !cached || content !== cached[node.name].content
+
+      cacheEntry[node.name] = {content, changed}
+    }
+  })
+
+  tagContentCache.set(file.key, cacheEntry)
+
+  return cacheEntry
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,8 +697,8 @@ importers:
         version: 2.7.0
     devDependencies:
       '@shopify/theme-hot-reload':
-        specifier: ^0.0.11
-        version: 0.0.11
+        specifier: ^0.0.18
+        version: 0.0.18
       '@vitest/coverage-istanbul':
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0)
@@ -6650,8 +6650,8 @@ packages:
       - encoding
     dev: false
 
-  /@shopify/theme-hot-reload@0.0.11:
-    resolution: {integrity: sha512-h4yJW1j+PIo1BzsElwIf2LPqI7iZE0XUUkucoXdKZZABcsS6/6+5KEAFSQEsn5VzIg1xS7I0ypOMQ7to2kvojQ==}
+  /@shopify/theme-hot-reload@0.0.18:
+    resolution: {integrity: sha512-l+IBuk+rG5T+5PKYyPrwgh7PDCxmEMpBFJeen6PM+h6RI4CDhAGRaiwUo5eN1o1JX51HdHHCts3rTEW+KUgq+Q==}
     dev: true
 
   /@shopify/theme-language-server-common@2.14.1:


### PR DESCRIPTION
### WHY are these changes introduced?

This PR fixes an issue related to hot-reloading compiled assets (such as scripts.js, block-scripts.js, etc).

### WHAT is this pull request doing?

This PR enriches the hot-reload event's payload by including details indicating whether the `javascript` or `stylesheet` tags were modified. This approach triggers a full-reload event the first time users update a section file with a `javascript` tag, but it caches this information, and subsequent updates will only trigger a full reload if the content of the `javascript` tag has changed.

### How to test your changes?

- Update your local `theme-hot-reload` package to use [this branch](https://github.com/Shopify/theme-hot-reload/pull/41)
- Run `SHOPIFY_CLI_LOCAL_HOT_RELOAD=true shopify-dev theme dev`
- Change the {% javavascript %} content within a section file
- Verify that the browser correctly performs a full refresh

Check the demo [here](https://github.com/Shopify/theme-hot-reload/pull/41)

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
