### PR TITLE
[stable] Fix theme preview installation link for Management API apps

### DIFF
--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
@@ -7,11 +7,13 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 import {vi, describe, test, expect, beforeEach} from 'vitest'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
+import {partnersFqdn, adminFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
 vi.mock('../../../utilities/extensions/theme/host-theme-manager')
 vi.mock('@shopify/cli-kit/node/output')
 vi.mock('@shopify/cli-kit/node/session')
 vi.mock('@shopify/cli-kit/node/themes/api')
+vi.mock('@shopify/cli-kit/node/context/fqdn')
 vi.mock('@shopify/cli-kit/node/ui', async (realImport) => {
   const realModule = await realImport<typeof import('@shopify/cli-kit/node/ui')>()
   const mockModule = {renderInfo: vi.fn()}
@@ -24,6 +26,8 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
 
   beforeEach(() => {
     vi.mocked(ensureAuthenticatedAdmin).mockResolvedValue(mockAdminSession)
+    vi.mocked(partnersFqdn).mockResolvedValue('partners.shopify.com')
+    vi.mocked(adminFqdn).mockResolvedValue('admin.shopify.com')
   })
 
   test('Returns undefined if no theme extensions are present', async () => {
@@ -43,13 +47,14 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
     expect(result).toBeUndefined()
   })
 
-  test('Returns PreviewThemeAppExtensionsOptions if theme extensions are present', async () => {
+  test('Returns PreviewThemeAppExtensionsOptions if theme extensions are present - Partners API app', async () => {
     // Given
     const mockTheme = {id: 123} as Theme
     vi.mocked(fetchTheme).mockResolvedValue(mockTheme)
 
     const storeFqdn = 'test.myshopify.com'
     const theme = '123'
+    // Regular Partners API app
     const remoteApp = testOrganizationApp()
     const localApp = testApp({allExtensions: [await testThemeExtensions()]})
 
@@ -71,6 +76,63 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
             link: {
               label: 'Install your app in your development store',
               url: 'https://partners.shopify.com/1/apps/1/test',
+            },
+          },
+        ],
+        [
+          {
+            link: {
+              label: 'Setup your theme app extension in the host theme',
+              url: 'https://test.myshopify.com/admin/themes/123/editor',
+            },
+          },
+        ],
+        [
+          'Preview your theme app extension at',
+          {
+            link: {
+              label: 'http://127.0.0.1:9293',
+              url: 'http://127.0.0.1:9293',
+            },
+          },
+        ],
+      ],
+      orderedNextSteps: true,
+    })
+  })
+
+  test('Returns PreviewThemeAppExtensionsOptions if theme extensions are present - Management API app', async () => {
+    // Given
+    const mockTheme = {id: 123} as Theme
+    vi.mocked(fetchTheme).mockResolvedValue(mockTheme)
+
+    const storeFqdn = 'test.myshopify.com'
+    const theme = '123'
+    // Management API app with GID format
+    const remoteApp = testOrganizationApp({
+      id: 'gid://shopify/App/1234',
+      apiKey: 'e4c79fb7b99c002a35efdcc44e0ea8f7',
+    })
+    const localApp = testApp({allExtensions: [await testThemeExtensions()]})
+
+    // When
+    const result = await setupPreviewThemeAppExtensionsProcess({
+      localApp,
+      remoteApp,
+      storeFqdn,
+      theme,
+    })
+
+    // Then
+    expect(result).toBeDefined()
+    expect(renderInfo).toBeCalledWith({
+      headline: 'The theme app extension development server is ready.',
+      nextSteps: [
+        [
+          {
+            link: {
+              label: 'Install your app in your development store',
+              url: 'https://admin.shopify.com/?organization_id=1&no_redirect=true&redirect=/oauth/redirect_from_developer_dashboard?client_id%3De4c79fb7b99c002a35efdcc44e0ea8f7',
             },
           },
         ],

--- a/packages/cli-kit/src/public/node/context/fqdn.test.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeStoreFqdn,
   businessPlatformFqdn,
   appDevFqdn,
+  adminFqdn,
 } from './fqdn.js'
 import {spinFqdn} from '../context/spin.js'
 import {Environment, serviceEnvironment} from '../../../private/node/context/service.js'
@@ -208,6 +209,42 @@ describe('identity', () => {
 
     // Then
     expect(got).toEqual('identity.spin.com')
+  })
+})
+
+describe('adminFqdn', () => {
+  test('returns the local fqdn when the environment is local', async () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Local)
+
+    // When
+    const got = await adminFqdn()
+
+    // Then
+    expect(got).toEqual('admin.myshopify.io')
+  })
+
+  test('returns the production fqdn when the environment is production', async () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Production)
+
+    // When
+    const got = await adminFqdn()
+
+    // Then
+    expect(got).toEqual('admin.shopify.com')
+  })
+
+  test("returns the spin fqdn if the environment is spin and it's running in a Spin environment", async () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Spin)
+    vi.mocked(spinFqdn).mockResolvedValue('spin.com')
+
+    // When
+    const got = await adminFqdn()
+
+    // Then
+    expect(got).toEqual('admin.shopify.spin.com')
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -39,6 +39,24 @@ export async function partnersFqdn(): Promise<string> {
 }
 
 /**
+ * It returns the Admin service we should interact with.
+ *
+ * @returns Fully-qualified domain of the Admin service we should interact with.
+ */
+export async function adminFqdn(): Promise<string> {
+  const environment = serviceEnvironment()
+  const productionFqdn = 'admin.shopify.com'
+  switch (environment) {
+    case 'local':
+      return new DevServerCore().host('admin')
+    case 'spin':
+      return `admin.shopify.${await spinFqdn()}`
+    default:
+      return productionFqdn
+  }
+}
+
+/**
  * It returns the App Management API service we should interact with.
  *
  * @returns Fully-qualified domain of the App Management service we should interact with.


### PR DESCRIPTION
Cherrypick commits from https://github.com/Shopify/cli/pull/5824