### PR TITLE
Use improved config module loading by default

### DIFF
--- a/.changeset/famous-humans-repair.md
+++ b/.changeset/famous-humans-repair.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Unsupported sections in your app.toml file will present a validation error. Opt-out with SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS.

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -5,7 +5,6 @@ export const environmentVariableNames = {
   enableAppLogPolling: 'SHOPIFY_CLI_ENABLE_APP_LOG_POLLING',
   templatesJsonPath: 'SHOPIFY_CLI_APP_TEMPLATES_JSON_PATH',
   mkcertBinaryPath: 'SHOPIFY_CLI_MKCERT_BINARY',
-  enableUnsupportedConfigPropertyChecks: 'SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS',
   disableUnsupportedConfigPropertyChecks: 'SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS',
   disableMinificationOnDev: 'SHOPIFY_CLI_DISABLE_MINIFICATION_ON_DEV',
   disableWasmTomlPatch: 'SHOPIFY_CLI_DISABLE_WASM_TOML_PATCH',

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2547,8 +2547,7 @@ wrong = "property"
     await expect(loadTestingApp()).rejects.toThrow(AbortError)
   })
 
-  test('loads the app with an unsupported config property, under failure mode', async () => {
-    vi.stubEnv('SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS', '1')
+  test('loads the app with an unsupported config property, under failure mode (default)', async () => {
     const linkedAppConfigurationWithExtraConfig = `
     name = "for-testing"
     client_id = "1234567890"
@@ -2575,7 +2574,6 @@ wrong = "property"
     await expect(loadTestingApp()).rejects.toThrow(
       'Unsupported section(s) in app configuration: and_another, something_else',
     )
-    vi.unstubAllEnvs()
   })
 
   test('loads the app with an unsupported config property, under passthrough mode', async () => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -55,7 +55,6 @@ import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
 import {showNotificationsIfNeeded} from '@shopify/cli-kit/node/notifications-system'
 import ignore from 'ignore'
 import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
-import {isShopify} from '@shopify/cli-kit/node/context/local'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 
 const defaultExtensionDirectory = 'extensions/*'
@@ -185,18 +184,11 @@ export function parseConfigurationObjectAgainstSpecification<TSchema extends zod
 /**
  * Returns true if we should fail if an unsupported app.toml config property is found.
  *
- * This is activated if SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS is set or the developer is an internal Shopify dev.
+ * This is deactivated if SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS is set
  */
 async function shouldFailIfUnsupportedConfigProperty(): Promise<boolean> {
   const env = getEnvironmentVariables()
-  const enableUnsupportedConfigPropertyChecks = env[environmentVariableNames.enableUnsupportedConfigPropertyChecks]
-
-  if (isTruthy(enableUnsupportedConfigPropertyChecks)) return true
-
-  const isInternalDeveloper = await isShopify()
-  if (!isInternalDeveloper) return false
-
-  // internal devs can also opt-out
+  // devs can also opt-out
   const disableUnsupportedConfigPropertyChecks = env[environmentVariableNames.disableUnsupportedConfigPropertyChecks]
   return !isTruthy(disableUnsupportedConfigPropertyChecks)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To improve validation of app configuration files by enforcing stricter checks on unsupported sections in app.toml files. See #5816

Makes this improved validation the default for all. Opt-out supported via `SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS`.
