### PR TITLE
Allow theme rename command to be called with multiple environments

### DIFF
--- a/.changeset/great-dragons-float.md
+++ b/.changeset/great-dragons-float.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme': minor
+'@shopify/cli': minor
+---
+
+Allow theme rename command to be run with multiple environments

--- a/.changeset/wet-lions-cross.md
+++ b/.changeset/wet-lions-cross.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme': minor
+'@shopify/cli': minor
+---
+
+Allow commands run with multiple environments to require "one of" a list of flags

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6762,6 +6762,16 @@
       "hiddenAliases": [
       ],
       "id": "theme:rename",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "name",
+        [
+          "live",
+          "development",
+          "theme"
+        ]
+      ],
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",

--- a/packages/theme/src/cli/commands/theme/rename.ts
+++ b/packages/theme/src/cli/commands/theme/rename.ts
@@ -1,11 +1,9 @@
-import ThemeCommand from '../../utilities/theme-command.js'
-import {RenameOptions, renameTheme} from '../../services/rename.js'
-import {ensureThemeStore} from '../../utilities/theme-store.js'
+import ThemeCommand, {RequiredFlags} from '../../utilities/theme-command.js'
 import {themeFlags} from '../../flags.js'
+import {RenameOptions, renameTheme} from '../../services/rename.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
-import {promptThemeName} from '@shopify/cli-kit/node/themes/utils'
+import {AdminSession} from '@shopify/cli-kit/node/session'
 
 export default class Rename extends ThemeCommand {
   static summary = 'Renames an existing theme.'
@@ -43,21 +41,9 @@ export default class Rename extends ThemeCommand {
     }),
   }
 
-  public async run(): Promise<void> {
-    const {flags} = await this.parse(Rename)
-    const {password, development, name, theme, live} = flags
+  static multiEnvironmentsFlags: RequiredFlags = ['store', 'password', 'name', ['live', 'development', 'theme']]
 
-    const store = ensureThemeStore(flags)
-    const adminSession = await ensureAuthenticatedThemes(store, password)
-    const newName = name || (await promptThemeName('New name for the theme'))
-
-    const renameOptions: RenameOptions = {
-      newName,
-      development,
-      theme,
-      live,
-    }
-
-    await renameTheme(adminSession, renameOptions)
+  async command(flags: RenameOptions, adminSession: AdminSession) {
+    await renameTheme(flags, adminSession)
   }
 }

