### PR TITLE
Add back changeset file required for snapit

### DIFF
--- a/.changeset/force-snapshot-build.md.ignore
+++ b/.changeset/force-snapshot-build.md.ignore
@@ -1,0 +1,3 @@
+---
+'@shopify/cli': patchAdd commentMore actions
+---


### PR DESCRIPTION
This file was accidentally removed in https://github.com/Shopify/cli/pull/5965/commits/bd2e5a83d18332884c998079b5871707a7733f0a and is required for the `/snapit` command to work. Here's an example of the failure: https://github.com/Shopify/cli/actions/runs/15617379317/job/43993886342