### PR TITLE
Improvements to config module loading via contracts

### DIFF
--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -6,6 +6,8 @@ export const environmentVariableNames = {
   templatesJsonPath: 'SHOPIFY_CLI_APP_TEMPLATES_JSON_PATH',
   mkcertBinaryPath: 'SHOPIFY_CLI_MKCERT_BINARY',
   useWasmTomlPatch: 'SHOPIFY_CLI_USE_WASM_TOML_PATCH',
+  enableUnsupportedConfigPropertyChecks: 'SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS',
+  disableUnsupportedConfigPropertyChecks: 'SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS',
 }
 
 export const configurationFileNames = {

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2481,6 +2481,73 @@ wrong = "property"
 
     await expect(loadTestingApp()).rejects.toThrow(AbortError)
   })
+
+  test('loads the app with an unsupported config property, under failure mode', async () => {
+    vi.stubEnv('SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS', '1')
+    const linkedAppConfigurationWithExtraConfig = `
+    name = "for-testing"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [build]
+    include_config_on_deploy = true
+
+    [webhooks]
+    api_version = "2023-07"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
+    [something_else]
+    not_valid = true
+
+    [and_another]
+    bad = true
+    `
+    await writeConfig(linkedAppConfigurationWithExtraConfig)
+
+    await expect(loadTestingApp()).rejects.toThrow(
+      'Unsupported section(s) in app configuration: and_another, something_else',
+    )
+    vi.unstubAllEnvs()
+  })
+
+  test('loads the app with an unsupported config property, under passthrough mode', async () => {
+    vi.stubEnv('SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS', '1')
+    const linkedAppConfigurationWithExtraConfig = `
+    name = "for-testing"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [build]
+    include_config_on_deploy = true
+
+    [webhooks]
+    api_version = "2023-07"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
+    [something_else]
+    not_valid = true
+
+    [and_another]
+    bad = true
+    `
+    await writeConfig(linkedAppConfigurationWithExtraConfig)
+
+    const app = await loadTestingApp()
+    expect(app.allExtensions.map((ext) => ext.specification.identifier).sort()).toEqual([
+      'app_access',
+      'app_home',
+      'branding',
+      'webhooks',
+    ])
+
+    vi.unstubAllEnvs()
+  })
 })
 
 describe('getAppConfigurationFileName', () => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -18,7 +18,7 @@ import {
   AppLinkedInterface,
   AppHiddenConfig,
 } from './app.js'
-import {configurationFileNames, dotEnvFileNames} from '../../constants.js'
+import {configurationFileNames, dotEnvFileNames, environmentVariableNames} from '../../constants.js'
 import metadata from '../../metadata.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
 import {ExtensionsArraySchema, UnifiedSchema} from '../extensions/schemas.js'
@@ -53,6 +53,9 @@ import {joinWithAnd, slugify} from '@shopify/cli-kit/common/string'
 import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
 import {showNotificationsIfNeeded} from '@shopify/cli-kit/node/notifications-system'
 import ignore from 'ignore'
+import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
+import {isShopify} from '@shopify/cli-kit/node/context/local'
+import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 
 const defaultExtensionDirectory = 'extensions/*'
 
@@ -176,6 +179,25 @@ export function parseConfigurationObjectAgainstSpecification<TSchema extends zod
       )
     }
   }
+}
+
+/**
+ * Returns true if we should fail if an unsupported app.toml config property is found.
+ *
+ * This is activated if SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS is set or the developer is an internal Shopify dev.
+ */
+async function shouldFailIfUnsupportedConfigProperty(): Promise<boolean> {
+  const env = getEnvironmentVariables()
+  const enableUnsupportedConfigPropertyChecks = env[environmentVariableNames.enableUnsupportedConfigPropertyChecks]
+
+  if (isTruthy(enableUnsupportedConfigPropertyChecks)) return true
+
+  const isInternalDeveloper = await isShopify()
+  if (!isInternalDeveloper) return false
+
+  // internal devs can also opt-out
+  const disableUnsupportedConfigPropertyChecks = env[environmentVariableNames.disableUnsupportedConfigPropertyChecks]
+  return !isTruthy(disableUnsupportedConfigPropertyChecks)
 }
 
 export class AppErrors {
@@ -640,6 +662,8 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
   }
 
   private async createConfigExtensionInstances(directory: string, appConfiguration: TConfig & CurrentAppConfiguration) {
+    const failIfUnsupportedConfigProperty = await shouldFailIfUnsupportedConfigProperty()
+
     const extensionInstancesWithKeys = await Promise.all(
       this.specifications
         .filter((specification) => specification.uidStrategy === 'single')
@@ -679,7 +703,15 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
       })
 
     if (unusedKeys.length > 0) {
-      outputDebug(outputContent`Unused keys in app configuration: ${outputToken.json(unusedKeys)}`)
+      if (failIfUnsupportedConfigProperty) {
+        this.abortOrReport(
+          outputContent`Unsupported section(s) in app configuration: ${unusedKeys.sort().join(', ')}`,
+          undefined,
+          appConfiguration.path,
+        )
+      } else {
+        outputDebug(outputContent`Unused keys in app configuration: ${outputToken.json(unusedKeys)}`)
+      }
     }
     return extensionInstancesWithKeys
       .filter(([instance]) => instance)

--- a/packages/cli-kit/src/public/node/json-schema.test.ts
+++ b/packages/cli-kit/src/public/node/json-schema.test.ts
@@ -3,6 +3,202 @@ import {decodeToml} from './toml.js'
 import {describe, expect, test} from 'vitest'
 import {zod} from '@shopify/cli-kit/node/schema'
 
