### PR TITLE
Follow-up refactoring from #5728

### DIFF
--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -208,14 +208,12 @@ async function handlePushOutput(
   session: AdminSession,
   options: PushOptions,
 ) {
-  const hasErrors = hasUploadErrors(results)
-
   if (options.json) {
-    handleJsonOutput(theme, hasErrors, session, results)
+    handleJsonOutput(theme, session, results)
   } else if (options.publish) {
-    handlePublishOutput(hasErrors, session)
+    handlePublishOutput(session, results)
   } else {
-    handleOutput(theme, hasErrors, session)
+    handleOutput(theme, session, results)
   }
 }
 
@@ -223,11 +221,10 @@ async function handlePushOutput(
  * Handles the JSON output for the push operation.
  *
  * @param theme - The theme being pushed.
- * @param hasErrors - Indicates if there were any errors during the push operation.
  * @param session - The admin session for the theme.
  * @param results - The map of upload results.
  */
-function handleJsonOutput(theme: Theme, hasErrors: boolean, session: AdminSession, results: Map<string, Result>) {
+function handleJsonOutput(theme: Theme, session: AdminSession, results: Map<string, Result>) {
   const output: JsonOutput = {
     theme: {
       id: theme.id,
@@ -238,7 +235,7 @@ function handleJsonOutput(theme: Theme, hasErrors: boolean, session: AdminSessio
       preview_url: themePreviewUrl(theme, session),
     },
   }
-
+  const hasErrors = hasUploadErrors(results)
   if (hasErrors) {
     const message = `The theme '${theme.name}' was pushed with errors`
     output.theme.warning = message
@@ -260,10 +257,11 @@ function handleJsonOutput(theme: Theme, hasErrors: boolean, session: AdminSessio
 /**
  * Handles the output for the publish operation.
  *
- * @param hasErrors - Indicates if there were any errors during the push operation.
  * @param session - The admin session for the theme.
+ * @param results - The map of upload results.
  */
-function handlePublishOutput(hasErrors: boolean, session: AdminSession) {
+function handlePublishOutput(session: AdminSession, results: Map<string, Result>) {
+  const hasErrors = hasUploadErrors(results)
   if (hasErrors) {
     renderWarning({body: `Your theme was published with errors and is now live at https://${session.storeFqdn}`})
   } else {
@@ -275,10 +273,11 @@ function handlePublishOutput(hasErrors: boolean, session: AdminSession) {
  * Handles the output for the push operation.
  *
  * @param theme - The theme being pushed.
- * @param hasErrors - Indicates if there were any errors during the push operation.
  * @param session - The admin session for the theme.
+ * @param results - The map of upload results.
  */
-function handleOutput(theme: Theme, hasErrors: boolean, session: AdminSession) {
+function handleOutput(theme: Theme, session: AdminSession, results: Map<string, Result>) {
+  const hasErrors = hasUploadErrors(results)
   const nextSteps = [
     [
       {


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/cli/pull/5728#discussion_r2067855575

This is a follow-up refactoring from PR #5728.

### WHAT is this pull request doing?

This PR removes the `hasErrors` parameter from `handleJsonOutput`, as the method now directly receives `results` since PR #5728.

### How to test your changes?

N/A – This is a no-op PR and doesn't change the behavior of `shopify theme push --json`.

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
