### PR TITLE
Handle SHOPIFY_FLAG_ENVIRONMENT correctly when passed as an environment variable

### DIFF
--- a/.changeset/cuddly-rocks-push.md
+++ b/.changeset/cuddly-rocks-push.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix issue where SHOPIFY_FLAG_ENVIRONMENT was not being used correctly when passed as an environment variable

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -140,7 +140,13 @@ This flag is required in non-interactive terminal environments, such as a CI env
     if (!environmentsFileName) return originalResult
 
     const environmentFileExists = await environmentFilePath(environmentsFileName, {from: flags.path})
-    const environments = flags.environment ?? []
+
+    // Handle both string and array cases for environment flag
+    let environments: string[] = []
+    if (flags.environment) {
+      environments = Array.isArray(flags.environment) ? flags.environment : [flags.environment]
+    }
+
     const environmentSpecified = environments.length > 0
 
     // Noop if no environment file exists and none was specified
@@ -175,7 +181,7 @@ This flag is required in non-interactive terminal environments, such as a CI env
     reportEnvironmentApplication<TFlags, TGlobalFlags, TArgs>(
       noDefaultsResult.flags,
       result.flags,
-      isDefaultEnvironment ? 'default' : (flags.environment?.[0] as string),
+      isDefaultEnvironment ? 'default' : (environments[0] as string),
       environment,
     )
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/5594

When using the environment variable `SHOPIFY_FLAG_ENVIRONMENT`, you would get inconsistent behaviour. Sometimes it would read use the environment and sometimes it would ignore it and use a default or cached value.

In `base-command` at `const environments = flags.environment ?? []` if `flags.environment` = `myshop` then `environments.length` would end up as 6 and skip additional processing.

### WHAT is this pull request doing?

Ensure, `environments` ends up as an array.

### How to test your changes?

**Setup**
- Pull down the branch
- Build the branch
- Make sure you have a `shopify.theme.toml` file with a few environments.
- In your terminal or bash profile, add `export SHOPIFY_FLAG_ENVIRONMENT=<yourenvironment>
- run `echo $SHOPIFY_FLAG_ENVIRONMENT` and make sure you see the environment output
**Testing**
- Run `shopify theme dev` -e <yourotherenvironment>
- Run `shopify theme dev` and check if it uses <yourenvironment>
- Do the same with `shopify theme list`
- Change <yourotherenvironment> to <default> and ensure using `SHOPIFY_FLAG_ENVIRONMENT` overrides a default env.

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
