### PR TITLE
Render `%` in progress bar when executing `theme-download`

### DIFF
--- a/.changeset/shy-emus-jump.md
+++ b/.changeset/shy-emus-jump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Change `theme download` progress bar to render percentage

--- a/packages/theme/src/cli/utilities/theme-downloader.ts
+++ b/packages/theme/src/cli/utilities/theme-downloader.ts
@@ -64,8 +64,14 @@ function buildDownloadTasks(
 
   const filenames = checksums.map((checksum) => checksum.key)
 
+  const getProgress = (params: {current: number; total: number}) =>
+    `[${Math.round((params.current / params.total) * 100)}%]`
+
   const batches = batchedTasks(filenames, MAX_GRAPHQL_THEME_FILES, (batchedFilenames, i) => {
-    const title = `Downloading files ${i}..${i + batchedFilenames.length} / ${filenames.length} files`
+    const title = `Downloading files from remote theme ${getProgress({
+      current: i,
+      total: filenames.length,
+    })}`
     return {
       title,
       task: async () => downloadFiles(theme, themeFileSystem, batchedFilenames, session),


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/developer-tools-team/issues/457

### WHAT is this pull request doing?
Renders a `%` rather than `1..50/200` in the progress bar when executing `theme pull`
- Instead of following the much more complicated approach with promises in `theme-uploader`, I didn't touch the way we batch files / jobs. I just updated the way we render progress to keep things simple. I **did** try that approach earlier - [link](https://github.com/Shopify/cli/pull/5809)

This brings things in line with `theme push`


https://github.com/user-attachments/assets/8281f441-be51-4264-8085-cb6dbea9cc5b

### How to test your changes?
1) Build this branch
2) Execute `shopify-dev theme pull` in an empty directory or by passing the `--path`flag
3) Verify that the progress is a `%`
### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
