### PR TITLE
Add yarn berry (v2+) support to instalNodeModules

### DIFF
--- a/.changeset/gold-needles-kiss.md
+++ b/.changeset/gold-needles-kiss.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add yarn berry (v2+) compatibility in installNodeModules

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -22,13 +22,12 @@ import {
   PackageManager,
   determineYarnInstallCommand,
 } from './node-package-manager.js'
-import {AbortError} from './error.js'
 import {captureOutput, exec} from './system.js'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from './fs.js'
 import {joinPath, dirname} from './path.js'
 import {inferPackageManagerForGlobalCLI} from './is-global.js'
-import {cacheClear} from '../../private/node/conf-store.js'
 import {outputDebug} from './output.js'
+import {cacheClear} from '../../private/node/conf-store.js'
 import latestVersion from 'latest-version'
 import {vi, describe, test, expect, beforeEach, afterEach} from 'vitest'
 
@@ -117,7 +116,7 @@ describe('packageManagerFromUserAgent', () => {
 
 describe('install', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    // Mocks are cleared automatically by vitest
   })
 
   describe('non-yarn package managers', () => {
@@ -191,10 +190,13 @@ describe('install', () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@3.6.4'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@3.6.4',
+          }),
+        )
 
         // When
         await installNodeModules({
@@ -214,15 +216,17 @@ describe('install', () => {
       })
     })
 
-
     test('uses install command when yarn v1 is detected via packageManager field', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@1.22.19'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@1.22.19',
+          }),
+        )
 
         // When
         await installNodeModules({
@@ -372,9 +376,12 @@ describe('install', () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          packageManager: 'yarn@3.0.0'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            packageManager: 'yarn@3.0.0',
+          }),
+        )
         const mockStdout = {write: vi.fn()} as any
         const mockStderr = {write: vi.fn()} as any
 
@@ -401,9 +408,12 @@ describe('install', () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          packageManager: 'yarn@2.4.3'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            packageManager: 'yarn@2.4.3',
+          }),
+        )
         const mockAbortController = new AbortController()
 
         // When
@@ -994,7 +1004,9 @@ describe('findUpAndReadPackageJson', () => {
       await mkdir(subDirectory)
 
       // When/Then
-      await expect(() => findUpAndReadPackageJson(subDirectory)).rejects.toThrowError(FindUpAndReadPackageJsonNotFoundError)
+      await expect(() => findUpAndReadPackageJson(subDirectory)).rejects.toThrowError(
+        FindUpAndReadPackageJsonNotFoundError,
+      )
     })
   })
 })
@@ -1342,21 +1354,23 @@ describe('inferPackageManager', () => {
 
 describe('determineYarnInstallCommand', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    // Mocks are cleared automatically by vitest
   })
-
 
   describe('packageManager field detection', () => {
     test('returns ["add"] when package.json has packageManager field with yarn v2+', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@3.0.0'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@3.0.0',
+          }),
+        )
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
       })
     })
@@ -1364,13 +1378,16 @@ describe('determineYarnInstallCommand', () => {
     test('returns ["add"] when package.json has prerelease version yarn@4.0.0-beta.1', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@4.0.0-beta.1'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@4.0.0-beta.1',
+          }),
+        )
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
       })
     })
@@ -1378,13 +1395,16 @@ describe('determineYarnInstallCommand', () => {
     test('returns ["add"] when package.json has dist-tag yarn@next', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@next'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@next',
+          }),
+        )
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
       })
     })
@@ -1392,13 +1412,16 @@ describe('determineYarnInstallCommand', () => {
     test('returns ["add"] when package.json has dist-tag yarn@latest', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@latest'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@latest',
+          }),
+        )
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
       })
     })
@@ -1406,13 +1429,16 @@ describe('determineYarnInstallCommand', () => {
     test('returns ["add"] when package.json has dist-tag yarn@canary', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@canary'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@canary',
+          }),
+        )
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
       })
     })
@@ -1420,13 +1446,16 @@ describe('determineYarnInstallCommand', () => {
     test('returns ["add"] when package.json has coercible version yarn@4', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@4'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@4',
+          }),
+        )
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
       })
     })
@@ -1434,13 +1463,16 @@ describe('determineYarnInstallCommand', () => {
     test('returns ["install"] when package.json has coercible version yarn@1.22', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@1.22'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@1.22',
+          }),
+        )
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['install'])
       })
     })
@@ -1449,10 +1481,13 @@ describe('determineYarnInstallCommand', () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Create package.json in root
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@3.6.4'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@3.6.4',
+          }),
+        )
 
         // Create subdirectory
         const subDir = joinPath(tmpDir, 'src', 'components')
@@ -1461,7 +1496,7 @@ describe('determineYarnInstallCommand', () => {
 
         // Call from subdirectory - should find root package.json
         const result = await determineYarnInstallCommand(subDir)
-        
+
         expect(result).toEqual(['add'])
       })
     })
@@ -1469,13 +1504,16 @@ describe('determineYarnInstallCommand', () => {
     test('returns ["add"] when package.json has packageManager field with yarn v2', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@2.4.3'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@2.4.3',
+          }),
+        )
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
       })
     })
@@ -1483,17 +1521,19 @@ describe('determineYarnInstallCommand', () => {
     test('returns ["install"] when package.json has packageManager field with yarn v1', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@1.22.19'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@1.22.19',
+          }),
+        )
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['install'])
       })
     })
-
   })
 
   describe('yarn --version command detection', () => {
@@ -1501,28 +1541,31 @@ describe('determineYarnInstallCommand', () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
         await writeFile(packageJsonPath, JSON.stringify({name: 'test-package'}))
-        
+
         mockedCaptureOutput.mockResolvedValueOnce('3.6.4')
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
-        expect(mockedCaptureOutput).toHaveBeenCalledWith('yarn', ['--version'], expect.objectContaining({
-          cwd: tmpDir
-        }))
+        expect(mockedCaptureOutput).toHaveBeenCalledWith(
+          'yarn',
+          ['--version'],
+          expect.objectContaining({
+            cwd: tmpDir,
+          }),
+        )
       })
     })
-
 
     test('returns ["install"] when yarn --version shows v1.x', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
         await writeFile(packageJsonPath, JSON.stringify({name: 'test-package'}))
-        
+
         mockedCaptureOutput.mockResolvedValueOnce('1.22.19')
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['install'])
       })
     })
@@ -1531,15 +1574,14 @@ describe('determineYarnInstallCommand', () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
         await writeFile(packageJsonPath, JSON.stringify({name: 'test-package'}))
-        
+
         mockedCaptureOutput.mockRejectedValueOnce(new Error('spawn yarn ENOENT'))
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['install'])
       })
     })
-
   })
 
   describe('.yarnrc.yml file detection', () => {
@@ -1549,11 +1591,11 @@ describe('determineYarnInstallCommand', () => {
         const yarnrcPath = joinPath(tmpDir, '.yarnrc.yml')
         await writeFile(packageJsonPath, JSON.stringify({name: 'test-package'}))
         await writeFile(yarnrcPath, 'yarnPath: .yarn/releases/yarn-3.6.4.cjs')
-        
+
         mockedCaptureOutput.mockRejectedValueOnce(new Error('Command failed'))
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
       })
     })
@@ -1562,11 +1604,11 @@ describe('determineYarnInstallCommand', () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
         await writeFile(packageJsonPath, JSON.stringify({name: 'test-package'}))
-        
+
         mockedCaptureOutput.mockRejectedValueOnce(new Error('Command failed'))
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['install'])
       })
     })
@@ -1577,49 +1619,58 @@ describe('determineYarnInstallCommand', () => {
         const yarnrcPath = joinPath(tmpDir, '.yarnrc.yml')
         await writeFile(packageJsonPath, JSON.stringify({name: 'test-package'}))
         await writeFile(yarnrcPath, 'yarnPath: .yarn/releases/yarn-3.6.4.cjs')
-        
+
         mockedCaptureOutput.mockRejectedValueOnce(new Error('spawn yarn ENOENT'))
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['install'])
       })
     })
   })
 
-
   describe('error handling and fallbacks', () => {
     test('falls back to yarn --version when packageManager has invalid semver yarn@invalid-version', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@invalid-version'
-        }))
-        
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@invalid-version',
+          }),
+        )
+
         mockedCaptureOutput.mockResolvedValueOnce('3.6.4')
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['add'])
-        expect(mockedCaptureOutput).toHaveBeenCalledWith('yarn', ['--version'], expect.objectContaining({
-          cwd: tmpDir
-        }))
+        expect(mockedCaptureOutput).toHaveBeenCalledWith(
+          'yarn',
+          ['--version'],
+          expect.objectContaining({
+            cwd: tmpDir,
+          }),
+        )
       })
     })
 
     test('falls back to yarn --version when packageManager has unknown tag yarn@unknown-tag', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@unknown-tag'
-        }))
-        
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@unknown-tag',
+          }),
+        )
+
         mockedCaptureOutput.mockResolvedValueOnce('1.22.19')
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['install'])
       })
     })
@@ -1629,7 +1680,7 @@ describe('determineYarnInstallCommand', () => {
         mockedCaptureOutput.mockRejectedValueOnce(new Error('Command failed'))
 
         const result = await determineYarnInstallCommand(tmpDir)
-        
+
         expect(result).toEqual(['install'])
       })
     })
@@ -1637,13 +1688,16 @@ describe('determineYarnInstallCommand', () => {
     test('logs debug information during detection process', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const packageJsonPath = joinPath(tmpDir, 'package.json')
-        await writeFile(packageJsonPath, JSON.stringify({
-          name: 'test-package',
-          packageManager: 'yarn@3.6.4'
-        }))
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            name: 'test-package',
+            packageManager: 'yarn@3.6.4',
+          }),
+        )
 
         await determineYarnInstallCommand(tmpDir)
-        
+
         expect(mockedOutputDebug).toHaveBeenCalledWith('Detected yarn v3.6.4 from packageManager field: yarn@3.6.4')
       })
     })

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -36,10 +36,19 @@ vi.mock('./version.js')
 vi.mock('./system.js')
 vi.mock('latest-version')
 vi.mock('./is-global')
-vi.mock('./output.js')
 
 const mockedExec = vi.mocked(exec)
 const mockedCaptureOutput = vi.mocked(captureOutput)
+
+// Mock only outputDebug, not the entire output module
+vi.mock('./output.js', async () => {
+  const actual = await vi.importActual('./output.js')
+  return {
+    ...actual,
+    outputDebug: vi.fn(),
+  }
+})
+
 const mockedOutputDebug = vi.mocked(outputDebug)
 
 describe('installNPMDependenciesRecursively', () => {

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -27,10 +27,10 @@ import {inTemporaryDirectory, mkdir, touchFile, writeFile} from './fs.js'
 import {joinPath, dirname} from './path.js'
 import {inferPackageManagerForGlobalCLI} from './is-global.js'
 import {outputDebug} from './output.js'
+import {AbortController} from './abort.js'
 import {cacheClear} from '../../private/node/conf-store.js'
 import latestVersion from 'latest-version'
 import {vi, describe, test, expect, beforeEach, afterEach} from 'vitest'
-import {AbortController} from '@shopify/cli-kit/node/abort'
 
 vi.mock('./version.js')
 vi.mock('./system.js')

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -30,6 +30,7 @@ import {outputDebug} from './output.js'
 import {cacheClear} from '../../private/node/conf-store.js'
 import latestVersion from 'latest-version'
 import {vi, describe, test, expect, beforeEach, afterEach} from 'vitest'
+import {AbortController} from '@shopify/cli-kit/node/abort'
 
 vi.mock('./version.js')
 vi.mock('./system.js')

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -24,7 +24,7 @@ import {
 } from './node-package-manager.js'
 import {captureOutput, exec} from './system.js'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from './fs.js'
-import {joinPath, dirname} from './path.js'
+import {joinPath, dirname, normalizePath} from './path.js'
 import {inferPackageManagerForGlobalCLI} from './is-global.js'
 import {outputDebug} from './output.js'
 import {AbortController} from './abort.js'
@@ -606,7 +606,9 @@ describe('getDependencies', () => {
       const packageJsonPath = joinPath(tmpDir, 'package.json')
 
       // When
-      await expect(getDependencies(packageJsonPath)).rejects.toThrowError(PackageJsonNotFoundError)
+      await expect(getDependencies(packageJsonPath)).rejects.toEqual(
+        new PackageJsonNotFoundError(normalizePath(tmpDir)),
+      )
     })
   })
 })
