### PR TITLE
Fix payload type of dispatch log event

### DIFF
--- a/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
+++ b/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
@@ -166,7 +166,7 @@ describe('extensionServerReducer()', () => {
       extensions: [extension],
     }
 
-    const action = createLogAction({level: 'info', args: ['test'], extensionName: extension.name})
+    const action = createLogAction({level: 'info', message: 'test', extensionName: extension.name})
     const state = extensionServerReducer(previousState, action)
 
     expect(state).toStrictEqual(previousState)

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -38,7 +38,7 @@ declare global {
       focus: {uuid: string}[]
       unfocus: void
       navigate: {url: string}
-      log: {level: string; args: unknown[]; extensionName: string}
+      log: {level: string; message: string; extensionName: string}
     }
 
     // API responses


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

https://github.com/Shopify/cli/pull/5932 introduced a new `log` dispatch event and the typing of the payload was inconsistent between the definition of the event and the handler.

### WHAT is this pull request doing?

Making the types consistent to what the handler expects in `packages/app/src/cli/services/dev/extension/websocket/handlers.ts:71`

> Question: Is there a way to import `packages/ui-extensions-server-kit/src/types.ts` in the cli so the types are not redefined (which allows them to fall out of sync as happened here)?

### How to test your changes?

See question above.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
