### PR TITLE
Introduce SingleTask component

### DIFF
--- a/packages/cli-kit/bin/documentation/examples.ts
+++ b/packages/cli-kit/bin/documentation/examples.ts
@@ -12,6 +12,7 @@ import {
   renderSuccess,
   renderTable,
   renderTasks,
+  renderSingleTask,
   renderTextPrompt,
   renderWarning,
 } from '../../src/public/node/ui.js'
@@ -21,6 +22,7 @@ import {AbortSignal} from '../../src/public/node/abort.js'
 import {Stdout} from '../../src/private/node/ui.js'
 import {Stdin, waitFor} from '../../src/private/node/testing/ui.js'
 import {Writable} from 'node:stream'
+import { sleep } from '../../src/public/node/system.js'
 
 interface Example {
   type: 'static' | 'async' | 'prompt'
@@ -582,6 +584,25 @@ export const examples: {[key in string]: Example} = {
       )
 
       return stdout.lastFrame()!
+    },
+  },
+  renderSingleTask: {
+    type: 'async',
+    basic: async () => {
+      const stdout = new Stdout({columns: TERMINAL_WIDTH})
+
+      await renderSingleTask({
+        title: 'Loading app',
+        taskPromise: async () => {
+          await sleep(1)
+        },
+      }, {renderOptions: {stdout: stdout as any, debug: true}})
+
+      // Find the last frame that includes mention of "Loading"
+      const loadingFrame = stdout.frames.findLast(frame => frame.includes('Loading'))
+
+      // Gives a frame where the loading bar is visible
+      return loadingFrame ?? stdout.lastFrame()!
     },
   },
   renderTextPrompt: {

--- a/packages/cli-kit/src/private/node/ui/components/SingleTask.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SingleTask.test.tsx
@@ -1,0 +1,182 @@
+import {SingleTask} from './SingleTask.js'
+import {render} from '../../testing/ui.js'
+import React from 'react'
+import {describe, expect, test} from 'vitest'
+
+describe('SingleTask', () => {
+  test('unmounts when promise resolves successfully', async () => {
+    // Given
+    const title = 'Uploading files'
+    let resolvePromise: (value: string) => void
+    const taskPromise = new Promise<string>((resolve) => {
+      resolvePromise = resolve
+    })
+
+    // When
+    const renderInstance = render(<SingleTask title={title} taskPromise={taskPromise} />)
+
+    // Wait for initial render
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // Resolve the promise
+    resolvePromise!('success')
+
+    // Wait for component to update and unmount
+    await renderInstance.waitUntilExit()
+
+    // Then - component should unmount cleanly
+    expect(renderInstance.lastFrame()).toBeDefined()
+  })
+
+  test('unmounts when promise rejects', async () => {
+    // Given
+    const title = 'Failed task'
+    let rejectPromise: (error: Error) => void
+    const taskPromise = new Promise<string>((resolve, reject) => {
+      rejectPromise = reject
+    })
+
+    // When
+    const renderInstance = render(<SingleTask title={title} taskPromise={taskPromise} />)
+
+    // Wait for initial render
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // Reject the promise and expect waitUntilExit to reject
+    rejectPromise!(new Error('Task failed'))
+
+    // The component should exit with the error
+    await expect(renderInstance.waitUntilExit()).rejects.toThrow('Task failed')
+  })
+
+  test('handles promise that resolves immediately', async () => {
+    // Given
+    const title = 'Instant task'
+    const taskPromise = Promise.resolve('immediate success')
+
+    // When
+    const renderInstance = render(<SingleTask title={title} taskPromise={taskPromise} />)
+    await renderInstance.waitUntilExit()
+
+    // Then - component should complete successfully
+    expect(renderInstance.lastFrame()).toBeDefined()
+  })
+
+  test('handles promise that rejects immediately', async () => {
+    // Given
+    const title = 'Instant failure'
+    const taskPromise = Promise.reject(new Error('Immediate error'))
+
+    // When
+    const renderInstance = render(<SingleTask title={title} taskPromise={taskPromise} />)
+
+    // Then - should exit with error
+    await expect(renderInstance.waitUntilExit()).rejects.toThrow('Immediate error')
+  })
+
+  test('handles different types of promise return values', async () => {
+    // Test with string
+    const stringTask = Promise.resolve('task completed')
+    const stringRender = render(<SingleTask title="String task" taskPromise={stringTask} />)
+    await stringRender.waitUntilExit()
+    expect(stringRender.lastFrame()).toBeDefined()
+
+    // Test with object
+    const objectTask = Promise.resolve({id: 1, name: 'test'})
+    const objectRender = render(<SingleTask title="Object task" taskPromise={objectTask} />)
+    await objectRender.waitUntilExit()
+    expect(objectRender.lastFrame()).toBeDefined()
+
+    // Test with number
+    const numberTask = Promise.resolve(42)
+    const numberRender = render(<SingleTask title="Number task" taskPromise={numberTask} />)
+    await numberRender.waitUntilExit()
+    expect(numberRender.lastFrame()).toBeDefined()
+
+    // Test with boolean
+    const booleanTask = Promise.resolve(true)
+    const booleanRender = render(<SingleTask title="Boolean task" taskPromise={booleanTask} />)
+    await booleanRender.waitUntilExit()
+    expect(booleanRender.lastFrame()).toBeDefined()
+  })
+
+  test('handles promise with delayed resolution', async () => {
+    // Given
+    const title = 'Delayed task'
+    const taskPromise = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('completed'), 100)
+    })
+
+    // When
+    const renderInstance = render(<SingleTask title={title} taskPromise={taskPromise} />)
+
+    // Wait for completion
+    await renderInstance.waitUntilExit()
+
+    // Then
+    expect(renderInstance.lastFrame()).toBeDefined()
+  })
+
+  test('handles promise with delayed rejection', async () => {
+    // Given
+    const title = 'Delayed failure'
+    const taskPromise = new Promise<string>((resolve, reject) => {
+      setTimeout(() => reject(new Error('delayed error')), 100)
+    })
+
+    // When
+    const renderInstance = render(<SingleTask title={title} taskPromise={taskPromise} />)
+
+    // Wait for completion - should throw error
+    await expect(renderInstance.waitUntilExit()).rejects.toThrow('delayed error')
+  })
+
+  test('preserves error types and messages', async () => {
+    // Test with custom error
+    class CustomError extends Error {
+      constructor(message: string, public code: string) {
+        super(message)
+        this.name = 'CustomError'
+      }
+    }
+
+    const customError = new CustomError('Custom error message', 'CUSTOM_CODE')
+    const taskPromise = Promise.reject(customError)
+
+    // When
+    const renderInstance = render(<SingleTask title="Custom error task" taskPromise={taskPromise} />)
+
+    // Then - should preserve the exact error
+    await expect(renderInstance.waitUntilExit()).rejects.toThrow('Custom error message')
+  })
+
+  test('handles concurrent promise operations', async () => {
+    // Given - Multiple SingleTask components with different promises
+    const fastPromise = new Promise((resolve) => setTimeout(() => resolve('fast'), 50))
+    const slowPromise = new Promise((resolve) => setTimeout(() => resolve('slow'), 150))
+
+    // When
+    const fastRender = render(<SingleTask title="Fast task" taskPromise={fastPromise} />)
+    const slowRender = render(<SingleTask title="Slow task" taskPromise={slowPromise} />)
+
+    // Then - Both should complete successfully
+    await fastRender.waitUntilExit()
+    await slowRender.waitUntilExit()
+
+    expect(fastRender.lastFrame()).toBeDefined()
+    expect(slowRender.lastFrame()).toBeDefined()
+  })
+
+  test('passes noColor prop to LoadingBar component', async () => {
+    // Given
+    const title = 'No color task'
+    const taskPromise = Promise.resolve()
+
+    // When - Test that noColor prop doesn't break the component
+    const renderInstance = render(<SingleTask title={title} taskPromise={taskPromise} noColor />)
+    await renderInstance.waitUntilExit()
+
+    // Then - Component should complete successfully with noColor prop
+    expect(renderInstance.lastFrame()).toBeDefined()
+  })
+})

