### PR TITLE
Improve message that displays when org doesn't have dev stores

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1487,9 +1487,9 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     devSessionCreate: (_input: DevSessionCreateOptions) => Promise.resolve({devSessionCreate: {userErrors: []}}),
     devSessionUpdate: (_input: DevSessionUpdateOptions) => Promise.resolve({devSessionUpdate: {userErrors: []}}),
     devSessionDelete: (_input: DevSessionDeleteOptions) => Promise.resolve({devSessionDelete: {userErrors: []}}),
-    getCreateDevStoreLink: (_input: string) =>
+    getCreateDevStoreLink: (org: Organization) =>
       Promise.resolve(
-        `Looks like you don't have a dev store in the Partners org you selected. Keep going — create a dev store on Shopify Partners: https://partners.shopify.com/1234/stores`,
+        `Looks like you don't have any dev stores associated with ${org.businessName}'s Partner Dashboard. Create one now https://partners.shopify.com/1234/stores`,
       ),
     ...stubs,
   }

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -196,7 +196,7 @@ describe('selectStore', async () => {
 
     // Then
     await expect(got).rejects.toThrow()
-    expect(developerPlatformClient.getCreateDevStoreLink).toHaveBeenCalledWith(ORG1.id)
+    expect(developerPlatformClient.getCreateDevStoreLink).toHaveBeenCalledWith(ORG1)
     expect(developerPlatformClient.devStoresForOrg).toHaveBeenCalledTimes(10)
   })
 
@@ -210,8 +210,8 @@ describe('selectStore', async () => {
 
     // Then
     await expect(got).rejects.toThrow()
-    expect(developerPlatformClient.getCreateDevStoreLink).toHaveBeenCalledWith(ORG1.id)
-    const res = await Promise.resolve(developerPlatformClient.getCreateDevStoreLink(ORG1.id))
+    expect(developerPlatformClient.getCreateDevStoreLink).toHaveBeenCalledWith(ORG1)
+    const res = await Promise.resolve(developerPlatformClient.getCreateDevStoreLink(ORG1))
     expect(res).toContain('https://partners.shopify.com/1234/stores')
   })
 
@@ -220,9 +220,9 @@ describe('selectStore', async () => {
     vi.mocked(selectStorePrompt).mockResolvedValue(undefined)
     const developerPlatformClient = testDeveloperPlatformClient({
       clientName: ClientName.AppManagement,
-      getCreateDevStoreLink: (_input: string) =>
+      getCreateDevStoreLink: (org: Organization) =>
         Promise.resolve(
-          `Looks like you don't have a dev store in the organization you selected. Keep going — create a dev store on the Developer Dashboard: https://dev.shopify.com/dashboard/1234/stores`,
+          `Looks like you don't have any dev stores associated with ${org.businessName}'s Dev Dashboard. Create one now https://dev.shopify.com/dashboard/1234/stores`,
         ),
     })
 
@@ -231,8 +231,8 @@ describe('selectStore', async () => {
 
     // Then
     await expect(got).rejects.toThrow()
-    expect(developerPlatformClient.getCreateDevStoreLink).toHaveBeenCalledWith(ORG1.id)
-    const res = await Promise.resolve(developerPlatformClient.getCreateDevStoreLink(ORG1.id))
+    expect(developerPlatformClient.getCreateDevStoreLink).toHaveBeenCalledWith(ORG1)
+    const res = await Promise.resolve(developerPlatformClient.getCreateDevStoreLink(ORG1))
     expect(res).toContain('https://dev.shopify.com/dashboard/1234/stores')
   })
 

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -44,7 +44,7 @@ export async function selectStore(
   })
   if (!store) {
     renderInfo({
-      body: await developerPlatformClient.getCreateDevStoreLink(org.id),
+      body: await developerPlatformClient.getCreateDevStoreLink(org),
     })
     await sleep(5)
 

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -320,5 +320,5 @@ export interface DeveloperPlatformClient {
   devSessionCreate: (input: DevSessionCreateOptions) => Promise<DevSessionCreateMutation>
   devSessionUpdate: (input: DevSessionUpdateOptions) => Promise<DevSessionUpdateMutation>
   devSessionDelete: (input: DevSessionSharedOptions) => Promise<DevSessionDeleteMutation>
-  getCreateDevStoreLink: (input: string) => Promise<string>
+  getCreateDevStoreLink: (org: Organization) => Promise<string>
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -1016,11 +1016,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return appDevRequest(DevSessionDelete, shopFqdn, await this.token(), {appId: appIdNumber})
   }
 
-  async getCreateDevStoreLink(orgId: string): Promise<string> {
-    const url = `https://${await developerDashboardFqdn()}/dashboard/${orgId}/stores`
+  async getCreateDevStoreLink(org: Organization): Promise<string> {
+    const url = `https://${await developerDashboardFqdn()}/dashboard/${org.id}/stores`
     return (
-      `Looks like you don't have a dev store in the organization you selected. ` +
-      `Keep going — create a dev store on the Developer Dashboard:\n${url}\n`
+      `Looks like you don't have any dev stores associated with ${org.businessName}'s Dev Dashboard.` +
+      ` Create one now \n${url}`
     )
   }
 

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -622,11 +622,11 @@ export class PartnersClient implements DeveloperPlatformClient {
     return Promise.resolve()
   }
 
-  async getCreateDevStoreLink(orgId: string): Promise<string> {
-    const url = `https://${await partnersFqdn()}/${orgId}/stores`
+  async getCreateDevStoreLink(org: Organization): Promise<string> {
+    const url = `https://${await partnersFqdn()}/${org.id}/stores`
     return (
-      `Looks like you don't have a dev store in the Partners org you selected. ` +
-      `Keep going — create a dev store on Shopify Partners:\n${url}\n`
+      `Looks like you don't have any dev stores associated with ${org.businessName}'s Partner Dashboard.` +
+      ` Create one now \n${url}`
     )
   }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/temp-project-mover-megswim-20250605132259/issues/210

### WHAT is this pull request doing?

Changes the message when the user has no dev stores to specify if they have no Dev Dashboard dev stores vs Partner Dashboard dev stores vs other dev stores. See the screenshots in the top hatting below.

### How to test your changes?

#### Developer Dashboard on local dev
https://docs.google.com/document/d/1C_Ec15V3zhutFYcCcrwJzh3SslGA7TzE-vTPJ2DdMiA/edit?tab=t.0

If you already have App Dev Stores, you can set all their types to null in the BP shops table to make them go away.

```
SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify auth logout

SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify app init --path="$HOME/src/tmp" --template=remix --flavor=javascript

# Choose user dev@shopify.com in the login
# Choose org Test Business One

SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify app dev --path=/Users/rodmcnew/src/tmp/focused-investment-app --reset
```

Results in:
![image](https://github.com/user-attachments/assets/76d812b6-8f1d-4c32-9d39-812396bc5121)

### Partner Dashboard on local dev

Partners needs this special way of running it
```
SPIN_IDENTITY_SERVICE_FQDN='identity.shop.dev' ENABLE_INTERCEPTORS=1 DISABLE_SHOPIFY_INTERNAL_API_INTERCEPTOR=1 bin/rails s
```

```
SHOPIFY_CLI_NEVER_USE_APP_MANAGEMENT_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify auth logout

SHOPIFY_CLI_NEVER_USE_APP_MANAGEMENT_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify app init --path="$HOME/src/tmp" --template=remix --flavor=javascript

# Choose user partners@shopify.com in the login
# Choose org ReSello (Partner Dashboard)

SHOPIFY_CLI_NEVER_USE_APP_MANAGEMENT_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify app dev --path=/Users/rodmcnew/src/tmp/focused-investment-app --reset
```

Results in:
![image](https://github.com/user-attachments/assets/21b79d18-28df-4762-b6de-de271be2d93d)


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
