### PR TITLE
use `SQLITE_DATABASE` resource type, to permit larger file uploads

### DIFF
--- a/packages/store/src/apis/admin/index.ts
+++ b/packages/store/src/apis/admin/index.ts
@@ -1,25 +1,24 @@
-import {Shop} from './types.js'
-import {StagedUploadsCreate} from '../../cli/api/graphql/admin/generated/staged_uploads_create.js'
+import {Shop, SQLiteStagedUploadsCreate} from './types.js'
 import {ShopDetails} from '../../cli/api/graphql/admin/generated/shop_details.js'
 import {adminRequestDoc} from '@shopify/cli-kit/node/api/admin'
 import {ensureAuthenticatedAdmin} from '@shopify/cli-kit/node/session'
+import type {StagedUploadsCreateMutation} from '../../cli/api/graphql/admin/generated/staged_uploads_create.js'
 import type {
-  StagedUploadsCreateMutation,
-  StagedUploadsCreateMutationVariables,
-} from '../../cli/api/graphql/admin/generated/staged_uploads_create.js'
-import type {StagedUploadInput} from '../../cli/api/graphql/admin/generated/types.js'
-
+  SQLiteStagedUploadInput,
+  SQLiteStagedUploadsCreateMutationVariables,
+  SQLiteStagedUploadsCreateMutation,
+} from './types.js'
 import type {ShopDetailsQuery, ShopDetailsQueryVariables} from '../../cli/api/graphql/admin/generated/shop_details.js'
 
 export async function createStagedUploadAdmin(
   storeFqdn: string,
-  input: StagedUploadInput[],
+  input: SQLiteStagedUploadInput[],
   version?: string,
 ): Promise<StagedUploadsCreateMutation> {
   const adminSession = await ensureAuthenticatedAdmin(storeFqdn)
 
-  return adminRequestDoc<StagedUploadsCreateMutation, StagedUploadsCreateMutationVariables>({
-    query: StagedUploadsCreate,
+  return adminRequestDoc<SQLiteStagedUploadsCreateMutation, SQLiteStagedUploadsCreateMutationVariables>({
+    query: SQLiteStagedUploadsCreate,
     session: adminSession,
     variables: {
       input,

--- a/packages/store/src/apis/admin/index.ts
+++ b/packages/store/src/apis/admin/index.ts
@@ -14,6 +14,7 @@ import type {ShopDetailsQuery, ShopDetailsQueryVariables} from '../../cli/api/gr
 export async function createStagedUploadAdmin(
   storeFqdn: string,
   input: StagedUploadInput[],
+  version?: string,
 ): Promise<StagedUploadsCreateMutation> {
   const adminSession = await ensureAuthenticatedAdmin(storeFqdn)
 
@@ -23,6 +24,7 @@ export async function createStagedUploadAdmin(
     variables: {
       input,
     },
+    version,
   })
 }
 

--- a/packages/store/src/apis/admin/types.ts
+++ b/packages/store/src/apis/admin/types.ts
@@ -1,4 +1,42 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+
+import {StagedUploadsCreate} from '../../cli/api/graphql/admin/generated/staged_uploads_create.js'
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
 export interface Shop {
   id: string
   name: string
 }
+export type SQLiteStagedUploadInput = {
+  filename: string
+  mimeType: 'application/x-sqlite3'
+  httpMethod: 'POST'
+  fileSize?: string
+  resource: 'SQLITE_DATABASE'
+}
+export type SQLiteStagedUploadsCreateMutationVariables = {
+  input: SQLiteStagedUploadInput[]
+}
+
+export type SQLiteStagedUploadsCreateMutation = {
+  stagedUploadsCreate?: {
+    stagedTargets?:
+      | {
+          url?: string | null
+          resourceUrl?: string | null
+          parameters: {name: string; value: string}[]
+        }[]
+      | null
+    userErrors: {field?: string[] | null; message: string}[]
+  } | null
+}
+
+export const SQLiteStagedUploadsCreate = {
+  ...StagedUploadsCreate,
+  definitions: [
+    {
+      ...StagedUploadsCreate.definitions[0],
+      name: {kind: 'Name', value: 'SQLiteStagedUploadsCreate'},
+    },
+  ],
+} as unknown as DocumentNode<SQLiteStagedUploadsCreateMutation, SQLiteStagedUploadsCreateMutationVariables>

--- a/packages/store/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/store/src/cli/api/graphql/admin/generated/types.d.ts
@@ -232,3 +232,10 @@ export type StagedUploadTargetGenerateUploadResource =
    * [fileCreate mutation](https://shopify.dev/api/admin-graphql/latest/mutations/fileCreate).
    */
   | 'VIDEO'
+  /**
+   * A SQLite database file.
+   *
+   * For example, after uploading the database file, you can use the
+   * bulkDataImportStart mutation to import the data into a Shopify store.
+   */
+  | 'SQLITE_DATABASE'

--- a/packages/store/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/store/src/cli/api/graphql/admin/generated/types.d.ts
@@ -232,10 +232,3 @@ export type StagedUploadTargetGenerateUploadResource =
    * [fileCreate mutation](https://shopify.dev/api/admin-graphql/latest/mutations/fileCreate).
    */
   | 'VIDEO'
-  /**
-   * A SQLite database file.
-   *
-   * For example, after uploading the database file, you can use the
-   * bulkDataImportStart mutation to import the data into a Shopify store.
-   */
-  | 'SQLITE_DATABASE'

--- a/packages/store/src/services/store/utils/file-uploader.ts
+++ b/packages/store/src/services/store/utils/file-uploader.ts
@@ -1,4 +1,5 @@
-import {StagedUploadInput, createStagedUploadAdmin} from '../../../apis/admin/index.js'
+import {createStagedUploadAdmin} from '../../../apis/admin/index.js'
+import {SQLiteStagedUploadInput} from '../../../apis/admin/types.js'
 import {ValidationError, OperationError, ErrorCodes} from '../errors/errors.js'
 import {fetch} from '@shopify/cli-kit/node/http'
 import {fileExistsSync, fileSize, isDirectory, readFileSync} from '@shopify/cli-kit/node/fs'
@@ -12,7 +13,7 @@ export class FileUploader {
 
     const fileBuffer = readFileSync(filePath)
     const sizeOfFile = await fileSize(filePath)
-    const uploadInput: StagedUploadInput = {
+    const uploadInput: SQLiteStagedUploadInput = {
       resource: 'SQLITE_DATABASE',
       filename: 'database.sqlite',
       mimeType: 'application/x-sqlite3',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/workflows-operations/issues/3359

### WHAT is this pull request doing?

This PR updates the SQLite file upload functionality to:

1. Use the `SQLITE_DATABASE` resource type instead of `FILE` for staged uploads
2. Increase the maximum file size limit from 20MB to 300MB
3. Add API version parameter to the staged upload request (using 'unstable')
4. Fix the resource URL construction by appending the key parameter value
5. TEMPORARILY Add SQLite-specific types until SQLITE_DATBASE resource type visibility changes are in place

### How to test your changes?

`npm shopify store copy --from-file file_bigger_than_20_mb_smaller_than_300mb.sqlite --to-store target_store`
with an sqlite file

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes