### PR TITLE
Sort template specifications on partners client

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -365,9 +365,22 @@ export class PartnersClient implements DeveloperPlatformClient {
       }
     })
 
+    let counter = 0
+    const templatesWithPriority = templates.map((template) => ({
+      ...template,
+      sortPriority: template.sortPriority ?? counter++,
+    }))
+
+    const groupOrder: string[] = []
+    for (const template of templatesWithPriority) {
+      if (template.group && !groupOrder.includes(template.group)) {
+        groupOrder.push(template.group)
+      }
+    }
+
     return {
-      templates,
-      groupOrder: [],
+      templates: templatesWithPriority,
+      groupOrder,
     }
   }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/pull/6080

[Slack thread](https://shopify.slack.com/archives/C030LHFCA5T/p1751986806980689)

tl;dr - `shopify app generate extension` is showing strange ordering for the Partner client. Headings show up multiple times.

![image](https://github.com/user-attachments/assets/59996365-9fed-44fb-8289-ebd4d4bae504)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR provides a `groupOrder` attribute to the downstream UI components ensuring that there will be no multiple headings 

Developer Platform:
<img width="584" alt="Screenshot 2025-07-09 at 9 37 16 AM" src="https://github.com/user-attachments/assets/e7094207-94d9-4e67-ab8d-ef1eb135023f" />

Legacy Partners Platform:
<img width="576" alt="Screenshot 2025-07-09 at 9 36 53 AM" src="https://github.com/user-attachments/assets/5d6b3082-56c4-4f48-8736-870f8d4c2e8c" />


### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

- Create an app `shopify app init`
- Select a Partners organization
- Generate an extension with `shopify app generate extension`
- View that there are no duplicate headings in the list

Do this again with a Dev Dash organization
- View that the extension list is ordered as described in the [original PR](https://github.com/Shopify/cli/pull/5938)