### PR TITLE
Add LoadingBar UI component

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/LoadingBar.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/LoadingBar.test.tsx
@@ -1,0 +1,207 @@
+import {LoadingBar} from './LoadingBar.js'
+import {render} from '../../testing/ui.js'
+import {shouldDisplayColors, unstyled} from '../../../../public/node/output.js'
+import useLayout from '../hooks/use-layout.js'
+import React from 'react'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('../hooks/use-layout.js')
+vi.mock('../../../../public/node/output.js', async () => {
+  const original: any = await vi.importActual('../../../../public/node/output.js')
+  return {
+    ...original,
+    shouldDisplayColors: vi.fn(),
+  }
+})
+
+beforeEach(() => {
+  // Default terminal width
+  vi.mocked(useLayout).mockReturnValue({
+    twoThirds: 53,
+    oneThird: 27,
+    fullWidth: 80,
+  })
+  vi.mocked(shouldDisplayColors).mockReturnValue(true)
+})
+
+describe('LoadingBar', () => {
+  test('renders loading bar with default colored characters', async () => {
+    // Given
+    const title = 'Loading content'
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+      Loading content ..."
+    `)
+  })
+
+  test('renders loading bar with hill pattern when noColor prop is true', async () => {
+    // Given
+    const title = 'Processing files'
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} noColor />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅
+      Processing files ..."
+    `)
+  })
+
+  test('renders loading bar with hill pattern when shouldDisplayColors returns false', async () => {
+    // Given
+    vi.mocked(shouldDisplayColors).mockReturnValue(false)
+    const title = 'Downloading packages'
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅
+      Downloading packages ..."
+    `)
+  })
+
+  test('handles narrow terminal width correctly', async () => {
+    // Given
+    vi.mocked(useLayout).mockReturnValue({
+      twoThirds: 20,
+      oneThird: 10,
+      fullWidth: 30,
+    })
+    const title = 'Building app'
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+      Building app ..."
+    `)
+  })
+
+  test('handles narrow terminal width correctly in no-color mode', async () => {
+    // Given
+    vi.mocked(useLayout).mockReturnValue({
+      twoThirds: 15,
+      oneThird: 8,
+      fullWidth: 23,
+    })
+    const title = 'Installing'
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} noColor />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇
+      Installing ..."
+    `)
+  })
+
+  test('handles very narrow terminal width in no-color mode', async () => {
+    // Given
+    vi.mocked(useLayout).mockReturnValue({
+      twoThirds: 5,
+      oneThird: 3,
+      fullWidth: 8,
+    })
+    const title = 'Wait'
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} noColor />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▁▁▁▂▂
+      Wait ..."
+    `)
+  })
+
+  test('handles wide terminal width correctly', async () => {
+    // Given
+    vi.mocked(useLayout).mockReturnValue({
+      twoThirds: 100,
+      oneThird: 50,
+      fullWidth: 150,
+    })
+    const title = 'Synchronizing data'
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+      Synchronizing data ..."
+    `)
+  })
+
+  test('handles wide terminal width correctly in no-color mode with pattern repetition', async () => {
+    // Given
+    vi.mocked(useLayout).mockReturnValue({
+      twoThirds: 90,
+      oneThird: 45,
+      fullWidth: 135,
+    })
+    const title = 'Analyzing dependencies'
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} noColor />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁
+      Analyzing dependencies ..."
+    `)
+  })
+
+  test('renders correctly with empty title', async () => {
+    // Given
+    const title = ''
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+       ..."
+    `)
+  })
+
+  test('noColor prop overrides shouldDisplayColors when both would show colors', async () => {
+    // Given
+    vi.mocked(shouldDisplayColors).mockReturnValue(true)
+    const title = 'Testing override'
+
+    // When
+    const {lastFrame} = render(<LoadingBar title={title} noColor />)
+
+    // Then
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅
+      Testing override ..."
+    `)
+  })
+
+  test('renders consistently with same props', async () => {
+    // Given
+    const title = 'Consistent test'
+    const props = {title, noColor: false}
+
+    // When
+    const {lastFrame: frame1} = render(<LoadingBar {...props} />)
+    const {lastFrame: frame2} = render(<LoadingBar {...props} />)
+
+    // Then
+    expect(frame1()).toBe(frame2())
+  })
+})

--- a/packages/cli-kit/src/private/node/ui/components/LoadingBar.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/LoadingBar.tsx
@@ -1,0 +1,30 @@
+import {TextAnimation} from './TextAnimation.js'
+import useLayout from '../hooks/use-layout.js'
+import {shouldDisplayColors} from '../../../../public/node/output.js'
+import React from 'react'
+import {Box, Text} from 'ink'
+
+const loadingBarChar = '▀'
+const hillString = '▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁'
+
+interface LoadingBarProps {
+  title: string
+  noColor?: boolean
+}
+
+const LoadingBar = ({title, noColor}: React.PropsWithChildren<LoadingBarProps>) => {
+  const {twoThirds} = useLayout()
+  let loadingBar = new Array(twoThirds).fill(loadingBarChar).join('')
+  if (noColor ?? !shouldDisplayColors()) {
+    loadingBar = hillString.repeat(Math.ceil(twoThirds / hillString.length))
+  }
+
+  return (
+    <Box flexDirection="column">
+      <TextAnimation text={loadingBar} maxWidth={twoThirds} />
+      <Text>{title} ...</Text>
+    </Box>
+  )
+}
+
+export {LoadingBar}

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.test.tsx
@@ -26,81 +26,6 @@ beforeEach(() => {
 })
 
 describe('Tasks', () => {
-  test('shows a loading state at the start', async () => {
-    // Given
-    const firstTaskFunction = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 2000))
-    })
-
-    const firstTask = {
-      title: 'task 1',
-      task: firstTaskFunction,
-    }
-
-    // When
-    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} />)
-    await taskHasRendered()
-
-    // Then
-    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-      task 1 ..."
-    `)
-    expect(firstTaskFunction).toHaveBeenCalled()
-  })
-
-  test('shows a loading state that is useful in no-color mode', async () => {
-    // Given
-    const firstTaskFunction = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 2000))
-    })
-
-    const firstTask = {
-      title: 'task 1',
-      task: firstTaskFunction,
-    }
-
-    // When
-    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} noColor />)
-
-    // Then
-    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆
-      task 1 ..."
-    `)
-    expect(firstTaskFunction).toHaveBeenCalled()
-  })
-
-  test('truncates the no-color display correctly for narrow screens', async () => {
-    // Given
-    vi.mocked(useStdout).mockReturnValue({
-      stdout: new Stdout({
-        columns: 10,
-        rows: 80,
-      }) as any,
-      write: () => {},
-    })
-
-    const firstTaskFunction = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 2000))
-    })
-
-    const firstTask = {
-      title: 'task 1',
-      task: firstTaskFunction,
-    }
-
-    // When
-    const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} noColor />)
-
-    // Then
-    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▁▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆
-      task 1 ..."
-    `)
-    expect(firstTaskFunction).toHaveBeenCalled()
-  })
-
   test('shows nothing at the end in case of success', async () => {
     // Given
     const firstTaskFunction = vi.fn(async () => {})
@@ -154,8 +79,10 @@ describe('Tasks', () => {
   test('it supports subtasks', async () => {
     // Given
     const firstSubtaskFunction = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 2000))
+      await new Promise((resolve) => setTimeout(resolve, 100))
     })
+
+    const secondSubtaskFunction = vi.fn(async () => {})
 
     const firstTask = {
       title: 'task 1',
@@ -167,7 +94,7 @@ describe('Tasks', () => {
           },
           {
             title: 'subtask 2',
-            task: async () => {},
+            task: secondSubtaskFunction,
           },
         ]
       },
@@ -180,22 +107,21 @@ describe('Tasks', () => {
 
     // When
     const renderInstance = render(<Tasks tasks={[firstTask, secondTask]} silent={false} />)
-
-    await taskHasRendered()
+    await renderInstance.waitUntilExit()
 
     // Then
-    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-      subtask 1 ..."
-    `)
-
     expect(firstSubtaskFunction).toHaveBeenCalled()
+    expect(secondSubtaskFunction).toHaveBeenCalled()
   })
 
   test('supports skipping', async () => {
     // Given
     const firstTaskFunction = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 2000))
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    const secondTaskFunction = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
     })
 
     const firstTask = {
@@ -206,32 +132,26 @@ describe('Tasks', () => {
 
     const secondTask = {
       title: 'task 2',
-      task: async () => {
-        await new Promise((resolve) => setTimeout(resolve, 2000))
-      },
+      task: secondTaskFunction,
     }
 
     // When
     const renderInstance = render(<Tasks tasks={[firstTask, secondTask]} silent={false} />)
-
-    await taskHasRendered()
+    await renderInstance.waitUntilExit()
 
     // Then
-    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-      task 2 ..."
-    `)
     expect(firstTaskFunction).toHaveBeenCalledTimes(0)
+    expect(secondTaskFunction).toHaveBeenCalled()
   })
 
   test('supports skipping a subtask', async () => {
     // Given
     const firstSubTaskFunction = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 2000))
+      await new Promise((resolve) => setTimeout(resolve, 100))
     })
 
     const secondSubTaskFunction = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 2000))
+      await new Promise((resolve) => setTimeout(resolve, 100))
     })
 
     const firstTask = {
@@ -253,15 +173,9 @@ describe('Tasks', () => {
 
     // When
     const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} />)
-
-    await taskHasRendered()
+    await renderInstance.waitUntilExit()
 
     // Then
-    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-      subtask 2 ..."
-    `)
-
     expect(firstSubTaskFunction).toHaveBeenCalledTimes(0)
     expect(secondSubTaskFunction).toHaveBeenCalled()
   })
