### PR TITLE
Remove opt-out for improve config module loading

### DIFF
--- a/.changeset/funny-pumpkins-smash.md
+++ b/.changeset/funny-pumpkins-smash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Opt-out removed for validation of unsupported app configuration sections

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -5,7 +5,6 @@ export const environmentVariableNames = {
   enableAppLogPolling: 'SHOPIFY_CLI_ENABLE_APP_LOG_POLLING',
   templatesJsonPath: 'SHOPIFY_CLI_APP_TEMPLATES_JSON_PATH',
   mkcertBinaryPath: 'SHOPIFY_CLI_MKCERT_BINARY',
-  disableUnsupportedConfigPropertyChecks: 'SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS',
   disableMinificationOnDev: 'SHOPIFY_CLI_DISABLE_MINIFICATION_ON_DEV',
   disableWasmTomlPatch: 'SHOPIFY_CLI_DISABLE_WASM_TOML_PATCH',
 }

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2547,7 +2547,7 @@ wrong = "property"
     await expect(loadTestingApp()).rejects.toThrow(AbortError)
   })
 
-  test('loads the app with an unsupported config property, under failure mode (default)', async () => {
+  test('loads the app with an unsupported config property', async () => {
     const linkedAppConfigurationWithExtraConfig = `
     name = "for-testing"
     client_id = "1234567890"
@@ -2574,42 +2574,6 @@ wrong = "property"
     await expect(loadTestingApp()).rejects.toThrow(
       'Unsupported section(s) in app configuration: and_another, something_else',
     )
-  })
-
-  test('loads the app with an unsupported config property, under passthrough mode', async () => {
-    vi.stubEnv('SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS', '1')
-    const linkedAppConfigurationWithExtraConfig = `
-    name = "for-testing"
-    client_id = "1234567890"
-    application_url = "https://example.com/lala"
-    embedded = true
-
-    [build]
-    include_config_on_deploy = true
-
-    [webhooks]
-    api_version = "2023-07"
-
-    [auth]
-    redirect_urls = [ "https://example.com/api/auth" ]
-
-    [something_else]
-    not_valid = true
-
-    [and_another]
-    bad = true
-    `
-    await writeConfig(linkedAppConfigurationWithExtraConfig)
-
-    const app = await loadTestingApp()
-    expect(app.allExtensions.map((ext) => ext.specification.identifier).sort()).toEqual([
-      'app_access',
-      'app_home',
-      'branding',
-      'webhooks',
-    ])
-
-    vi.unstubAllEnvs()
   })
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

To improve validation of app configuration files by enforcing stricter checks on unsupported sections in app.toml files. See #5816

Removes the `SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS` opt-out.
