### PR TITLE
Do not require authentication for app function replay

### DIFF
--- a/packages/app/src/cli/commands/app/build.ts
+++ b/packages/app/src/cli/commands/app/build.ts
@@ -2,7 +2,7 @@ import {appFlags} from '../../flags.js'
 import build from '../../services/build.js'
 import {showApiKeyDeprecationWarning} from '../../prompts/deprecation-warnings.js'
 import AppCommand, {AppCommandOutput} from '../../utilities/app-command.js'
-import {linkedAppContext} from '../../services/app-context.js'
+import {localAppContext} from '../../services/app-context.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
@@ -44,10 +44,8 @@ export default class Build extends AppCommand {
       cmd_app_dependency_installation_skipped: flags['skip-dependencies-installation'],
     }))
 
-    const {app} = await linkedAppContext({
+    const app = await localAppContext({
       directory: flags.path,
-      clientId: apiKey,
-      forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
     })
 

--- a/packages/app/src/cli/commands/app/function/build.ts
+++ b/packages/app/src/cli/commands/app/function/build.ts
@@ -1,7 +1,8 @@
-import {inFunctionContext, functionFlags} from '../../../services/function/common.js'
+import {chooseFunction, functionFlags} from '../../../services/function/common.js'
 import {buildFunctionExtension} from '../../../services/build/extension.js'
 import {appFlags} from '../../../flags.js'
 import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
+import {localAppContext} from '../../../services/app-context.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 
@@ -21,23 +22,22 @@ export default class FunctionBuild extends AppCommand {
   public async run(): Promise<AppCommandOutput> {
     const {flags} = await this.parse(FunctionBuild)
 
-    const app = await inFunctionContext({
-      path: flags.path,
+    const app = await localAppContext({
+      directory: flags.path,
       userProvidedConfigName: flags.config,
-      apiKey: flags['client-id'],
-      reset: flags.reset,
-      callback: async (app, _, ourFunction) => {
-        await buildFunctionExtension(ourFunction, {
-          app,
-          stdout: process.stdout,
-          stderr: process.stderr,
-          useTasks: true,
-          environment: 'production',
-        })
-        renderSuccess({headline: 'Function built successfully.'})
-        return app
-      },
     })
+
+    const ourFunction = await chooseFunction(app, flags.path)
+
+    await buildFunctionExtension(ourFunction, {
+      app,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      useTasks: true,
+      environment: 'production',
+    })
+    renderSuccess({headline: 'Function built successfully.'})
+
     return {app}
   }
 }

--- a/packages/app/src/cli/commands/app/function/replay.ts
+++ b/packages/app/src/cli/commands/app/function/replay.ts
@@ -1,8 +1,9 @@
-import {functionFlags, inFunctionContext} from '../../../services/function/common.js'
+import {chooseFunction, functionFlags} from '../../../services/function/common.js'
 import {replay} from '../../../services/function/replay.js'
 import {appFlags} from '../../../flags.js'
 import {showApiKeyDeprecationWarning} from '../../../prompts/deprecation-warnings.js'
 import AppCommand, {AppCommandOutput} from '../../../utilities/app-command.js'
+import {localAppContext} from '../../../services/app-context.js'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 
@@ -45,25 +46,23 @@ export default class FunctionReplay extends AppCommand {
     if (flags['api-key']) {
       await showApiKeyDeprecationWarning()
     }
-    const apiKey = flags['client-id'] ?? flags['api-key']
 
-    const app = await inFunctionContext({
-      path: flags.path,
-      apiKey,
+    const app = await localAppContext({
+      directory: flags.path,
       userProvidedConfigName: flags.config,
-      reset: flags.reset,
-      callback: async (app, _, ourFunction) => {
-        await replay({
-          app,
-          extension: ourFunction,
-          path: flags.path,
-          log: flags.log,
-          json: flags.json,
-          watch: flags.watch,
-        })
-        return app
-      },
     })
+
+    const ourFunction = await chooseFunction(app, flags.path)
+
+    await replay({
+      app,
+      extension: ourFunction,
+      path: flags.path,
+      log: flags.log,
+      json: flags.json,
+      watch: flags.watch,
+    })
+
     return {app}
   }
 }

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -2,7 +2,7 @@
 import {FileWatcher, OutputContextOptions} from './file-watcher.js'
 import {ESBuildContextManager} from './app-watcher-esbuild.js'
 import {handleWatcherEvents} from './app-event-watcher-handler.js'
-import {AppLinkedInterface} from '../../../models/app/app.js'
+import {AppInterface} from '../../../models/app/app.js'
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
 import {ExtensionBuildOptions} from '../../build/extension.js'
 import {outputDebug} from '@shopify/cli-kit/node/output'
@@ -76,7 +76,7 @@ export interface ExtensionEvent {
  * to determine how long it took to process the event.
  */
 export interface AppEvent {
-  app: AppLinkedInterface
+  app: AppInterface
   extensionEvents: ExtensionEvent[]
   path: string
   startTime: [number, number]
@@ -90,7 +90,7 @@ type ExtensionBuildResult = {status: 'ok'; uid: string} | {status: 'error'; erro
  */
 export class AppEventWatcher extends EventEmitter {
   buildOutputPath: string
-  private app: AppLinkedInterface
+  private app: AppInterface
   private options: OutputContextOptions
   private readonly appURL?: string
   private readonly esbuildManager: ESBuildContextManager
@@ -100,7 +100,7 @@ export class AppEventWatcher extends EventEmitter {
   private fileWatcher?: FileWatcher
 
   constructor(
-    app: AppLinkedInterface,
+    app: AppInterface,
     appURL?: string,
     buildOutputPath?: string,
     esbuildManager?: ESBuildContextManager,

--- a/packages/app/src/cli/services/dev/app-events/file-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/file-watcher.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import {AppLinkedInterface} from '../../../models/app/app.js'
+import {AppInterface} from '../../../models/app/app.js'
 import {configurationFileNames} from '../../../constants.js'
 import {dirname, isSubpath, joinPath, normalizePath, relativePath} from '@shopify/cli-kit/node/path'
 import {FSWatcher} from 'chokidar'
@@ -50,18 +50,14 @@ export interface OutputContextOptions {
 export class FileWatcher {
   private currentEvents: WatcherEvent[] = []
   private extensionPaths: string[] = []
-  private app: AppLinkedInterface
+  private app: AppInterface
   private readonly options: OutputContextOptions
   private onChangeCallback?: (events: WatcherEvent[]) => void
   private watcher?: FSWatcher
   private readonly debouncedEmit: () => void
   private readonly ignored: {[key: string]: ignore.Ignore | undefined} = {}
 
-  constructor(
-    app: AppLinkedInterface,
-    options: OutputContextOptions,
-    debounceTime: number = DEFAULT_DEBOUNCE_TIME_IN_MS,
-  ) {
+  constructor(app: AppInterface, options: OutputContextOptions, debounceTime: number = DEFAULT_DEBOUNCE_TIME_IN_MS) {
     this.app = app
     this.options = options
 
@@ -104,7 +100,7 @@ export class FileWatcher {
     this.options.signal.addEventListener('abort', this.close)
   }
 
-  updateApp(app: AppLinkedInterface) {
+  updateApp(app: AppInterface) {
     this.app = app
     this.extensionPaths = this.app.realExtensions
       .map((ext) => normalizePath(ext.directory))

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
@@ -3,13 +3,13 @@ import {pollAppLogs} from '../../app-logs/dev/poll-app-logs.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {AppLogsSubscribeMutationVariables} from '../../../api/graphql/app-management/generated/app-logs-subscribe.js'
 import {subscribeToAppLogs} from '../../app-logs/utils.js'
-import {AppLinkedInterface} from '../../../models/app/app.js'
+import {AppInterface} from '../../../models/app/app.js'
 import {AppEventWatcher, AppEvent} from '../app-events/app-event-watcher.js'
 
 import {createLogsDir} from '@shopify/cli-kit/node/logs'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 
-function hasFunctionExtensions(app: AppLinkedInterface): boolean {
+function hasFunctionExtensions(app: AppInterface): boolean {
   return app.allExtensions.some((extension) => extension.isFunctionExtension)
 }
 
@@ -19,7 +19,7 @@ interface SubscribeAndStartPollingOptions {
   storeName: string
   organizationId: string
   appWatcher: AppEventWatcher
-  localApp: AppLinkedInterface
+  localApp: AppInterface
 }
 
 export interface AppLogsSubscribeProcess extends BaseProcess<SubscribeAndStartPollingOptions> {
@@ -35,7 +35,7 @@ interface Props {
   storeName: string
   organizationId: string
   appWatcher: AppEventWatcher
-  localApp: AppLinkedInterface
+  localApp: AppInterface
 }
 
 export async function setupAppLogsPollingProcess({

--- a/packages/app/src/cli/services/function/common.test.ts
+++ b/packages/app/src/cli/services/function/common.test.ts
@@ -54,14 +54,8 @@ describe('inFunctionContext integration', () => {
     })
 
     // Then
-    expect(callback).toHaveBeenCalledWith(
-      app,
-      // developerPlatformClient
-      expect.any(Object),
-      ourFunction,
-      // orgId
-      expect.any(String),
-    )
+    expect(callback).toHaveBeenCalledOnce()
+    expect(renderFatalError).not.toHaveBeenCalled()
   })
 
   test('calls linkedAppContext with correct parameters', async () => {

--- a/packages/app/src/cli/services/function/replay.ts
+++ b/packages/app/src/cli/services/function/replay.ts
@@ -1,23 +1,24 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {renderReplay} from './ui.js'
 import {runFunction} from './runner.js'
-import {AppLinkedInterface} from '../../models/app/app.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {selectFunctionRunPrompt} from '../../prompts/function/replay.js'
 
+import {AppInterface} from '../../models/app/app.js'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {readFile} from '@shopify/cli-kit/node/fs'
 import {getLogsDir} from '@shopify/cli-kit/node/logs'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {AbortController} from '@shopify/cli-kit/node/abort'
+import {hashString} from '@shopify/cli-kit/node/crypto'
 
 import {existsSync, readdirSync} from 'fs'
 
 const LOG_SELECTOR_LIMIT = 100
 
 interface ReplayOptions {
-  app: AppLinkedInterface
+  app: AppInterface
   extension: ExtensionInstance<FunctionConfigType>
   stdout?: boolean
   path: string
@@ -53,8 +54,8 @@ export async function replay(options: ReplayOptions) {
   const abortController = new AbortController()
 
   try {
-    const apiKey = options.app.configuration.client_id
-    const functionRunsDir = joinPath(getLogsDir(), apiKey)
+    const pathHash = hashString(options.path)
+    const functionRunsDir = joinPath(getLogsDir(), pathHash)
 
     const selectedRun = options.log
       ? await getRunFromIdentifier(functionRunsDir, extension.handle, options.log)

--- a/packages/app/src/cli/services/function/ui/components/Replay/Replay.tsx
+++ b/packages/app/src/cli/services/function/ui/components/Replay/Replay.tsx
@@ -3,9 +3,9 @@ import {useFunctionWatcher} from './hooks/useFunctionWatcher.js'
 import {FunctionRunData} from '../../../replay.js'
 import {ExtensionInstance} from '../../../../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../../../../models/extensions/specifications/function.js'
-import {AppLinkedInterface} from '../../../../../models/app/app.js'
 import {prettyPrintJsonIfPossible} from '../../../../app-logs/utils.js'
 import {AppEventWatcher} from '../../../../dev/app-events/app-event-watcher.js'
+import {AppInterface} from '../../../../../models/app/app.js'
 import figures from '@shopify/cli-kit/node/figures'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import React, {FunctionComponent} from 'react'
@@ -16,7 +16,7 @@ import {handleCtrlC} from '@shopify/cli-kit/node/ui'
 export interface ReplayProps {
   selectedRun: FunctionRunData
   abortController: AbortController
-  app: AppLinkedInterface
+  app: AppInterface
   extension: ExtensionInstance<FunctionConfigType>
 }
 

--- a/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
+++ b/packages/app/src/cli/services/function/ui/components/Replay/hooks/useFunctionWatcher.ts
@@ -1,10 +1,10 @@
 import {FunctionRunData} from '../../../../replay.js'
-import {AppLinkedInterface} from '../../../../../../models/app/app.js'
 import {FunctionConfigType} from '../../../../../../models/extensions/specifications/function.js'
 import {ExtensionInstance} from '../../../../../../models/extensions/extension-instance.js'
 import {FunctionRunFromRunner, ReplayLog} from '../types.js'
 import {runFunction} from '../../../../runner.js'
 import {AppEventWatcher, EventType} from '../../../../../dev/app-events/app-event-watcher.js'
+import {AppInterface} from '../../../../../../models/app/app.js'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import {useEffect, useState} from 'react'
 import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
@@ -15,7 +15,7 @@ import {Writable} from 'stream'
 interface WatchFunctionForReplayOptions {
   selectedRun: FunctionRunData
   abortController: AbortController
-  app: AppLinkedInterface
+  app: AppInterface
   extension: ExtensionInstance<FunctionConfigType>
   appWatcher: AppEventWatcher
 }

--- a/packages/app/src/cli/utilities/app-command.ts
+++ b/packages/app/src/cli/utilities/app-command.ts
@@ -1,5 +1,5 @@
 import {configurationFileNames} from '../constants.js'
-import {AppLinkedInterface} from '../models/app/app.js'
+import {AppInterface} from '../models/app/app.js'
 import BaseCommand from '@shopify/cli-kit/node/base-command'
 
 /**
@@ -9,7 +9,7 @@ import BaseCommand from '@shopify/cli-kit/node/base-command'
  * - A remoteApp is fetched
  */
 export interface AppCommandOutput {
-  app: AppLinkedInterface
+  app: AppInterface
 }
 
 export default abstract class AppCommand extends BaseCommand {


### PR DESCRIPTION
### WHY are these changes introduced?



### WHAT is this pull request doing?

- Use `localAppContext` in the `app function replay` command
- For the log folder, instead of using the api-key, I'm now using a hash of the current path [here](https://github.com/Shopify/cli/pull/5981/files#diff-0efb825e99b63a37735de72863a181a3e040814e24287287034e29848e6f7c80R57), because the api key could be missing if we don't require to link the app

### How to test your changes?

- `p shopify auth logout`
- `p shopify app function replay`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
