### PR TITLE
Add new loading mode: local

### DIFF
--- a/.changeset/tender-readers-drop.md
+++ b/.changeset/tender-readers-drop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix issue in `app build` when the app has certain extension types

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -438,6 +438,41 @@ wrong = "property"
     await expect(loadTestingApp()).rejects.toThrow(/Invalid extension type "invalid_type"/)
   })
 
+  test('loads only known extension types when mode is local', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    // Create two extensions: one known and one unknown
+    const knownBlockConfiguration = `
+      name = "my_extension"
+      type = "theme"
+      `
+    await writeBlockConfig({
+      blockConfiguration: knownBlockConfiguration,
+      name: 'my-known-extension',
+    })
+    await writeFile(joinPath(blockPath('my-known-extension'), 'index.js'), '')
+
+    const unknownBlockConfiguration = `
+      name = "unknown_extension"
+      type = "unknown_type"
+      `
+    await writeBlockConfig({
+      blockConfiguration: unknownBlockConfiguration,
+      name: 'my-unknown-extension',
+    })
+    await writeFile(joinPath(blockPath('my-unknown-extension'), 'index.js'), '')
+
+    // When
+    const app = await loadTestingApp({mode: 'local'})
+
+    // Then
+    expect(app.allExtensions).toHaveLength(1)
+    expect(app.allExtensions[0]!.configuration.name).toBe('my_extension')
+    expect(app.allExtensions[0]!.configuration.type).toBe('theme')
+    expect(app.errors).toBeUndefined()
+  })
+
   test('throws if 2 or more extensions have the same handle', async () => {
     // Given
     await writeConfig(appConfiguration)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -58,7 +58,13 @@ import ignore from 'ignore'
 
 const defaultExtensionDirectory = 'extensions/*'
 
-export type AppLoaderMode = 'strict' | 'report'
+/**
+ * The mode in which the app is loaded, this affects how errors are handled:
+ * - strict: If there is any kind of error, the app won't be loaded.
+ * - report: The app will be loaded as much as possible, errors will be reported afterwards.
+ * - local: Errors for unknown extensions will be ignored. Other errors will prevent the app from loading.
+ */
+export type AppLoaderMode = 'strict' | 'report' | 'local'
 
 type AbortOrReport = <T>(errorMessage: OutputMessage, fallback: T, configurationPath: string) => T
 
@@ -466,6 +472,8 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
 
     if (specification) {
       usedKnownSpecification = true
+    } else if (this.mode === 'local') {
+      return undefined
     } else {
       return this.abortOrReport(
         outputContent`Invalid extension type "${type}" in "${relativizePath(configurationPath)}"`,

--- a/packages/app/src/cli/services/app-context.test.ts
+++ b/packages/app/src/cli/services/app-context.test.ts
@@ -358,56 +358,6 @@ describe('localAppContext', () => {
     })
   })
 
-  test('uses unsafeReportMode when provided', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given - use a valid configuration but with an extra field to test report mode
-      const content = `
-        name = "test-app"
-      `
-      await writeAppConfig(tmp, content)
-      const loadSpy = vi.spyOn(loader, 'loadApp')
-
-      // When
-      const result = await localAppContext({
-        directory: tmp,
-        unsafeReportMode: true,
-      })
-
-      // Then
-      expect(result).toBeDefined()
-      expect(loadSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mode: 'report',
-        }),
-      )
-      loadSpy.mockRestore()
-    })
-  })
-
-  test('defaults to strict mode when unsafeReportMode is not provided', async () => {
-    await inTemporaryDirectory(async (tmp) => {
-      // Given
-      const content = `
-        name = "test-app"
-      `
-      await writeAppConfig(tmp, content)
-      const loadSpy = vi.spyOn(loader, 'loadApp')
-
-      // When
-      await localAppContext({
-        directory: tmp,
-      })
-
-      // Then
-      expect(loadSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mode: 'strict',
-        }),
-      )
-      loadSpy.mockRestore()
-    })
-  })
-
   test('loads app with extensions', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given

--- a/packages/app/src/cli/services/app-context.ts
+++ b/packages/app/src/cli/services/app-context.ts
@@ -152,7 +152,6 @@ async function logMetadata(app: {apiKey: string}, organization: Organization, re
 export async function localAppContext({
   directory,
   userProvidedConfigName,
-  unsafeReportMode = false,
 }: LocalAppContextOptions): Promise<AppInterface> {
   // Load local specifications only
   const specifications = await loadLocalExtensionsSpecifications()
@@ -162,6 +161,6 @@ export async function localAppContext({
     directory,
     userProvidedConfigName,
     specifications,
-    mode: unsafeReportMode ? 'report' : 'strict',
+    mode: 'local',
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the handling of unknown extension types in local development mode, allowing the app to load successfully even when unknown extension types are present.

### WHAT is this pull request doing?

- Adds a new `local` mode to the `AppLoaderMode` type, which ignores errors for unknown extension types
- Updates the `localAppContext` function to use the new `local` mode instead of `strict`

### How to test your changes?

For know extensions only accessible when authenticated:
1. Create a local app with an `admin_link` extensions
2. Both `app build` and `app deploy` should work. `build` will ignore the admin_link extension

For completely unknown extensions:
1. Create a local app with an `admin_link` extension.
2. Change the type of the extension to "invalid_type"
3. `app build` still works because it ignore unknown extensions, `app deploy` should crash.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes