### PR TITLE
Add import extensions functionality on deploy

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1423,6 +1423,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     supportsStoreSearch: false,
     organizationSource: OrganizationSource.BusinessPlatform,
     bundleFormat: 'zip',
+    supportsDashboardManagedExtensions: true,
     session: () => Promise.resolve(testPartnersUserSession),
     unsafeRefreshToken: () => Promise.resolve(testPartnersUserSession.token),
     accountInfo: () => Promise.resolve(testPartnersUserSession.accountInfo),
@@ -1511,6 +1512,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
           | 'supportsStoreSearch'
           | 'organizationSource'
           | 'bundleFormat'
+          | 'supportsDashboardManagedExtensions'
         >
       ] = vi.fn().mockImplementation(value)
     }

--- a/packages/app/src/cli/services/fetch-extensions.ts
+++ b/packages/app/src/cli/services/fetch-extensions.ts
@@ -5,11 +5,13 @@ export async function getExtensions({
   apiKey,
   organizationId,
   extensionTypes,
+  onlyDashboardManaged = false,
 }: {
   developerPlatformClient: DeveloperPlatformClient
   apiKey: string
   organizationId: string
   extensionTypes: string[]
+  onlyDashboardManaged?: boolean
 }) {
   const initialRemoteExtensions = await developerPlatformClient.appExtensionRegistrations({
     id: apiKey,
@@ -17,10 +19,17 @@ export async function getExtensions({
     organizationId,
   })
   const {dashboardManagedExtensionRegistrations, extensionRegistrations} = initialRemoteExtensions.app
-  return extensionRegistrations.concat(dashboardManagedExtensionRegistrations).filter((ext) => {
+
+  const extensionsToFilter = onlyDashboardManaged
+    ? dashboardManagedExtensionRegistrations
+    : extensionRegistrations.concat(dashboardManagedExtensionRegistrations)
+
+  return extensionsToFilter.filter((ext) => {
     const isNeededExtensionType = extensionTypes.includes(ext.type.toLowerCase())
-    const hasActiveVersion = ext.activeVersion && ext.activeVersion.config
+    const hasActiveVersion = developerPlatformClient.supportsDashboardManagedExtensions
+      ? ext.activeVersion && ext.activeVersion.config
+      : true
     const hasDraftVersion = ext.draftVersion && ext.draftVersion.config
-    return isNeededExtensionType && (hasActiveVersion || hasDraftVersion)
+    return isNeededExtensionType && (hasActiveVersion ?? hasDraftVersion)
   })
 }

--- a/packages/app/src/cli/services/import-extensions.ts
+++ b/packages/app/src/cli/services/import-extensions.ts
@@ -5,7 +5,7 @@ import {ExtensionRegistration} from '../api/graphql/all_app_extension_registrati
 import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {MAX_EXTENSION_HANDLE_LENGTH} from '../models/extensions/schemas.js'
 import {OrganizationApp} from '../models/organization.js'
-import {allMigrationChoices} from '../prompts/import-extensions.js'
+import {allMigrationChoices, getMigrationChoices} from '../prompts/import-extensions.js'
 import {configurationFileNames} from '../constants.js'
 import {renderSelectPrompt, renderSuccess} from '@shopify/cli-kit/node/ui'
 import {basename, joinPath} from '@shopify/cli-kit/node/path'
@@ -16,21 +16,25 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 
 export const allExtensionTypes = allMigrationChoices.flatMap((choice) => choice.extensionTypes)
 
-interface ImportOptions {
+interface ImportAllOptions {
   app: AppLinkedInterface
   remoteApp: OrganizationApp
   developerPlatformClient: DeveloperPlatformClient
-  extensionTypes: string[]
   extensions: ExtensionRegistration[]
+}
+
+interface ImportOptions extends ImportAllOptions {
+  extensionTypes: string[]
   buildTomlObject: (
     ext: ExtensionRegistration,
     allExtensions: ExtensionRegistration[],
     appConfig: CurrentAppConfiguration,
   ) => string
+  all?: boolean
 }
 
 export async function importExtensions(options: ImportOptions) {
-  const {app, remoteApp, developerPlatformClient, extensionTypes, extensions, buildTomlObject} = options
+  const {app, remoteApp, developerPlatformClient, extensionTypes, extensions, buildTomlObject, all} = options
 
   let extensionsToMigrate = extensions.filter((ext) => extensionTypes.includes(ext.type.toLowerCase()))
 
@@ -38,18 +42,20 @@ export async function importExtensions(options: ImportOptions) {
     throw new AbortError('No extensions to migrate')
   }
 
-  const choices = extensionsToMigrate.map((ext) => {
-    return {label: ext.title, value: ext.uuid}
-  })
+  if (!all) {
+    const choices = extensionsToMigrate.map((ext) => {
+      return {label: ext.title, value: ext.uuid}
+    })
 
-  if (extensionsToMigrate.length > 1) {
-    choices.push({label: 'All', value: 'All'})
-  }
-  const promptAnswer = await renderSelectPrompt({message: 'Extensions to migrate', choices})
+    if (extensionsToMigrate.length > 1) {
+      choices.push({label: 'All', value: 'All'})
+    }
+    const promptAnswer = await renderSelectPrompt({message: 'Extensions to migrate', choices})
 
-  if (promptAnswer !== 'All') {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    extensionsToMigrate = [extensionsToMigrate.find((ext) => ext?.uuid === promptAnswer)!]
+    if (promptAnswer !== 'All') {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      extensionsToMigrate = [extensionsToMigrate.find((ext) => ext?.uuid === promptAnswer)!]
+    }
   }
 
   const extensionUuids: IdentifiersExtensions = {}
@@ -76,6 +82,20 @@ export async function importExtensions(options: ImportOptions) {
     command: 'deploy',
     developerPlatformClient,
   })
+}
+
+export async function importAllExtensions(options: ImportAllOptions) {
+  const migrationChoices = getMigrationChoices(options.extensions)
+  await Promise.all(
+    migrationChoices.map(async (choice) => {
+      return importExtensions({
+        ...options,
+        extensionTypes: choice.extensionTypes,
+        buildTomlObject: choice.buildTomlObject,
+        all: true,
+      })
+    }),
+  )
 }
 
 function renderSuccessMessages(generatedExtensions: {extension: ExtensionRegistration; directory: string}[]) {

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -262,6 +262,7 @@ export interface DeveloperPlatformClient {
   readonly supportsStoreSearch: boolean
   readonly organizationSource: OrganizationSource
   readonly bundleFormat: 'zip' | 'br'
+  readonly supportsDashboardManagedExtensions: boolean
   session: () => Promise<PartnersSession>
   /**
    * This is an unsafe method that should only be used when the session is expired.

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -1441,12 +1441,6 @@ describe('appExtensionRegistrations', () => {
             title: 'Regular Extension',
             type: 'ui_extension',
           },
-          {
-            id: 'dashboard-1',
-            uuid: 'mock-uuid',
-            title: 'Dashboard Extension',
-            type: 'ui_extension',
-          },
         ],
         dashboardManagedExtensionRegistrations: [
           {
@@ -1612,14 +1606,7 @@ describe('appExtensionRegistrations', () => {
 
     // Then
     expect(result.app.configurationRegistrations).toHaveLength(2)
-    expect(result.app.extensionRegistrations).toHaveLength(4)
+    expect(result.app.extensionRegistrations).toHaveLength(2)
     expect(result.app.dashboardManagedExtensionRegistrations).toHaveLength(2)
-
-    // Verify dashboard extensions are in both extensionRegistrations and dashboardManagedExtensionRegistrations
-    const dashboardIds = ['dashboard-1', 'dashboard-2']
-    dashboardIds.forEach((id) => {
-      expect(result.app.extensionRegistrations.some((reg) => reg.id === id)).toBe(true)
-      expect(result.app.dashboardManagedExtensionRegistrations.some((reg) => reg.id === id)).toBe(true)
-    })
   })
 })

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -191,6 +191,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   public readonly supportsStoreSearch = true
   public readonly organizationSource = OrganizationSource.BusinessPlatform
   public readonly bundleFormat = 'br'
+  public readonly supportsDashboardManagedExtensions = false
   private _session: PartnersSession | undefined
 
   constructor(session?: PartnersSession) {
@@ -574,11 +575,10 @@ export class AppManagementClient implements DeveloperPlatformClient {
       }
       if (CONFIG_EXTENSION_IDS.includes(registration.id)) {
         configurationRegistrations.push(registration)
+      } else if (mod.specification?.options?.managementExperience === 'dashboard') {
+        dashboardManagedExtensionRegistrations.push(registration)
       } else {
         extensionRegistrations.push(registration)
-        if (mod.specification?.options?.managementExperience === 'dashboard') {
-          dashboardManagedExtensionRegistrations.push(registration)
-        }
       }
     })
     return {

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -220,6 +220,7 @@ export class PartnersClient implements DeveloperPlatformClient {
   public readonly supportsStoreSearch = false
   public readonly organizationSource = OrganizationSource.Partners
   public readonly bundleFormat = 'zip'
+  public readonly supportsDashboardManagedExtensions = true
   private _session: PartnersSession | undefined
 
   constructor(session?: PartnersSession) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/469

### WHAT is this pull request doing?

- When running deploy with Partners API, it suggests to optionally migrate dashboard extensions:
<img width="588" height="177" alt="prompt-partners" src="https://github.com/user-attachments/assets/76829638-519a-4759-8ea5-b76e1c836564" />

- When running deploy with App Management API, it requires to migrate/remove dashboard extensions to continue:
<img width="813" height="178" alt="Monosnap node 2025-07-22 12-24-24" src="https://github.com/user-attachments/assets/387973f8-410f-4154-9432-d9d131bc3283" />


### How to test your changes?

- `shopify app deploy`

To add a dashboard managed extension in production, [this flag](https://partners.shopify.com/internal/betas/enable_dashboard_subscription_link_extension_creation) can be enabled.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
