### PR TITLE
Remove encryption certificate fingerprint blank validation for custom credit card

### DIFF
--- a/.changeset/four-humans-judge.md
+++ b/.changeset/four-humans-judge.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fixes the `Encryption certificate fingerprint can't be blank` error when generating a custom credit card payments extension with the `shopify app generate extension` command.

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
@@ -70,28 +70,6 @@ describe('CustomCreditCardPaymentsAppExtensionSchema', () => {
     )
   })
 
-  test('returns an error if encryption certificate fingerprint is blank', async () => {
-    // When/Then
-    expect(() =>
-      CustomCreditCardPaymentsAppExtensionSchema.parse({
-        ...config,
-        encryption_certificate_fingerprint: '',
-      }),
-    ).toThrowError(
-      new zod.ZodError([
-        {
-          code: zod.ZodIssueCode.too_small,
-          minimum: 1,
-          type: 'string',
-          inclusive: true,
-          exact: false,
-          message: "Encryption certificate fingerprint can't be blank",
-          path: ['encryption_certificate_fingerprint'],
-        },
-      ]),
-    )
-  })
-
   test('returns an error if buyer_label_translations has invalid format', async () => {
     // When/Then
     expect(() =>

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
@@ -30,9 +30,7 @@ export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensi
     multiple_capture: zod.boolean(),
     checkout_hosted_fields: zod.array(zod.string()).optional(),
     ui_extension_handle: zod.string().optional(),
-    encryption_certificate_fingerprint: zod
-      .string()
-      .min(1, {message: "Encryption certificate fingerprint can't be blank"}),
+    encryption_certificate_fingerprint: zod.string(),
     checkout_payment_method_fields: zod
       .array(
         zod.object({


### PR DESCRIPTION
## WHY are these changes introduced?

Similar to https://github.com/Shopify/cli/pull/6032
This was missed on the previous PR. Both should have the same validations for certificates.

Fixes the issue where the custom cc app extension creation systematically failed when using the templates due to the fact that :

The template includes a blank fingerprint field. [Code reference](https://github.com/Shopify/extensions-templates/blob/main/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid#L24)
The CLI schema enforces that the fingerprint field contains a string of at LEAST 1 character. [Code reference](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts#L33-L35)
Reason # 1 : This app extension creation failure is a bug/blocker for partners because the CLI systematically fails generating a credit card payment extension, and the developer cannot create a credit card extension.

Reason # 2 : There is already the same validation in core.

## WHAT is this pull request doing?
Removes the string contents validation, the key must still be present, but it can be empty now.
`encryption_certificate_fingerprint = ""`

## How to test your changes?
Pre-requisite : Have an app already setup with the local dev setup for dev dashboard, [as documented here](https://docs.google.com/document/d/1_fs9oHyxt4xqKnLk3WpMVIAU2gSaPUBHIVsFzcUMSlk/edit?tab=t.0#heading=h.d8gcz6c0yo4g)

The organization must have the credit_card_extensions organization beta flag enabled in business-platform

1- dev cd cli
2- checkout this branch : git checkout mza/rm-cc-cert-validation
3- Run the following command in your app :

`SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify app generate extension --path="<path/to/your_app>"`
4- Generate a custom credit card extension. This will use the [template](https://github.com/Shopify/extensions-templates/tree/main/payments-app-extension-credit-card) by default which contains an empty certificate.
Assert that it succeeds when running this from the cli directory (using the local CLI version) but fails when done elsewhere (deployed CLI version)

[See the following demo that was done for regular credit card extensions](https://share.descript.com/view/d21JsE1Ze9D)

## Post-release steps
### Measuring impact
How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev/) changes