### PR TITLE
Add CLI theme login auth error next steps

### DIFF
--- a/.changeset/fifty-flowers-beg.md
+++ b/.changeset/fifty-flowers-beg.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add CLI theme login auth error next steps

--- a/packages/cli-kit/src/private/node/session/exchange.test.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.test.ts
@@ -172,18 +172,7 @@ describe('refresh access tokens', () => {
     const got = () => refreshAccessToken(identityToken)
 
     // Then
-    await expect(got).rejects.toThrowError(
-      'You are not authorized to use the CLI to develop in the provided store.' +
-        '\n\n' +
-        "You can't use Shopify CLI with development stores if you only have Partner " +
-        'staff member access. If you want to use Shopify CLI to work on a development store, then ' +
-        'you should be the store owner or create a staff account on the store.' +
-        '\n\n' +
-        "If you're the store owner, then you need to log in to the store directly using the " +
-        'store URL at least once before you log in using Shopify CLI. ' +
-        'Logging in to the Shopify admin directly connects the development ' +
-        'store with your Shopify login.',
-    )
+    await expect(got).rejects.toThrowError('You are not authorized to use the CLI to develop in the provided store.')
   })
 
   describe('when there is a store in the request params', () => {
@@ -198,16 +187,7 @@ describe('refresh access tokens', () => {
 
       // Then
       await expect(got).rejects.toThrowError(
-        'You are not authorized to use the CLI to develop in the provided store: bob.myshopify.com' +
-          '\n\n' +
-          "You can't use Shopify CLI with development stores if you only have Partner " +
-          'staff member access. If you want to use Shopify CLI to work on a development store, then ' +
-          'you should be the store owner or create a staff account on the store.' +
-          '\n\n' +
-          "If you're the store owner, then you need to log in to the store directly using the " +
-          'store URL at least once before you log in using Shopify CLI. ' +
-          'Logging in to the Shopify admin directly connects the development ' +
-          'store with your Shopify login.',
+        'You are not authorized to use the CLI to develop in the provided store: bob.myshopify.com',
       )
     })
   })

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -196,17 +196,9 @@ interface TokenRequestResult {
 }
 
 function tokenRequestErrorHandler({error, store}: {error: string; store?: string}) {
-  const invalidTargetErrorMessage =
-    `You are not authorized to use the CLI to develop in the provided store${store ? `: ${store}` : '.'}` +
-    '\n\n' +
-    "You can't use Shopify CLI with development stores if you only have Partner " +
-    'staff member access. If you want to use Shopify CLI to work on a development store, then ' +
-    'you should be the store owner or create a staff account on the store.' +
-    '\n\n' +
-    "If you're the store owner, then you need to log in to the store directly using the " +
-    'store URL at least once before you log in using Shopify CLI. ' +
-    'Logging in to the Shopify admin directly connects the development ' +
-    'store with your Shopify login.'
+  const invalidTargetErrorMessage = `You are not authorized to use the CLI to develop in the provided store${
+    store ? `: ${store}` : '.'
+  }`
 
   if (error === 'invalid_grant') {
     // There's an scenario when Identity returns "invalid_grant" when trying to refresh the token
@@ -219,7 +211,11 @@ function tokenRequestErrorHandler({error, store}: {error: string; store?: string
     return new InvalidRequestError()
   }
   if (error === 'invalid_target') {
-    return new InvalidTargetError(invalidTargetErrorMessage)
+    return new InvalidTargetError(invalidTargetErrorMessage, '', [
+      'Ensure you have logged in to the store using the Shopify admin at least once.',
+      'Ensure you are the store owner, or have a staff account if you are attempting to log in to a development store.',
+      'Ensure you are using the permanent store domain, not a vanity domain.',
+    ])
   }
   // eslint-disable-next-line @shopify/cli/no-error-factory-functions
   return new AbortError(error)


### PR DESCRIPTION
### WHY are these changes introduced?

- We constantly get issues where folks use vanity domains instead of their primary domain (this is assigned when you create your store) in the CLI
- Adding next steps so they know how to debug the error

Closes https://github.com/Shopify/cli/issues/6046

### WHAT is this pull request doing?

- Updating error message when you failed theme login auth

### How to test your changes?

- Checkout the branch
- Run the following in the CLI directory root
  - `pnpm install && pnpm build`
  - `pnpm shopify theme dev --path '<path-to-theme>' --store <store-domain>` using a store's vanity domain instead of its primary domain

| Before | After |
| - | - |
| <img width="890" height="274" alt="image" src="https://github.com/user-attachments/assets/66c53559-9650-491c-9df4-eb35c9aa12a0" /> | <img width="890" height="249" alt="image" src="https://github.com/user-attachments/assets/d4dabbf8-2832-4981-b331-8a4980fdc8cd" /> |

### Post-release steps

n/a

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
