### PR TITLE
adjust `exitIfOldNodeVersion` to look at engine-declared node version instead of hardcoding

### DIFF
--- a/.changeset/shy-frogs-float.md
+++ b/.changeset/shy-frogs-float.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': major
+---
+
+cli-kit now exits with an error if the current Node version is lower than what the package.json engines require.


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/workflows-operations/issues/3367.

Replaces https://github.com/Shopify/cli/pull/6138.

### WHAT is this pull request doing?

Instead of hardcoding the minimum node version as 18, let's check the package.json and require that version.

### How to test your changes?

Try adjusting your node version with `nvm` and watch what happens:

<img width="1183" height="339" alt="image" src="https://github.com/user-attachments/assets/e9f7be42-27a2-4a45-a475-2db0bff3f615" />