### PR TITLE
Add workaround for zod/vitest incompatibility

### DIFF
--- a/configurations/vitest/setup.js
+++ b/configurations/vitest/setup.js
@@ -1,2 +1,18 @@
+import {expect} from 'vitest'
+import {z} from 'zod'
+
 process.env.SHOPIFY_UNIT_TEST = '1'
 process.removeAllListeners('warning')
+
+// This is a workaround for the issue with zod not supporting vitest's custom equality tester
+// https://github.com/vitest-dev/vitest/issues/7315#issuecomment-2606572923
+expect.addEqualityTesters([
+  function (a, b) {
+    const aOk = a instanceof z.ZodError
+    const bOk = b instanceof z.ZodError
+    if (aOk && bOk) {
+      return this.equals(a.message, b.message) && this.equals(a.issues, b.issues)
+    }
+    return aOk !== bOk ? false : undefined
+  },
+])

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "tmp": "^0.2.1",
     "ts-node": "^10.9.1",
     "typescript": "5.8.3",
-    "vitest": "^1.6.1"
+    "vitest": "^1.6.1",
+    "zod": "^3.24.1"
   },
   "workspaces": {
     "packages": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       vitest:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@18.19.70)(jsdom@20.0.3)(sass@1.89.1)
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
 
   packages/app:
     dependencies:


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

See for details:

- https://github.com/vitest-dev/vitest/issues/7315
- https://github.com/colinhacks/zod/issues/3950

TL;DR Zod does weird things with errors, which breaks Vitest's stricter error equality checks in v3. This workaround was suggested by the good folks behind Vitest, and avoids making our checks more lenient as was suggested in #5804

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Adds a custom equality check for Zod errors that doesn't break when using Vitest 3

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Update to Vitest 3 and see that the tests mentioned in #5804 don't fail as expected

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
