### PR TITLE
Detect shopify.app.toml is using correct schema when client_id is missing 

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3255,6 +3255,21 @@ describe('getAppConfigurationState', () => {
       expect(state).toMatchObject(resultShouldContain)
     })
   })
+
+  test('raises validation error when AppSchema is missing client_id', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // We know this is a TOML file that follows the AppSchema because
+      // it can contain extra fields (something_extra). In LegacyAppSchema, all fields are optional.
+      // This content is also missing a client_id field which should throw a validation error.
+      const content = `something_extra = "some_value"`
+      const appConfigPath = joinPath(tmpDir, 'shopify.app.toml')
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
+      await writeFile(appConfigPath, content)
+      await writeFile(packageJsonPath, '{}')
+
+      await expect(getAppConfigurationState(tmpDir, undefined)).rejects.toThrowError(/client_id/)
+    })
+  })
 })
 
 describe('loadConfigForAppCreation', () => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -17,6 +17,7 @@ import {
   SchemaForConfig,
   AppLinkedInterface,
   AppHiddenConfig,
+  isLegacyAppSchema,
 } from './app.js'
 import {showMultipleCLIWarningIfNeeded} from './validation/multi-cli-warning.js'
 import {configurationFileNames, dotEnvFileNames} from '../../constants.js'
@@ -860,15 +861,15 @@ export async function getAppConfigurationState(
   const {configurationPath, configurationFileName} = await getConfigurationPath(appDirectory, configName)
   const file = await loadConfigurationFileContent(configurationPath)
 
-  const configFileHasBeenLinked = isCurrentAppSchema(file as AppConfiguration)
+  const configFileHasNotBeenLinked = isLegacyAppSchema(file as AppConfiguration)
 
-  if (configFileHasBeenLinked) {
-    const parsedConfig = await parseConfigurationFile(AppSchema, configurationPath)
+  if (configFileHasNotBeenLinked) {
+    const parsedConfig = await parseConfigurationFile(LegacyAppSchema, configurationPath)
     return {
-      state: 'connected-app',
       appDirectory,
       configurationPath,
-      basicConfiguration: {
+      state: 'template-only',
+      startingOptions: {
         ...file,
         ...parsedConfig,
       },
@@ -876,12 +877,12 @@ export async function getAppConfigurationState(
       configurationFileName,
     }
   } else {
-    const parsedConfig = await parseConfigurationFile(LegacyAppSchema, configurationPath)
+    const parsedConfig = await parseConfigurationFile(AppSchema, configurationPath)
     return {
+      state: 'connected-app',
       appDirectory,
       configurationPath,
-      state: 'template-only',
-      startingOptions: {
+      basicConfiguration: {
         ...file,
         ...parsedConfig,
       },


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->
<img width="772" alt="Screenshot 2025-05-15 at 4 57 37 PM" src="https://github.com/user-attachments/assets/a3f60a17-b30c-4152-99b6-e5aae9efbd2a" />

### WHY are these changes introduced?

Fixes https://github.com/Shopify/develop-app-inner-loop/issues/2237

Prior to this PR, we assumed that if we are missing the `client_id` attribute in the TOML, that means that we are loading a TOML that is shaped like the `LegacyAppSchema`. `client_id` is required in `AppSchema`, however we should be able to validate the TOML as an `AppSchema` with a `client_id` missing. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

We determine if the schema is `LegacyAppSchema` _first_ and after we have determined that the TOML is not `LegacyAppSchema`, we can evaluate the TOML more accurately against `AppSchema` and return a correct zod validation error. (The TOML is likely not a `LegacyAppSchema` and we should rarely ever be using this zod schema since we only use it when developers are loading an app they cloned from a template or a very very old TOML that doesn't match the newest `AppSchema` TOML). 

Note that [previously](https://github.com/Shopify/cli/pull/5542) we tried to provide a better error message if the LegacyAppSchema zod Schema wasn't validated correctly but abandoned this approach. This is now a more correct solution.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

- Create an app
- Remove the `client_id` from the TOML file
- Attempt to deploy
- View the improved error