@@ -1029,7 +1031,7 @@ describe('addResolutionOrOverride', () => {
       const result = () => addResolutionOrOverride(tmpDir, {'@types/react': '17.0.30'})
 
       // Then
-      await expect(result).rejects.toThrowError(PackageJsonNotFoundError)
+      await expect(result).rejects.toThrow(new PackageJsonNotFoundError(normalizePath(tmpDir)))
     })
   })
 

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -1017,7 +1017,7 @@ describe('findUpAndReadPackageJson', () => {
 
       // When/Then
       await expect(() => findUpAndReadPackageJson(subDirectory)).rejects.toThrowError(
-        FindUpAndReadPackageJsonNotFoundError,
+        new FindUpAndReadPackageJsonNotFoundError(subDirectory),
       )
     })
   })

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -8,7 +8,7 @@ import {inferPackageManagerForGlobalCLI} from './is-global.js'
 import {outputToken, outputContent, outputDebug} from '../../public/node/output.js'
 import {PackageVersionKey, cacheRetrieve, cacheRetrieveOrRepopulate} from '../../private/node/conf-store.js'
 import latestVersion from 'latest-version'
-import {SemVer, satisfies, coerce, gte, valid} from 'semver'
+import {SemVer, satisfies as semverSatisfies, coerce, gte, valid} from 'semver'
 import type {Writable} from 'stream'
 import type {ExecOptions} from './system.js'
 
@@ -420,7 +420,7 @@ export function checkForCachedNewVersion(dependency: string, currentVersion: str
  * @returns A boolean indicating whether the version satisfies the requirements
  */
 export function versionSatisfies(version: string, requirements: string): boolean {
-  return satisfies(version, requirements)
+  return semverSatisfies(version, requirements)
 }
 
 /**

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -8,13 +8,7 @@ import {inferPackageManagerForGlobalCLI} from './is-global.js'
 import {outputToken, outputContent, outputDebug} from '../../public/node/output.js'
 import {PackageVersionKey, cacheRetrieve, cacheRetrieveOrRepopulate} from '../../private/node/conf-store.js'
 import latestVersion from 'latest-version'
-import {
-  SemVer,
-  satisfies as semverSatisfies,
-  coerce as semverCoerce,
-  gte as semverGte,
-  valid as semverValid,
-} from 'semver'
+import {SemVer, satisfies, coerce, gte, valid} from 'semver'
 import type {Writable} from 'stream'
 import type {ExecOptions} from './system.js'
 
@@ -211,9 +205,9 @@ export async function determineYarnInstallCommand(directory: string): Promise<st
       const versionPart = packageJsonContent.packageManager.replace(/^yarn@/, '')
 
       // First check if it's a valid semver
-      const validVersion = semverValid(versionPart)
+      const validVersion = valid(versionPart)
       if (validVersion) {
-        const isYarnBerry = semverGte(validVersion, '2.0.0')
+        const isYarnBerry = gte(validVersion, '2.0.0')
         outputDebug(`Detected yarn v${validVersion} from packageManager field: ${packageJsonContent.packageManager}`)
         return isYarnBerry ? ['add'] : ['install']
       }
@@ -226,9 +220,9 @@ export async function determineYarnInstallCommand(directory: string): Promise<st
       }
 
       // Try coercion as fallback for partial versions like "4" or "4.0"
-      const coercedVersion = semverCoerce(versionPart)
+      const coercedVersion = coerce(versionPart)
       if (coercedVersion) {
-        const isYarnBerry = semverGte(coercedVersion, '2.0.0')
+        const isYarnBerry = gte(coercedVersion, '2.0.0')
         outputDebug(
           `Coerced yarn version ${coercedVersion.version} from packageManager field: ${packageJsonContent.packageManager}`,
         )
@@ -253,9 +247,9 @@ export async function determineYarnInstallCommand(directory: string): Promise<st
 
   try {
     const versionOutput = await captureOutput('yarn', ['--version'], {cwd: directory})
-    const coercedVersion = semverCoerce(versionOutput.trim())
+    const coercedVersion = coerce(versionOutput.trim())
     if (coercedVersion) {
-      const isYarnBerry = semverGte(coercedVersion, '2.0.0')
+      const isYarnBerry = gte(coercedVersion, '2.0.0')
       outputDebug(`Detected yarn v${coercedVersion.version} from yarn --version command: ${versionOutput.trim()}`)
       return isYarnBerry ? ['add'] : ['install']
     }
@@ -426,7 +420,7 @@ export function checkForCachedNewVersion(dependency: string, currentVersion: str
  * @returns A boolean indicating whether the version satisfies the requirements
  */
 export function versionSatisfies(version: string, requirements: string): boolean {
-  return semverSatisfies(version, requirements)
+  return satisfies(version, requirements)
 }
 
 /**

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -76,7 +76,7 @@ export class UnknownPackageManagerError extends AbortError {
  */
 export class PackageJsonNotFoundError extends AbortError {
   constructor(directory: string) {
-    super(`The directory ${directory} doesn't have a package.json.`)
+    super(outputContent`The directory ${outputToken.path(directory)} doesn't have a package.json.`)
   }
 }
 
@@ -88,7 +88,7 @@ export class PackageJsonNotFoundError extends AbortError {
  */
 export class FindUpAndReadPackageJsonNotFoundError extends BugError {
   constructor(directory: string) {
-    super(`Couldn't find a package.json traversing directories from ${directory}`)
+    super(outputContent`Couldn't find a package.json traversing directories from ${outputToken.path(directory)}`)
   }
 }
 

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -194,31 +194,31 @@ function shouldRethrowError(error: unknown, isYarnCommand = false): boolean {
   if (!(error instanceof Error) || error instanceof BugError || error instanceof AbortError) {
     return false
   }
-  
+
   if (isYarnCommand) {
     // Check for specific error types that indicate yarn command failures
     const errorWithCode = error as Error & {code?: string; errno?: number; syscall?: string}
-    
+
     // ENOENT indicates yarn binary not found
     if (errorWithCode.code === 'ENOENT' || error.message.includes('ENOENT')) {
       return false
     }
-    
+
     // Command execution failures (non-zero exit codes)
     if (errorWithCode.code === 'EACCES' || errorWithCode.code === 'EPERM') {
       return false
     }
-    
+
     // Process execution errors from captureOutput
     if (errorWithCode.syscall && ['spawn', 'spawnSync'].includes(errorWithCode.syscall)) {
       return false
     }
-    
+
     // For any other errors during yarn command execution, assume they're yarn-related
     // and don't rethrow (let them fall through to fallback)
     return false
   }
-  
+
   return true
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

 The `installNodeModules` function in cli-kit hardcoded the ['install'] command for all package managers, including yarn. This caused build failures when using Yarn Berry (v2/v3+) because:

  - Yarn v1 (Classic): Uses yarn install command
  - Yarn v2/v3+ (Berry): Uses yarn add command for dependencies

  This incompatibility blocked the Hydrogen CLI upgrade command and other cli-kit consumers from working with modern yarn versions, forcing users to stay on legacy yarn v1 or face broken installations.

### WHAT is this pull request doing?

Enhanced installNodeModules with yarn version-aware command selection:

#### New Function: getYarnInstallCommand(directory: string)

  - Multi-tier version detection strategy with intelligent fallbacks
  - Comprehensive error handling for system availability issues

#### Enhanced installNodeModules Function
  - Zero breaking changes - npm/pnpm/bun behavior unchanged
  - Yarn-specific logic - detects version and uses appropriate command
  - Maintains all existing interfaces and stream options

#### Detection Strategy (Priority Order)
  1. packageManager field in package.json (modern standard)
  2. yarn --version command execution and parsing
  3. .yarnrc.yml file presence (Berry project indicator)
  4. Fallback to install (maximum backward compatibility)

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
