### PR TITLE
Hardcode extension only apps to be embedded = true to make the behaviour consistent with Partners ext-only apps

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -1130,7 +1130,7 @@ const MAGIC_URL = 'https://shopify.dev/apps/default-app-home'
 const MAGIC_REDIRECT_URL = 'https://shopify.dev/apps/default-app-home/api/auth'
 
 function createAppVars(options: CreateAppOptions, apiVersion?: string): CreateAppMutationVariables {
-  const {isLaunchable, scopesArray, name, isEmbedded} = options
+  const {isLaunchable, scopesArray, name} = options
   const source: AppVersionSource = {
     source: {
       name,
@@ -1139,7 +1139,10 @@ function createAppVars(options: CreateAppOptions, apiVersion?: string): CreateAp
           type: AppHomeSpecIdentifier,
           config: {
             app_url: isLaunchable ? 'https://example.com' : MAGIC_URL,
-            embedded: isEmbedded,
+            // Ext-only apps should be embedded = false, however we are hardcoding this to
+            // match Partners behaviour for now
+            // https://github.com/Shopify/develop-app-inner-loop/issues/2789
+            embedded: true,
           },
         },
         {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/develop-app-inner-loop/issues/2789

Currently, all Organization owned extension-only apps are being created without a `handle`. We theorize (but have not validated yet) that having a null handle will create issues with public distribution for Organization owned apps that handle their distribution in the Partners dashboard. This is meant to unblock that before Editions. 

We may have to create a migration to backfill `handle` for Organization only apps, but this PR will avoid adding any more ApiClients without a `handle`.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

The ApiClient requires an app to be embedded for the persistence model to[ generate a `handle` on save](https://github.com/shop/world/blob/05-14-add_uniqueness_check_on_name_for_eventbus_integration/areas/core/shopify/components/apps/app/models/api_client/extension.rb#L87). 

```
has_handle :handle, from: :title, sticky: true, if: :embedded?
```

This PR hardcodes `embedded = true` for all apps created with the app management client in the CLI. 

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

1. Create an ext-only app in a Developer Dashboard org
2. Confirm using `dev mysql open` that an api_client record was made and the row contains a non-nil `handle` value

Confirm the same thing with an ext-only app in a Partners org.
Also confirm the same with a Remix app in both Partners and Developer Dashboard.