### PR TITLE
Update `https.Agent` to leave `keepAlive` with the default value

### DIFF
--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -74,7 +74,6 @@ export function buildHeaders(token?: string): {[key: string]: string} {
 export async function httpsAgent(): Promise<https.Agent> {
   return new https.Agent({
     rejectUnauthorized: await shouldRejectUnauthorizedRequests(),
-    keepAlive: true,
   })
 }
 

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -106,7 +106,17 @@ export async function readFile(path: string, options?: ReadOptions): Promise<Buf
  * @returns A promise that resolves with the content of the file.
  */
 export async function readFile(path: string, options: ReadOptions = {encoding: 'utf8'}): Promise<string | Buffer> {
-  outputDebug(outputContent`Reading the content of file at ${outputToken.path(path)}...`)
+  let fileSize = 'unset'
+
+  try {
+    const {size} = await fsStat(path)
+    fileSize = size.toString()
+    // eslint-disable-next-line no-catch-all/no-catch-all, no-empty
+  } catch {}
+
+  // eslint-disable-next-line no-console
+  console.log(`Reading the content of file at ${path} (size: ${fileSize} bytes)...`)
+
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   return fsReadFile(path, options)

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -32,7 +32,7 @@ import {outputDebug} from '../output.js'
 export type ThemeParams = Partial<Pick<Theme, 'name' | 'role' | 'processing' | 'src'>>
 export type AssetParams = Pick<ThemeAsset, 'key'> & Partial<Pick<ThemeAsset, 'value' | 'attachment'>>
 const SkeletonThemeCdn = 'https://cdn.shopify.com/static/online-store/theme-skeleton.zip'
-const THEME_API_NETWORK_BEHAVIOUR: RequestModeInput = {
+export const THEME_API_NETWORK_BEHAVIOUR: RequestModeInput = {
   useNetworkLevelRetry: true,
   useAbortSignal: false,
   maxRetryTimeMs: 90 * 1000,

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -143,6 +143,23 @@ You can run this command only in a directory that matches the [default Shopify t
       flags = {...flags, theme: theme.id.toString(), 'overwrite-json': overwriteJson}
     }
 
+    // eslint-disable-next-line no-console
+    console.log('[SHOPIFY_#6062_DEBUG]', {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      openssl: process.versions.openssl,
+
+      env: {
+        HTTP_PROXY: process.env.HTTP_PROXY ? 'set' : 'not set',
+        HTTPS_PROXY: process.env.HTTPS_PROXY ? 'set' : 'not set',
+        NO_PROXY: process.env.NO_PROXY ? 'set' : 'not set',
+        NODE_TLS_REJECT_UNAUTHORIZED: process.env.NODE_TLS_REJECT_UNAUTHORIZED ?? 'not set',
+        NODE_OPTIONS: process.env.NODE_OPTIONS ?? 'not set',
+        NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS ? 'set' : 'not set',
+      },
+    })
+
     await dev({
       adminSession,
       directory: flags.path,

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -4,7 +4,7 @@ import {shopifyFetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {type AdminSession} from '@shopify/cli-kit/node/session'
-import {passwordProtected} from '@shopify/cli-kit/node/themes/api'
+import {passwordProtected, THEME_API_NETWORK_BEHAVIOUR} from '@shopify/cli-kit/node/themes/api'
 import {sleep} from '@shopify/cli-kit/node/system'
 
 export class ShopifyEssentialError extends Error {}
@@ -145,16 +145,20 @@ async function enrichSessionWithStorefrontPassword(
 ) {
   const params = new URLSearchParams({password})
 
-  const response = await shopifyFetch(`${storeUrl}/password`, {
-    method: 'POST',
-    redirect: 'manual',
-    body: params,
-    headers: {
-      ...headers,
-      ...defaultHeaders(),
-      Cookie: serializeCookies({_shopify_essential: shopifyEssential}),
+  const response = await shopifyFetch(
+    `${storeUrl}/password`,
+    {
+      method: 'POST',
+      redirect: 'manual',
+      body: params,
+      headers: {
+        ...headers,
+        ...defaultHeaders(),
+        Cookie: serializeCookies({_shopify_essential: shopifyEssential}),
+      },
     },
-  })
+    THEME_API_NETWORK_BEHAVIOUR,
+  )
 
   const setCookies = response.headers.raw()['set-cookie'] ?? []
   const storefrontDigest = getCookie(setCookies, 'storefront_digest')


### PR DESCRIPTION
Re: https://github.com/Shopify/cli/issues/6062

User logs suggest a pattern where the first request succeeds (across different endpoints), but the second request fails with "Client network socket disconnected before secure TLS connection was established".

This points to a possible issue with socket reuse. When `keepAlive` is enabled, the first request's socket is saved for reuse, but by the time the second request tries to use it, the server may have already closed its side.

There are a few factors that can lead to this issue: aggressive server timeouts, dns rotation, or network setups that don’t guarantee the same backend each time.

This PR adds basic diagnostics and leave `keepAlive` with the default value (`false`) — forcing a new TCP connection for each request. If this hypnotises gets validated, this configuration must be defined at the `RequestModeInput` level.