### PR TITLE
Prompt users who run `shopify theme init` to create their AI file

### DIFF
--- a/.changeset/smart-pears-camp.md
+++ b/.changeset/smart-pears-camp.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Prompt users who run `shopify theme init` to create their AI file

--- a/packages/theme/src/cli/commands/theme/init.ts
+++ b/packages/theme/src/cli/commands/theme/init.ts
@@ -1,11 +1,12 @@
 import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
-import {cloneRepoAndCheckoutLatestTag, cloneRepo} from '../../services/init.js'
+import {cloneRepoAndCheckoutLatestTag, cloneRepo, promptAndCreateAIFile} from '../../services/init.js'
 import {Args, Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {generateRandomNameForSubdirectory} from '@shopify/cli-kit/node/fs'
 import {renderTextPrompt} from '@shopify/cli-kit/node/ui'
 import {joinPath} from '@shopify/cli-kit/node/path'
+import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
 
 const SKELETON_THEME_URL = 'https://github.com/Shopify/skeleton-theme'
 
@@ -58,6 +59,10 @@ export default class Init extends ThemeCommand {
     } else {
       await cloneRepo(repoUrl, destination)
     }
+
+    if (!terminalSupportsPrompting()) return
+
+    await promptAndCreateAIFile(destination)
   }
 
   async promptName(directory: string) {

--- a/packages/theme/src/cli/services/init.test.ts
+++ b/packages/theme/src/cli/services/init.test.ts
@@ -87,7 +87,7 @@ describe('promptAndCreateAIFile()', () => {
     vi.mocked(renderSelectPrompt).mockResolvedValue('cursor')
     vi.mocked(joinPath)
       .mockReturnValueOnce('/path/to/theme/.cursor/rules')
-      .mockReturnValueOnce('/path/to/theme/.cursor/rules/theme-liquid.mdc')
+      .mockReturnValueOnce('/path/to/theme/.cursor/rules/liquid.mdc')
 
     // When
     await promptAndCreateAIFile(destination)
@@ -103,7 +103,7 @@ describe('promptAndCreateAIFile()', () => {
     })
 
     expect(fetch).toHaveBeenCalledWith(aiFileUrl)
-    expect(writeFile).toHaveBeenCalledWith('/path/to/theme/.cursor/rules/theme-liquid.mdc', mockFileContent)
+    expect(writeFile).toHaveBeenCalledWith('/path/to/theme/.cursor/rules/liquid.mdc', mockFileContent)
   })
 
   test('does not create any AI file when none option is selected', async () => {

--- a/packages/theme/src/cli/services/init.test.ts
+++ b/packages/theme/src/cli/services/init.test.ts
@@ -1,10 +1,20 @@
-import {cloneRepoAndCheckoutLatestTag, cloneRepo} from './init.js'
-import {describe, expect, vi, test} from 'vitest'
+import {cloneRepoAndCheckoutLatestTag, cloneRepo, promptAndCreateAIFile} from './init.js'
+import {describe, expect, vi, test, beforeEach} from 'vitest'
 import {downloadGitRepository} from '@shopify/cli-kit/node/git'
+import {renderSelectPrompt} from '@shopify/cli-kit/node/ui'
+import {writeFile} from '@shopify/cli-kit/node/fs'
+import {fetch} from '@shopify/cli-kit/node/http'
+import {joinPath} from '@shopify/cli-kit/node/path'
 
-vi.mock('@shopify/cli-kit/node/git', () => {
+vi.mock('@shopify/cli-kit/node/git')
+vi.mock('@shopify/cli-kit/node/fs')
+vi.mock('@shopify/cli-kit/node/http')
+vi.mock('@shopify/cli-kit/node/path')
+vi.mock('@shopify/cli-kit/node/ui', async () => {
+  const actual = await vi.importActual('@shopify/cli-kit/node/ui')
   return {
-    downloadGitRepository: vi.fn(),
+    ...actual,
+    renderSelectPrompt: vi.fn(),
   }
 })
 
@@ -34,5 +44,86 @@ describe('cloneRepo()', async () => {
 
     // Then
     expect(downloadGitRepository).toHaveBeenCalledWith({repoUrl, destination})
+  })
+})
+
+describe('promptAndCreateAIFile()', () => {
+  const destination = '/path/to/theme'
+  const aiFileUrl = 'https://raw.githubusercontent.com/Shopify/theme-liquid-docs/main/ai/liquid.mdc'
+  const mockFileContent = 'AI file content 🤖✨'
+
+  beforeEach(() => {
+    vi.mocked(fetch).mockResolvedValue({
+      text: vi.fn().mockResolvedValue(mockFileContent),
+    } as any)
+  })
+
+  test('creates VSCode AI file when vscode option is selected', async () => {
+    // Given
+    vi.mocked(renderSelectPrompt).mockResolvedValue('vscode')
+    vi.mocked(joinPath)
+      .mockReturnValueOnce('/path/to/theme/.github')
+      .mockReturnValueOnce('/path/to/theme/.github/copilot-instructions.md')
+
+    // When
+    await promptAndCreateAIFile(destination)
+
+    // Then
+    expect(renderSelectPrompt).toHaveBeenCalledWith({
+      message: 'Set up AI dev support?',
+      choices: [
+        {label: 'VSCode (GitHub Copilot)', value: 'vscode'},
+        {label: 'Cursor', value: 'cursor'},
+        {label: 'Skip', value: 'none'},
+      ],
+    })
+
+    expect(fetch).toHaveBeenCalledWith(aiFileUrl)
+    expect(writeFile).toHaveBeenCalledWith('/path/to/theme/.github/copilot-instructions.md', mockFileContent)
+  })
+
+  test('creates Cursor AI file when cursor option is selected', async () => {
+    // Given
+    vi.mocked(renderSelectPrompt).mockResolvedValue('cursor')
+    vi.mocked(joinPath)
+      .mockReturnValueOnce('/path/to/theme/.cursor/rules')
+      .mockReturnValueOnce('/path/to/theme/.cursor/rules/theme-liquid.mdc')
+
+    // When
+    await promptAndCreateAIFile(destination)
+
+    // Then
+    expect(renderSelectPrompt).toHaveBeenCalledWith({
+      message: 'Set up AI dev support?',
+      choices: [
+        {label: 'VSCode (GitHub Copilot)', value: 'vscode'},
+        {label: 'Cursor', value: 'cursor'},
+        {label: 'Skip', value: 'none'},
+      ],
+    })
+
+    expect(fetch).toHaveBeenCalledWith(aiFileUrl)
+    expect(writeFile).toHaveBeenCalledWith('/path/to/theme/.cursor/rules/theme-liquid.mdc', mockFileContent)
+  })
+
+  test('does not create any AI file when none option is selected', async () => {
+    // Given
+    vi.mocked(renderSelectPrompt).mockResolvedValue('none')
+
+    // When
+    await promptAndCreateAIFile(destination)
+
+    // Then
+    expect(renderSelectPrompt).toHaveBeenCalledWith({
+      message: 'Set up AI dev support?',
+      choices: [
+        {label: 'VSCode (GitHub Copilot)', value: 'vscode'},
+        {label: 'Cursor', value: 'cursor'},
+        {label: 'Skip', value: 'none'},
+      ],
+    })
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(writeFile).not.toHaveBeenCalled()
   })
 })

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -50,7 +50,7 @@ export async function promptAndCreateAIFile(destination: string) {
     case 'cursor': {
       const cursorDir = joinPath(destination, '.cursor', 'rules')
       await mkdir(cursorDir)
-      const aiFilePath = joinPath(cursorDir, 'theme-liquid.mdc')
+      const aiFilePath = joinPath(cursorDir, 'liquid.mdc')
       await downloadAndSaveAIFile(aiFileUrl, aiFilePath)
       break
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/732

### WHAT is this pull request doing?

This PR updates the `shopify theme init` command to prompt users about creating an AI file in their new theme.

### How to test your changes?

- Run `shopify theme init` or `pnpm shopify theme init /tmp/test` (if you haven't configured the CLI dev environment locally)

https://github.com/user-attachments/assets/19bf983b-63c9-43dc-95dc-778a80d85999


### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
