### PR TITLE
Use renderSingleTask in `app dev`

### DIFF
--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -10,6 +10,7 @@ import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
+import {renderSingleTask} from '@shopify/cli-kit/node/ui'
 
 export default class Dev extends AppLinkedCommand {
   static summary = 'Run the app.'
@@ -148,16 +149,22 @@ If you're using the Ruby app template, then you need to complete the following s
 
     await checkFolderIsValidApp(flags.path)
 
-    const appContextResult = await linkedAppContext({
-      directory: flags.path,
-      clientId: flags['client-id'] ?? flags['api-key'],
-      forceRelink: flags.reset,
-      userProvidedConfigName: flags.config,
-    })
-    const store = await storeContext({
-      appContextResult,
-      storeFqdn: flags.store,
-      forceReselectStore: flags.reset,
+    const {store, appContextResult} = await renderSingleTask({
+      title: 'Loading app',
+      taskPromise: async () => {
+        const appContextResult = await linkedAppContext({
+          directory: flags.path,
+          clientId: flags['client-id'] ?? flags['api-key'],
+          forceRelink: flags.reset,
+          userProvidedConfigName: flags.config,
+        })
+        const store = await storeContext({
+          appContextResult,
+          storeFqdn: flags.store,
+          forceReselectStore: flags.reset,
+        })
+        return {store, appContextResult}
+      },
     })
 
     const devOptions: DevOptions = {


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the user experience during app loading in the dev command by providing visual feedback. The time between the developer pressing Enter to start the CLI, and getting some feedback that something is happening, is reduced by ~75%.

### WHAT is this pull request doing?

Adds a loading indicator when initializing an app in the `dev` command. The app context and store context initialization is now wrapped in a `renderSingleTask` call that displays a "Loading app" message, providing better visual feedback to users during this process.

### How to test your changes?

1. Run `shopify app dev` with any app
2. Verify that a "Loading app" indicator appears during initialization
3. Confirm that the app loads correctly after the loading task completes

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes