### PR TITLE
Allow publish command to work with multiple environments

### DIFF
--- a/.changeset/hot-fishes-develop.md
+++ b/.changeset/hot-fishes-develop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Allow publish command to be called with multiple environments

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6338,6 +6338,11 @@
       "hiddenAliases": [
       ],
       "id": "theme:publish",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "theme"
+      ],
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6346,7 +6346,7 @@
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": false,
+      "strict": true,
       "summary": "Set a remote theme as the live theme."
     },
     "theme:pull": {

--- a/packages/theme/src/cli/commands/theme/publish.ts
+++ b/packages/theme/src/cli/commands/theme/publish.ts
@@ -1,6 +1,6 @@
 import ThemeCommand from '../../utilities/theme-command.js'
 import {themeFlags} from '../../flags.js'
-import {publish, renderArgumentsWarning} from '../../services/publish.js'
+import {publish} from '../../services/publish.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {OutputFlags} from '@oclif/core/interfaces'
@@ -21,9 +21,6 @@ If you want to publish your local theme, then you need to run \`shopify theme pu
 
   static description = this.descriptionWithoutMarkdown()
 
-  // Accept any number of args without naming them
-  static strict = false
-
   static flags = {
     ...globalFlags,
     ...themeFlags,
@@ -41,16 +38,7 @@ If you want to publish your local theme, then you need to run \`shopify theme pu
 
   static multiEnvironmentsFlags = ['store', 'password', 'theme']
 
-  async command(flags: PublishFlags, adminSession: AdminSession) {
-    // Deprecated use of passing the theme id as an argument
-    // ex: `shopify theme publish <themeid>`
-    const positionalArgValue =
-      this.argv && this.argv.length > 0 && typeof this.argv[0] === 'string' ? this.argv[0] : undefined
-
-    if (!flags.theme && positionalArgValue) {
-      flags.theme = positionalArgValue
-      renderArgumentsWarning(positionalArgValue)
-    }
-    await publish(adminSession, flags)
+  async command(flags: PublishFlags, adminSession: AdminSession, multiEnvironment?: boolean) {
+    await publish(adminSession, flags, multiEnvironment)
   }
 }

--- a/packages/theme/src/cli/services/publish.test.ts
+++ b/packages/theme/src/cli/services/publish.test.ts
@@ -33,7 +33,7 @@ describe('publish', () => {
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
     // When
-    await publish(session, '1', options)
+    await publish(session, options)
 
     // Then
     expect(renderConfirmationPrompt).toBeCalledWith({
@@ -66,7 +66,7 @@ describe('publish', () => {
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
 
     // When
-    await publish(session, '1', options)
+    await publish(session, options)
 
     // Then
     expect(renderConfirmationPrompt).toBeCalledWith({
@@ -84,7 +84,7 @@ describe('publish', () => {
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
 
     // When
-    await publish(session, '1', {...options, force: true})
+    await publish(session, {...options, force: true})
 
     // Then
     expect(renderConfirmationPrompt).not.toBeCalled()

--- a/packages/theme/src/cli/services/publish.ts
+++ b/packages/theme/src/cli/services/publish.ts
@@ -18,33 +18,38 @@ export function renderArgumentsWarning(id: string) {
   })
 }
 
-export async function publish(adminSession: AdminSession, themeId: string | undefined, options: {force: boolean}) {
-  const theme = await findOrSelectTheme(adminSession, {
+interface PublishServiceOptions {
+  theme: string | undefined
+  force: boolean
+}
+
+export async function publish(adminSession: AdminSession, options: PublishServiceOptions) {
+  const themeToPublish = await findOrSelectTheme(adminSession, {
     header: 'Select a theme to publish',
     filter: {
       development: false,
       live: false,
-      theme: themeId,
+      theme: options.theme,
     },
   })
 
-  const previewUrl = themePreviewUrl({...theme, role: 'live'} as Theme, adminSession)
+  const previewUrl = themePreviewUrl({...themeToPublish, role: 'live'} as Theme, adminSession)
 
   if (!options.force) {
     const accept = await renderConfirmationPrompt({
-      message: `Do you want to make '${theme.name}' the new live theme on ${adminSession.storeFqdn}?`,
-      confirmationMessage: `Yes, make '${theme.name}' the new live theme`,
+      message: `Do you want to make '${themeToPublish.name}' the new live theme on ${adminSession.storeFqdn}?`,
+      confirmationMessage: `Yes, make '${themeToPublish.name}' the new live theme`,
       cancellationMessage: 'No, cancel publish',
     })
     if (!accept) return
   }
 
-  await themePublish(theme.id, adminSession)
+  await themePublish(themeToPublish.id, adminSession)
 
   renderSuccess({
     body: [
       'The theme',
-      ...themeComponent(theme),
+      ...themeComponent(themeToPublish),
       'is now live at',
       {
         link: {


### PR DESCRIPTION
### WHY are these changes introduced?

We are changing the publish command to allow multiple environments to be specified in a single command to allow developers with multiple stores to work more efficiently.

### WHAT is this pull request doing?

Changing the publish command to use our multi environment infrastructure.

### How to test your changes?

- Pull down the branch
- Build the branch
- If you don't already have one, create a `shopify.theme.toml` file

*Note*: You will need to create an access token through your shop(s) to bypass the need to login during theme commands.
The most basic example of the structure needed would be this:
```
[environments.env1]
store = "myfirstshop.myshopify.com"
password = "access_token"
theme = "your-theme-to-publish"
force = "true"
[environments.env2]
store = "mysecondshop.myshopify.com"
password = "access_token"
theme = "your-theme-to-publish"
force= "true"
```

- Run `theme publish -e env1 -e env2` or whatever you named your environments.

- Look for the confirmation output for your stores in the terminal. The order may differ from your input (i.e you might have put env1, env2 but the output is env2, env1) due to the commands running concurrently.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
