### PR TITLE
Add card present payments app extension schema

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension.ts
@@ -28,6 +28,12 @@ import {
   CreditCardPaymentsAppExtensionSchema,
   creditCardPaymentsAppExtensionDeployConfig,
 } from './payments_app_extension_schemas/credit_card_payments_app_extension_schema.js'
+import {
+  CARD_PRESENT_TARGET,
+  CardPresentPaymentsAppExtensionConfigType,
+  CardPresentPaymentsAppExtensionSchema,
+  cardPresentPaymentsAppExtensionDeployConfig,
+} from './payments_app_extension_schemas/card_present_payments_app_extension_schema.js'
 import {createExtensionSpecification} from '../specification.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -37,6 +43,7 @@ const PaymentsAppExtensionSchema = zod.union([
   CustomOnsitePaymentsAppExtensionSchema,
   CustomCreditCardPaymentsAppExtensionSchema,
   CreditCardPaymentsAppExtensionSchema,
+  CardPresentPaymentsAppExtensionSchema,
 ])
 
 export type PaymentsAppExtensionConfigType = zod.infer<typeof PaymentsAppExtensionSchema>
@@ -60,6 +67,8 @@ const paymentExtensionSpec = createExtensionSpecification({
         return customCreditCardPaymentsAppExtensionDeployConfig(
           config as CustomCreditCardPaymentsAppExtensionConfigType,
         )
+      case CARD_PRESENT_TARGET:
+        return cardPresentPaymentsAppExtensionDeployConfig(config as CardPresentPaymentsAppExtensionConfigType)
       default:
         return {}
     }

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/card_present_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/card_present_payments_app_extension_schema.test.ts
@@ -1,0 +1,179 @@
+import {
+  CardPresentPaymentsAppExtensionConfigType,
+  CardPresentPaymentsAppExtensionSchema,
+  cardPresentPaymentsAppExtensionDeployConfig,
+  CARD_PRESENT_TARGET,
+} from './card_present_payments_app_extension_schema.js'
+import {describe, expect, test} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const config: CardPresentPaymentsAppExtensionConfigType = {
+  name: 'test extension',
+  type: 'payments_extension',
+  payment_session_url: 'http://foo.bar',
+  refund_session_url: 'http://foo.bar',
+  capture_session_url: 'http://foo.bar',
+  void_session_url: 'http://foo.bar',
+  sync_terminal_transaction_result_url: 'http://foo.bar',
+  merchant_label: 'some-label',
+  supported_countries: ['CA'],
+  supported_payment_methods: ['PAYMENT_METHOD'],
+  test_mode_available: true,
+  targeting: [{target: 'payments.card-present.render'}],
+  api_version: '2022-07',
+  description: 'my payments app extension',
+}
+
+describe('CardPresentPaymentsAppExtensionSchema', () => {
+  test('validates a configuration with valid fields', async () => {
+    const {success} = CardPresentPaymentsAppExtensionSchema.safeParse(config)
+
+    expect(success).toBe(true)
+  })
+
+  test('returns an error if no target is provided', async () => {
+    expect(() =>
+      CardPresentPaymentsAppExtensionSchema.parse({
+        ...config,
+        targeting: [{...config.targeting[0]!, target: null}],
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          received: null,
+          code: zod.ZodIssueCode.invalid_literal,
+          expected: CARD_PRESENT_TARGET,
+          path: ['targeting', 0, 'target'],
+          message: `Invalid literal value, expected "${CARD_PRESENT_TARGET}"`,
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if payment_session_url is not provided', async () => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const {payment_session_url, ...rest} = config
+    expect(() =>
+      CardPresentPaymentsAppExtensionSchema.parse({
+        ...rest,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['payment_session_url'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if refund_session_url is not provided', async () => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const {refund_session_url, ...rest} = config
+    expect(() =>
+      CardPresentPaymentsAppExtensionSchema.parse({
+        ...rest,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['refund_session_url'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if capture_session_url is not provided', async () => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const {capture_session_url, ...rest} = config
+    expect(() =>
+      CardPresentPaymentsAppExtensionSchema.parse({
+        ...rest,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['capture_session_url'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if void_session_url is not provided', async () => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const {void_session_url, ...rest} = config
+    expect(() =>
+      CardPresentPaymentsAppExtensionSchema.parse({
+        ...rest,
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['void_session_url'],
+          message: 'Required',
+        },
+      ]),
+    )
+  })
+
+  test('validates with optional sync_terminal_transaction_result_url', async () => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const {sync_terminal_transaction_result_url, ...rest} = config
+    const {success} = CardPresentPaymentsAppExtensionSchema.safeParse({
+      ...rest,
+    })
+
+    expect(success).toBe(true)
+  })
+
+  test('returns an error if sync_terminal_transaction_result_url is not a valid URL', async () => {
+    expect(() =>
+      CardPresentPaymentsAppExtensionSchema.parse({
+        ...config,
+        sync_terminal_transaction_result_url: 'not-a-url',
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          validation: 'url',
+          code: 'invalid_string',
+          message: 'Invalid url',
+          path: ['sync_terminal_transaction_result_url'],
+        },
+      ]),
+    )
+  })
+})
+
+describe('cardPresentPaymentsAppExtensionDeployConfig', () => {
+  test('maps deploy configuration from extension configuration', async () => {
+    const result = await cardPresentPaymentsAppExtensionDeployConfig(config)
+
+    expect(result).toMatchObject({
+      api_version: config.api_version,
+      start_payment_session_url: config.payment_session_url,
+      start_refund_session_url: config.refund_session_url,
+      start_capture_session_url: config.capture_session_url,
+      start_void_session_url: config.void_session_url,
+      merchant_label: config.merchant_label,
+      supported_countries: config.supported_countries,
+      supported_payment_methods: config.supported_payment_methods,
+      sync_terminal_transaction_result_url: config.sync_terminal_transaction_result_url,
+      test_mode_available: config.test_mode_available,
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/card_present_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/card_present_payments_app_extension_schema.ts
@@ -1,0 +1,62 @@
+import {
+  BasePaymentsAppExtensionSchema,
+  BasePaymentsAppExtensionDeployConfigType,
+} from './base_payments_app_extension_schema.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+export type CardPresentPaymentsAppExtensionConfigType = zod.infer<typeof CardPresentPaymentsAppExtensionSchema>
+
+export const CARD_PRESENT_TARGET = 'payments.card-present.render'
+
+export const CardPresentPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.required({
+  refund_session_url: true,
+  capture_session_url: true,
+  void_session_url: true,
+}).extend({
+  targeting: zod.array(zod.object({target: zod.literal(CARD_PRESENT_TARGET)})).length(1),
+  sync_terminal_transaction_result_url: zod.string().url().optional(),
+})
+
+export interface CardPresentPaymentsAppExtensionDeployConfigType extends BasePaymentsAppExtensionDeployConfigType {
+  // Following are overwritten as they are required for card present extensions
+  start_refund_session_url: string
+  start_capture_session_url: string
+  start_void_session_url: string
+
+  // CardPresent-specific fields
+  sync_terminal_transaction_result_url?: string
+}
+
+export function cardPresentDeployConfigToCLIConfig(
+  config: CardPresentPaymentsAppExtensionDeployConfigType,
+): Omit<CardPresentPaymentsAppExtensionConfigType, 'name' | 'type' | 'metafields' | 'targeting'> | undefined {
+  return {
+    api_version: config.api_version,
+    payment_session_url: config.start_payment_session_url,
+    refund_session_url: config.start_refund_session_url,
+    capture_session_url: config.start_capture_session_url,
+    void_session_url: config.start_void_session_url,
+    sync_terminal_transaction_result_url: config.sync_terminal_transaction_result_url,
+    merchant_label: config.merchant_label,
+    supported_countries: config.supported_countries,
+    supported_payment_methods: config.supported_payment_methods,
+    test_mode_available: config.test_mode_available,
+  }
+}
+
+export async function cardPresentPaymentsAppExtensionDeployConfig(
+  config: CardPresentPaymentsAppExtensionConfigType,
+): Promise<{[key: string]: unknown} | undefined> {
+  return {
+    api_version: config.api_version,
+    start_payment_session_url: config.payment_session_url,
+    start_refund_session_url: config.refund_session_url,
+    start_capture_session_url: config.capture_session_url,
+    start_void_session_url: config.void_session_url,
+    sync_terminal_transaction_result_url: config.sync_terminal_transaction_result_url,
+    merchant_label: config.merchant_label,
+    supported_countries: config.supported_countries,
+    supported_payment_methods: config.supported_payment_methods,
+    test_mode_available: config.test_mode_available,
+  }
+}

--- a/packages/app/src/cli/services/payments/extension-to-toml.test.ts
+++ b/packages/app/src/cli/services/payments/extension-to-toml.test.ts
@@ -12,6 +12,8 @@ const SAMPLE_CUSTOM_ONSITE_CONFIG =
   '{"start_payment_session_url":"https://test-domain.com/startsession/bogus-pay","start_refund_session_url":"https://test-domain.com/refund","start_capture_session_url":"https://test-domain.com/capture","start_void_session_url":"https://test-domain.com/void","confirmation_callback_url":null,"checkout_payment_method_fields":[{"key":"bogus_customer_document","type":"string","required":true}],"supported_payment_methods":["bogus-pay"],"supported_countries":["BR"],"test_mode_available":true,"merchant_label":"Test Label","default_buyer_label": "Bogus Pay Buyer Label","buyer_label_to_locale":[],"supports_3ds":false,"supports_oversell_protection":false,"api_version":"unstable","ui_extension_registration_uuid":"3f9d1c40-0f7d-48f9-b802-ca7d302ee8bc","multiple_capture":false,"supports_installments":false,"supports_deferred_payments":false}'
 const SAMPLE_REDEEMABLE_CONFIG =
   '{"start_payment_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/payment_sessions","start_refund_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/refund_sessions","start_capture_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/capture_sessions","start_void_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/void_sessions","supported_countries":["CA","MX","US"],"test_mode_available":true,"merchant_label":"Bogus Redeemable Payments App","default_buyer_label":null,"buyer_label_to_locale":null,"api_version":"unstable","ui_extension_registration_uuid":"3f9d1c40-0f7d-48f9-b802-ca7d302ee8bc","supported_payment_methods":["gift-card"],"balance_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/retrieve_balance","checkout_payment_method_fields":[{"key":"card_number","type":"string","required":true},{"key":"pin","type":"string","required":true}],"supported_buyer_contexts":[{"currency":"USD","countries":["US"]},{"currency":"GBP"}]}'
+const SAMPLE_CARD_PRESENT_CONFIG =
+  '{"start_payment_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/payment_sessions","start_refund_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/refund_sessions","start_capture_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/capture_sessions","start_void_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/void_sessions","sync_terminal_transaction_result_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/terminal_transaction_result","supported_payment_methods":["visa","master","american_express"],"supported_countries":["AU","CA","GB","US"],"test_mode_available":true,"merchant_label":"Card Present Payments App Extension","api_version":"2025-04"}'
 
 const translateDeployConfigKeyToCLI = (deployConfigKey: string): string => {
   switch (deployConfigKey) {
@@ -433,6 +435,44 @@ ui_extension_handle = "checkout-ui-extension"
 
   [[extensions.targeting]]
   target = "payments.redeemable.render"
+`)
+  })
+
+  test('correctly builds a toml string for a card present app', async () => {
+    // Given
+    const extension1: ExtensionRegistration = {
+      id: '30366498817',
+      uuid: '626ab61a-e494-4e16-b511-e8721ec011a4',
+      title: 'Bogus Pay',
+      type: DashboardPaymentExtensionType.CardPresent,
+      draftVersion: {
+        config: SAMPLE_CARD_PRESENT_CONFIG,
+      },
+    }
+
+    // When
+    const got = buildTomlObject(extension1, [extension1])
+
+    // Then
+    expectIncludesKeys(got, SAMPLE_CARD_PRESENT_CONFIG)
+    expect(got).toEqual(`api_version = "2025-04"
+
+[[extensions]]
+name = "Bogus Pay"
+type = "payments_extension"
+handle = "bogus-pay"
+payment_session_url = "https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/payment_sessions"
+refund_session_url = "https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/refund_sessions"
+capture_session_url = "https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/capture_sessions"
+void_session_url = "https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/void_sessions"
+sync_terminal_transaction_result_url = "https://bogus-payment-sessions.shopifycloud.com/bogus/card_present/terminal_transaction_result"
+merchant_label = "Card Present Payments App Extension"
+supported_countries = [ "AU", "CA", "GB", "US" ]
+supported_payment_methods = [ "visa", "master", "american_express" ]
+test_mode_available = true
+
+  [[extensions.targeting]]
+  target = "payments.card-present.render"
 `)
   })
 })

--- a/packages/app/src/cli/services/payments/extension-to-toml.ts
+++ b/packages/app/src/cli/services/payments/extension-to-toml.ts
@@ -25,6 +25,11 @@ import {
   customOnsiteDeployConfigToCLIConfig,
   CUSTOM_ONSITE_TARGET,
 } from '../../models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.js'
+import {
+  CardPresentPaymentsAppExtensionDeployConfigType,
+  cardPresentDeployConfigToCLIConfig,
+  CARD_PRESENT_TARGET,
+} from '../../models/extensions/specifications/payments_app_extension_schemas/card_present_payments_app_extension_schema.js'
 import {MAX_EXTENSION_HANDLE_LENGTH} from '../../models/extensions/schemas.js'
 import {encodeToml} from '@shopify/cli-kit/node/toml'
 import {slugify} from '@shopify/cli-kit/common/string'
@@ -41,6 +46,8 @@ function typeToContext(type: string) {
       return CUSTOM_ONSITE_TARGET
     case DashboardPaymentExtensionType.Redeemable:
       return REDEEMABLE_TARGET
+    case DashboardPaymentExtensionType.CardPresent:
+      return CARD_PRESENT_TARGET
   }
 }
 export enum DashboardPaymentExtensionType {
@@ -49,6 +56,7 @@ export enum DashboardPaymentExtensionType {
   CustomCreditCard = 'payments_app_custom_credit_card',
   CustomOnsite = 'payments_app_custom_onsite',
   Redeemable = 'payments_app_redeemable',
+  CardPresent = 'payments_app_card_present',
 }
 
 export function buildTomlObject(extension: ExtensionRegistration, allExtensions: ExtensionRegistration[]): string {
@@ -83,6 +91,12 @@ export function buildTomlObject(extension: ExtensionRegistration, allExtensions:
         extension,
         allExtensions,
         redeemableDeployConfigToCLIConfig,
+      )
+    case CARD_PRESENT_TARGET:
+      return buildPaymentsToml<CardPresentPaymentsAppExtensionDeployConfigType>(
+        extension,
+        allExtensions,
+        cardPresentDeployConfigToCLIConfig,
       )
     default:
       throw new Error(`Unsupported extension: ${context}`)


### PR DESCRIPTION
### WHY are these changes introduced?

- closes https://github.com/shop/issues-retail-on-payments-platform/issues/174
- depends on https://github.com/Shopify/partners/pull/59179 

Adds a new payments app extension type card present for supporting retail in person payments on PPP.

### WHAT is this pull request doing?

Adds schema for CardPresent payments app extensions. 

### How to test your changes?

1. Follow the setup [here](https://docs.google.com/document/d/1snRB1z5JxyPnBYwTGD-IpHaxiTofIuO1sXTz546JevY/edit?tab=t.up7mshwiz187) to create a card present payment app extension.
2. `shopify app deploy` will until the core extension gating requirements  are update in [this pr](https://app.graphite.dev/github/pr/shop/world/52819).

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
