### PR TITLE
Update no message when generating a certificate

### DIFF
--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -215,6 +215,6 @@ export function generateCertificatePrompt() {
   return renderConfirmationPrompt({
     message: '--use-localhost requires a certificate for `localhost`. Generate it now?',
     confirmationMessage: 'Yes, use mkcert to generate it',
-    cancellationMessage: "No, I'll provide it manually",
+    cancellationMessage: "No, I'll run `app dev` again without `--use-localhost`",
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Since we’re not publishing the manually instructions, should we change the second option

### WHAT is this pull request doing?

Update this message:

```
?  --use-localhost requires a certificate for `localhost`. Generate it now?

>  (y) Yes, use mkcert to generate it
   (n) No, I'll provide it manually
```

to:

```
   (n) No, I'll run `app dev` again without `--use-localhost`
```

### How to test your changes?

Using an app that doesn't have mkcert files in `./shopify`

```
pnpm build && pnpm shopify app dev --path='[PATH]' --use-localhost
```

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
