### PR TITLE
npm prefix fails should not leak out

### DIFF
--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -892,6 +892,26 @@ describe('getPackageManager', () => {
     })
   })
 
+  test('falls back to packageManagerFromUserAgent when npm prefix fails', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      vi.stubEnv('npm_config_user_agent', 'yarn/1.22.0')
+
+      // Mock npm prefix to fail
+      mockedCaptureOutput.mockRejectedValueOnce(new Error('npm prefix failed'))
+
+      // When
+      const packageManager = await getPackageManager(tmpDir)
+
+      // Then
+      expect(mockedCaptureOutput).toHaveBeenCalledWith('npm', ['prefix'], expect.anything())
+      expect(packageManager).toEqual('yarn')
+
+      // Restore original implementation
+      vi.unstubAllEnvs()
+    })
+  })
+
   test("tries to guess the package manager from the environment if it can't find a package.json", async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -110,10 +110,18 @@ export function packageManagerFromUserAgent(env = process.env): PackageManager {
  * @returns The dependency manager
  */
 export async function getPackageManager(fromDirectory: string): Promise<PackageManager> {
-  const directory = await captureOutput('npm', ['prefix'], {cwd: fromDirectory})
-  outputDebug(outputContent`Obtaining the dependency manager in directory ${outputToken.path(directory)}...`)
-  const packageJson = joinPath(directory, 'package.json')
-  if (!(await fileExists(packageJson))) {
+  let directory: string | undefined
+  let packageJson: string | undefined
+  try {
+    directory = await captureOutput('npm', ['prefix'], {cwd: fromDirectory})
+    outputDebug(outputContent`Obtaining the dependency manager in directory ${outputToken.path(directory)}...`)
+    packageJson = joinPath(directory, 'package.json')
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    // if problems locating directoy/package file, we use user agent instead
+  }
+
+  if (!directory || !packageJson || !(await fileExists(packageJson))) {
     return packageManagerFromUserAgent()
   }
   const yarnLockPath = joinPath(directory, yarnLockfile)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [this Bugsnag issue](https://app.bugsnag.com/shopify/cli/errors/6683f85fde91d40008a444ca?filters[event.unhandled]=true&filters[metaData.Command.cmd_all_plugin][][type]=ne&filters[metaData.Command.cmd_all_plugin][][value]=%40shopify%2Fcli-hydrogen&filters[metaData.Command.cmd_all_plugin][][type]=ne&filters[metaData.Command.cmd_all_plugin][][value]=%40shopify%2Ftheme&filters[release.seen_in]=3.80.0&filters[error.status]=open&filters[event.since]=7d&event_id=682985a201261ecb923a0000). 

The current implementation of `getPackageManager` doesn't handle failures when trying to determine the package manager directory using `npm prefix`. This can lead to uncaught exceptions when the command fails.

### WHAT is this pull request doing?

Adds error handling to the `getPackageManager` function to gracefully fall back to using the user agent when `npm prefix` fails. This makes the package manager detection more robust in environments where npm commands might fail.

The changes include:
- Adding a try/catch block around the directory detection logic
- Falling back to `packageManagerFromUserAgent()` when directory detection fails
- Adding a test case to verify this fallback behavior

### How to test your changes?

1. Create a test environment where `npm prefix` would fail (e.g., by temporarily removing npm from PATH)
2. Verify that the package manager is still correctly detected from the user agent
3. Run the new test case to confirm the fallback behavior works as expected

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes