### PR TITLE
No longer abort theme GraphQL requests on the client side

### DIFF
--- a/.changeset/gorgeous-colts-retire.md
+++ b/.changeset/gorgeous-colts-retire.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+No longer abort theme GraphQL requests on the client side

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -38,8 +38,7 @@ const themeAccessSession = {...session, token: 'shptka_token'}
 const sessions = {CLI: session, 'Theme Access': themeAccessSession}
 const expectedApiOptions = expect.objectContaining({
   maxRetryTimeMs: 90000,
-  timeoutMs: 90000,
-  useAbortSignal: true,
+  useAbortSignal: false,
   useNetworkLevelRetry: true,
 })
 
@@ -58,6 +57,7 @@ describe('fetchTheme', () => {
       session,
       variables: {id: 'gid://shopify/OnlineStoreTheme/123'},
       responseOptions: {handleErrors: false},
+      requestBehaviour: expectedApiOptions,
     })
 
     expect(theme).not.toBeNull()
@@ -83,6 +83,7 @@ describe('fetchTheme', () => {
       session,
       variables: {id: 'gid://shopify/OnlineStoreTheme/123'},
       responseOptions: {handleErrors: false},
+      requestBehaviour: expectedApiOptions,
     })
   })
 })
@@ -109,6 +110,7 @@ describe('fetchThemes', () => {
       session,
       variables: {after: null},
       responseOptions: {handleErrors: false},
+      requestBehaviour: expectedApiOptions,
     })
     expect(themes).toHaveLength(2)
 
@@ -541,8 +543,7 @@ describe('bulkUploadThemeAssets', async () => {
       },
       requestBehaviour: expect.objectContaining({
         maxRetryTimeMs: 90000,
-        timeoutMs: 90000,
-        useAbortSignal: true,
+        useAbortSignal: false,
         useNetworkLevelRetry: true,
       }),
     })
@@ -603,8 +604,7 @@ describe('bulkUploadThemeAssets', async () => {
       },
       requestBehaviour: expect.objectContaining({
         maxRetryTimeMs: 90000,
-        timeoutMs: 90000,
-        useAbortSignal: true,
+        useAbortSignal: false,
         useNetworkLevelRetry: true,
       }),
     })

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -34,8 +34,7 @@ export type AssetParams = Pick<ThemeAsset, 'key'> & Partial<Pick<ThemeAsset, 'va
 const SkeletonThemeCdn = 'https://cdn.shopify.com/static/online-store/theme-skeleton.zip'
 const THEME_API_NETWORK_BEHAVIOUR: RequestModeInput = {
   useNetworkLevelRetry: true,
-  useAbortSignal: true,
-  timeoutMs: 90 * 1000,
+  useAbortSignal: false,
   maxRetryTimeMs: 90 * 1000,
 }
 
@@ -48,6 +47,7 @@ export async function fetchTheme(id: number, session: AdminSession): Promise<The
       session,
       variables: {id: gid},
       responseOptions: {handleErrors: false},
+      requestBehaviour: THEME_API_NETWORK_BEHAVIOUR,
     })
 
     if (theme) {
@@ -83,6 +83,7 @@ export async function fetchThemes(session: AdminSession): Promise<Theme[]> {
       session,
       variables: {after},
       responseOptions: {handleErrors: false},
+      requestBehaviour: THEME_API_NETWORK_BEHAVIOUR,
     })
     if (!response.themes) {
       unexpectedGraphQLError('Failed to fetch themes')


### PR DESCRIPTION
### WHY are these changes being introduced?

Re: https://github.com/Shopify/cli/issues/5918 / https://github.com/Shopify/cli/issues/6062

### WHAT does this pull request do?

Requests to the themes APIs should not be aborted on the client side and should instead rely on the server-side timeout.

Even after increasing the timeout, we have still been seeing unexpected [closed](https://github.com/Shopify/cli/issues/6062) connections. This started when the stricter `requestBehaviour` was introduced.

Theme setups can vary a lot—some have a few large files, while others have many small ones. Relying on the server-side timeout seems to be more accurate and has proven more stable. Partners did not report friction when we used this approach before.

### How to test your changes

Run `shopify theme push` on your own theme.

### Post-release steps

N/A

### Measuring impact

How will we know this change was effective? Please select one:

- [ ] n/a - this doesn't need measurement, such as a linting rule or simple bug fix
- [x] Existing analytics will cover this change
- [ ] PR includes analytics updates to measure impact

### Checklist

- [x] Considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] Considered possible [documentation](https://shopify.dev) changes