### PR TITLE
Fetch management_experience from App Management API

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/active-app-release-from-api-key.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/active-app-release-from-api-key.ts
@@ -22,7 +22,7 @@ export type ActiveAppReleaseFromApiKeyQuery = {
           userIdentifier: string
           handle: string
           config: JsonMapType
-          specification: {identifier: string; externalIdentifier: string; name: string}
+          specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
         }[]
       }
     }
@@ -88,6 +88,7 @@ export const ActiveAppReleaseFromApiKey = {
                 {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'managementExperience'}},
               ],
             },
           },

--- a/packages/app/src/cli/api/graphql/app-management/generated/active-app-release.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/active-app-release.ts
@@ -22,7 +22,7 @@ export type ActiveAppReleaseQuery = {
           userIdentifier: string
           handle: string
           config: JsonMapType
-          specification: {identifier: string; externalIdentifier: string; name: string}
+          specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
         }[]
       }
     }
@@ -42,7 +42,7 @@ export type AppVersionInfoFragment = {
         userIdentifier: string
         handle: string
         config: JsonMapType
-        specification: {identifier: string; externalIdentifier: string; name: string}
+        specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
       }[]
     }
   }
@@ -53,7 +53,7 @@ export type ReleasedAppModuleFragment = {
   userIdentifier: string
   handle: string
   config: JsonMapType
-  specification: {identifier: string; externalIdentifier: string; name: string}
+  specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
 }
 
 export const ReleasedAppModuleFragmentDoc = {
@@ -79,6 +79,7 @@ export const ReleasedAppModuleFragmentDoc = {
                 {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'managementExperience'}},
               ],
             },
           },
@@ -176,6 +177,7 @@ export const AppVersionInfoFragmentDoc = {
                 {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'managementExperience'}},
               ],
             },
           },
@@ -242,6 +244,7 @@ export const ActiveAppRelease = {
                 {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'managementExperience'}},
               ],
             },
           },

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-id.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-id.ts
@@ -17,7 +17,7 @@ export type AppVersionByIdQuery = {
       userIdentifier: string
       handle: string
       config: JsonMapType
-      specification: {identifier: string; externalIdentifier: string; name: string}
+      specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
     }[]
   }
 }
@@ -30,7 +30,7 @@ export type VersionInfoFragment = {
     userIdentifier: string
     handle: string
     config: JsonMapType
-    specification: {identifier: string; externalIdentifier: string; name: string}
+    specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
   }[]
 }
 
@@ -87,6 +87,7 @@ export const VersionInfoFragmentDoc = {
                 {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'managementExperience'}},
               ],
             },
           },
@@ -153,6 +154,7 @@ export const AppVersionById = {
                 {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'managementExperience'}},
               ],
             },
           },

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
@@ -17,7 +17,7 @@ export type AppVersionByTagQuery = {
       userIdentifier: string
       handle: string
       config: JsonMapType
-      specification: {identifier: string; externalIdentifier: string; name: string}
+      specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
     }[]
   }
 }
@@ -80,6 +80,7 @@ export const AppVersionByTag = {
                 {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'managementExperience'}},
               ],
             },
           },

--- a/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
@@ -19,7 +19,7 @@ export type CreateAppVersionMutation = {
         userIdentifier: string
         handle: string
         config: JsonMapType
-        specification: {identifier: string; externalIdentifier: string; name: string}
+        specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
       }[]
       metadata: {versionTag?: string | null; message?: string | null}
     } | null
@@ -159,6 +159,7 @@ export const CreateAppVersion = {
                 {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'managementExperience'}},
               ],
             },
           },

--- a/packages/app/src/cli/api/graphql/app-management/queries/active-app-release.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/active-app-release.graphql
@@ -34,5 +34,6 @@ fragment ReleasedAppModule on AppModule {
     identifier
     externalIdentifier
     name
+    managementExperience
   }
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -564,6 +564,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
     const configurationRegistrations: ExtensionRegistration[] = []
     const extensionRegistrations: ExtensionRegistration[] = []
+    const dashboardManagedExtensionRegistrations: ExtensionRegistration[] = []
     app.appModuleVersions.forEach((mod) => {
       const registration = {
         id: mod.registrationId,
@@ -575,11 +576,14 @@ export class AppManagementClient implements DeveloperPlatformClient {
         configurationRegistrations.push(registration)
       } else {
         extensionRegistrations.push(registration)
+        if (mod.specification?.options?.managementExperience === 'dashboard') {
+          dashboardManagedExtensionRegistrations.push(registration)
+        }
       }
     })
     return {
       app: {
-        dashboardManagedExtensionRegistrations: [],
+        dashboardManagedExtensionRegistrations,
         configurationRegistrations,
         extensionRegistrations,
       },
@@ -1313,7 +1317,7 @@ function appModuleVersion(mod: ReleasedAppModuleFragment): Required<AppModuleVer
     specification: {
       ...mod.specification,
       identifier: mod.specification.identifier,
-      options: {managementExperience: 'cli'},
+      options: {managementExperience: mod.specification.managementExperience as 'cli' | 'custom' | 'dashboard'},
       experience: experience(mod.specification.identifier),
     },
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/shop/issues-develop/issues/469

When fetching the active app release with its extensions, we were incorrectly assuming all of them were cli managed.

### WHAT is this pull request doing?

⚠️ This PR requires https://github.com/shop/world/pull/115323 to be released first

Uses the new management_experience field from the API to find out the dashboard managed extensions.

### How to test your changes?

- `p shopify app import extensions` with App Management API

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
