### PR TITLE
Bump trampoline version to 1.0.2

### DIFF
--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -20,7 +20,7 @@ export const PREFERRED_JAVY_PLUGIN_VERSION = 'v2'
 
 const BINARYEN_VERSION = '123.0.0'
 
-export const TRAMPOLINE_VERSION = 'v1.0.0'
+export const TRAMPOLINE_VERSION = 'v1.0.2'
 
 interface DownloadableBinary {
   path: string


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue where a second invocation of `shopify app function build` to a Rust Function using the new Wasm API would result in an error as the trampoline binary errored in the case that a module used more than one memory. This is fixed in `1.0.2` to only error in the case when there is more than one non-imported memory.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Bump the binary version to 1.0.2

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run `shopify app function build` against any new Rust Function (uses the Wasm API, so `shopify_function` crate version >= 1.0.0) multiple times, see that it succeeds.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
