### PR TITLE
Revert "[Feature] Display POS Extension logs within the CLI output"

### DIFF
--- a/.changeset/chatty-rats-pull.md
+++ b/.changeset/chatty-rats-pull.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions-server-kit': minor
-'@shopify/app': minor
----
-
-Add support for displaying POS dev logs

--- a/packages/app/src/cli/services/dev/extension/websocket/handlers.test.ts
+++ b/packages/app/src/cli/services/dev/extension/websocket/handlers.test.ts
@@ -2,23 +2,14 @@ import {
   getConnectionDoneHandler,
   getOnMessageHandler,
   getPayloadUpdateHandler,
-  handleLogMessage,
-  parseLogMessage,
   websocketUpgradeHandler,
 } from './handlers.js'
 import {SetupWebSocketConnectionOptions} from './models.js'
 import {ExtensionsEndpointPayload} from '../payload/models.js'
-import {vi, describe, test, expect, Mock} from 'vitest'
-import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
+import {vi, describe, test, expect} from 'vitest'
 import WebSocket, {RawData, WebSocketServer} from 'ws'
 import {IncomingMessage} from 'h3'
-import colors from '@shopify/cli-kit/node/colors'
-import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {Duplex} from 'stream'
-
-vi.mock('@shopify/cli-kit/node/ui/components', () => ({
-  useConcurrentOutputContext: vi.fn(),
-}))
 
 function getMockRequest() {
   const request = {
@@ -66,9 +57,6 @@ function getMockSetupWebSocketConnectionOptions() {
       updateExtensions: vi.fn(),
     },
     manifestVersion: '3',
-    stdout: {
-      write: vi.fn(),
-    },
   } as unknown as SetupWebSocketConnectionOptions
 }
 
@@ -194,133 +182,5 @@ describe('getOnMessageHandler()', () => {
       version: '3',
     }) as unknown as RawData
     wss.clients.forEach((ws) => expect(ws.send).toHaveBeenCalledWith(outgoingMessage))
-  })
-
-  test('on an incoming dispatch with type log calls handleLogMessage and does not notify clients', () => {
-    const wss = getMockWebsocketServer()
-    const options = getMockSetupWebSocketConnectionOptions()
-    const data = JSON.stringify({
-      event: 'dispatch',
-      data: {
-        type: 'log',
-        payload: {
-          level: 'info',
-          message: 'Test log message',
-          extensionName: 'test-extension',
-        },
-      },
-    }) as unknown as RawData
-
-    getOnMessageHandler(wss, options)(data)
-
-    // Verify useConcurrentOutputContext (any therefore handleLogMessage) was called with correct parameters
-    expect(useConcurrentOutputContext).toHaveBeenCalledWith(
-      {outputPrefix: 'test-extension', stripAnsi: false},
-      expect.any(Function),
-    )
-
-    // Verify no client messages were sent since this was a log event
-    wss.clients.forEach((ws) => expect(ws.send).not.toHaveBeenCalled())
-  })
-})
-
-describe('parseLogMessage()', () => {
-  test('parses and formats JSON array of strings', () => {
-    const message = JSON.stringify(['Hello', 'world', 'test'], null, 2)
-    const result = parseLogMessage(message)
-    expect(result).toBe('Hello world test')
-  })
-
-  test('parses and formats JSON array with mixed types', () => {
-    const message = JSON.stringify(['String', 42, true, null], null, 2)
-    const result = parseLogMessage(message)
-    expect(result).toBe('String 42 true null')
-  })
-
-  test('parses and formats JSON array with objects', () => {
-    const object = {user: 'john', age: 30}
-    const message = JSON.stringify(['Message:', object], null, 2)
-    const result = parseLogMessage(message)
-    expect(result).toBe(outputContent`Message: ${outputToken.json(object)}`.value)
-  })
-
-  test('returns original message when JSON parsing fails', () => {
-    const invalidJson = 'This is not JSON'
-    const result = parseLogMessage(invalidJson)
-    expect(result).toBe('This is not JSON')
-  })
-
-  test('returns original message for JSON that is not an array', () => {
-    const malformedJson = '{"invalid": json}'
-    const result = parseLogMessage(malformedJson)
-    expect(result).toBe('{"invalid": json}')
-  })
-})
-
-describe('handleLogMessage()', () => {
-  // Helper function to abstract the common expect pattern
-  function expectLogMessageOutput(
-    extensionName: string,
-    expectedOutput: string,
-    options: SetupWebSocketConnectionOptions,
-  ) {
-    expect(useConcurrentOutputContext).toHaveBeenCalledWith(
-      {outputPrefix: extensionName, stripAnsi: false},
-      expect.any(Function),
-    )
-    const contextCallback = (useConcurrentOutputContext as Mock).mock.calls[0][1]
-    contextCallback()
-
-    expect(options.stdout.write).toHaveBeenCalledWith(expectedOutput)
-  }
-
-  test('outputs info level log message with correct formatting', () => {
-    const options = getMockSetupWebSocketConnectionOptions()
-    const eventData = {
-      payload: {
-        level: 'info',
-        message: 'Test info message',
-        extensionName: 'test-extension',
-      },
-    }
-
-    handleLogMessage(eventData, options)
-
-    expectLogMessageOutput('test-extension', `INFO: Test info message`, options)
-  })
-
-  test('outputs log message with parsed JSON array', () => {
-    const options = getMockSetupWebSocketConnectionOptions()
-    const message = JSON.stringify(['Hello', 'world', {user: 'test'}], null, 2)
-    const eventData = {
-      payload: {
-        level: 'info',
-        message,
-        extensionName: 'test-extension',
-      },
-    }
-
-    handleLogMessage(eventData, options)
-
-    expectLogMessageOutput(
-      'test-extension',
-      outputContent`INFO: Hello world ${outputToken.json({user: 'test'})}`.value,
-      options,
-    )
-  })
-
-  test('outputs error level log message with error formatting', () => {
-    const options = getMockSetupWebSocketConnectionOptions()
-    const eventData = {
-      payload: {
-        level: 'error',
-        message: 'Test error message',
-        extensionName: 'error-extension',
-      },
-    }
-
-    handleLogMessage(eventData, options)
-
-    expectLogMessageOutput('error-extension', `${colors.bold.redBright('ERROR')}: Test error message`, options)
   })
 })

--- a/packages/app/src/cli/services/dev/extension/websocket/handlers.ts
+++ b/packages/app/src/cli/services/dev/extension/websocket/handlers.ts
@@ -7,7 +7,6 @@ import {
 } from './models.js'
 import {RawData, WebSocket, WebSocketServer} from 'ws'
 import {outputDebug, outputContent, outputToken} from '@shopify/cli-kit/node/output'
-import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
 import {IncomingMessage} from 'http'
 import {Duplex} from 'stream'
 
@@ -36,56 +35,6 @@ export function getConnectionDoneHandler(wss: WebSocketServer, options: SetupWeb
     ws.send(JSON.stringify(connectedPayload))
     ws.on('message', getOnMessageHandler(wss, options))
   }
-}
-
-export function parseLogMessage(message: string): string {
-  try {
-    const parsed = JSON.parse(message)
-
-    // it is expected that the message is an array of console arguments
-    if (!Array.isArray(parsed)) {
-      return message
-    }
-
-    const formatted = parsed
-      .map((arg) => {
-        if (typeof arg === 'object' && arg !== null) {
-          return outputToken.json(arg).output()
-        } else {
-          return String(arg)
-        }
-      })
-      .join(' ')
-
-    return outputContent`${formatted}`.value
-  } catch (error) {
-    // If parsing fails, return the original message
-    if (error instanceof SyntaxError) {
-      return message
-    }
-    throw error
-  }
-}
-
-export function handleLogMessage(
-  eventData: {payload: {level: string; message: string; extensionName: string}},
-  options: SetupWebSocketConnectionOptions,
-) {
-  const {level, message, extensionName} = eventData.payload
-  const formattedMessage = parseLogMessage(message)
-
-  const levelColors = {
-    debug: (text: string) => outputToken.gray(text),
-    warn: (text: string) => outputToken.yellow(text),
-    error: (text: string) => outputToken.errorText(text),
-  } as const
-
-  const uppercaseLevel = level.toUpperCase()
-  const colouredLevel = levelColors[level as keyof typeof levelColors]?.(uppercaseLevel) ?? uppercaseLevel
-
-  useConcurrentOutputContext({outputPrefix: extensionName, stripAnsi: false}, () => {
-    options.stdout.write(outputContent`${colouredLevel}: ${formattedMessage}`.value)
-  })
 }
 
 export function getOnMessageHandler(wss: WebSocketServer, options: SetupWebSocketConnectionOptions) {
@@ -120,13 +69,9 @@ ${outputToken.json(eventData)}
         options.payloadStore.updateExtensions(eventData.extensions)
       }
     } else if (eventType === 'dispatch') {
-      if (eventData.type === 'log') {
-        handleLogMessage(eventData, options)
-      } else {
-        const outGoingMessage = getOutgoingDispatchMessage(jsonData, options)
+      const outGoingMessage = getOutgoingDispatchMessage(jsonData, options)
 
-        notifyClients(wss, outGoingMessage, options)
-      }
+      notifyClients(wss, outGoingMessage, options)
     }
   }
 }

