### PR TITLE
Add warning for non multi env commands

### DIFF
--- a/.changeset/olive-peas-sit.md
+++ b/.changeset/olive-peas-sit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Add a warning for users declaring multiple environments in a command that only supports a single environment

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -58,7 +58,7 @@ export default abstract class ThemeCommand extends Command {
   >(_opts?: Input<TFlags, TGlobalFlags, TArgs>): Promise<void> {
     // Parse command flags using the current command class definitions
     const klass = this.constructor as unknown as Input<TFlags, TGlobalFlags, TArgs> & {
-      multiEnvironmentsFlags: string[]
+      multiEnvironmentsFlags: string[] | null
       flags: FlagOutput
     }
     const requiredFlags = klass.multiEnvironmentsFlags
@@ -75,6 +75,11 @@ export default abstract class ThemeCommand extends Command {
     }
 
     // Multiple environments
+    if (requiredFlags === null) {
+      renderWarning({body: 'This command does not support multiple environments.'})
+      return
+    }
+
     const environmentsMap = await this.loadEnvironments(environments, flags)
     const validationResults = await this.validateEnvironments(environmentsMap, requiredFlags)
 


### PR DESCRIPTION
### WHY are these changes introduced?
As we continue converting theme commands to use the new ThemeCommand class, we need a way to indicate which commands don't support multiple environments.

### WHAT is this pull request doing?
Allow multiEnvironmentsFlags to accept null as a value. When a command sets this to null, it will render a warning if users attempt to run it with multiple environments.

### How to test your changes?
- Ensure you have `shopify.theme.toml` file with at least two stores
- Pull down the branch
- Go into `commands/theme/list.ts` and replace `static multiEnvironmentsFlags = ['store', 'password']` with `  static multiEnvironmentsFlags = null`
- Build the branch
- Run `theme list -e first_store -e second_store`, to ensure it returns the warning
- Run `theme list -e first_store` or `theme list` to ensure the commands still work in single environments

### Post-release steps
N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [X] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've considered possible [documentation](https://shopify.dev) changes
