### PR TITLE
Use example for missing store help text

### DIFF
--- a/.changeset/small-boxes-dress.md
+++ b/.changeset/small-boxes-dress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Add clarity to helper text when a store is missing

--- a/packages/theme/src/cli/utilities/theme-store.ts
+++ b/packages/theme/src/cli/utilities/theme-store.ts
@@ -9,7 +9,7 @@ export function ensureThemeStore(flags: {store: string | undefined}): string {
     throw new AbortError(
       'A store is required',
       `Specify the store passing ${
-        outputContent`${outputToken.genericShellCommand(`--${themeFlags.store.name}={your_store_url}`)}`.value
+        outputContent`${outputToken.genericShellCommand(`--${themeFlags.store.name}=example.myshopify.com`)}`.value
       } or set the ${
         outputContent`${outputToken.genericShellCommand(themeFlags.store.env as string)}`.value
       } environment variable.`,


### PR DESCRIPTION
We've seen a few users be confused by this text where they end up including the curly braces in the command like this:

```sh
shopify theme dev --store={mystore.myshopify.com}
```

...which will continue to fail. I considered switching to angled brackets (`--store=<your_store_url>`) but thought I might as well just use an example URL instead.