### PR TITLE
Move from .npmrc to pnpm-workspace.yml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,8 +1,1 @@
-strict-peer-dependencies=false
-auto-install-peers=true
-link-workspace-packages=true
-public-hoist-pattern[]=*vitest*
-public-hoist-pattern[]=*vite*
-public-hoist-pattern[]=*eslint*
-public-hoist-pattern[]=*prettier*
 @shopify:registry=https://registry.npmjs.org/

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,11 @@ onlyBuiltDependencies:
   - nx
   - protobufjs
   - yarn
+strictPeerDependencies: false
+autoInstallPeers: true
+linkWorkspacePackages: true
+publicHoistPattern:
+  - '*vitest*'
+  - '*vite*'
+  - '*eslint*'
+  - '*prettier*'


### PR DESCRIPTION
### WHY are these changes introduced?

Move pnpm configuration from `.npmrc` to `pnpm-workspace.yaml` to better organize package management settings.

Node latest version is showing warnings for unknown properties in the `npmrc` file. ([related issue in pnpm's repo](https://github.com/pnpm/pnpm/issues/9274))

[Pnpm supports](https://pnpm.io/settings) declaring this configuration in the `pnpm-workspace.yaml` file, which is more appropriate and eliminates all warnings.

### WHAT is this pull request doing?

- Removes configuration settings from `.npmrc` file
- Moves the following settings to `pnpm-workspace.yaml`:
  - `strictPeerDependencies: false`
  - `autoInstallPeers: true`
  - `linkWorkspacePackages: true`
  - Public hoisting patterns for vitest, vite, eslint, and prettier

### How to test your changes?

1. Run `pnpm install` to verify that dependencies are still correctly installed
2. Verify that hoisted packages (vitest, vite, eslint, prettier) are still accessible
3. Check that workspace packages are properly linked

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes