### PR TITLE
Fix import-extensions post migration

### DIFF
--- a/packages/app/src/cli/services/fetch-extensions.ts
+++ b/packages/app/src/cli/services/fetch-extensions.ts
@@ -26,9 +26,7 @@ export async function getExtensions({
 
   return extensionsToFilter.filter((ext) => {
     const isNeededExtensionType = extensionTypes.includes(ext.type.toLowerCase())
-    const hasActiveVersion = developerPlatformClient.supportsDashboardManagedExtensions
-      ? ext.activeVersion && ext.activeVersion.config
-      : true
+    const hasActiveVersion = ext.activeVersion && ext.activeVersion.config
     const hasDraftVersion = ext.draftVersion && ext.draftVersion.config
     return isNeededExtensionType && (hasActiveVersion ?? hasDraftVersion)
   })

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -572,6 +572,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
         uuid: mod.registrationUuid!,
         title: mod.registrationTitle,
         type: mod.type,
+        activeVersion: mod.config ? {config: JSON.stringify(mod.config)} : undefined,
       }
       if (CONFIG_EXTENSION_IDS.includes(registration.id)) {
         configurationRegistrations.push(registration)


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure that module configuration data is properly included when registering extensions with the developer platform.

### WHAT is this pull request doing?

Adds the `activeVersion` field with the module's configuration data when registering extensions through the AppManagementClient. This ensures that any configuration associated with a module is properly serialized and sent to the platform.

### How to test your changes?

1. Create an app with extensions that have configuration
2. Deploy the app using `shopify app deploy`
3. Verify that the configuration is properly saved and accessible in the deployed app

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes