### PR TITLE
Promote localhost and tunnel-url more forcefully

### DIFF
--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -155,14 +155,21 @@ class TunnelClientInstance implements TunnelClient {
 
 function whatToTry() {
   return [
-    'Run the command again or',
+    'You can run the command again, or try networking with Shopify via',
+    {
+      command: '--use-localhost',
+    },
+    'or',
+    {
+      command: '--tunnel-url <custom tunnel>',
+    },
+    '.',
     {
       link: {
-        label: 'see Shopify CLI documentation',
+        label: 'See documentation for details.',
         url: 'https://shopify.dev/docs/apps/build/cli-for-apps/networking-options',
       },
     },
-    'for more options.',
   ]
 }
 


### PR DESCRIPTION
Update error message on Cloudflare tunnel failure to promote alternatives more explicitly.

<img width="1862" height="700" alt="image" src="https://github.com/user-attachments/assets/18065661-023a-4449-a3f0-c0e2cc7f4177" />

<img width="1860" height="458" alt="image" src="https://github.com/user-attachments/assets/b81451c4-b9b6-4956-b098-20d96f1069d2" />


### WHY are these changes introduced?

Promote more adoption of `--use-localhost`.