--- a/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.tsx
+++ b/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.tsx
@@ -5,7 +5,6 @@ import {
   createRefreshAction,
   createFocusAction,
   createUnfocusAction,
-  createLogAction,
 } from '../state'
 
 import {ExtensionServerClient} from '../ExtensionServerClient'
@@ -36,7 +35,6 @@ export function ExtensionServerProvider({children, options: defaultOptions}: Ext
       client.on('refresh', (payload) => dispatch(createRefreshAction(payload))),
       client.on('focus', (payload) => dispatch(createFocusAction(payload))),
       client.on('unfocus', (payload) => dispatch(createUnfocusAction(payload))),
-      client.on('log', (payload) => dispatch(createLogAction(payload))),
     ]
 
     return () => listeners.forEach((unsubscribe) => unsubscribe())

--- a/packages/ui-extensions-server-kit/src/state/actions/actions.ts
+++ b/packages/ui-extensions-server-kit/src/state/actions/actions.ts
@@ -1,4 +1,4 @@
-import type {ConnectedAction, UpdateAction, RefreshAction, FocusAction, UnfocusAction, LogAction} from './types'
+import type {ConnectedAction, UpdateAction, RefreshAction, FocusAction, UnfocusAction} from './types'
 
 export function createConnectedAction(payload: ConnectedAction['payload']): ConnectedAction {
   return {
@@ -31,13 +31,6 @@ export function createFocusAction(payload: FocusAction['payload']): FocusAction 
 export function createUnfocusAction(payload: UnfocusAction['payload']): UnfocusAction {
   return {
     type: 'unfocus',
-    payload,
-  }
-}
-
-export function createLogAction(payload: LogAction['payload']): LogAction {
-  return {
-    type: 'log',
     payload,
   }
 }

--- a/packages/ui-extensions-server-kit/src/state/actions/types.ts
+++ b/packages/ui-extensions-server-kit/src/state/actions/types.ts
@@ -23,15 +23,4 @@ export interface UnfocusAction {
   payload: ExtensionServer.InboundEvents['unfocus']
 }
 
-export interface LogAction {
-  type: 'log'
-  payload: ExtensionServer.InboundEvents['log']
-}
-
-export type ExtensionServerActions =
-  | ConnectedAction
-  | UpdateAction
-  | RefreshAction
-  | FocusAction
-  | UnfocusAction
-  | LogAction
+export type ExtensionServerActions = ConnectedAction | UpdateAction | RefreshAction | FocusAction | UnfocusAction

--- a/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
+++ b/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
@@ -7,7 +7,6 @@ import {
   createRefreshAction,
   createFocusAction,
   createUnfocusAction,
-  createLogAction,
 } from '../actions'
 
 import type {ExtensionServerState} from './types'
@@ -157,18 +156,5 @@ describe('extensionServerReducer()', () => {
 
       expect(state.extensions[0].development.focused).toBe(false)
     })
-  })
-
-  test('does not mutate the state when receiving log events', () => {
-    const extension = mockExtension()
-    const previousState: ExtensionServerState = {
-      store: 'test-store.com',
-      extensions: [extension],
-    }
-
-    const action = createLogAction({level: 'info', args: ['test'], extensionName: extension.name})
-    const state = extensionServerReducer(previousState, action)
-
-    expect(state).toStrictEqual(previousState)
   })
 })

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -38,7 +38,6 @@ declare global {
       focus: {uuid: string}[]
       unfocus: void
       navigate: {url: string}
-      log: {level: string; args: unknown[]; extensionName: string}
     }
 
     // API responses


### PR DESCRIPTION
Reverts Shopify/cli#5932

I accidentally jumped the gun in merging this PR as I didn't realize the [AppUI](https://vault.shopify.io/teams/3013-AppUI) team also needed to review these changes and it turns out they have some [good suggests](https://shopify.slack.com/archives/C04K7BZDH3N/p1749140890903219?thread_ts=1748871348.228269&cid=C04K7BZDH3N) for improvements.

For the same reason, https://github.com/Shopify/cli/pull/5947 will also be closed as it is fixing a bug that I caught in this code when testing the nightly release.