### PR TITLE
Show a nice error message if user is running node <20

### DIFF
--- a/packages/store/src/commands/store/copy.ts
+++ b/packages/store/src/commands/store/copy.ts
@@ -11,6 +11,7 @@ import {MockApiClient} from '../../services/store/mock/mock-api-client.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {joinPath, cwd} from '@shopify/cli-kit/node/path'
 import {loadHelpClass} from '@oclif/core'
+import {renderError} from '@shopify/cli-kit/node/ui'
 
 export default class Copy extends BaseBDCommand {
   static summary = 'Copy, export, or import store data'
@@ -36,6 +37,7 @@ export default class Copy extends BaseBDCommand {
   }
 
   async runCommand(): Promise<void> {
+    await this.validateNodeVersion()
     this.flags = (await this.parse(Copy)).flags as FlagOptions
 
     if (this.flags.key) {
@@ -76,6 +78,19 @@ export default class Copy extends BaseBDCommand {
         return new StoreImportOperation(bpSession, apiClient)
       default:
         throw new Error(`Unknown operation mode: ${mode}`)
+    }
+  }
+
+  private async validateNodeVersion(): Promise<void> {
+    const nodeVersion = process.versions.node
+    const nodeMajorVersion = Number(nodeVersion.split('.')[0])
+
+    if (nodeMajorVersion < 20) {
+      renderError({
+        headline: 'Update to Node 20 or higher to run `shopify store copy`.',
+        body: [`The \`store copy\` command requires Node 20 or higher. Current Node version: ${nodeMajorVersion}.`],
+      })
+      process.exit(1)
     }
   }
 


### PR DESCRIPTION


### WHY are these changes introduced?

https://github.com/Shopify/workflows-operations/issues/3367

### WHAT is this pull request doing?

Show a nice error if user is running node version <20.

### How to test your changes?

```
nvm install 18
nvm use 18
pnpm shopify store copy [...]
```

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XfVysWF5fmEHlj0h40hJ/c8e9648a-d8f5-4694-a0e3-f408e845ca81.png)
