### PR TITLE
Add export/import functionality to store copy command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -63,7 +63,6 @@
 * [`shopify plugins unlink [PLUGIN]`](#shopify-plugins-unlink-plugin)
 * [`shopify plugins update`](#shopify-plugins-update)
 * [`shopify search [query]`](#shopify-search-query)
-* [`shopify store copy`](#shopify-store-copy)
 * [`shopify theme check`](#shopify-theme-check)
 * [`shopify theme console`](#shopify-theme-console)
 * [`shopify theme delete`](#shopify-theme-delete)
@@ -1718,20 +1717,6 @@ EXAMPLES
       shopify search <query>
       # search for a phrase on Shopify.dev
       shopify search "<a search query separated by spaces>"
-```
-
-## `shopify store copy`
-
-Copy a theme to another store.
-
-```
-USAGE
-  $ shopify store copy
-
-DESCRIPTION
-  Copy a theme to another store.
-
-  This command allows you to copy a theme from one Shopify store to another.
 ```
 
 ## `shopify theme check`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4878,15 +4878,24 @@
       "args": {
       },
       "customPluginName": "@shopify/store",
-      "description": "Copy data from one store to another",
+      "description": "Copy data between stores, export store data to SQLite, or import data from SQLite to a store",
       "flags": {
-        "from": {
-          "description": "The store to copy data from.",
-          "env": "SHOPIFY_FLAG_COPY_STORE_FROM",
+        "fromFile": {
+          "description": "The SQLite file to import data from.",
+          "env": "SHOPIFY_FLAG_FROM_FILE",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "from",
-          "required": true,
+          "name": "fromFile",
+          "required": false,
+          "type": "option"
+        },
+        "fromStore": {
+          "description": "The source store domain to copy/export data from (e.g., source.myshopify.com).",
+          "env": "SHOPIFY_FLAG_FROM_STORE",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fromStore",
+          "required": false,
           "type": "option"
         },
         "key": {
@@ -4927,13 +4936,22 @@
           "required": false,
           "type": "boolean"
         },
-        "to": {
-          "description": "The store to copy data to.",
-          "env": "SHOPIFY_FLAG_COPY_STORE_TO",
+        "toFile": {
+          "description": "The SQLite file path to export data to. Use <sqlite> to auto-generate filename.",
+          "env": "SHOPIFY_FLAG_TO_FILE",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "to",
-          "required": true,
+          "name": "toFile",
+          "required": false,
+          "type": "option"
+        },
+        "toStore": {
+          "description": "The target store domain to copy/import data to (e.g., target.myshopify.com).",
+          "env": "SHOPIFY_FLAG_TO_STORE",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "toStore",
+          "required": false,
           "type": "option"
         },
         "verbose": {
@@ -4954,7 +4972,7 @@
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Copy data from one store to another"
+      "summary": "Copy, export, or import store data"
     },
     "theme:check": {
       "aliases": [

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4878,11 +4878,75 @@
       "args": {
       },
       "customPluginName": "@shopify/store",
-      "description": "This command allows you to copy a theme from one Shopify store to another.",
-      "enableJsonFlag": false,
+      "description": "Copy data from one store to another",
       "flags": {
+        "from": {
+          "description": "The store to copy data from.",
+          "env": "SHOPIFY_FLAG_COPY_STORE_FROM",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "from",
+          "required": true,
+          "type": "option"
+        },
+        "key": {
+          "default": [
+            "products:handle"
+          ],
+          "description": "The identity key to use to match resources",
+          "env": "SHOPIFY_FLAG_IDENTITY_KEY",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "name": "key",
+          "required": false,
+          "type": "option"
+        },
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "open": {
+          "allowNo": false,
+          "char": "o",
+          "description": "Open the sqlite db in a sqlite browser.",
+          "env": "SHOPIFY_FLAG_OPEN",
+          "name": "open",
+          "required": false,
+          "type": "boolean"
+        },
+        "skipConfirmation": {
+          "allowNo": false,
+          "char": "y",
+          "description": "Skip confirmation prompt.",
+          "env": "SHOPIFY_FLAG_YES",
+          "name": "skipConfirmation",
+          "required": false,
+          "type": "boolean"
+        },
+        "to": {
+          "description": "The store to copy data to.",
+          "env": "SHOPIFY_FLAG_COPY_STORE_TO",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "to",
+          "required": true,
+          "type": "option"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        }
       },
       "hasDynamicHelp": false,
+      "hidden": true,
       "hiddenAliases": [
       ],
       "id": "store:copy",
@@ -4890,7 +4954,7 @@
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Copy a theme to another store."
+      "summary": "Copy data from one store to another"
     },
     "theme:check": {
       "aliases": [

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -43,7 +43,8 @@
   },
   "dependencies": {
     "@oclif/core": "3.26.5",
-    "@shopify/cli-kit": "3.76.2"
+    "@shopify/cli-kit": "3.81.1",
+    "graphql-request": "6.1.0"
   },
   "devDependencies": {},
   "peerDependencies": {},

--- a/packages/store/src/apis/destinations/graphql.ts
+++ b/packages/store/src/apis/destinations/graphql.ts
@@ -1,4 +1,7 @@
-export const CurrentUserAccountQuery = `#graphql
+import {gql} from 'graphql-request'
+
+// eslint-disable-next-line @shopify/cli/no-inline-graphql
+export const CurrentUserAccountQuery = gql`
   query currentUserAccount {
     currentUserAccount {
       email

--- a/packages/store/src/apis/destinations/index.ts
+++ b/packages/store/src/apis/destinations/index.ts
@@ -8,7 +8,9 @@ export const fetchOrgs = async (session: string): Promise<Organization[]> => {
 
   const orgs: Organization[] = []
   for (const org of resp.currentUserAccount.organizations.edges) {
-    const shops = org.node.categories[0]!.destinations.edges.map((edge) => {
+    const categories = org.node.categories[0]
+    if (!categories) continue
+    const shops = categories.destinations.edges.map((edge) => {
       const shop = {
         ...edge.node,
         organizationId: org.node.id,

--- a/packages/store/src/apis/organizations/graphql.ts
+++ b/packages/store/src/apis/organizations/graphql.ts
@@ -1,18 +1,21 @@
-export const bulkDataStoreCopyStartMutation = `#graphql
+import {gql} from 'graphql-request'
+
+// eslint-disable-next-line @shopify/cli/no-inline-graphql
+export const bulkDataStoreCopyStartMutation = gql`
   mutation BulkDataStoreCopyStart($input: BulkDataStoreCopyStartInput!) {
-  bulkDataStoreCopyStart(input: $input) {
-    success
-    operation {
-      id
-      operationType
-      status
-    }
-    userErrors {
-      field
-      message
+    bulkDataStoreCopyStart(input: $input) {
+      success
+      operation {
+        id
+        operationType
+        status
+      }
+      userErrors {
+        field
+        message
+      }
     }
   }
-}
 `
 
 export const bulkDataOperationByIdQuery = `#graphql

--- a/packages/store/src/apis/organizations/index.ts
+++ b/packages/store/src/apis/organizations/index.ts
@@ -41,14 +41,17 @@ export async function startBulkDataStoreCopy(
     targetStoreIdentifier: {
       domain: targetShopDomain,
     },
-    resourceConfigs: Object.entries(resourceConfigs).reduce((acc, [resource, config]) => {
-      acc[resource] = {
-        identifier: {
-          field: config.identifier.field || 'HANDLE',
-        },
-      }
-      return acc
-    }, {} as {[key: string]: {identifier: {field: string}}}),
+    resourceConfigs: Object.entries(resourceConfigs).reduce<{[key: string]: {identifier: {field: string}}}>(
+      (acc, [resource, config]) => {
+        acc[resource] = {
+          identifier: {
+            field: config.identifier.field ?? 'HANDLE',
+          },
+        }
+        return acc
+      },
+      {},
+    ),
   }
 
   return organizationsRequest<BulkDataStoreCopyStartResponse>(organizationId, bulkDataStoreCopyStartMutation, token, {

--- a/packages/store/src/commands/store/copy.test.ts
+++ b/packages/store/src/commands/store/copy.test.ts
@@ -131,7 +131,7 @@ describe('Copy', () => {
     })
 
     test('should successfully copy data from source to target shop', async () => {
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com'])
 
       expect(ensureAuthenticatedBusinessPlatform).toHaveBeenCalled()
       expect(fetchOrgs).toHaveBeenCalledWith(mockBpSession)
@@ -170,7 +170,7 @@ describe('Copy', () => {
       })
       vi.mocked(renderSuccess).mockReturnValue(undefined)
 
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com', '--skipConfirmation'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com', '--skipConfirmation'])
 
       expect(confirmCopyPrompt).not.toHaveBeenCalled()
       expect(renderError).not.toHaveBeenCalled()
@@ -189,7 +189,7 @@ describe('Copy', () => {
       vi.mocked(confirmCopyPrompt).mockResolvedValue(false)
       vi.mocked(outputInfo).mockImplementation(() => {})
 
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com'])
 
       expect(outputInfo).toHaveBeenCalledWith('Exiting.')
       expect(process.exit).toHaveBeenCalledWith(0)
@@ -200,24 +200,32 @@ describe('Copy', () => {
       })
     })
 
-    test('should throw error when to flag is missing', async () => {
-      await run(['--from=target.myshopify.com'])
+    test('should throw error when invalid flag combination', async () => {
+      await run(['--fromStore=source.myshopify.com'])
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
-        body: expect.stringContaining('required flag to'),
+        body: 'Invalid flag combination. Valid operations are: copy (--fromStore --toStore), export (--fromStore --toFile), or import (--fromFile --toStore)',
       })
     })
 
-    test('should throw error when from flag is missing', async () => {
-      await run(['--to=target.myshopify.com'])
+    test('should throw error when no flags provided', async () => {
+      await run([])
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
-        body: expect.stringContaining('required flag from'),
+        body: 'Invalid flag combination. Valid operations are: copy (--fromStore --toStore), export (--fromStore --toFile), or import (--fromFile --toStore)',
+      })
+    })
+
+    test('should throw error when mixing store and file flags', async () => {
+      await run(['--fromStore=source.myshopify.com', '--fromFile=input.sqlite', '--toStore=target.myshopify.com'])
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Invalid flag combination. Valid operations are: copy (--fromStore --toStore), export (--fromStore --toFile), or import (--fromFile --toStore)',
       })
     })
 
     test('should throw error export not implemented', async () => {
-      await run(['--from=source.myshopify.com', '--to=foo.sqlite'])
+      await run(['--fromStore=source.myshopify.com', '--toFile=foo.sqlite'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -225,8 +233,8 @@ describe('Copy', () => {
       })
     })
 
-    test('should throw error export not implemented when --to is <sqlite>', async () => {
-      await run(['--from=source.myshopify.com', '--to=<sqlite>'])
+    test('should throw error export not implemented when --toFile is <sqlite>', async () => {
+      await run(['--fromStore=source.myshopify.com', '--toFile=<sqlite>'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -235,7 +243,7 @@ describe('Copy', () => {
     })
 
     test('should throw error when source shop is not found', async () => {
-      await run(['--from=nonexistent.myshopify.com', '--to=target.myshopify.com'])
+      await run(['--fromStore=nonexistent.myshopify.com', '--toStore=target.myshopify.com'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -244,7 +252,7 @@ describe('Copy', () => {
     })
 
     test('should throw error when target shop is not found', async () => {
-      await run(['--from=source.myshopify.com', '--to=nonexistent.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=nonexistent.myshopify.com'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -253,7 +261,7 @@ describe('Copy', () => {
     })
 
     test('should throw error when source and target shops are the same', async () => {
-      await run(['--from=source.myshopify.com', '--to=source.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=source.myshopify.com'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -280,7 +288,7 @@ describe('Copy', () => {
       }
       vi.mocked(fetchOrgs).mockResolvedValue([mockOrganization, differentOrg])
 
-      await run(['--from=source.myshopify.com', '--to=different.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=different.myshopify.com'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -307,7 +315,7 @@ describe('Copy', () => {
       }
       vi.mocked(fetchOrgs).mockResolvedValue([mockOrganization, singleShopOrg])
 
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com'])
 
       expect(startBulkDataStoreCopy).toHaveBeenCalled()
     })
@@ -322,7 +330,7 @@ describe('Copy', () => {
       }
       vi.mocked(parseResourceConfigFlags).mockReturnValue(mockResourceConfig)
 
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com', '--key=products:handle'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com', '--key=products:handle'])
 
       expect(parseResourceConfigFlags).toHaveBeenCalledWith(['products:handle'])
       expect(startBulkDataStoreCopy).toHaveBeenCalledWith(
@@ -351,7 +359,7 @@ describe('Copy', () => {
       }
       vi.mocked(startBulkDataStoreCopy).mockResolvedValue(failedResponse)
 
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -383,7 +391,7 @@ describe('Copy', () => {
       }
       vi.mocked(pollBulkDataOperation).mockResolvedValue(failedOperation)
 
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -440,7 +448,7 @@ describe('Copy', () => {
       }
       vi.mocked(pollBulkDataOperation).mockResolvedValue(operationWithErrors)
 
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com'])
 
       expect(renderWarning).toHaveBeenCalledWith({
         body: [
@@ -483,7 +491,7 @@ describe('Copy', () => {
         .mockResolvedValueOnce(inProgressOperation)
         .mockResolvedValueOnce(mockCompletedOperation)
 
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com'])
 
       expect(pollBulkDataOperation).toHaveBeenCalledTimes(3)
       expect(pollBulkDataOperation).toHaveBeenCalledWith('org1', 'operation-123', mockBpSession)
@@ -491,7 +499,7 @@ describe('Copy', () => {
     })
 
     test('should throw error for export mode (not implemented)', async () => {
-      await run(['--from=source.myshopify.com', '--to=output.sqlite'])
+      await run(['--fromStore=source.myshopify.com', '--toFile=output.sqlite'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -500,7 +508,7 @@ describe('Copy', () => {
     })
 
     test('should throw error for import mode (not implemented)', async () => {
-      await run(['--from=input.sqlite', '--to=target.myshopify.com'])
+      await run(['--fromFile=input.sqlite', '--toStore=target.myshopify.com'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
@@ -555,7 +563,7 @@ describe('Copy', () => {
 
       vi.mocked(pollBulkDataOperation).mockResolvedValueOnce(inProgressOperation).mockResolvedValueOnce(failedOperation)
 
-      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+      await run(['--fromStore=source.myshopify.com', '--toStore=target.myshopify.com'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',

--- a/packages/store/src/commands/store/copy.test.ts
+++ b/packages/store/src/commands/store/copy.test.ts
@@ -200,21 +200,37 @@ describe('Copy', () => {
       })
     })
 
-    test('should throw error when from flag is missing', async () => {
-      await run(['--to=target.myshopify.com'])
-
+    test('should throw error when to flag is missing', async () => {
+      await run(['--from=target.myshopify.com'])
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
-        body: expect.stringContaining('Missing required flag from'),
+        body: expect.stringContaining('required flag to'),
       })
     })
 
-    test('should throw error when to flag is missing', async () => {
-      await run(['--from=source.myshopify.com'])
+    test('should throw error when from flag is missing', async () => {
+      await run(['--to=target.myshopify.com'])
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: expect.stringContaining('required flag from'),
+      })
+    })
+
+    test('should throw error export not implemented', async () => {
+      await run(['--from=source.myshopify.com', '--to=foo.sqlite'])
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
-        body: expect.stringContaining('Missing required flag to'),
+        body: 'Store export functionality is not implemented yet',
+      })
+    })
+
+    test('should throw error export not implemented when --to is <sqlite>', async () => {
+      await run(['--from=source.myshopify.com', '--to=<sqlite>'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Store export functionality is not implemented yet',
       })
     })
 
@@ -472,6 +488,24 @@ describe('Copy', () => {
       expect(pollBulkDataOperation).toHaveBeenCalledTimes(3)
       expect(pollBulkDataOperation).toHaveBeenCalledWith('org1', 'operation-123', mockBpSession)
       expect(renderSuccess).toHaveBeenCalled()
+    })
+
+    test('should throw error for export mode (not implemented)', async () => {
+      await run(['--from=source.myshopify.com', '--to=output.sqlite'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Store export functionality is not implemented yet',
+      })
+    })
+
+    test('should throw error for import mode (not implemented)', async () => {
+      await run(['--from=input.sqlite', '--to=target.myshopify.com'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Store import functionality is not implemented yet',
+      })
     })
 
     test('should throw error when polling returns FAILED status', async () => {

--- a/packages/store/src/commands/store/copy.test.ts
+++ b/packages/store/src/commands/store/copy.test.ts
@@ -1,219 +1,531 @@
 import Copy from './copy.js'
 import {fetchOrgs} from '../../apis/destinations/index.js'
 import {startBulkDataStoreCopy, pollBulkDataOperation} from '../../apis/organizations/index.js'
-import {describe, expect, vi, test} from 'vitest'
+import {confirmCopyPrompt} from '../../prompts/confirm_copy.js'
+import {parseResourceConfigFlags} from '../../lib/resource-config.js'
+import {Shop, Organization} from '../../apis/destinations/types.js'
+import {BulkDataStoreCopyStartResponse, BulkDataOperationByIdResponse} from '../../apis/organizations/types.js'
+import {describe, vi, expect, test, beforeEach} from 'vitest'
+import {Config} from '@oclif/core'
 import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
-import type {Organization} from '../../apis/destinations/types.js'
-import type {BulkDataStoreCopyStartResponse, BulkDataOperationByIdResponse} from '../../apis/organizations/types.js'
+import {renderSuccess, renderTasks, renderWarning, renderError} from '@shopify/cli-kit/node/ui'
+import {outputInfo} from '@shopify/cli-kit/node/output'
 
-vi.mock('../../apis/destinations/index.js', async () => {
-  const actual = (await vi.importActual('../../apis/destinations/index.js')) as any
-  return {
-    ...actual,
-    fetchOrgs: vi.fn(),
-  }
-})
-
-vi.mock('../../apis/organizations/index.js', async () => {
-  const actual = (await vi.importActual('../../apis/organizations/index.js')) as any
-  return {
-    ...actual,
-    startBulkDataStoreCopy: vi.fn(),
-    pollBulkDataOperation: vi.fn(),
-  }
-})
-
-vi.mock('../../prompts/confirm_copy.js')
-vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('@shopify/cli-kit/node/session')
+vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('@shopify/cli-kit/node/output')
+vi.mock('../../apis/destinations/index.js')
+vi.mock('../../apis/organizations/index.js')
+vi.mock('../../prompts/confirm_copy.js')
+vi.mock('../../lib/resource-config.js')
 
-describe('Copy command', () => {
-  const mockSession = 'test-session-token'
-  const orgId = 'gid://Organization/123'
-  const sourceShopDomain = 'source-shop.myshopify.com'
-  const targetShopDomain = 'target-shop.myshopify.com'
+const CommandConfig = new Config({root: __dirname})
 
-  const createMockOrganization = (): Organization => ({
-    id: orgId,
+describe('Copy', () => {
+  const mockBpSession = 'mock-bp-session-token'
+  const mockSourceShop: Shop = {
+    id: 'shop1',
+    name: 'Source Shop',
+    webUrl: 'https://source.myshopify.com',
+    handle: 'source',
+    publicId: 'gid://shopify/Shop/1',
+    shortName: 'source',
+    domain: 'source.myshopify.com',
+    organizationId: 'org1',
+  }
+  const mockTargetShop: Shop = {
+    id: 'shop2',
+    name: 'Target Shop',
+    webUrl: 'https://target.myshopify.com',
+    handle: 'target',
+    publicId: 'gid://shopify/Shop/2',
+    shortName: 'target',
+    domain: 'target.myshopify.com',
+    organizationId: 'org1',
+  }
+  const mockOrganization: Organization = {
+    id: 'org1',
     name: 'Test Organization',
-    shops: [
-      {
-        id: 'shop-1',
-        name: 'Source Shop',
-        domain: sourceShopDomain,
-        organizationId: orgId,
-        webUrl: `https://${sourceShopDomain}`,
-        storeType: 'development',
-        handle: 'source-shop',
-        publicId: 'pub-1',
-        shortName: 'source',
-      },
-      {
-        id: 'shop-2',
-        name: 'Target Shop',
-        domain: targetShopDomain,
-        organizationId: orgId,
-        webUrl: `https://${targetShopDomain}`,
-        storeType: 'development',
-        handle: 'target-shop',
-        publicId: 'pub-2',
-        shortName: 'target',
-      },
-    ],
-  })
+    shops: [mockSourceShop, mockTargetShop],
+  }
 
-  const createMockCopyResponse = (): BulkDataStoreCopyStartResponse => ({
+  const mockCopyStartResponse: BulkDataStoreCopyStartResponse = {
     bulkDataStoreCopyStart: {
       success: true,
+      userErrors: [],
       operation: {
         id: 'operation-123',
-        operationType: 'COPY',
-        status: 'RUNNING',
+        operationType: 'STORE_COPY',
+        status: 'IN_PROGRESS',
       },
-      userErrors: [],
     },
-  })
+  }
 
-  const createMockOperationResponse = (status: 'RUNNING' | 'COMPLETED'): BulkDataOperationByIdResponse => ({
+  const mockCompletedOperation: BulkDataOperationByIdResponse = {
     organization: {
       name: 'Test Organization',
       bulkData: {
         operation: {
           id: 'operation-123',
           operationType: 'STORE_COPY',
-          status,
+          status: 'COMPLETED',
           sourceStore: {
-            id: 'shop-1',
+            id: 'shop1',
             name: 'Source Shop',
           },
           targetStore: {
-            id: 'shop-2',
+            id: 'shop2',
             name: 'Target Shop',
           },
           storeOperations: [
             {
-              id: 'source-shop-export-operation',
+              id: 'store-op-1',
               store: {
-                id: 'shop-1',
-                name: 'Source Shop',
+                id: 'shop2',
+                name: 'Target Shop',
               },
-              remoteOperationType: 'export',
+              remoteOperationType: 'COPY',
               remoteOperationStatus: 'COMPLETED',
               totalObjectCount: 100,
               completedObjectCount: 100,
-              url: 'https://example.com/export-operation',
-            },
-            {
-              id: 'target-shop-import-operation',
-              store: {
-                id: 'shop-2',
-                name: 'Target Shop',
-              },
-              remoteOperationType: 'import',
-              remoteOperationStatus: status,
-              totalObjectCount: 100,
-              completedObjectCount: status === 'COMPLETED' ? 100 : 48,
-              url: 'https://example.com/import-operation',
+              url: 'https://target.myshopify.com',
             },
           ],
         },
       },
     },
+  }
+
+  beforeEach(() => {
+    vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('Process exit called')
+    })
   })
 
-  const setupMocks = () => {
-    const mockOrg = createMockOrganization()
-    const mockCopyResponse = createMockCopyResponse()
-    const mockRunningOperation = createMockOperationResponse('RUNNING')
+  describe('run', () => {
+    async function run(argv: string[]) {
+      await CommandConfig.load()
+      const copy = new Copy(argv, CommandConfig)
+      await copy.run()
+    }
 
-    vi.mocked(ensureAuthenticatedBusinessPlatform).mockResolvedValue(mockSession)
-    vi.mocked(fetchOrgs).mockResolvedValue([mockOrg])
-    vi.mocked(startBulkDataStoreCopy).mockResolvedValue(mockCopyResponse)
-    vi.mocked(pollBulkDataOperation).mockResolvedValue(mockRunningOperation)
-
-    return {mockOrg, mockCopyResponse, mockRunningOperation}
-  }
-
-  const runCopyCommand = async (flags: any) => {
-    const {mockOrg} = setupMocks()
-
-    const mockRunningOperation = createMockOperationResponse('RUNNING')
-    const mockCompletedOperation = createMockOperationResponse('COMPLETED')
-
-    vi.mocked(pollBulkDataOperation)
-      .mockResolvedValueOnce(mockRunningOperation)
-      .mockResolvedValueOnce(mockRunningOperation)
-      .mockResolvedValueOnce(mockRunningOperation)
-      .mockResolvedValueOnce(mockRunningOperation)
-      .mockResolvedValueOnce(mockCompletedOperation)
-
-    const copy = new Copy([], {} as any)
-    copy.flags = flags
-
-    vi.spyOn(global, 'setTimeout').mockImplementation((callback: any) => {
-      callback()
-      return {} as any
+    beforeEach(() => {
+      vi.mocked(ensureAuthenticatedBusinessPlatform).mockResolvedValue(mockBpSession)
+      vi.mocked(fetchOrgs).mockResolvedValue([mockOrganization])
+      vi.mocked(confirmCopyPrompt).mockResolvedValue(true)
+      vi.mocked(parseResourceConfigFlags).mockReturnValue({})
+      vi.mocked(startBulkDataStoreCopy).mockResolvedValue(mockCopyStartResponse)
+      vi.mocked(pollBulkDataOperation).mockResolvedValue(mockCompletedOperation)
+      vi.mocked(renderTasks).mockImplementation(async (tasks) => {
+        const ctx = {}
+        // Process tasks sequentially
+        const processTask = async (index: number): Promise<void> => {
+          if (index < tasks.length) {
+            await tasks[index]!.task(ctx, tasks[index]!)
+            await processTask(index + 1)
+          }
+        }
+        await processTask(0)
+        return ctx
+      })
     })
 
-    const sourceShop = mockOrg.shops.find((shop) => shop.domain === sourceShopDomain)!
-    const targetShop = mockOrg.shops.find((shop) => shop.domain === targetShopDomain)!
+    test('should successfully copy data from source to target shop', async () => {
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
 
-    // eslint-disable-next-line dot-notation
-    return copy['executeCopyOperation'](orgId, sourceShop, targetShop, mockSession)
-  }
-
-  describe('when copying between shops in the same organization', () => {
-    test('calls startBulkDataStoreCopy with the correct arguments', async () => {
-      await runCopyCommand({
-        from: sourceShopDomain,
-        to: targetShopDomain,
+      expect(ensureAuthenticatedBusinessPlatform).toHaveBeenCalled()
+      expect(fetchOrgs).toHaveBeenCalledWith(mockBpSession)
+      expect(confirmCopyPrompt).toHaveBeenCalledWith('source.myshopify.com', 'target.myshopify.com')
+      expect(outputInfo).toHaveBeenCalledWith('Copying from source.myshopify.com to target.myshopify.com')
+      expect(startBulkDataStoreCopy).toHaveBeenCalledWith(
+        'org1',
+        'source.myshopify.com',
+        'target.myshopify.com',
+        {},
+        mockBpSession,
+      )
+      expect(renderSuccess).toHaveBeenCalledWith({
+        body: ['Copy operation from', {info: 'source.myshopify.com'}, 'to', {info: 'target.myshopify.com'}, 'complete'],
       })
-
-      expect(startBulkDataStoreCopy).toHaveBeenCalledWith(orgId, sourceShopDomain, targetShopDomain, {}, mockSession)
     })
 
-    test('polls the operation until it is completed', async () => {
-      const result = await runCopyCommand({
-        from: sourceShopDomain,
-        to: targetShopDomain,
+    test('should skip confirmation when --skip-confirmation flag is provided', async () => {
+      vi.mocked(ensureAuthenticatedBusinessPlatform).mockResolvedValue(mockBpSession)
+      vi.mocked(fetchOrgs).mockResolvedValue([mockOrganization])
+      vi.mocked(parseResourceConfigFlags).mockReturnValue({})
+      vi.mocked(outputInfo).mockImplementation(() => {})
+      vi.mocked(startBulkDataStoreCopy).mockResolvedValue(mockCopyStartResponse)
+      vi.mocked(pollBulkDataOperation).mockResolvedValue(mockCompletedOperation)
+      vi.mocked(renderTasks).mockImplementation(async (tasks) => {
+        const ctx = {}
+        // Process tasks sequentially
+        const processTask = async (index: number): Promise<void> => {
+          if (index < tasks.length) {
+            await tasks[index]!.task(ctx, tasks[index]!)
+            await processTask(index + 1)
+          }
+        }
+        await processTask(0)
+        return ctx
       })
+      vi.mocked(renderSuccess).mockReturnValue(undefined)
 
-      expect(pollBulkDataOperation).toHaveBeenCalledTimes(5)
-      expect(result.organization.bulkData.operation.status).toBe('COMPLETED')
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com', '--skipConfirmation'])
+
+      expect(confirmCopyPrompt).not.toHaveBeenCalled()
+      expect(renderError).not.toHaveBeenCalled()
+      expect(startBulkDataStoreCopy).toHaveBeenCalledWith(
+        'org1',
+        'source.myshopify.com',
+        'target.myshopify.com',
+        {},
+        mockBpSession,
+      )
     })
 
-    // eslint-disable-next-line vitest/max-nested-describe
-    describe('when there are resource configs specified', () => {
-      test('transforms field resource config into correct format', async () => {
-        await runCopyCommand({
-          from: sourceShopDomain,
-          to: targetShopDomain,
-          key: ['products:handle'],
-        })
+    test('should exit when user cancels confirmation', async () => {
+      vi.mocked(ensureAuthenticatedBusinessPlatform).mockResolvedValue(mockBpSession)
+      vi.mocked(fetchOrgs).mockResolvedValue([mockOrganization])
+      vi.mocked(confirmCopyPrompt).mockResolvedValue(false)
+      vi.mocked(outputInfo).mockImplementation(() => {})
 
-        expect(startBulkDataStoreCopy).toHaveBeenCalledWith(
-          orgId,
-          sourceShopDomain,
-          targetShopDomain,
-          {products: {identifier: {field: 'HANDLE', customId: undefined}}},
-          mockSession,
-        )
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+
+      expect(outputInfo).toHaveBeenCalledWith('Exiting.')
+      expect(process.exit).toHaveBeenCalledWith(0)
+      expect(startBulkDataStoreCopy).not.toHaveBeenCalled()
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Process exit called',
       })
+    })
 
-      test('transforms unique metafield resource config into correct format', async () => {
-        await runCopyCommand({
-          from: sourceShopDomain,
-          to: targetShopDomain,
-          key: ['products:metafield:custom:salesforce_id'],
-        })
+    test('should throw error when from flag is missing', async () => {
+      await run(['--to=target.myshopify.com'])
 
-        expect(startBulkDataStoreCopy).toHaveBeenCalledWith(
-          orgId,
-          sourceShopDomain,
-          targetShopDomain,
-          {products: {identifier: {field: undefined, customId: {namespace: 'custom', key: 'salesforce_id'}}}},
-          mockSession,
-        )
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: expect.stringContaining('Missing required flag from'),
+      })
+    })
+
+    test('should throw error when to flag is missing', async () => {
+      await run(['--from=source.myshopify.com'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: expect.stringContaining('Missing required flag to'),
+      })
+    })
+
+    test('should throw error when source shop is not found', async () => {
+      await run(['--from=nonexistent.myshopify.com', '--to=target.myshopify.com'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Source shop nonexistent.myshopify.com not found',
+      })
+    })
+
+    test('should throw error when target shop is not found', async () => {
+      await run(['--from=source.myshopify.com', '--to=nonexistent.myshopify.com'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Target shop nonexistent.myshopify.com not found',
+      })
+    })
+
+    test('should throw error when source and target shops are the same', async () => {
+      await run(['--from=source.myshopify.com', '--to=source.myshopify.com'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Source and target shops are the same',
+      })
+    })
+
+    test('should throw error when shops are in different organizations', async () => {
+      const differentOrgShop: Shop = {
+        id: 'shop3',
+        name: 'Different Shop',
+        webUrl: 'https://different.myshopify.com',
+        handle: 'different',
+        publicId: 'gid://shopify/Shop/3',
+        shortName: 'different',
+        domain: 'different.myshopify.com',
+        organizationId: 'org2',
+      }
+      const differentOrg: Organization = {
+        id: 'org2',
+        name: 'Different Organization',
+        // Include source shop to pass the filter
+        shops: [mockSourceShop, differentOrgShop],
+      }
+      vi.mocked(fetchOrgs).mockResolvedValue([mockOrganization, differentOrg])
+
+      await run(['--from=source.myshopify.com', '--to=different.myshopify.com'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Source and target shops are not in the same organization',
+      })
+    })
+
+    test('should filter out organizations with single shop', async () => {
+      const singleShopOrg: Organization = {
+        id: 'org3',
+        name: 'Single Shop Org',
+        shops: [
+          {
+            id: 'shop4',
+            name: 'Single Shop',
+            webUrl: 'https://single.myshopify.com',
+            handle: 'single',
+            publicId: 'gid://shopify/Shop/4',
+            shortName: 'single',
+            domain: 'single.myshopify.com',
+            organizationId: 'org3',
+          },
+        ],
+      }
+      vi.mocked(fetchOrgs).mockResolvedValue([mockOrganization, singleShopOrg])
+
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+
+      expect(startBulkDataStoreCopy).toHaveBeenCalled()
+    })
+
+    test('should pass resource config flags when provided', async () => {
+      const mockResourceConfig = {
+        products: {
+          identifier: {
+            field: 'HANDLE',
+          },
+        },
+      }
+      vi.mocked(parseResourceConfigFlags).mockReturnValue(mockResourceConfig)
+
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com', '--key=products:handle'])
+
+      expect(parseResourceConfigFlags).toHaveBeenCalledWith(['products:handle'])
+      expect(startBulkDataStoreCopy).toHaveBeenCalledWith(
+        'org1',
+        'source.myshopify.com',
+        'target.myshopify.com',
+        mockResourceConfig,
+        mockBpSession,
+      )
+    })
+
+    test('should throw error when copy operation fails to start', async () => {
+      const failedResponse: BulkDataStoreCopyStartResponse = {
+        bulkDataStoreCopyStart: {
+          success: false,
+          userErrors: [
+            {field: 'configuration', message: 'Invalid configuration'},
+            {field: 'permissions', message: 'Insufficient permissions'},
+          ],
+          operation: {
+            id: '',
+            operationType: '',
+            status: 'FAILED',
+          },
+        },
+      }
+      vi.mocked(startBulkDataStoreCopy).mockResolvedValue(failedResponse)
+
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Failed to start copy operation: Invalid configuration, Insufficient permissions',
+      })
+    })
+
+    test('should throw error when copy operation status is FAILED', async () => {
+      const failedOperation: BulkDataOperationByIdResponse = {
+        organization: {
+          name: 'Test Organization',
+          bulkData: {
+            operation: {
+              id: 'operation-123',
+              operationType: 'STORE_COPY',
+              status: 'FAILED',
+              sourceStore: {
+                id: 'shop1',
+                name: 'Source Shop',
+              },
+              targetStore: {
+                id: 'shop2',
+                name: 'Target Shop',
+              },
+              storeOperations: [],
+            },
+          },
+        },
+      }
+      vi.mocked(pollBulkDataOperation).mockResolvedValue(failedOperation)
+
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Copy operation failed',
+      })
+    })
+
+    test('should render warning when copy completes with errors', async () => {
+      const operationWithErrors: BulkDataOperationByIdResponse = {
+        organization: {
+          name: 'Test Organization',
+          bulkData: {
+            operation: {
+              id: 'operation-123',
+              operationType: 'STORE_COPY',
+              status: 'COMPLETED',
+              sourceStore: {
+                id: 'shop1',
+                name: 'Source Shop',
+              },
+              targetStore: {
+                id: 'shop2',
+                name: 'Target Shop',
+              },
+              storeOperations: [
+                {
+                  id: 'store-op-1',
+                  store: {
+                    id: 'shop2',
+                    name: 'Target Shop',
+                  },
+                  remoteOperationType: 'COPY',
+                  remoteOperationStatus: 'COMPLETED',
+                  totalObjectCount: 100,
+                  completedObjectCount: 100,
+                  url: 'https://target.myshopify.com',
+                },
+                {
+                  id: 'store-op-2',
+                  store: {
+                    id: 'shop2',
+                    name: 'Target Shop',
+                  },
+                  remoteOperationType: 'COPY',
+                  remoteOperationStatus: 'FAILED',
+                  totalObjectCount: 50,
+                  completedObjectCount: 0,
+                  url: 'https://target.myshopify.com',
+                },
+              ],
+            },
+          },
+        },
+      }
+      vi.mocked(pollBulkDataOperation).mockResolvedValue(operationWithErrors)
+
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+
+      expect(renderWarning).toHaveBeenCalledWith({
+        body: [
+          'Copy operation from',
+          {info: 'source.myshopify.com'},
+          'to',
+          {info: 'target.myshopify.com'},
+          'completed with',
+          {error: 'errors'},
+        ],
+      })
+      expect(renderSuccess).not.toHaveBeenCalled()
+    })
+
+    test('should poll until operation is completed', async () => {
+      const inProgressOperation: BulkDataOperationByIdResponse = {
+        organization: {
+          name: 'Test Organization',
+          bulkData: {
+            operation: {
+              id: 'operation-123',
+              operationType: 'STORE_COPY',
+              status: 'IN_PROGRESS',
+              sourceStore: {
+                id: 'shop1',
+                name: 'Source Shop',
+              },
+              targetStore: {
+                id: 'shop2',
+                name: 'Target Shop',
+              },
+              storeOperations: [],
+            },
+          },
+        },
+      }
+
+      vi.mocked(pollBulkDataOperation)
+        .mockResolvedValueOnce(inProgressOperation)
+        .mockResolvedValueOnce(inProgressOperation)
+        .mockResolvedValueOnce(mockCompletedOperation)
+
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+
+      expect(pollBulkDataOperation).toHaveBeenCalledTimes(3)
+      expect(pollBulkDataOperation).toHaveBeenCalledWith('org1', 'operation-123', mockBpSession)
+      expect(renderSuccess).toHaveBeenCalled()
+    })
+
+    test('should throw error when polling returns FAILED status', async () => {
+      const inProgressOperation: BulkDataOperationByIdResponse = {
+        organization: {
+          name: 'Test Organization',
+          bulkData: {
+            operation: {
+              id: 'operation-123',
+              operationType: 'STORE_COPY',
+              status: 'IN_PROGRESS',
+              sourceStore: {
+                id: 'shop1',
+                name: 'Source Shop',
+              },
+              targetStore: {
+                id: 'shop2',
+                name: 'Target Shop',
+              },
+              storeOperations: [],
+            },
+          },
+        },
+      }
+
+      const failedOperation: BulkDataOperationByIdResponse = {
+        organization: {
+          name: 'Test Organization',
+          bulkData: {
+            operation: {
+              id: 'operation-123',
+              operationType: 'STORE_COPY',
+              status: 'FAILED',
+              sourceStore: {
+                id: 'shop1',
+                name: 'Source Shop',
+              },
+              targetStore: {
+                id: 'shop2',
+                name: 'Target Shop',
+              },
+              storeOperations: [],
+            },
+          },
+        },
+      }
+
+      vi.mocked(pollBulkDataOperation).mockResolvedValueOnce(inProgressOperation).mockResolvedValueOnce(failedOperation)
+
+      await run(['--from=source.myshopify.com', '--to=target.myshopify.com'])
+
+      expect(renderError).toHaveBeenCalledWith({
+        headline: 'Operation failed',
+        body: 'Copy operation failed',
       })
     })
   })

--- a/packages/store/src/commands/store/copy.test.ts
+++ b/packages/store/src/commands/store/copy.test.ts
@@ -239,7 +239,7 @@ describe('Copy', () => {
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
-        body: 'Source shop nonexistent.myshopify.com not found',
+        body: 'Source shop (nonexistent.myshopify.com) not found.',
       })
     })
 
@@ -248,7 +248,7 @@ describe('Copy', () => {
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
-        body: 'Target shop nonexistent.myshopify.com not found',
+        body: 'Target shop (nonexistent.myshopify.com) not found.',
       })
     })
 
@@ -257,7 +257,7 @@ describe('Copy', () => {
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
-        body: 'Source and target shops are the same',
+        body: 'Source and target shops must not be the same.',
       })
     })
 
@@ -284,7 +284,7 @@ describe('Copy', () => {
 
       expect(renderError).toHaveBeenCalledWith({
         headline: 'Operation failed',
-        body: 'Source and target shops are not in the same organization',
+        body: 'Source and target shops must be in the same organization.',
       })
     })
 

--- a/packages/store/src/commands/store/copy.ts
+++ b/packages/store/src/commands/store/copy.ts
@@ -7,13 +7,14 @@ import {commonFlags, shopSelectionFlags, resourceConfigFlags} from '../../lib/fl
 import {parseResourceConfigFlags} from '../../lib/resource-config.js'
 import {confirmCopyPrompt} from '../../prompts/confirm_copy.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {renderSuccess, Task, renderTasks, renderWarning, Token, renderText} from '@shopify/cli-kit/node/ui'
+import {renderSuccess, Task, renderTasks, renderWarning, Token} from '@shopify/cli-kit/node/ui'
 import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
+import {outputInfo} from '@shopify/cli-kit/node/output'
 
 export default class Copy extends BaseBDCommand {
   static summary = 'Copy data from one store to another'
   static description = 'Copy data from one store to another'
-
+  static hidden = true
   static flags = {
     ...shopSelectionFlags,
     ...resourceConfigFlags,
@@ -31,7 +32,7 @@ export default class Copy extends BaseBDCommand {
     const {sourceShop, targetShop} = this.shopsFromFlags(this.flags.from as string, this.flags.to as string, orgs)
 
     if (!this.flags.skipConfirmation) {
-      if ((await confirmCopyPrompt(sourceShop.domain, targetShop.domain)) === false) {
+      if (!(await confirmCopyPrompt(sourceShop.domain, targetShop.domain))) {
         this.handleExit()
       }
     }
@@ -82,7 +83,7 @@ export default class Copy extends BaseBDCommand {
     sourceShop: Shop,
     targetShop: Shop,
   ): Promise<BulkDataOperationByIdResponse> {
-    renderText({text: `Copying from ${sourceShop.domain} to ${targetShop.domain}`})
+    outputInfo(`Copying from ${sourceShop.domain} to ${targetShop.domain}`)
 
     const copyResponse: BulkDataStoreCopyStartResponse = await startBulkDataStoreCopy(
       organizationId,

--- a/packages/store/src/commands/store/copy.ts
+++ b/packages/store/src/commands/store/copy.ts
@@ -1,21 +1,11 @@
-import {Shop, Organization} from '../../apis/destinations/types.js'
-import {BulkDataStoreCopyStartResponse, BulkDataOperationByIdResponse} from '../../apis/organizations/types.js'
 import {BaseBDCommand} from '../../lib/base-command.js'
-import {fetchOrgs} from '../../apis/destinations/index.js'
-import {startBulkDataStoreCopy, pollBulkDataOperation} from '../../apis/organizations/index.js'
 import {commonFlags, shopSelectionFlags, resourceConfigFlags} from '../../lib/flags.js'
-import {parseResourceConfigFlags} from '../../lib/resource-config.js'
-import {confirmCopyPrompt} from '../../prompts/confirm_copy.js'
+import {OperationMode} from '../../services/store/types/operations.js'
+import {isStoreIdentifier, isFileIdentifier} from '../../services/store/utils/validation.js'
+import {StoreCopyOperation} from '../../services/store/operations/store-copy.js'
+import {StoreExportOperation} from '../../services/store/operations/store-export.js'
+import {StoreImportOperation} from '../../services/store/operations/store-import.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {renderSuccess, Task, renderTasks, renderWarning, Token} from '@shopify/cli-kit/node/ui'
-import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
-import {outputInfo} from '@shopify/cli-kit/node/output'
-
-enum OperationMode {
-  STORE_COPY = 'STORE_COPY',
-  STORE_EXPORT = 'STORE_EXPORT',
-  STORE_IMPORT = 'STORE_IMPORT',
-}
 
 export default class Copy extends BaseBDCommand {
   static summary = 'Copy, export, or import store data'
@@ -40,24 +30,28 @@ export default class Copy extends BaseBDCommand {
 
     const operationMode = this.determineOperationMode(from, to)
 
-    switch (operationMode) {
+    const operation = this.getOperation(operationMode)
+    await operation.execute(from, to, this.flags)
+  }
+
+  private getOperation(mode: OperationMode) {
+    switch (mode) {
       case OperationMode.STORE_COPY:
-        await this.handleStoreCopy(from, to)
-        break
+        return new StoreCopyOperation()
       case OperationMode.STORE_EXPORT:
-        await this.handleStoreExport(from, to)
-        break
+        return new StoreExportOperation()
       case OperationMode.STORE_IMPORT:
-        await this.handleStoreImport(from, to)
-        break
+        return new StoreImportOperation()
+      default:
+        throw new Error(`Unknown operation mode: ${mode}`)
     }
   }
 
   private determineOperationMode(from: string, to: string | undefined): OperationMode {
-    const isFromStore = from ? this.isStoreIdentifier(from) : false
-    const isFromFile = from ? this.isFileIdentifier(from) : false
-    const isToStore = to ? this.isStoreIdentifier(to) : false
-    const isToFile = to ? this.isFileIdentifier(to) : false
+    const isFromStore = from ? isStoreIdentifier(from) : false
+    const isFromFile = from ? isFileIdentifier(from) : false
+    const isToStore = to ? isStoreIdentifier(to) : false
+    const isToFile = to ? isFileIdentifier(to) : false
 
     if (isFromStore && isToStore) {
       return OperationMode.STORE_COPY
@@ -68,172 +62,5 @@ export default class Copy extends BaseBDCommand {
     }
 
     throw new Error('Invalid combination of --from and --to flags')
-  }
-
-  private isStoreIdentifier(value: string): boolean {
-    return value.endsWith('.myshopify.com')
-  }
-
-  private isFileIdentifier(value: string): boolean {
-    return value.endsWith('.sqlite') || value === '<sqlite>'
-  }
-
-  private async handleStoreCopy(from: string, to: string): Promise<void> {
-    const bpSession = await ensureAuthenticatedBusinessPlatform()
-
-    const orgs = await this.fetchOrgs(bpSession)
-
-    const {sourceShop, targetShop} = this.shopsFromFlags(from, to, orgs)
-
-    if (!this.flags.skipConfirmation) {
-      if (!(await confirmCopyPrompt(sourceShop.domain, targetShop.domain))) {
-        this.handleExit()
-      }
-    }
-
-    const copyOperation = await this.copyDataWithProgress(sourceShop.organizationId, sourceShop, targetShop, bpSession)
-
-    const status = copyOperation.organization.bulkData.operation.status
-    if (status === 'FAILED') {
-      throw new Error(`Copy failed`)
-    }
-
-    this.renderCopyResult(sourceShop, targetShop, copyOperation)
-  }
-
-  private async handleStoreExport(from: string, to: string | undefined): Promise<void> {
-    throw new Error('Store export functionality is not implemented yet')
-  }
-
-  private async handleStoreImport(from: string, to: string): Promise<void> {
-    throw new Error('Store import functionality is not implemented yet')
-  }
-
-  private async fetchOrgs(bpSession: string): Promise<Organization[]> {
-    return (await fetchOrgs(bpSession)).filter((org) => org.shops.length > 1)
-  }
-
-  private shopsFromFlags(from: string, to: string, orgs: Organization[]): {sourceShop: Shop; targetShop: Shop} {
-    const allShops = orgs.flatMap((org) => org.shops)
-    const sourceShop = allShops.find((shop) => shop.domain === from)
-    const targetShop = allShops.find((shop) => shop.domain === to)
-
-    if (!sourceShop) {
-      throw new Error(`Source shop ${from} not found`)
-    }
-    if (!targetShop) {
-      throw new Error(`Target shop ${to} not found`)
-    }
-
-    if (sourceShop.id === targetShop.id) {
-      throw new Error('Source and target shops are the same')
-    }
-    if (sourceShop.organizationId !== targetShop.organizationId) {
-      throw new Error('Source and target shops are not in the same organization')
-    }
-
-    return {sourceShop, targetShop}
-  }
-
-  private async startCopyOperation(
-    bpSession: string,
-    organizationId: string,
-    sourceShop: Shop,
-    targetShop: Shop,
-  ): Promise<BulkDataOperationByIdResponse> {
-    outputInfo(`Copying from ${sourceShop.domain} to ${targetShop.domain}`)
-
-    const copyResponse: BulkDataStoreCopyStartResponse = await startBulkDataStoreCopy(
-      organizationId,
-      sourceShop.domain,
-      targetShop.domain,
-      parseResourceConfigFlags(this.flags.key as string[]),
-      bpSession,
-    )
-
-    if (!copyResponse.bulkDataStoreCopyStart.success) {
-      const errors = copyResponse.bulkDataStoreCopyStart.userErrors.map((error) => error.message).join(', ')
-      throw new Error(`Failed to start copy operation: ${errors}`)
-    }
-
-    const operationId = copyResponse.bulkDataStoreCopyStart.operation.id
-    return pollBulkDataOperation(organizationId, operationId, bpSession)
-  }
-
-  private async waitForCopyCompletion(
-    bpSession: string,
-    organizationId: string,
-    initialOperation: BulkDataOperationByIdResponse,
-  ): Promise<BulkDataOperationByIdResponse> {
-    let currentOperation = initialOperation
-    const operationId = currentOperation.organization.bulkData.operation.id
-
-    while (true) {
-      const status = currentOperation.organization.bulkData.operation.status
-
-      if (status === 'COMPLETED') {
-        return currentOperation
-      } else if (status === 'FAILED') {
-        throw new Error(`Copy operation failed`)
-      }
-
-      // eslint-disable-next-line no-await-in-loop
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-      // eslint-disable-next-line no-await-in-loop
-      currentOperation = await pollBulkDataOperation(organizationId, operationId, bpSession)
-    }
-  }
-
-  private async executeCopyOperation(
-    organizationId: string,
-    sourceShop: Shop,
-    targetShop: Shop,
-    bpSession: string,
-  ): Promise<BulkDataOperationByIdResponse> {
-    const initialOperation = await this.startCopyOperation(bpSession, organizationId, sourceShop, targetShop)
-    return this.waitForCopyCompletion(bpSession, organizationId, initialOperation)
-  }
-
-  private async copyDataWithProgress(
-    organizationId: string,
-    sourceShop: Shop,
-    targetShop: Shop,
-    bpSession: string,
-  ): Promise<BulkDataOperationByIdResponse> {
-    interface Context {
-      copyOperation: BulkDataOperationByIdResponse
-    }
-
-    const tasks: Task<Context>[] = [
-      {
-        title: `Starting copy from ${sourceShop.domain} to ${targetShop.domain}`,
-        task: async (ctx: Context) => {
-          ctx.copyOperation = await this.executeCopyOperation(organizationId, sourceShop, targetShop, bpSession)
-        },
-      },
-    ]
-
-    const ctx: Context = await renderTasks(tasks)
-    return ctx.copyOperation
-  }
-
-  private renderCopyResult(sourceShop: Shop, targetShop: Shop, copyOperation: BulkDataOperationByIdResponse): void {
-    const msg: Token[] = [`Copy operation from`, {info: sourceShop.domain}, `to`, {info: targetShop.domain}]
-
-    const storeOperations = copyOperation.organization.bulkData.operation.storeOperations
-    const hasErrors = storeOperations.some((op) => op.remoteOperationStatus === 'FAILED')
-
-    if (hasErrors) {
-      msg.push(`completed with`)
-      msg.push({error: `errors`})
-      renderWarning({
-        body: msg,
-      })
-    } else {
-      msg.push('complete')
-      renderSuccess({
-        body: msg,
-      })
-    }
   }
 }

--- a/packages/store/src/lib/base-command.ts
+++ b/packages/store/src/lib/base-command.ts
@@ -1,6 +1,7 @@
 import {FlagOptions} from './types.js'
 import Command from '@shopify/cli-kit/node/base-command'
-import {renderText, renderError} from '@shopify/cli-kit/node/ui'
+import {outputInfo} from '@shopify/cli-kit/node/output'
+import {renderError} from '@shopify/cli-kit/node/ui'
 
 export abstract class BaseBDCommand extends Command {
   abstract runCommand(): Promise<void>
@@ -23,7 +24,7 @@ export abstract class BaseBDCommand extends Command {
   }
 
   handleExit() {
-    renderText({text: 'Exiting.'})
+    outputInfo('Exiting.')
     process.exit(0)
   }
 }

--- a/packages/store/src/lib/flags.ts
+++ b/packages/store/src/lib/flags.ts
@@ -2,12 +2,13 @@ import {Flags} from '@oclif/core'
 
 export const shopSelectionFlags = {
   from: Flags.string({
-    description: 'The store to copy data from.',
+    description: 'The store domain or SQLite file to copy/export data from.',
     required: true,
     env: 'SHOPIFY_FLAG_COPY_STORE_FROM',
   }),
   to: Flags.string({
-    description: 'The store to copy data to.',
+    description:
+      'The store domain or SQLite file path to copy/import data to. Leave empty to auto-generate filename for exports.',
     required: true,
     env: 'SHOPIFY_FLAG_COPY_STORE_TO',
   }),

--- a/packages/store/src/lib/flags.ts
+++ b/packages/store/src/lib/flags.ts
@@ -1,16 +1,28 @@
 import {Flags} from '@oclif/core'
 
-export const shopSelectionFlags = {
-  from: Flags.string({
-    description: 'The store domain or SQLite file to copy/export data from.',
-    required: true,
-    env: 'SHOPIFY_FLAG_COPY_STORE_FROM',
+export const storeFlags = {
+  fromStore: Flags.string({
+    description: 'The source store domain to copy/export data from (e.g., source.myshopify.com).',
+    required: false,
+    env: 'SHOPIFY_FLAG_FROM_STORE',
   }),
-  to: Flags.string({
-    description:
-      'The store domain or SQLite file path to copy/import data to. Leave empty to auto-generate filename for exports.',
-    required: true,
-    env: 'SHOPIFY_FLAG_COPY_STORE_TO',
+  toStore: Flags.string({
+    description: 'The target store domain to copy/import data to (e.g., target.myshopify.com).',
+    required: false,
+    env: 'SHOPIFY_FLAG_TO_STORE',
+  }),
+}
+
+export const fileFlags = {
+  fromFile: Flags.string({
+    description: 'The SQLite file to import data from.',
+    required: false,
+    env: 'SHOPIFY_FLAG_FROM_FILE',
+  }),
+  toFile: Flags.string({
+    description: 'The SQLite file path to export data to. Use <sqlite> to auto-generate filename.',
+    required: false,
+    env: 'SHOPIFY_FLAG_TO_FILE',
   }),
 }
 

--- a/packages/store/src/lib/resource-config.ts
+++ b/packages/store/src/lib/resource-config.ts
@@ -53,15 +53,24 @@ export function parseResourceConfigFlags(flags: string[]): ResourceConfigs {
     const parts = flag.split(':')
     validateFlagFormat(flag, parts)
 
-    const resource = parts[0]!
-    const secondPart = parts[1]!
+    const resource = parts[0]
+    const secondPart = parts[1]
+
+    if (!resource || !secondPart) {
+      throw new Error(`Invalid flag format: ${flag}`)
+    }
 
     if (secondPart === METAFIELD_KEYWORD) {
       validateMetafieldFormat(flag, parts)
       validateMetafieldResource(resource)
 
-      const namespace = parts[2]!
-      const key = parts[3]!
+      const namespace = parts[2]
+      const key = parts[3]
+
+      if (!namespace || !key) {
+        throw new Error(`Invalid metafield format: ${flag}`)
+      }
+
       resourceConfigs[resource] = createMetafieldBasedConfig(namespace, key)
     } else {
       resourceConfigs[resource] = createFieldBasedConfig(secondPart)

--- a/packages/store/src/services/store/operations/store-copy.ts
+++ b/packages/store/src/services/store/operations/store-copy.ts
@@ -1,0 +1,177 @@
+import {StoreOperation} from '../types/operations.js'
+import {FlagOptions} from '../../../lib/types.js'
+import {BulkDataStoreCopyStartResponse, BulkDataOperationByIdResponse} from '../../../apis/organizations/types.js'
+import {Shop} from '../../../apis/destinations/types.js'
+import {startBulkDataStoreCopy, pollBulkDataOperation} from '../../../apis/organizations/index.js'
+import {parseResourceConfigFlags} from '../../../lib/resource-config.js'
+import {confirmCopyPrompt} from '../../../prompts/confirm_copy.js'
+import {fetchOrganizations, findShop} from '../utils/store-utils.js'
+import {renderSuccess, Task, renderTasks, renderWarning, Token} from '@shopify/cli-kit/node/ui'
+import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
+import {outputInfo} from '@shopify/cli-kit/node/output'
+
+export class StoreCopyOperation implements StoreOperation {
+  fromArg: string | undefined
+  toArg: string | undefined
+
+  async execute(from: string, to: string, flags: FlagOptions): Promise<void> {
+    this.fromArg = from
+    this.toArg = to
+
+    const bpSession = await ensureAuthenticatedBusinessPlatform()
+    const orgs = await fetchOrganizations(bpSession)
+
+    const sourceShop = findShop(from, orgs)
+    const targetShop = findShop(to, orgs)
+
+    this.validateShops(sourceShop, targetShop)
+
+    // sanity check and to make typescript happy about non-null assertion
+    if (!sourceShop || !targetShop) {
+      throw new Error('Source or target shop not found.')
+    }
+
+    if (!flags.skipConfirmation) {
+      if (!(await confirmCopyPrompt(sourceShop.domain, targetShop.domain))) {
+        outputInfo('Exiting.')
+        process.exit(0)
+      }
+    }
+
+    const copyOperation = await this.copyDataWithProgress(
+      sourceShop.organizationId,
+      sourceShop,
+      targetShop,
+      bpSession,
+      flags,
+    )
+
+    const status = copyOperation.organization.bulkData.operation.status
+    if (status === 'FAILED') {
+      throw new Error(`Copy failed`)
+    }
+
+    this.renderCopyResult(sourceShop, targetShop, copyOperation)
+  }
+
+  private validateShops(sourceShop: Shop | undefined, targetShop: Shop | undefined): void {
+    if (!sourceShop) {
+      throw new Error(`Source shop (${this.fromArg}) not found.`)
+    }
+    if (!targetShop) {
+      throw new Error(`Target shop (${this.toArg}) not found.`)
+    }
+
+    if (sourceShop.id === targetShop.id) {
+      throw new Error('Source and target shops must not be the same.')
+    }
+    if (sourceShop.organizationId !== targetShop.organizationId) {
+      throw new Error('Source and target shops must be in the same organization.')
+    }
+  }
+
+  private async startCopyOperation(
+    bpSession: string,
+    organizationId: string,
+    sourceShop: Shop,
+    targetShop: Shop,
+    flags: FlagOptions,
+  ): Promise<BulkDataOperationByIdResponse> {
+    outputInfo(`Copying from ${sourceShop.domain} to ${targetShop.domain}`)
+
+    const copyResponse: BulkDataStoreCopyStartResponse = await startBulkDataStoreCopy(
+      organizationId,
+      sourceShop.domain,
+      targetShop.domain,
+      parseResourceConfigFlags(flags.key as string[]),
+      bpSession,
+    )
+
+    if (!copyResponse.bulkDataStoreCopyStart.success) {
+      const errors = copyResponse.bulkDataStoreCopyStart.userErrors.map((error) => error.message).join(', ')
+      throw new Error(`Failed to start copy operation: ${errors}`)
+    }
+
+    const operationId = copyResponse.bulkDataStoreCopyStart.operation.id
+    return pollBulkDataOperation(organizationId, operationId, bpSession)
+  }
+
+  private async waitForCopyCompletion(
+    bpSession: string,
+    organizationId: string,
+    initialOperation: BulkDataOperationByIdResponse,
+  ): Promise<BulkDataOperationByIdResponse> {
+    let currentOperation = initialOperation
+    const operationId = currentOperation.organization.bulkData.operation.id
+
+    while (true) {
+      const status = currentOperation.organization.bulkData.operation.status
+
+      if (status === 'COMPLETED') {
+        return currentOperation
+      } else if (status === 'FAILED') {
+        throw new Error(`Copy operation failed`)
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      // eslint-disable-next-line no-await-in-loop
+      currentOperation = await pollBulkDataOperation(organizationId, operationId, bpSession)
+    }
+  }
+
+  private async executeCopyOperation(
+    organizationId: string,
+    sourceShop: Shop,
+    targetShop: Shop,
+    bpSession: string,
+    flags: FlagOptions,
+  ): Promise<BulkDataOperationByIdResponse> {
+    const initialOperation = await this.startCopyOperation(bpSession, organizationId, sourceShop, targetShop, flags)
+    return this.waitForCopyCompletion(bpSession, organizationId, initialOperation)
+  }
+
+  private async copyDataWithProgress(
+    organizationId: string,
+    sourceShop: Shop,
+    targetShop: Shop,
+    bpSession: string,
+    flags: FlagOptions,
+  ): Promise<BulkDataOperationByIdResponse> {
+    interface Context {
+      copyOperation: BulkDataOperationByIdResponse
+    }
+
+    const tasks: Task<Context>[] = [
+      {
+        title: `Starting copy from ${sourceShop.domain} to ${targetShop.domain}`,
+        task: async (ctx: Context) => {
+          ctx.copyOperation = await this.executeCopyOperation(organizationId, sourceShop, targetShop, bpSession, flags)
+        },
+      },
+    ]
+
+    const ctx: Context = await renderTasks(tasks)
+    return ctx.copyOperation
+  }
+
+  private renderCopyResult(sourceShop: Shop, targetShop: Shop, copyOperation: BulkDataOperationByIdResponse): void {
+    const msg: Token[] = [`Copy operation from`, {info: sourceShop.domain}, `to`, {info: targetShop.domain}]
+
+    const storeOperations = copyOperation.organization.bulkData.operation.storeOperations
+    const hasErrors = storeOperations.some((op) => op.remoteOperationStatus === 'FAILED')
+
+    if (hasErrors) {
+      msg.push(`completed with`)
+      msg.push({error: `errors`})
+      renderWarning({
+        body: msg,
+      })
+    } else {
+      msg.push('complete')
+      renderSuccess({
+        body: msg,
+      })
+    }
+  }
+}

--- a/packages/store/src/services/store/operations/store-copy.ts
+++ b/packages/store/src/services/store/operations/store-copy.ts
@@ -14,15 +14,15 @@ export class StoreCopyOperation implements StoreOperation {
   fromArg: string | undefined
   toArg: string | undefined
 
-  async execute(from: string, to: string, flags: FlagOptions): Promise<void> {
-    this.fromArg = from
-    this.toArg = to
+  async execute(fromStore: string, toStore: string, flags: FlagOptions): Promise<void> {
+    this.fromArg = fromStore
+    this.toArg = toStore
 
     const bpSession = await ensureAuthenticatedBusinessPlatform()
     const orgs = await fetchOrganizations(bpSession)
 
-    const sourceShop = findShop(from, orgs)
-    const targetShop = findShop(to, orgs)
+    const sourceShop = findShop(fromStore, orgs)
+    const targetShop = findShop(toStore, orgs)
 
     this.validateShops(sourceShop, targetShop)
 

--- a/packages/store/src/services/store/operations/store-export.ts
+++ b/packages/store/src/services/store/operations/store-export.ts
@@ -1,0 +1,17 @@
+import {StoreOperation} from '../types/operations.js'
+import {FlagOptions} from '../../../lib/types.js'
+import {generateExportFilename} from '../utils/file-utils.js'
+
+export class StoreExportOperation implements StoreOperation {
+  async execute(from: string, to: string, flags: FlagOptions): Promise<void> {
+    // TODO: Implement actual export logic
+    throw new Error('Store export functionality is not implemented yet')
+  }
+
+  private determineOutputPath(from: string, to: string): string {
+    if (to === '<sqlite>') {
+      return generateExportFilename(from)
+    }
+    return to
+  }
+}

--- a/packages/store/src/services/store/operations/store-export.ts
+++ b/packages/store/src/services/store/operations/store-export.ts
@@ -3,15 +3,15 @@ import {FlagOptions} from '../../../lib/types.js'
 import {generateExportFilename} from '../utils/file-utils.js'
 
 export class StoreExportOperation implements StoreOperation {
-  async execute(from: string, to: string, flags: FlagOptions): Promise<void> {
+  async execute(fromStore: string, toFile: string, flags: FlagOptions): Promise<void> {
     // TODO: Implement actual export logic
     throw new Error('Store export functionality is not implemented yet')
   }
 
-  private determineOutputPath(from: string, to: string): string {
-    if (to === '<sqlite>') {
-      return generateExportFilename(from)
+  private determineOutputPath(fromStore: string, toFile: string): string {
+    if (toFile === '') {
+      return generateExportFilename(fromStore)
     }
-    return to
+    return toFile
   }
 }

--- a/packages/store/src/services/store/operations/store-import.ts
+++ b/packages/store/src/services/store/operations/store-import.ts
@@ -1,0 +1,12 @@
+import {StoreOperation} from '../types/operations.js'
+import {FlagOptions} from '../../../lib/types.js'
+
+export class StoreImportOperation implements StoreOperation {
+  async execute(from: string, to: string, flags: FlagOptions): Promise<void> {
+    // TODO: Implement actual import logic
+    throw new Error('Store import functionality is not implemented yet')
+
+    // Future implementation will validate file exists
+    // await validateFileExists(from)
+  }
+}

--- a/packages/store/src/services/store/operations/store-import.ts
+++ b/packages/store/src/services/store/operations/store-import.ts
@@ -2,11 +2,11 @@ import {StoreOperation} from '../types/operations.js'
 import {FlagOptions} from '../../../lib/types.js'
 
 export class StoreImportOperation implements StoreOperation {
-  async execute(from: string, to: string, flags: FlagOptions): Promise<void> {
+  async execute(fromFile: string, toStore: string, flags: FlagOptions): Promise<void> {
     // TODO: Implement actual import logic
     throw new Error('Store import functionality is not implemented yet')
 
     // Future implementation will validate file exists
-    // await validateFileExists(from)
+    // await validateFileExists(fromFile)
   }
 }

--- a/packages/store/src/services/store/types/operations.ts
+++ b/packages/store/src/services/store/types/operations.ts
@@ -7,5 +7,5 @@ export enum OperationMode {
 }
 
 export interface StoreOperation {
-  execute(from: string, to: string | undefined, flags: FlagOptions): Promise<void>
+  execute(source: string, target: string, flags: FlagOptions): Promise<void>
 }

--- a/packages/store/src/services/store/types/operations.ts
+++ b/packages/store/src/services/store/types/operations.ts
@@ -1,0 +1,11 @@
+import {FlagOptions} from '../../../lib/types.js'
+
+export enum OperationMode {
+  STORE_COPY = 'STORE_COPY',
+  STORE_EXPORT = 'STORE_EXPORT',
+  STORE_IMPORT = 'STORE_IMPORT',
+}
+
+export interface StoreOperation {
+  execute(from: string, to: string | undefined, flags: FlagOptions): Promise<void>
+}

--- a/packages/store/src/services/store/utils/file-utils.ts
+++ b/packages/store/src/services/store/utils/file-utils.ts
@@ -1,0 +1,37 @@
+import {access, constants} from 'fs/promises'
+import {dirname} from 'path'
+
+export async function validateFileExists(filePath: string): Promise<void> {
+  try {
+    await access(filePath, constants.F_OK)
+  } catch {
+    throw new Error(`File not found: ${filePath}`)
+  }
+}
+
+export async function validateDirectoryWritable(filePath: string): Promise<void> {
+  const directory = dirname(filePath)
+  try {
+    await access(directory, constants.W_OK)
+  } catch {
+    throw new Error(`Directory is not writable: ${directory}`)
+  }
+}
+
+export async function validateFileDoesNotExist(filePath: string): Promise<void> {
+  try {
+    await access(filePath, constants.F_OK)
+    throw new Error(`File already exists: ${filePath}`)
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('File already exists')) {
+      throw error
+    }
+    // File doesn't exist, which is what we want
+  }
+}
+
+export function generateExportFilename(storeDomain: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const storeName = storeDomain.replace('.myshopify.com', '')
+  return `${storeName}_${timestamp}.sqlite`
+}

--- a/packages/store/src/services/store/utils/store-utils.ts
+++ b/packages/store/src/services/store/utils/store-utils.ts
@@ -1,0 +1,11 @@
+import {Shop, Organization} from '../../../apis/destinations/types.js'
+import {fetchOrgs} from '../../../apis/destinations/index.js'
+
+export async function fetchOrganizations(bpSession: string): Promise<Organization[]> {
+  return (await fetchOrgs(bpSession)).filter((org) => org.shops.length > 1)
+}
+
+export function findShop(shopDomain: string, orgs: Organization[]): Shop | undefined {
+  const allShops = orgs.flatMap((org) => org.shops)
+  return allShops.find((shop) => shop.domain === shopDomain)
+}

--- a/packages/store/src/services/store/utils/validation.ts
+++ b/packages/store/src/services/store/utils/validation.ts
@@ -1,0 +1,7 @@
+export function isStoreIdentifier(value: string): boolean {
+  return value.endsWith('.myshopify.com')
+}
+
+export function isFileIdentifier(value: string): boolean {
+  return value.endsWith('.sqlite') || value === '<sqlite>'
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,8 +699,11 @@ importers:
         specifier: 3.26.5
         version: 3.26.5
       '@shopify/cli-kit':
-        specifier: 3.76.2
-        version: 3.76.2(@types/react@17.0.2)
+        specifier: 3.81.1
+        version: link:../cli-kit
+      graphql-request:
+        specifier: 6.1.0
+        version: 6.1.0(graphql@16.10.0)
 
   packages/theme:
     dependencies:
@@ -3278,11 +3281,6 @@ packages:
         optional: true
       vite:
         optional: true
-
-  '@shopify/cli-kit@3.76.2':
-    resolution: {integrity: sha512-zVygGafdK12Lc/y7qQ+mlyJVKwTDgoj94An20+Pmza5SF/DHqZ01vV1LgpUy00Xlnbwl1Z1q0O0v8zMQs27LyQ==}
-    engines: {node: ^18.20.0 || >=20.10.0}
-    os: [darwin, linux, win32]
 
   '@shopify/dates@1.1.5':
     resolution: {integrity: sha512-WpShtWjylq0iH4FQhpEz1g5tCZRw/GgZ00uYUxUinVyBqaUbRqiAq7EnwXzGO/aTpAUF6yXgDTxoji3aFOiC8A==}
@@ -12732,77 +12730,6 @@ snapshots:
       - react
       - react-dom
 
-  '@shopify/cli-kit@3.76.2(@types/react@17.0.2)':
-    dependencies:
-      '@apidevtools/json-schema-ref-parser': 11.7.3
-      '@bugsnag/js': 7.25.0
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
-      '@iarna/toml': 2.2.5
-      '@oclif/core': 3.26.5
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.57.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 1.30.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.28.0
-      '@types/archiver': 5.3.2
-      ajv: 8.17.1
-      ansi-escapes: 6.2.1
-      archiver: 5.3.2
-      bottleneck: 2.19.5
-      chalk: 5.4.1
-      change-case: 4.1.2
-      color-json: 3.0.5
-      commondir: 1.0.1
-      conf: 11.0.2
-      deepmerge: 4.3.1
-      del: 6.1.1
-      dotenv: 16.4.7
-      env-paths: 3.0.0
-      execa: 7.2.0
-      fast-glob: 3.3.3
-      figures: 5.0.0
-      find-up: 6.3.0
-      form-data: 4.0.1
-      fs-extra: 11.1.0
-      get-port-please: 3.1.2
-      gradient-string: 2.0.2
-      graphql: 16.10.0
-      graphql-request: 6.1.0(graphql@16.10.0)
-      ignore: 6.0.2
-      ink: 4.4.1(@types/react@17.0.2)(react@18.3.1)
-      is-interactive: 2.0.0
-      jose: 5.9.6
-      latest-version: 7.0.0
-      liquidjs: 10.20.1
-      lodash: 4.17.21
-      macaddress: 0.5.3
-      minimatch: 9.0.5
-      mrmime: 1.0.1
-      network-interfaces: 1.1.0
-      node-abort-controller: 3.1.1
-      node-fetch: 3.3.2
-      open: 8.4.2
-      pathe: 1.1.2
-      react: 18.3.1
-      semver: 7.6.3
-      simple-git: 3.27.0
-      stacktracey: 2.1.8
-      strip-ansi: 7.1.0
-      supports-hyperlinks: 3.1.0
-      tempy: 3.1.0
-      terminal-link: 3.0.0
-      ts-error: 1.0.6
-      which: 4.0.0
-      zod: 3.24.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - encoding
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
   '@shopify/dates@1.1.5':
     dependencies:
       '@shopify/decorators': 2.0.8
@@ -13979,14 +13906,14 @@ snapshots:
       msw: 2.8.7(@types/node@18.19.70)(typescript@5.8.3)
       vite: 6.3.5(@types/node@18.19.70)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0)
 
-  '@vitest/mocker@3.2.1(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0))':
+  '@vitest/mocker@3.2.1(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@18.19.70)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.2.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.8.7(@types/node@22.15.29)(typescript@5.8.3)
-      vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@18.19.70)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.2.1':
     dependencies:
@@ -19407,7 +19334,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.1
-      '@vitest/mocker': 3.2.1(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.1(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@18.19.70)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.1
       '@vitest/runner': 3.2.1
       '@vitest/snapshot': 3.2.1


### PR DESCRIPTION
# Enhance store copy command to support export and import functionality

### WHY are these changes introduced?

This PR extends the `store copy` command to support not only copying data between stores but also exporting store data to SQLite files and importing data from SQLite files to stores.

### WHAT is this pull request doing?

- Expands the command description to reflect the new export/import capabilities
- Adds logic to determine operation mode (copy, export, or import) based on the format of `--fromStore` and `--toStore` parameters etc
- Implements error handling for the new export and import modes (functionality marked as "not implemented yet")
- Updates flag descriptions to clarify that they can accept both store domains and SQLite file paths
- Adds comprehensive test coverage for the new functionality and error cases

