### PR TITLE
Fix: Allow compliance webhooks with legacy install flow

### DIFF
--- a/.changeset/compliance-webhooks-legacy-flow.md
+++ b/.changeset/compliance-webhooks-legacy-flow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix validation to allow compliance webhooks with legacy install flow

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -580,7 +580,10 @@ export class App<
   private validateWebhookLegacyFlowCompatibility(): void {
     if (!isCurrentAppSchema(this.configuration)) return
 
-    const hasAppSpecificWebhooks = (this.configuration.webhooks?.subscriptions?.length ?? 0) > 0
+    const hasAppSpecificWebhooks =
+      this.configuration.webhooks?.subscriptions?.some(
+        (subscription) => subscription.topics && subscription.topics.length > 0,
+      ) ?? false
     const usesLegacyInstallFlow = this.configuration.access_scopes?.use_legacy_install_flow === true
 
     if (hasAppSpecificWebhooks && usesLegacyInstallFlow) {


### PR DESCRIPTION
Patch version of https://github.com/Shopify/cli/pull/6108