### PR TITLE
Experiment: Improve CLI messaging for app proxy development

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -25,6 +25,7 @@ import {Identifiers} from '../app/identifiers.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationWithoutPath} from '../app/app.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
+import {EventType} from '../../services/dev/app-events/app-event-watcher.js'
 import {ok} from '@shopify/cli-kit/node/result'
 import {constantize, slugify} from '@shopify/cli-kit/common/string'
 import {hashString, nonRandomUUID} from '@shopify/cli-kit/node/crypto'
@@ -449,9 +450,9 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     }
   }
 
-  async getDevSessionUpdateMessage(): Promise<string | undefined> {
+  async getDevSessionUpdateMessage(eventType: EventType): Promise<string[] | undefined> {
     if (!this.specification.getDevSessionUpdateMessage) return undefined
-    return this.specification.getDevSessionUpdateMessage(this.configuration)
+    return this.specification.getDevSessionUpdateMessage(this.configuration, eventType)
   }
 
   /**

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -25,7 +25,6 @@ import {Identifiers} from '../app/identifiers.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationWithoutPath} from '../app/app.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
-import {EventType} from '../../services/dev/app-events/app-event-watcher.js'
 import {ok} from '@shopify/cli-kit/node/result'
 import {constantize, slugify} from '@shopify/cli-kit/common/string'
 import {hashString, nonRandomUUID} from '@shopify/cli-kit/node/crypto'
@@ -450,9 +449,9 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     }
   }
 
-  async getDevSessionUpdateMessage(eventType: EventType): Promise<string[] | undefined> {
-    if (!this.specification.getDevSessionUpdateMessage) return undefined
-    return this.specification.getDevSessionUpdateMessage(this.configuration, eventType)
+  async getDevSessionUpdateMessages(): Promise<string[] | undefined> {
+    if (!this.specification.getDevSessionUpdateMessages) return undefined
+    return this.specification.getDevSessionUpdateMessages(this.configuration)
   }
 
   /**

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -7,6 +7,7 @@ import {Flag} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationWithoutPath} from '../app/app.js'
 import {loadLocalesConfig} from '../../utilities/extensions/locales-configuration.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
+import {EventType} from '../../services/dev/app-events/app-event-watcher.js'
 import {Result} from '@shopify/cli-kit/node/result'
 import {capitalize} from '@shopify/cli-kit/common/string'
 import {ParseConfigurationResult, zod} from '@shopify/cli-kit/node/schema'
@@ -74,7 +75,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   buildValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   hasExtensionPointTarget?(config: TConfiguration, target: string): boolean
   appModuleFeatures: (config?: TConfiguration) => ExtensionFeature[]
-  getDevSessionUpdateMessage?: (config: TConfiguration) => Promise<string>
+  getDevSessionUpdateMessage?: (config: TConfiguration, eventType: EventType) => Promise<string[]>
   patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
 
   /**
@@ -231,7 +232,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
   appModuleFeatures?: (config?: TConfiguration) => ExtensionFeature[]
   transformConfig: TransformationConfig | CustomTransformationConfig
   uidStrategy?: UidStrategy
-  getDevSessionUpdateMessage?: (config: TConfiguration) => Promise<string>
+  getDevSessionUpdateMessage?: (config: TConfiguration, eventType: EventType) => Promise<string[]>
   patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
 }): ExtensionSpecification<TConfiguration> {
   const appModuleFeatures = spec.appModuleFeatures ?? (() => [])

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -7,7 +7,6 @@ import {Flag} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationWithoutPath} from '../app/app.js'
 import {loadLocalesConfig} from '../../utilities/extensions/locales-configuration.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
-import {EventType} from '../../services/dev/app-events/app-event-watcher.js'
 import {Result} from '@shopify/cli-kit/node/result'
 import {capitalize} from '@shopify/cli-kit/common/string'
 import {ParseConfigurationResult, zod} from '@shopify/cli-kit/node/schema'
@@ -75,7 +74,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   buildValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   hasExtensionPointTarget?(config: TConfiguration, target: string): boolean
   appModuleFeatures: (config?: TConfiguration) => ExtensionFeature[]
-  getDevSessionUpdateMessage?: (config: TConfiguration, eventType: EventType) => Promise<string[]>
+  getDevSessionUpdateMessages?: (config: TConfiguration) => Promise<string[]>
   patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
 
   /**
@@ -187,7 +186,7 @@ export function createExtensionSpecification<TConfiguration extends BaseConfigTy
     reverseTransform: spec.transformRemoteToLocal,
     experience: spec.experience ?? 'extension',
     uidStrategy: spec.uidStrategy ?? (spec.experience === 'configuration' ? 'single' : 'uuid'),
-    getDevSessionUpdateMessage: spec.getDevSessionUpdateMessage,
+    getDevSessionUpdateMessages: spec.getDevSessionUpdateMessages,
   }
   const merged = {...defaults, ...spec}
 
@@ -232,7 +231,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
   appModuleFeatures?: (config?: TConfiguration) => ExtensionFeature[]
   transformConfig: TransformationConfig | CustomTransformationConfig
   uidStrategy?: UidStrategy
-  getDevSessionUpdateMessage?: (config: TConfiguration, eventType: EventType) => Promise<string[]>
+  getDevSessionUpdateMessages?: (config: TConfiguration) => Promise<string[]>
   patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
 }): ExtensionSpecification<TConfiguration> {
   const appModuleFeatures = spec.appModuleFeatures ?? (() => [])
@@ -246,7 +245,7 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
     transformRemoteToLocal: resolveReverseAppConfigTransform(spec.schema, spec.transformConfig),
     experience: 'configuration',
     uidStrategy: spec.uidStrategy ?? 'single',
-    getDevSessionUpdateMessage: spec.getDevSessionUpdateMessage,
+    getDevSessionUpdateMessages: spec.getDevSessionUpdateMessages,
     patchWithAppDevURLs: spec.patchWithAppDevURLs,
   })
 }

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
@@ -75,7 +75,7 @@ describe('app_config_app_access', () => {
     })
   })
 
-  describe('getDevSessionUpdateMessage', () => {
+  describe('getDevSessionUpdateMessages', () => {
     test('should return message with scopes when scopes are provided', async () => {
       // Given
       const config = {
@@ -88,10 +88,10 @@ describe('app_config_app_access', () => {
       }
 
       // When
-      const result = await spec.getDevSessionUpdateMessage!(config)
+      const result = await spec.getDevSessionUpdateMessages!(config)
 
       // Then
-      expect(result).toBe('Access scopes auto-granted: read_products, write_products')
+      expect(result).toEqual(['Access scopes auto-granted: read_products, write_products'])
     })
 
     test('should return message with required_scopes when only required_scopes are provided', async () => {
@@ -106,10 +106,10 @@ describe('app_config_app_access', () => {
       }
 
       // When
-      const result = await spec.getDevSessionUpdateMessage!(config)
+      const result = await spec.getDevSessionUpdateMessages!(config)
 
       // Then
-      expect(result).toBe('Access scopes auto-granted: write_orders, read_inventory')
+      expect(result).toEqual(['Access scopes auto-granted: write_orders, read_inventory'])
     })
 
     test('should return default message when no scopes are provided', async () => {
@@ -121,10 +121,10 @@ describe('app_config_app_access', () => {
       }
 
       // When
-      const result = await spec.getDevSessionUpdateMessage!(config)
+      const result = await spec.getDevSessionUpdateMessages!(config)
 
       // Then
-      expect(result).toBe('App has been installed')
+      expect(result).toEqual(['App has been installed'])
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -54,7 +54,7 @@ const appAccessSpec = createConfigExtensionSpecification({
           .join(', ')
       : config.access_scopes?.required_scopes?.join(', ')
 
-    return scopesString ? `Access scopes auto-granted: ${scopesString}` : `App has been installed`
+    return [scopesString ? `Access scopes auto-granted: ${scopesString}` : `App has been installed`]
   },
   patchWithAppDevURLs: (config, urls) => {
     if (urls.redirectUrlWhitelist) {

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -46,7 +46,7 @@ const appAccessSpec = createConfigExtensionSpecification({
   identifier: AppAccessSpecIdentifier,
   schema: AppAccessSchema,
   transformConfig: AppAccessTransformConfig,
-  getDevSessionUpdateMessage: async (config) => {
+  getDevSessionUpdateMessages: async (config) => {
     const scopesString = config.access_scopes?.scopes
       ? config.access_scopes.scopes
           .split(',')

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
@@ -1,6 +1,7 @@
 import {validateUrl} from '../../app/validation/common.js'
 import {ExtensionSpecification, TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {BaseSchema} from '../schemas.js'
+import {EventType} from '../../../services/dev/app-events/app-event-watcher.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const AppProxySchema = BaseSchema.extend({
@@ -33,6 +34,16 @@ const appProxySpec: ExtensionSpecification = createConfigExtensionSpecification(
         prefix: urls.appProxy.proxySubPathPrefix,
       }
     }
+  },
+  getDevSessionUpdateMessage: async (config, eventType) => {
+    if (eventType === EventType.Deleted) {
+      return []
+    }
+    const messages = [`Using app proxy URL: ${config.app_proxy?.url}`]
+    if (eventType === EventType.Updated) {
+      messages.push(`Note: Changes to app proxy prefix and subpath won't affect existing installations.`)
+    }
+    return messages
   },
 })
 

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
@@ -1,7 +1,6 @@
 import {validateUrl} from '../../app/validation/common.js'
 import {ExtensionSpecification, TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {BaseSchema} from '../schemas.js'
-import {EventType} from '../../../services/dev/app-events/app-event-watcher.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const AppProxySchema = BaseSchema.extend({
@@ -26,6 +25,12 @@ const appProxySpec: ExtensionSpecification = createConfigExtensionSpecification(
   identifier: AppProxySpecIdentifier,
   schema: AppProxySchema,
   transformConfig: AppProxyTransformConfig,
+  getDevSessionUpdateMessages: async (config) => {
+    return [
+      `Using app proxy URL: ${config.app_proxy?.url}`,
+      `Note: Changes to app proxy prefix and subpath won't affect existing installations.`,
+    ]
+  },
   patchWithAppDevURLs: (config, urls) => {
     if (urls.appProxy) {
       config.app_proxy = {
@@ -34,16 +39,6 @@ const appProxySpec: ExtensionSpecification = createConfigExtensionSpecification(
         prefix: urls.appProxy.proxySubPathPrefix,
       }
     }
-  },
-  getDevSessionUpdateMessage: async (config, eventType) => {
-    if (eventType === EventType.Deleted) {
-      return []
-    }
-    const messages = [`Using app proxy URL: ${config.app_proxy?.url}`]
-    if (eventType === EventType.Updated) {
-      messages.push(`Note: Changes to app proxy prefix and subpath won't affect existing installations.`)
-    }
-    return messages
   },
 })
 

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.test.ts
@@ -172,7 +172,7 @@ describe('DevSessionLogger', () => {
 
     test('logs messages', async () => {
       const mockExtension = {
-        getDevSessionUpdateMessage: vi.fn().mockResolvedValue('This has been updated.'),
+        getDevSessionUpdateMessages: vi.fn().mockResolvedValue(['This has been updated.']),
         entrySourceFilePath: '',
         devUUID: '',
         localIdentifier: '',
@@ -197,6 +197,32 @@ describe('DevSessionLogger', () => {
           "└  This has been updated.",
         ]
       `)
+    })
+
+    test('does not log messages when extension is deleted', async () => {
+      const mockExtension = {
+        getDevSessionUpdateMessages: vi.fn().mockResolvedValue(['This would be logged if not deleted.']),
+        entrySourceFilePath: '',
+        devUUID: '',
+        localIdentifier: '',
+        idEnvironmentVariableName: '',
+      } as unknown as ExtensionInstance
+
+      const event: AppEvent = {
+        app: {configuration: {}} as any,
+        extensionEvents: [
+          {
+            type: 'deleted' as EventType,
+            extension: mockExtension,
+          },
+        ],
+        path: '',
+        startTime: [0, 0],
+      }
+
+      await logger.logExtensionUpdateMessages(event)
+      expect(output).toMatchInlineSnapshot(`[]`)
+      expect(mockExtension.getDevSessionUpdateMessages).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-logger.ts
@@ -1,5 +1,5 @@
 import {UserError} from './dev-session.js'
-import {AppEvent} from '../../app-events/app-event-watcher.js'
+import {AppEvent, EventType} from '../../app-events/app-event-watcher.js'
 import {ExtensionInstance} from '../../../../models/extensions/extension-instance.js'
 import {outputToken, outputContent, outputDebug} from '@shopify/cli-kit/node/output'
 import {useConcurrentOutputContext} from '@shopify/cli-kit/node/ui/components'
@@ -78,7 +78,8 @@ export class DevSessionLogger {
     const extensionEvents = event.extensionEvents ?? []
     const messageArrays = await Promise.all(
       extensionEvents.map(async (eve) => {
-        const messages = await eve.extension.getDevSessionUpdateMessage(eve.type)
+        if (eve.type === EventType.Deleted) return []
+        const messages = await eve.extension.getDevSessionUpdateMessages()
         return messages ?? []
       }),
     )


### PR DESCRIPTION
## Summary
- Enhanced dev session logger to provide clearer messaging for app proxy configuration changes
- Refactored extension specifications to return multiple update messages instead of single message
- Added specific messaging for app proxy URL updates and important deployment notes

## Changes
- Updated `getDevSessionUpdateMessage` to `getDevSessionUpdateMessages` to support multiple messages
- Added app proxy-specific messages showing the proxy URL being used
- Included warning about prefix/subpath changes not affecting existing installations
- Improved message formatting with proper indentation for multiple messages

## Test plan
- [ ] Run `shopify app dev` with app proxy configuration
- [ ] Verify new messaging appears in CLI output
- [ ] Confirm existing app access scope messages still work
- [ ] Test that deleted extensions don't log messages

🤖 Generated with [Claude Code](https://claude.ai/code)