### PR TITLE
Use vitest monorepo suppo for unit testst

### DIFF
--- a/.github/actions/run-and-save-test-coverage/action.yml
+++ b/.github/actions/run-and-save-test-coverage/action.yml
@@ -8,10 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Unit tests with coverage
-      run: pnpm nx run-many --all --skip-nx-cache --target=test:coverage --exclude=features --output-style=stream
-      shell: bash
-    - name: Combine Jest coverages
-      run: npx istanbul-merge --out="coverage.raw.json" "packages/*/coverage/coverage-final.json"
+      run: pnpm vitest run --coverage --reporter json --outputFile ./coverage/report.json
       shell: bash
     - name: Convert coverage to Jest
       run: ./bin/save-coverage-file.js

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -85,7 +85,7 @@ jobs:
         run: pnpm nx run-many --all --skip-nx-cache  --target=bundle --output-style=stream
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.20.3' }}
       - name: Unit tests
-        run: pnpm nx run-many --all --skip-nx-cache --target=test --exclude=features --output-style=stream
+        run: pnpm vitest run
       - name: Acceptance tests
         if: ${{ matrix.node == '18.20.3' }}
         env:
@@ -288,7 +288,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Unit tests
-        run: pnpm test:unit --output-style=stream
+        run: pnpm vitest run
 
   pr-acceptance-tests:
     name: '[PR] Accept. Test with Node ${{ matrix.node }} in ${{ matrix.os }}'

--- a/bin/save-coverage-file.js
+++ b/bin/save-coverage-file.js
@@ -4,55 +4,19 @@ const require = createRequire(import.meta.url);
 const fs = require("fs");
 
 /**
- * This takes a large combined Jest-format coverage file, and a collection of JSON test reports, and combines them into one master file.
+ * This takes a combined coverage file and creates a report in the format expected by our coverage tools.
  */
 
-const coveragePackages = ["cli", "cli-kit", "app"];
-
-const masterCoverageFile = process.cwd() + "/coverage.raw.json";
+const masterCoverageFile = process.cwd() + "/coverage/coverage-final.json";
+const sourceReportFile = process.cwd() + "/coverage/report.json";
 const masterReportFile = process.cwd() + "/report.json";
 
-// Create the starting file -- the master coverage file and empty test results
-const masterCoverage = {
-  numTotalTestSuites: 0,
-  numPassedTestSuites: 0,
-  numFailedTestSuites: 0,
-  numPendingTestSuites: 0,
-  numTotalTests: 0,
-  numPassedTests: 0,
-  numFailedTests: 0,
-  numPendingTests: 0,
-  numTodoTests: 0,
-  startTime: 999999999999999,
-  success: true,
-  testResults: [],
-  coverageMap: require(masterCoverageFile),
-};
+// Read the coverage report from vitest
+const coverageData = require(masterCoverageFile);
 
-// merge each package's test results into the master file
-coveragePackages.forEach((pkg) => {
-  const testReportFilename =
-    process.cwd() + `/packages/${pkg}/coverage/report.json`;
-  const testReport = require(testReportFilename);
-  masterCoverage.numTotalTestSuites += testReport.numTotalTestSuites;
-  masterCoverage.numPassedTestSuites += testReport.numPassedTestSuites;
-  masterCoverage.numFailedTestSuites += testReport.numFailedTestSuites;
-  masterCoverage.numPendingTestSuites += testReport.numPendingTestSuites;
-  masterCoverage.numTotalTests += testReport.numTotalTests;
-  masterCoverage.numPassedTests += testReport.numPassedTests;
-  masterCoverage.numFailedTests += testReport.numFailedTests;
-  masterCoverage.numPendingTests += testReport.numPendingTests;
-  masterCoverage.numTodoTests += testReport.numTodoTests;
-  masterCoverage.startTime = Math.min(
-    masterCoverage.startTime,
-    testReport.startTime
-  );
-  masterCoverage.success = masterCoverage.success && testReport.success;
-  masterCoverage.testResults = [
-    ...masterCoverage.testResults,
-    ...testReport.testResults,
-  ];
-});
+// Read the test results from the report
+const masterCoverage = require(sourceReportFile);
+masterCoverage.coverageMap = coverageData;
 
 // write it out
 fs.writeFile(masterReportFile, JSON.stringify(masterCoverage), (err) => {
@@ -61,5 +25,5 @@ fs.writeFile(masterReportFile, JSON.stringify(masterCoverage), (err) => {
     process.exit(1);
   }
 
-  console.log("Coverage report appended to " + masterReportFile);
+  console.log("Coverage report saved to " + masterReportFile);
 });

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "test:affected": "nx affected --target=test",
     "test:features": "pnpm nx run features:test",
     "test:regenerate-snapshots": "nx build cli && packages/features/snapshots/regenerate.sh",
-    "test:unit": "nx run-many --target=test --all --skip-nx-cache --exclude=features",
-    "test": "nx run-many --target=test --all --skip-nx-cache",
+    "test:unit": "pnpm vitest run",
+    "test": "pnpm vitest run && pnpm nx run features:test",
     "type-check:affected": "nx affected --target=type-check",
     "type-check": "nx run-many --target=type-check --all --skip-nx-cache",
     "update-bugsnag": "bin/update-bugsnag.js"

--- a/packages/theme/src/cli/services/pull.test.ts
+++ b/packages/theme/src/cli/services/pull.test.ts
@@ -13,6 +13,8 @@ import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 import {insideGitDirectory, isClean} from '@shopify/cli-kit/node/git'
 import {test, describe, expect, vi, beforeEach} from 'vitest'
+import {dirname, joinPath} from '@shopify/cli-kit/node/path'
+import {fileURLToPath} from 'node:url'
 
 vi.mock('../utilities/theme-selector.js')
 vi.mock('../utilities/theme-store.js')
@@ -124,7 +126,8 @@ describe('pull', () => {
   describe('isEmptyDir', () => {
     test('returns true when directory is empty', async () => {
       // Given
-      const root = 'src/cli/utilities/fixtures/theme'
+      const locationOfThisFile = dirname(fileURLToPath(import.meta.url))
+      const root = joinPath(locationOfThisFile, '../utilities/fixtures/theme')
 
       // When
       const result = await isEmptyDir(root)


### PR DESCRIPTION
### WHY are these changes introduced?

Simplify debugging unit test failures in CI by using vitest's monorepo support instead of going via nx.

### WHAT is this pull request doing?

When we run tests via nx, the logged output/failures/successes from each package's test run end up interleaved. It can be difficult to work out the cause of an issue. Vitest ensures output is clearly attributable back to a test/package.

### How to test your changes?

1. Run `pnpm test:unit` to verify that all unit tests pass with Vitest
2. Run `pnpm test` to verify both unit and feature tests work correctly
3. Check that the coverage reports are generated correctly in CI

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes