### PR TITLE
Update error message when types for the target cannot be found in the installed @shopify/ui-extensions version

### DIFF
--- a/.changeset/tasty-peas-learn.md
+++ b/.changeset/tasty-peas-learn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update error message when types for the target cannot be found in the installed @shopify/ui-extensions version

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -9,6 +9,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 import {err, ok} from '@shopify/cli-kit/node/result'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {describe, expect, test, vi} from 'vitest'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 describe('ui_extension', async () => {
   interface GetUIExtensionProps {
@@ -1062,7 +1063,10 @@ Please check the configuration in ${uiExtension.configurationPath}`),
 
         // When
         await expect(extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)).rejects.toThrow(
-          'Type reference for admin.unknown.action.render could not be found. You might be using the wrong @shopify/ui-extensions version.',
+          new AbortError(
+            'Type reference for admin.unknown.action.render could not be found. You might be using the wrong @shopify/ui-extensions version.',
+            'Fix the error by ensuring you have the correct version of @shopify/ui-extensions, for example 2025.10.0, in your dependencies.',
+          ),
         )
 
         // No shopify.d.ts file should be created

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -280,6 +280,14 @@ export function getShouldRenderTarget(target: string) {
   return target.replace(/\.render$/, '.should-render')
 }
 
+function convertApiVersionToSemver(apiVersion: string): string {
+  const [year, month] = apiVersion.split('-')
+  if (!year || !month) {
+    throw new AbortError('Invalid API version format. Expected format: YYYY-MM')
+  }
+  return `${year}.${month}.0`
+}
+
 function getSharedTypeDefinition(fullPath: string, typeFilePath: string, target: string, apiVersion: string) {
   try {
     // Check if target types can be found
@@ -293,7 +301,9 @@ function getSharedTypeDefinition(fullPath: string, typeFilePath: string, target:
   } catch (_) {
     throw new AbortError(
       `Type reference for ${target} could not be found. You might be using the wrong @shopify/ui-extensions version.`,
-      `Fix the error by ensuring you install @shopify/ui-extensions@${apiVersion} in your dependencies.`,
+      `Fix the error by ensuring you have the correct version of @shopify/ui-extensions, for example ${convertApiVersionToSemver(
+        apiVersion,
+      )}, in your dependencies.`,
     )
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The error message when types for a target cannot be found in the installed `@shopify/ui-extensions` version was not clear enough for users to understand how to fix the issue.

Fix https://github.com/shop/issues-appui/issues/203

### WHAT is this pull request doing?

Improves the error message when UI extension types cannot be found by:

1. Adding a more helpful error message that includes a specific example version format (e.g., 2025.10.0)
2. Creating a utility function `convertApiVersionToSemver` to properly format the API version in the error message
3. Updating the test to match the new error format

### How to test your changes?

Unit tests should be sufficient

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes