### PR TITLE
Fix `_shopify_essential` issues related to data replication and unstable connections

### DIFF
--- a/.changeset/tame-mugs-arrive.md
+++ b/.changeset/tame-mugs-arrive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `_shopify_essential` issues related to data replication and unstable connections


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5510

### WHAT is this pull request doing?

The storefront session relies on the fact the theme is created. However, when we're working with a brand new theme, there's no guarantee it will be immediately available (see: https://kovyrin.net/2024/06/16/interview-inside-shopify-monolith). Additionally, users might experience unstable connections—either on their end or on the edge—which can cause an error in the authentication request.

We can see an example of the second case in [this report](https://github.com/Shopify/cli/issues/5510#issuecomment-2912436468), where "Request ID: unknown" is noted.

This PR updates the storefront session module to automatically retry after a failure, covering both of the situations mentioned above.

### How to test your changes?

Running `shopify theme dev` is enough, but we need to make a small change to the code to emulate the error scenario, as the the video below demonstrates:

https://github.com/user-attachments/assets/cce30118-b61e-4e2e-9df6-5da62af9afb5

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
