### PR TITLE
[Feature] Display UI Extension Logs from Extensibility Host

### DIFF
--- a/packages/app/src/cli/services/dev/extension/websocket/handlers.test.ts
+++ b/packages/app/src/cli/services/dev/extension/websocket/handlers.test.ts
@@ -2,7 +2,7 @@ import {
   getConnectionDoneHandler,
   getOnMessageHandler,
   getPayloadUpdateHandler,
-  handleLogMessage,
+  handleLogEvent,
   parseLogMessage,
   websocketUpgradeHandler,
 } from './handlers.js'
@@ -196,18 +196,15 @@ describe('getOnMessageHandler()', () => {
     wss.clients.forEach((ws) => expect(ws.send).toHaveBeenCalledWith(outgoingMessage))
   })
 
-  test('on an incoming dispatch with type log calls handleLogMessage and does not notify clients', () => {
+  test('on an incoming log event calls handleLogMessage and does not notify clients', () => {
     const wss = getMockWebsocketServer()
     const options = getMockSetupWebSocketConnectionOptions()
     const data = JSON.stringify({
-      event: 'dispatch',
+      event: 'log',
       data: {
-        type: 'log',
-        payload: {
-          level: 'info',
-          message: 'Test log message',
-          extensionName: 'test-extension',
-        },
+        type: 'info',
+        message: 'Test log message',
+        extensionName: 'test-extension',
       },
     }) as unknown as RawData
 
@@ -257,7 +254,7 @@ describe('parseLogMessage()', () => {
   })
 })
 
-describe('handleLogMessage()', () => {
+describe('handleLogEvent()', () => {
   // Helper function to abstract the common expect pattern
   function expectLogMessageOutput(
     extensionName: string,
@@ -277,14 +274,12 @@ describe('handleLogMessage()', () => {
   test('outputs info level log message with correct formatting', () => {
     const options = getMockSetupWebSocketConnectionOptions()
     const eventData = {
-      payload: {
-        level: 'info',
-        message: 'Test info message',
-        extensionName: 'test-extension',
-      },
+      type: 'info',
+      message: 'Test info message',
+      extensionName: 'test-extension',
     }
 
-    handleLogMessage(eventData, options)
+    handleLogEvent(eventData, options)
 
     expectLogMessageOutput('test-extension', `INFO: Test info message`, options)
   })
@@ -293,14 +288,12 @@ describe('handleLogMessage()', () => {
     const options = getMockSetupWebSocketConnectionOptions()
     const message = JSON.stringify(['Hello', 'world', {user: 'test'}], null, 2)
     const eventData = {
-      payload: {
-        level: 'info',
-        message,
-        extensionName: 'test-extension',
-      },
+      type: 'info',
+      message,
+      extensionName: 'test-extension',
     }
 
-    handleLogMessage(eventData, options)
+    handleLogEvent(eventData, options)
 
     expectLogMessageOutput(
       'test-extension',
@@ -312,14 +305,12 @@ describe('handleLogMessage()', () => {
   test('outputs error level log message with error formatting', () => {
     const options = getMockSetupWebSocketConnectionOptions()
     const eventData = {
-      payload: {
-        level: 'error',
-        message: 'Test error message',
-        extensionName: 'error-extension',
-      },
+      type: 'error',
+      message: 'Test error message',
+      extensionName: 'error-extension',
     }
 
-    handleLogMessage(eventData, options)
+    handleLogEvent(eventData, options)
 
     expectLogMessageOutput('error-extension', `${colors.bold.redBright('ERROR')}: Test error message`, options)
   })

--- a/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.tsx
+++ b/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.tsx
@@ -5,7 +5,6 @@ import {
   createRefreshAction,
   createFocusAction,
   createUnfocusAction,
-  createLogAction,
 } from '../state'
 
 import {ExtensionServerClient} from '../ExtensionServerClient'
@@ -36,7 +35,6 @@ export function ExtensionServerProvider({children, options: defaultOptions}: Ext
       client.on('refresh', (payload) => dispatch(createRefreshAction(payload))),
       client.on('focus', (payload) => dispatch(createFocusAction(payload))),
       client.on('unfocus', (payload) => dispatch(createUnfocusAction(payload))),
-      client.on('log', (payload) => dispatch(createLogAction(payload))),
     ]
 
     return () => listeners.forEach((unsubscribe) => unsubscribe())

--- a/packages/ui-extensions-server-kit/src/state/actions/actions.ts
+++ b/packages/ui-extensions-server-kit/src/state/actions/actions.ts
@@ -1,4 +1,4 @@
-import type {ConnectedAction, UpdateAction, RefreshAction, FocusAction, UnfocusAction, LogAction} from './types'
+import type {ConnectedAction, UpdateAction, RefreshAction, FocusAction, UnfocusAction} from './types'
 
 export function createConnectedAction(payload: ConnectedAction['payload']): ConnectedAction {
   return {
@@ -31,13 +31,6 @@ export function createFocusAction(payload: FocusAction['payload']): FocusAction 
 export function createUnfocusAction(payload: UnfocusAction['payload']): UnfocusAction {
   return {
     type: 'unfocus',
-    payload,
-  }
-}
-
-export function createLogAction(payload: LogAction['payload']): LogAction {
-  return {
-    type: 'log',
     payload,
   }
 }

--- a/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
+++ b/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
@@ -7,7 +7,6 @@ import {
   createRefreshAction,
   createFocusAction,
   createUnfocusAction,
-  createLogAction,
 } from '../actions'
 
 import type {ExtensionServerState} from './types'
@@ -157,18 +156,5 @@ describe('extensionServerReducer()', () => {
 
       expect(state.extensions[0].development.focused).toBe(false)
     })
-  })
-
-  test('does not mutate the state when receiving log events', () => {
-    const extension = mockExtension()
-    const previousState: ExtensionServerState = {
-      store: 'test-store.com',
-      extensions: [extension],
-    }
-
-    const action = createLogAction({level: 'info', message: 'test', extensionName: extension.name})
-    const state = extensionServerReducer(previousState, action)
-
-    expect(state).toStrictEqual(previousState)
   })
 })

--- a/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
+++ b/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
@@ -166,7 +166,7 @@ describe('extensionServerReducer()', () => {
       extensions: [extension],
     }
 
-    const action = createLogAction({level: 'info', args: ['test'], extensionName: extension.name})
+    const action = createLogAction({level: 'info', message: 'test', extensionName: extension.name})
     const state = extensionServerReducer(previousState, action)
 
     expect(state).toStrictEqual(previousState)

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -38,7 +38,6 @@ declare global {
       focus: {uuid: string}[]
       unfocus: void
       navigate: {url: string}
-      log: {level: string; message: string; extensionName: string}
     }
 
     // API responses

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -38,7 +38,7 @@ declare global {
       focus: {uuid: string}[]
       unfocus: void
       navigate: {url: string}
-      log: {level: string; args: unknown[]; extensionName: string}
+      log: {level: string; message: string; extensionName: string}
     }
 
     // API responses


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

We have had lots of feedback from [summit hackdays](https://docs.google.com/document/d/1eazVFaX-3umYTmuAUvboQh1h-rZZkQsKLflxK6caxcI/edit?tab=t.0#heading=h.1kw0jorzvrnf) that debugging POS UI Extensions is hard because the default Safari debugger misses logs or fails to start or is otherwise annoying. All of these complaits match our team's experience.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Adds support for a new event type (`log`) on the websocket connection between the POS app and CLI dev server. When log events are received, they are logged to the terminal console.

<img width="661" alt="image" src="https://github.com/user-attachments/assets/a9e87f14-6b98-4b9b-9168-235ae5f4cff0" />

### Haven't we seen this before?

Yes. This was originally merged in https://github.com/Shopify/cli/pull/5932 but reverted as the @Shopify/app-ui requested changes be made. This accounts for their [feedback](https://shopify.slack.com/archives/C04K7BZDH3N/p1749140890903219?thread_ts=1748871348.228269&cid=C04K7BZDH3N). 

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Run: packages/app/src/cli/services/dev/extension/websocket/handlers.test.ts

Or, you can follow the instructions in https://github.com/Shopify/pos-next-react-native/pull/61872 to test the end-to-end flow.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

1. Update [debugging docs](https://shopify.dev/docs/api/pos-ui-extensions/unstable/debugging) on shopify.dev

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
