### PR TITLE
added error handling for authorization when backend server may not be reachable

### DIFF
--- a/.changeset/young-rocks-watch.md
+++ b/.changeset/young-rocks-watch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add error handling when the authorization service is not reachable

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -73,7 +73,7 @@ describe('requestDeviceAuthorization', () => {
 
     // When/Then
     await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrow(
-      'Received unexpected response. This may be a service outage. Please try again later.',
+      'Received unexpected response from the authorization service. If this issue persists, please contact support at https://help.shopify.com',
     )
   })
 
@@ -86,7 +86,7 @@ describe('requestDeviceAuthorization', () => {
 
     // When/Then
     await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrow(
-      'Received unexpected response. This may be a service outage. Please try again later.',
+      'Received unexpected response from the authorization service. If this issue persists, please contact support at https://help.shopify.com',
     )
   })
 })

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -63,6 +63,32 @@ describe('requestDeviceAuthorization', () => {
     })
     expect(got).toEqual(dataExpected)
   })
+
+  test('when the response is not valid JSON, throw an error', async () => {
+    // Given
+    const response = new Response('not valid JSON')
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+
+    // When/Then
+    await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrow(
+      'Received unexpected response. This may be a service outage. Please try again later.',
+    )
+  })
+
+  test('when the response is empty, throw an error', async () => {
+    // Given
+    const response = new Response('')
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+
+    // When/Then
+    await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrow(
+      'Received unexpected response. This may be a service outage. Please try again later.',
+    )
+  })
 })
 
 describe('pollForDeviceAuthorization', () => {

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -45,7 +45,9 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
   try {
     jsonResult = await response.json()
   } catch (error) {
-    throw new BugError('Received unexpected response. This may be a service outage. Please try again later.')
+    throw new BugError(
+      'Received unexpected response from the authorization service. If this issue persists, please contact support at https://help.shopify.com',
+    )
   }
 
   outputDebug(outputContent`Received device authorization code: ${outputToken.json(jsonResult)}`)

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -41,7 +41,12 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
   })
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const jsonResult: any = await response.json()
+  let jsonResult: any
+  try {
+    jsonResult = await response.json()
+  } catch (error) {
+    throw new BugError('Received unexpected response. This may be a service outage. Please try again later.')
+  }
 
   outputDebug(outputContent`Received device authorization code: ${outputToken.json(jsonResult)}`)
   if (!jsonResult.device_code || !jsonResult.verification_uri_complete) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/740

When a backend service went down last week, we started returning `Unexpected end of JSON input`. The appearance of the error made it look like a CLI bug.

### WHAT is this pull request doing?

Adding extra error handling when the backend service is down or having issues.

### How to test your changes?

There are associated tests to see what happens when returns are not proper JSON.

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
