### PR TITLE
Update behaviour for theme command calls

### DIFF
--- a/.changeset/itchy-houses-kick.md
+++ b/.changeset/itchy-houses-kick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+fix the way we detect single or non environments & improve output for multienvironment commands

--- a/.changeset/itchy-houses-kick.md
+++ b/.changeset/itchy-houses-kick.md
@@ -2,4 +2,7 @@
 '@shopify/theme': patch
 ---
 
-fix the way we detect single or non environments & improve output for multienvironment commands
+Improvement and fixes when handling multi-environment commands
+
+- Fixes a bug where passing a single environment to multi-env commands would cause it to fail if the environment didn't have all of the required attributes for multi-env
+- Updates output when running multi-env commands to ensure the results from each command don't overlap one another

--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -1,0 +1,129 @@
+import ThemeCommand from './theme-command.js'
+import {describe, vi, expect, test, beforeEach} from 'vitest'
+import {Config, Flags} from '@oclif/core'
+import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
+import {loadEnvironment} from '@shopify/cli-kit/node/environments'
+import {renderConcurrent} from '@shopify/cli-kit/node/ui'
+import {Writable} from 'stream'
+
+vi.mock('@shopify/cli-kit/node/session')
+vi.mock('@shopify/cli-kit/node/environments')
+vi.mock('@shopify/cli-kit/node/ui')
+
+const CommandConfig = new Config({root: __dirname})
+
+class TestThemeCommand extends ThemeCommand {
+  static flags = {
+    environment: Flags.string({
+      multiple: true,
+      default: [],
+      env: 'SHOPIFY_FLAG_ENVIRONMENT',
+    }),
+    store: Flags.string({
+      env: 'SHOPIFY_FLAG_STORE',
+    }),
+    password: Flags.string({
+      env: 'SHOPIFY_FLAG_PASSWORD',
+    }),
+  }
+
+  static multiEnvironmentsFlags = ['store']
+
+  commandCalls: {flags: any; session: AdminSession; context?: any}[] = []
+
+  async command(flags: any, session: AdminSession, context?: {stdout?: Writable; stderr?: Writable}): Promise<void> {
+    this.commandCalls.push({flags, session, context})
+  }
+}
+
+describe('ThemeCommand', () => {
+  let mockSession: AdminSession
+
+  beforeEach(() => {
+    mockSession = {
+      token: 'test-token',
+      storeFqdn: 'test-store.myshopify.com',
+    }
+    vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(mockSession)
+  })
+
+  describe('run', () => {
+    test('no environment provided', async () => {
+      // Given
+      await CommandConfig.load()
+      const command = new TestThemeCommand([], CommandConfig)
+
+      // When
+      await command.run()
+
+      // Then
+      expect(ensureAuthenticatedThemes).toHaveBeenCalledOnce()
+      expect(loadEnvironment).not.toHaveBeenCalled()
+      expect(renderConcurrent).not.toHaveBeenCalled()
+      expect(command.commandCalls).toHaveLength(1)
+      expect(command.commandCalls[0]).toMatchObject({
+        flags: {environment: []},
+        session: mockSession,
+        context: undefined,
+      })
+    })
+
+    test('single environment provided', async () => {
+      // Given
+      const environmentConfig = {store: 'env-store.myshopify.com', theme: '123'}
+      vi.mocked(loadEnvironment).mockResolvedValue(environmentConfig)
+
+      await CommandConfig.load()
+      const command = new TestThemeCommand(['--environment', 'development'], CommandConfig)
+
+      // When
+      await command.run()
+
+      // Then
+      expect(loadEnvironment).toHaveBeenCalledWith('development', 'shopify.theme.toml')
+      expect(ensureAuthenticatedThemes).toHaveBeenCalledTimes(1)
+      expect(renderConcurrent).not.toHaveBeenCalled()
+      expect(command.commandCalls).toHaveLength(1)
+      expect(command.commandCalls[0]).toMatchObject({
+        flags: {
+          environment: ['development'],
+          store: 'env-store.myshopify.com',
+          theme: '123',
+        },
+        session: mockSession,
+        context: undefined,
+      })
+    })
+
+    test('multiple environments provided - uses renderConcurrent for parallel execution', async () => {
+      // Given
+      const environmentConfig = {store: 'store.myshopify.com', theme: '123'}
+      vi.mocked(loadEnvironment).mockResolvedValue(environmentConfig)
+      vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(mockSession)
+
+      vi.mocked(renderConcurrent).mockResolvedValue(undefined)
+
+      await CommandConfig.load()
+      const command = new TestThemeCommand(['--environment', 'development', '--environment', 'staging'], CommandConfig)
+
+      // When
+      await command.run()
+
+      // Then
+      expect(loadEnvironment).toHaveBeenCalledWith('development', 'shopify.theme.toml')
+      expect(loadEnvironment).toHaveBeenCalledWith('staging', 'shopify.theme.toml')
+      expect(ensureAuthenticatedThemes).toHaveBeenCalledTimes(2)
+
+      expect(renderConcurrent).toHaveBeenCalledOnce()
+      expect(renderConcurrent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          processes: expect.arrayContaining([
+            expect.objectContaining({prefix: 'development'}),
+            expect.objectContaining({prefix: 'staging'}),
+          ]),
+          showTimestamps: true,
+        }),
+      )
+    })
+  })
+})

--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -4,7 +4,7 @@ import {Config, Flags} from '@oclif/core'
 import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {loadEnvironment} from '@shopify/cli-kit/node/environments'
 import {renderConcurrent} from '@shopify/cli-kit/node/ui'
-import {Writable} from 'stream'
+import type {Writable} from 'stream'
 
 vi.mock('@shopify/cli-kit/node/session')
 vi.mock('@shopify/cli-kit/node/environments')
@@ -70,7 +70,7 @@ describe('ThemeCommand', () => {
 
     test('single environment provided', async () => {
       // Given
-      const environmentConfig = {store: 'env-store.myshopify.com', theme: '123'}
+      const environmentConfig = {store: 'env-store.myshopify.com'}
       vi.mocked(loadEnvironment).mockResolvedValue(environmentConfig)
 
       await CommandConfig.load()
@@ -88,7 +88,6 @@ describe('ThemeCommand', () => {
         flags: {
           environment: ['development'],
           store: 'env-store.myshopify.com',
-          theme: '123',
         },
         session: mockSession,
         context: undefined,
@@ -97,7 +96,7 @@ describe('ThemeCommand', () => {
 
     test('multiple environments provided - uses renderConcurrent for parallel execution', async () => {
       // Given
-      const environmentConfig = {store: 'store.myshopify.com', theme: '123'}
+      const environmentConfig = {store: 'store.myshopify.com'}
       vi.mocked(loadEnvironment).mockResolvedValue(environmentConfig)
       vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(mockSession)
 

--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -80,7 +80,7 @@ describe('ThemeCommand', () => {
       await command.run()
 
       // Then
-      expect(loadEnvironment).toHaveBeenCalledWith('development', 'shopify.theme.toml')
+      expect(loadEnvironment).toHaveBeenCalledWith('development', 'shopify.theme.toml', {from: undefined})
       expect(ensureAuthenticatedThemes).toHaveBeenCalledTimes(1)
       expect(renderConcurrent).not.toHaveBeenCalled()
       expect(command.commandCalls).toHaveLength(1)
@@ -110,8 +110,8 @@ describe('ThemeCommand', () => {
       await command.run()
 
       // Then
-      expect(loadEnvironment).toHaveBeenCalledWith('development', 'shopify.theme.toml')
-      expect(loadEnvironment).toHaveBeenCalledWith('staging', 'shopify.theme.toml')
+      expect(loadEnvironment).toHaveBeenCalledWith('development', 'shopify.theme.toml', {from: undefined, silent: true})
+      expect(loadEnvironment).toHaveBeenCalledWith('staging', 'shopify.theme.toml', {from: undefined, silent: true})
       expect(ensureAuthenticatedThemes).toHaveBeenCalledTimes(2)
 
       expect(renderConcurrent).toHaveBeenCalledOnce()

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -4,8 +4,10 @@ import {ArgOutput, FlagOutput, Input} from '@oclif/core/lib/interfaces/parser.js
 import Command from '@shopify/cli-kit/node/base-command'
 import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {loadEnvironment} from '@shopify/cli-kit/node/environments'
-import {renderWarning} from '@shopify/cli-kit/node/ui'
+import {renderWarning, renderConcurrent} from '@shopify/cli-kit/node/ui'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {AbortController} from '@shopify/cli-kit/node/abort'
+import {Writable} from 'stream'
 
 export interface FlagValues {
   [key: string]: boolean | string | string[] | number | undefined
@@ -36,7 +38,11 @@ export default abstract class ThemeCommand extends Command {
     return configurationFileName
   }
 
-  async command(_flags: FlagValues, _session: AdminSession): Promise<void> {}
+  async command(
+    _flags: FlagValues,
+    _session: AdminSession,
+    _context?: {stdout?: Writable; stderr?: Writable},
+  ): Promise<void> {}
 
   async run<
     TFlags extends FlagOutput & {path?: string; verbose?: boolean},
@@ -50,19 +56,37 @@ export default abstract class ThemeCommand extends Command {
     const requiredFlags = klass.multiEnvironmentsFlags
     const {flags} = await this.parse(klass)
 
-    // Single environment
-    if (!flags.environment) {
+    // No environment provided
+    if (!flags.environment?.length) {
       const session = await this.ensureAuthenticated(flags)
+
       await this.command(flags, session)
+
       return
     }
 
-    // Synchronously authenticate all environments
-    const sessions: {[storeFqdn: string]: AdminSession} = {}
     // OCLIF parses flags.environment as an array when using the --environment & -e flag but
     // as a string when using the direct environment variable SHOPIFY_FLAG_ENVIRONMENT
     // This handles both cases
     const environments = Array.isArray(flags.environment) ? flags.environment : [flags.environment]
+
+    // If only one environment is specified, treat it as single environment mode
+    if (environments.length === 1) {
+      const environmentConfig = await loadEnvironment(environments[0], 'shopify.theme.toml', {from: flags.path})
+      const environmentFlags = {
+        ...flags,
+        ...environmentConfig,
+        environment: environments,
+      }
+
+      const session = await this.ensureAuthenticated(environmentConfig as FlagValues)
+      await this.command(environmentFlags, session)
+
+      return
+    }
+
+    // Multiple environments
+    const sessions: {[storeFqdn: string]: AdminSession} = {}
 
     // Authenticate on all environments sequentially to avoid race conditions,
     // with authentication happening in parallel.
@@ -73,27 +97,34 @@ export default abstract class ThemeCommand extends Command {
       sessions[environmentName] = await this.ensureAuthenticated(environmentConfig as FlagValues)
     }
 
-    // Concurrently run commands
-    await Promise.all(
-      environments.map(async (environment: string) => {
-        const environmentConfig = await loadEnvironment(environment, 'shopify.theme.toml', {from: flags.path})
-        const environmentFlags = {
-          ...flags,
-          ...environmentConfig,
-          environment: [environment],
-        }
+    // Use renderConcurrent for multi-environment execution
+    const abortController = new AbortController()
 
-        if (!this.validConfig(environmentConfig as FlagValues, requiredFlags, environment)) return
+    await renderConcurrent({
+      processes: environments.map((environment: string) => ({
+        prefix: environment,
+        action: async (stdout: Writable, stderr: Writable, _signal) => {
+          const environmentConfig = await loadEnvironment(environment, 'shopify.theme.toml', {from: flags.path})
+          const environmentFlags = {
+            ...flags,
+            ...environmentConfig,
+            environment: [environment],
+          }
 
-        const session = sessions[environment]
+          if (!this.validConfig(environmentConfig as FlagValues, requiredFlags, environment)) return
 
-        if (!session) {
-          throw new AbortError(`No session found for environment ${environment}`)
-        }
+          const session = sessions[environment]
 
-        return this.command(environmentFlags, session)
-      }),
-    )
+          if (!session) {
+            throw new AbortError(`No session found for environment ${environment}`)
+          }
+
+          await this.command(environmentFlags, session, {stdout, stderr})
+        },
+      })),
+      abortSignal: abortController.signal,
+      showTimestamps: true,
+    })
   }
 
   private async ensureAuthenticated(flags: FlagValues) {

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -7,7 +7,7 @@ import {loadEnvironment} from '@shopify/cli-kit/node/environments'
 import {renderWarning, renderConcurrent} from '@shopify/cli-kit/node/ui'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {AbortController} from '@shopify/cli-kit/node/abort'
-import {Writable} from 'stream'
+import type {Writable} from 'stream'
 
 export interface FlagValues {
   [key: string]: boolean | string | string[] | number | undefined
@@ -72,28 +72,8 @@ export default abstract class ThemeCommand extends Command {
 
     // If only one environment is specified, treat it as single environment mode
     if (environments.length === 1) {
-      const environmentName = environments[0]
-      // If the environment is the default environment, the config is already available.
-      if (environmentName === 'default') {
-        const session = await this.ensureAuthenticated(flags)
-        await this.command(flags, session)
-        return
-      }
-
-      // For non-default environments, we need to load the config
-      const environmentConfig = await loadEnvironment(environmentName, 'shopify.theme.toml', {
-        from: flags.path,
-        silent: true,
-      })
-      const environmentFlags = {
-        ...flags,
-        ...environmentConfig,
-        environment: environments,
-      }
-
-      const session = await this.ensureAuthenticated(environmentConfig as FlagValues)
-      await this.command(environmentFlags, session)
-
+      const session = await this.ensureAuthenticated(flags)
+      await this.command(flags, session)
       return
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/735

We have some issues with the way we handle multiple environments which is done in `theme-command`. 

### WHAT is this pull request doing?

**Environment Detection Fix:**

- Changed from `if (!flags.environment)` to `if (!flags.environment?.length)` to properly distinguish between no environments ([]) and actual environment values (["dev"])
- Added proper handling for single vs multiple environment scenarios

**Improved Multi-Environment Execution:**

- Replaced Promise.all with renderConcurrent for multiple environments to prevent terminal output conflicts
- Each environment process gets its own isolated stdout/stderr streams
- Added `CommandContext` interface to pass stream references to commands
- Integrated `AbortController` for proper cancellation handling

### How to test your changes?
- Pull the branch
- Build the branch
- Have a `shopify.theme.toml` file with a few environments

We want to test 4 different scenarios that use `theme-command.ts`' `command` method
   - No environment provided: `shopify theme list` using the cached store in your system
   - Default environment provided (To run this you will need an `environments.default` in your `.toml` file
         - `shopify theme list` which will use the default environment
   - Single environment provided: `shopify theme list -e <mystore>`
   - Multi environment provided: `shopify theme list -e <mystore> -e <myotherstore>`

Check that we get the proper output from the right environment(s)

### Post-release steps

I will monitor rollout over the week.

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [X] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
