### PR TITLE
Show updated modules when migrating them to the new dev platform

### DIFF
--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -126,7 +126,8 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Extensions:',
               items: [
                 {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
-                'to update extension',
+                {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
+                'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
               ],
             },
@@ -186,7 +187,8 @@ describe('deployOrReleaseConfirmationPrompt', () => {
                   item: ['to create dashboard', {subdued: '(new, from Partner Dashboard)'}],
                   color: 'green',
                 },
-                'to update extension',
+                {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
+                'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
                 {bullet: '-', item: ['remote extension', {subdued: '(removed)'}], color: 'red'},
                 {bullet: '-', item: ['remote dashboard', {subdued: '(removed, from Partner Dashboard)'}], color: 'red'},
@@ -238,7 +240,8 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Extensions:',
               items: [
                 {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
-                'to update extension',
+                {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
+                'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
                 {bullet: '-', item: ['remote extension', {subdued: '(removed)'}], color: 'red'},
               ],
@@ -282,7 +285,8 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Extensions:',
               items: [
                 {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
-                'to update extension',
+                {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
+                'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
                 {bullet: '-', item: ['remote extension', {subdued: '(removed)'}], color: 'red'},
               ],
@@ -334,7 +338,8 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               helperText: 'Removing extensions can permanently delete app user data',
               items: [
                 {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
-                'to update extension',
+                {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
+                'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
                 {bullet: '-', item: ['remote extension', {subdued: '(removed)'}], color: 'red'},
               ],
@@ -389,7 +394,8 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Extensions:',
               items: [
                 {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
-                'to update extension',
+                {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
+                'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
               ],
             },
@@ -429,10 +435,12 @@ function buildCompleteBreakdownInfo() {
 
   emptyBreakdownInfo.extensionIdentifiersBreakdown.onlyRemote.push(buildExtensionBreakdownInfo('remote extension'))
   emptyBreakdownInfo.extensionIdentifiersBreakdown.toCreate.push(buildExtensionBreakdownInfo('to create extension'))
-  emptyBreakdownInfo.extensionIdentifiersBreakdown.toUpdate.push(
-    buildExtensionBreakdownInfo('to update extension'),
+  emptyBreakdownInfo.extensionIdentifiersBreakdown.unchanged.push(
+    buildExtensionBreakdownInfo('unchanged extension'),
     buildDashboardBreakdownInfo('from dashboard extension'),
   )
+
+  emptyBreakdownInfo.extensionIdentifiersBreakdown.toUpdate.push(buildExtensionBreakdownInfo('to update extension'))
 
   emptyBreakdownInfo.configExtensionIdentifiersBreakdown!.existingFieldNames.push('existing field name1')
   emptyBreakdownInfo.configExtensionIdentifiersBreakdown!.existingUpdatedFieldNames.push('updating field name1')
@@ -457,6 +465,7 @@ function buildEmptyExtensionsBreakdownInfo(): ExtensionIdentifiersBreakdown {
     onlyRemote: [],
     toCreate: [],
     toUpdate: [],
+    unchanged: [],
   }
 }
 

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -103,7 +103,7 @@ async function deployConfirmationPrompt({
 }
 
 async function buildExtensionsContentPrompt(extensionsContentBreakdown: ExtensionIdentifiersBreakdown) {
-  const {onlyRemote, toCreate: toCreateBreakdown, toUpdate} = extensionsContentBreakdown
+  const {onlyRemote, toCreate: toCreateBreakdown, toUpdate, unchanged} = extensionsContentBreakdown
 
   const mapExtensionToInfoTableItem = (extension: ExtensionIdentifierBreakdownInfo, preffix: string) => {
     switch (extension.experience) {
@@ -116,7 +116,8 @@ async function buildExtensionsContentPrompt(extensionsContentBreakdown: Extensio
   let extensionsInfoTable
   const section = {
     new: toCreateBreakdown.map((extension) => mapExtensionToInfoTableItem(extension, 'new, ')),
-    unchanged: toUpdate.map((extension) => mapExtensionToInfoTableItem(extension, '')),
+    unchanged: unchanged.map((extension) => mapExtensionToInfoTableItem(extension, '')),
+    updated: toUpdate.map((extension) => mapExtensionToInfoTableItem(extension, 'updated, ')),
     removed: onlyRemote.map((extension) => mapExtensionToInfoTableItem(extension, 'removed, ')),
   }
   const extensionsInfo = buildDeployReleaseInfoTableSection(section)

--- a/packages/app/src/cli/services/context/id-matching.ts
+++ b/packages/app/src/cli/services/context/id-matching.ts
@@ -114,7 +114,12 @@ function matchByUIDandUUID(
 
   outputAddedIDs(localMatchedWithoutUID)
 
-  return {matched: {...matchedByUID, ...totalMatchedWithoutUID}, toCreate, toConfirm, toManualMatch}
+  return {
+    matched: {...matchedByUID, ...totalMatchedWithoutUID},
+    toCreate,
+    toConfirm,
+    toManualMatch,
+  }
 }
 
 function outputAddedIDs(localMatchedWithoutUID: LocalSource[]) {

--- a/packages/app/src/cli/services/context/identifiers.test.ts
+++ b/packages/app/src/cli/services/context/identifiers.test.ts
@@ -79,6 +79,7 @@ function buildExtensionsBreakdown() {
       toCreate: [],
       toUpdate: [],
       fromDashboard: [],
+      unchanged: [],
     },
     extensionsToConfirm: {
       validMatches: {},

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -165,6 +165,7 @@ function buildExtensionsBreakdown() {
       toCreate: [],
       toUpdate: [],
       fromDashboard: [],
+      unchanged: [],
     },
     versionDetails: {
       id: 1,


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/shop/issues-develop/issues/10835

To improve the clarity of extension deployment information by properly categorizing extensions as "unchanged" or "updated" in the deployment prompt.

### WHAT is this pull request doing?

This PR refines how extensions are categorized during deployment:

1. Adds a new `unchanged` field to the `ExtensionIdentifiersBreakdown` interface
2. Properly separates extensions that are truly being updated from those that remain unchanged
3. Updates the deployment prompt to display extensions in appropriate categories:
   - New extensions
   - Unchanged extensions
   - Updated extensions
   - Removed extensions

ONLY extensions that are being "migrated" to dev dash and adding a UID are shown as `UPDATED`


![Captura de pantalla 2025-07-21 a las 12.40.41.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nNsubxpSjsPXUKXMmDt6/721b9587-176c-4e8a-954f-a70d44cb96c0.png)

### How to test your changes?

1. Run a deployment with a mix of new, updated, and unchanged extensions
2. Verify that the deployment prompt correctly categorizes each extension
3. Confirm that extensions being migrated to DevDash appear in the "updated" section

To force a extension to be migrated, running everything locally, delete the `user_identifier` from an extension in the active version in the Database.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes