### PR TITLE
Fix partners platform deploy using uid in path for extensions instead of uuid

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -219,6 +219,7 @@ export async function testUIExtension(
     name: uiExtension?.name ?? 'test-ui-extension',
     type: uiExtension?.type ?? 'product_subscription',
     handle: uiExtension?.handle ?? 'test-ui-extension',
+    uid: uiExtension?.uid ?? undefined,
     metafields: [],
     capabilities: {
       block_progress: false,

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -428,7 +428,7 @@ export class App<
           handle: module.handle,
           uid: module.uid,
           uuid: identifiers?.extensions[module.localIdentifier],
-          assets: module.outputFolderId,
+          assets: module.uid,
           target: module.contextValue,
           config: (config ?? {}) as JsonMapType,
         }

--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -161,6 +161,7 @@ describe('keepBuiltSourcemapsLocally', async () => {
           directory: outputPath,
           uid: 'uid1',
         })
+        const bundleInputPath = joinPath(bundleDirectory, extensionInstance.uid)
         const someDirPath = joinPath(bundleDirectory, 'wrongUID')
         const otherDirPath = joinPath(bundleDirectory, 'otherUID')
 
@@ -172,7 +173,7 @@ describe('keepBuiltSourcemapsLocally', async () => {
         await writeFile(joinPath(otherDirPath, 'scriptToIgnore.js'), 'abc')
         await writeFile(joinPath(otherDirPath, 'scriptToIgnore.js.map'), 'abc map')
 
-        await extensionInstance.keepBuiltSourcemapsLocally(bundleDirectory)
+        await extensionInstance.keepBuiltSourcemapsLocally(bundleInputPath)
 
         expect(fileExistsSync(joinPath(outputPath, 'dist', 'scriptToMove.js'))).toBe(false)
         expect(fileExistsSync(joinPath(outputPath, 'dist', 'scriptToMove.js.map'))).toBe(false)
@@ -258,7 +259,7 @@ describe('build', async () => {
       }
 
       // When
-      await extension.copyIntoBundle(options, bundleDirectory)
+      await extension.copyIntoBundle(options, bundleDirectory, 'uuid')
 
       // Then
       const outputTomlPath = joinPath(extension.outputPath, 'shopify.extension.toml')

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -375,7 +375,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     await this.keepBuiltSourcemapsLocally(bundleInputPath)
   }
 
-  async copyIntoBundle(options: ExtensionBuildOptions, bundleDirectory: string, extensionUuid: string | undefined) {
+  async copyIntoBundle(options: ExtensionBuildOptions, bundleDirectory: string, extensionUuid?: string) {
     const defaultOutputPath = this.outputPath
 
     if (this.features.includes('bundling')) {

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -250,7 +250,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     return `https://${fqdn}/${options.orgId}/apps/${options.appId}/extensions/${parnersPath}/${options.extensionId}`
   }
 
-  getOutputFolderId(registrationUuid?: string | undefined) {
+  getOutputFolderId(registrationUuid?: string) {
     return this.configuration.uid ?? registrationUuid ?? this.handle
   }
 

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -251,6 +251,8 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   getOutputFolderId(registrationUuid?: string) {
+    // We want to return the UID only for Dev Dashboard apps,
+    // that's why we take it from the configuration
     return this.configuration.uid ?? registrationUuid ?? this.handle
   }
 

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -398,7 +398,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     }
   }
 
-  getOutputPathForDirectory(directory: string, registrationUuid?: string | undefined) {
+  getOutputPathForDirectory(directory: string, registrationUuid?: string) {
     const id = this.getOutputFolderId(registrationUuid)
     const outputFile = this.isThemeExtension ? '' : joinPath('dist', this.outputFileName)
     return joinPath(directory, id, outputFile)

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -360,7 +360,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     }
   }
 
-  async buildForBundle(options: ExtensionBuildOptions, bundleDirectory: string, registrationUuid?: string | undefined) {
+  async buildForBundle(options: ExtensionBuildOptions, bundleDirectory: string, registrationUuid?: string) {
     if (this.features.includes('bundling')) {
       // Modules that are going to be inclued in the bundle should be built in the bundle directory
       this.outputPath = this.getOutputPathForDirectory(bundleDirectory, registrationUuid)

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -33,17 +33,18 @@ export async function bundleAndBuildExtensions(options: BundleOptions) {
       return {
         prefix: extension.localIdentifier,
         action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
+          const extensionIdentifier = options.identifiers?.extensions[extension.localIdentifier]
           if (options.skipBuild) {
             await extension.copyIntoBundle(
               {stderr, stdout, signal, app: options.app, environment: 'production'},
               bundleDirectory,
-              options.identifiers?.extensions[extension.localIdentifier],
+              extensionIdentifier,
             )
           } else {
             await extension.buildForBundle(
               {stderr, stdout, signal, app: options.app, environment: 'production'},
               bundleDirectory,
-              options.identifiers?.extensions[extension.localIdentifier],
+              extensionIdentifier,
             )
           }
         },

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -37,11 +37,13 @@ export async function bundleAndBuildExtensions(options: BundleOptions) {
             await extension.copyIntoBundle(
               {stderr, stdout, signal, app: options.app, environment: 'production'},
               bundleDirectory,
+              options.identifiers?.extensions[extension.localIdentifier],
             )
           } else {
             await extension.buildForBundle(
               {stderr, stdout, signal, app: options.app, environment: 'production'},
               bundleDirectory,
+              options.identifiers?.extensions[extension.localIdentifier],
             )
           }
         },

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -220,7 +220,7 @@ export class AppEventWatcher extends EventEmitter {
       .filter((extEvent) => extEvent.type === EventType.Deleted)
       .map((extEvent) => extEvent.extension)
     const promises = extensions.map(async (ext) => {
-      const outputPath = joinPath(this.buildOutputPath, ext.outputFolderId)
+      const outputPath = joinPath(this.buildOutputPath, ext.getOutputFolderId())
       return rmdir(outputPath, {force: true})
     })
     await Promise.all(promises)

--- a/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.test.ts
@@ -14,8 +14,16 @@ vi.mock('@luckycatfactory/esbuild-graphql-loader', () => ({
   },
 }))
 
-const extension1 = await testUIExtension({type: 'ui_extension', directory: '/extensions/ui_extension_1', uid: 'uid1'})
-const extension2 = await testUIExtension({type: 'ui_extension', directory: '/extensions/ui_extension_2', uid: 'uid2'})
+const extension1 = await testUIExtension({
+  type: 'ui_extension',
+  directory: '/extensions/ui_extension_1',
+  uid: 'uid1',
+})
+const extension2 = await testUIExtension({
+  type: 'ui_extension',
+  directory: '/extensions/ui_extension_2',
+  uid: 'uid2',
+})
 
 describe('app-watcher-esbuild', () => {
   const options: DevAppWatcherOptions = {
@@ -186,7 +194,7 @@ describe('app-watcher-esbuild', () => {
     await mgr.rebuildContext(ext)
 
     // Get the built file
-    const builtFile = joinPath(outputRoot, ext.uid, 'dist', `${ext.handle}.js`)
+    const builtFile = joinPath(outputRoot, ext.getOutputFolderId(), 'dist', `${ext.handle}.js`)
     await expect(fs.fileExists(builtFile)).resolves.toBe(true)
     const content = await fs.readFile(builtFile, {encoding: 'utf8'})
 

--- a/packages/app/src/cli/services/dev/update-extension.test.ts
+++ b/packages/app/src/cli/services/dev/update-extension.test.ts
@@ -43,6 +43,7 @@ describe('updateExtensionDraft()', () => {
         settings: {type: 'object'},
         type: 'web_pixel_extension',
         handle,
+        uid: 'uid1',
       } as any
 
       const mockExtension = await testUIExtension({


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/pull/6183

Fixes an issue where extension assets were being incorrectly referenced by `outputFolderId` instead of using the extension's unique identifier.

### WHAT is this pull request doing?

Refactors how extension output folders are identified and referenced:

1. Removes the `outputFolderId` getter and replaces it with a more flexible `getOutputFolderId()` method that can accept a registration UUID
2. Updates the asset reference in the app model to use the extension's `uid` instead of `outputFolderId`
3. Modifies the bundle process to pass the extension UUID to the relevant methods
4. Updates the path handling in the app event watcher to use the new method

This change ensures that extension assets are consistently referenced by their unique identifiers throughout the codebase.

### How to test your changes?

1. Create an app with multiple extensions
2. Deploy the app and verify that all extension assets are correctly bundled and referenced
3. Run the dev server and confirm that file watching and rebuilding works correctly
4. Delete an extension and verify that its output directory is properly cleaned up

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes