### PR TITLE
Add overwrite prompt for store export if file exists

### DIFF
--- a/packages/store/src/prompts/confirm_export.test.ts
+++ b/packages/store/src/prompts/confirm_export.test.ts
@@ -5,7 +5,7 @@ import {describe, expect, vi, test} from 'vitest'
 vi.mock('@shopify/cli-kit/node/ui')
 
 describe('confirmExportPrompt', () => {
-  test('returns true when user confirms', async () => {
+  test('returns true when user confirms export to new file', async () => {
     const toFile = 'data.sqlite'
     const fromStore = 'shop.myshopify.com'
     const message = `Export data from ${fromStore} to ${toFile}?`
@@ -14,7 +14,7 @@ describe('confirmExportPrompt', () => {
 
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
 
-    const result = await confirmExportPrompt(fromStore, toFile)
+    const result = await confirmExportPrompt(fromStore, toFile, false)
 
     expect(renderConfirmationPrompt).toHaveBeenCalledWith({
       message,
@@ -24,11 +24,41 @@ describe('confirmExportPrompt', () => {
     expect(result).toBe(true)
   })
 
-  test('returns false when user cancels', async () => {
+  test('returns false when user cancels export to new file', async () => {
     const toFile = 'export.sqlite'
     const fromStore = 'test-shop.myshopify.com'
     vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
-    const result = await confirmExportPrompt(fromStore, toFile)
+    const result = await confirmExportPrompt(fromStore, toFile, false)
+    expect(result).toBe(false)
+  })
+
+  test('returns true when user confirms export to existing file', async () => {
+    const toFile = 'data.sqlite'
+    const fromStore = 'shop.myshopify.com'
+    const message = [
+      `Export data from ${fromStore} to ${toFile}`,
+      {warn: `\n"${toFile}" already exists do you want to overwrite it?`},
+    ]
+    const confirmationMessage = 'Yes, export and overwrite'
+    const cancellationMessage = 'Cancel'
+
+    vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+
+    const result = await confirmExportPrompt(fromStore, toFile, true)
+
+    expect(renderConfirmationPrompt).toHaveBeenCalledWith({
+      message,
+      confirmationMessage,
+      cancellationMessage,
+    })
+    expect(result).toBe(true)
+  })
+
+  test('returns false when user cancels export to existing file', async () => {
+    const toFile = 'export.sqlite'
+    const fromStore = 'test-shop.myshopify.com'
+    vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
+    const result = await confirmExportPrompt(fromStore, toFile, true)
     expect(result).toBe(false)
   })
 })

--- a/packages/store/src/prompts/confirm_export.ts
+++ b/packages/store/src/prompts/confirm_export.ts
@@ -1,9 +1,18 @@
 import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
 
-export async function confirmExportPrompt(fromStore: string, toFile: string): Promise<boolean> {
+export async function confirmExportPrompt(fromStore: string, toFile: string, fileExists: boolean): Promise<boolean> {
+  const message = fileExists
+    ? [
+        `Export data from ${fromStore} to ${toFile}`,
+        {warn: `\n"${toFile}" already exists do you want to overwrite it?`},
+      ]
+    : `Export data from ${fromStore} to ${toFile}?`
+
+  const confirmationMessage = fileExists ? 'Yes, export and overwrite' : 'Yes, export'
+
   return renderConfirmationPrompt({
-    message: `Export data from ${fromStore} to ${toFile}?`,
-    confirmationMessage: 'Yes, export',
+    message,
+    confirmationMessage,
     cancellationMessage: 'Cancel',
   })
 }

--- a/packages/store/src/services/store/operations/store-export.test.ts
+++ b/packages/store/src/services/store/operations/store-export.test.ts
@@ -14,9 +14,11 @@ import {OperationError, ErrorCodes} from '../errors/errors.js'
 import {confirmExportPrompt} from '../../../prompts/confirm_export.js'
 import {describe, vi, expect, test, beforeEach} from 'vitest'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
+import {fileExistsSync} from '@shopify/cli-kit/node/fs'
 
 vi.mock('../utils/result-file-handler.js')
 vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('../../../prompts/copy_info.js')
 vi.mock('../../../prompts/export_results.js')
 vi.mock('../../../prompts/confirm_export.js')
@@ -54,13 +56,16 @@ describe('StoreExportOperation', () => {
       operation: mockCompletedOperation,
       isComplete: true,
     })
+
+    vi.mocked(fileExistsSync).mockReturnValue(false)
   })
 
   test('should show confirm prompt before export', async () => {
+    vi.mocked(fileExistsSync).mockReturnValue(true)
     vi.mocked(confirmExportPrompt).mockResolvedValue(true)
     await operation.execute('source.myshopify.com', 'export.sqlite', {})
 
-    expect(confirmExportPrompt).toHaveBeenCalledWith('source.myshopify.com', 'export.sqlite')
+    expect(confirmExportPrompt).toHaveBeenCalledWith('source.myshopify.com', 'export.sqlite', true)
     expect(renderExportResult).toHaveBeenCalled()
   })
 
@@ -75,7 +80,7 @@ describe('StoreExportOperation', () => {
     vi.mocked(confirmExportPrompt).mockResolvedValue(true)
     await operation.execute('source.myshopify.com', 'output.sqlite', {})
 
-    expect(confirmExportPrompt).toHaveBeenCalledWith('source.myshopify.com', 'output.sqlite')
+    expect(confirmExportPrompt).toHaveBeenCalledWith('source.myshopify.com', 'output.sqlite', false)
     expect(renderCopyInfo).toHaveBeenCalledWith('Export Operation', 'source.myshopify.com', 'output.sqlite')
     expect(renderExportResult).toHaveBeenCalledWith('source.myshopify.com', mockCompletedOperation)
     expect(mockResultFileHandler.promptAndHandleResultFile).toHaveBeenCalledWith(

--- a/packages/store/src/services/store/operations/store-export.ts
+++ b/packages/store/src/services/store/operations/store-export.ts
@@ -13,6 +13,7 @@ import {renderExportResult} from '../../../prompts/export_results.js'
 import {confirmExportPrompt} from '../../../prompts/confirm_export.js'
 import {Task, renderTasks} from '@shopify/cli-kit/node/ui'
 import {outputInfo} from '@shopify/cli-kit/node/output'
+import {fileExistsSync} from '@shopify/cli-kit/node/fs'
 
 export class StoreExportOperation implements StoreOperation {
   fromArg: string | undefined
@@ -36,7 +37,8 @@ export class StoreExportOperation implements StoreOperation {
     const apiShopId = await this.validateShop(sourceShopDomain)
 
     if (!flags['no-prompt']) {
-      if (!(await confirmExportPrompt(sourceShopDomain, toFile))) {
+      const fileExists = fileExistsSync(toFile)
+      if (!(await confirmExportPrompt(sourceShopDomain, toFile, fileExists))) {
         outputInfo('Exiting.')
         process.exit(0)
       }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/workflows-operations/issues/3364

### WHAT is this pull request doing?

<img width="663" height="106" alt="Screenshot 2025-07-15 at 3 21 13 PM" src="https://github.com/user-attachments/assets/44841142-f18a-49f5-bf7a-2a506fb637f7" />

Adds a confirmation prompt when attempting to export store data to a file that already exists. This prevents accidental overwriting of existing files by:

1. Update `confirmExportPrompt` function so that it asks users if they want to overwrite an existing file if the file exists
2. Showing the appropriate confirmation prompt based on whether the file exists or not

### How to test your changes?
run this command twice, the first time you will see the normal flow, the second time you will see the overwrite flow

`pnpm shopify store copy --from-store=source --to-file=file --mock`
### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes