### PR TITLE
Revert requesting scope organization.on-demand-user-access

### DIFF
--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_dev_store_by_domain.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_dev_store_by_domain.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-duplicate-type-constituents */
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
 import * as Types from './types.js'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -23,7 +23,6 @@ export type FetchDevStoreByDomainQuery = {
         }
       }[]
     } | null
-    currentUser?: {organizationPermissions: string[]} | {organizationPermissions: string[]} | null
   } | null
 }
 
@@ -115,17 +114,6 @@ export const FetchDevStoreByDomain = {
                           ],
                         },
                       },
-                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: {kind: 'Name', value: 'currentUser'},
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      {kind: 'Field', name: {kind: 'Name', value: 'organizationPermissions'}},
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],
                   },

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/list_app_dev_stores.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/list_app_dev_stores.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-duplicate-type-constituents */
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
 import * as Types from './types.js'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -24,7 +24,6 @@ export type ListAppDevStoresQuery = {
       }[]
       pageInfo: {hasNextPage: boolean}
     } | null
-    currentUser?: {organizationPermissions: string[]} | {organizationPermissions: string[]} | null
   } | null
 }
 
@@ -127,17 +126,6 @@ export const ListAppDevStores = {
                           ],
                         },
                       },
-                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: {kind: 'Name', value: 'currentUser'},
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      {kind: 'Field', name: {kind: 'Name', value: 'organizationPermissions'}},
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],
                   },

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/queries/fetch_dev_store_by_domain.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/queries/fetch_dev_store_by_domain.graphql
@@ -14,8 +14,5 @@
           }
         }
       }
-      currentUser {
-        organizationPermissions
-      }
     }
   }

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/queries/list_app_dev_stores.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/queries/list_app_dev_stores.graphql
@@ -17,8 +17,5 @@ query ListAppDevStores($searchTerm: String) {
         hasNextPage
       }
     }
-    currentUser {
-      organizationPermissions
-    }
   }
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -536,7 +536,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
 
     const shopArray = organization.accessibleShops?.edges.map((value) => value.node) ?? []
-    const provisionable = isStoreProvisionable(organization.currentUser?.organizationPermissions ?? [])
+    const provisionable = false
     return {
       stores: mapBusinessPlatformStoresToOrganizationStores(shopArray, provisionable),
       hasMorePages: storesResult.organization?.accessibleShops?.pageInfo.hasNextPage ?? false,
@@ -838,7 +838,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
 
     const bpStoresArray = organization.accessibleShops?.edges.map((value) => value.node) ?? []
-    const provisionable = isStoreProvisionable(organization.currentUser?.organizationPermissions ?? [])
+    const provisionable = false
     const storesArray = mapBusinessPlatformStoresToOrganizationStores(bpStoresArray, provisionable)
     return storesArray[0]
   }
@@ -1338,8 +1338,4 @@ function toUserError(err: CreateAppVersionMutation['appVersionCreate']['userErro
     details.push({extension_id: extensionId})
   }
   return {...err, details}
-}
-
-function isStoreProvisionable(permissions: string[]) {
-  return permissions.includes('ondemand_access_to_stores')
 }

--- a/packages/cli-kit/src/private/node/session/scopes.test.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.test.ts
@@ -20,7 +20,6 @@ describe('allDefaultScopes', () => {
       'https://api.shopify.com/auth/partners.app.cli.access',
       'https://api.shopify.com/auth/destinations.readonly',
       'https://api.shopify.com/auth/organization.store-management',
-      'https://api.shopify.com/auth/organization.on-demand-user-access',
       'https://api.shopify.com/auth/organization.apps.manage',
       ...customScopes,
     ])
@@ -40,7 +39,6 @@ describe('allDefaultScopes', () => {
       'https://api.shopify.com/auth/partners.app.cli.access',
       'https://api.shopify.com/auth/destinations.readonly',
       'https://api.shopify.com/auth/organization.store-management',
-      'https://api.shopify.com/auth/organization.on-demand-user-access',
       'https://api.shopify.com/auth/organization.apps.manage',
     ])
   })

--- a/packages/cli-kit/src/private/node/session/scopes.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.ts
@@ -52,7 +52,7 @@ function defaultApiScopes(api: API): string[] {
     case 'partners':
       return ['cli']
     case 'business-platform':
-      return ['destinations', 'store-management', 'on-demand-user-access']
+      return ['destinations', 'store-management']
     case 'app-management':
       return ['app-management']
     default:


### PR DESCRIPTION
### WHY are these changes introduced?

For https://github.com/shop/issues-develop/issues/123#issuecomment-2963814760

The CLI scopes in Identity are flipping back and forth between allowing and not allowing `organization.on-demand-user-access`. Shopify currently doesn't know why or how to prevent it. We want to avoid reverting Gordon's large [stack](https://app.graphite.dev/github/pr/Shopify/cli/5596/Provision-user-access-to-stores-only-when-permitted) of PRs related to this because it was a lot of work getting those shipped.

### WHAT is this pull request doing?

Make CLI not request scope `organization.on-demand-user-access` with the smallest possible change. We don't need it yet since the [feature](https://github.com/shop/issues-develop/issues/123) it supports is not currently released.

### How to test your changes?

`pnpm  shopify app dev --path="$HOME/src/tmp/niche-supply-app" --reset --verbose` on a Plus Dev Platform 2 org.

### Post-release steps

Cli app dev on a Dev Platform 2 org.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
