### PR TITLE
[stable] Queue and consolidate app events during dev session updates

### DIFF
--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
@@ -1,7 +1,7 @@
 import {DevSessionLogger} from './dev-session-logger.js'
 import {DevSessionStatusManager} from './dev-session-status-manager.js'
 import {DevSessionProcessOptions} from './dev-session-process.js'
-import {AppEvent, AppEventWatcher} from '../../app-events/app-event-watcher.js'
+import {AppEvent, AppEventWatcher, ExtensionEvent} from '../../app-events/app-event-watcher.js'
 import {compressBundle, getUploadURL, uploadToGCS, writeManifestToBundle} from '../../../bundle.js'
 import {DevSessionCreateOptions, DevSessionUpdateOptions} from '../../../../utilities/developer-platform-client.js'
 import {AppManifest} from '../../../../models/app/app.js'
@@ -39,7 +39,8 @@ export class DevSession {
   private readonly options: DevSessionProcessOptions
   private readonly appWatcher: AppEventWatcher
   private readonly bundlePath: string
-  private currentBundleController?: AbortController
+  private updateInProgress = false
+  private appEventsQueue: AppEvent[] = []
 
   private constructor(processOptions: DevSessionProcessOptions, stdout: Writable) {
     this.statusManager = processOptions.devSessionStatusManager
@@ -61,12 +62,34 @@ export class DevSession {
 
   /**
    * Handle the app event, after validating the event it might trigger a dev session update.
+   * If an update is already in progress, it will queue the event to be processed after
+   * the current update completes.
    * @param event - The app event
    */
   private async onEvent(event: AppEvent) {
     const eventIsValid = await this.validateAppEvent(event)
     if (!eventIsValid) return
-    this.currentBundleController?.abort()
+
+    this.appEventsQueue.push(event)
+
+    if (!this.updateInProgress) await this.processEvents()
+  }
+
+  /**
+   * Process an app event by bundling extensions and uploading them.
+   * After completion, it will check if there are any pending events in the queue,
+   * consolidate them into a single event, and process it.
+   * @param event - The app event to process
+   */
+  private async processEvents() {
+    this.updateInProgress = true
+    const events = [...this.appEventsQueue]
+
+    this.appEventsQueue = []
+
+    const event = this.consolidateAppEvents(events)
+    if (!event) return
+
     this.statusManager.setMessage('CHANGE_DETECTED')
     await this.updatePreviewURL(event)
     await this.logger.logExtensionEvents(event)
@@ -77,6 +100,53 @@ export class DevSession {
     await this.logger.debug(
       `✅ Event handled [Network: ${endHRTimeInMs(networkStartTime)}ms - Total: ${endHRTimeInMs(event.startTime)}ms]`,
     )
+
+    if (this.appEventsQueue.length > 0) {
+      await this.processEvents()
+    }
+
+    this.updateInProgress = false
+  }
+
+  /**
+   * Consolidate multiple app events into a single app event.
+   * Takes the app from the latest event and merges extension events from all events.
+   * @param events - Array of app events to consolidate
+   * @returns A consolidated app event
+   */
+  private consolidateAppEvents(events: AppEvent[]): AppEvent | undefined {
+    if (events.length === 0) return undefined
+    if (events.length === 1) return events[0]
+
+    const firstEvent = events[0]
+    const lastEvent = events[events.length - 1]
+
+    if (!firstEvent || !lastEvent) return undefined
+
+    const allExtensionEvents = new Map<string, ExtensionEvent>()
+
+    // Process all events from oldest to newest to get the latest state of each extension
+
+    // The latest event has priority over the previous ones always, examples:
+    // - created/updated and then deleted, keep deleted, the extension won't be included in the manifest.
+    // - updated multiple times, keep the latest one, as they are technically the same event.
+    // - created and then updated, keep the updated event, the manifest is the same in both cases.
+    // - deleted and then created/updated, keep the created/updated event.
+    for (const event of events) {
+      for (const extensionEvent of event.extensionEvents) {
+        allExtensionEvents.set(extensionEvent.extension.uid, extensionEvent)
+      }
+    }
+
+    const consolidatedEvent: AppEvent = {
+      app: lastEvent.app,
+      path: lastEvent.path,
+      extensionEvents: Array.from(allExtensionEvents.values()),
+      startTime: firstEvent.startTime,
+      appWasReloaded: events.some((event) => event.appWasReloaded),
+    }
+
+    return consolidatedEvent
   }
 
   /**
@@ -210,16 +280,10 @@ export class DevSession {
    * @param updating - Whether the dev session is being updated or created
    */
   private async bundleExtensionsAndUpload(appEvent: AppEvent): Promise<DevSessionResult> {
-    // Every time we create a new bundle, we need a new controller.
-    // At this point the existing `currentBundleController` is already aborted.
-    const newBundleController = new AbortController()
-    this.currentBundleController = newBundleController
-
     try {
       const {manifest, inheritedModuleUids, assets} = await this.createManifest(appEvent)
-      const signedURL = await this.uploadAssetsIfNeeded(assets, newBundleController, !this.statusManager.status.isReady)
+      const signedURL = await this.uploadAssetsIfNeeded(assets, !this.statusManager.status.isReady)
 
-      if (newBundleController.signal.aborted) return {status: 'aborted'}
       const payload = {
         shopFqdn: this.options.storeFqdn,
         appId: this.options.appId,
@@ -295,11 +359,7 @@ export class DevSession {
    * @param bundleController - abortController to abort the bundle process if a new change is detected
    * @returns The signed URL if we uploaded any assets, otherwise undefined
    */
-  private async uploadAssetsIfNeeded(
-    assets: string[],
-    bundleController: AbortController,
-    includeManifest: boolean,
-  ): Promise<string | undefined> {
+  private async uploadAssetsIfNeeded(assets: string[], includeManifest: boolean): Promise<string | undefined> {
     if (!assets.length && !includeManifest) return undefined
     const compressedBundlePath = joinPath(
       dirname(this.bundlePath),
@@ -307,18 +367,15 @@ export class DevSession {
     )
 
     // Create zip file with everything
-    if (bundleController.signal.aborted) return undefined
     const filePattern = [...assets.map((ext) => `${ext}/**`), '!**/*.js.map']
     if (includeManifest) filePattern.push('manifest.json')
 
     await compressBundle(this.bundlePath, compressedBundlePath, filePattern)
 
     // Get a signed URL to upload the zip file
-    if (bundleController.signal.aborted) return undefined
     const signedURL = await this.getSignedURLWithRetry()
 
     // Upload the zip file
-    if (bundleController.signal.aborted) return undefined
     await uploadToGCS(signedURL, compressedBundlePath)
     return signedURL
   }

--- a/packages/cli-kit/src/public/node/serial-batch-processor.test.ts
+++ b/packages/cli-kit/src/public/node/serial-batch-processor.test.ts
@@ -1,0 +1,112 @@
+import {SerialBatchProcessor} from './serial-batch-processor.js'
+import {describe, test, expect, vi, beforeEach} from 'vitest'
+
+describe('SerialBatchProcessor', () => {
+  let processBatchMock: ReturnType<typeof vi.fn<[items: string[]], Promise<void>>>
+
+  beforeEach(() => {
+    // Default mock that resolves immediately
+    processBatchMock = vi.fn(async (_items: string[]) => Promise.resolve())
+  })
+
+  test('should process a single item in a batch', async () => {
+    const processor = new SerialBatchProcessor<string>(processBatchMock)
+    processor.enqueue('item1')
+    await processor.waitForCompletion()
+
+    expect(processBatchMock).toHaveBeenCalledTimes(1)
+    expect(processBatchMock).toHaveBeenCalledWith(['item1'])
+  })
+
+  test('should process items in separate batches if enqueued after processing of a batch starts', async () => {
+    let resolveFirstBatch: () => void = () => {}
+
+    processBatchMock.mockImplementationOnce(async (_items) => {
+      await new Promise<void>((resolve) => {
+        resolveFirstBatch = resolve
+      })
+    })
+
+    const processor = new SerialBatchProcessor<string>(processBatchMock)
+
+    // Enqueue first item, processing will start and pause
+    processor.enqueue('itemA')
+
+    // Enqueue second item while first is "processing"
+    processor.enqueue('itemB')
+
+    // Complete processing of the first batch
+    resolveFirstBatch()
+
+    // Wait for all processing to complete
+    await processor.waitForCompletion()
+
+    expect(processBatchMock).toHaveBeenCalledTimes(2)
+    expect(processBatchMock).toHaveBeenNthCalledWith(1, ['itemA'])
+    expect(processBatchMock).toHaveBeenNthCalledWith(2, ['itemB'])
+  })
+
+  test('waitForCompletion should resolve after all batches are processed', async () => {
+    let resolveFirstBatch: () => void = () => {}
+    const firstBatchPromise = new Promise<void>((resolve) => (resolveFirstBatch = resolve))
+    let resolveSecondBatch: () => void = () => {}
+    const secondBatchPromise = new Promise<void>((resolve) => (resolveSecondBatch = resolve))
+
+    processBatchMock
+      .mockImplementationOnce(async (_items) => firstBatchPromise)
+      .mockImplementationOnce(async (_items) => secondBatchPromise)
+
+    const processor = new SerialBatchProcessor<string>(processBatchMock)
+    // Starts first batch
+    processor.enqueue('item1')
+    // Queued for second batch
+    processor.enqueue('item2')
+
+    let completed = false
+    const completionPromise = processor.waitForCompletion().then(() => {
+      completed = true
+    })
+
+    expect(completed).toBe(false)
+
+    resolveFirstBatch()
+
+    // Still waiting for the second batch
+    expect(completed).toBe(false)
+
+    resolveSecondBatch()
+    // Ensure it resolves
+    await completionPromise
+    expect(completed).toBe(true)
+    expect(processBatchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('waitForCompletion should resolve immediately if no items are queued and no processing is active', async () => {
+    const processor = new SerialBatchProcessor<string>(processBatchMock)
+    await processor.waitForCompletion()
+    expect(processBatchMock).not.toHaveBeenCalled()
+  })
+
+  test('processBatch errors should propagate and processingPromise should be reset allowing future processing', async () => {
+    const testError = new Error('Batch processing failed')
+    processBatchMock.mockImplementationOnce(async () => {
+      throw testError
+    })
+
+    const processor = new SerialBatchProcessor<string>(processBatchMock)
+
+    processor.enqueue('item1-fail')
+
+    await expect(processor.waitForCompletion()).rejects.toThrow(testError)
+
+    // Reset mock for the next successful attempt
+    processBatchMock.mockImplementationOnce(async (_items) => Promise.resolve())
+
+    // Enqueue another item, should start new processing
+    processor.enqueue('item2-success')
+    await processor.waitForCompletion()
+    // First call failed, second succeeded
+    expect(processBatchMock).toHaveBeenCalledTimes(2)
+    expect(processBatchMock).toHaveBeenLastCalledWith(['item2-success'])
+  })
+})

--- a/packages/cli-kit/src/public/node/serial-batch-processor.ts
+++ b/packages/cli-kit/src/public/node/serial-batch-processor.ts
@@ -1,0 +1,42 @@
+/**
+ * Handles serial processing of items with automatic batching
+ * Only one processing operation runs at a time, with new items
+ * automatically queued for the next batch.
+ */
+export class SerialBatchProcessor<T> {
+  private queue: T[] = []
+  private processingPromise: Promise<void> | undefined = undefined
+
+  constructor(private readonly processBatch: (items: T[]) => Promise<void>) {}
+
+  enqueue(item: T): void {
+    this.queue.push(item)
+
+    if (!this.processingPromise) {
+      this.processingPromise = this.startProcessing()
+    }
+  }
+
+  async waitForCompletion(): Promise<void> {
+    if (this.processingPromise) {
+      return this.processingPromise
+    }
+  }
+
+  private async startProcessing(): Promise<void> {
+    try {
+      while (this.queue.length > 0) {
+        // Get current batch and clear queue
+        const batch = [...this.queue]
+        this.queue = []
+
+        // Process the current batch
+        // eslint-disable-next-line no-await-in-loop
+        await this.processBatch(batch)
+      }
+    } finally {
+      // Always make sure we reset the processing state
+      this.processingPromise = undefined
+    }
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the handling of rapid file changes during development by implementing a queue system for app events, preventing race conditions and ensuring all changes are properly processed.

### WHAT is this pull request doing?

Implements a more robust event handling system in the DevSession class:

1. Adds a queue system for app events to handle rapid changes
2. Introduces a consolidation mechanism that merges multiple events into a single update
3. Replaces the abort controller approach with a more reliable state tracking system
4. Ensures events are processed sequentially, preventing race conditions
5. Optimizes the update process by combining related changes

### How to test your changes?

1. Run `dev` on a project with multiple extensions
2. Make rapid changes to multiple extension files
3. Verify that all changes are properly processed and reflected in the preview
4. Check the logs to confirm events are being consolidated correctly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes