### PR TITLE
Minify JS extensions by default on app dev

### DIFF
--- a/.changeset/happy-points-cover.md
+++ b/.changeset/happy-points-cover.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Minify JS extensions by default on app dev. To opt-out: SHOPIFY_CLI_APP_DEV_DISABLE_MINIFICATION=1

--- a/.changeset/happy-points-cover.md
+++ b/.changeset/happy-points-cover.md
@@ -2,4 +2,4 @@
 '@shopify/app': patch
 ---
 
-Minify JS extensions by default on app dev. To opt-out: SHOPIFY_CLI_APP_DEV_DISABLE_MINIFICATION=1
+Minify JS extensions by default on app dev. To opt-out: SHOPIFY_CLI_DISABLE_MINIFICATION_ON_DEV=1

--- a/.changeset/silent-years-smash.md
+++ b/.changeset/silent-years-smash.md
@@ -1,7 +1,6 @@
 ---
 '@shopify/ui-extensions-dev-console-app': minor
 '@shopify/features': minor
-'@shopify/ui-extensions-dev-console-app': minor
 '@shopify/theme': minor
 '@shopify/app': minor
 '@shopify/cli': minor

--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -8,6 +8,7 @@ export const environmentVariableNames = {
   useWasmTomlPatch: 'SHOPIFY_CLI_USE_WASM_TOML_PATCH',
   enableUnsupportedConfigPropertyChecks: 'SHOPIFY_CLI_ENABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS',
   disableUnsupportedConfigPropertyChecks: 'SHOPIFY_CLI_DISABLE_UNSUPPORTED_CONFIG_PROPERTY_CHECKS',
+  disableMinificationOnDev: 'SHOPIFY_CLI_DISABLE_MINIFICATION_ON_DEV',
 }
 
 export const configurationFileNames = {

--- a/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.ts
@@ -1,10 +1,13 @@
 import {AppEvent, EventType} from './app-event-watcher.js'
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
 import {getESBuildOptions} from '../../extensions/bundle.js'
+import {environmentVariableNames} from '../../../constants.js'
 import {BuildContext, context as esContext, StdinOptions} from 'esbuild'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {copyFile} from '@shopify/cli-kit/node/fs'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
+import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
+import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
 
 export interface DevAppWatcherOptions {
   dotEnvVariables: {[key: string]: string}
@@ -117,8 +120,11 @@ export class ESBuildContextManager {
   }
 
   private async extensionEsBuildOptions(stdin: StdinOptions, outputPath: string) {
+    const env = getEnvironmentVariables()
+    const disableMinificationOnDev = env[environmentVariableNames.disableMinificationOnDev]
+    const minify = !isTruthy(disableMinificationOnDev)
     return getESBuildOptions({
-      minify: false,
+      minify,
       outputPath,
       environment: 'development',
       env: {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5825
Fixes https://github.com/Shopify/develop-app-outer-loop/issues/1533

### WHAT is this pull request doing?

Enables minification by default on JS extensions while running `app dev`.

This is basically the same as @keiraarts suggested in https://github.com/Shopify/cli/pull/5831 (thanks!), but adding a flag to ensure we can keep the current behavior, so that users can debug more easily if needed.

### How to test your changes?

- `npm i -g @shopify/cli@0.0.0-snapshot-20250521104958 --@shopify:registry=https://registry.npmjs.org`
- `shopify app init --template none --name minify-app`
- `cd minify-app`
- `shopify app generate extension --template admin_action --name admin-action --flavor typescript`
- `shopify app dev` => wait until it's ready and quit
- `cat .shopify/dev-bundle/{your-extension-id}/dist/admin-action.js` => minified
- `SHOPIFY_CLI_DISABLE_MINIFICATION_ON_DEV=1 shopify app dev` => wait until it's ready and quit
- `cat .shopify/dev-bundle/{your-extension-id}/dist/admin-action.js` => not minified

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