--- a/packages/cli-kit/src/private/node/ui/components/SingleTask.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SingleTask.tsx
@@ -1,0 +1,37 @@
+import {LoadingBar} from './LoadingBar.js'
+import {useExitOnCtrlC} from '../hooks/use-exit-on-ctrl-c.js'
+import React, {useEffect, useState} from 'react'
+import {useApp} from 'ink'
+
+interface SingleTaskProps {
+  title: string
+  taskPromise: Promise<unknown>
+  noColor?: boolean
+}
+
+const SingleTask = ({taskPromise, title, noColor}: React.PropsWithChildren<SingleTaskProps>) => {
+  const [isDone, setIsDone] = useState(false)
+  const {exit: unmountInk} = useApp()
+  useExitOnCtrlC()
+
+  useEffect(() => {
+    taskPromise
+      .then(() => {
+        setIsDone(true)
+        unmountInk()
+      })
+      .catch((error) => {
+        setIsDone(true)
+        unmountInk(error)
+      })
+  }, [taskPromise, unmountInk])
+
+  if (isDone) {
+    // clear things once done
+    return null
+  }
+
+  return <LoadingBar title={title} noColor={noColor} />
+}
+
+export {SingleTask}

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -30,6 +30,7 @@ import {TextPrompt, TextPromptProps} from '../../private/node/ui/components/Text
 import {AutocompletePromptProps, AutocompletePrompt} from '../../private/node/ui/components/AutocompletePrompt.js'
 import {InfoTableSection} from '../../private/node/ui/components/Prompts/InfoTable.js'
 import {InfoMessageProps} from '../../private/node/ui/components/Prompts/InfoMessage.js'
