### PR TITLE
Constrain the number of concurrent threads used by vitest during github action runs

### DIFF
--- a/.github/actions/run-and-save-test-coverage/action.yml
+++ b/.github/actions/run-and-save-test-coverage/action.yml
@@ -10,6 +10,9 @@ runs:
     - name: Unit tests with coverage
       run: pnpm vitest run --coverage --reporter json --outputFile ./coverage/report.json
       shell: bash
+      env:
+        VITEST_MIN_THREADS: "1"
+        VITEST_MAX_THREADS: "4"
     - name: Convert coverage to Jest
       run: ./bin/save-coverage-file.js
       shell: bash

--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -86,6 +86,9 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '18.20.3' }}
       - name: Unit tests
         run: pnpm vitest run
+        env:
+          VITEST_MIN_THREADS: "1"
+          VITEST_MAX_THREADS: "4"
       - name: Acceptance tests
         if: ${{ matrix.node == '18.20.3' }}
         env:
@@ -289,6 +292,9 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Unit tests
         run: pnpm vitest run
+        env:
+          VITEST_MIN_THREADS: "1"
+          VITEST_MAX_THREADS: "4"
 
   pr-acceptance-tests:
     name: '[PR] Accept. Test with Node ${{ matrix.node }} in ${{ matrix.os }}'


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the stability and performance of our test runs in CI by limiting the number of threads used by Vitest. We see the occasional SIGABRT error which implies over-use of resources. Lets limit the concurrency level vitest will reach for.

---

### WHAT is this pull request doing?

Adding environment variables to control Vitest thread count in GitHub Actions:
- Sets `VITEST_MIN_THREADS="1"` and `VITEST_MAX_THREADS="4"` in all workflows that run Vitest tests
- Applied to the main test workflow, PR acceptance tests, and test coverage action

### How to test your changes?

1. Run a CI build with these changes
2. Verify that tests complete successfully with the thread limitations in place
3. Check that test runs are more stable compared to previous builds

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes