### PR TITLE
Extract logic to detect pre-release versions

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -149,6 +149,7 @@ import {webhooksRequest} from '@shopify/cli-kit/node/api/webhooks'
 import {functionsRequestDoc} from '@shopify/cli-kit/node/api/functions'
 import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
+import {isPreReleaseVersion} from '@shopify/cli-kit/node/version'
 
 const TEMPLATE_JSON_URL = 'https://cdn.shopify.com/static/cli/extensions/templates.json'
 
@@ -1144,10 +1145,9 @@ export async function allowedTemplates(
     const satisfiesMinCliVersion = !ext.minimumCliVersion || versionSatisfies(version, `>=${ext.minimumCliVersion}`)
     const satisfiesDeprecatedFromCliVersion =
       !ext.deprecatedFromCliVersion || versionSatisfies(version, `<${ext.deprecatedFromCliVersion}`)
-    const isDevelopmentVersion = version.startsWith('0.0.0')
     const satisfiesVersion = satisfiesMinCliVersion && satisfiesDeprecatedFromCliVersion
-    const satisfiesDevelopmentVersion = isDevelopmentVersion && ext.deprecatedFromCliVersion === undefined
-    return hasAnyNeededBetas && (satisfiesVersion || satisfiesDevelopmentVersion)
+    const satisfiesPreReleaseVersion = isPreReleaseVersion(version) && ext.deprecatedFromCliVersion === undefined
+    return hasAnyNeededBetas && (satisfiesVersion || satisfiesPreReleaseVersion)
   })
 }
 

--- a/packages/cli-kit/src/public/node/hooks/prerun.ts
+++ b/packages/cli-kit/src/public/node/hooks/prerun.ts
@@ -6,6 +6,7 @@ import {getOutputUpdateCLIReminder} from '../../../public/node/upgrade.js'
 import Command from '../../../public/node/base-command.js'
 import {runAtMinimumInterval} from '../../../private/node/conf-store.js'
 import {fetchNotificationsInBackground} from '../notifications-system.js'
+import {isPreReleaseVersion} from '../version.js'
 import {Hook} from '@oclif/core'
 
 export declare interface CommandContent {
@@ -93,7 +94,7 @@ function findAlias(aliases: string[]) {
 export async function warnOnAvailableUpgrade(): Promise<void> {
   const cliDependency = '@shopify/cli'
   const currentVersion = CLI_KIT_VERSION
-  if (currentVersion.startsWith('0.0.0')) {
+  if (isPreReleaseVersion(currentVersion)) {
     // This is a nightly/snapshot/experimental version, so we don't want to check for updates
     return
   }

--- a/packages/cli-kit/src/public/node/version.test.ts
+++ b/packages/cli-kit/src/public/node/version.test.ts
@@ -1,4 +1,4 @@
-import {localCLIVersion, globalCLIVersion} from './version.js'
+import {localCLIVersion, globalCLIVersion, isPreReleaseVersion} from './version.js'
 import {inTemporaryDirectory} from '../node/fs.js'
 import {captureOutput} from '../node/system.js'
 import {describe, expect, test, vi} from 'vitest'
@@ -76,5 +76,15 @@ describe('globalCLIVersion', () => {
     // Then
     expect(got).toBeUndefined()
     expect(captureOutput).not.toHaveBeenCalled()
+  })
+})
+
+describe('isPreReleaseVersion', () => {
+  test('returns true when the version is a pre-release version', () => {
+    expect(isPreReleaseVersion('0.0.0')).toBe(true)
+  })
+
+  test('returns false when the version is not a pre-release version', () => {
+    expect(isPreReleaseVersion('3.68.0')).toBe(false)
   })
 })

--- a/packages/cli-kit/src/public/node/version.ts
+++ b/packages/cli-kit/src/public/node/version.ts
@@ -1,7 +1,6 @@
 import {captureOutput} from '../node/system.js'
 import which from 'which'
 import {satisfies} from 'semver'
-
 /**
  * Returns the version of the local dependency of the CLI if it's installed in the provided directory.
  *
@@ -33,7 +32,7 @@ export async function globalCLIVersion(): Promise<string | undefined> {
     const versionMatch = output.match(/@shopify\/cli\/([^\s]+)/)
     if (versionMatch && versionMatch[1]) {
       const version = versionMatch[1]
-      if (satisfies(version, `>=3.59.0`) || version.startsWith('0.0.0')) {
+      if (satisfies(version, `>=3.59.0`) || isPreReleaseVersion(version)) {
         return version
       }
     }
@@ -42,4 +41,15 @@ export async function globalCLIVersion(): Promise<string | undefined> {
   } catch {
     return undefined
   }
+}
+
+/**
+ * Returns true if the given version is a pre-release version.
+ * Meaning is a `nightly`, `snapshot`, or `experimental` version.
+ *
+ * @param version - The version to check.
+ * @returns True if the version is a pre-release version.
+ */
+export function isPreReleaseVersion(version: string): boolean {
+  return version.startsWith('0.0.0')
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the handling of pre-release versions in the CLI by creating a dedicated utility function that centralizes the logic for identifying pre-release versions.

### WHAT is this pull request doing?

- Introduces a new `isPreReleaseVersion()` utility function in the version module that checks if a version is a pre-release version (starts with '0.0.0')
- Replaces direct string checks (`version.startsWith('0.0.0')`) with the new utility function across multiple files
- Updates the logic in `allowedTemplates()` to use the new function, renaming variables for better clarity (`isDevelopmentVersion` → `satisfiesPreReleaseVersion`)
- Adds tests for the new utility function

### How to test your changes?

1. Run the test suite to verify the new function works as expected
2. Test the CLI with both regular and pre-release versions to ensure version checks behave correctly
3. Verify that template filtering works properly with pre-release versions

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes