### PR TITLE
Removed workflows folder when cloning skeleton theme

### DIFF
--- a/.changeset/four-rabbits-occur.md
+++ b/.changeset/four-rabbits-occur.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Removed workflows folder in .github when cloning skeleton theme

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -1,7 +1,7 @@
 import {renderSelectPrompt, renderTasks} from '@shopify/cli-kit/node/ui'
 import {downloadGitRepository, removeGitRemote} from '@shopify/cli-kit/node/git'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {mkdir, writeFile} from '@shopify/cli-kit/node/fs'
+import {mkdir, writeFile, rmdir, fileExists} from '@shopify/cli-kit/node/fs'
 import {fetch} from '@shopify/cli-kit/node/http'
 
 export async function cloneRepo(repoUrl: string, destination: string) {
@@ -24,9 +24,18 @@ async function downloadRepository(repoUrl: string, destination: string, latestTa
           shallow: true,
         })
         await removeGitRemote(destination)
+        await removeSkeletonGitHubFolder(destination)
       },
     },
   ])
+}
+
+async function removeSkeletonGitHubFolder(destination: string) {
+  const githubDir = joinPath(destination, '.github')
+
+  if (await fileExists(githubDir)) {
+    await rmdir(githubDir)
+  }
 }
 
 export async function promptAndCreateAIFile(destination: string) {


### PR DESCRIPTION
### WHY are these changes introduced?

When you run `theme init` it includes the `.github/workflows` folder that has theme check and the CLA agreement. If you push your skeleton theme to your own repo, it's trying to run those workflows.

### WHAT is this pull request doing?

After cloning the repo, we discard the `.github` folder. It will still be created if a user chooses to have the Copilot AI file.

### How to test your changes?
- Pull down the branch
- Build the branch
- Run `theme init` and look for the absence of the `.github` folder
- Bonus: Run `theme init` and when prompted for AI dev support, choose `VSCode` and check if a `.github` folder is still made along with the AI file.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