@@ -272,8 +186,6 @@ describe('Tasks', () => {
       if (task.retryCount < task.retry) {
         throw new Error(`something went wrong${task.retryCount}`)
       }
-
-      await new Promise((resolve) => setTimeout(resolve, 2000))
     })
 
     const firstTask: Task = {
@@ -284,14 +196,9 @@ describe('Tasks', () => {
 
     // When
     const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} />)
-
-    await taskHasRendered()
+    await renderInstance.waitUntilExit()
 
     // Then
-    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-      task 1 ..."
-    `)
     expect(firstTask.retryCount).toBe(3)
     expect(firstTask.errors).toEqual([
       Error('something went wrong0'),
@@ -306,8 +213,6 @@ describe('Tasks', () => {
       if (task.retryCount <= task.retry) {
         throw new Error(`something went wrong${task.retryCount}`)
       }
-
-      await new Promise((resolve) => setTimeout(resolve, 2000))
     })
 
     const secondTaskFunction = vi.fn(async () => {})
@@ -326,10 +231,8 @@ describe('Tasks', () => {
     // When
     const renderInstance = render(<Tasks tasks={[firstTask, secondTask]} silent={false} />)
 
-    await taskHasRendered()
-
     // Then
-    expect(unstyled(getLastFrameAfterUnmount(renderInstance)!)).toMatchInlineSnapshot('""')
+    await expect(renderInstance.waitUntilExit()).rejects.toThrow('something went wrong3')
     expect(firstTask.retryCount).toBe(3)
     expect(firstTask.errors).toEqual([
       Error('something went wrong0'),
@@ -345,8 +248,6 @@ describe('Tasks', () => {
       if (task.retryCount < task.retry) {
         throw new Error(`something went wrong${task.retryCount}`)
       }
-
-      await new Promise((resolve) => setTimeout(resolve, 2000))
     })
 
     const firstSubTask: Task = {
@@ -364,14 +265,9 @@ describe('Tasks', () => {
 
     // When
     const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} />)
-
-    await taskHasRendered()
+    await renderInstance.waitUntilExit()
 
     // Then
-    expect(unstyled(renderInstance.lastFrame()!)).toMatchInlineSnapshot(`
-      "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-      subtask 1 ..."
-    `)
     expect(firstSubTask.retryCount).toBe(3)
     expect(firstSubTask.errors).toEqual([
       Error('something went wrong0'),
@@ -386,8 +282,6 @@ describe('Tasks', () => {
       if (task.retryCount <= task.retry) {
         throw new Error(`something went wrong${task.retryCount}`)
       }
-
-      await new Promise((resolve) => setTimeout(resolve, 2000))
     })
 
     const secondSubTaskFunction = vi.fn(async () => {})
@@ -413,10 +307,8 @@ describe('Tasks', () => {
     // When
     const renderInstance = render(<Tasks tasks={[firstTask]} silent={false} />)
 
-    await taskHasRendered()
-
     // Then
-    expect(unstyled(getLastFrameAfterUnmount(renderInstance)!)).toMatchInlineSnapshot('""')
+    await expect(renderInstance.waitUntilExit()).rejects.toThrow('something went wrong3')
     expect(firstSubTask.retryCount).toBe(3)
     expect(firstSubTask.errors).toEqual([
       Error('something went wrong0'),

--- a/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
@@ -1,16 +1,11 @@
-import {TextAnimation} from './TextAnimation.js'
-import useLayout from '../hooks/use-layout.js'
+import {LoadingBar} from './LoadingBar.js'
 import useAsyncAndUnmount from '../hooks/use-async-and-unmount.js'
 import {isUnitTest} from '../../../../public/node/context/local.js'
 import {AbortSignal} from '../../../../public/node/abort.js'
-import {shouldDisplayColors} from '../../../../public/node/output.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
 import {handleCtrlC} from '../../ui.js'
-import {Box, Text, useStdin, useInput} from 'ink'
+import {useStdin, useInput} from 'ink'
 import React, {useRef, useState} from 'react'
-
-const loadingBarChar = '▀'
-const hillString = '▁▁▂▂▃▃▄▄▅▅▆▆▇▇██▇▇▆▆▅▅▄▄▃▃▂▂▁▁'
 
 export interface Task<TContext = unknown> {
   title: string
@@ -70,11 +65,6 @@ function Tasks<TContext>({
   abortSignal,
   noColor,
 }: React.PropsWithChildren<TasksProps<TContext>>) {
-  const {twoThirds} = useLayout()
-  let loadingBar = new Array(twoThirds).fill(loadingBarChar).join('')
-  if (noColor ?? !shouldDisplayColors()) {
-    loadingBar = hillString.repeat(Math.ceil(twoThirds / hillString.length))
-  }
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const [currentTask, setCurrentTask] = useState<Task<TContext>>(tasks[0]!)
   const [state, setState] = useState<TasksState>(TasksState.Loading)
@@ -126,12 +116,7 @@ function Tasks<TContext>({
     return null
   }
 
-  return state === TasksState.Loading && !isAborted ? (
-    <Box flexDirection="column">
-      <TextAnimation text={loadingBar} maxWidth={twoThirds} />
-      <Text>{currentTask.title} ...</Text>
-    </Box>
-  ) : null
+  return state === TasksState.Loading && !isAborted ? <LoadingBar title={currentTask.title} noColor={noColor} /> : null
 }
 
 export {Tasks}


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the loading/rainbow bar component in the CLI by extracting it into a reusable component that can be used across different parts of the application.

### WHAT is this pull request doing?

- Creates a new `LoadingBar` component that can be used to display loading states
- Extracts loading bar functionality from the `Tasks` component into this new reusable component
- Adds comprehensive tests for the `LoadingBar` component to ensure it works correctly in different scenarios:
  - With and without colors
  - With different terminal widths
  - With different titles
- Updates the `Tasks` component to use the new `LoadingBar` component
- Refactors some of the `Tasks` tests to be more reliable and less dependent on timing

### How to test your changes?

1. Run any CLI command that shows a loading state (e.g., `deploy`)
2. Verify that the loading bar appears correctly
3. Test with `NO_COLOR=1` environment variable to ensure the loading bar displays correctly in no-color mode
4. Test in terminals with different widths to ensure the loading bar adapts properly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes