### PR TITLE
Fix app preview link for Management API apps

### DIFF
--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
@@ -43,14 +43,14 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
     expect(result).toBeUndefined()
   })
 
-  test('Returns PreviewThemeAppExtensionsOptions if theme extensions are present', async () => {
+  test('Returns PreviewThemeAppExtensionsOptions if theme extensions are present - Partners API app', async () => {
     // Given
     const mockTheme = {id: 123} as Theme
     vi.mocked(fetchTheme).mockResolvedValue(mockTheme)
 
     const storeFqdn = 'test.myshopify.com'
     const theme = '123'
-    const remoteApp = testOrganizationApp()
+    const remoteApp = testOrganizationApp() // Regular Partners API app
     const localApp = testApp({allExtensions: [await testThemeExtensions()]})
 
     // When
@@ -71,6 +71,62 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
             link: {
               label: 'Install your app in your development store',
               url: 'https://partners.shopify.com/1/apps/1/test',
+            },
+          },
+        ],
+        [
+          {
+            link: {
+              label: 'Setup your theme app extension in the host theme',
+              url: 'https://test.myshopify.com/admin/themes/123/editor',
+            },
+          },
+        ],
+        [
+          'Preview your theme app extension at',
+          {
+            link: {
+              label: 'http://127.0.0.1:9293',
+              url: 'http://127.0.0.1:9293',
+            },
+          },
+        ],
+      ],
+      orderedNextSteps: true,
+    })
+  })
+
+  test('Returns PreviewThemeAppExtensionsOptions if theme extensions are present - Management API app', async () => {
+    // Given
+    const mockTheme = {id: 123} as Theme
+    vi.mocked(fetchTheme).mockResolvedValue(mockTheme)
+
+    const storeFqdn = 'test.myshopify.com'
+    const theme = '123'
+    const remoteApp = testOrganizationApp({
+      id: 'gid://shopify/App/1234', // Management API app with GID format
+      apiKey: 'e4c79fb7b99c002a35efdcc44e0ea8f7',
+    })
+    const localApp = testApp({allExtensions: [await testThemeExtensions()]})
+
+    // When
+    const result = await setupPreviewThemeAppExtensionsProcess({
+      localApp,
+      remoteApp,
+      storeFqdn,
+      theme,
+    })
+
+    // Then
+    expect(result).toBeDefined()
+    expect(renderInfo).toBeCalledWith({
+      headline: 'The theme app extension development server is ready.',
+      nextSteps: [
+        [
+          {
+            link: {
+              label: 'Install your app in your development store',
+              url: 'https://admin.shopify.com/?organization_id=1&no_redirect=true&redirect=/oauth/redirect_from_developer_dashboard?client_id%3De4c79fb7b99c002a35efdcc44e0ea8f7',
             },
           },
         ],

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -146,7 +146,14 @@ export async function findOrCreateHostTheme(adminSession: AdminSession, theme?: 
 }
 
 async function buildAppUrl(remoteApp: OrganizationApp) {
-  const fqdn = await partnersFqdn()
-
-  return `https://${fqdn}/${remoteApp.organizationId}/apps/${remoteApp.id}/test`
+  // Check if the app ID is in GID format (gid://shopify/App/<INTEGER>), which indicates it's a Management API app
+  if (remoteApp.id.startsWith('gid://')) {
+    // For Management API apps, we need to generate a different URL format
+    // Extract the organization ID and use the app API key for the client_id parameter
+    return `https://admin.shopify.com/?organization_id=${remoteApp.organizationId}&no_redirect=true&redirect=/oauth/redirect_from_developer_dashboard?client_id%3D${remoteApp.apiKey}`
+  } else {
+    // For Partners API apps, use the original URL format
+    const fqdn = await partnersFqdn()
+    return `https://${fqdn}/${remoteApp.organizationId}/apps/${remoteApp.id}/test`
+  }
 }


### PR DESCRIPTION
- Modified buildAppUrl function to conditionally render the correct URL based on app source
- When app ID starts with "gid://" (Management API app), generate URL with client_id format
- Otherwise, use original Partners Dashboard URL format
- Updated tests to cover both Partners API and Management API apps

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
