### PR TITLE
Handle access denied file upload error

### DIFF
--- a/packages/store/src/services/store/errors/errors.test.ts
+++ b/packages/store/src/services/store/errors/errors.test.ts
@@ -225,4 +225,15 @@ describe('Unauthorized Error Codes', () => {
       "You are not authorized to copy data between these stores\n\nTo export data from \"source.myshopify.com\"\n• You'll need the 'bulk data > export' permission\n\nTo import data to \"target.myshopify.com\"\n• You'll need the 'bulk data > import' permission",
     )
   })
+
+  test('should create STAGED_UPLOAD_ACCESS_DENIED error', () => {
+    const error = new OperationError('upload', ErrorCodes.STAGED_UPLOAD_ACCESS_DENIED)
+
+    expect(error).toBeInstanceOf(OperationError)
+    expect(error.operation).toBe('upload')
+    expect(error.code).toBe(ErrorCodes.STAGED_UPLOAD_ACCESS_DENIED)
+    expect(error.message).toBe(
+      "You don't have permission to upload files to this store.\n\nYou'll need the 'bulk data > import' permission to upload files.",
+    )
+  })
 })

--- a/packages/store/src/services/store/errors/errors.ts
+++ b/packages/store/src/services/store/errors/errors.ts
@@ -30,6 +30,7 @@ export const ErrorCodes = {
   UNAUTHORIZED_IMPORT: 'UNAUTHORIZED_IMPORT',
   UNAUTHORIZED_COPY: 'UNAUTHORIZED_COPY',
   MISSING_EA_ACCESS: 'MISSING_EA_ACCESS',
+  STAGED_UPLOAD_ACCESS_DENIED: 'STAGED_UPLOAD_ACCESS_DENIED',
 } as const
 
 interface ErrorParams {
@@ -132,6 +133,8 @@ function generateErrorMessage(code: string, params?: ErrorParams, requestId?: st
       )
     case ErrorCodes.MISSING_EA_ACCESS:
       return `This command is in Early Access and is not yet available for the requested store(s).`
+    case ErrorCodes.STAGED_UPLOAD_ACCESS_DENIED:
+      return `You don't have permission to upload files to this store.\n\nYou'll need the 'bulk data > import' permission to upload files.`
 
     default:
       return 'An error occurred'

--- a/packages/store/src/services/store/utils/file-uploader.test.ts
+++ b/packages/store/src/services/store/utils/file-uploader.test.ts
@@ -177,5 +177,26 @@ describe('FileUploader', () => {
         params: {details: '403 Forbidden. Access denied'},
       })
     })
+
+    test('should throw staged upload access denied error when GraphQL returns ACCESS_DENIED', async () => {
+      const accessDeniedError = {
+        errors: [
+          {
+            message: 'Access denied for stagedUploadsCreate field.',
+            extensions: {
+              code: 'ACCESS_DENIED',
+            },
+          },
+        ],
+      }
+      vi.mocked(createStagedUploadAdmin).mockRejectedValue(accessDeniedError)
+
+      const promise = fileUploader.uploadSqliteFile(mockFilePath, mockStoreFqdn)
+      await expect(promise).rejects.toThrow(OperationError)
+      await expect(promise).rejects.toMatchObject({
+        operation: 'upload',
+        code: ErrorCodes.STAGED_UPLOAD_ACCESS_DENIED,
+      })
+    })
   })
 })


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/workflows-operations/issues/3398

Adds error handling for `file_uploader` to handle `ACCESS_DENIED` errors for stagedUploadCreate. What the error looks like in prod:

<img width="948" height="445" alt="accessdnied" src="https://github.com/user-attachments/assets/0b59cf54-0c24-44f4-bcb2-5a65b17c4094" />


### WHAT is this pull request doing?

Instead of the above, we'll now show this:
<img width="966" height="110" alt="Screenshot 2025-07-21 at 3 46 49 PM" src="https://github.com/user-attachments/assets/b8fd244d-f7b4-45f4-aeca-1cdde7e451df" />

This [PR](https://github.com/shop/world/pull/113293) makes it so that adding `bulk_data` permissions from admin will allow access of stagedUploadCreate for sqlite files for staff members of a shop that aren't shop owners.
### How to test your changes?

Get added to an EA shop but not as owner, make sure you don't have `bulk_data_import` or `bulk_data_export` permissions. Then try running an import e.g. ` pnpm shopify store copy --from-file=test.sqlite --to-store=rusty-development-dev-3`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
