### PR TITLE
Use UID for the assets folder and manifest

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -428,7 +428,7 @@ export class App<
           handle: module.handle,
           uid: module.uid,
           uuid: identifiers?.extensions[module.localIdentifier],
-          assets: module.uid,
+          assets: module.outputFolderId,
           target: module.contextValue,
           config: (config ?? {}) as JsonMapType,
         }

--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -129,9 +129,10 @@ describe('keepBuiltSourcemapsLocally', async () => {
           type: 'ui_extension',
           handle: 'scriptToMove',
           directory: outputPath,
+          uid: 'uid1',
         })
-        const someDirPath = joinPath(bundleDirectory, 'some_dir')
-        const otherDirPath = joinPath(bundleDirectory, 'other_dir')
+        const someDirPath = joinPath(bundleDirectory, 'uid1')
+        const otherDirPath = joinPath(bundleDirectory, 'otherUID')
 
         await mkdir(someDirPath)
         await writeFile(joinPath(someDirPath, 'scriptToMove.js'), 'abc')
@@ -141,7 +142,7 @@ describe('keepBuiltSourcemapsLocally', async () => {
         await writeFile(joinPath(otherDirPath, 'scriptToIgnore.js'), 'abc')
         await writeFile(joinPath(otherDirPath, 'scriptToIgnore.js.map'), 'abc map')
 
-        await extensionInstance.keepBuiltSourcemapsLocally(bundleDirectory, 'some_dir')
+        await extensionInstance.keepBuiltSourcemapsLocally(bundleDirectory)
 
         expect(fileExistsSync(joinPath(outputPath, 'dist', 'scriptToMove.js'))).toBe(false)
         expect(fileExistsSync(joinPath(outputPath, 'dist', 'scriptToMove.js.map'))).toBe(true)
@@ -158,9 +159,10 @@ describe('keepBuiltSourcemapsLocally', async () => {
           type: 'ui_extension',
           handle: 'scriptToMove',
           directory: outputPath,
+          uid: 'uid1',
         })
-        const someDirPath = joinPath(bundleDirectory, 'some_dir')
-        const otherDirPath = joinPath(bundleDirectory, 'other_dir')
+        const someDirPath = joinPath(bundleDirectory, 'wrongUID')
+        const otherDirPath = joinPath(bundleDirectory, 'otherUID')
 
         await mkdir(someDirPath)
         await writeFile(joinPath(someDirPath, 'scriptToMove.js'), 'abc')
@@ -170,7 +172,7 @@ describe('keepBuiltSourcemapsLocally', async () => {
         await writeFile(joinPath(otherDirPath, 'scriptToIgnore.js'), 'abc')
         await writeFile(joinPath(otherDirPath, 'scriptToIgnore.js.map'), 'abc map')
 
-        await extensionInstance.keepBuiltSourcemapsLocally(bundleDirectory, 'other_dir')
+        await extensionInstance.keepBuiltSourcemapsLocally(bundleDirectory)
 
         expect(fileExistsSync(joinPath(outputPath, 'dist', 'scriptToMove.js'))).toBe(false)
         expect(fileExistsSync(joinPath(outputPath, 'dist', 'scriptToMove.js.map'))).toBe(false)
@@ -187,9 +189,10 @@ describe('keepBuiltSourcemapsLocally', async () => {
           type: 'web_pixel_extension',
           handle: 'scriptToMove',
           directory: outputPath,
+          uid: 'uid1',
         })
-        const someDirPath = joinPath(bundleDirectory, 'some_dir')
-        const otherDirPath = joinPath(bundleDirectory, 'other_dir')
+        const someDirPath = joinPath(bundleDirectory, 'uid1')
+        const otherDirPath = joinPath(bundleDirectory, 'otherUID')
 
         await mkdir(someDirPath)
         await writeFile(joinPath(someDirPath, 'scriptToMove.js'), 'abc')
@@ -199,7 +202,7 @@ describe('keepBuiltSourcemapsLocally', async () => {
         await writeFile(joinPath(otherDirPath, 'scriptToIgnore.js'), 'abc')
         await writeFile(joinPath(otherDirPath, 'scriptToIgnore.js.map'), 'abc map')
 
-        await extensionInstance.keepBuiltSourcemapsLocally(bundleDirectory, 'some_dir')
+        await extensionInstance.keepBuiltSourcemapsLocally(bundleDirectory)
 
         expect(fileExistsSync(joinPath(outputPath, 'dist', 'scriptToMove.js'))).toBe(false)
         expect(fileExistsSync(joinPath(outputPath, 'dist', 'scriptToMove.js.map'))).toBe(false)

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -37,13 +37,11 @@ export async function bundleAndBuildExtensions(options: BundleOptions) {
             await extension.copyIntoBundle(
               {stderr, stdout, signal, app: options.app, environment: 'production'},
               bundleDirectory,
-              options.identifiers,
             )
           } else {
             await extension.buildForBundle(
               {stderr, stdout, signal, app: options.app, environment: 'production'},
               bundleDirectory,
-              options.identifiers,
             )
           }
         },

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -220,7 +220,7 @@ export class AppEventWatcher extends EventEmitter {
       .filter((extEvent) => extEvent.type === EventType.Deleted)
       .map((extEvent) => extEvent.extension)
     const promises = extensions.map(async (ext) => {
-      const outputPath = joinPath(this.buildOutputPath, ext.getOutputFolderId())
+      const outputPath = joinPath(this.buildOutputPath, ext.outputFolderId)
       return rmdir(outputPath, {force: true})
     })
     await Promise.all(promises)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes the inconsistency in how extension assets are referenced in the bundling process.

### WHAT is this pull request doing?

This PR changes how extension assets are referenced during the bundling process:

1. Updates manifest generation to use the more explicit `module.outputFolderId` instead of `module.uid` for assets folder.
2. Adds a new `outputFolderId` getter to the ExtensionInstance class that returns the extension's uid
3. Refactors the `keepBuiltSourcemapsLocally`, `buildForBundle`, and `copyIntoBundle` methods to use the extension's `outputFolderId` directly
4. Removes the now-redundant `getOutputFolderId` method and simplifies related code

### How to test your changes?

1. Create an app with multiple extensions
2. Run `shopify app deploy` to verify extensions are deployed correctly
3. Verify that sourcemaps are correctly preserved in the extension folder
4. Try to deploy a recently migrated app: everything should work

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes