### PR TITLE
NX TUI should auto-exit

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -73,5 +73,8 @@
     "production": [
       "default"
     ]
+  },
+  "tui": {
+    "autoExit": true
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To enable automatic exit of the TUI (Terminal User Interface) after task completion. See https://nx.dev/recipes/running-tasks/terminal-ui

It's pretty close to zero value to us. If this option isn't applied, every interactive run of nx stays open for 3 extra seconds in case the user wants to inspect the task log.

---

### WHAT is this pull request doing?

Adds a new `tui` configuration section to `nx.json` with `autoExit` set to `true`. This will make the TUI automatically exit after tasks are completed rather than requiring manual exit.

### How to test your changes?

1. Run any Nx command that uses the TUI
2. Verify that the TUI automatically exits after the task completes
3. Try reverting the change and confirm that the TUI stays open until manually exited

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes