### PR TITLE
Delete nx test tasks

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -42,7 +42,7 @@ commands:
     run: pnpm run clean
   test:
     desc: 'Runs the tests'
-    run: pnpm run test:affected
+    run: pnpm run test:unit
   build:
     desc: 'Build the project'
     run: pnpm run build:affected

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "post-release": "./bin/post-release",
     "shopify:run": "node packages/cli/bin/dev.js",
     "shopify": "nx build cli && node packages/cli/bin/dev.js",
-    "test:affected": "nx affected --target=test",
     "test:features": "pnpm nx run features:test",
     "test:regenerate-snapshots": "nx build cli && packages/features/snapshots/regenerate.sh",
     "test:unit": "pnpm vitest run",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,9 +38,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
-    "test": "nx run app:test",
-    "test:coverage": "nx test:coverage",
-    "test:watch": "nx test:watch",
+    "vitest": "vitest",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -36,27 +36,6 @@
         "cwd": "packages/app"
       }
     },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run",
-        "cwd": "packages/app"
-      }
-    },
-    "test:coverage": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run --reporter json --coverage --outputFile ./coverage/report.json",
-        "cwd": "packages/app"
-      }
-    },
-    "test:watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest watch",
-        "cwd": "packages/app"
-      }
-    },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -52,9 +52,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
-    "test": "nx test",
-    "test:coverage": "nx test:coverage",
-    "test:watch": "nx test:watch",
+    "vitest": "vitest",
     "type-check": "nx type-check",
     "refresh-code-documentation": "nx refresh-code-documentation"
   },

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -61,27 +61,6 @@
         "cwd": "packages/cli-kit"
       }
     },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run",
-        "cwd": "packages/cli-kit"
-      }
-    },
-    "test:coverage": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run --reporter json --coverage --outputFile ./coverage/report.json",
-        "cwd": "packages/cli-kit"
-      }
-    },
-    "test:watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest watch",
-        "cwd": "packages/cli-kit"
-      }
-    },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,9 +47,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "prepack": "NODE_ENV=production node ../../bin/update-bugsnag cli && cp ../../README.md README.md",
-    "test": "nx run cli:test",
-    "test:coverage": "nx test:coverage",
-    "test:watch": "nx test:watch",
+    "vitest": "vitest",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -43,27 +43,6 @@
         "cwd": "packages/cli"
       }
     },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run",
-        "cwd": "packages/cli"
-      }
-    },
-    "test:coverage": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run --reporter json --coverage --outputFile ./coverage/report.json",
-        "cwd": "packages/cli"
-      }
-    },
-    "test:watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest watch",
-        "cwd": "packages/cli"
-      }
-    },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -46,8 +46,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "prepack": "NODE_ENV=production node ../../bin/update-bugsnag create-app && cp ../../README.md README.md",
-    "test": "nx run create-app:test",
-    "test:watch": "nx test:watch",
+    "vitest": "vitest",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -43,20 +43,6 @@
         "cwd": "packages/create-app"
       }
     },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run",
-        "cwd": "packages/create-app"
-      }
-    },
-    "test:watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest watch",
-        "cwd": "packages/create-app"
-      }
-    },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/plugin-cloudflare/package.json
+++ b/packages/plugin-cloudflare/package.json
@@ -37,8 +37,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
-    "test": "nx run plugin-cloudflare:test",
-    "test:watch": "nx test:watch",
+    "vitest": "vitest",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/plugin-cloudflare/project.json
+++ b/packages/plugin-cloudflare/project.json
@@ -35,20 +35,6 @@
         "cwd": "packages/plugin-cloudflare"
       }
     },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run",
-        "cwd": "packages/plugin-cloudflare"
-      }
-    },
-    "test:watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest watch",
-        "cwd": "packages/plugin-cloudflare"
-      }
-    },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/plugin-did-you-mean/package.json
+++ b/packages/plugin-did-you-mean/package.json
@@ -32,8 +32,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
-    "test": "nx run plugin-did-you-mean:test",
-    "test:watch": "nx test:watch",
+    "vitest": "vitest",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/plugin-did-you-mean/project.json
+++ b/packages/plugin-did-you-mean/project.json
@@ -35,20 +35,6 @@
         "cwd": "packages/plugin-did-you-mean"
       }
     },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run",
-        "cwd": "packages/plugin-did-you-mean"
-      }
-    },
-    "test:watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest watch",
-        "cwd": "packages/plugin-did-you-mean"
-      }
-    },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -32,8 +32,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
-    "test": "nx run theme:test",
-    "test:watch": "nx test:watch",
+    "vitest": "vitest",
     "type-check": "nx type-check"
   },
   "eslintConfig": {

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -44,20 +44,6 @@
         "cwd": "packages/theme"
       }
     },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run",
-        "cwd": "packages/theme"
-      }
-    },
-    "test:watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest watch",
-        "cwd": "packages/theme"
-      }
-    },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/ui-extensions-dev-console/package.json
+++ b/packages/ui-extensions-dev-console/package.json
@@ -9,8 +9,7 @@
     "dev": "nx dev",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "test": "nx run ui-extensions-dev-console:test",
-    "test:watch": "nx test:watch"
+    "vitest": "vitest"
   },
   "eslintConfig": {
     "plugins": [

--- a/packages/ui-extensions-dev-console/project.json
+++ b/packages/ui-extensions-dev-console/project.json
@@ -42,20 +42,6 @@
         "command": "pnpm vite dev",
         "cwd": "packages/ui-extensions-dev-console"
       }
-    },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run",
-        "cwd": "packages/ui-extensions-dev-console"
-      }
-    },
-    "test:watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest watch",
-        "cwd": "packages/ui-extensions-dev-console"
-      }
     }
   }
 }

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -34,8 +34,7 @@
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
     "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
-    "test": "nx run ui-extensions-server-kit:test",
-    "test:watch": "nx test:watch"
+    "vitest": "vitest"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/ui-extensions-server-kit/project.json
+++ b/packages/ui-extensions-server-kit/project.json
@@ -53,20 +53,6 @@
         "command": "pnpm eslint src --fix",
         "cwd": "packages/ui-extensions-server-kit"
       }
-    },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest run",
-        "cwd": "packages/ui-extensions-server-kit"
-      }
-    },
-    "test:watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm vitest watch",
-        "cwd": "packages/ui-extensions-server-kit"
-      }
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Now we use vitest directly for unit tests in CI, drop the nx tasks used for unit tests.

🚨 We lose `test:affected` with this change. That said, through plain vitest our entire test suite takes ~40s so there's not much to gain.

### WHAT is this pull request doing?

- Changes the `test` command in `dev.yml` to use `pnpm run test:unit` instead of `pnpm run test:affected`
- Removes the `test:affected` script from the root `package.json`
- Replaces package-specific test commands (`test`, `test:coverage`, `test:watch`) with a single `vitest` command in all packages
- Removes all NX test executor configurations from project.json files

### How to test your changes?

1. Run `pnpm run test:unit` to verify all tests still run correctly
2. Try running vitest directly in individual packages using `cd packages/<package-name> && pnpm vitest`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes