### PR TITLE
Force all requests in app management to have an unauthorizedHandler

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -123,12 +123,10 @@ import {CliTesting} from '../../api/graphql/webhooks/generated/cli-testing.js'
 import {PublicApiVersions} from '../../api/graphql/webhooks/generated/public-api-versions.js'
 import {
   SchemaDefinitionByTarget,
-  SchemaDefinitionByTargetQuery,
   SchemaDefinitionByTargetQueryVariables,
 } from '../../api/graphql/functions/generated/schema-definition-by-target.js'
 import {
   SchemaDefinitionByApiType,
-  SchemaDefinitionByApiTypeQuery,
   SchemaDefinitionByApiTypeQueryVariables,
 } from '../../api/graphql/functions/generated/schema-definition-by-api-type.js'
 import {WebhooksSpecIdentifier} from '../../models/extensions/specifications/app_config_webhook.js'
@@ -149,23 +147,27 @@ import {
   appManagementRequestDoc,
   appManagementAppLogsUrl,
   appManagementHeaders,
+  AppManagementRequestOptions,
 } from '@shopify/cli-kit/node/api/app-management'
-import {appDevRequest} from '@shopify/cli-kit/node/api/app-dev'
+import {appDevRequestDoc, AppDevRequestOptions} from '@shopify/cli-kit/node/api/app-dev'
 import {
   businessPlatformOrganizationsRequest,
   businessPlatformOrganizationsRequestDoc,
+  BusinessPlatformOrganizationsRequestOptions,
   businessPlatformRequestDoc,
+  BusinessPlatformRequestOptions,
 } from '@shopify/cli-kit/node/api/business-platform'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 import {versionSatisfies} from '@shopify/cli-kit/node/node-package-manager'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {developerDashboardFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {webhooksRequest} from '@shopify/cli-kit/node/api/webhooks'
-import {functionsRequestDoc} from '@shopify/cli-kit/node/api/functions'
+import {functionsRequestDoc, FunctionsRequestOptions} from '@shopify/cli-kit/node/api/functions'
 import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 import {isPreReleaseVersion} from '@shopify/cli-kit/node/version'
 import {UnauthorizedHandler} from '@shopify/cli-kit/node/api/graphql'
+import {Variables} from 'graphql-request'
+import {webhooksRequestDoc, WebhooksRequestOptions} from '@shopify/cli-kit/node/api/webhooks'
 
 const TEMPLATE_JSON_URL = 'https://cdn.shopify.com/static/cli/extensions/templates.json'
 
@@ -198,17 +200,14 @@ export class AppManagementClient implements DeveloperPlatformClient {
     input: AppLogsSubscribeMutationVariables,
     organizationId: string,
   ): Promise<AppLogsSubscribeMutation> {
-    const token = await this.token()
-
-    return appManagementRequestDoc<AppLogsSubscribeMutation, AppLogsSubscribeMutationVariables>(
+    return this.appManagementRequest<AppLogsSubscribeMutation, AppLogsSubscribeMutationVariables>({
       organizationId,
-      AppLogsSubscribe,
-      token,
-      {
+      query: AppLogsSubscribe,
+      variables: {
         shopIds: input.shopIds,
         apiKey: input.apiKey,
       },
-    )
+    })
   }
 
   async appLogs(
@@ -266,9 +265,15 @@ export class AppManagementClient implements DeveloperPlatformClient {
       const tokenResult = await ensureAuthenticatedAppManagementAndBusinessPlatform()
       const {appManagementToken, businessPlatformToken, userId} = tokenResult
 
-      const userInfoResult = await businessPlatformRequestDoc(UserInfo, businessPlatformToken, undefined, {
-        cacheTTL: {hours: 6},
-        cacheExtraKey: userId,
+      // This one can't use the shared businessPlatformRequest because the token is not globally available yet.
+      const userInfoResult = await businessPlatformRequestDoc({
+        query: UserInfo,
+        cacheOptions: {
+          cacheTTL: {hours: 6},
+          cacheExtraKey: userId,
+        },
+        token: businessPlatformToken,
+        unauthorizedHandler: this.createUnauthorizedHandler(),
       })
 
       if (getPartnersToken() && userInfoResult.currentUserAccount) {
@@ -354,7 +359,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   }
 
   async organizations(): Promise<Organization[]> {
-    const organizationsResult = await businessPlatformRequestDoc(ListOrganizations, await this.businessPlatformToken())
+    const organizationsResult = await this.businessPlatformRequest({query: ListOrganizations})
     if (!organizationsResult.currentUserAccount) return []
     return organizationsResult.currentUserAccount.organizations.nodes.map((org) => ({
       id: idFromEncodedGid(org.id),
@@ -366,12 +371,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
   async orgFromId(orgId: string): Promise<Organization | undefined> {
     const base64Id = encodedGidFromOrganizationId(orgId)
     const variables = {organizationId: base64Id}
-    const organizationResult = await businessPlatformRequestDoc(
-      FindOrganizations,
-      await this.businessPlatformToken(),
+    const organizationResult = await this.businessPlatformRequest({
+      query: FindOrganizations,
       variables,
-      {cacheTTL: {hours: 6}},
-    )
+      cacheOptions: {cacheTTL: {hours: 6}},
+    })
     const org = organizationResult.currentUserAccount?.organization
     if (!org) {
       return
@@ -402,15 +406,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
         .map((word) => `title:${word}`)
         .join(' '),
     }
-    const result = await appManagementRequestDoc(
-      organizationId,
-      query,
-      await this.token(),
-      variables,
-      undefined,
-      undefined,
-      createUnauthorizedHandler(this),
-    )
+    const result = await this.appManagementRequest({organizationId, query, variables})
     if (!result.appsConnection) {
       throw new BugError('Server failed to retrieve apps')
     }
@@ -431,15 +427,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
   async specifications({organizationId}: MinimalAppIdentifiers): Promise<RemoteSpecification[]> {
     const query = FetchSpecifications
-    const result = await appManagementRequestDoc(
-      organizationId,
-      query,
-      await this.token(),
-      undefined,
-      undefined,
-      undefined,
-      createUnauthorizedHandler(this),
-    )
+    const result = await this.appManagementRequest({organizationId, query})
     return result.specifications.map(
       (spec): RemoteSpecification => ({
         name: spec.name,
@@ -504,15 +492,12 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const variables = createAppVars(options, apiVersion)
 
     const mutation = CreateApp
-    const result = await appManagementRequestDoc(
-      org.id,
-      mutation,
-      await this.token(),
+    const result = await this.appManagementRequest({
+      organizationId: org.id,
+      query: mutation,
       variables,
-      undefined,
-      undefined,
-      createUnauthorizedHandler(this),
-    )
+    })
+
     if (!result.appCreate.app || result.appCreate.userErrors?.length > 0) {
       const errors = result.appCreate.userErrors.map((error) => error.message).join(', ')
       throw new AbortError(errors)
@@ -539,12 +524,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
   // partners-client and app-management-client. Since we need transferDisabled and convertableToPartnerTest values
   // from the Partners OrganizationStore schema, we will return this type for now
   async devStoresForOrg(orgId: string, searchTerm?: string): Promise<Paginateable<{stores: OrganizationStore[]}>> {
-    const storesResult = await businessPlatformOrganizationsRequestDoc(
-      ListAppDevStores,
-      await this.businessPlatformToken(),
-      orgId,
-      {searchTerm},
-    )
+    const storesResult = await this.businessPlatformOrganizationsRequest({
+      query: ListAppDevStores,
+      organizationId: orgId,
+      variables: {searchTerm},
+    })
     const organization = storesResult.organization
 
     if (!organization) {
@@ -592,15 +576,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   async appVersions({id, organizationId, title}: MinimalOrganizationApp): Promise<AppVersionsQuerySchemaInterface> {
     const query = AppVersions
     const variables = {appId: id}
-    const result = await appManagementRequestDoc(
-      organizationId,
-      query,
-      await this.token(),
-      variables,
-      undefined,
-      undefined,
-      createUnauthorizedHandler(this),
-    )
+    const result = await this.appManagementRequest({organizationId, query, variables})
     return {
       app: {
         id: result.app.id,
@@ -635,15 +611,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   ): Promise<AppVersionWithContext> {
     const query = AppVersionByTag
     const variables = {versionTag}
-    const result = await appManagementRequestDoc(
-      organizationId,
-      query,
-      await this.token(),
-      variables,
-      undefined,
-      undefined,
-      createUnauthorizedHandler(this),
-    )
+    const result = await this.appManagementRequest({organizationId, query, variables})
     const version = result.versionByTag
     if (!version) {
       throw new AbortError(`Version not found for tag: ${versionTag}`)
@@ -666,7 +634,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const variables = {versionId}
     const [currentVersion, selectedVersion] = await Promise.all([
       this.activeAppVersionRawResult(app),
-      appManagementRequestDoc(app.organizationId, AppVersionById, await this.token(), variables),
+      this.appManagementRequest({organizationId: app.organizationId, query: AppVersionById, variables}),
     ])
     const currentModules = currentVersion.app.activeRelease.version.appModules
     const selectedVersionModules = selectedVersion.version.appModules
@@ -707,15 +675,12 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
   async generateSignedUploadUrl({organizationId}: MinimalAppIdentifiers): Promise<AssetUrlSchema> {
     const variables = {sourceExtension: 'BR' as SourceExtension}
-    const result = await appManagementRequestDoc(
+    const result = await this.appManagementRequest({
       organizationId,
-      CreateAssetUrl,
-      await this.token(),
+      query: CreateAssetUrl,
       variables,
-      {cacheTTL: {minutes: 59}},
-      undefined,
-      createUnauthorizedHandler(this),
-    )
+      cacheOptions: {cacheTTL: {minutes: 59}},
+    })
     return {
       assetUrl: result.appRequestSourceUploadUrl.sourceUploadUrl,
       userErrors: result.appRequestSourceUploadUrl.userErrors,
@@ -767,15 +732,12 @@ export class AppManagementClient implements DeveloperPlatformClient {
       metadata,
     }
 
-    const result = await appManagementRequestDoc(
+    const result = await this.appManagementRequest({
       organizationId,
-      CreateAppVersion,
-      await this.token(),
+      query: CreateAppVersion,
       variables,
-      undefined,
-      {requestMode: 'slow-request'},
-      createUnauthorizedHandler(this),
-    )
+      requestOptions: {requestMode: 'slow-request'},
+    })
     const {version} = result.appVersionCreate
     const userErrors = result.appVersionCreate.userErrors.map(toUserError) ?? []
     if (!version) return {appDeploy: {userErrors}}
@@ -803,15 +765,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
     if (noRelease) return versionResult
 
     const releaseVariables = {appId, versionId: version.id}
-    const releaseResult = await appManagementRequestDoc(
+    const releaseResult = await this.appManagementRequest({
       organizationId,
-      ReleaseVersion,
-      await this.token(),
-      releaseVariables,
-      undefined,
-      undefined,
-      createUnauthorizedHandler(this),
-    )
+      query: ReleaseVersion,
+      variables: releaseVariables,
+    })
     if (releaseResult.appReleaseCreate.userErrors) {
       versionResult.appDeploy.userErrors = (versionResult.appDeploy.userErrors ?? []).concat(
         releaseResult.appReleaseCreate.userErrors.map(toUserError),
@@ -829,15 +787,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
     version: AppVersionIdentifiers
   }): Promise<AppReleaseSchema> {
     const releaseVariables = {appId, versionId}
-    const releaseResult = await appManagementRequestDoc(
+    const releaseResult = await this.appManagementRequest({
       organizationId,
-      ReleaseVersion,
-      await this.token(),
-      releaseVariables,
-      undefined,
-      undefined,
-      createUnauthorizedHandler(this),
-    )
+      query: ReleaseVersion,
+      variables: releaseVariables,
+    })
 
     if (releaseResult.appReleaseCreate.release) {
       return {
@@ -871,12 +825,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
   async storeByDomain(orgId: string, shopDomain: string): Promise<OrganizationStore | undefined> {
     const queryVariables: FetchDevStoreByDomainQueryVariables = {domain: shopDomain}
-    const storesResult = await businessPlatformOrganizationsRequestDoc(
-      FetchDevStoreByDomain,
-      await this.businessPlatformToken(),
-      orgId,
-      queryVariables,
-    )
+    const storesResult = await this.businessPlatformOrganizationsRequest({
+      query: FetchDevStoreByDomain,
+      organizationId: orgId,
+      variables: queryVariables,
+    })
 
     const organization = storesResult.organization
 
@@ -899,12 +852,13 @@ export class AppManagementClient implements DeveloperPlatformClient {
       input: {shopifyShopId: encodedShopId},
     }
 
-    const fullResult = await businessPlatformOrganizationsRequestDoc(
-      ProvisionShopAccess,
-      await this.businessPlatformToken(),
-      orgId,
+    const fullResult = await businessPlatformOrganizationsRequestDoc({
+      query: ProvisionShopAccess,
+      token: await this.businessPlatformToken(),
+      organizationId: orgId,
       variables,
-    )
+      unauthorizedHandler: this.createUnauthorizedHandler(),
+    })
     const provisionResult = fullResult.organizationUserProvisionShopAccess
     if (!provisionResult.success) {
       const errorMessages = provisionResult.userErrors?.map((error) => error.message).join(', ') ?? ''
@@ -942,7 +896,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       sharedSecret: input.shared_secret,
       topic: input.topic,
     }
-    const result = await webhooksRequest(organizationId, query, await this.token(), variables)
+    const result = await this.webhooksRequest({organizationId, query, variables})
     let sendSampleWebhook: SampleWebhook = {samplePayload: '{}', headers: '{}', success: false, userErrors: []}
     const cliTesting = result.cliTesting
     if (cliTesting) {
@@ -957,7 +911,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   }
 
   async apiVersions(organizationId: string): Promise<PublicApiVersionsSchema> {
-    const result = await webhooksRequest(organizationId, PublicApiVersions, await this.token(), {})
+    const result = await this.webhooksRequest({organizationId, query: PublicApiVersions, variables: {}})
     return {publicApiVersions: result.publicApiVersions.map((version) => version.handle)}
   }
 
@@ -967,7 +921,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   ): Promise<WebhookTopicsSchema> {
     const query = AvailableTopics
     const variables = {apiVersion}
-    const result = await webhooksRequest(organizationId, query, await this.token(), variables)
+    const result = await this.webhooksRequest({organizationId, query, variables})
 
     return {
       webhookTopics: result.availableTopics ?? [],
@@ -999,17 +953,15 @@ export class AppManagementClient implements DeveloperPlatformClient {
     try {
       const {app} = await this.activeAppVersionRawResult({apiKey, organizationId})
       const appIdNumber = String(numberFromGid(app.id))
-      const token = await this.token()
-      const result = await functionsRequestDoc<SchemaDefinitionByTargetQuery, SchemaDefinitionByTargetQueryVariables>(
+      const result = await this.functionsRequest({
         organizationId,
-        SchemaDefinitionByTarget,
-        token,
-        appIdNumber,
-        {
+        query: SchemaDefinitionByTarget,
+        appId: appIdNumber,
+        variables: {
           handle: input.handle,
           version: input.version,
         },
-      )
+      })
 
       return result?.target?.api?.schema?.definition ?? null
     } catch (error) {
@@ -1025,14 +977,12 @@ export class AppManagementClient implements DeveloperPlatformClient {
     try {
       const {app} = await this.activeAppVersionRawResult({apiKey, organizationId})
       const appIdNumber = String(numberFromGid(app.id))
-      const token = await this.token()
-      const result = await functionsRequestDoc<SchemaDefinitionByApiTypeQuery, SchemaDefinitionByApiTypeQueryVariables>(
+      const result = await this.functionsRequest({
         organizationId,
-        SchemaDefinitionByApiType,
-        token,
-        appIdNumber,
-        input,
-      )
+        query: SchemaDefinitionByApiType,
+        appId: appIdNumber,
+        variables: input,
+      })
 
       return result?.api?.schema?.definition ?? null
     } catch (error) {
@@ -1054,9 +1004,10 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
   async devSessionCreate({appId, assetsUrl, shopFqdn}: DevSessionCreateOptions): Promise<DevSessionCreateMutation> {
     const appIdNumber = String(numberFromGid(appId))
-    return appDevRequest(DevSessionCreate, shopFqdn, await this.token(), {
-      appId: appIdNumber,
-      assetsUrl: assetsUrl ?? '',
+    return this.appDevRequest({
+      query: DevSessionCreate,
+      shopFqdn,
+      variables: {appId: appIdNumber, assetsUrl: assetsUrl ?? ''},
     })
   }
 
@@ -1074,12 +1025,12 @@ export class AppManagementClient implements DeveloperPlatformClient {
       manifest: JSON.stringify(manifest),
       inheritedModuleUids,
     }
-    return appDevRequest(DevSessionUpdate, shopFqdn, await this.token(), variables)
+    return this.appDevRequest({query: DevSessionUpdate, shopFqdn, variables})
   }
 
   async devSessionDelete({appId, shopFqdn}: DevSessionDeleteOptions): Promise<DevSessionDeleteMutation> {
     const appIdNumber = String(numberFromGid(appId))
-    return appDevRequest(DevSessionDelete, shopFqdn, await this.token(), {appId: appIdNumber})
+    return this.appDevRequest({query: DevSessionDelete, shopFqdn, variables: {appId: appIdNumber}})
   }
 
   async getCreateDevStoreLink(org: Organization): Promise<string> {
@@ -1090,12 +1041,8 @@ export class AppManagementClient implements DeveloperPlatformClient {
     )
   }
 
-  private createUnauthorizedHandler(): UnauthorizedHandler {
-    return createUnauthorizedHandler(this)
-  }
-
   private async activeAppVersionRawResult({organizationId, apiKey}: AppApiKeyAndOrgId): Promise<ActiveAppReleaseQuery> {
-    return appManagementRequestDoc(organizationId, ActiveAppReleaseFromApiKey, await this.token(), {apiKey})
+    return this.appManagementRequest({organizationId, query: ActiveAppReleaseFromApiKey, variables: {apiKey}})
   }
 
   private async organizationBetaFlags(
@@ -1105,17 +1052,82 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const variables: OrganizationBetaFlagsQueryVariables = {
       organizationId: encodedGidFromOrganizationId(organizationId),
     }
-    const flagsResult = await businessPlatformOrganizationsRequest<OrganizationBetaFlagsQuerySchema>(
-      organizationBetaFlagsQuery(allBetaFlags),
-      await this.businessPlatformToken(),
+    const flagsResult = await businessPlatformOrganizationsRequest<OrganizationBetaFlagsQuerySchema>({
+      query: organizationBetaFlagsQuery(allBetaFlags),
+      token: await this.businessPlatformToken(),
       organizationId,
       variables,
-    )
+      unauthorizedHandler: this.createUnauthorizedHandler(),
+    })
     const result: {[flag: (typeof allBetaFlags)[number]]: boolean} = {}
     allBetaFlags.forEach((flag) => {
       result[flag] = Boolean(flagsResult.organization[`flag_${flag}`])
     })
     return result
+  }
+
+  private async appManagementRequest<TResult, TVariables extends Variables>(
+    options: Omit<AppManagementRequestOptions<TResult, TVariables>, 'unauthorizedHandler' | 'token'>,
+  ): Promise<TResult> {
+    return appManagementRequestDoc({
+      ...options,
+      token: await this.token(),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
+    })
+  }
+
+  private async appDevRequest<TResult, TVariables extends Variables>(
+    options: Omit<AppDevRequestOptions<TResult, TVariables>, 'unauthorizedHandler' | 'token'>,
+  ): Promise<TResult> {
+    return appDevRequestDoc({
+      ...options,
+      token: await this.token(),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
+    })
+  }
+
+  private async businessPlatformRequest<TResult, TVariables extends Variables>(
+    options: Omit<BusinessPlatformRequestOptions<TResult, TVariables>, 'unauthorizedHandler' | 'token'>,
+  ): Promise<TResult> {
+    return businessPlatformRequestDoc({
+      ...options,
+      token: await this.businessPlatformToken(),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
+    })
+  }
+
+  private async businessPlatformOrganizationsRequest<TResult, TVariables extends Variables>(
+    options: Omit<BusinessPlatformOrganizationsRequestOptions<TResult, TVariables>, 'unauthorizedHandler' | 'token'>,
+  ): Promise<TResult> {
+    return businessPlatformOrganizationsRequestDoc({
+      ...options,
+      token: await this.businessPlatformToken(),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
+    })
+  }
+
+  private async functionsRequest<TResult, TVariables extends Variables>(
+    options: Omit<FunctionsRequestOptions<TResult, TVariables>, 'unauthorizedHandler' | 'token'>,
+  ): Promise<TResult> {
+    return functionsRequestDoc<TResult, TVariables>({
+      ...options,
+      token: await this.token(),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
+    })
+  }
+
+  private async webhooksRequest<TResult, TVariables extends Variables>(
+    options: Omit<WebhooksRequestOptions<TResult, TVariables>, 'unauthorizedHandler' | 'token'>,
+  ): Promise<TResult> {
+    return webhooksRequestDoc<TResult, TVariables>({
+      ...options,
+      token: await this.token(),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
+    })
+  }
+
+  private createUnauthorizedHandler(): UnauthorizedHandler {
+    return createUnauthorizedHandler(this)
   }
 }
 

--- a/packages/cli-kit/src/public/node/api/admin.ts
+++ b/packages/cli-kit/src/public/node/api/admin.ts
@@ -80,7 +80,7 @@ export async function adminRequestDoc<TResult, TVariables extends Variables>(
   }
   let unauthorizedHandler: UnauthorizedHandler | undefined
   if ('refresh' in session) {
-    unauthorizedHandler = {type: 'simple', handler: session.refresh as () => Promise<void>}
+    unauthorizedHandler = {type: 'token_refresh', handler: session.refresh as () => Promise<{token: string}>}
   }
   const result = graphqlRequestDoc<TResult, TVariables>({
     ...opts,

--- a/packages/cli-kit/src/public/node/api/app-dev.test.ts
+++ b/packages/cli-kit/src/public/node/api/app-dev.test.ts
@@ -1,4 +1,4 @@
-import {appDevRequest} from './app-dev.js'
+import {appDevRequestDoc} from './app-dev.js'
 import {graphqlRequestDoc} from './graphql.js'
 import {serviceEnvironment, Environment} from '../../../private/node/context/service.js'
 import {test, vi, expect, describe} from 'vitest'
@@ -33,7 +33,16 @@ describe('appDevRequest', () => {
     const query = 'query' as unknown as TypedDocumentNode<object, {variables: string}>
 
     // When
-    await appDevRequest(query, shopFqdn, mockedToken, {variables: 'variables'})
+    await appDevRequestDoc({
+      query,
+      shopFqdn,
+      token: mockedToken,
+      variables: {variables: 'variables'},
+      unauthorizedHandler: {
+        type: 'token_refresh',
+        handler: vi.fn().mockResolvedValue({token: mockedToken}),
+      },
+    })
 
     // Then
     expect(graphqlRequestDoc).toHaveBeenLastCalledWith({
@@ -42,6 +51,10 @@ describe('appDevRequest', () => {
       url: 'https://test-shop.shop.dev/app_dev/unstable/graphql.json',
       token: mockedToken,
       variables: {variables: 'variables'},
+      unauthorizedHandler: {
+        type: 'token_refresh',
+        handler: expect.any(Function),
+      },
     })
   })
 
@@ -51,7 +64,16 @@ describe('appDevRequest', () => {
     const query = 'query' as unknown as TypedDocumentNode<object, {variables: string}>
 
     // When
-    await appDevRequest(query, shopFqdn, mockedToken, {variables: 'variables'})
+    await appDevRequestDoc({
+      query,
+      shopFqdn,
+      token: mockedToken,
+      variables: {variables: 'variables'},
+      unauthorizedHandler: {
+        type: 'token_refresh',
+        handler: vi.fn().mockResolvedValue({token: mockedToken}),
+      },
+    })
 
     // Then
     expect(graphqlRequestDoc).toHaveBeenLastCalledWith({
@@ -61,6 +83,10 @@ describe('appDevRequest', () => {
       token: mockedToken,
       addedHeaders: {'x-forwarded-host': shopFqdn},
       variables: {variables: 'variables'},
+      unauthorizedHandler: {
+        type: 'token_refresh',
+        handler: expect.any(Function),
+      },
     })
   })
 })

--- a/packages/cli-kit/src/public/node/api/app-management.test.ts
+++ b/packages/cli-kit/src/public/node/api/app-management.test.ts
@@ -27,13 +27,18 @@ describe('appManagementRequestDoc', () => {
 
     // When
     const query = 'query' as unknown as TypedDocumentNode<object, {variables: string}>
-    await appManagementRequestDoc(
-      orgId,
+    await appManagementRequestDoc({
+      organizationId: orgId,
       query,
-      mockedToken,
-      {variables: 'variables'},
-      {cacheTTL: {hours: 1}, cacheExtraKey: '1234'},
-    )
+      token: mockedToken,
+      variables: {variables: 'variables'},
+      requestOptions: {requestMode: 'slow-request'},
+      cacheOptions: {cacheTTL: {hours: 1}, cacheExtraKey: `1234`},
+      unauthorizedHandler: {
+        type: 'token_refresh',
+        handler: vi.fn().mockResolvedValue({token: mockedToken}),
+      },
+    })
 
     // Then
     expect(graphqlRequestDoc).toHaveBeenLastCalledWith({
@@ -44,6 +49,11 @@ describe('appManagementRequestDoc', () => {
       variables: {variables: 'variables'},
       responseOptions: {onResponse: handleDeprecations},
       cacheOptions: {cacheTTL: {hours: 1}, cacheExtraKey: `1234${orgId}`},
+      preferredBehaviour: 'slow-request',
+      unauthorizedHandler: {
+        type: 'token_refresh',
+        handler: expect.any(Function),
+      },
     })
   })
 })

--- a/packages/cli-kit/src/public/node/api/business-platform.ts
+++ b/packages/cli-kit/src/public/node/api/business-platform.ts
@@ -1,4 +1,4 @@
-import {CacheOptions, Exact, GraphQLVariables, graphqlRequest, graphqlRequestDoc} from './graphql.js'
+import {CacheOptions, GraphQLVariables, UnauthorizedHandler, graphqlRequest, graphqlRequestDoc} from './graphql.js'
 import {handleDeprecations} from './partners.js'
 import {businessPlatformFqdn} from '../context/fqdn.js'
 import {TypedDocumentNode} from '@graphql-typed-document-node/core'
@@ -45,25 +45,34 @@ export async function businessPlatformRequest<T>(
 }
 
 /**
- * Executes a GraphQL query against the Business Platform Destinations API. Uses typed documents.
- *
  * @param query - GraphQL query to execute.
  * @param token - Business Platform token.
  * @param variables - GraphQL variables to pass to the query.
  * @param cacheOptions - Cache options for the request. If not present, the request will not be cached.
+ */
+export interface BusinessPlatformRequestOptions<TResult, TVariables extends Variables> {
+  query: TypedDocumentNode<TResult, TVariables>
+  token: string
+  variables?: TVariables
+  cacheOptions?: CacheOptions
+  unauthorizedHandler: UnauthorizedHandler
+}
+
+/**
+ * Executes a GraphQL query against the Business Platform Destinations API. Uses typed documents.
+ *
+ * @param options - The options for the request.
  * @returns The response of the query of generic type <TResult>.
  */
 export async function businessPlatformRequestDoc<TResult, TVariables extends Variables>(
-  query: TypedDocumentNode<TResult, TVariables>,
-  token: string,
-  variables?: TVariables,
-  cacheOptions?: CacheOptions,
+  options: BusinessPlatformRequestOptions<TResult, TVariables>,
 ): Promise<TResult> {
   return graphqlRequestDoc<TResult, TVariables>({
-    ...(await setupRequest(token)),
-    query,
-    variables,
-    cacheOptions,
+    ...(await setupRequest(options.token)),
+    query: options.query,
+    variables: options.variables,
+    cacheOptions: options.cacheOptions,
+    unauthorizedHandler: options.unauthorizedHandler,
   })
 }
 
@@ -85,46 +94,49 @@ async function setupOrganizationsRequest(token: string, organizationId: string) 
   }
 }
 
+export interface BusinessPlatformOrganizationsRequestNonTypedOptions {
+  query: string
+  token: string
+  organizationId: string
+  unauthorizedHandler: UnauthorizedHandler
+  variables?: GraphQLVariables
+}
+
 /**
  * Executes a GraphQL query against the Business Platform Organizations API.
  *
- * @param query - GraphQL query to execute.
- * @param token - Business Platform token.
- * @param organizationId - Organization ID as a numeric (non-GID) value.
- * @param variables - GraphQL variables to pass to the query.
+ * @param options - The options for the request.
  * @returns The response of the query of generic type <T>.
  */
 export async function businessPlatformOrganizationsRequest<T>(
-  query: string,
-  token: string,
-  organizationId: string,
-  variables?: GraphQLVariables,
+  options: BusinessPlatformOrganizationsRequestNonTypedOptions,
 ): Promise<T> {
   return graphqlRequest<T>({
-    query,
-    ...(await setupOrganizationsRequest(token, organizationId)),
-    variables,
+    query: options.query,
+    ...(await setupOrganizationsRequest(options.token, options.organizationId)),
+    variables: options.variables,
+    unauthorizedHandler: options.unauthorizedHandler,
   })
+}
+
+export interface BusinessPlatformOrganizationsRequestOptions<TResult, TVariables extends Variables>
+  extends BusinessPlatformRequestOptions<TResult, TVariables> {
+  organizationId: string
 }
 
 /**
  * Executes a GraphQL query against the Business Platform Organizations API. Uses typed documents.
  *
- * @param query - GraphQL query to execute.
- * @param token - Business Platform token.
- * @param organizationId - Organization ID as a numeric value.
- * @param variables - GraphQL variables to pass to the query.
+ * @param options - The options for the request.
  * @returns The response of the query of generic type <T>.
  */
 export async function businessPlatformOrganizationsRequestDoc<TResult, TVariables extends Variables>(
-  query: TypedDocumentNode<TResult, TVariables> | TypedDocumentNode<TResult, Exact<{[key: string]: never}>>,
-  token: string,
-  organizationId: string,
-  variables?: TVariables,
+  options: BusinessPlatformOrganizationsRequestOptions<TResult, TVariables>,
 ): Promise<TResult> {
   return graphqlRequestDoc<TResult, TVariables>({
-    query,
-    ...(await setupOrganizationsRequest(token, organizationId)),
-    variables,
+    query: options.query,
+    ...(await setupOrganizationsRequest(options.token, options.organizationId)),
+    variables: options.variables,
+    unauthorizedHandler: options.unauthorizedHandler,
   })
 }

--- a/packages/cli-kit/src/public/node/api/functions.ts
+++ b/packages/cli-kit/src/public/node/api/functions.ts
@@ -1,4 +1,4 @@
-import {graphqlRequestDoc} from './graphql.js'
+import {graphqlRequestDoc, UnauthorizedHandler} from './graphql.js'
 import {handleDeprecations} from './app-management.js'
 import {appManagementFqdn} from '../context/fqdn.js'
 import {TypedDocumentNode} from '@graphql-typed-document-node/core'
@@ -35,27 +35,37 @@ async function setupRequest(orgId: string, token: string, appId: string) {
 }
 
 /**
- * Executes a rate-limited GraphQL request against the App Management Functions API.
- *
  * @param orgId - Organization identifier.
  * @param query - Typed GraphQL document node.
  * @param token - Authentication token.
  * @param appId - App identifier.
  * @param variables - Optional query variables.
+ * @param unauthorizedHandler - Optional handler for unauthorized requests.
+ */
+export interface FunctionsRequestOptions<TResult, TVariables extends Variables> {
+  organizationId: string
+  query: TypedDocumentNode<TResult, TVariables>
+  token: string
+  appId: string
+  unauthorizedHandler: UnauthorizedHandler
+  variables?: TVariables
+}
+
+/**
+ * Executes a rate-limited GraphQL request against the App Management Functions API.
+ *
+ * @param options - Request options.
  * @returns Promise resolving to the typed query result.
  */
 export async function functionsRequestDoc<TResult, TVariables extends Variables>(
-  orgId: string,
-  query: TypedDocumentNode<TResult, TVariables>,
-  token: string,
-  appId: string,
-  variables?: TVariables,
+  options: FunctionsRequestOptions<TResult, TVariables>,
 ): Promise<TResult> {
   const result = await limiter.schedule<TResult>(async () => {
     return graphqlRequestDoc<TResult, TVariables>({
-      ...(await setupRequest(orgId, token, appId)),
-      query,
-      variables,
+      ...(await setupRequest(options.organizationId, options.token, options.appId)),
+      query: options.query,
+      variables: options.variables,
+      unauthorizedHandler: options.unauthorizedHandler,
     })
   })
 

--- a/packages/cli-kit/src/public/node/api/webhooks.ts
+++ b/packages/cli-kit/src/public/node/api/webhooks.ts
@@ -1,4 +1,4 @@
-import {graphqlRequestDoc} from './graphql.js'
+import {graphqlRequestDoc, UnauthorizedHandler} from './graphql.js'
 import {appManagementFqdn} from '../context/fqdn.js'
 import Bottleneck from 'bottleneck'
 import {Variables} from 'graphql-request'
@@ -13,31 +13,37 @@ const limiter = new Bottleneck({
 })
 
 /**
+ * Options for making requests to the Webhooks API.
+ */
+export interface WebhooksRequestOptions<TResult, TVariables extends Variables> {
+  organizationId: string
+  query: TypedDocumentNode<TResult, TVariables>
+  token: string
+  unauthorizedHandler: UnauthorizedHandler
+  variables?: TVariables
+}
+
+/**
  * Executes an org-scoped GraphQL query against the App Management API.
  * Uses typed documents.
  *
- * @param organizationId - Organization ID required to check permissions.
- * @param query - GraphQL query to execute.
- * @param token - Partners token.
- * @param variables - GraphQL variables to pass to the query.
+ * @param options - The options for the request.
  * @returns The response of the query of generic type <T>.
  */
-export async function webhooksRequest<TResult, TVariables extends Variables>(
-  organizationId: string,
-  query: TypedDocumentNode<TResult, TVariables>,
-  token: string,
-  variables?: TVariables,
+export async function webhooksRequestDoc<TResult, TVariables extends Variables>(
+  options: WebhooksRequestOptions<TResult, TVariables>,
 ): Promise<TResult> {
   const api = 'Webhooks'
   const fqdn = await appManagementFqdn()
-  const url = `https://${fqdn}/webhooks/unstable/organizations/${organizationId}/graphql.json`
+  const url = `https://${fqdn}/webhooks/unstable/organizations/${options.organizationId}/graphql.json`
   const result = limiter.schedule<TResult>(() =>
     graphqlRequestDoc<TResult, TVariables>({
-      query,
+      query: options.query,
       api,
       url,
-      token,
-      variables,
+      token: options.token,
+      variables: options.variables,
+      unauthorizedHandler: options.unauthorizedHandler,
     }),
   )
 


### PR DESCRIPTION
### WHY are these changes introduced?

This PR refactors the API request functions to use a more consistent object parameter pattern instead of positional parameters.

### WHAT is this pull request doing?

Refactors API request functions across multiple client implementations to use a single object parameter pattern instead of multiple positional parameters. This change:

- Converts functions like `appManagementRequestDoc`, `businessPlatformRequest`, and others to accept a single options object
- Adds proper TypeScript interfaces for these request options
- Centralizes the creation of unauthorized handlers
- Makes parameter passing more explicit and less error-prone
- Improves code readability by making it clear which parameters are being passed

### How to test your changes?

Just use the CLI, no behavior change in this PR.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes