### PR TITLE
update copy from/to spacing

### DIFF
--- a/packages/store/src/prompts/copy_info.test.ts
+++ b/packages/store/src/prompts/copy_info.test.ts
@@ -14,7 +14,7 @@ describe('renderCopyInfo', () => {
 
     expect(renderInfo).toHaveBeenCalledWith({
       headline,
-      body: [{subdued: 'From:'}, from, {subdued: '\nTo:'}, to],
+      body: [{subdued: 'From:'}, from, {subdued: '\nTo:  '}, to],
     })
   })
 })

--- a/packages/store/src/prompts/copy_info.ts
+++ b/packages/store/src/prompts/copy_info.ts
@@ -3,6 +3,6 @@ import {renderInfo} from '@shopify/cli-kit/node/ui'
 export function renderCopyInfo(headline: string, from: string, to: string) {
   renderInfo({
     headline,
-    body: [{subdued: 'From:'}, from, {subdued: '\nTo:'}, to],
+    body: [{subdued: 'From:'}, from, {subdued: '\nTo:  '}, to],
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Updates spacing to align to/from values for copy info banner:

**Before**
<img width="571" alt="Screenshot 2025-07-09 at 12 44 57 PM" src="https://github.com/user-attachments/assets/c9a1eca4-a965-4dc7-bd9b-61783240f931" />

**After**
<img width="569" alt="Screenshot 2025-07-09 at 12 45 18 PM" src="https://github.com/user-attachments/assets/b20d6fd1-0956-462c-83a8-855c816762ae" />
