### PR TITLE
Fix linting errors when gql types generated for store package

### DIFF
--- a/packages/store/project.json
+++ b/packages/store/project.json
@@ -33,14 +33,14 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm eslint \"src/**/*.ts\"",
+        "command": "pnpm eslint \"src/**/*.ts\" --ignore-pattern \"src/cli/api/graphql/*/generated/**\"",
         "cwd": "packages/store"
       }
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm eslint 'src/**/*.ts' --fix",
+        "command": "pnpm eslint 'src/**/*.ts' --fix --ignore-pattern \"src/cli/api/graphql/*/generated/**\"",
         "cwd": "packages/store"
       }
     },
@@ -79,8 +79,8 @@
       ],
       "options": {
         "commands": [
-          "pnpm eslint 'src/cli/api/graphql/admin/generated/**/*.ts' --fix",
-          "pnpm eslint 'src/cli/api/graphql/business-platform-destinations/generated/**/*.ts' --fix"
+          "pnpm eslint 'src/cli/api/graphql/admin/generated/**/*.ts' --fix --rule '@typescript-eslint/ban-ts-comment: off' --rule 'eslint-comments/no-unused-disable: off'",
+          "pnpm eslint 'src/cli/api/graphql/business-platform-destinations/generated/**/*.ts' --fix --rule '@typescript-eslint/ban-ts-comment: off' --rule 'eslint-comments/no-unused-disable: off'"
         ],
         "cwd": "packages/store"
       }

--- a/packages/store/src/cli/api/graphql/admin/generated/staged_uploads_create.ts
+++ b/packages/store/src/cli/api/graphql/admin/generated/staged_uploads_create.ts
@@ -1,14 +1,103 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/ban-types, @typescript-eslint/no-duplicate-type-constituents, @typescript-eslint/no-redundant-type-constituents, @nx/enforce-module-boundaries */
-import {JsonMapType} from '@shopify/cli-kit/node/toml'
-import * as Types from './types';
+import * as Types from './types.js'
 
-import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
 export type StagedUploadsCreateMutationVariables = Types.Exact<{
-  input: Array<Types.StagedUploadInput> | Types.StagedUploadInput;
-}>;
+  input: Types.StagedUploadInput[] | Types.StagedUploadInput
+}>
 
+export type StagedUploadsCreateMutation = {
+  stagedUploadsCreate?: {
+    stagedTargets?:
+      | {
+          url?: string | null
+          resourceUrl?: string | null
+          parameters: {name: string; value: string}[]
+        }[]
+      | null
+    userErrors: {field?: string[] | null; message: string}[]
+  } | null
+}
 
-export type StagedUploadsCreateMutation = { stagedUploadsCreate?: { stagedTargets?: Array<{ url?: string | null, resourceUrl?: string | null, parameters: Array<{ name: string, value: string }> }> | null, userErrors: Array<{ field?: Array<string> | null, message: string }> } | null };
-
-
-export const StagedUploadsCreateDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"StagedUploadsCreate"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"StagedUploadInput"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"stagedUploadsCreate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"stagedTargets"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"resourceUrl"}},{"kind":"Field","name":{"kind":"Name","value":"parameters"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"__typename"}}]}},{"kind":"Field","name":{"kind":"Name","value":"__typename"}}]}},{"kind":"Field","name":{"kind":"Name","value":"userErrors"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"field"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"Field","name":{"kind":"Name","value":"__typename"}}]}},{"kind":"Field","name":{"kind":"Name","value":"__typename"}}]}}]}}]} as unknown as DocumentNode<StagedUploadsCreateMutation, StagedUploadsCreateMutationVariables>;
+export const StagedUploadsCreate = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {kind: 'Name', value: 'StagedUploadsCreate'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'input'}},
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'ListType',
+              type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'StagedUploadInput'}}},
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'stagedUploadsCreate'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'input'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'input'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'stagedTargets'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'url'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'resourceUrl'}},
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'parameters'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'value'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'userErrors'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'field'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<StagedUploadsCreateMutation, StagedUploadsCreateMutationVariables>

--- a/packages/store/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/store/src/cli/api/graphql/admin/generated/types.d.ts
@@ -1,52 +1,53 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any, tsdoc/syntax, @typescript-eslint/no-duplicate-type-constituents, @typescript-eslint/no-redundant-type-constituents, @nx/enforce-module-boundaries  */
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
-export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+
+export type Maybe<T> = T | null
+export type InputMaybe<T> = Maybe<T>
+export type Exact<T extends {[key: string]: unknown}> = {[K in keyof T]: T[K]}
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {[SubKey in K]?: Maybe<T[SubKey]>}
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {[SubKey in K]: Maybe<T[SubKey]>}
+export type MakeEmpty<T extends {[key: string]: unknown}, K extends keyof T> = {[_ in K]?: never}
+export type Incremental<T> = T | {[P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never}
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
+  ID: {input: string; output: string}
+  String: {input: string; output: string}
+  Boolean: {input: boolean; output: boolean}
+  Int: {input: number; output: number}
+  Float: {input: number; output: number}
   /**
    * An Amazon Web Services Amazon Resource Name (ARN), including the Region and account ID.
    * For more information, refer to [Amazon Resource Names](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
    */
-  ARN: { input: any; output: any; }
+  ARN: {input: any; output: any}
   /**
    * Represents non-fractional signed whole numeric values. Since the value may
    * exceed the size of a 32-bit integer, it's encoded as a string.
    */
-  BigInt: { input: any; output: any; }
+  BigInt: {input: any; output: any}
   /**
    * A string containing a hexadecimal representation of a color.
    *
    * For example, "#6A8D48".
    */
-  Color: { input: any; output: any; }
+  Color: {input: any; output: any}
   /**
    * Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date string.
    * For example, September 7, 2019 is represented as `"2019-07-16"`.
    */
-  Date: { input: any; output: any; }
+  Date: {input: any; output: any}
   /**
    * Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date and time string.
    * For example, 3:50 pm on September 7, 2019 in the time zone of UTC (Coordinated Universal Time) is
    * represented as `"2019-09-07T15:50:00Z`".
    */
-  DateTime: { input: any; output: any; }
+  DateTime: {input: any; output: any}
   /**
    * A signed decimal number, which supports arbitrary precision and is serialized as a string.
    *
    * Example values: `"29.99"`, `"29.999"`.
    */
-  Decimal: { input: any; output: any; }
+  Decimal: {input: any; output: any}
   /**
    * A string containing a strict subset of HTML code. Non-allowed tags will be stripped out.
    * Allowed tags:
@@ -62,14 +63,14 @@ export type Scalars = {
    *
    * Example value: `"Your current domain is <strong>example.myshopify.com</strong>."`
    */
-  FormattedString: { input: any; output: any; }
+  FormattedString: {input: any; output: any}
   /**
    * A string containing HTML code. Refer to the [HTML spec](https://html.spec.whatwg.org/#elements-3) for a
    * complete list of HTML elements.
    *
    * Example value: `"<p>Grey cotton knit sweater.</p>"`
    */
-  HTML: { input: any; output: any; }
+  HTML: {input: any; output: any}
   /**
    * A [JSON](https://www.json.org/json-en.html) object.
    *
@@ -85,18 +86,18 @@ export type Scalars = {
    *   }
    * }`
    */
-  JSON: { input: JsonMapType | string; output: JsonMapType; }
+  JSON: {input: JsonMapType | string; output: JsonMapType}
   /** A monetary value string without a currency symbol or code. Example value: `"100.57"`. */
-  Money: { input: any; output: any; }
+  Money: {input: any; output: any}
   /** A scalar value. */
-  Scalar: { input: any; output: any; }
+  Scalar: {input: any; output: any}
   /**
    * Represents a unique identifier in the Storefront API. A `StorefrontID` value can
    * be used wherever an ID is expected in the Storefront API.
    *
    * Example value: `"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEwMDc5Nzg1MTAw"`.
    */
-  StorefrontID: { input: any; output: any; }
+  StorefrontID: {input: any; output: any}
   /**
    * Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
    * [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
@@ -104,20 +105,20 @@ export type Scalars = {
    * For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
    * (`example.myshopify.com`).
    */
-  URL: { input: string; output: string; }
+  URL: {input: string; output: string}
   /**
    * An unsigned 64-bit integer. Represents whole numeric values between 0 and 2^64 - 1 encoded as a string of base-10 digits.
    *
    * Example value: `"50"`.
    */
-  UnsignedInt64: { input: any; output: any; }
+  UnsignedInt64: {input: any; output: any}
   /**
    * Time between UTC time and a location's observed time, in the format `"+HH:MM"` or `"-HH:MM"`.
    *
    * Example value: `"-07:00"`.
    */
-  UtcOffset: { input: any; output: any; }
-};
+  UtcOffset: {input: any; output: any}
+}
 
 /**
  * The possible HTTP methods that can be used when sending a request to upload a file using information from a
@@ -127,7 +128,7 @@ export type StagedUploadHttpMethodType =
   /** The POST HTTP method. */
   | 'POST'
   /** The PUT HTTP method. */
-  | 'PUT';
+  | 'PUT'
 
 /** The input fields for generating staged upload targets. */
 export type StagedUploadInput = {
@@ -136,19 +137,19 @@ export type StagedUploadInput = {
    * [VIDEO](https://shopify.dev/api/admin-graphql/latest/enums/StagedUploadTargetGenerateUploadResource#value-video)
    * or [MODEL_3D](https://shopify.dev/api/admin-graphql/latest/enums/StagedUploadTargetGenerateUploadResource#value-model3d).
    */
-  fileSize?: InputMaybe<Scalars['UnsignedInt64']['input']>;
+  fileSize?: InputMaybe<Scalars['UnsignedInt64']['input']>
   /** The file's name and extension. */
-  filename: Scalars['String']['input'];
+  filename: Scalars['String']['input']
   /**
    * The HTTP method to be used when sending a request to upload the file using the returned staged
    * upload target.
    */
-  httpMethod?: InputMaybe<StagedUploadHttpMethodType>;
+  httpMethod?: InputMaybe<StagedUploadHttpMethodType>
   /** The file's MIME type. */
-  mimeType: Scalars['String']['input'];
+  mimeType: Scalars['String']['input']
   /** The file's intended Shopify resource type. */
-  resource: StagedUploadTargetGenerateUploadResource;
-};
+  resource: StagedUploadTargetGenerateUploadResource
+}
 
 /** The resource type to receive. */
 export type StagedUploadTargetGenerateUploadResource =
@@ -230,4 +231,4 @@ export type StagedUploadTargetGenerateUploadResource =
    * or to the [Files page](https://shopify.com/admin/settings/files) in Shopify admin using the
    * [fileCreate mutation](https://shopify.dev/api/admin-graphql/latest/mutations/fileCreate).
    */
-  | 'VIDEO';
+  | 'VIDEO'

--- a/packages/store/src/cli/api/graphql/business-platform-destinations/generated/current_user_account.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-destinations/generated/current_user_account.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
+/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/ban-types, @typescript-eslint/no-duplicate-type-constituents, @typescript-eslint/no-redundant-type-constituents, @nx/enforce-module-boundaries */
 import * as Types from './types.js'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'

--- a/packages/store/src/cli/api/graphql/business-platform-destinations/generated/types.d.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-destinations/generated/types.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/no-explicit-any  */
+/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any, tsdoc/syntax, @typescript-eslint/no-duplicate-type-constituents, @typescript-eslint/no-redundant-type-constituents, @nx/enforce-module-boundaries  */
 export type Maybe<T> = T | null
 export type InputMaybe<T> = Maybe<T>
 export type Exact<T extends {[key: string]: unknown}> = {[K in keyof T]: T[K]}


### PR DESCRIPTION
### WHY are these changes introduced?

To improve ESLint configuration for generated GraphQL files in the store package, preventing linting errors while maintaining code quality standards.

### WHAT is this pull request doing?

- Updates ESLint commands to ignore generated GraphQL files in the regular linting process
- Adds specific ESLint rules for generated files with `--ignore-pattern` for both regular and fix commands
- Enhances ESLint disable comments in generated GraphQL files to suppress additional rules:
  - `@typescript-eslint/naming-convention`
  - `@typescript-eslint/ban-types`
  - `@typescript-eslint/no-duplicate-type-constituents`
  - `@typescript-eslint/no-redundant-type-constituents`
  - `@nx/enforce-module-boundaries`
- Modifies the post-generate linting commands to disable specific rules for generated files

### How to test your changes?

1. Run `pnpm lint` in the store package to verify no linting errors occur for generated files
2. Run `pnpm lint:fix` to confirm the fix command works correctly
3. Generate new GraphQL files to ensure they're properly ignored by the linting process

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes