### PR TITLE
Simplify theme command environment paths

### DIFF
--- a/.changeset/poor-hornets-compete.md
+++ b/.changeset/poor-hornets-compete.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Clean up theme command to run either single/no environment or multiple environments

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -56,22 +56,10 @@ export default abstract class ThemeCommand extends Command {
     const requiredFlags = klass.multiEnvironmentsFlags
     const {flags} = await this.parse(klass)
 
-    // No environment provided
-    if (!flags.environment?.length) {
-      const session = await this.ensureAuthenticated(flags)
+    const environments = (Array.isArray(flags.environment) ? flags.environment : [flags.environment]).filter(Boolean)
 
-      await this.command(flags, session)
-
-      return
-    }
-
-    // OCLIF parses flags.environment as an array when using the --environment & -e flag but
-    // as a string when using the direct environment variable SHOPIFY_FLAG_ENVIRONMENT
-    // This handles both cases
-    const environments = Array.isArray(flags.environment) ? flags.environment : [flags.environment]
-
-    // If only one environment is specified, treat it as single environment mode
-    if (environments.length === 1) {
+    // Single environment or no environment
+    if (environments.length <= 1) {
       const session = await this.ensureAuthenticated(flags)
       await this.command(flags, session)
       return


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up to https://github.com/Shopify/cli/pull/5954#discussion_r2154407460

We can further simplify the codepaths that a theme command can go through. 

### WHAT is this pull request doing?

In both no environment and single environment scenarios, they both make a session and then run the command. They are now lumped together based on what the `environments` variable has.

### How to test your changes?

- Pull down the branch
- Build the branch
- Run a series of commands
    - `shopify theme list`
    - `shopify theme list -e mystore`
    - `shopify theme list -e mystore -e myotherstore`
- Ensure commands output the proper store(s)

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
