### PR TITLE
don't mention tunnels in URL override message

### DIFF
--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -346,7 +346,7 @@ describe('updateURLsPrompt', () => {
     expect(got).toEqual(true)
     expect(renderConfirmationPrompt).toHaveBeenCalledWith({
       message:
-        "Have Shopify override your app URLs with tunnel URLs when running `app dev` against your dev store? This won't affect your app on other stores",
+        "Have Shopify override your app URLs when running `app dev` against your dev store? This won't affect your app on other stores",
       infoTable: {
         'Currently released app URL': ['http://current-url'],
         '=> Dev URL': ['http://new-url'],
@@ -379,7 +379,7 @@ describe('updateURLsPrompt', () => {
     expect(got).toEqual(true)
     expect(renderConfirmationPrompt).toHaveBeenCalledWith({
       message:
-        "Have Shopify override your app URLs with tunnel URLs when running `app dev` against your dev store? This won't affect your app on other stores",
+        "Have Shopify override your app URLs when running `app dev` against your dev store? This won't affect your app on other stores",
       infoTable: {
         'Currently released app URL': ['http://current-url'],
         '=> Dev URL': ['http://new-url'],

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -204,7 +204,7 @@ function updateURLsPromptWithDevSessions(currentAppUrl: string, urls: Applicatio
 
   return renderConfirmationPrompt({
     message:
-      "Have Shopify override your app URLs with tunnel URLs when running `app dev` against your dev store? This won't affect your app on other stores",
+      "Have Shopify override your app URLs when running `app dev` against your dev store? This won't affect your app on other stores",
     confirmationMessage: 'Yes, automatically update',
     cancellationMessage: 'No, never',
     infoTable,


### PR DESCRIPTION
### WHY are these changes introduced?

Because sometimes the updated URL isn't a tunnel