### PR TITLE
Fix release for ui-extensions-server-kit

### DIFF
--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -4,6 +4,11 @@
   "packageManager": "pnpm@10.11.1",
   "private": false,
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shopify/cli.git",
+    "directory": "packages/ui-extensions-server-kit"
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
### WHY are these changes introduced?

The nightly release of `ui-extensions-server-kit` [is broken](https://github.com/Shopify/cli/actions/runs/15464803550/job/43534307190):

```
ui-extensions-server-kit - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/Shopify/cli" from provenance
```

### WHAT is this pull request doing?

Add required repository info to package.json: https://docs.npmjs.com/generating-provenance-statements#prerequisites

### How to test your changes?

Merge and release

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
