### PR TITLE
Fix typo in force-snapshot-build

### DIFF
--- a/.changeset/force-snapshot-build.md.ignore
+++ b/.changeset/force-snapshot-build.md.ignore
@@ -1,3 +1,3 @@
 ---
-'@shopify/cli': patchAdd commentMore actions
+'@shopify/cli': patch
 ---


### PR DESCRIPTION
Oddly there was a typo in my copy/paste to bring this file back which is causing `/snapit` to continue to fail. This fixes the file to be what it was originally.