### PR TITLE
derive theme preview link from developer platform client instead of app id

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -34,6 +34,7 @@ import {
   AppVersionIdentifiers,
   AppVersionWithContext,
   AssetUrlSchema,
+  ClientName,
   CreateAppOptions,
   DeveloperPlatformClient,
   DevSessionCreateOptions,
@@ -1413,7 +1414,7 @@ const appLogsSubscribeResponse: AppLogsSubscribeResponse = {
 
 export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClient> = {}): DeveloperPlatformClient {
   const clientStub: DeveloperPlatformClient = {
-    clientName: 'test',
+    clientName: ClientName.AppManagement,
     webUiName: 'Test Dashboard',
     requiresOrganization: false,
     supportsAtomicDeployments: false,

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
@@ -1,6 +1,12 @@
 import {setupPreviewThemeAppExtensionsProcess, findOrCreateHostTheme} from './theme-app-extension.js'
 import {HostThemeManager} from '../../../utilities/extensions/theme/host-theme-manager.js'
-import {testApp, testOrganizationApp, testThemeExtensions} from '../../../models/app/app.test-data.js'
+import {
+  testApp,
+  testDeveloperPlatformClient,
+  testOrganizationApp,
+  testThemeExtensions,
+} from '../../../models/app/app.test-data.js'
+import {ClientName} from '../../../utilities/developer-platform-client.js'
 import {AdminSession, ensureAuthenticatedAdmin} from '@shopify/cli-kit/node/session'
 import {fetchTheme} from '@shopify/cli-kit/node/themes/api'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -108,10 +114,12 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
 
     const storeFqdn = 'test.myshopify.com'
     const theme = '123'
-    // Management API app with GID format
     const remoteApp = testOrganizationApp({
       id: 'gid://shopify/App/1234',
       apiKey: 'e4c79fb7b99c002a35efdcc44e0ea8f7',
+      developerPlatformClient: testDeveloperPlatformClient({
+        clientName: ClientName.AppManagement,
+      }),
     })
     const localApp = testApp({allExtensions: [await testThemeExtensions()]})
 

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -2,6 +2,7 @@ import {BaseProcess, DevProcessFunction} from './types.js'
 import {HostThemeManager} from '../../../utilities/extensions/theme/host-theme-manager.js'
 import {AppInterface} from '../../../models/app/app.js'
 import {OrganizationApp} from '../../../models/organization.js'
+import {ClientName} from '../../../utilities/developer-platform-client.js'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {AdminSession, ensureAuthenticatedAdmin} from '@shopify/cli-kit/node/session'
 import {fetchTheme} from '@shopify/cli-kit/node/themes/api'
@@ -146,14 +147,10 @@ export async function findOrCreateHostTheme(adminSession: AdminSession, theme?: 
 }
 
 async function buildAppUrl(remoteApp: OrganizationApp) {
-  // Check if the app ID is in GID format (gid://shopify/App/<INTEGER>), which indicates it's a Management API app
-  if (remoteApp.id.startsWith('gid://')) {
-    // For Management API apps, we need to generate a different URL format
-    // Extract the organization ID and use the app API key for the client_id parameter
+  if (remoteApp.developerPlatformClient?.clientName === ClientName.AppManagement) {
     const fqdn = await adminFqdn()
     return `https://${fqdn}/?organization_id=${remoteApp.organizationId}&no_redirect=true&redirect=/oauth/redirect_from_developer_dashboard?client_id%3D${remoteApp.apiKey}`
   } else {
-    // For Partners API apps, use the original URL format
     const fqdn = await partnersFqdn()
     return `https://${fqdn}/${remoteApp.organizationId}/apps/${remoteApp.id}/test`
   }

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -61,7 +61,11 @@ describe('selectStore', async () => {
     vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE1)
 
     // When
-    const got = await selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, testDeveloperPlatformClient())
+    const got = await selectStore(
+      {stores: [STORE1, STORE2], hasMorePages: false},
+      ORG1,
+      testDeveloperPlatformClient({clientName: ClientName.Partners}),
+    )
 
     // Then
     expect(got).toEqual(STORE1)
@@ -97,7 +101,11 @@ describe('selectStore', async () => {
     vi.mocked(confirmConversionToTransferDisabledStorePrompt).mockResolvedValueOnce(true)
 
     // When
-    const got = await selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, testDeveloperPlatformClient())
+    const got = await selectStore(
+      {stores: [STORE1, STORE2], hasMorePages: false},
+      ORG1,
+      testDeveloperPlatformClient({clientName: ClientName.Partners}),
+    )
 
     // Then
     expect(got).toEqual(STORE2)
@@ -117,7 +125,11 @@ describe('selectStore', async () => {
     vi.mocked(confirmConversionToTransferDisabledStorePrompt).mockResolvedValueOnce(false)
 
     // When
-    const got = await selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, testDeveloperPlatformClient())
+    const got = await selectStore(
+      {stores: [STORE1, STORE2], hasMorePages: false},
+      ORG1,
+      testDeveloperPlatformClient({clientName: ClientName.Partners}),
+    )
 
     // Then
     expect(got).toEqual(STORE1)
@@ -135,7 +147,7 @@ describe('selectStore', async () => {
     vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE2)
     vi.mocked(isSpinEnvironment).mockReturnValue(true)
     vi.mocked(firstPartyDev).mockReturnValue(true)
-    const developerPlatformClient = testDeveloperPlatformClient()
+    const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.Partners})
 
     // When
     const got = await selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient)
@@ -159,7 +171,7 @@ describe('selectStore', async () => {
     const got = selectStore(
       {stores: [STORE1, STORE2, STORE3], hasMorePages: false},
       ORG1,
-      testDeveloperPlatformClient(),
+      testDeveloperPlatformClient({clientName: ClientName.Partners}),
     )
 
     // Then
@@ -172,7 +184,12 @@ describe('selectStore', async () => {
     vi.mocked(reloadStoreListPrompt).mockResolvedValue(false)
 
     // When
-    const got = () => selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, testDeveloperPlatformClient())
+    const got = () =>
+      selectStore(
+        {stores: [STORE1, STORE2], hasMorePages: false},
+        ORG1,
+        testDeveloperPlatformClient({clientName: ClientName.Partners}),
+      )
 
     // Then
     await expect(got).rejects.toThrowError()
@@ -189,7 +206,7 @@ describe('selectStore', async () => {
     vi.mocked(selectStorePrompt).mockResolvedValue(undefined)
     vi.mocked(reloadStoreListPrompt).mockResolvedValueOnce(true)
     vi.mocked(reloadStoreListPrompt).mockResolvedValueOnce(false)
-    const developerPlatformClient = testDeveloperPlatformClient()
+    const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.Partners})
 
     // When
     const got = selectStore({stores: [], hasMorePages: false}, ORG1, developerPlatformClient)
@@ -203,7 +220,7 @@ describe('selectStore', async () => {
   test('prompts user to create with Partners link', async () => {
     // Given
     vi.mocked(selectStorePrompt).mockResolvedValue(undefined)
-    const developerPlatformClient = testDeveloperPlatformClient()
+    const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.Partners})
 
     // When
     const got = selectStore({stores: [], hasMorePages: false}, ORG1, developerPlatformClient)
@@ -244,7 +261,7 @@ describe('selectStore', async () => {
     const got = await selectStore(
       {stores: [STORE1, STORE2], hasMorePages: false},
       ORG1,
-      testDeveloperPlatformClient({supportsStoreSearch: true}),
+      testDeveloperPlatformClient({clientName: ClientName.Partners, supportsStoreSearch: true}),
     )
 
     // Then

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -253,7 +253,7 @@ interface ErrorDetail {
 }
 
 export interface DeveloperPlatformClient {
-  readonly clientName: string
+  readonly clientName: ClientName
   readonly webUiName: string
   readonly supportsAtomicDeployments: boolean
   readonly requiresOrganization: boolean


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

- comment on https://github.com/Shopify/cli/pull/5824 indicating we should derive this logic from the developer platform client instead, which I agree with
- this is still a "sprinkle" of logic which could probably be contained within the client itself, but given its small, contained to its own function, and theme related, I think this is fine for now
- I also updated the developer platform `clientName` to use the enum instead of just `string`

