### PR TITLE
Fix port detection

### DIFF
--- a/packages/cli-kit/src/public/node/tcp.test.ts
+++ b/packages/cli-kit/src/public/node/tcp.test.ts
@@ -1,4 +1,4 @@
-import {getAvailableTCPPort} from './tcp.js'
+import {getAvailableTCPPort, checkPortAvailability} from './tcp.js'
 import * as system from './system.js'
 import {AbortError} from './error.js'
 import * as port from 'get-port-please'
@@ -66,5 +66,50 @@ describe('getAvailableTCPPort', () => {
 
     got = await getAvailableTCPPort(123)
     expect(got).toBe(66)
+  })
+})
+
+describe('checkPortAvailability', () => {
+  test('returns true when port is available', async () => {
+    // Given
+    const portNumber = 3000
+    vi.mocked(port.checkPort).mockResolvedValue(portNumber)
+
+    // When
+    const result = await checkPortAvailability(portNumber)
+
+    // Then
+    expect(result).toBe(true)
+    expect(port.checkPort).toHaveBeenCalledWith(portNumber, undefined)
+  })
+
+  test('returns false when port is not available', async () => {
+    // Given
+    const portNumber = 3000
+    vi.mocked(port.checkPort).mockResolvedValue(false)
+
+    // When
+    const result = await checkPortAvailability(portNumber)
+
+    // Then
+    expect(result).toBe(false)
+    expect(port.checkPort).toHaveBeenCalledWith(portNumber, undefined)
+  })
+
+  test('uses 0.0.0.0 as host when HOST env var is set', async () => {
+    // Given
+    const portNumber = 3000
+    vi.stubEnv('HOST', 'localhost')
+    vi.mocked(port.checkPort).mockResolvedValue(portNumber)
+
+    // When
+    const result = await checkPortAvailability(portNumber)
+
+    // Then
+    expect(result).toBe(true)
+    expect(port.checkPort).toHaveBeenCalledWith(portNumber, '0.0.0.0')
+
+    // Cleanup
+    vi.unstubAllEnvs()
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Continuation of https://github.com/Shopify/cli/pull/5794

@isaacroldan realized that the CLI does not allow multiple dev sessions anymore after the previous PR, and that it works with `0.0.0.0` instead of `localhost` as the port.

### WHAT is this pull request doing?

- Use `0.0.0.0` as the host only when HOST env var is defined
- Use the same logic for `checkPortAvailability` and `getAvailableTCPPort`

Tested on Mac, Linux and Windows.

### How to test your changes?

- Multiple dev sessions
- `HOST=wrong pnpm shopify app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