--- a/packages/theme/src/cli/services/rename.test.ts
+++ b/packages/theme/src/cli/services/rename.test.ts
@@ -23,7 +23,7 @@ const developmentTheme = {
 
 const options: RenameOptions = {
   development: false,
-  newName: 'Renamed Theme',
+  name: 'Renamed Theme',
   live: false,
 }
 
@@ -33,10 +33,10 @@ describe('renameTheme', () => {
     vi.mocked(findOrSelectTheme).mockResolvedValue(developmentTheme)
 
     // When
-    await renameTheme(adminSession, {...options, development: true})
+    await renameTheme({...options, development: true}, adminSession)
 
     // Then
-    expect(themeUpdate).toBeCalledWith(developmentTheme.id, {name: options.newName}, adminSession)
+    expect(themeUpdate).toBeCalledWith(developmentTheme.id, {name: options.name}, adminSession)
     expect(renderSuccess).toBeCalledWith({
       body: ['The theme', "'my development theme'", {subdued: '(#1)'}, 'was renamed to', "'Renamed Theme'"],
     })
@@ -52,10 +52,10 @@ describe('renameTheme', () => {
     vi.mocked(findOrSelectTheme).mockResolvedValue(theme1)
 
     // When
-    await renameTheme(adminSession, {...options, theme: '2'})
+    await renameTheme({...options, theme: '2'}, adminSession)
 
     // Then
-    expect(themeUpdate).toBeCalledWith(theme1.id, {name: options.newName}, adminSession)
+    expect(themeUpdate).toBeCalledWith(theme1.id, {name: options.name}, adminSession)
     expect(renderSuccess).toBeCalledWith({
       body: ['The theme', "'my theme'", {subdued: '(#2)'}, 'was renamed to', "'Renamed Theme'"],
     })
@@ -71,10 +71,10 @@ describe('renameTheme', () => {
     vi.mocked(findOrSelectTheme).mockResolvedValue(theme1)
 
     // When
-    await renameTheme(adminSession, {...options, live: true})
+    await renameTheme({...options, live: true}, adminSession)
 
     // Then
-    expect(themeUpdate).toBeCalledWith(theme1.id, {name: options.newName}, adminSession)
+    expect(themeUpdate).toBeCalledWith(theme1.id, {name: options.name}, adminSession)
     expect(renderSuccess).toBeCalledWith({
       body: ['The theme', "'live theme'", {subdued: '(#2)'}, 'was renamed to', "'Renamed Theme'"],
     })

--- a/packages/theme/src/cli/services/rename.ts
+++ b/packages/theme/src/cli/services/rename.ts
@@ -3,15 +3,19 @@ import {themeComponent} from '../utilities/theme-ui.js'
 import {themeUpdate} from '@shopify/cli-kit/node/themes/api'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
+import {promptThemeName} from '@shopify/cli-kit/node/themes/utils'
 
 export interface RenameOptions {
-  newName: string
+  name?: string
   development?: boolean
   theme?: string
   live?: boolean
+  environment?: string
 }
 
-export async function renameTheme(adminSession: AdminSession, options: RenameOptions) {
+export async function renameTheme(options: RenameOptions, adminSession: AdminSession) {
+  const newName = options.name || (await promptThemeName('New name for the theme'))
+
   const theme = await findOrSelectTheme(adminSession, {
     header: 'Select a theme to rename',
     filter: {
@@ -20,8 +24,16 @@ export async function renameTheme(adminSession: AdminSession, options: RenameOpt
       live: options.live,
     },
   })
-  await themeUpdate(theme.id, {name: options.newName}, adminSession)
+
+  await themeUpdate(theme.id, {name: newName}, adminSession)
+
   renderSuccess({
-    body: ['The theme', ...themeComponent(theme), 'was renamed to', `'${options.newName}'`],
+    body: [
+      ...(options.environment ? [{subdued: `Environment: ${options.environment}\n\n`}] : []),
+      'The theme',
+      ...themeComponent(theme),
+      'was renamed to',
+      `'${newName}'`,
+    ],
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Previously `theme rename` command could only be run with a single `--environment` flag. This PR allows `rename` to be used in multiple environments in a single command run. 

Since multi environment commands must run without interactions we need to define which flags are required to run the command. In some cases a command will provide a few different flags that all meet the same requirement, so this PR also updates validation logic to accept "one of" required flags. 

For example: `rename` requires `store`, `password`, `name`, and one of: `live`, `theme`, or `development` (since `rename` can use any of the three to understand what to rename)

### WHAT is this pull request doing?

- Updates environment validation logic to understand "one of" flag requirements
- Removes flag parsing and auth from `Rename` in favour of `ThemeCommand`'s `run` logic
- Prefixes output with the environment name, when present

https://github.com/user-attachments/assets/f9cbbe15-c474-45e2-85de-954d0cf793bd

### How to test your changes?

- Pull down the branch `gh pr checkout 6161` or install the snapit version
```sh
pnpm i -g @shopify/cli@0.0.0-snapshot-20250724234104 --@shopify:registry=https://registry.npmjs.org
```
- Add a `shopify.theme.toml` file

<details><summary>Example toml</summary>

```
[environments.store1]
theme = "<theme>"
store = "<store>"
password  = "<shptka_password>"

[environments.store2]
theme = "<theme>"
store = "<store>"
password  = "<shptka_password>"
```

</details> 

```ts
shopify theme rename -e store1 -e store2 -n "Summer Edition" --live
```
- Rename should accept flags from both CLI and `shopify.theme.toml`
- Rename run with a single environment or no environment should work as normal
- Since rename does not allow `--force` flag, no confirmation prompt should be shown. If you manually added `force` to flags to test confirmations, missing a "one of" flag would look like: 

<details><summary>Confirmation prompt</summary>

<img width="824" height="348" alt="confirmation-prompt" src="https://github.com/user-attachments/assets/81990074-4e74-49e2-a3cf-94f272abfa89" />

</details> 

- Environments missing flags should display a warning and it's theme shouldn't be renamed
- Environments with incorrect flags (ex. password = "fake") should have the environment name prefixed to the error message


> If provided both `live` and `theme`, `findOrSelectTheme` would choose role > theme (same as current single or no env runs)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
