### PR TITLE
[stable] Fix app preview not starting correctly for apps without extensions

### DIFF
--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
@@ -300,7 +300,7 @@ export class DevSession {
     bundleController: AbortController,
     includeManifest: boolean,
   ): Promise<string | undefined> {
-    if (!assets.length) return undefined
+    if (!assets.length && !includeManifest) return undefined
     const compressedBundlePath = joinPath(
       dirname(this.bundlePath),
       `dev-bundle.${this.options.developerPlatformClient.bundleFormat}`,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a bug where the dev bundle would not be created when there are no assets but a manifest is required.

### WHAT is this pull request doing?

Modifies the condition in the `DevSession` class to create a dev bundle when `includeManifest` is true, even if there are no assets. Previously, the function would return early if there were no assets, regardless of whether a manifest was needed.

### How to test your changes?

1. Run a dev session with no extensions
2. Verify that the app preview is started

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes