### PR TITLE
Enable authentication errors to display store names

### DIFF
--- a/.changeset/sour-pillows-talk.md
+++ b/.changeset/sour-pillows-talk.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Enable authentication errors to display store names


### PR DESCRIPTION
Fixes [#452](https://github.com/Shopify/developer-tools-team/issues/452)

### WHY are these changes introduced?
Previously users hitting an authentication error wouldn't know which store they were trying to authenticate against. This is because we preserve `--store` values locally and don't show the user which we're operating against.

### WHAT is this pull request doing?

Added store to the `tokenRequest` params in `requestAppToken`:
```typescript
const params = {
  ...
  ...(api === 'admin' && {destination: `https://${store}/admin`, store}),
}
```

Modified `tokenRequest` to return both error and store:
```typescript
return err({error: payload.error, store: params.store})
```

Updated `tokenRequestErrorHandler` to use store in the invalid target error message (if store is defined):
```typescript
function tokenRequestErrorHandler({error, store}: {error: string; store?: string}) {
  const invalidTargetErrorMessage =
     'You are not authorized to use the CLI to develop in the provided store' +
    (store ? `: ${store}` : '.') +
    ...
}
```

<img width="848" alt="error-message" src="https://github.com/user-attachments/assets/5ef07463-6c29-4748-8575-90bd621f11b6" />


### How to test your changes?
- Pull down the branch
- Build the branch
- Run a theme command on a store you don't have access to: 
`pnpm shopify theme info --store=unathenticated.myshopify.com`
- It should display `You are not authorized to use the CLI to develop in the provided store: unathenticated.myshopify.com`


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
