### PR TITLE
Use shopId to route Organization API requests

### DIFF
--- a/packages/store/src/apis/organizations/index.ts
+++ b/packages/store/src/apis/organizations/index.ts
@@ -18,7 +18,7 @@ import {GraphQLVariables, graphqlRequest, CacheOptions, UnauthorizedHandler} fro
 import {businessPlatformFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
 export async function organizationsRequest<T>(
-  organizationId: string,
+  shopId: string,
   query: string,
   token: string,
   variables?: GraphQLVariables,
@@ -27,9 +27,9 @@ export async function organizationsRequest<T>(
 ): Promise<T> {
   const api = 'BusinessPlatform'
   const fqdn = await businessPlatformFqdn()
-  const decodedOrganizationGid = Buffer.from(organizationId, 'base64').toString('utf-8')
-  const numericOrganizationId = decodedOrganizationGid.split('/').pop()
-  const url = `https://${fqdn}/organizations/api/unstable/organization/${numericOrganizationId}/graphql`
+  const decodedShopGid = Buffer.from(shopId, 'base64').toString('utf-8')
+  const numericShopId = decodedShopGid.split('/').pop()
+  const url = `https://${fqdn}/organizations/api/unstable/shop/${numericShopId}/graphql`
 
   return graphqlRequest<T>({
     token,
@@ -43,7 +43,7 @@ export async function organizationsRequest<T>(
 }
 
 export async function startBulkDataStoreCopy(
-  organizationId: string,
+  shopId: string,
   sourceShopDomain: string,
   targetShopDomain: string,
   resourceConfigs: ResourceConfigs,
@@ -71,7 +71,7 @@ export async function startBulkDataStoreCopy(
   }
 
   return organizationsRequest<BulkDataStoreCopyStartResponse>(
-    organizationId,
+    shopId,
     bulkDataStoreCopyStartMutation,
     token,
     {

--- a/packages/store/src/services/store/api/api-client.ts
+++ b/packages/store/src/services/store/api/api-client.ts
@@ -23,14 +23,14 @@ export class ApiClient implements ApiClientInterface {
   }
 
   async startBulkDataStoreCopy(
-    organizationId: string,
+    shopId: string,
     sourceShopDomain: string,
     targetShopDomain: string,
     resourceConfigs: ResourceConfigs,
     token: string,
   ): Promise<BulkDataStoreCopyStartResponse> {
     return startBulkDataStoreCopy(
-      organizationId,
+      shopId,
       sourceShopDomain,
       targetShopDomain,
       resourceConfigs,

--- a/packages/store/src/services/store/mock/mock-api-client.ts
+++ b/packages/store/src/services/store/mock/mock-api-client.ts
@@ -19,7 +19,7 @@ export class MockApiClient implements ApiClientInterface {
   }
 
   async startBulkDataStoreCopy(
-    _organizationId: string,
+    _shopId: string,
     _sourceShopDomain: string,
     _targetShopDomain: string,
     _resourceConfigs: ResourceConfigs,

--- a/packages/store/src/services/store/types/api-client.ts
+++ b/packages/store/src/services/store/types/api-client.ts
@@ -11,7 +11,7 @@ export interface ApiClientInterface {
   fetchOrganizations(session: string): Promise<Organization[]>
 
   startBulkDataStoreCopy(
-    organizationId: string,
+    shopId: string,
     sourceShopDomain: string,
     targetShopDomain: string,
     resourceConfigs: ResourceConfigs,

--- a/packages/store/src/services/store/utils/bulk-operation-task-generator.ts
+++ b/packages/store/src/services/store/utils/bulk-operation-task-generator.ts
@@ -10,7 +10,7 @@ interface BulkOperationConfig {
 
 export interface BulkOperationContext {
   operation: BulkDataOperationByIdResponse
-  organizationId: string
+  apiShopId: string
   bpSession: string
   isComplete: boolean
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When shop is part of implicit organization the organization ID is not exposed to destinations API and so we can't access Organizations API routed via organization_id. However we can use shop_id as workaround.

### WHAT is this pull request doing?

- Replaced `organizationId` parameter to `apiShopId` in API client interfaces and implementations
- Updates URL construction to use `/shop/` instead of `/organization/` in the API endpoint path
- Modifies store operations (copy, export, import) to use the shop's `publicId` directly instead of passing around the organization ID
- Simplifies function signatures by removing redundant parameters

### How to test your changes?

1. Run store copy operations between shops
2. Test store export functionality
3. Verify store import operations
4. Ensure all operations complete successfully with the new parameter naming

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes