### PR TITLE
Stop loading organization_id from toml and using it to select the client

### DIFF
--- a/packages/app/src/cli/commands/app/init.ts
+++ b/packages/app/src/cli/commands/app/init.ts
@@ -88,7 +88,7 @@ export default class Init extends AppLinkedCommand {
     let appName: string
     if (flags['client-id']) {
       // If a client-id is provided we don't need to prompt the user and can link directly to that app.
-      const selectedApp = await appFromIdentifiers({apiKey: flags['client-id'], developerPlatformClient})
+      const selectedApp = await appFromIdentifiers({apiKey: flags['client-id']})
       appName = selectedApp.title
       developerPlatformClient = selectedApp.developerPlatformClient ?? developerPlatformClient
       selectAppResult = {result: 'existing', app: selectedApp}

--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -689,28 +689,6 @@ describe('allExtensions', () => {
 
     expect(app.allExtensions).toHaveLength(0)
   })
-
-  test('includes configuration extensions when using App Management API, ignoring include_config_on_deploy', async () => {
-    const configuration = {
-      ...CORRECT_CURRENT_APP_SCHEMA,
-      organization_id: '12345',
-      build: {
-        automatically_update_urls_on_dev: true,
-        dev_store_url: 'https://google.com',
-        include_config_on_deploy: false,
-      },
-    }
-    const configExtension = await testAppAccessConfigExtension()
-    const app = testApp(
-      {
-        configuration,
-        allExtensions: [configExtension],
-      },
-      'current',
-    )
-
-    expect(app.allExtensions).toContain(configExtension)
-  })
 })
 
 describe('manifest', () => {

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -80,7 +80,6 @@ function fixSingleWildcards(value: string[] | undefined) {
  */
 export const AppSchema = zod.object({
   client_id: zod.string(),
-  organization_id: zod.string().optional(),
   build: zod
     .object({
       automatically_update_urls_on_dev: zod.boolean().optional(),
@@ -208,7 +207,7 @@ export function appHiddenConfigPath(appDirectory: string) {
  * Get the field names from the configuration that aren't found in the basic built-in app configuration schema.
  */
 export function filterNonVersionedAppFields(configuration: object): string[] {
-  const builtInFieldNames = Object.keys(AppSchema.shape).concat('path')
+  const builtInFieldNames = Object.keys(AppSchema.shape).concat('path', 'organization_id')
   return Object.keys(configuration).filter((fieldName) => {
     return !builtInFieldNames.includes(fieldName)
   })
@@ -406,11 +405,6 @@ export class App<
     )
   }
 
-  get appManagementApiEnabled() {
-    if (isLegacyAppSchema(this.configuration)) return false
-    return this.configuration.organization_id !== undefined
-  }
-
   setDevApplicationURLs(devApplicationURLs: ApplicationURLs) {
     this.patchAppConfiguration(devApplicationURLs)
     this.realExtensions.forEach((ext) => ext.patchWithAppDevURLs(devApplicationURLs))
@@ -552,8 +546,7 @@ export class App<
 
   get includeConfigOnDeploy() {
     if (isLegacyAppSchema(this.configuration)) return false
-    if (this.appManagementApiEnabled) return true
-    return this.configuration.build?.include_config_on_deploy
+    return this.configuration.build?.include_config_on_deploy ?? true
   }
 
   private patchAppConfiguration(devApplicationURLs: ApplicationURLs) {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -684,7 +684,7 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
     const unusedKeys = Object.keys(appConfiguration)
       .filter((key) => !extensionInstancesWithKeys.some(([_, keys]) => keys.includes(key)))
       .filter((key) => {
-        const configKeysThatAreNeverModules = [...Object.keys(AppSchema.shape), 'path']
+        const configKeysThatAreNeverModules = [...Object.keys(AppSchema.shape), 'path', 'organization_id']
         return !configKeysThatAreNeverModules.includes(key)
       })
 

--- a/packages/app/src/cli/services/app-context.ts
+++ b/packages/app/src/cli/services/app-context.ts
@@ -88,11 +88,10 @@ export async function linkedAppContext({
 
   // Fetch the remote app, using a different clientID if provided via flag.
   // Then update the current developerPlatformClient with the one from the remoteApp
-  let developerPlatformClient = selectDeveloperPlatformClient({configuration: configState.basicConfiguration})
+  let developerPlatformClient = selectDeveloperPlatformClient()
   if (!remoteApp) {
     const apiKey = configState.basicConfiguration.client_id
-    const organizationId = configState.basicConfiguration.organization_id
-    remoteApp = await appFromIdentifiers({apiKey, developerPlatformClient, organizationId})
+    remoteApp = await appFromIdentifiers({apiKey})
   }
   developerPlatformClient = remoteApp.developerPlatformClient ?? developerPlatformClient
 

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -378,7 +378,11 @@ describe('deploy', () => {
   test('doesnt push the configuration extension if include config on deploy is disabled', async () => {
     // Given
     const extensionNonUuidManaged = await testAppConfigExtensions()
-    const app = testAppLinked({allExtensions: [extensionNonUuidManaged]})
+    const localApp = {
+      allExtensions: [extensionNonUuidManaged],
+      configuration: {...DEFAULT_CONFIG, build: {include_config_on_deploy: false}},
+    }
+    const app = testAppLinked(localApp)
     const commitReference = 'https://github.com/deploytest/repo/commit/d4e5ce7999242b200acde378654d62c14b211bcc'
 
     // When

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -58,7 +58,7 @@ describe('fetchOrganizations', async () => {
     const got = await fetchOrganizations()
 
     // Then
-    expect(got).toEqual([ORG1, ORG2])
+    expect(got).toEqual([ORG2, ORG1])
     expect(partnersClient.organizations).toHaveBeenCalled()
     expect(appManagementClient.organizations).toHaveBeenCalled()
   })

--- a/packages/app/src/cli/services/generate.test.ts
+++ b/packages/app/src/cli/services/generate.test.ts
@@ -12,8 +12,6 @@ import {
 } from '../models/app/app.test-data.js'
 import {ExtensionInstance} from '../models/extensions/extension-instance.js'
 import generateExtensionPrompts from '../prompts/generate/extension.js'
-import * as developerPlatformClient from '../utilities/developer-platform-client.js'
-import {PartnersClient} from '../utilities/developer-platform-client/partners-client.js'
 import {AppLinkedInterface} from '../models/app/app.js'
 import {OrganizationApp} from '../models/organization.js'
 import {RemoteAwareExtensionSpecification} from '../models/extensions/specification.js'
@@ -40,13 +38,6 @@ vi.mock('../prompts/generate/extension.js')
 vi.mock('../services/generate/extension.js')
 vi.mock('../services/context.js')
 vi.mock('./local-storage.js')
-
-beforeEach(() => {
-  // Never bother loading the app just to get a platform client
-  vi.spyOn(developerPlatformClient, 'sniffServiceOptionsAndAppConfigToSelectPlatformClient').mockResolvedValue(
-    new PartnersClient(),
-  )
-})
 
 afterEach(() => {
   mockAndCaptureOutput().clear()

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -43,8 +43,7 @@ import {
 } from '../api/graphql/extension_migrate_to_ui_extension.js'
 import {RemoteSpecification} from '../api/graphql/extension_specifications.js'
 import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../api/graphql/extension_migrate_app_module.js'
-import {AppConfiguration, AppManifest, isCurrentAppSchema} from '../models/app/app.js'
-import {loadAppConfiguration} from '../models/app/loader.js'
+import {AppManifest} from '../models/app/app.js'
 import {
   ExtensionUpdateDraftMutation,
   ExtensionUpdateDraftMutationVariables,
@@ -72,7 +71,6 @@ export type Paginateable<T> = T & {
 }
 
 interface SelectDeveloperPlatformClientOptions {
-  configuration?: AppConfiguration | undefined
   organization?: Organization
 }
 
@@ -83,62 +81,25 @@ export interface AppVersionIdentifiers {
 
 export function allDeveloperPlatformClients(): DeveloperPlatformClient[] {
   const clients: DeveloperPlatformClient[] = []
+
+  clients.push(new AppManagementClient())
+
   if (!blockPartnersAccess()) {
     clients.push(new PartnersClient())
   }
 
-  clients.push(new AppManagementClient())
   return clients
 }
 
-/**
- * Attempts to load an app's configuration in order to select a developer platform client.
- *
- * The provided options are a subset of what is common across most services.
- *
- * @param directory - The working directory for this command (possibly via `--path`)
- * @param configName - An optional configuration file name to force, provided by the developer
- * @param developerPlatformClient - An optional developer platform client to use, forced by the developer
- */
-export async function sniffServiceOptionsAndAppConfigToSelectPlatformClient(options: {
-  directory: string
-  configName?: string
-  developerPlatformClient?: DeveloperPlatformClient
-}): Promise<DeveloperPlatformClient> {
-  if (options.developerPlatformClient) {
-    return options.developerPlatformClient
-  }
-  try {
-    const {configuration} = await loadAppConfiguration({
-      ...options,
-      userProvidedConfigName: options.configName,
-    })
-    const developerPlatformClient = selectDeveloperPlatformClient({configuration})
-    return developerPlatformClient
-    // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch (error) {
-    // If the app is invalid, we really don't care at this point. This function is purely responsible for selecting
-    // a client.
-    return new PartnersClient()
-  }
-}
-
 export function selectDeveloperPlatformClient({
-  configuration,
   organization,
 }: SelectDeveloperPlatformClientOptions = {}): DeveloperPlatformClient {
   if (organization) return selectDeveloperPlatformClientByOrg(organization)
-  return selectDeveloperPlatformClientByConfig(configuration)
+  return new PartnersClient()
 }
 
 function selectDeveloperPlatformClientByOrg(organization: Organization): DeveloperPlatformClient {
   if (organization.source === OrganizationSource.BusinessPlatform) return new AppManagementClient()
-  return new PartnersClient()
-}
-
-function selectDeveloperPlatformClientByConfig(configuration: AppConfiguration | undefined): DeveloperPlatformClient {
-  if (!configuration || (isCurrentAppSchema(configuration) && configuration.organization_id))
-    return new AppManagementClient()
   return new PartnersClient()
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Support removing the ORG_ID from the apps toml.
This PR actually stops loading it.


### WHAT is this pull request doing?

- Removes the `organization_id` field from the app schema (we won't load it anymore)
- Set `includeConfigOnDeploy` to true by default if not specified already in the config. In preparation for the migration where it will be true always.
- Updates the `appFromIdentifiers` function, now it will try to fetch the app from all clients and return the first that succeeds. 
- Other simplifications and clean ups.

### How to test your changes?

1. Just make sure everything still works, creating an app, adding extensions, deploying... in both a partners app and a dev dash app.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes