### PR TITLE
Add useExitOnCtrlC hook

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Tasks.tsx
@@ -3,8 +3,7 @@ import useAsyncAndUnmount from '../hooks/use-async-and-unmount.js'
 import {isUnitTest} from '../../../../public/node/context/local.js'
 import {AbortSignal} from '../../../../public/node/abort.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
-import {handleCtrlC} from '../../ui.js'
-import {useStdin, useInput} from 'ink'
+import {useExitOnCtrlC} from '../hooks/use-exit-on-ctrl-c.js'
 import React, {useRef, useState} from 'react'
 
 export interface Task<TContext = unknown> {
@@ -69,7 +68,6 @@ function Tasks<TContext>({
   const [currentTask, setCurrentTask] = useState<Task<TContext>>(tasks[0]!)
   const [state, setState] = useState<TasksState>(TasksState.Loading)
   const ctx = useRef<TContext>({} as TContext)
-  const {isRawModeSupported} = useStdin()
 
   const runTasks = async () => {
     for (const task of tasks) {
@@ -99,16 +97,7 @@ function Tasks<TContext>({
     },
   })
 
-  useInput(
-    (input, key) => {
-      handleCtrlC(input, key)
-
-      if (key.return) {
-        return null
-      }
-    },
-    {isActive: Boolean(isRawModeSupported)},
-  )
+  useExitOnCtrlC()
 
   const {isAborted} = useAbortSignal(abortSignal)
 

--- a/packages/cli-kit/src/private/node/ui/hooks/use-exit-on-ctrl-c.test.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-exit-on-ctrl-c.test.ts
@@ -1,0 +1,126 @@
+import {useExitOnCtrlC} from './use-exit-on-ctrl-c.js'
+import {handleCtrlC} from '../../ui.js'
+import {describe, expect, test, vi} from 'vitest'
+import {useInput, useStdin} from 'ink'
+
+vi.mock('ink', () => ({
+  useInput: vi.fn(),
+  useStdin: vi.fn(),
+}))
+
+vi.mock('../../ui.js', () => ({
+  handleCtrlC: vi.fn(),
+}))
+
+// Helper function to render the hook without JSX
+function renderHook(hookFn: () => void) {
+  hookFn()
+}
+
+describe('useExitOnCtrlC', () => {
+  test('registers input handler when raw mode is supported', () => {
+    // Given
+    vi.mocked(useStdin).mockReturnValue({
+      isRawModeSupported: true,
+    } as any)
+    vi.mocked(useInput).mockImplementation(() => {})
+
+    // When
+    renderHook(() => useExitOnCtrlC())
+
+    // Then
+    expect(useInput).toHaveBeenCalledWith(expect.any(Function), {isActive: true})
+  })
+
+  test('does not register input handler when raw mode is not supported', () => {
+    // Given
+    vi.mocked(useStdin).mockReturnValue({
+      isRawModeSupported: false,
+    } as any)
+    vi.mocked(useInput).mockImplementation(() => {})
+
+    // When
+    renderHook(() => useExitOnCtrlC())
+
+    // Then
+    expect(useInput).toHaveBeenCalledWith(expect.any(Function), {isActive: false})
+  })
+
+  test('does not register input handler when raw mode support is undefined', () => {
+    // Given
+    vi.mocked(useStdin).mockReturnValue({
+      isRawModeSupported: undefined,
+    } as any)
+    vi.mocked(useInput).mockImplementation(() => {})
+
+    // When
+    renderHook(() => useExitOnCtrlC())
+
+    // Then
+    expect(useInput).toHaveBeenCalledWith(expect.any(Function), {isActive: false})
+  })
+
+  test('calls handleCtrlC when input is received', () => {
+    // Given
+    vi.mocked(useStdin).mockReturnValue({
+      isRawModeSupported: true,
+    } as any)
+
+    let inputHandler: ((input: string, key: any) => void) | undefined
+    vi.mocked(useInput).mockImplementation((handler) => {
+      inputHandler = handler
+    })
+
+    // When
+    renderHook(() => useExitOnCtrlC())
+
+    // Simulate ctrl+c input
+    const mockKey = {ctrl: true}
+    inputHandler?.('c', mockKey)
+
+    // Then
+    expect(handleCtrlC).toHaveBeenCalledWith('c', mockKey)
+  })
+
+  test('calls handleCtrlC with different input', () => {
+    // Given
+    vi.mocked(useStdin).mockReturnValue({
+      isRawModeSupported: true,
+    } as any)
+
+    let inputHandler: ((input: string, key: any) => void) | undefined
+    vi.mocked(useInput).mockImplementation((handler) => {
+      inputHandler = handler
+    })
+
+    // When
+    renderHook(() => useExitOnCtrlC())
+
+    // Simulate different input
+    const mockKey = {ctrl: false}
+    inputHandler?.('a', mockKey)
+
+    // Then
+    expect(handleCtrlC).toHaveBeenCalledWith('a', mockKey)
+  })
+
+  test('input handler is only active when raw mode is supported', () => {
+    // Test with raw mode supported
+    vi.mocked(useStdin).mockReturnValue({
+      isRawModeSupported: true,
+    } as any)
+
+    renderHook(() => useExitOnCtrlC())
+
+    expect(useInput).toHaveBeenLastCalledWith(expect.any(Function), {isActive: true})
+
+    // Test with raw mode not supported
+    vi.mocked(useStdin).mockReturnValue({
+      isRawModeSupported: false,
+    } as any)
+
+    renderHook(() => useExitOnCtrlC())
+
+    expect(useInput).toHaveBeenLastCalledWith(expect.any(Function), {isActive: false})
+  })
+})

--- a/packages/cli-kit/src/private/node/ui/hooks/use-exit-on-ctrl-c.ts
+++ b/packages/cli-kit/src/private/node/ui/hooks/use-exit-on-ctrl-c.ts
@@ -1,0 +1,18 @@
+import {handleCtrlC} from '../../ui.js'
+import {useInput, useStdin} from 'ink'
+
+/**
+ * This hook will cause the process to exit when the user presses Ctrl+C.
+ */
+export function useExitOnCtrlC() {
+  const {isRawModeSupported} = useStdin()
+  useInput(
+    (input, key) => {
+      handleCtrlC(input, key)
+      if (key.return) {
+        return null
+      }
+    },
+    {isActive: Boolean(isRawModeSupported)},
+  )
+}


### PR DESCRIPTION
### WHY are these changes introduced?

To improve code organization and maintainability by extracting the Ctrl+C handling logic into a reusable hook.

### WHAT is this pull request doing?

Creates a new `useExitOnCtrlC` hook that encapsulates the logic for handling Ctrl+C keyboard input to exit the process. This hook:

- Extracts the Ctrl+C handling logic from the Tasks component
- Provides a reusable implementation that can be used across different components
- Includes comprehensive test coverage for the new hook

The Tasks component has been updated to use this new hook, simplifying its implementation.

### How to test your changes?

1. Run any CLI command that uses the Tasks component
2. Press Ctrl+C during execution
3. Verify that the process exits correctly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes