### PR TITLE
Add `encodeYaml` and `decodeYaml` (WIP)

### DIFF
--- a/.changeset/tame-rats-watch.md
+++ b/.changeset/tame-rats-watch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Added encodeYaml and decodeYaml functions

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -163,6 +163,7 @@
     "terminal-link": "3.0.0",
     "ts-error": "1.0.6",
     "which": "4.0.0",
+    "yaml": "2.7.0",
     "zod": "3.24.1"
   },
   "devDependencies": {

--- a/packages/cli-kit/src/public/node/yaml.test.ts
+++ b/packages/cli-kit/src/public/node/yaml.test.ts
@@ -1,0 +1,51 @@
+import {decodeYaml, encodeYaml} from './yaml.js'
+import {describe, expect, test} from 'vitest'
+
+describe('decodeYaml', () => {
+  test('converts a YAML string to a simple object', () => {
+    const input = `
+    name: app
+    `
+    const result = decodeYaml(input)
+    expect(result).toStrictEqual({name: 'app'})
+  })
+
+  test('converts a YAML string to a nested object', () => {
+    const input = `
+    webhooks:
+      api_version: 2023-07
+    `
+    const result = decodeYaml(input)
+    expect(result).toStrictEqual({webhooks: {api_version: '2023-07'}})
+  })
+
+  test('converts a YAML string to a deeply nested object', () => {
+    const input = `
+    access:
+      admin:
+        direct_api_mode: online
+    `
+    const result = decodeYaml(input)
+    expect(result).toStrictEqual({access: {admin: {direct_api_mode: 'online'}}})
+  })
+})
+
+describe('encodeYaml', () => {
+  test('converts a simple object to YAML string', () => {
+    const input = {name: 'app'}
+    const result = encodeYaml(input)
+    expect(result).toBe('name: app\n')
+  })
+
+  test('converts a nested object to YAML string', () => {
+    const input = {webhooks: {api_version: '2023-07'}}
+    const result = encodeYaml(input)
+    expect(result).toBe('webhooks:\n  api_version: 2023-07\n')
+  })
+
+  test('converts a deeply nested object to YAML string', () => {
+    const input = {access: {admin: {direct_api_mode: 'online'}}}
+    const result = encodeYaml(input)
+    expect(result).toBe('access:\n  admin:\n    direct_api_mode: online\n')
+  })
+})

--- a/packages/cli-kit/src/public/node/yaml.ts
+++ b/packages/cli-kit/src/public/node/yaml.ts
@@ -5,7 +5,7 @@ import YAML from 'yaml'
  * Given a YAML string, it returns an object.
  *
  * @param input - YAML string.
- * @returns object.
+ * @returns Object.
  */
 export function decodeYaml(input: string): JsonMapType {
   const normalizedInput = input.replace(/\r\n$/g, '\n')
@@ -15,7 +15,7 @@ export function decodeYaml(input: string): JsonMapType {
 /**
  * Given an object, it returns a YAML string.
  *
- * @param content - object.
+ * @param content - Object.
  * @returns YAML string.
  */
 export function encodeYaml(content: JsonMapType | object): string {

--- a/packages/cli-kit/src/public/node/yaml.ts
+++ b/packages/cli-kit/src/public/node/yaml.ts
@@ -1,0 +1,23 @@
+import {JsonMapType} from '@shopify/cli-kit/node/toml'
+import YAML from 'yaml'
+
+/**
+ * Given a YAML string, it returns an object.
+ *
+ * @param input - YAML string.
+ * @returns object.
+ */
+export function decodeYaml(input: string): JsonMapType {
+  const normalizedInput = input.replace(/\r\n$/g, '\n')
+  return YAML.parse(normalizedInput)
+}
+
+/**
+ * Given an object, it returns a YAML string.
+ *
+ * @param content - object.
+ * @returns YAML string.
+ */
+export function encodeYaml(content: JsonMapType | object): string {
+  return YAML.stringify(content)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,9 @@ importers:
       which:
         specifier: 4.0.0
         version: 4.0.0
+      yaml:
+        specifier: 2.7.0
+        version: 2.7.0
       zod:
         specifier: 3.24.1
         version: 3.24.1
@@ -3346,7 +3349,7 @@ packages:
       util-arity: 1.1.0
       verror: 1.10.1
       xmlbuilder: 15.1.1
-      yaml: 2.3.2
+      yaml: 2.7.0
       yup: 1.2.0
     dev: true
 
@@ -17808,11 +17811,6 @@ packages:
   /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
-    dev: true
-
-  /yaml@2.3.2:
-    resolution: {integrity: sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==}
-    engines: {node: '>= 14'}
     dev: true
 
   /yaml@2.7.0:


### PR DESCRIPTION
### WHY are these changes introduced?

The CLI already has `encodeToml` and `decodeToml`.

https://github.com/Shopify/cli/blob/main/packages/cli-kit/src/public/node/toml.ts

We're adding `encodeYaml` and `decodeYaml` for a new service coming soon, which will support both `json` and `yml` data files.

### WHAT is this pull request doing?

- Adding the new dependancy of `yaml`
- Adding `encodeYaml` and `decodeYaml` wrapper functions



### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
