### PR TITLE
Track if current build is fork

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -52,3 +52,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          SHOPIFY_CLI_BUILD_REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHOPIFY_CLI_BUILD_REPO: ${{ github.repository }}

--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -47,3 +47,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          SHOPIFY_CLI_BUILD_REPO: ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,5 @@ packages/ui-extensions-dev-console/.eslintrc.js
 packages/ui-extensions-dev-console/css-transform.js
 packages/ui-extensions-dev-console/dist
 packages/cli-kit/src/cli/api/graphql/*/*_schema.graphql
+
+.claude

--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -65,6 +65,7 @@ interface EnvironmentData {
   env_is_global: boolean
   env_auth_method: string
   env_is_wsl: boolean
+  env_build_repository: string
 }
 
 export async function getEnvironmentData(config: Interfaces.Config): Promise<EnvironmentData> {
@@ -89,6 +90,7 @@ export async function getEnvironmentData(config: Interfaces.Config): Promise<Env
     env_is_global: currentProcessIsGlobal(),
     env_auth_method: await getLastSeenAuthMethod(),
     env_is_wsl: await isWsl(),
+    env_build_repository: process.env.SHOPIFY_CLI_BUILD_REPO ?? 'unknown',
   }
 }
 

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -10,7 +10,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 type Optional<T> = T | null
 
 // This is the topic name of the main event we log to Monorail, the command tracker
-export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.17'
+export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.18'
 
 export interface Schemas {
   [MONORAIL_COMMAND_TOPIC]: {

--- a/packages/cli/bin/bundle.js
+++ b/packages/cli/bin/bundle.js
@@ -46,6 +46,8 @@ esBuild({
     // Necessary for theme-check-node to work
     'process.env.WEBPACK_MODE': 'true',
     'import.meta.vitest': 'false',
+    // Injected during build to detect fork vs original repo
+    'process.env.SHOPIFY_CLI_BUILD_REPO': JSON.stringify(process.env.SHOPIFY_CLI_BUILD_REPO || 'unknown'),
   },
   inject: ['../../bin/bundling/cjs-shims.js'],
   external,


### PR DESCRIPTION
### WHY are these changes introduced?

To track which repository is being used to build the CLI, which helps with analytics and debugging.

### WHAT is this pull request doing?

- Adds a new environment variable `SHOPIFY_CLI_BUILD_REPO` to track the repository used for building the CLI
- Passes this variable in all GitHub workflow files that handle building and releasing
- Includes this information in analytics data via the new `env_build_repository` field

### How to test your changes?

1. Run a build locally with `SHOPIFY_CLI_BUILD_REPO=your-repo/cli` set
2. Verify that analytics data includes the repository information

ALTERNATIVELY

1. Run the `release-manual` GH workflow pointing to this branch and select `experimental`
2. In the experimental release, run any command with verbose, see that  `env_build_repository` is included 

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes