### PR TITLE
update dev docs links for package command

### DIFF
--- a/.changeset/lazy-otters-invite.md
+++ b/.changeset/lazy-otters-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Update links to shopify dev docs

--- a/docs-shopify.dev/commands/theme-package.doc.ts
+++ b/docs-shopify.dev/commands/theme-package.doc.ts
@@ -5,9 +5,9 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'theme package',
   description: `Packages your local theme files into a ZIP file that can be uploaded to Shopify.
 
-  Only folders that match the [default Shopify theme folder structure](/docs/themes/tools/cli#directory-structure) are included in the package.
+  Only folders that match the [default Shopify theme folder structure](/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.
 
-  The ZIP file uses the name \`theme_name-theme_version.zip\`, based on parameters in your [settings_schema.json](/docs/themes/architecture/config/settings-schema-json) file.`,
+  The ZIP file uses the name \`theme_name-theme_version.zip\`, based on parameters in your [settings_schema.json](/docs/storefronts/themes/architecture/config/settings-schema-json) file.`,
   overviewPreviewDescription: `Package your theme into a .zip file, ready to upload to the Online Store.`,
   type: 'command',
   isVisualComponent: false,

--- a/docs-shopify.dev/generated/generated_docs_data.json
+++ b/docs-shopify.dev/generated/generated_docs_data.json
@@ -5831,7 +5831,7 @@
   },
   {
     "name": "theme package",
-    "description": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the [default Shopify theme folder structure](/docs/themes/tools/cli#directory-structure) are included in the package.\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your [settings_schema.json](/docs/themes/architecture/config/settings-schema-json) file.",
+    "description": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the [default Shopify theme folder structure](/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your [settings_schema.json](/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
     "overviewPreviewDescription": "Package your theme into a .zip file, ready to upload to the Online Store.",
     "type": "command",
     "isVisualComponent": false,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2108,10 +2108,10 @@ DESCRIPTION
   Packages your local theme files into a ZIP file that can be uploaded to Shopify.
 
   Only folders that match the "default Shopify theme folder structure"
-  (https://shopify.dev/docs/themes/tools/cli#directory-structure) are included in the package.
+  (https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.
 
   The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your "settings_schema.json"
-  (https://shopify.dev/docs/themes/architecture/config/settings-schema-json) file.
+  (https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.
 ```
 
 ## `shopify theme profile`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5863,8 +5863,8 @@
       "args": {
       },
       "customPluginName": "@shopify/theme",
-      "description": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure) are included in the package.\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your \"settings_schema.json\" (https://shopify.dev/docs/themes/architecture/config/settings-schema-json) file.",
-      "descriptionWithMarkdown": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure) are included in the package.\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your [settings_schema.json](https://shopify.dev/docs/themes/architecture/config/settings-schema-json) file.",
+      "description": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the \"default Shopify theme folder structure\" (https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your \"settings_schema.json\" (https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
+      "descriptionWithMarkdown": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the [default Shopify theme folder structure](https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your [settings_schema.json](https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
       "flags": {
         "no-color": {
           "allowNo": false,

--- a/packages/theme/src/cli/commands/theme/package.ts
+++ b/packages/theme/src/cli/commands/theme/package.ts
@@ -8,9 +8,9 @@ export default class Package extends ThemeCommand {
 
   static descriptionWithMarkdown = `Packages your local theme files into a ZIP file that can be uploaded to Shopify.
 
-  Only folders that match the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure) are included in the package.
+  Only folders that match the [default Shopify theme folder structure](https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.
 
-  The ZIP file uses the name \`theme_name-theme_version.zip\`, based on parameters in your [settings_schema.json](https://shopify.dev/docs/themes/architecture/config/settings-schema-json) file.`
+  The ZIP file uses the name \`theme_name-theme_version.zip\`, based on parameters in your [settings_schema.json](https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.`
 
   static description = this.descriptionWithoutMarkdown()
 


### PR DESCRIPTION
### WHY are these changes introduced?

Theme package dev docs were pointing to CLI 2.X d

### WHAT is this pull request doing?

Updating the links so they point to the proper docs

### How to test your changes?

Click the links

### Post-release steps

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
