### PR TITLE
[stable] Update function-runner to v9.0.0

### DIFF
--- a/.changeset/gorgeous-parents-impress.md
+++ b/.changeset/gorgeous-parents-impress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Function Runner version updated to v9.0.0

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs'
 import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
-export const PREFERRED_FUNCTION_RUNNER_VERSION = 'v8.0.1'
+export const PREFERRED_FUNCTION_RUNNER_VERSION = 'v9.0.0'
 
 // Javy dependencies.
 export const PREFERRED_JAVY_VERSION = 'v5.0.3'


### PR DESCRIPTION
Cherry-pick commits from https://github.com/Shopify/cli/pull/5823