### PR TITLE
find stores by prefix or full domain

### DIFF
--- a/packages/store/src/services/store/operations/store-copy.ts
+++ b/packages/store/src/services/store/operations/store-copy.ts
@@ -4,7 +4,7 @@ import {BulkDataStoreCopyStartResponse, BulkDataOperationByIdResponse} from '../
 import {Organization, Shop} from '../../../apis/destinations/index.js'
 import {parseResourceConfigFlags} from '../../../lib/resource-config.js'
 import {confirmCopyPrompt} from '../../../prompts/confirm_copy.js'
-import {findShop} from '../utils/store-utils.js'
+import {findStore} from '../utils/store-utils.js'
 import {ApiClient} from '../api/api-client.js'
 import {ApiClientInterface} from '../types/api-client.js'
 import {BulkOperationTaskGenerator, BulkOperationContext} from '../utils/bulk-operation-task-generator.js'
@@ -30,8 +30,8 @@ export class StoreCopyOperation implements StoreOperation {
     this.fromArg = fromStore
     this.toArg = toStore
 
-    const sourceShop = findShop(fromStore, this.orgs)
-    const targetShop = findShop(toStore, this.orgs)
+    const sourceShop = findStore(fromStore, this.orgs)
+    const targetShop = findStore(toStore, this.orgs)
 
     this.validateShops(sourceShop, targetShop)
 

--- a/packages/store/src/services/store/operations/store-export.ts
+++ b/packages/store/src/services/store/operations/store-export.ts
@@ -2,7 +2,7 @@ import {StoreOperation} from '../types/operations.js'
 import {FlagOptions} from '../../../lib/types.js'
 import {BulkDataStoreExportStartResponse, BulkDataOperationByIdResponse} from '../../../apis/organizations/types.js'
 import {Organization, Shop} from '../../../apis/destinations/index.js'
-import {findShop} from '../utils/store-utils.js'
+import {findStore} from '../utils/store-utils.js'
 import {ResultFileHandler} from '../utils/result-file-handler.js'
 import {ApiClient} from '../api/api-client.js'
 import {ApiClientInterface} from '../types/api-client.js'
@@ -28,7 +28,7 @@ export class StoreExportOperation implements StoreOperation {
   async execute(fromStore: string, toFile: string, flags: FlagOptions): Promise<void> {
     this.fromArg = fromStore
 
-    const sourceShop = findShop(fromStore, this.orgs)
+    const sourceShop = findStore(fromStore, this.orgs)
     this.validateShop(sourceShop)
 
     renderCopyInfo('Export Operation', sourceShop.domain, toFile)

--- a/packages/store/src/services/store/operations/store-import.ts
+++ b/packages/store/src/services/store/operations/store-import.ts
@@ -3,7 +3,7 @@ import {FlagOptions} from '../../../lib/types.js'
 import {BulkDataStoreImportStartResponse, BulkDataOperationByIdResponse} from '../../../apis/organizations/types.js'
 import {Organization, Shop} from '../../../apis/destinations/index.js'
 import {parseResourceConfigFlags} from '../../../lib/resource-config.js'
-import {findShop} from '../utils/store-utils.js'
+import {findStore} from '../utils/store-utils.js'
 import {FileUploader} from '../utils/file-uploader.js'
 import {MockFileUploader} from '../utils/mock-file-uploader.js'
 import {ResultFileHandler} from '../utils/result-file-handler.js'
@@ -43,7 +43,7 @@ export class StoreImportOperation implements StoreOperation {
 
     await this.validateInputFile(fromFile)
 
-    const targetShop = findShop(toStore, this.orgs)
+    const targetShop = findStore(toStore, this.orgs)
     this.validateShop(targetShop)
 
     if (!flags['no-prompt']) {

--- a/packages/store/src/services/store/utils/store-utils.test.ts
+++ b/packages/store/src/services/store/utils/store-utils.test.ts
@@ -82,6 +82,19 @@ describe('store-utils', () => {
       })
     })
 
+    test('should find shop by prefix', () => {
+      const result = findShop('shop3', mockOrganizations)
+      expect(result).toEqual({
+        id: 'gid://shop/3',
+        domain: 'shop3.myshopify.com',
+        organizationId: 'gid://organization/2',
+        name: 'Shop 3',
+        status: 'active',
+        publicId: 'shop3',
+        webUrl: 'https://shop3.myshopify.com',
+      })
+    })
+
     test('should return undefined when shop does not exist', () => {
       const result = findShop('nonexistent.myshopify.com', mockOrganizations)
       expect(result).toBeUndefined()

--- a/packages/store/src/services/store/utils/store-utils.test.ts
+++ b/packages/store/src/services/store/utils/store-utils.test.ts
@@ -1,10 +1,10 @@
-import {findShop, ensureOrgHasBulkDataAccess} from './store-utils.js'
+import {findStore, ensureOrgHasBulkDataAccess} from './store-utils.js'
 import {Organization} from '../../../apis/destinations/index.js'
 import {MockApiClient} from '../mock/mock-api-client.js'
 import {describe, vi, expect, test, beforeEach} from 'vitest'
 
 describe('store-utils', () => {
-  describe('findShop', () => {
+  describe('findStore', () => {
     const mockOrganizations: Organization[] = [
       {
         id: 'gid://organization/1',
@@ -57,7 +57,7 @@ describe('store-utils', () => {
     ]
 
     test('should find shop by domain when it exists', () => {
-      const result = findShop('shop2.myshopify.com', mockOrganizations)
+      const result = findStore('shop2.myshopify.com', mockOrganizations)
       expect(result).toEqual({
         id: 'gid://shop/2',
         domain: 'shop2.myshopify.com',
@@ -70,7 +70,7 @@ describe('store-utils', () => {
     })
 
     test('should find shop from second organization', () => {
-      const result = findShop('shop3.myshopify.com', mockOrganizations)
+      const result = findStore('shop3.myshopify.com', mockOrganizations)
       expect(result).toEqual({
         id: 'gid://shop/3',
         domain: 'shop3.myshopify.com',
@@ -83,7 +83,7 @@ describe('store-utils', () => {
     })
 
     test('should find shop by prefix', () => {
-      const result = findShop('shop3', mockOrganizations)
+      const result = findStore('shop3', mockOrganizations)
       expect(result).toEqual({
         id: 'gid://shop/3',
         domain: 'shop3.myshopify.com',
@@ -96,12 +96,12 @@ describe('store-utils', () => {
     })
 
     test('should return undefined when shop does not exist', () => {
-      const result = findShop('nonexistent.myshopify.com', mockOrganizations)
+      const result = findStore('nonexistent.myshopify.com', mockOrganizations)
       expect(result).toBeUndefined()
     })
 
     test('should return undefined when organizations array is empty', () => {
-      const result = findShop('shop1.myshopify.com', [])
+      const result = findStore('shop1.myshopify.com', [])
       expect(result).toBeUndefined()
     })
 
@@ -113,7 +113,7 @@ describe('store-utils', () => {
           shops: [],
         },
       ]
-      const result = findShop('shop1.myshopify.com', orgsWithNoShops)
+      const result = findStore('shop1.myshopify.com', orgsWithNoShops)
       expect(result).toBeUndefined()
     })
   })

--- a/packages/store/src/services/store/utils/store-utils.ts
+++ b/packages/store/src/services/store/utils/store-utils.ts
@@ -1,7 +1,7 @@
 import {Shop, Organization} from '../../../apis/destinations/index.js'
 import {ApiClientInterface} from '../types/api-client.js'
 
-export function findShop(shopDomain: string, orgs: Organization[]): Shop | undefined {
+export function findStore(shopDomain: string, orgs: Organization[]): Shop | undefined {
   const allShops = orgs.flatMap((org) => org.shops)
   const byDomain = allShops.find((shop) => shop.domain === shopDomain)
   const byPrefix = allShops.find((shop) => shop.domain === `${shopDomain}.myshopify.com`)

--- a/packages/store/src/services/store/utils/store-utils.ts
+++ b/packages/store/src/services/store/utils/store-utils.ts
@@ -3,7 +3,9 @@ import {ApiClientInterface} from '../types/api-client.js'
 
 export function findShop(shopDomain: string, orgs: Organization[]): Shop | undefined {
   const allShops = orgs.flatMap((org) => org.shops)
-  return allShops.find((shop) => shop.domain === shopDomain)
+  const byDomain = allShops.find((shop) => shop.domain === shopDomain)
+  const byPrefix = allShops.find((shop) => shop.domain === `${shopDomain}.myshopify.com`)
+  return byDomain ?? byPrefix
 }
 
 export async function ensureOrgHasBulkDataAccess(


### PR DESCRIPTION
### WHAT

Closes https://github.com/Shopify/workflows-operations/issues/3335

### HOW

- findShop utility will lookup by full domain or prefix