+import {SingleTask} from '../../private/node/ui/components/SingleTask.js'
 import React from 'react'
 import {Key as InkKey, RenderOptions} from 'ink'
 
@@ -480,6 +481,34 @@ export async function renderTasks<TContext>(tasks: Task<TContext>[], {renderOpti
       .then(() => {})
       .catch(reject)
   })
+}
+
+/**
+ * Awaits a single promise and displays a loading bar while it's in progress. The promise's result is returned.
+ * @param options - Configuration object
+ * @param options.title - The title to display with the loading bar
+ * @param options.taskPromise - The promise to track
+ * @param renderOptions - Optional render configuration
+ * @returns The result of the promise
+ * @example
+ * ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+ * Loading app ...
+ */
+// eslint-disable-next-line max-params
+export async function renderSingleTask<T>(
+  {title, taskPromise}: {title: string; taskPromise: Promise<T> | (() => Promise<T>)},
+  {renderOptions}: RenderTasksOptions = {},
+) {
+  const promise = typeof taskPromise === 'function' ? taskPromise() : taskPromise
+  const [_renderResult, taskResult] = await Promise.all([
+    render(<SingleTask title={title} taskPromise={promise} />, {
+      ...renderOptions,
+      exitOnCtrlC: false,
+    }),
+    promise,
+  ])
+
+  return taskResult
 }
 
 export interface RenderTextPromptOptions extends Omit<TextPromptProps, 'onSubmit'> {


### PR DESCRIPTION
### WHY are these changes introduced?

This PR introduces a new UI component to simplify displaying loading indicators while awaiting promise resolution. See example usage below.

By using this component when "slow" asynchronous functions are run, we can present a more responsive experience: rather than being greeted by a blank screen or a pause in feedback, the loading bar reassures the developer that something is happening.

### WHAT is this pull request doing?

- Adds a new `SingleTask` React component that shows a loading bar while a promise is in progress
- Implements `renderSingleTask` public API function that wraps the component for easy use
- Includes comprehensive test coverage for both the component and public API

The `renderSingleTask` function provides a simple way to display a loading indicator while awaiting a promise, and returns the promise's result when complete.

Example usage:
```typescript
const result = await renderSingleTask({
  title: 'Uploading files',
  taskPromise: uploadFilesToServer()
});
```

### How to test your changes?

1. Run the test suite: `pnpm test packages/cli-kit/src/private/node/ui/components/SingleTask.test.tsx`
2. Create a simple CLI command that uses `renderSingleTask` with a delayed promise to see the loading bar in action

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes