### PR TITLE
Fix theme package trying to use default environment

### DIFF
--- a/.changeset/twelve-crabs-bake.md
+++ b/.changeset/twelve-crabs-bake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix an issue with running `theme package` with a default environment present

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -162,6 +162,7 @@ This flag is required in non-interactive terminal environments, such as a CI env
     )
 
     if (!environment) return originalResult
+    if (isDefaultEnvironment && !commandSupportsFlag(options?.flags, 'environment')) return originalResult
 
     // Parse using noDefaultsOptions to derive a list of flags specified as
     // command-line arguments.
@@ -303,7 +304,7 @@ function argsFromEnvironment<TFlags extends FlagOutput, TGlobalFlags extends Fla
 ): string[] {
   const args: string[] = []
   for (const [label, value] of Object.entries(environment)) {
-    const flagIsRelevantToCommand = options?.flags && Object.prototype.hasOwnProperty.call(options.flags, label)
+    const flagIsRelevantToCommand = commandSupportsFlag(options?.flags, label)
     const userSpecifiedThisFlag =
       noDefaultsResult.flags && Object.prototype.hasOwnProperty.call(noDefaultsResult.flags, label)
     if (flagIsRelevantToCommand && !userSpecifiedThisFlag) {
@@ -325,6 +326,10 @@ function argsFromEnvironment<TFlags extends FlagOutput, TGlobalFlags extends Fla
     }
   }
   return args
+}
+
+function commandSupportsFlag(flags: FlagInput | undefined, flagName: string): boolean {
+  return Boolean(flags) && Object.prototype.hasOwnProperty.call(flags, flagName)
 }
 
 export default BaseCommand


### PR DESCRIPTION
### WHY are these changes introduced?

- Closes https://github.com/Shopify/cli/issues/6033

The package command does not support an environment flag and would fail if a default environment was present in a users `shopify.theme.toml` because we try to load it automatically.

This adds an early return if we're using the default environment but the command doesn't support it.