### PR TITLE
UI extension shared type implemention should throw AbortError with actionable issue

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -1062,7 +1062,7 @@ Please check the configuration in ${uiExtension.configurationPath}`),
 
         // When
         await expect(extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)).rejects.toThrow(
-          'Type reference for admin.unknown.action.render could not be found. You might be using the wrong @shopify/ui-extensions version. Fix the error by ensuring you install @shopify/ui-extensions@2025-10 in your dependencies.',
+          'Type reference for admin.unknown.action.render could not be found. You might be using the wrong @shopify/ui-extensions version.',
         )
 
         // No shopify.d.ts file should be created

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -8,6 +8,7 @@ import {fileExists, findPathUp} from '@shopify/cli-kit/node/fs'
 import {dirname, joinPath, relativizePath} from '@shopify/cli-kit/node/path'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {zod} from '@shopify/cli-kit/node/schema'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {createRequire} from 'module'
 
 const require = createRequire(import.meta.url)
@@ -290,8 +291,9 @@ function getSharedTypeDefinition(fullPath: string, typeFilePath: string, target:
   const globalThis: { shopify: typeof shopify };
 }\n`
   } catch (_) {
-    throw new Error(
-      `Type reference for ${target} could not be found. You might be using the wrong @shopify/ui-extensions version. Fix the error by ensuring you install @shopify/ui-extensions@${apiVersion} in your dependencies.`,
+    throw new AbortError(
+      `Type reference for ${target} could not be found. You might be using the wrong @shopify/ui-extensions version.`,
+      `Fix the error by ensuring you install @shopify/ui-extensions@${apiVersion} in your dependencies.`,
     )
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [this Bugnsag issue](https://app.bugsnag.com/shopify/cli/errors/680272e3176d741c89527395?filters[event.unhandled]=true&filters[metaData.Command.cmd_all_plugin][][type]=ne&filters[metaData.Command.cmd_all_plugin][][value]=%40shopify%2Fcli-hydrogen&filters[metaData.Command.cmd_all_plugin][][type]=ne&filters[metaData.Command.cmd_all_plugin][][value]=%40shopify%2Ftheme&filters[release.seen_in]=3.80.0&filters[error.status]=open&filters[event.since]=7d).

Improves error handling for UI extension type reference issues.

### WHAT is this pull request doing?

Enhances error messaging when a type reference for UI extensions cannot be found:
- Replaces standard `Error` with `AbortError` for better error handling
- Splits the error message into a main message and a solution hint
- Removes the version-specific guidance from the test expectation to match the new error format

### How to test your changes?

1. Try to build a UI extension with an incorrect or missing `@shopify/ui-extensions` version
2. Verify that the error message is clear and provides actionable guidance

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes