### PR TITLE
Remove git remote on theme init

### DIFF
--- a/.changeset/remove-git-remote-theme-init.md
+++ b/.changeset/remove-git-remote-theme-init.md
@@ -1,0 +1,6 @@
+---
+"@shopify/theme": patch
+"@shopify/cli-kit": patch
+---
+
+Remove git remote after cloning theme in `theme init` command to prevent accidental pushes to the skeleton theme repository

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -361,3 +361,30 @@ export async function getLatestTag(directory?: string): Promise<string | undefin
   const tags = await git({baseDir: directory}).tags()
   return tags.latest
 }
+
+/**
+ * Remove a git remote from the given directory.
+ *
+ * @param directory - The directory where the git repository is located.
+ * @param remoteName - The name of the remote to remove (defaults to 'origin').
+ * @returns A promise that resolves when the remote is removed.
+ */
+export async function removeGitRemote(directory: string, remoteName = 'origin'): Promise<void> {
+  outputDebug(outputContent`Removing git remote ${remoteName} from ${outputToken.path(directory)}...`)
+  await ensureGitIsPresentOrAbort()
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const repo = git(directory)
+
+  // Check if remote exists first
+  const remotes = await repo.getRemotes()
+  const remoteExists = remotes.some((remote: {name: string}) => remote.name === remoteName)
+
+  if (!remoteExists) {
+    outputDebug(outputContent`Remote ${remoteName} does not exist, no action needed`)
+    return
+  }
+
+  await repo.removeRemote(remoteName)
+}

--- a/packages/theme/src/cli/services/init.test.ts
+++ b/packages/theme/src/cli/services/init.test.ts
@@ -24,12 +24,13 @@ describe('cloneRepoAndCheckoutLatestTag()', async () => {
     const repoUrl = 'https://github.com/Shopify/dawn.git'
     const destination = 'destination'
     const latestTag = true
+    const shallow = true
 
     // When
     await cloneRepoAndCheckoutLatestTag(repoUrl, destination)
 
     // Then
-    expect(downloadGitRepository).toHaveBeenCalledWith({repoUrl, destination, latestTag})
+    expect(downloadGitRepository).toHaveBeenCalledWith({repoUrl, destination, latestTag, shallow})
   })
 })
 
@@ -38,12 +39,12 @@ describe('cloneRepo()', async () => {
     // Given
     const repoUrl = 'https://github.com/Shopify/dawn.git'
     const destination = 'destination'
-
+    const shallow = true
     // When
     await cloneRepo(repoUrl, destination)
 
     // Then
-    expect(downloadGitRepository).toHaveBeenCalledWith({repoUrl, destination})
+    expect(downloadGitRepository).toHaveBeenCalledWith({repoUrl, destination, shallow})
   })
 })
 

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -1,5 +1,5 @@
 import {renderSelectPrompt, renderTasks} from '@shopify/cli-kit/node/ui'
-import {downloadGitRepository} from '@shopify/cli-kit/node/git'
+import {downloadGitRepository, removeGitRemote} from '@shopify/cli-kit/node/git'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {mkdir, writeFile} from '@shopify/cli-kit/node/fs'
 import {fetch} from '@shopify/cli-kit/node/http'
@@ -22,6 +22,7 @@ async function downloadRepository(repoUrl: string, destination: string, latestTa
           destination,
           latestTag,
         })
+        await removeGitRemote(destination)
       },
     },
   ])

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -21,6 +21,7 @@ async function downloadRepository(repoUrl: string, destination: string, latestTa
           repoUrl,
           destination,
           latestTag,
+          shallow: true,
         })
         await removeGitRemote(destination)
       },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5957

This PR fixes an issue where `shopify theme init` was leaving the git remote pointing to the skeleton theme repository (`https://github.com/Shopify/skeleton-theme.git`).

### WHAT is this pull request doing?

Under the hood,  we are running `simple-git`'s `removeRemote` method. Before that, we check to see if any remote exists, if it doesn't we skip running `removeRemote`

Before:
![image](https://github.com/user-attachments/assets/af412a5d-c7a3-49c6-8825-ea458e4fcfc4)

After:
![image](https://github.com/user-attachments/assets/76011680-0962-4c2d-98b8-3a1a26325778)

### How to test your changes?

- Pull down the branch
- Build the branch
- Run `shopify theme init`
- CD into the new theme folder and run `git remote -v` (you should have nothing be returned)

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
