### PR TITLE
Simplify and remove duplicated unauthorized handler

### DIFF
--- a/packages/cli-kit/src/private/node/api.test.ts
+++ b/packages/cli-kit/src/private/node/api.test.ts
@@ -68,7 +68,6 @@ describe('retryAwareRequest', () => {
         maxRetryTimeMs: 10000,
       },
       undefined,
-      undefined,
       {
         defaultDelayMs: 500,
         scheduleDelay: mockScheduleDelayFn,
@@ -118,7 +117,6 @@ describe('retryAwareRequest', () => {
         maxRetryTimeMs: 10000,
       },
       undefined,
-      undefined,
       {
         limitRetriesTo: 7,
         scheduleDelay: mockScheduleDelayFn,
@@ -129,58 +127,6 @@ describe('retryAwareRequest', () => {
 
     expect(mockRequestFn).toHaveBeenCalledTimes(8)
     expect(mockScheduleDelayFn).toHaveBeenCalledTimes(7)
-  })
-
-  test('calls unauthorizedHandler when receiving 401', async () => {
-    const unauthorizedResponse = {
-      status: 401,
-      errors: [
-        {
-          extensions: {
-            code: '401',
-          },
-        } as any,
-      ],
-      headers: new Headers(),
-    }
-
-    const mockRequestFn = vi
-      .fn()
-      .mockImplementationOnce(() => {
-        throw new ClientError(unauthorizedResponse, {query: ''})
-      })
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-          data: {hello: 'world!'},
-          headers: new Headers(),
-        })
-      })
-
-    const mockUnauthorizedHandler = vi.fn()
-    const result = retryAwareRequest(
-      {
-        request: mockRequestFn,
-        url: 'https://example.com',
-        useNetworkLevelRetry: true,
-        maxRetryTimeMs: 10000,
-      },
-      undefined,
-      mockUnauthorizedHandler,
-      {
-        scheduleDelay: vi.fn((fn) => fn()),
-      },
-    )
-    await vi.runAllTimersAsync()
-
-    await expect(result).resolves.toEqual({
-      headers: expect.anything(),
-      status: 200,
-      data: {hello: 'world!'},
-    })
-
-    expect(mockRequestFn).toHaveBeenCalledTimes(2)
-    expect(mockUnauthorizedHandler).toHaveBeenCalledTimes(1)
   })
 
   test('fails on network issue if retries are disabled', async () => {
@@ -225,7 +171,6 @@ describe('retryAwareRequest', () => {
         maxRetryTimeMs: 10000,
       },
       undefined,
-      undefined,
       {
         defaultDelayMs: 500,
         scheduleDelay: mockScheduleDelayFn,
@@ -244,7 +189,6 @@ describe('retryAwareRequest', () => {
         url: 'https://example.com',
         useNetworkLevelRetry: false,
       },
-      undefined,
       undefined,
       {
         defaultDelayMs: 500,

--- a/packages/cli-kit/src/private/node/api.ts
+++ b/packages/cli-kit/src/private/node/api.ts
@@ -277,7 +277,6 @@ ${result.sanitizedHeaders}
 export async function retryAwareRequest<T extends {headers: Headers; status: number}>(
   requestOptions: RequestOptions<T>,
   errorHandler?: (error: unknown, requestId: string | undefined) => unknown,
-  unauthorizedHandler?: () => Promise<void>,
   retryOptions: {
     limitRetriesTo?: number
     defaultDelayMs?: number
@@ -315,12 +314,7 @@ ${result.sanitizedHeaders}
         throw result.error
       }
     } else if (result.status === 'unauthorized') {
-      if (unauthorizedHandler) {
-        // eslint-disable-next-line no-await-in-loop
-        await unauthorizedHandler()
-      } else {
-        throw result.clientError
-      }
+      throw result.clientError
     }
 
     if (limitRetriesTo <= retriesUsed) {

--- a/packages/cli-kit/src/public/node/api/graphql.ts
+++ b/packages/cli-kit/src/public/node/api/graphql.ts
@@ -46,17 +46,10 @@ interface RefreshedTokenOnAuthorizedResponse {
 
 export type RefreshTokenOnAuthorizedResponse = Promise<RefreshedTokenOnAuthorizedResponse>
 
-interface SimpleUnauthorizedHandler {
-  type: 'simple'
-  handler: () => Promise<void>
-}
-
-interface TokenRefreshHandler {
+export interface UnauthorizedHandler {
   type: 'token_refresh'
   handler: () => RefreshTokenOnAuthorizedResponse
 }
-
-export type UnauthorizedHandler = SimpleUnauthorizedHandler | TokenRefreshHandler
 
 interface GraphQLRequestBaseOptions<TResult> {
   api: string
@@ -149,8 +142,7 @@ async function performGraphQLRequest<TResult>(options: PerformGraphQLRequestOpti
     }
   }
 
-  const simpleUnauthorizedHandler = unauthorizedHandler?.type === 'simple' ? unauthorizedHandler.handler : undefined
-  const tokenRefreshHandler = unauthorizedHandler?.type === 'token_refresh' ? unauthorizedHandler.handler : undefined
+  const tokenRefreshHandler = unauthorizedHandler?.handler
 
   const tokenRefreshUnauthorizedHandlerFunction = tokenRefreshHandler
     ? async () => {
@@ -174,7 +166,6 @@ async function performGraphQLRequest<TResult>(options: PerformGraphQLRequestOpti
     retryAwareRequest(
       {request: rawGraphQLRequest, url, ...requestBehaviour},
       responseOptions?.handleErrors === false ? undefined : errorHandler(api),
-      simpleUnauthorizedHandler,
     )
 
   const executeWithTimer = () =>

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
@@ -33,6 +33,7 @@ export async function initializeDevServerSession(
     outputDebug('Refreshing theme session...')
     const newSession = await fetchDevServerSession(themeId, adminSession, adminPassword, storefrontPassword)
     Object.assign(session, newSession)
+    return newSession
   }
 
   setInterval(() => {

--- a/packages/theme/src/cli/utilities/theme-environment/types.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/types.ts
@@ -41,7 +41,7 @@ export interface DevServerSession extends AdminSession {
    * Refreshes the current session, ensuring any tokens and session cookies
    * are up-to-date.
    */
-  refresh?: () => Promise<void>
+  refresh?: () => Promise<AdminSession>
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

This PR simplifies the API error handling by removing the simple unauthorized handler option, which was redundant with the token refresh handler.

### WHAT is this pull request doing?

- Removes the `unauthorizedHandler` parameter from `retryAwareRequest` function
- Simplifies the `UnauthorizedHandler` interface to only include the token refresh type
- Updates the `refresh` function in `DevServerSession` to return the new session data
- Removes conditional handling for simple unauthorized handlers in favor of throwing the error directly

### How to test your changes?

Everything should work the same

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes