### PR TITLE
Fix invalid config name in dev summary

### DIFF
--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -8,7 +8,7 @@ import {DeployOptions} from './deploy.js'
 import {isServiceAccount, isUserAccount} from './context/partner-account-info.js'
 import {formatConfigInfoBody} from './format-config-info-body.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
-import {AppInterface, isCurrentAppSchema, CurrentAppConfiguration, AppLinkedInterface} from '../models/app/app.js'
+import {AppInterface, CurrentAppConfiguration, AppLinkedInterface} from '../models/app/app.js'
 import {Identifiers, updateAppIdentifiers, getAppIdentifiers} from '../models/app/identifiers.js'
 import {Organization, OrganizationApp, OrganizationSource, OrganizationStore} from '../models/organization.js'
 import metadata from '../metadata.js'
@@ -196,7 +196,7 @@ async function checkIncludeConfigOnDeploy({
     org: org.businessName,
     appName: remoteApp.title,
     appDotEnv: app.dotenv?.path,
-    configFile: isCurrentAppSchema(app.configuration) ? basename(app.configuration.path) : undefined,
+    configFile: basename(app.configuration.path),
     includeConfigOnDeploy: previousIncludeConfigOnDeploy,
     messages: [resetHelpMessage],
   })
@@ -305,15 +305,7 @@ interface ReusedValuesOptions {
 /**
  * Message shown to the user in case we are reusing a previous configuration
  */
-export function showReusedDevValues({
-  organization,
-  app,
-  remoteApp,
-  selectedStore,
-  cachedInfo,
-  tunnelMode,
-}: ReusedValuesOptions) {
-  if (!cachedInfo) return
+export function showReusedDevValues({organization, app, remoteApp, selectedStore, tunnelMode}: ReusedValuesOptions) {
   if (sniffForJson()) return
 
   let updateURLs = 'Not yet configured'
@@ -337,7 +329,7 @@ export function showReusedDevValues({
     appName: remoteApp.title,
     devStore: selectedStore.shopDomain,
     updateURLs,
-    configFile: cachedInfo.configFile,
+    configFile: basename(app.configuration.path),
     messages,
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

`dev` is not showing the correct toml file in the initial summary when using the `--config` flag.

### WHAT is this pull request doing?

- Simplifies the `showReusedDevValues` function by removing the unused `cachedInfo` parameter and directly using the app configuration path. 


![Captura de pantalla 2025-05-16 a las 12.04.08.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nNsubxpSjsPXUKXMmDt6/3ea6451f-9568-48e4-93d3-273d3057a61c.png)

### How to test your changes?

1. Run `shopify app config use <initial_config>`
2. Run `shopify app dev --config <a_new_config>`
3. Validate that you see the toml for `<a_new_config>` and not `<initial_config>`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes