### PR TITLE
Remove org_id from app management URL

### DIFF
--- a/packages/app/src/cli/commands/app/init.ts
+++ b/packages/app/src/cli/commands/app/init.ts
@@ -168,7 +168,7 @@ async function selectAppOrNewAppName(
   } else {
     const app = await selectAppPrompt(searchForAppsByNameFactory(developerPlatformClient, org.id), apps, hasMorePages)
 
-    const fullSelectedApp = await developerPlatformClient.appFromIdentifiers(app)
+    const fullSelectedApp = await developerPlatformClient.appFromIdentifiers(app.apiKey)
     if (!fullSelectedApp) throw new AbortError(`App with id ${app.id} not found`)
     return {result: 'existing', app: fullSelectedApp}
   }

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -17,7 +17,6 @@ import {
   MinimalAppIdentifiers,
   OrganizationApp,
   MinimalOrganizationApp,
-  AppApiKeyAndOrgId,
   OrganizationSource,
 } from '../organization.js'
 import {RemoteSpecification} from '../../api/graphql/extension_specifications.js'
@@ -1428,7 +1427,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     session: () => Promise.resolve(testPartnersUserSession),
     unsafeRefreshToken: () => Promise.resolve(testPartnersUserSession.token),
     accountInfo: () => Promise.resolve(testPartnersUserSession.accountInfo),
-    appFromIdentifiers: (_app: AppApiKeyAndOrgId) => Promise.resolve(testOrganizationApp()),
+    appFromIdentifiers: (_apiKey: string) => Promise.resolve(testOrganizationApp()),
     organizations: () => Promise.resolve(organizationsResponse),
     orgFromId: (_organizationId: string) => Promise.resolve(testOrganization()),
     appsForOrg: (_organizationId: string) => Promise.resolve({apps: [testOrganizationApp()], hasMorePages: false}),

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -12,12 +12,9 @@ export interface Organization {
   source: OrganizationSource
 }
 
-export interface AppApiKeyAndOrgId {
+export interface MinimalAppIdentifiers {
   apiKey: string
   organizationId: string
-}
-
-export type MinimalAppIdentifiers = AppApiKeyAndOrgId & {
   id: string
 }
 

--- a/packages/app/src/cli/services/app/config/link-service.test.ts
+++ b/packages/app/src/cli/services/app/config/link-service.test.ts
@@ -1,7 +1,7 @@
 import link from './link.js'
 import {testOrganizationApp, testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
 import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
-import {AppApiKeyAndOrgId, OrganizationApp, OrganizationSource} from '../../../models/organization.js'
+import {OrganizationApp, OrganizationSource} from '../../../models/organization.js'
 import {appNamePrompt, createAsNewAppPrompt, selectOrganizationPrompt} from '../../../prompts/dev.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
@@ -19,7 +19,7 @@ beforeEach(async () => {})
 function buildDeveloperPlatformClient(): DeveloperPlatformClient {
   return testDeveloperPlatformClient({
     supportsDevSessions: true,
-    async appFromIdentifiers({apiKey}: AppApiKeyAndOrgId): Promise<OrganizationApp | undefined> {
+    async appFromIdentifiers(apiKey: string): Promise<OrganizationApp | undefined> {
       switch (apiKey) {
         case 'api-key':
           return testOrganizationApp({developerPlatformClient: this as DeveloperPlatformClient})

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -13,7 +13,7 @@ import {getCachedCommandInfo} from '../../local-storage.js'
 import {AppInterface, CurrentAppConfiguration} from '../../../models/app/app.js'
 import {fetchAppRemoteConfiguration} from '../select-app.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
-import {MinimalAppIdentifiers, AppApiKeyAndOrgId, OrganizationApp} from '../../../models/organization.js'
+import {MinimalAppIdentifiers, OrganizationApp} from '../../../models/organization.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {fileExistsSync, inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -49,7 +49,7 @@ const DEFAULT_REMOTE_CONFIGURATION = {
 
 function buildDeveloperPlatformClient(extraFields: Partial<DeveloperPlatformClient> = {}): DeveloperPlatformClient {
   return testDeveloperPlatformClient({
-    async appFromIdentifiers({apiKey}: AppApiKeyAndOrgId): Promise<OrganizationApp | undefined> {
+    async appFromIdentifiers(apiKey: string): Promise<OrganizationApp | undefined> {
       switch (apiKey) {
         case 'api-key':
           return testOrganizationApp({developerPlatformClient: this as DeveloperPlatformClient})
@@ -807,7 +807,7 @@ embedded = false
       vi.mocked(loadApp).mockResolvedValue(await mockApp(tmp))
       vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
       vi.mocked(appFromIdentifiers).mockImplementation(async ({apiKey}: {apiKey: string}) => {
-        return (await developerPlatformClient.appFromIdentifiers({apiKey, organizationId: '1'}))!
+        return (await developerPlatformClient.appFromIdentifiers(apiKey))!
       })
 
       // When

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -12,7 +12,6 @@ import {DeployOptions} from './deploy.js'
 import {isServiceAccount, isUserAccount} from './context/partner-account-info.js'
 import {
   MinimalAppIdentifiers,
-  AppApiKeyAndOrgId,
   Organization,
   OrganizationApp,
   OrganizationSource,
@@ -102,7 +101,7 @@ const deployOptions = (app: AppLinkedInterface, reset = false, force = false): D
 function buildDeveloperPlatformClient(extras?: Partial<DeveloperPlatformClient>): DeveloperPlatformClient {
   return testDeveloperPlatformClient({
     ...extras,
-    async appFromIdentifiers({apiKey}: AppApiKeyAndOrgId) {
+    async appFromIdentifiers(apiKey: string) {
       for (const app of [APP1, APP2]) {
         if (apiKey === app.apiKey) return app
       }

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -81,10 +81,7 @@ export const appFromIdentifiers = async (options: AppFromIdOptions): Promise<Org
       organizationId = org.id
     }
   }
-  const app = await developerPlatformClient.appFromIdentifiers({
-    apiKey: options.apiKey,
-    organizationId,
-  })
+  const app = await developerPlatformClient.appFromIdentifiers(options.apiKey)
   if (!app) {
     const accountInfo = await developerPlatformClient.accountInfo()
     let identifier = 'Unknown account'

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -1,6 +1,6 @@
 import {selectOrCreateApp} from './select-app.js'
 import {AppInterface, WebType} from '../../models/app/app.js'
-import {AppApiKeyAndOrgId, Organization, OrganizationSource} from '../../models/organization.js'
+import {Organization, OrganizationSource} from '../../models/organization.js'
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {testApp, testOrganizationApp, testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {describe, expect, vi, test} from 'vitest'
@@ -42,7 +42,7 @@ const APPS = [
 function mockDeveloperPlatformClient() {
   const developerPlatformClient = testDeveloperPlatformClient({
     createApp: async () => ({...APP1, newApp: true}),
-    async appFromIdentifiers({apiKey}: AppApiKeyAndOrgId) {
+    async appFromIdentifiers(apiKey: string) {
       if (apiKey === APP1.apiKey) return APP1
       if (apiKey === APP2.apiKey) return APP2
       throw new Error(`App with client ID ${apiKey} not found`)

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -40,7 +40,7 @@ export async function selectOrCreateApp(
 
     if (selectedToml) setCachedCommandTomlPreference(selectedToml)
 
-    const fullSelectedApp = await developerPlatformClient.appFromIdentifiers(app)
+    const fullSelectedApp = await developerPlatformClient.appFromIdentifiers(app.apiKey)
 
     if (!fullSelectedApp) {
       // This is unlikely, and a bug. But we still want a nice user facing message plus appropriate context logged.

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -1,6 +1,6 @@
 import {InfoOptions, info} from './info.js'
 import {AppInterface, AppLinkedInterface} from '../models/app/app.js'
-import {AppApiKeyAndOrgId, OrganizationApp, OrganizationSource} from '../models/organization.js'
+import {OrganizationApp, OrganizationSource} from '../models/organization.js'
 import {selectOrganizationPrompt} from '../prompts/dev.js'
 import {
   testDeveloperPlatformClient,
@@ -34,7 +34,7 @@ const ORG1 = {
 
 function buildDeveloperPlatformClient(): DeveloperPlatformClient {
   return testDeveloperPlatformClient({
-    async appFromIdentifiers({apiKey}: AppApiKeyAndOrgId): Promise<OrganizationApp> {
+    async appFromIdentifiers(apiKey: string): Promise<OrganizationApp> {
       switch (apiKey) {
         case '123':
           return APP1

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -3,7 +3,6 @@ import {AppManagementClient} from './developer-platform-client/app-management-cl
 import {PartnersSession} from '../../cli/services/context/partner-account-info.js'
 import {
   MinimalAppIdentifiers,
-  AppApiKeyAndOrgId,
   MinimalOrganizationApp,
   Organization,
   OrganizationApp,
@@ -271,7 +270,7 @@ export interface DeveloperPlatformClient {
    */
   unsafeRefreshToken: () => Promise<string>
   accountInfo: () => Promise<PartnersSession['accountInfo']>
-  appFromIdentifiers: (app: AppApiKeyAndOrgId) => Promise<OrganizationApp | undefined>
+  appFromIdentifiers: (apiKey: string) => Promise<OrganizationApp | undefined>
   organizations: () => Promise<Organization[]>
   orgFromId: (orgId: string) => Promise<Organization | undefined>
   orgAndApps: (orgId: string) => Promise<Paginateable<{organization: Organization; apps: MinimalOrganizationApp[]}>>

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -350,10 +350,9 @@ describe('searching for apps', () => {
 
     // Then
     expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      organizationId: orgId,
       query: ListApps,
       token: 'token',
-      variables: {query: queryVariable},
+      variables: {query: queryVariable, organizationId: orgId},
       unauthorizedHandler: {
         type: 'token_refresh',
         handler: expect.any(Function),
@@ -413,7 +412,6 @@ describe('createApp', () => {
       variables: {},
     })
     expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      organizationId: org.id,
       query: CreateApp,
       token: 'token',
       variables: {
@@ -503,7 +501,6 @@ describe('createApp', () => {
 
     // Then
     expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      organizationId: org.id,
       query: CreateApp,
       token: 'token',
       variables: {
@@ -772,7 +769,6 @@ describe('deploy', () => {
 
     // Then
     expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      organizationId: 'gid://shopify/Organization/123',
       query: expect.anything(),
       token: 'token',
       variables: {
@@ -855,7 +851,6 @@ describe('deploy', () => {
 
     // Then
     expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      organizationId: 'gid://shopify/Organization/123',
       query: expect.anything(),
       token: 'token',
       variables: {
@@ -938,7 +933,6 @@ describe('deploy', () => {
 
     // Then
     expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      organizationId: 'gid://shopify/Organization/123',
       query: expect.anything(),
       token: 'token',
       variables: {
@@ -999,7 +993,6 @@ describe('deploy', () => {
 
     // Then
     expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      organizationId: 'gid://shopify/Organization/123',
       query: expect.anything(),
       token: 'token',
       variables: {
@@ -1053,7 +1046,6 @@ describe('deploy', () => {
 
     // Then
     expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      organizationId: 'gid://shopify/Organization/123',
       query: expect.anything(),
       token: 'token',
       variables: expect.objectContaining({
@@ -1198,7 +1190,6 @@ describe('deploy', () => {
 
     // Then
     expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      organizationId: 'gid://shopify/Organization/123',
       query: AppVersions,
       token: 'token',
       variables: expect.objectContaining({appId}),
@@ -1263,7 +1254,7 @@ describe('AppManagementClient', () => {
 
       const app: MinimalAppIdentifiers = {
         apiKey: 'test-api-key',
-        organizationId: 'test-org-id',
+        organizationId: '213141',
         id: 'test-app-id',
       }
 
@@ -1273,12 +1264,12 @@ describe('AppManagementClient', () => {
 
       // Then
       expect(appManagementRequestDoc).toHaveBeenCalledWith({
-        organizationId: app.organizationId,
         query: CreateAssetUrl,
         token: 'token',
-        variables: expect.objectContaining({
+        variables: {
           sourceExtension: 'BR' as SourceExtension,
-        }),
+          organizationId: 'gid://shopify/Organization/213141',
+        },
         unauthorizedHandler: {
           handler: expect.any(Function),
           type: 'token_refresh',

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -17,7 +17,6 @@ import {
 import {fetchCurrentAccountInformation, PartnersSession} from '../../../cli/services/context/partner-account-info.js'
 import {
   MinimalAppIdentifiers,
-  AppApiKeyAndOrgId,
   MinimalOrganizationApp,
   Organization,
   OrganizationApp,
@@ -285,7 +284,7 @@ export class PartnersClient implements DeveloperPlatformClient {
     return (await this.session()).accountInfo
   }
 
-  async appFromIdentifiers({apiKey}: AppApiKeyAndOrgId): Promise<OrganizationApp | undefined> {
+  async appFromIdentifiers(apiKey: string): Promise<OrganizationApp | undefined> {
     const variables: FindAppQueryVariables = {apiKey}
     const res: FindAppQuerySchema = await this.request(FindAppQuery, variables)
     const app = res.app

--- a/packages/cli-kit/src/public/node/api/app-management.test.ts
+++ b/packages/cli-kit/src/public/node/api/app-management.test.ts
@@ -12,7 +12,7 @@ vi.mock('../context/fqdn.js')
 const mockedResult = 'OK'
 const appManagementFqdnValue = 'shopify.com'
 const orgId = Math.floor(Math.random() * 1000000000000).toString()
-const url = `https://${appManagementFqdnValue}/app_management/unstable/organizations/${orgId}/graphql.json`
+const url = `https://${appManagementFqdnValue}/app_management/unstable/graphql.json`
 
 const mockedToken = 'token'
 
@@ -28,7 +28,6 @@ describe('appManagementRequestDoc', () => {
     // When
     const query = 'query' as unknown as TypedDocumentNode<object, {variables: string}>
     await appManagementRequestDoc({
-      organizationId: orgId,
       query,
       token: mockedToken,
       variables: {variables: 'variables'},
@@ -48,7 +47,7 @@ describe('appManagementRequestDoc', () => {
       token: mockedToken,
       variables: {variables: 'variables'},
       responseOptions: {onResponse: handleDeprecations},
-      cacheOptions: {cacheTTL: {hours: 1}, cacheExtraKey: `1234${orgId}`},
+      cacheOptions: {cacheTTL: {hours: 1}, cacheExtraKey: `1234`},
       preferredBehaviour: 'slow-request',
       unauthorizedHandler: {
         type: 'token_refresh',


### PR DESCRIPTION
### WHY are these changes introduced?

⚠️ Requires https://github.com/shop/world/pull/27672 to be released

Support removing the org_id from the app tomls.

### WHAT is this pull request doing?

- Remove ORG_ID from app managament API URLs.
  Refactor all calls to the app management API to not include the organization ID. 
  Add `organizationId` to the requested fields when fetching an app detail.

- Add ORG_ID as a variable for some queries/mutations
  And update some to include it as part of the variables when the query/mutation is at the org level (like CreateApp),

### How to test your changes?

1. Just use the CLI, check that the flow of creating an app, adding extensions and deploying all works.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes