### PR TITLE
Bump zod 3.25.51 to get v4 subdir

### DIFF
--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -164,7 +164,7 @@
     "terminal-link": "3.0.0",
     "ts-error": "1.0.6",
     "which": "4.0.0",
-    "zod": "3.24.1"
+    "zod": "3.25.51"
   },
   "devDependencies": {
     "@types/brotli": "^1.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,8 +496,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       zod:
-        specifier: 3.24.1
-        version: 3.24.1
+        specifier: 3.25.51
+        version: 3.25.51
     devDependencies:
       '@types/brotli':
         specifier: ^1.3.4
@@ -9264,8 +9264,8 @@ packages:
     peerDependencies:
       zod: ^3.24.4
 
-  zod@3.24.1:
-    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+  zod@3.25.51:
+    resolution: {integrity: sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==}
 
 snapshots:
 
@@ -17137,8 +17137,8 @@ snapshots:
       strip-json-comments: 5.0.1
       summary: 2.1.0
       typescript: 5.8.3
-      zod: 3.24.1
-      zod-validation-error: 3.4.1(zod@3.24.1)
+      zod: 3.25.51
+      zod-validation-error: 3.4.1(zod@3.25.51)
 
   knuth-shuffle-seeded@1.0.6:
     dependencies:
@@ -19796,8 +19796,8 @@ snapshots:
       compress-commons: 4.1.2
       readable-stream: 3.6.2
 
-  zod-validation-error@3.4.1(zod@3.24.1):
+  zod-validation-error@3.4.1(zod@3.25.51):
     dependencies:
-      zod: 3.24.1
+      zod: 3.25.51
 
-  zod@3.24.1: {}
+  zod@3.25.51: {}


### PR DESCRIPTION
### WHY are these changes introduced?

Zod has added a major version v4, which is available in NPM version 3.25.0. To prevent conflicts in monorepos and bundling issues v4 has been placed in a subdirectory so existing projects can make use of v3. Upgrading Shopify CLI to 3.25.0 allows downstream projects to make use of zod v4 without dependency problems of having two zod versions.

Relevant reading for context of why
- [Versioning with subpaths ("zod/v4") to enable incremental migration](https://github.com/colinhacks/zod/issues/4371)
- Example of [Next.js experiencing similar problem](https://github.com/vercel/next.js/discussions/48079) and [Hacker News discussion](https://news.ycombinator.com/item?id=44030850)

### WHAT is this pull request doing?

- Bumping the zod npm version from 3.24.1 to 3.25.51

No updates have been made to actually update the CLI to use v4. It will continue using Zod v3.

### How to test your changes?

- Tested can build and run

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
