### PR TITLE
add confirmation step to exports

### DIFF
--- a/packages/store/src/prompts/confirm_export.test.ts
+++ b/packages/store/src/prompts/confirm_export.test.ts
@@ -1,0 +1,34 @@
+import {confirmExportPrompt} from './confirm_export.js'
+import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
+import {describe, expect, vi, test} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/ui')
+
+describe('confirmExportPrompt', () => {
+  test('returns true when user confirms', async () => {
+    const toFile = 'data.sqlite'
+    const fromStore = 'shop.myshopify.com'
+    const message = `Export data from ${fromStore} to ${toFile}?`
+    const confirmationMessage = 'Yes, export'
+    const cancellationMessage = 'Cancel'
+
+    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+
+    const result = await confirmExportPrompt(fromStore, toFile)
+
+    expect(renderConfirmationPrompt).toHaveBeenCalledWith({
+      message,
+      confirmationMessage,
+      cancellationMessage,
+    })
+    expect(result).toBe(true)
+  })
+
+  test('returns false when user cancels', async () => {
+    const toFile = 'export.sqlite'
+    const fromStore = 'test-shop.myshopify.com'
+    vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
+    const result = await confirmExportPrompt(fromStore, toFile)
+    expect(result).toBe(false)
+  })
+})

--- a/packages/store/src/prompts/confirm_export.ts
+++ b/packages/store/src/prompts/confirm_export.ts
@@ -1,0 +1,9 @@
+import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
+
+export async function confirmExportPrompt(fromStore: string, toFile: string): Promise<boolean> {
+  return renderConfirmationPrompt({
+    message: `Export data from ${fromStore} to ${toFile}?`,
+    confirmationMessage: 'Yes, export',
+    cancellationMessage: 'Cancel',
+  })
+}

--- a/packages/store/src/prompts/export_results.test.ts
+++ b/packages/store/src/prompts/export_results.test.ts
@@ -58,7 +58,12 @@ describe('renderExportResult', () => {
     renderExportResult(sourceShop, exportOperation)
 
     expect(renderSuccess).toHaveBeenCalledWith({
-      body: ['Export operation from', {info: 'source-shop.myshopify.com'}, 'complete'],
+      body: [
+        'Export operation from',
+        {info: 'source-shop.myshopify.com'},
+        'complete',
+        {link: {label: 'export file available for download', url: 'https://example.com/results'}},
+      ],
     })
     expect(renderWarning).not.toHaveBeenCalled()
   })

--- a/packages/store/src/prompts/export_results.ts
+++ b/packages/store/src/prompts/export_results.ts
@@ -7,6 +7,7 @@ export function renderExportResult(sourceShop: Shop, exportOperation: BulkDataOp
 
   const storeOperations = exportOperation.organization.bulkData.operation.storeOperations
   const hasErrors = storeOperations.some((op) => op.remoteOperationStatus === 'FAILED')
+  const url = storeOperations[0]?.url
 
   if (hasErrors) {
     msg.push(`completed with`)
@@ -16,6 +17,10 @@ export function renderExportResult(sourceShop: Shop, exportOperation: BulkDataOp
     })
   } else {
     msg.push('complete')
+    if (url) {
+      const link = {link: {label: 'export file available for download', url}}
+      msg.push(link)
+    }
     renderSuccess({
       body: msg,
     })

--- a/packages/store/src/services/store/operations/store-export.ts
+++ b/packages/store/src/services/store/operations/store-export.ts
@@ -10,7 +10,9 @@ import {BulkOperationTaskGenerator, BulkOperationContext} from '../utils/bulk-op
 import {renderCopyInfo} from '../../../prompts/copy_info.js'
 import {ValidationError, OperationError, ErrorCodes} from '../errors/errors.js'
 import {renderExportResult} from '../../../prompts/export_results.js'
+import {confirmExportPrompt} from '../../../prompts/confirm_export.js'
 import {Task, renderTasks} from '@shopify/cli-kit/node/ui'
+import {outputInfo} from '@shopify/cli-kit/node/output'
 
 export class StoreExportOperation implements StoreOperation {
   fromArg: string | undefined
@@ -31,6 +33,13 @@ export class StoreExportOperation implements StoreOperation {
 
     const sourceShop = findStore(fromStore, this.orgs)
     this.validateShop(sourceShop)
+
+    if (!flags['no-prompt']) {
+      if (!(await confirmExportPrompt(sourceShop.domain, toFile))) {
+        outputInfo('Exiting.')
+        process.exit(0)
+      }
+    }
 
     renderCopyInfo('Export Operation', sourceShop.domain, toFile)
     const exportOperation = await this.exportDataWithProgress(sourceShop.organizationId, sourceShop, this.bpSession)


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the user experience during store export operations by adding a confirmation prompt and enhancing the export results display.

### WHAT is this pull request doing?

- Adds a confirmation prompt before exporting data from a store
- `--no-prompt` flag to skip confirmation for automated workflows
- export results display by adding a download link when available
- Adds tests for the new confirmation prompt functionality

### How to test your changes?

1. Run a store export operation: `shopify store export source.myshopify.com export.sqlite`
2. Verify the confirmation prompt appears and works correctly
3. Test with `--no-prompt` flag to ensure it skips the confirmation
4. Complete an export and verify the download link appears in the success message

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes