### PR TITLE
To ensure we get failure metrics we need to throw the error instead of exiting with code 1

### DIFF
--- a/packages/store/src/lib/base-command.ts
+++ b/packages/store/src/lib/base-command.ts
@@ -1,7 +1,7 @@
 import {FlagOptions} from './types.js'
 import {checkForUndefinedFieldError} from '../services/store/utils/graphql-errors.js'
 import Command from '@shopify/cli-kit/node/base-command'
-import {renderError} from '@shopify/cli-kit/node/ui'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 export abstract class BaseBDCommand extends Command {
   abstract runCommand(): Promise<void>
@@ -17,11 +17,8 @@ export abstract class BaseBDCommand extends Command {
         if (checkForUndefinedFieldError(error)) {
           errorMessage = `This command is in Early Accesss and is not yet available for the requested store(s).`
         }
-        renderError({
-          headline: `Operation failed`,
-          body: errorMessage,
-        })
-        process.exit(1)
+
+        throw new AbortError(errorMessage)
       } else {
         throw error
       }


### PR DESCRIPTION
### WHY are these changes introduced?

closes https://github.com/Shopify/workflows-operations/issues/3390

### WHAT is this pull request doing?

Replaces the manual error rendering and process exit with a proper AbortError throw in the BaseBDCommand's error handling. This ensures that we still get proper monorail reporting. This change:

- Throws an AbortError with the error message instead of rendering the error and calling process.exit(1)
- Maintains the same error message for Early Access commands

### How to test your changes?

Run a command you know will error (ex importing a file into a non dev store) with the `--verbose` flag

Ensure you see something like

![Screenshot 2025-07-17 at 1.57.49 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nNXNzCKyqHYacpSEpWpP/dc7411c2-aee2-4a65-b27f-ebf363ef1104.png)

and that success is false.

Also ensure the failure renders as expected

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [] I've considered possible [documentation](https://shopify.dev) changes