### PR TITLE
Update results UI for copy + import

### DIFF
--- a/packages/store/src/prompts/copy_result.test.ts
+++ b/packages/store/src/prompts/copy_result.test.ts
@@ -57,8 +57,9 @@ describe('renderCopyResult', () => {
     renderCopyResult(sourceShop, targetShop, mockOperation)
 
     expect(renderOperationResult).toHaveBeenCalledWith(
-      ['Copy operation from', {info: 'source-shop.myshopify.com'}, 'to', {info: 'target-shop.myshopify.com'}],
+      [{subdued: 'From:'}, 'source-shop.myshopify.com', {subdued: '\nTo:  '}, 'target-shop.myshopify.com'],
       mockOperation,
+      targetShop,
     )
   })
 })

--- a/packages/store/src/prompts/copy_result.ts
+++ b/packages/store/src/prompts/copy_result.ts
@@ -8,6 +8,6 @@ export function renderCopyResult(
   targetShop: Shop,
   copyOperation: BulkDataOperationByIdResponse,
 ): void {
-  const msg: Token[] = [`Copy operation from`, {info: sourceShop.domain}, `to`, {info: targetShop.domain}]
-  renderOperationResult(msg, copyOperation)
+  const msg: Token[] = [{subdued: 'From:'}, sourceShop.domain, {subdued: '\nTo:  '}, targetShop.domain]
+  renderOperationResult(msg, copyOperation, targetShop)
 }

--- a/packages/store/src/prompts/export_results.test.ts
+++ b/packages/store/src/prompts/export_results.test.ts
@@ -26,7 +26,7 @@ describe('renderExportResult', () => {
         bulkData: {
           operation: {
             id: 'bulk-op-1',
-            operationType: 'EXPORT',
+            operationType: 'STORE_EXPORT',
             status: 'COMPLETED',
             sourceStore: {
               id: '1',
@@ -75,7 +75,7 @@ describe('renderExportResult', () => {
         bulkData: {
           operation: {
             id: 'bulk-op-1',
-            operationType: 'EXPORT',
+            operationType: 'STORE_EXPORT',
             status: 'COMPLETED',
             sourceStore: {
               id: '1',
@@ -119,7 +119,7 @@ describe('renderExportResult', () => {
         bulkData: {
           operation: {
             id: 'bulk-op-1',
-            operationType: 'EXPORT',
+            operationType: 'STORE_EXPORT',
             status: 'COMPLETED',
             sourceStore: {
               id: '1',

--- a/packages/store/src/prompts/import_result.test.ts
+++ b/packages/store/src/prompts/import_result.test.ts
@@ -25,7 +25,7 @@ describe('renderImportResult', () => {
       bulkData: {
         operation: {
           id: 'bulk-op-1',
-          operationType: 'IMPORT',
+          operationType: 'STORE_IMPORT',
           status: 'COMPLETED',
           sourceStore: {
             id: '1',
@@ -42,11 +42,13 @@ describe('renderImportResult', () => {
   }
 
   test('calls renderOperationResult with correct base message', () => {
-    renderImportResult(targetShop, mockOperation)
+    const filePath = 'input.sqlite'
+    renderImportResult(filePath, targetShop, mockOperation)
 
     expect(renderOperationResult).toHaveBeenCalledWith(
-      ['Import operation to', {info: 'target-shop.myshopify.com'}],
+      [{subdued: 'From:'}, 'input.sqlite', {subdued: '\nTo:  '}, 'target-shop.myshopify.com'],
       mockOperation,
+      targetShop,
     )
   })
 })

--- a/packages/store/src/prompts/import_result.ts
+++ b/packages/store/src/prompts/import_result.ts
@@ -3,7 +3,11 @@ import {BulkDataOperationByIdResponse} from '../apis/organizations/types.js'
 import {Shop} from '../apis/destinations/index.js'
 import {Token} from '@shopify/cli-kit/node/ui'
 
-export function renderImportResult(targetShop: Shop, importOperation: BulkDataOperationByIdResponse): void {
-  const msg: Token[] = [`Import operation to`, {info: targetShop.domain}]
-  renderOperationResult(msg, importOperation)
+export function renderImportResult(
+  filePath: string,
+  targetShop: Shop,
+  importOperation: BulkDataOperationByIdResponse,
+): void {
+  const msg: Token[] = [{subdued: 'From:'}, filePath, {subdued: '\nTo:  '}, targetShop.domain]
+  renderOperationResult(msg, importOperation, targetShop)
 }

--- a/packages/store/src/prompts/operation_result.test.ts
+++ b/packages/store/src/prompts/operation_result.test.ts
@@ -46,7 +46,9 @@ describe('renderOperationResult', () => {
     renderOperationResult([...baseMsg], operation)
 
     expect(renderSuccess).toHaveBeenCalledWith({
-      body: ['Base message', 'complete. '],
+      headline: 'Copy completed',
+      body: ['Base message'],
+      nextSteps: undefined,
     })
     expect(renderWarning).not.toHaveBeenCalled()
   })
@@ -90,11 +92,9 @@ describe('renderOperationResult', () => {
     renderOperationResult([...baseMsg], operation)
 
     expect(renderSuccess).toHaveBeenCalledWith({
-      body: [
-        'Base message',
-        'complete. ',
-        {link: {label: 'Results file can be downloaded for more details', url: 'https://example.com/results'}},
-      ],
+      headline: 'Copy completed',
+      body: ['Base message'],
+      nextSteps: [['Download', {link: {label: 'result data', url: 'https://example.com/results'}}]],
     })
     expect(renderWarning).not.toHaveBeenCalled()
   })
@@ -137,7 +137,9 @@ describe('renderOperationResult', () => {
     renderOperationResult([...baseMsg], operation)
 
     expect(renderWarning).toHaveBeenCalledWith({
-      body: ['Base message', 'completed with', {error: 'errors. '}],
+      headline: 'Copy completed with errors',
+      body: ['Base message'],
+      nextSteps: undefined,
     })
     expect(renderSuccess).not.toHaveBeenCalled()
   })
@@ -181,13 +183,187 @@ describe('renderOperationResult', () => {
     renderOperationResult([...baseMsg], operation)
 
     expect(renderWarning).toHaveBeenCalledWith({
-      body: [
-        'Base message',
-        'completed with',
-        {error: 'errors. '},
-        {link: {label: 'Results file can be downloaded for more details', url: 'https://example.com/results'}},
-      ],
+      headline: 'Copy completed with errors',
+      body: ['Base message'],
+      nextSteps: [['Download', {link: {label: 'result data', url: 'https://example.com/results'}}]],
     })
     expect(renderSuccess).not.toHaveBeenCalled()
+  })
+
+  test('renders success with target store link for STORE_COPY operation', () => {
+    const targetShop = {
+      id: '2',
+      domain: 'target-shop.myshopify.com',
+      name: 'Target Shop',
+      status: 'ACTIVE',
+      webUrl: 'https://target-shop.myshopify.com',
+      handle: 'target-shop',
+      publicId: 'pub2',
+      shortName: 'target',
+      organizationId: 'org1',
+    }
+
+    const operation: BulkDataOperationByIdResponse = {
+      organization: {
+        name: 'Test Organization',
+        bulkData: {
+          operation: {
+            id: 'bulk-op-1',
+            operationType: 'STORE_COPY',
+            status: 'COMPLETED',
+            sourceStore: {
+              id: '1',
+              name: 'Source Store',
+            },
+            targetStore: {
+              id: '2',
+              name: 'Target Store',
+            },
+            storeOperations: [
+              {
+                id: 'op1',
+                store: {
+                  id: '1',
+                  name: 'Store 1',
+                },
+                remoteOperationType: 'EXPORT',
+                remoteOperationStatus: 'COMPLETED',
+                totalObjectCount: 100,
+                completedObjectCount: 100,
+                url: 'https://example.com/results',
+              },
+            ],
+          },
+        },
+      },
+    }
+
+    renderOperationResult([...baseMsg], operation, targetShop)
+
+    expect(renderSuccess).toHaveBeenCalledWith({
+      headline: 'Copy completed',
+      body: ['Base message'],
+      nextSteps: [
+        ['View', {link: {label: 'target shop', url: 'https://target-shop.myshopify.com'}}],
+        ['Download', {link: {label: 'result data', url: 'https://example.com/results'}}],
+      ],
+    })
+  })
+
+  test('renders success with target store link for STORE_IMPORT operation', () => {
+    const targetShop = {
+      id: '2',
+      domain: 'target-shop.myshopify.com',
+      name: 'Target Shop',
+      status: 'ACTIVE',
+      webUrl: 'https://target-shop.myshopify.com',
+      handle: 'target-shop',
+      publicId: 'pub2',
+      shortName: 'target',
+      organizationId: 'org1',
+    }
+
+    const operation: BulkDataOperationByIdResponse = {
+      organization: {
+        name: 'Test Organization',
+        bulkData: {
+          operation: {
+            id: 'bulk-op-1',
+            operationType: 'STORE_IMPORT',
+            status: 'COMPLETED',
+            sourceStore: {
+              id: '2',
+              name: 'Target Store',
+            },
+            targetStore: {
+              id: '2',
+              name: 'Target Store',
+            },
+            storeOperations: [
+              {
+                id: 'op1',
+                store: {
+                  id: '2',
+                  name: 'Target Store',
+                },
+                remoteOperationType: 'IMPORT',
+                remoteOperationStatus: 'COMPLETED',
+                totalObjectCount: 100,
+                completedObjectCount: 100,
+                url: 'https://example.com/results',
+              },
+            ],
+          },
+        },
+      },
+    }
+
+    renderOperationResult([...baseMsg], operation, targetShop)
+
+    expect(renderSuccess).toHaveBeenCalledWith({
+      headline: 'Copy completed',
+      body: ['Base message'],
+      nextSteps: [
+        ['View', {link: {label: 'target shop', url: 'https://target-shop.myshopify.com'}}],
+        ['Download', {link: {label: 'result data', url: 'https://example.com/results'}}],
+      ],
+    })
+  })
+
+  test('does not render target store link for STORE_EXPORT operation', () => {
+    const targetShop = {
+      id: '1',
+      domain: 'source-shop.myshopify.com',
+      name: 'Source Shop',
+      status: 'ACTIVE',
+      webUrl: 'https://source-shop.myshopify.com',
+      handle: 'source-shop',
+      publicId: 'pub1',
+      shortName: 'source',
+      organizationId: 'org1',
+    }
+
+    const operation: BulkDataOperationByIdResponse = {
+      organization: {
+        name: 'Test Organization',
+        bulkData: {
+          operation: {
+            id: 'bulk-op-1',
+            operationType: 'STORE_EXPORT',
+            status: 'COMPLETED',
+            sourceStore: {
+              id: '1',
+              name: 'Source Store',
+            },
+            targetStore: {
+              id: '1',
+              name: 'Source Store',
+            },
+            storeOperations: [
+              {
+                id: 'op1',
+                store: {
+                  id: '1',
+                  name: 'Source Store',
+                },
+                remoteOperationType: 'EXPORT',
+                remoteOperationStatus: 'COMPLETED',
+                totalObjectCount: 100,
+                completedObjectCount: 100,
+                url: 'https://example.com/results',
+              },
+            ],
+          },
+        },
+      },
+    }
+
+    renderOperationResult([...baseMsg], operation, targetShop)
+
+    expect(renderSuccess).toHaveBeenCalledWith({
+      headline: 'Copy completed',
+      body: ['Base message'],
+      nextSteps: [['Download', {link: {label: 'result data', url: 'https://example.com/results'}}]],
+    })
   })
 })

--- a/packages/store/src/services/store/mock/mock-api-client.ts
+++ b/packages/store/src/services/store/mock/mock-api-client.ts
@@ -42,7 +42,7 @@ export class MockApiClient implements ApiClientInterface {
         success: true,
         operation: {
           id: 'mock-export-operation-id',
-          operationType: 'EXPORT',
+          operationType: 'STORE_EXPORT',
           status: 'IN_PROGRESS',
         },
         userErrors: [],
@@ -64,7 +64,7 @@ export class MockApiClient implements ApiClientInterface {
         success: true,
         operation: {
           id: 'mock-import-operation-id',
-          operationType: 'IMPORT',
+          operationType: 'STORE_IMPORT',
           status: 'IN_PROGRESS',
         },
         userErrors: [],

--- a/packages/store/src/services/store/mock/mock-data.ts
+++ b/packages/store/src/services/store/mock/mock-data.ts
@@ -196,7 +196,7 @@ export const TEST_COMPLETED_EXPORT_OPERATION: BulkDataOperationByIdResponse = {
     bulkData: {
       operation: {
         id: 'export-operation-123',
-        operationType: 'EXPORT',
+        operationType: 'STORE_EXPORT',
         status: 'COMPLETED',
         sourceStore: {
           id: 'shop1',
@@ -246,7 +246,7 @@ export const TEST_COMPLETED_IMPORT_OPERATION: BulkDataOperationByIdResponse = {
     bulkData: {
       operation: {
         id: 'import-operation-123',
-        operationType: 'IMPORT',
+        operationType: 'STORE_IMPORT',
         status: 'COMPLETED',
         sourceStore: {
           id: 'shop2',

--- a/packages/store/src/services/store/operations/store-import.test.ts
+++ b/packages/store/src/services/store/operations/store-import.test.ts
@@ -78,7 +78,7 @@ describe('StoreImportOperation', () => {
       cancellationMessage: 'Cancel',
     })
     expect(renderCopyInfo).toHaveBeenCalledWith('Import Operation', 'input.sqlite', 'target.myshopify.com')
-    expect(renderImportResult).toHaveBeenCalledWith(mockTargetShop, mockCompletedOperation)
+    expect(renderImportResult).toHaveBeenCalledWith('input.sqlite', mockTargetShop, mockCompletedOperation)
   })
 
   test('should throw error when input file does not exist', async () => {

--- a/packages/store/src/services/store/operations/store-import.ts
+++ b/packages/store/src/services/store/operations/store-import.ts
@@ -70,7 +70,7 @@ export class StoreImportOperation implements StoreOperation {
       throw new OperationError('import', ErrorCodes.IMPORT_FAILED)
     }
 
-    renderImportResult(targetShop, importOperation)
+    renderImportResult(fromFile, targetShop, importOperation)
   }
 
   private async validateInputFile(filePath: string): Promise<void> {


### PR DESCRIPTION
### WHY are these changes introduced?

Improves UI by cleaning up visual structure of results for copy and import operations (success/warning)

### Before (left col) / After (right col)
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/VqqHovG3hmKnoZC4I5sl/89fef9c8-8714-4e64-81ca-8043d09d7e34.png)


### WHAT is this pull request doing?

- Redesigns the operation result output format with a clearer structure including headline, body, and next steps
- Adds "From:" and "To:" labels to make source and destination more obvious
- Adds a direct link to the target shop in the next steps for import and copy operations
- Updates operation type constants to use the correct prefixed versions (STORE_EXPORT, STORE_IMPORT)
- Improves the download link text to be more concise
- Passes the target shop to the renderOperationResult function to enable shop-specific links

### How to test your changes?

1. Run a store copy operation: `shopify store copy source-shop target-shop`
2. Run a store import operation: `shopify store import input.sqlite target-shop`
3. Verify the new output format shows clear "From:" and "To:" labels
4. Confirm the next steps section includes appropriate links to the target shop and/or result data
5. Verify that the warning structure / links work as expected

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes