### PR TITLE
init store package

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,6 +246,18 @@
           ]
         }
       },
+      "packages/store": {
+        "project": "**/*.ts!",
+        "entry": [
+          "**/{commands,hooks}/**/*.ts!",
+          "**/index.ts!"
+        ],
+        "vite": {
+          "config": [
+            "vite.config.ts"
+          ]
+        }
+      },
       "packages/theme": {
         "project": "**/*.ts!",
         "entry": [

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -63,6 +63,7 @@
 * [`shopify plugins unlink [PLUGIN]`](#shopify-plugins-unlink-plugin)
 * [`shopify plugins update`](#shopify-plugins-update)
 * [`shopify search [query]`](#shopify-search-query)
+* [`shopify store copy`](#shopify-store-copy)
 * [`shopify theme check`](#shopify-theme-check)
 * [`shopify theme console`](#shopify-theme-console)
 * [`shopify theme delete`](#shopify-theme-delete)
@@ -1717,6 +1718,20 @@ EXAMPLES
       shopify search <query>
       # search for a phrase on Shopify.dev
       shopify search "<a search query separated by spaces>"
+```
+
+## `shopify store copy`
+
+Copy a theme to another store.
+
+```
+USAGE
+  $ shopify store copy
+
+DESCRIPTION
+  Copy a theme to another store.
+
+  This command allows you to copy a theme from one Shopify store to another.
 ```
 
 ## `shopify theme check`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4872,6 +4872,26 @@
       "strict": true,
       "usage": "search [query]"
     },
+    "store:copy": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "customPluginName": "@shopify/store",
+      "description": "This command allows you to copy a theme from one Shopify store to another.",
+      "enableJsonFlag": false,
+      "flags": {
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [
+      ],
+      "id": "store:copy",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Copy a theme to another store."
+    },
     "theme:check": {
       "aliases": [
       ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -116,6 +116,7 @@
     "@shopify/plugin-cloudflare": "3.82.0",
     "@shopify/plugin-did-you-mean": "3.82.0",
     "@shopify/theme": "3.82.0",
+    "@shopify/store": "3.81.1",
     "@shopify/cli-hydrogen": "10.0.1",
     "@types/global-agent": "3.0.0",
     "@typescript-eslint/eslint-plugin": "7.13.1",
@@ -151,6 +152,9 @@
       },
       "theme": {
         "description": "Build Liquid themes."
+      },
+      "store:": {
+        "description": "Manage stores and store data."
       },
       "app": {
         "description": "Build Shopify apps."

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import Generate from './cli/commands/notifications/generate.js'
 import ClearCache from './cli/commands/cache/clear.js'
 import {createGlobalProxyAgent} from 'global-agent'
 import ThemeCommands from '@shopify/theme'
+import StoreCommands from '@shopify/store'
 import {COMMANDS as HydrogenCommands, HOOKS as HydrogenHooks} from '@shopify/cli-hydrogen'
 import {commands as AppCommands} from '@shopify/app'
 import {commands as PluginCommandsCommands} from '@oclif/plugin-commands'
@@ -98,6 +99,12 @@ themeCommands.forEach((command) => {
   ;(ThemeCommands[command] as any).customPluginName = '@shopify/theme'
 })
 
+const storeCommands = Object.keys(StoreCommands) as (keyof typeof StoreCommands)[]
+storeCommands.forEach((command) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(StoreCommands[command] as any).customPluginName = '@shopify/store'
+})
+
 const hydrogenCommands = Object.keys(HydrogenCommands) as (keyof typeof HydrogenCommands)[]
 hydrogenCommands.forEach((command) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -126,6 +133,7 @@ pluginPluginsCommands.forEach((command) => {
 export const COMMANDS: any = {
   ...AppCommands,
   ...ThemeCommands,
+  ...StoreCommands,
   ...PluginPluginsCommands,
   ...DidYouMeanCommands,
   ...PluginCommandsCommands,

--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @shopify/store

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@shopify/store",
+  "version": "3.81.1",
+  "packageManager": "pnpm@10.11.1",
+  "private": true,
+  "description": "Utilities managing stores and store data.",
+  "homepage": "https://github.com/shopify/cli#readme",
+  "bugs": {
+    "url": "https://github.com/Shopify/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shopify/cli.git",
+    "directory": "packages/store"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "/dist",
+    "/oclif.manifest.json"
+  ],
+  "scripts": {
+    "build": "nx build",
+    "dev": "nx dev",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
+    "test": "nx run store:test",
+    "test:watch": "nx test:watch",
+    "type-check": "nx type-check"
+  },
+  "eslintConfig": {
+    "extends": [
+      "../../.eslintrc.cjs"
+    ]
+  },
+  "dependencies": {
+    "@oclif/core": "3.26.5",
+    "@shopify/cli-kit": "3.81.1"
+  },
+  "devDependencies": {},
+  "peerDependencies": {},
+  "engines": {
+    "node": ">=20.10.0"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "publishConfig": {
+    "@shopify:registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "engine-strict": true
+}

--- a/packages/store/project.json
+++ b/packages/store/project.json
@@ -1,0 +1,69 @@
+{
+  "name": "store",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/store/src",
+  "projectType": "library",
+  "tags": ["scope:feature"],
+  "targets": {
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm rimraf dist/",
+        "cwd": "packages/store"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist"],
+      "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
+      "options": {
+        "command": "pnpm tsc -b ./tsconfig.build.json",
+        "cwd": "packages/store"
+      }
+    },
+    "dev": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist"],
+      "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
+      "options": {
+        "command": "pnpm tsc -b ./tsconfig.build.json --watch",
+        "cwd": "packages/store"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm eslint \"src/**/*.ts\"",
+        "cwd": "packages/store"
+      }
+    },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm eslint 'src/**/*.ts' --fix",
+        "cwd": "packages/store"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm vitest run",
+        "cwd": "packages/store"
+      }
+    },
+    "test:watch": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm vitest watch",
+        "cwd": "packages/store"
+      }
+    },
+    "type-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm tsc --noEmit",
+        "cwd": "packages/store"
+      }
+    }
+  }
+}

--- a/packages/store/src/cli/commands/store/copy.ts
+++ b/packages/store/src/cli/commands/store/copy.ts
@@ -1,8 +1,8 @@
 import Command from '@shopify/cli-kit/node/base-command'
 
 export default class CopyCommand extends Command {
-  static summary = 'Copy a theme to another store.'
-  static description = 'This command allows you to copy a theme from one Shopify store to another.'
+  static summary = 'Copy data to another store.'
+  static description = 'This command allows you to copy data from one Shopify store to another.'
 
   async run() {
     console.log('This command is not yet implemented.')

--- a/packages/store/src/cli/commands/store/copy.ts
+++ b/packages/store/src/cli/commands/store/copy.ts
@@ -1,0 +1,10 @@
+import Command from '@shopify/cli-kit/node/base-command'
+
+export default class CopyCommand extends Command {
+  static summary = 'Copy a theme to another store.'
+  static description = 'This command allows you to copy a theme from one Shopify store to another.'
+
+  async run() {
+    console.log('This command is not yet implemented.')
+  }
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,0 +1,7 @@
+import CopyCommand from './cli/commands/store/copy.js'
+
+const COMMANDS = {
+  'store:copy': CopyCommand,
+}
+
+export default COMMANDS

--- a/packages/store/tsconfig.build.json
+++ b/packages/store/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts"],
+  "references": [
+    {"path": "../cli-kit"}
+  ]
+}

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../configurations/tsconfig.json",
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./dist"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "references": [
+    {"path": "../cli-kit"}
+  ]
+}

--- a/packages/store/vite.config.ts
+++ b/packages/store/vite.config.ts
@@ -1,0 +1,3 @@
+import config from '../../configurations/vite.config'
+
+export default config(__dirname)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       '@shopify/plugin-did-you-mean':
         specifier: 3.82.0
         version: link:../plugin-did-you-mean
+      '@shopify/store':
+        specifier: 3.81.1
+        version: link:../store
       '@shopify/theme':
         specifier: 3.82.0
         version: link:../theme
@@ -689,6 +692,15 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
         version: 3.2.1(vitest@3.2.1(@types/node@22.15.29)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(sass@1.89.1)(yaml@2.7.0))
+
+  packages/store:
+    dependencies:
+      '@oclif/core':
+        specifier: 3.26.5
+        version: 3.26.5
+      '@shopify/cli-kit':
+        specifier: 3.81.1
+        version: link:../cli-kit
 
   packages/theme:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
       {"path": "./packages/cli"},
       {"path": "./packages/app"},
       {"path": "./packages/theme"},
+      {"path": "./packages/store"},
       {"path": "./packages/cli-kit"},
       {"path": "./packages/create-app"},
       {"path": "./packages/ui-extensions-server-kit"},

--- a/vitest.workspace.json
+++ b/vitest.workspace.json
@@ -5,6 +5,7 @@
   "packages/plugin-cloudflare",
   "packages/plugin-did-you-mean",
   "packages/theme",
+  "packages/store",
   "packages/ui-extensions-dev-console",
   "packages/ui-extensions-server-kit",
   "packages/ui-extensions-test-utils"


### PR DESCRIPTION

### WHAT is this pull request doing?

Adds a new `@shopify/store` package with a `store:copy` command that will allow users to copy a theme from one Shopify store to another. The command structure is set up, though the implementation is currently a placeholder.

Key changes:
- Creates a new `@shopify/store` package with necessary configuration files
- Adds a `store:copy` command with appropriate documentation
- Integrates the new package into the CLI framework
- Updates package.json and other configuration files to include the new package

### How to test your changes?

1. Run `pnpm install` to update dependencies
2. Run `shopify store copy --help` to verify the command is registered
3. Verify the command appears in the CLI help documentation

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes