### PR TITLE
Invoke `wasm-opt` with  --enable-nontrapping-float-to-int

### DIFF
--- a/.changeset/cyan-bikes-sell.md
+++ b/.changeset/cyan-bikes-sell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Invoke wasm-opt with the --enable-nontrapping-float-to-int flag when building functions

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -253,6 +253,7 @@ describe('runWasmOpt', () => {
         '-Oz',
         '--enable-bulk-memory',
         '--enable-multimemory',
+        '--enable-nontrapping-float-to-int',
         '--strip-debug',
         '-o',
         modulePath,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -245,6 +245,7 @@ export async function runWasmOpt(modulePath: string) {
     '-Oz',
     '--enable-bulk-memory',
     '--enable-multimemory',
+    '--enable-nontrapping-float-to-int',
     '--strip-debug',
     // overwrite our existing module with the optimized version
     '-o',


### PR DESCRIPTION
Rust 1.87 now uses LLVM 20, which in turn enables non-trapping floating point by default
https://releases.llvm.org/20.1.0/docs/ReleaseNotes.html#changes-to-the-webassembly-backend

Without this change, any Rust functions built with 1.87 will fail to optimize.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
