### PR TITLE
Update casing on 'operation' during copy operation banner

### DIFF
--- a/packages/store/src/services/store/operations/store-copy.test.ts
+++ b/packages/store/src/services/store/operations/store-copy.test.ts
@@ -87,7 +87,7 @@ describe('StoreCopyOperation', () => {
       await operation.execute('source.myshopify.com', 'target.myshopify.com', {})
 
       expect(confirmCopyPrompt).toHaveBeenCalledWith('source.myshopify.com', 'target.myshopify.com')
-      expect(renderCopyInfo).toHaveBeenCalledWith('Copy Operation', 'source.myshopify.com', 'target.myshopify.com')
+      expect(renderCopyInfo).toHaveBeenCalledWith('Copy operation', 'source.myshopify.com', 'target.myshopify.com')
       expect(renderCopyResult).toHaveBeenCalledWith(
         'source.myshopify.com',
         'target.myshopify.com',

--- a/packages/store/src/services/store/operations/store-copy.ts
+++ b/packages/store/src/services/store/operations/store-copy.ts
@@ -40,7 +40,7 @@ export class StoreCopyOperation implements StoreOperation {
       }
     }
 
-    renderCopyInfo('Copy Operation', sourceShopDomain, targetShopDomain)
+    renderCopyInfo('Copy operation', sourceShopDomain, targetShopDomain)
 
     const copyOperation = await this.copyDataWithProgress(
       apiShopId,


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure consistent capitalization in the copy operation message. Closes https://github.com/Shopify/workflows-operations/issues/3413#issue-3263903501

### WHAT is this pull request doing?

Changes the capitalization of "Copy Operation" to "Copy operation" in the `renderCopyInfo` function call to maintain consistent styling in user-facing messages.

### How to test your changes?

1. Run a store copy operation
2. Verify that the message displays "Copy operation" with lowercase "o"
3. Ensure the functionality of the copy operation remains unchanged

| Before | After |
|----------|----------|
|  ![Screenshot 2025-07-25 at 1.13.51 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/VqqHovG3hmKnoZC4I5sl/3011dcd9-dfb2-49e1-a237-fd321cffd673.png) | ![Screenshot 2025-07-25 at 1.18.46 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/VqqHovG3hmKnoZC4I5sl/ab7d4245-9de9-401d-97d6-32b60c9fe0eb.png) |
### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes