### PR TITLE
Fix app dev with HOST env var

### DIFF
--- a/.changeset/afraid-camels-swim.md
+++ b/.changeset/afraid-camels-swim.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix app dev issue about unavailable port when HOST env var is set

--- a/packages/cli-kit/src/public/node/tcp.ts
+++ b/packages/cli-kit/src/public/node/tcp.ts
@@ -53,7 +53,7 @@ export async function getAvailableTCPPort(preferredPort?: number, options?: GetT
  * @returns A promise that resolves with a boolean indicating if the port is available.
  */
 export async function checkPortAvailability(portNumber: number): Promise<boolean> {
-  return (await port.checkPort(portNumber)) === portNumber
+  return (await port.checkPort(portNumber, 'localhost')) === portNumber
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2743

Related to https://github.com/Shopify/cli/issues/3578#issuecomment-2151433171

### WHAT is this pull request doing?

As @ozziexsh found [here](https://github.com/Shopify/cli/issues/3578#issuecomment-2151433171), the library used to find an available port was not working when a HOST env var is defined.

To solve it, I'm passing `localhost` as the host to prevent the library from using the HOST env var.

### How to test your changes?

- `HOST=http://localhost p shopify app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
