### PR TITLE
Fix import path from '@shopify/ui-extension' to '@shopify/ui-extensions'

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -661,14 +661,14 @@ describe('generateExtensionTypes', () => {
       const ext1TypeFilePath = joinPath(ext1Dir, 'shopify.d.ts')
       const ext1FileContent = await readFile(ext1TypeFilePath)
       const normalizedExt1Content = ext1FileContent.toString().replace(/\\/g, '/')
-      expect(normalizedExt1Content).toBe(`import '@shopify/ui-extension';\n
+      expect(normalizedExt1Content).toBe(`import '@shopify/ui-extensions';\n
 declare module './ext1-module-1.jsx' { // mocked ext1 module 1 definition }
 declare module './ext1-module-2.jsx' { // mocked ext1 module 2 definition }`)
 
       const ext2TypeFilePath = joinPath(ext2Dir, 'shopify.d.ts')
       const ext2FileContent = await readFile(ext2TypeFilePath)
       const normalizedExt2Content = ext2FileContent.toString().replace(/\\/g, '/')
-      expect(normalizedExt2Content).toBe(`import '@shopify/ui-extension';\n
+      expect(normalizedExt2Content).toBe(`import '@shopify/ui-extensions';\n
 declare module './ext2-module-1.jsx' { // mocked ext2 module 1 definition }
 declare module './ext2-module-2.jsx' { // mocked ext2 module 2 definition }`)
     })

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -538,7 +538,7 @@ export class App<
       const originalContent = exists ? readFileSync(typeFilePath).toString() : ''
       // We need this top-level import to work around the TS restriction of not allowing  declaring modules with relative paths.
       // This is needed to enable file-specific global type declarations.
-      const typeContent = [`import '@shopify/ui-extension';\n`, ...Array.from(types)].join('\n')
+      const typeContent = [`import '@shopify/ui-extensions';\n`, ...Array.from(types)].join('\n')
       if (originalContent === typeContent) {
         return
       }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