+const COMPLEX_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    product: {
+      type: 'object',
+      required: ['metafields'],
+      additionalProperties: false,
+      properties: {
+        metafields: {
+          $ref: '#/definitions/OwnerTypeMetafieldNamespaces',
+        },
+      },
+      title: 'Custom Data \u003e Metafields',
+      description:
+        'Namespaces for metafields under this owner type. For example, `[product.metafields.app.example]` creates a metafield under the `$app` namespace, with the key `example`.\n\nRequires the following access scope: write_products',
+    },
+  },
+  definitions: {
+    MetaFieldDefinitionTypes: {
+      type: 'string',
+      oneOf: [
+        {
+          type: 'string',
+          pattern:
+            '(?\u003ctype\u003e(list\\.)?(metaobject_reference|mixed_reference))\u003c(?\u003creferences\u003e(\\$app:[a-zA-Z0-9_-]+(,\\s*)?)+)\u003e',
+        },
+        {
+          type: 'string',
+          enum: [
+            'boolean',
+            'color',
+            'date_time',
+            'date',
+            'dimension',
+            'json',
+            'language',
+            'list.color',
+            'list.date_time',
+            'list.date',
+            'list.dimension',
+            'list.number_decimal',
+            'list.number_integer',
+            'list.rating',
+            'list.single_line_text_field',
+            'list.url',
+            'list.volume',
+            'list.weight',
+            'money',
+            'multi_line_text_field',
+            'number_decimal',
+            'number_integer',
+            'rating',
+            'rich_text_field',
+            'single_line_text_field',
+            'url',
+            'link',
+            'list.link',
+            'volume',
+            'weight',
+            'company_reference',
+            'list.company_reference',
+            'customer_reference',
+            'list.customer_reference',
+            'product_reference',
+            'list.product_reference',
+            'collection_reference',
+            'list.collection_reference',
+            'variant_reference',
+            'list.variant_reference',
+            'file_reference',
+            'list.file_reference',
+            'product_taxonomy_value_reference',
+            'list.product_taxonomy_value_reference',
+            'metaobject_reference',
+            'list.metaobject_reference',
+            'mixed_reference',
+            'list.mixed_reference',
+            'page_reference',
+            'list.page_reference',
+            'order_reference',
+          ],
+        },
+      ],
+      title: 'Custom Data \u003e Types',
+      description:
+        'Set the [data type](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types) of the metafield.\n\nEach [metafield](https://shopify.dev/docs/apps/build/custom-data) and [metafield definition](https://shopify.dev/docs/apps/build/custom-data/metafields/definitions) has a type, which defines the type of information that it can store. The metafield types have built-in validation and [Liquid](https://shopify.dev/docs/api/liquid/objects/metafield) support.',
+    },
+    ValidationRule: {
+      type: 'object',
+      additionalProperties: {
+        type: ['number', 'string', 'object', 'array'],
+      },
+      title: 'Custom Data \u003e Validation Rules',
+      description:
+        'Validation options enable you to apply additional constraints to the data that a metafield can store, such as a minimum or maximum value, or a regular expression. This guide shows you how to manage validation options using the GraphQL Admin API.',
+    },
+    OwnerTypeMetafieldNamespaces: {
+      type: 'object',
+      additionalProperties: {
+        $ref: '#/definitions/MetafieldsCollection',
+      },
+      properties: {
+        app: {
+          $ref: '#/definitions/MetafieldsCollection',
+        },
+      },
+      title: 'Custom Data \u003e Metafields',
+      description:
+        'Namespaces for metafields under this owner type. For example, `[products.metafields.app]` creates metafields under the `app` namespace for products.',
+    },
+    MetafieldsCollection: {
+      type: 'object',
+      additionalProperties: {
+        $ref: '#/definitions/Metafield',
+      },
+      title: 'Custom Data \u003e Metafields',
+      description:
+        'A namespace for metafields. `.app` places metafields under the `$app` namespace; `.other` places metafields under the `$app:other` namespace.',
+    },
+    Metafield: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['type'],
+      title: 'Custom Data \u003e Metafields',
+      description:
+        "Metafields are a flexible way for your app to add and store additional information about a Shopify resource, such as a product, a collection, [and many other owner types](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType). The additional information stored in metafields can be almost anything related to a resource. Some examples are specifications, size charts, downloadable documents, release dates, images, or part numbers.\n\nMerchants and other apps can retrieve and edit the data that's stored in metafields from the Shopify admin. You can also access metafields in themes using Liquid and through the Storefront API.",
+      properties: {
+        type: {
+          $ref: '#/definitions/MetaFieldDefinitionTypes',
+        },
+        name: {
+          type: 'string',
+          title: 'Custom Data \u003e Metafields',
+          description: 'The human-readable name of the metafield definition.',
+        },
+        description: {
+          type: 'string',
+          title: 'Custom Data \u003e Metafields',
+          description: 'The description of the metafield definition.',
+        },
+        validations: {
+          $ref: '#/definitions/ValidationRule',
+        },
+        capabilities: {
+          $ref: '#/definitions/MetafieldCapabilities',
+        },
+        access: {
+          $ref: '#/definitions/MetafieldAccessControls',
+        },
+      },
+    },
+    MetafieldCapabilities: {
+      type: 'object',
+      additionalProperties: false,
+      title: 'Custom Data \u003e Metafields',
+      description: 'The capabilities of the metafield definition.',
+      properties: {
+        admin_filterable: {
+          type: 'boolean',
+          title: 'Custom Data \u003e Metafields \u003e Admin Filterable',
+          description:
+            'The admin filterable capability allows you to use a metafield definition and its values to filter resource lists in the Shopify admin. This capability makes it easier for merchants to find and manage resources such as products based on their specific metafield values.',
+        },
+      },
+    },
+    MetafieldAccessControls: {
+      type: 'object',
+      additionalProperties: false,
+      title: 'Custom Data \u003e Metafields',
+      description: 'The access settings that apply to each of the metafields that belong to the metafield definition.',
+      properties: {
+        admin: {
+          title: 'Custom Data \u003e Access Control',
+          description: 'Access configuration for Admin API surface areas, including the GraphQL Admin API.',
+          type: 'string',
+          enum: ['merchant_read', 'merchant_read_write'],
+        },
+        storefront: {
+          title: 'Custom Data \u003e Access Control',
+          description:
+            'Access configuration for Storefront API surface areas, including the GraphQL Storefront API and Liquid.',
+          type: 'string',
+          enum: ['none', 'public_read'],
+        },
+        customer_account: {
+          title: 'Custom Data \u003e Access Control',
+          description: 'The Customer Account API access setting to use for the metafields under this definition.',
+          type: 'string',
+          enum: ['none', 'read', 'read_write'],
+        },
+      },
+    },
+  },
+}
+
 describe('jsonSchemaValidate', () => {
   test.each([
     [
@@ -261,203 +457,6 @@ describe('normaliseJsonSchema', () => {
 
 describe('validate complex schema', () => {
   test('validates with useful error messages', async () => {
-    const schema = {
-      type: 'object',
-      additionalProperties: false,
-      properties: {
-        product: {
-          type: 'object',
-          required: ['metafields'],
-          additionalProperties: false,
-          properties: {
-            metafields: {
-              $ref: '#/definitions/OwnerTypeMetafieldNamespaces',
-            },
-          },
-          title: 'Custom Data \u003e Metafields',
-          description:
-            'Namespaces for metafields under this owner type. For example, `[product.metafields.app.example]` creates a metafield under the `$app` namespace, with the key `example`.\n\nRequires the following access scope: write_products',
-        },
-      },
-      definitions: {
-        MetaFieldDefinitionTypes: {
-          type: 'string',
-          oneOf: [
-            {
-              type: 'string',
-              pattern:
-                '(?\u003ctype\u003e(list\\.)?(metaobject_reference|mixed_reference))\u003c(?\u003creferences\u003e(\\$app:[a-zA-Z0-9_-]+(,\\s*)?)+)\u003e',
-            },
-            {
-              type: 'string',
-              enum: [
-                'boolean',
-                'color',
-                'date_time',
-                'date',
-                'dimension',
-                'json',
-                'language',
-                'list.color',
-                'list.date_time',
-                'list.date',
-                'list.dimension',
-                'list.number_decimal',
-                'list.number_integer',
-                'list.rating',
-                'list.single_line_text_field',
-                'list.url',
-                'list.volume',
-                'list.weight',
-                'money',
-                'multi_line_text_field',
-                'number_decimal',
-                'number_integer',
-                'rating',
-                'rich_text_field',
-                'single_line_text_field',
-                'url',
-                'link',
-                'list.link',
-                'volume',
-                'weight',
-                'company_reference',
-                'list.company_reference',
-                'customer_reference',
-                'list.customer_reference',
-                'product_reference',
-                'list.product_reference',
-                'collection_reference',
-                'list.collection_reference',
-                'variant_reference',
-                'list.variant_reference',
-                'file_reference',
-                'list.file_reference',
-                'product_taxonomy_value_reference',
-                'list.product_taxonomy_value_reference',
-                'metaobject_reference',
-                'list.metaobject_reference',
-                'mixed_reference',
-                'list.mixed_reference',
-                'page_reference',
-                'list.page_reference',
-                'order_reference',
-              ],
-            },
-          ],
-          title: 'Custom Data \u003e Types',
-          description:
-            'Set the [data type](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types) of the metafield.\n\nEach [metafield](https://shopify.dev/docs/apps/build/custom-data) and [metafield definition](https://shopify.dev/docs/apps/build/custom-data/metafields/definitions) has a type, which defines the type of information that it can store. The metafield types have built-in validation and [Liquid](https://shopify.dev/docs/api/liquid/objects/metafield) support.',
-        },
-        ValidationRule: {
-          type: 'object',
-          additionalProperties: {
-            type: ['number', 'string', 'object', 'array'],
-          },
-          title: 'Custom Data \u003e Validation Rules',
-          description:
-            'Validation options enable you to apply additional constraints to the data that a metafield can store, such as a minimum or maximum value, or a regular expression. This guide shows you how to manage validation options using the GraphQL Admin API.',
-        },
-        OwnerTypeMetafieldNamespaces: {
-          type: 'object',
-          additionalProperties: {
-            $ref: '#/definitions/MetafieldsCollection',
-          },
-          properties: {
-            app: {
-              $ref: '#/definitions/MetafieldsCollection',
-            },
-          },
-          title: 'Custom Data \u003e Metafields',
-          description:
-            'Namespaces for metafields under this owner type. For example, `[products.metafields.app]` creates metafields under the `app` namespace for products.',
-        },
-        MetafieldsCollection: {
-          type: 'object',
-          additionalProperties: {
-            $ref: '#/definitions/Metafield',
-          },
-          title: 'Custom Data \u003e Metafields',
-          description:
-            'A namespace for metafields. `.app` places metafields under the `$app` namespace; `.other` places metafields under the `$app:other` namespace.',
-        },
-        Metafield: {
-          type: 'object',
-          additionalProperties: false,
-          required: ['type'],
-          title: 'Custom Data \u003e Metafields',
-          description:
-            "Metafields are a flexible way for your app to add and store additional information about a Shopify resource, such as a product, a collection, [and many other owner types](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType). The additional information stored in metafields can be almost anything related to a resource. Some examples are specifications, size charts, downloadable documents, release dates, images, or part numbers.\n\nMerchants and other apps can retrieve and edit the data that's stored in metafields from the Shopify admin. You can also access metafields in themes using Liquid and through the Storefront API.",
-          properties: {
-            type: {
-              $ref: '#/definitions/MetaFieldDefinitionTypes',
-            },
-            name: {
-              type: 'string',
-              title: 'Custom Data \u003e Metafields',
-              description: 'The human-readable name of the metafield definition.',
-            },
-            description: {
-              type: 'string',
-              title: 'Custom Data \u003e Metafields',
-              description: 'The description of the metafield definition.',
-            },
-            validations: {
-              $ref: '#/definitions/ValidationRule',
-            },
-            capabilities: {
-              $ref: '#/definitions/MetafieldCapabilities',
-            },
-            access: {
-              $ref: '#/definitions/MetafieldAccessControls',
-            },
-          },
-        },
-        MetafieldCapabilities: {
-          type: 'object',
-          additionalProperties: false,
-          title: 'Custom Data \u003e Metafields',
-          description: 'The capabilities of the metafield definition.',
-          properties: {
-            admin_filterable: {
-              type: 'boolean',
-              title: 'Custom Data \u003e Metafields \u003e Admin Filterable',
-              description:
-                'The admin filterable capability allows you to use a metafield definition and its values to filter resource lists in the Shopify admin. This capability makes it easier for merchants to find and manage resources such as products based on their specific metafield values.',
-            },
-          },
-        },
-        MetafieldAccessControls: {
-          type: 'object',
-          additionalProperties: false,
-          title: 'Custom Data \u003e Metafields',
-          description:
-            'The access settings that apply to each of the metafields that belong to the metafield definition.',
-          properties: {
-            admin: {
-              title: 'Custom Data \u003e Access Control',
-              description: 'Access configuration for Admin API surface areas, including the GraphQL Admin API.',
-              type: 'string',
-              enum: ['merchant_read', 'merchant_read_write'],
-            },
-            storefront: {
-              title: 'Custom Data \u003e Access Control',
-              description:
-                'Access configuration for Storefront API surface areas, including the GraphQL Storefront API and Liquid.',
-              type: 'string',
-              enum: ['none', 'public_read'],
-            },
-            customer_account: {
-              title: 'Custom Data \u003e Access Control',
-              description: 'The Customer Account API access setting to use for the metafields under this definition.',
-              type: 'string',
-              enum: ['none', 'read', 'read_write'],
-            },
-          },
-        },
-      },
-    }
-
     const subject = decodeToml(`
 [product.metafields.app.first_published]
 type = "year"
@@ -465,7 +464,7 @@ nime = "First published"
 bar = "boo"
 validations.min = false`)
 
-    const result = jsonSchemaValidate(subject, schema, 'fail')
+    const result = jsonSchemaValidate(subject, COMPLEX_SCHEMA, 'fail')
     expect(result.state).toBe('error')
     expect(result.errors).toMatchInlineSnapshot(`
       [
@@ -512,5 +511,53 @@ validations.min = false`)
         },
       ]
     `)
+  })
+
+  test('correctly strips additional properties', () => {
+    const subject = {
+      product: {metafields: {app: {example: {type: 'single_line_text_field'}}}},
+    } as any
+    let result = jsonSchemaValidate(subject, COMPLEX_SCHEMA, 'strip')
+    expect(result.state).toBe('ok')
+    expect(result.data).toEqual({
+      product: {metafields: {app: {example: {type: 'single_line_text_field'}}}},
+    })
+
+    // extra top-level properties are ignored and don't cause errors
+    subject.extra = {property: 'ignore'}
+    result = jsonSchemaValidate(subject, COMPLEX_SCHEMA, 'strip')
+    expect(result.state).toBe('ok')
+    expect(result.data).toEqual({
+      product: {metafields: {app: {example: {type: 'single_line_text_field'}}}},
+    })
+
+    // an extra property within my sub-schema is an error, if they're not allowed
+    subject.product.metafields.app.example.extra = {property: 'causes failure'}
+    result = jsonSchemaValidate(subject, COMPLEX_SCHEMA, 'strip')
+    expect(result.state).toBe('error')
+    expect(result.errors).toMatchInlineSnapshot(`
+      [
+        {
+          "message": "No additional properties allowed. You can set access, capabilities, description, name, validations.",
+          "path": [
+            "product",
+            "metafields",
+            "app",
+            "example",
+            "extra",
+          ],
+        },
+      ]
+    `)
+
+    // but, if the sub-schema allows extra properties, then they're allowed
+    const complexSchemaWithAllowedAdditionalProperties = JSON.parse(JSON.stringify(COMPLEX_SCHEMA))
+    complexSchemaWithAllowedAdditionalProperties.definitions.Metafield.additionalProperties = true
+
+    result = jsonSchemaValidate(subject, complexSchemaWithAllowedAdditionalProperties, 'strip')
+    expect(result.state).toBe('ok')
+    expect(result.data).toEqual({
+      product: {metafields: {app: {example: {type: 'single_line_text_field', extra: {property: 'causes failure'}}}}},
+    })
   })
 })


### PR DESCRIPTION
Closes https://github.com/shop/issues-app-storage/issues/97 

### WHY are these changes introduced? 

When loading configuration-style modules (not extension-style), we introduce two improvements:

1. Additional top-level keys cause a validation failure

If I add a misspelled entry in my TOML -- `[access_scopez]` or something less obvious! -- these will currently be ignored as the block cannot be ascribed back to some module. With this change, any unusued top-level keys cause a validation error instead.

2. Additional properties inside sections are respected

Lets say I have TOML like this:

```toml
[product.metafields.app.example]
type = "single_line_text_field"
admin.access = "merchant_read_write"  # this is an unsupported property! its meant to be access.admin
```

Today, this is treated as an additional property and stripped away -- so, this doesn't cause a validation error. This is due to how we validate multiple modules against a single input file/structure. With this change, the above would give a useful validation error. In fact, it builds on the downstack PR and will tell you _which_ properties are actually supported.

### WHAT is this pull request doing?

> [!IMPORTANT] 
> These changes are not activated by default as they are a breaking change if a developer -- for some reason -- has extra config sections (the CLI will often try to strip these away anyway, so its a hard state to be in for very long). Instead these are activated for Shopify internal devs so we get some usage feedback, or can be opted-in to.

Adds environment variables to control how the CLI handles unsupported configuration properties in app.toml:
- `SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS`: Forces validation to fail when unsupported properties are found -- default behaviour for 1P devs
- `SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS`: Allows unsupported properties to pass through without errors -- default behaviour

### How to test your changes?

1. Create an app.toml file with unsupported sections
2. Run the CLI without any environment variables to see the default behavior
3. Set `SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS=1` and run again to see validation fail
4. Set `SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS=1` and run again to see validation pass

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes