### PR TITLE
[stable] Update phrasing 

### DIFF
--- a/.changeset/fast-pigs-tickle.md
+++ b/.changeset/fast-pigs-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Adjust phrasing in CLI for the Remix templates from Early Access to Release Candidate

--- a/packages/app/src/cli/prompts/init/init.ts
+++ b/packages/app/src/cli/prompts/init/init.ts
@@ -43,11 +43,11 @@ export const templates = {
         ...(process.env.POLARIS_UNIFIED && {
           javascriptPolarisEarlyAccess: {
             branch: 'polaris-docs-2025-js',
-            label: 'JavaScript (Polaris Early Access)',
+            label: 'JavaScript (Polaris Release Candidate)',
           },
           typescriptPolarisEarlyAccess: {
             branch: 'polaris-docs-2025',
-            label: 'TypeScript (Polaris Early Access)',
+            label: 'TypeScript (Polaris Release Candidate)',
           },
         }),
       },


### PR DESCRIPTION
The Polaris release is being grouped as a "Release Candidate" and not being called "Early Access" any more.

Cherry-picked from https://github.com/Shopify/cli/pull/5850