### PR TITLE
Richer JSON schema errors

### DIFF
--- a/.changeset/little-eyes-peel.md
+++ b/.changeset/little-eyes-peel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Display richer error messages when apps are misconfigured

--- a/packages/cli-kit/src/public/node/json-schema.test.ts
+++ b/packages/cli-kit/src/public/node/json-schema.test.ts
@@ -1,4 +1,5 @@
 import {jsonSchemaValidate, normaliseJsonSchema} from './json-schema.js'
+import {decodeToml} from './toml.js'
 import {describe, expect, test} from 'vitest'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -255,5 +256,261 @@ describe('normaliseJsonSchema', () => {
 
     const dereferenced = await normaliseJsonSchema(JSON.stringify(schema))
     expect(dereferenced).toEqual(schema)
+  })
+})
+
+describe('validate complex schema', () => {
+  test('validates with useful error messages', async () => {
+    const schema = {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        product: {
+          type: 'object',
+          required: ['metafields'],
+          additionalProperties: false,
+          properties: {
+            metafields: {
+              $ref: '#/definitions/OwnerTypeMetafieldNamespaces',
+            },
+          },
+          title: 'Custom Data \u003e Metafields',
+          description:
+            'Namespaces for metafields under this owner type. For example, `[product.metafields.app.example]` creates a metafield under the `$app` namespace, with the key `example`.\n\nRequires the following access scope: write_products',
+        },
+      },
+      definitions: {
+        MetaFieldDefinitionTypes: {
+          type: 'string',
+          oneOf: [
+            {
+              type: 'string',
+              pattern:
+                '(?\u003ctype\u003e(list\\.)?(metaobject_reference|mixed_reference))\u003c(?\u003creferences\u003e(\\$app:[a-zA-Z0-9_-]+(,\\s*)?)+)\u003e',
+            },
+            {
+              type: 'string',
+              enum: [
+                'boolean',
+                'color',
+                'date_time',
+                'date',
+                'dimension',
+                'json',
+                'language',
+                'list.color',
+                'list.date_time',
+                'list.date',
+                'list.dimension',
+                'list.number_decimal',
+                'list.number_integer',
+                'list.rating',
+                'list.single_line_text_field',
+                'list.url',
+                'list.volume',
+                'list.weight',
+                'money',
+                'multi_line_text_field',
+                'number_decimal',
+                'number_integer',
+                'rating',
+                'rich_text_field',
+                'single_line_text_field',
+                'url',
+                'link',
+                'list.link',
+                'volume',
+                'weight',
+                'company_reference',
+                'list.company_reference',
+                'customer_reference',
+                'list.customer_reference',
+                'product_reference',
+                'list.product_reference',
+                'collection_reference',
+                'list.collection_reference',
+                'variant_reference',
+                'list.variant_reference',
+                'file_reference',
+                'list.file_reference',
+                'product_taxonomy_value_reference',
+                'list.product_taxonomy_value_reference',
+                'metaobject_reference',
+                'list.metaobject_reference',
+                'mixed_reference',
+                'list.mixed_reference',
+                'page_reference',
+                'list.page_reference',
+                'order_reference',
+              ],
+            },
+          ],
+          title: 'Custom Data \u003e Types',
+          description:
+            'Set the [data type](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types) of the metafield.\n\nEach [metafield](https://shopify.dev/docs/apps/build/custom-data) and [metafield definition](https://shopify.dev/docs/apps/build/custom-data/metafields/definitions) has a type, which defines the type of information that it can store. The metafield types have built-in validation and [Liquid](https://shopify.dev/docs/api/liquid/objects/metafield) support.',
+        },
+        ValidationRule: {
+          type: 'object',
+          additionalProperties: {
+            type: ['number', 'string', 'object', 'array'],
+          },
+          title: 'Custom Data \u003e Validation Rules',
+          description:
+            'Validation options enable you to apply additional constraints to the data that a metafield can store, such as a minimum or maximum value, or a regular expression. This guide shows you how to manage validation options using the GraphQL Admin API.',
+        },
+        OwnerTypeMetafieldNamespaces: {
+          type: 'object',
+          additionalProperties: {
+            $ref: '#/definitions/MetafieldsCollection',
+          },
+          properties: {
+            app: {
+              $ref: '#/definitions/MetafieldsCollection',
+            },
+          },
+          title: 'Custom Data \u003e Metafields',
+          description:
+            'Namespaces for metafields under this owner type. For example, `[products.metafields.app]` creates metafields under the `app` namespace for products.',
+        },
+        MetafieldsCollection: {
+          type: 'object',
+          additionalProperties: {
+            $ref: '#/definitions/Metafield',
+          },
+          title: 'Custom Data \u003e Metafields',
+          description:
+            'A namespace for metafields. `.app` places metafields under the `$app` namespace; `.other` places metafields under the `$app:other` namespace.',
+        },
+        Metafield: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['type'],
+          title: 'Custom Data \u003e Metafields',
+          description:
+            "Metafields are a flexible way for your app to add and store additional information about a Shopify resource, such as a product, a collection, [and many other owner types](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType). The additional information stored in metafields can be almost anything related to a resource. Some examples are specifications, size charts, downloadable documents, release dates, images, or part numbers.\n\nMerchants and other apps can retrieve and edit the data that's stored in metafields from the Shopify admin. You can also access metafields in themes using Liquid and through the Storefront API.",
+          properties: {
+            type: {
+              $ref: '#/definitions/MetaFieldDefinitionTypes',
+            },
+            name: {
+              type: 'string',
+              title: 'Custom Data \u003e Metafields',
+              description: 'The human-readable name of the metafield definition.',
+            },
+            description: {
+              type: 'string',
+              title: 'Custom Data \u003e Metafields',
+              description: 'The description of the metafield definition.',
+            },
+            validations: {
+              $ref: '#/definitions/ValidationRule',
+            },
+            capabilities: {
+              $ref: '#/definitions/MetafieldCapabilities',
+            },
+            access: {
+              $ref: '#/definitions/MetafieldAccessControls',
+            },
+          },
+        },
+        MetafieldCapabilities: {
+          type: 'object',
+          additionalProperties: false,
+          title: 'Custom Data \u003e Metafields',
+          description: 'The capabilities of the metafield definition.',
+          properties: {
+            admin_filterable: {
+              type: 'boolean',
+              title: 'Custom Data \u003e Metafields \u003e Admin Filterable',
+              description:
+                'The admin filterable capability allows you to use a metafield definition and its values to filter resource lists in the Shopify admin. This capability makes it easier for merchants to find and manage resources such as products based on their specific metafield values.',
+            },
+          },
+        },
+        MetafieldAccessControls: {
+          type: 'object',
+          additionalProperties: false,
+          title: 'Custom Data \u003e Metafields',
+          description:
+            'The access settings that apply to each of the metafields that belong to the metafield definition.',
+          properties: {
+            admin: {
+              title: 'Custom Data \u003e Access Control',
+              description: 'Access configuration for Admin API surface areas, including the GraphQL Admin API.',
+              type: 'string',
+              enum: ['merchant_read', 'merchant_read_write'],
+            },
+            storefront: {
+              title: 'Custom Data \u003e Access Control',
+              description:
+                'Access configuration for Storefront API surface areas, including the GraphQL Storefront API and Liquid.',
+              type: 'string',
+              enum: ['none', 'public_read'],
+            },
+            customer_account: {
+              title: 'Custom Data \u003e Access Control',
+              description: 'The Customer Account API access setting to use for the metafields under this definition.',
+              type: 'string',
+              enum: ['none', 'read', 'read_write'],
+            },
+          },
+        },
+      },
+    }
+
+    const subject = decodeToml(`
+[product.metafields.app.first_published]
+type = "year"
+nime = "First published"
+bar = "boo"
+validations.min = false`)
+
+    const result = jsonSchemaValidate(subject, schema, 'fail')
+    expect(result.state).toBe('error')
+    expect(result.errors).toMatchInlineSnapshot(`
+      [
+        {
+          "message": "No additional properties allowed. You can set access, capabilities, description, name.",
+          "path": [
+            "product",
+            "metafields",
+            "app",
+            "first_published",
+            "nime",
+          ],
+        },
+        {
+          "message": "No additional properties allowed. You can set access, capabilities, description, name.",
+          "path": [
+            "product",
+            "metafields",
+            "app",
+            "first_published",
+            "bar",
+          ],
+        },
+        {
+          "message": "Expected number, string, object, array, received boolean",
+          "path": [
+            "product",
+            "metafields",
+            "app",
+            "first_published",
+            "validations",
+            "min",
+          ],
+        },
+        {
+          "message": "Invalid input",
+          "path": [
+            "product",
+            "metafields",
+            "app",
+            "first_published",
+            "type",
+          ],
+        },
+      ]
+    `)
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the developer experience when working with misconfigured apps by providing more detailed and helpful error messages.

Specifically:
- if there are multiple JSON schema errors, they're all presented
- if the developer has an issue due to `additionalProperties: false`, a useful error message -- where the supported properties are displayed -- is given instead

A test is added based on a snapshot of one of the more complex JSON schema.

### WHAT is this pull request doing?

Enhances the JSON schema validation in `@shopify/cli-kit` to display richer error messages when apps are misconfigured. The changes include:

- Configuring Ajv to collect all errors and provide verbose output -- not displayed
- Improving error message formatting for type mismatches
- Adding helpful context for additional property errors by listing allowed properties
- Adding comprehensive tests to verify the enhanced error messages

### How to test your changes?

1. Create an app with an intentionally misconfigured schema (e.g., invalid metafield type or additional properties)
2. Run the CLI command that validates the configuration
3. Verify that the error messages are more descriptive and provide guidance on how to fix the issues
