### PR TITLE
Make developerPlatformClient not optional in OrganizationApp

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -201,6 +201,7 @@ export function testOrganizationApp(app: Partial<OrganizationApp> = {}): Organiz
     grantedScopes: [],
     disabledFlags: ['5b25141b'],
     flags: [],
+    developerPlatformClient: testDeveloperPlatformClient(),
   }
   return {...defaultApp, ...app}
 }

--- a/packages/app/src/cli/models/organization.ts
+++ b/packages/app/src/cli/models/organization.ts
@@ -49,7 +49,7 @@ export type OrganizationApp = MinimalOrganizationApp & {
   }
   configuration?: AppConfigurationUsedByCli
   flags: Flag[]
-  developerPlatformClient?: DeveloperPlatformClient
+  developerPlatformClient: DeveloperPlatformClient
 }
 
 export interface OrganizationStore {

--- a/packages/app/src/cli/services/app-context.ts
+++ b/packages/app/src/cli/services/app-context.ts
@@ -6,7 +6,7 @@ import {fetchOrgFromId} from './dev/fetch.js'
 import {addUidToTomlsIfNecessary} from './app/add-uid-to-extension-toml.js'
 import {loadLocalExtensionsSpecifications} from '../models/extensions/load-specifications.js'
 import {Organization, OrganizationApp, OrganizationSource} from '../models/organization.js'
-import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../utilities/developer-platform-client.js'
+import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {getAppConfigurationState, loadAppUsingConfigurationState, loadApp} from '../models/app/loader.js'
 import {RemoteAwareExtensionSpecification} from '../models/extensions/specification.js'
 import {AppLinkedInterface, AppInterface} from '../models/app/app.js'
@@ -87,13 +87,11 @@ export async function linkedAppContext({
   }
 
   // Fetch the remote app, using a different clientID if provided via flag.
-  // Then update the current developerPlatformClient with the one from the remoteApp
-  let developerPlatformClient = selectDeveloperPlatformClient()
   if (!remoteApp) {
     const apiKey = configState.basicConfiguration.client_id
     remoteApp = await appFromIdentifiers({apiKey})
   }
-  developerPlatformClient = remoteApp.developerPlatformClient ?? developerPlatformClient
+  const developerPlatformClient = remoteApp.developerPlatformClient
 
   const organization = await fetchOrgFromId(remoteApp.organizationId, developerPlatformClient)
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -22,12 +22,7 @@ import {
   appFromIdentifiers,
   InvalidApiKeyErrorMessage,
 } from '../../context.js'
-import {
-  Flag,
-  DeveloperPlatformClient,
-  CreateAppOptions,
-  selectDeveloperPlatformClient,
-} from '../../../utilities/developer-platform-client.js'
+import {Flag, DeveloperPlatformClient, CreateAppOptions} from '../../../utilities/developer-platform-client.js'
 import {configurationFileNames} from '../../../constants.js'
 import {writeAppConfigurationFile} from '../write-app-configuration-file.js'
 import {getCachedCommandInfo} from '../../local-storage.js'
@@ -131,8 +126,6 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
   const {creationOptions, appDirectory: possibleAppDirectory} = await getAppCreationDefaultsFromLocalApp(options)
   const appDirectory = possibleAppDirectory ?? options.directory
 
-  const defaultDeveloperPlatformClient = selectDeveloperPlatformClient()
-
   if (options.apiKey) {
     // Remote API Key provided by the caller, so use that app specifically
     const remoteApp = await appFromIdentifiers({apiKey: options.apiKey})
@@ -145,13 +138,13 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
     return {
       remoteApp,
       appDirectory,
-      developerPlatformClient: remoteApp.developerPlatformClient ?? defaultDeveloperPlatformClient,
+      developerPlatformClient: remoteApp.developerPlatformClient,
     }
   }
 
   const remoteApp = await fetchOrCreateOrganizationApp({...creationOptions, directory: appDirectory})
 
-  const developerPlatformClient = remoteApp.developerPlatformClient ?? defaultDeveloperPlatformClient
+  const developerPlatformClient = remoteApp.developerPlatformClient
 
   return {
     remoteApp,

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -284,7 +284,6 @@ export async function fetchOrCreateOrganizationApp(options: CreateAppOptions): P
   const developerPlatformClient = selectDeveloperPlatformClient({organization: org})
   const {organization, apps, hasMorePages} = await developerPlatformClient.orgAndApps(org.id)
   const remoteApp = await selectOrCreateApp(apps, hasMorePages, organization, developerPlatformClient, options)
-  remoteApp.developerPlatformClient = developerPlatformClient
 
   await logMetadataForLoadedContext(remoteApp, developerPlatformClient.organizationSource)
 

--- a/packages/app/src/cli/services/context/breakdown-extensions.test.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.test.ts
@@ -427,8 +427,8 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
           toCreate: [],
-          toUpdate: [buildExtensionBreakdownInfo('EXTENSION_A'), buildExtensionBreakdownInfo('extension-a-2')],
-          unchanged: [],
+          unchanged: [buildExtensionBreakdownInfo('EXTENSION_A'), buildExtensionBreakdownInfo('extension-a-2')],
+          toUpdate: [],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,

--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -328,8 +328,8 @@ function loadLocalExtensionsIdentifiersBreakdown({
   return {
     onlyRemote: [] as ExtensionIdentifierBreakdownInfo[],
     toCreate: [] as ExtensionIdentifierBreakdownInfo[],
-    unchanged: [] as ExtensionIdentifierBreakdownInfo[],
-    toUpdate: [...identifiersToUpdate, ...identifiersToCreate, ...dashboardToUpdate],
+    toUpdate: [] as ExtensionIdentifierBreakdownInfo[],
+    unchanged: [...identifiersToUpdate, ...identifiersToCreate, ...dashboardToUpdate],
   }
 }
 

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -143,6 +143,7 @@ describe('setup-dev-processes', () => {
       organizationId: '5678',
       grantedScopes: [],
       flags: [],
+      developerPlatformClient,
     }
 
     const graphiqlKey = 'somekey'
@@ -332,6 +333,7 @@ describe('setup-dev-processes', () => {
       organizationId: '5678',
       grantedScopes: [],
       flags: [],
+      developerPlatformClient,
     }
 
     const res = await setupDevProcesses({
@@ -426,6 +428,7 @@ describe('setup-dev-processes', () => {
       organizationId: '5678',
       grantedScopes: [],
       flags: [],
+      developerPlatformClient,
     }
 
     const graphiqlKey = 'somekey'
@@ -522,6 +525,7 @@ describe('setup-dev-processes', () => {
       organizationId: '5678',
       grantedScopes: [],
       flags: [],
+      developerPlatformClient,
     }
 
     const graphiqlKey = 'somekey'
@@ -617,6 +621,7 @@ describe('setup-dev-processes', () => {
       organizationId: '5678',
       grantedScopes: [],
       flags: [],
+      developerPlatformClient,
     }
 
     const graphiqlKey = 'somekey'

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
@@ -61,7 +61,9 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
     const storeFqdn = 'test.myshopify.com'
     const theme = '123'
     // Regular Partners API app
-    const remoteApp = testOrganizationApp()
+    const remoteApp = testOrganizationApp({
+      developerPlatformClient: testDeveloperPlatformClient({clientName: ClientName.Partners}),
+    })
     const localApp = testApp({allExtensions: [await testThemeExtensions()]})
 
     // When

--- a/packages/app/src/cli/services/import-extensions.test.ts
+++ b/packages/app/src/cli/services/import-extensions.test.ts
@@ -21,6 +21,7 @@ const organizationApp: OrganizationApp = {
   apiSecretKeys: [],
   grantedScopes: [],
   flags: [],
+  developerPlatformClient: testDeveloperPlatformClient(),
 }
 
 const flowExtensionA: ExtensionRegistration = {

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -28,6 +28,7 @@ const APP: OrganizationApp = {
   redirectUrlWhitelist: [],
   apiSecretKeys: [],
   flags: [],
+  developerPlatformClient: testDeveloperPlatformClient(),
 }
 
 beforeEach(() => {


### PR DESCRIPTION
### WHY are these changes introduced?

Support the project to remove ORG_ID from app tomls.

### WHAT is this pull request doing?

Changes the `developerPlatformClient` property on the `OrganizationApp` type from optional to required, and updates all relevant code to ensure this property is always provided. This eliminates the need for fallback logic when accessing the developer platform client.

### How to test your changes?

1. Just make sure the CLI works, creating an app, adding extensions, deploying...

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes