### PR TITLE
[Main] Fix client credential request

### DIFF
--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -9,7 +9,6 @@ import {adminUrl, supportedApiVersions} from '@shopify/cli-kit/node/api/admin'
 import {fetch} from '@shopify/cli-kit/node/http'
 import {renderLiquidTemplate} from '@shopify/cli-kit/node/liquid'
 import {outputDebug} from '@shopify/cli-kit/node/output'
-import {encode as queryStringEncode} from 'node:querystring'
 import {Server} from 'http'
 import {Writable} from 'stream'
 import {createRequire} from 'module'
@@ -75,17 +74,19 @@ export function setupGraphiQLServer({
     try {
       outputDebug('refreshing token', stdout)
       _token = undefined
-      const queryString = queryStringEncode({
+      const bodyData = {
         client_id: apiKey,
         client_secret: apiSecret,
         grant_type: 'client_credentials',
-      })
-      const tokenResponse = await fetch(`https://${storeFqdn}/admin/oauth/access_token?${queryString}`, {
+      }
+      const tokenResponse = await fetch(`https://${storeFqdn}/admin/oauth/access_token`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify(bodyData),
       })
+
       const tokenJson = (await tokenResponse.json()) as {access_token: string}
       return tokenJson.access_token
     } catch (_error) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes:
  - https://github.com/shop/issues-app-access/issues/745

### WHAT is this pull request doing?
  - When getting access tokens from client credentials, send data in request body instead of URL params

### How to test your changes?
I start `shopify app dev` and debugged to see client credentials body query, and checked GraphiQL still works
![image](https://github.com/user-attachments/assets/bf1994d0-811d-4f92-abc6-d32b23e6df5d)

![image](https://github.com/user-attachments/assets/fca656c5-1371-4262-8762-cead5b8c8e6f)

### Post-release steps

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
