### PR TITLE
[Feature] Display UI Extension Logs from Extensibility Host

### DIFF
--- a/.changeset/chatty-rats-pull.md
+++ b/.changeset/chatty-rats-pull.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-server-kit': minor
+'@shopify/app': minor
+---
+
+Add support for displaying POS dev logs

--- a/packages/app/src/cli/services/dev/extension/websocket/handlers.ts
+++ b/packages/app/src/cli/services/dev/extension/websocket/handlers.ts
@@ -7,6 +7,7 @@ import {
 } from './models.js'
 import {RawData, WebSocket, WebSocketServer} from 'ws'
 import {outputDebug, outputContent, outputToken} from '@shopify/cli-kit/node/output'
+import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
 import {IncomingMessage} from 'http'
 import {Duplex} from 'stream'
 
@@ -35,6 +36,56 @@ export function getConnectionDoneHandler(wss: WebSocketServer, options: SetupWeb
     ws.send(JSON.stringify(connectedPayload))
     ws.on('message', getOnMessageHandler(wss, options))
   }
+}
+
+export function parseLogMessage(message: string): string {
+  try {
+    const parsed = JSON.parse(message)
+
+    // it is expected that the message is an array of console arguments
+    if (!Array.isArray(parsed)) {
+      return message
+    }
+
+    const formatted = parsed
+      .map((arg) => {
+        if (typeof arg === 'object' && arg !== null) {
+          return outputToken.json(arg).output()
+        } else {
+          return String(arg)
+        }
+      })
+      .join(' ')
+
+    return outputContent`${formatted}`.value
+  } catch (error) {
+    // If parsing fails, return the original message
+    if (error instanceof SyntaxError) {
+      return message
+    }
+    throw error
+  }
+}
+
+export function handleLogEvent(
+  eventData: {type: string; message: string; extensionName: string},
+  options: SetupWebSocketConnectionOptions,
+) {
+  const {type, message, extensionName} = eventData
+  const formattedMessage = parseLogMessage(message)
+
+  const levelColors = {
+    debug: (text: string) => outputToken.gray(text),
+    warn: (text: string) => outputToken.yellow(text),
+    error: (text: string) => outputToken.errorText(text),
+  } as const
+
+  const uppercaseLevel = type.toUpperCase()
+  const colouredLevel = levelColors[type as keyof typeof levelColors]?.(uppercaseLevel) ?? uppercaseLevel
+
+  useConcurrentOutputContext({outputPrefix: extensionName, stripAnsi: false}, () => {
+    options.stdout.write(outputContent`${colouredLevel}: ${formattedMessage}`.value)
+  })
 }
 
 export function getOnMessageHandler(wss: WebSocketServer, options: SetupWebSocketConnectionOptions) {
@@ -72,6 +123,8 @@ ${outputToken.json(eventData)}
       const outGoingMessage = getOutgoingDispatchMessage(jsonData, options)
 
       notifyClients(wss, outGoingMessage, options)
+    } else if (eventType === 'log') {
+      handleLogEvent(eventData, options)
     }
   }
 }

--- a/packages/ui-extensions-server-kit/src/state/actions/types.ts
+++ b/packages/ui-extensions-server-kit/src/state/actions/types.ts
@@ -23,4 +23,15 @@ export interface UnfocusAction {
   payload: ExtensionServer.InboundEvents['unfocus']
 }
 
-export type ExtensionServerActions = ConnectedAction | UpdateAction | RefreshAction | FocusAction | UnfocusAction
+export interface LogAction {
+  type: 'log'
+  payload: ExtensionServer.InboundEvents['log']
+}
+
+export type ExtensionServerActions =
+  | ConnectedAction
+  | UpdateAction
+  | RefreshAction
+  | FocusAction
+  | UnfocusAction
+  | LogAction


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

We have had lots of feedback from [summit hackdays](https://docs.google.com/document/d/1eazVFaX-3umYTmuAUvboQh1h-rZZkQsKLflxK6caxcI/edit?tab=t.0#heading=h.1kw0jorzvrnf) that debugging POS UI Extensions is hard because the default Safari debugger misses logs or fails to start or is otherwise annoying. All of these complaits match our team's experience.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Adds support for a new event type (`log`) on the websocket connection between the POS app and CLI dev server. When log events are received, they are logged to the terminal console.

<img width="661" alt="image" src="https://github.com/user-attachments/assets/a9e87f14-6b98-4b9b-9168-235ae5f4cff0" />

### Haven't we seen this before?

Yes. This was originally merged in https://github.com/Shopify/cli/pull/5932 but reverted as the @Shopify/app-ui requested changes be made. This accounts for their [feedback](https://shopify.slack.com/archives/C04K7BZDH3N/p1749140890903219?thread_ts=1748871348.228269&cid=C04K7BZDH3N). 

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Run: packages/app/src/cli/services/dev/extension/websocket/handlers.test.ts

Or, you can follow the instructions in https://github.com/Shopify/pos-next-react-native/pull/61872 to test the end-to-end flow.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

1. Update [debugging docs](https://shopify.dev/docs/api/pos-ui-extensions/unstable/debugging) on shopify.dev

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
