### PR TITLE
Fix unexpected error when inferring package manager 

### DIFF
--- a/packages/cli-kit/src/public/node/is-global.ts
+++ b/packages/cli-kit/src/public/node/is-global.ts
@@ -6,7 +6,7 @@ import {renderSelectPrompt} from './ui.js'
 import {globalCLIVersion} from './version.js'
 import {isUnitTest} from './context/local.js'
 import {execaSync} from 'execa'
-
+import which from 'which'
 let _isGlobal: boolean | undefined
 
 /**
@@ -22,6 +22,12 @@ export function currentProcessIsGlobal(argv = process.argv): boolean {
 
     // Path where the current project is (app/hydrogen)
     const path = sniffForPath() ?? cwd()
+
+    // Check if npm exists before trying to use it
+    const npmPath = which.sync('npm', { nothrow: true })
+    if (!npmPath) {
+      return false
+    }
 
     // Closest parent directory to contain a package.json file or node_modules directory
     // https://docs.npmjs.com/cli/v8/commands/npm-prefix#description


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When I initialize an app, I receive an unexpected io error.
I run NixOS version 25.05, shopify-cli version [3.69.3](https://github.com/NixOS/nixpkgs/blob/063f43f2dbdef86376cc29ad646c45c46e93234c/pkgs/by-name/sh/shopify-cli/package.nix#L8).
I ran `nix-shell -p shopify-cli`, then run `shopify app init` to then receive this:
```
╭─ error ──────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                  │
│  Command failed with ENOENT: npm prefix                                                          │
│  spawnSync npm ENOENT                                                                            │
│                                                                                                  │
│  To investigate the issue, examine this stack trace:                                             │
│    at spawnSync (node:internal/child_process:1120)                                               │
│    at spawnSync (node:child_process:868)                                                         │
│    at execaSync (nix/store/rzmyp344b58d4zi9scwgji4cq3rhm29g-shopify-3.69.3/lib/node_modules/sho  │
│    pify/node_modules/@shopify/cli/dist/chunk-B6RI3XO4.js:25170)                                  │
│    at currentProcessIsGlobal (nix/store/rzmyp344b58d4zi9scwgji4cq3rhm29g-shopify-3.69.3/lib/nod  │
│    e_modules/shopify/node_modules/@shopify/cli/dist/chunk-B6RI3XO4.js:25542)                     │
│    at inferPackageManagerForGlobalCLI (nix/store/rzmyp344b58d4zi9scwgji4cq3rhm29g-shopify-3.69.  │
│    3/lib/node_modules/shopify/node_modules/@shopify/cli/dist/chunk-B6RI3XO4.js:25566)            │
│    at inferPackageManager (nix/store/rzmyp344b58d4zi9scwgji4cq3rhm29g-shopify-3.69.3/lib/node_m  │
│    odules/shopify/node_modules/@shopify/cli/dist/chunk-7D77RINN.js:13898)                        │
│    at run (nix/store/rzmyp344b58d4zi9scwgji4cq3rhm29g-shopify-3.69.3/lib/node_modules/shopify/n  │
│    ode_modules/@shopify/cli/dist/index.js:172883)                                                │
│    at _run (nix/store/rzmyp344b58d4zi9scwgji4cq3rhm29g-shopify-3.69.3/lib/node_modules/shopify/  │
│    node_modules/@shopify/cli/dist/chunk-27ILOE3X.js:156263)                                      │
│    at runCommand (nix/store/rzmyp344b58d4zi9scwgji4cq3rhm29g-shopify-3.69.3/lib/node_modules/sh  │
│    opify/node_modules/@shopify/cli/dist/chunk-27ILOE3X.js:155083)                                │
│    at run (nix/store/rzmyp344b58d4zi9scwgji4cq3rhm29g-shopify-3.69.3/lib/node_modules/shopify/n  │
│    ode_modules/@shopify/cli/dist/chunk-27ILOE3X.js:156339)                                       │
│                                                                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Adds a check for the npm command before running it.
If it is not found then it will signify to the caller that the environment is not global as npm cannot even be used to check for it.
It may be preferred for the caller logic to simply evaluate the false return value and then assume the package manager to be unknown. Then later in the logic, an error specifically for the acknowledgement of an unknown package manager will be shown to the user. This is much easier to understand rather than the IO error shown previously. 

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Boot a NixOS environment without npm installed.
Initiate a nix shell with the shopify-cli package and attempt to create an app.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
