### PR TITLE
Pass organization_id variable on app creation

### DIFF
--- a/.changeset/weak-horses-protect.md
+++ b/.changeset/weak-horses-protect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update app create graphql to use organizationId

--- a/packages/app/src/cli/api/graphql/app-management/generated/create-app.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-app.ts
@@ -6,6 +6,7 @@ import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/co
 
 export type CreateAppMutationVariables = Types.Exact<{
   initialVersion: Types.AppVersionInput
+  organizationId?: Types.InputMaybe<Types.Scalars['ID']['input']>
 }>
 
 export type CreateAppMutation = {
@@ -28,6 +29,11 @@ export const CreateApp = {
           variable: {kind: 'Variable', name: {kind: 'Name', value: 'initialVersion'}},
           type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'AppVersionInput'}}},
         },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'organizationId'}},
+          type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}},
+        },
       ],
       selectionSet: {
         kind: 'SelectionSet',
@@ -40,6 +46,11 @@ export const CreateApp = {
                 kind: 'Argument',
                 name: {kind: 'Name', value: 'initialVersion'},
                 value: {kind: 'Variable', name: {kind: 'Name', value: 'initialVersion'}},
+              },
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'organizationId'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'organizationId'}},
               },
             ],
             selectionSet: {

--- a/packages/app/src/cli/api/graphql/app-management/queries/create-app.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/create-app.graphql
@@ -1,5 +1,5 @@
-mutation CreateApp($initialVersion: AppVersionInput!) {
-  appCreate(initialVersion: $initialVersion) {
+mutation CreateApp($initialVersion: AppVersionInput!, $organizationId: ID) {
+  appCreate(initialVersion: $initialVersion, organizationId: $organizationId) {
     app {
       id
       key

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -486,7 +486,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
         .sort()
         .at(-1) ?? 'unstable'
 
-    const variables = createAppVars(options, apiVersion)
+    const variables = createAppVars(options, org.id, apiVersion)
 
     const mutation = CreateApp
     const result = await appManagementRequestDoc(
@@ -1099,7 +1099,7 @@ interface AppVersionSourceUrl {
 const MAGIC_URL = 'https://shopify.dev/apps/default-app-home'
 const MAGIC_REDIRECT_URL = 'https://shopify.dev/apps/default-app-home/api/auth'
 
-function createAppVars(options: CreateAppOptions, apiVersion?: string): CreateAppMutationVariables {
+function createAppVars(options: CreateAppOptions, organizationId: string, apiVersion?: string): CreateAppMutationVariables {
   const {isLaunchable, scopesArray, name, isEmbedded} = options
   const source: AppVersionSource = {
     source: {
@@ -1131,16 +1131,21 @@ function createAppVars(options: CreateAppOptions, apiVersion?: string): CreateAp
     },
   }
 
-  return {initialVersion: {source: source.source as unknown as JsonMapType}}
+  return {initialVersion: {source: source.source as unknown as JsonMapType}, organizationId: shopifyGidFromOrganizationId(organizationId)}
 }
 
 // Business platform uses base64-encoded GIDs, while App Management uses
-// just the integer portion of that ID. These functions convert between the two.
+// different GID formats depending on the API endpoint. These functions convert between formats.
 
 // 1234 => gid://organization/Organization/1234 => base64
 export function encodedGidFromOrganizationId(id: string): string {
   const gid = `gid://organization/Organization/${id}`
   return Buffer.from(gid).toString('base64')
+}
+
+// 1234 => gid://shopify/Organization/1234
+export function shopifyGidFromOrganizationId(id: string): string {
+  return `gid://shopify/Organization/${id}`
 }
 
 // base64 => gid://organization/Organization/1234 => 1234


### PR DESCRIPTION
### WHY are these changes introduced?

To enable app creation within a specific organization context by passing the organization ID to the app creation mutation.

### WHAT is this pull request doing?

- Adds an `organizationId` parameter to the `CreateApp` GraphQL mutation
- Updates the GraphQL query to include this parameter in the `appCreate` operation
- Modifies the `createAppVars` function to include the organization ID in the mutation variables
- Adds a new utility function `shopifyGidFromOrganizationId` to format organization IDs in the required GID format
- Updates tests to verify the organization ID is correctly passed during app creation

### How to test your changes?

1. Create a new app using the CLI while authenticated to a specific organization
2. Verify the app is created within the correct organization context
3. Check that the app appears in the organization's app list

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes