### PR TITLE
Provide error when using non-theme access app password

### DIFF
--- a/.changeset/gorgeous-students-work.md
+++ b/.changeset/gorgeous-students-work.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Provide error when using non-theme access app password

--- a/packages/theme/src/cli/flags.ts
+++ b/packages/theme/src/cli/flags.ts
@@ -1,5 +1,6 @@
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 
 /**
@@ -17,6 +18,13 @@ export const themeFlags = {
   password: Flags.string({
     description: 'Password generated from the Theme Access app.',
     env: 'SHOPIFY_CLI_THEME_TOKEN',
+    parse: async (input) => {
+      if (input.startsWith('shptka_')) {
+        return input
+      }
+
+      throw new AbortError('Invalid password. Please generate a new password from the Theme Access app.')
+    },
   }),
   store: Flags.string({
     char: 's',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/6131

### WHAT is this pull request doing?

- When folks use non-Theme Access App passwords, we need to let them know this isn't valid

### How to test your changes?

Try passing in password from a private app to see the error:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7Aw7RUiAwv4C9dQHD64L/40396572-be28-46c9-a8a7-213e817be23e.png)

Not the biggest fan of how the error is formatted, but that's pretty standard for `AbortError` in CLI.

1. Pass in password using flag

```
npx shopify theme dev --password <non-taa-pwd>
```

2. Pass in password using env var
```
SHOPIFY_CLI_THEME_TOKEN=<non-taa-password> npx shopify theme dev
```

3. Pass in password using toml file
    - Create `shopify.theme.toml` with non-taa password
    - Run `npx shopify theme dev`



### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
