### PR TITLE
Update authentication requirements for CLI commands (typegen + run)

### DIFF
--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -1,7 +1,8 @@
-import {functionFlags, inFunctionContext, getOrGenerateSchemaPath} from '../../../services/function/common.js'
+import {chooseFunction, functionFlags, getOrGenerateSchemaPath} from '../../../services/function/common.js'
 import {runFunction} from '../../../services/function/runner.js'
 import {appFlags} from '../../../flags.js'
-import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
+import AppUnlinkedCommand, {AppUnlinkedCommandOutput} from '../../../utilities/app-unlinked-command.js'
+import {localAppContext} from '../../../services/app-context.js'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 import {renderAutocompletePrompt, isTTY} from '@shopify/cli-kit/node/ui'
@@ -9,7 +10,7 @@ import {outputDebug} from '@shopify/cli-kit/node/output'
 
 const DEFAULT_FUNCTION_EXPORT = '_start'
 
-export default class FunctionRun extends AppLinkedCommand {
+export default class FunctionRun extends AppUnlinkedCommand {
   static summary = 'Run a function locally for testing.'
 
   static descriptionWithMarkdown = `Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).`
@@ -34,62 +35,64 @@ export default class FunctionRun extends AppLinkedCommand {
     }),
   }
 
-  public async run(): Promise<AppLinkedCommandOutput> {
+  public async run(): Promise<AppUnlinkedCommandOutput> {
     const {flags} = await this.parse(FunctionRun)
-    const app = await inFunctionContext({
-      path: flags.path,
+
+    let functionExport = DEFAULT_FUNCTION_EXPORT
+
+    const app = await localAppContext({
+      directory: flags.path,
       userProvidedConfigName: flags.config,
-      apiKey: flags['client-id'],
-      reset: flags.reset,
-      callback: async (app, developerPlatformClient, ourFunction, orgId) => {
-        let functionExport = DEFAULT_FUNCTION_EXPORT
+    })
 
-        if (flags.export !== undefined) {
-          outputDebug(`Using export ${flags.export} from the --export flag.`)
-          functionExport = flags.export
-        } else if (
-          ourFunction.configuration.targeting !== undefined &&
-          ourFunction.configuration.targeting.length > 0
-        ) {
-          const targeting = ourFunction.configuration.targeting
+    const ourFunction = await chooseFunction(app, flags.path)
 
-          if (targeting.length > 1 && isTTY({})) {
-            const targets = targeting.map((target) => ({
-              label: target.target,
-              value: target.export || DEFAULT_FUNCTION_EXPORT,
-            }))
+    if (flags.export !== undefined) {
+      outputDebug(`Using export ${flags.export} from the --export flag.`)
+      functionExport = flags.export
+    } else if (ourFunction.configuration.targeting !== undefined && ourFunction.configuration.targeting.length > 0) {
+      const targeting = ourFunction.configuration.targeting
 
-            functionExport = await renderAutocompletePrompt({
-              message: `Which target would you like to execute?`,
-              choices: targets,
-            })
-          } else {
-            functionExport = targeting?.[0]?.export || DEFAULT_FUNCTION_EXPORT
-            outputDebug(
-              `Using export '${functionExport}'. Use the --export flag or an interactive terminal to select a different export.`,
-            )
-          }
-        } else {
-          outputDebug(
-            `No targeting information found. Using the default export '${functionExport}'. Use the --export flag or an interactive terminal to select a different export.`,
-          )
-        }
+      if (targeting.length > 1 && isTTY({})) {
+        const targets = targeting.map((target) => ({
+          label: target.target,
+          value: target.export || DEFAULT_FUNCTION_EXPORT,
+        }))
 
-        const inputQueryPath = ourFunction?.configuration.targeting?.[0]?.input_query
-        const queryPath = inputQueryPath && `${ourFunction?.directory}/${inputQueryPath}`
-        const schemaPath = await getOrGenerateSchemaPath(ourFunction, app, developerPlatformClient, orgId)
-
-        await runFunction({
-          functionExtension: ourFunction,
-          json: flags.json,
-          inputPath: flags.input,
-          export: functionExport,
-          stdin: 'inherit',
-          schemaPath,
-          queryPath,
+        functionExport = await renderAutocompletePrompt({
+          message: `Which target would you like to execute?`,
+          choices: targets,
         })
-        return app
-      },
+      } else {
+        functionExport = targeting?.[0]?.export || DEFAULT_FUNCTION_EXPORT
+        outputDebug(
+          `Using export '${functionExport}'. Use the --export flag or an interactive terminal to select a different export.`,
+        )
+      }
+    } else {
+      outputDebug(
+        `No targeting information found. Using the default export '${functionExport}'. Use the --export flag or an interactive terminal to select a different export.`,
+      )
+    }
+
+    const inputQueryPath = ourFunction?.configuration.targeting?.[0]?.input_query
+    const queryPath = inputQueryPath && `${ourFunction?.directory}/${inputQueryPath}`
+    const schemaPath = await getOrGenerateSchemaPath(
+      ourFunction,
+      flags.path,
+      flags['client-id'],
+      flags.reset,
+      flags.config,
+    )
+
+    await runFunction({
+      functionExtension: ourFunction,
+      json: flags.json,
+      inputPath: flags.input,
+      export: functionExport,
+      stdin: 'inherit',
+      schemaPath,
+      queryPath,
     })
 
     return {app}

--- a/packages/app/src/cli/commands/app/function/typegen.ts
+++ b/packages/app/src/cli/commands/app/function/typegen.ts
@@ -1,11 +1,12 @@
-import {functionFlags, inFunctionContext} from '../../../services/function/common.js'
+import {chooseFunction, functionFlags} from '../../../services/function/common.js'
 import {buildGraphqlTypes} from '../../../services/function/build.js'
 import {appFlags} from '../../../flags.js'
-import AppLinkedCommand from '../../../utilities/app-linked-command.js'
+import AppUnlinkedCommand, {AppUnlinkedCommandOutput} from '../../../utilities/app-unlinked-command.js'
+import {localAppContext} from '../../../services/app-context.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 
-export default class FunctionTypegen extends AppLinkedCommand {
+export default class FunctionTypegen extends AppUnlinkedCommand {
   static summary = 'Generate GraphQL types for a JavaScript function.'
 
   static descriptionWithMarkdown = `Creates GraphQL types based on your [input query](https://shopify.dev/docs/apps/functions/input-output#input) for a function written in JavaScript.`
@@ -18,19 +19,19 @@ export default class FunctionTypegen extends AppLinkedCommand {
     ...functionFlags,
   }
 
-  public async run() {
+  public async run(): Promise<AppUnlinkedCommandOutput> {
     const {flags} = await this.parse(FunctionTypegen)
-    const app = await inFunctionContext({
-      path: flags.path,
-      apiKey: flags['client-id'],
-      reset: flags.reset,
+
+    const app = await localAppContext({
+      directory: flags.path,
       userProvidedConfigName: flags.config,
-      callback: async (app, _, ourFunction) => {
-        await buildGraphqlTypes(ourFunction, {stdout: process.stdout, stderr: process.stderr, app})
-        renderSuccess({headline: 'GraphQL types generated successfully.'})
-        return app
-      },
     })
+
+    const ourFunction = await chooseFunction(app, flags.path)
+
+    await buildGraphqlTypes(ourFunction, {stdout: process.stdout, stderr: process.stderr, app})
+    renderSuccess({headline: 'GraphQL types generated successfully.'})
+
     return {app}
   }
 }

--- a/packages/app/src/cli/services/function/common.ts
+++ b/packages/app/src/cli/services/function/common.ts
@@ -1,9 +1,8 @@
-import {AppInterface, AppLinkedInterface} from '../../models/app/app.js'
+import {AppInterface} from '../../models/app/app.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {generateSchemaService} from '../generate-schema.js'
 import {linkedAppContext} from '../app-context.js'
-import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {resolvePath, cwd, joinPath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {Flags} from '@oclif/core'
@@ -20,35 +19,6 @@ export const functionFlags = {
     noCacheDefault: true,
     env: 'SHOPIFY_FLAG_PATH',
   }),
-}
-
-export async function inFunctionContext({
-  path,
-  userProvidedConfigName,
-  apiKey,
-  callback,
-  reset,
-}: {
-  path: string
-  userProvidedConfigName?: string
-  apiKey?: string
-  reset?: boolean
-  callback: (
-    app: AppLinkedInterface,
-    developerPlatformClient: DeveloperPlatformClient,
-    ourFunction: ExtensionInstance<FunctionConfigType>,
-    orgId: string,
-  ) => Promise<AppLinkedInterface>
-}) {
-  const {app, developerPlatformClient, organization} = await linkedAppContext({
-    directory: path,
-    clientId: apiKey,
-    forceRelink: reset ?? false,
-    userProvidedConfigName,
-  })
-
-  const ourFunction = await chooseFunction(app, path)
-  return callback(app, developerPlatformClient, ourFunction, organization.id)
 }
 
 export async function chooseFunction(app: AppInterface, path: string): Promise<ExtensionInstance<FunctionConfigType>> {
@@ -73,22 +43,29 @@ export async function chooseFunction(app: AppInterface, path: string): Promise<E
 
 export async function getOrGenerateSchemaPath(
   extension: ExtensionInstance<FunctionConfigType>,
-  app: AppLinkedInterface,
-  developerPlatformClient: DeveloperPlatformClient,
-  orgId: string,
+  appDirectory: string,
+  clientId: string | undefined,
+  forceRelink: boolean,
+  userProvidedConfigName: string | undefined,
 ): Promise<string | undefined> {
   const path = joinPath(extension.directory, 'schema.graphql')
   if (await fileExists(path)) {
     return path
   }
 
+  const {app, developerPlatformClient, organization} = await linkedAppContext({
+    directory: appDirectory,
+    clientId,
+    forceRelink,
+    userProvidedConfigName,
+  })
+
   await generateSchemaService({
     app,
     developerPlatformClient,
     extension,
     stdout: false,
-    path: extension.directory,
-    orgId,
+    orgId: organization.id,
   })
 
   return (await fileExists(path)) ? path : undefined

--- a/packages/app/src/cli/services/generate-schema.test.ts
+++ b/packages/app/src/cli/services/generate-schema.test.ts
@@ -40,7 +40,6 @@ describe('generateSchemaService', () => {
       await generateSchemaService({
         app,
         extension,
-        path: tmpDir,
         stdout: false,
         developerPlatformClient: testDeveloperPlatformClient(),
         orgId,
@@ -67,7 +66,6 @@ describe('generateSchemaService', () => {
       await generateSchemaService({
         app,
         extension,
-        path,
         stdout,
         developerPlatformClient: testDeveloperPlatformClient(),
         orgId,
@@ -108,7 +106,6 @@ describe('generateSchemaService', () => {
         await generateSchemaService({
           app,
           extension,
-          path,
           stdout: false,
           developerPlatformClient,
           orgId,
@@ -154,7 +151,6 @@ describe('generateSchemaService', () => {
           },
         })
 
-        const path = tmpDir
         const expectedTarget = extension.configuration.targeting![0]!.target
         const version = extension.configuration.api_version
         const orgId = 'test'
@@ -163,7 +159,6 @@ describe('generateSchemaService', () => {
         await generateSchemaService({
           app,
           extension,
-          path,
           stdout: false,
           developerPlatformClient,
           orgId,
@@ -194,7 +189,6 @@ describe('generateSchemaService', () => {
     const result = generateSchemaService({
       app,
       extension,
-      path: '',
       stdout: true,
       developerPlatformClient,
       orgId,

--- a/packages/app/src/cli/services/generate-schema.ts
+++ b/packages/app/src/cli/services/generate-schema.ts
@@ -13,7 +13,6 @@ interface GenerateSchemaOptions {
   app: AppLinkedInterface
   extension: ExtensionInstance<FunctionConfigType>
   stdout: boolean
-  path: string
   developerPlatformClient: DeveloperPlatformClient
   orgId: string
 }


### PR DESCRIPTION
### WHY are these changes introduced?

- Fixes shop/issues-develop#1311
- Updates `function typegen` to not require authentication to run
- Updates `function run` to _conditionally_ require authentication. It does this by embedding conditional app linking inside the `getOrGenerateSchemaPath` function - if the schema is already there, the linked app is not required, otherwise it is (which forces auth).

### WHAT is this pull request doing?
- In addition to the changes above, this PR removes the `inFunctionContext` function. This function was previously performing some boilerplate around app loading and function selecting, but it was constraining when we had commands that wanted to mix authenticated and non-authenticated environment. I realized that the only line of code `inFunctionContext` was actually saving us was the `chooseFunction` step. This seemed like not much benefit to another level of abstraction, so I removed it. Commands now have to load the app (linked or local) and invoke chooseFunction as necessary themselves. This change affected `function replay` and `function schema` commands, even though those commands have no functional changes within this PR.
- Also removed `path` from `GenerateSchemaOptions` as it was unused

### How to test your changes?
- You can create an app with a function and invoke the modified commands for that function (replay, run, schema, typegen)
- NOTE: I have not thoroughly tophatted these changes yet since I am having many issues running functions locally.
- I noticed we don't have automated/unit tests for the command files - probably something to improve later but I wasn't sure it should be scoped into this PR or not.