### PR TITLE
Pass app module context through to registration's activeVersion if it exists

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/active-app-release-from-api-key.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/active-app-release-from-api-key.ts
@@ -23,6 +23,7 @@ export type ActiveAppReleaseFromApiKeyQuery = {
           userIdentifier: string
           handle: string
           config: JsonMapType
+          target?: string | null
           specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
         }[]
       }
@@ -80,6 +81,7 @@ export const ActiveAppReleaseFromApiKey = {
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
           {kind: 'Field', name: {kind: 'Name', value: 'config'}},
+          {kind: 'Field', name: {kind: 'Name', value: 'target'}},
           {
             kind: 'Field',
             name: {kind: 'Name', value: 'specification'},

--- a/packages/app/src/cli/api/graphql/app-management/generated/active-app-release.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/active-app-release.ts
@@ -23,6 +23,7 @@ export type ActiveAppReleaseQuery = {
           userIdentifier: string
           handle: string
           config: JsonMapType
+          target?: string | null
           specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
         }[]
       }
@@ -44,6 +45,7 @@ export type AppVersionInfoFragment = {
         userIdentifier: string
         handle: string
         config: JsonMapType
+        target?: string | null
         specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
       }[]
     }
@@ -55,6 +57,7 @@ export type ReleasedAppModuleFragment = {
   userIdentifier: string
   handle: string
   config: JsonMapType
+  target?: string | null
   specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
 }
 
@@ -72,6 +75,7 @@ export const ReleasedAppModuleFragmentDoc = {
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
           {kind: 'Field', name: {kind: 'Name', value: 'config'}},
+          {kind: 'Field', name: {kind: 'Name', value: 'target'}},
           {
             kind: 'Field',
             name: {kind: 'Name', value: 'specification'},
@@ -171,6 +175,7 @@ export const AppVersionInfoFragmentDoc = {
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
           {kind: 'Field', name: {kind: 'Name', value: 'config'}},
+          {kind: 'Field', name: {kind: 'Name', value: 'target'}},
           {
             kind: 'Field',
             name: {kind: 'Name', value: 'specification'},
@@ -238,6 +243,7 @@ export const ActiveAppRelease = {
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
           {kind: 'Field', name: {kind: 'Name', value: 'config'}},
+          {kind: 'Field', name: {kind: 'Name', value: 'target'}},
           {
             kind: 'Field',
             name: {kind: 'Name', value: 'specification'},

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-id.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-id.ts
@@ -17,6 +17,7 @@ export type AppVersionByIdQuery = {
       userIdentifier: string
       handle: string
       config: JsonMapType
+      target?: string | null
       specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
     }[]
   }
@@ -30,6 +31,7 @@ export type VersionInfoFragment = {
     userIdentifier: string
     handle: string
     config: JsonMapType
+    target?: string | null
     specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
   }[]
 }
@@ -78,6 +80,7 @@ export const VersionInfoFragmentDoc = {
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
           {kind: 'Field', name: {kind: 'Name', value: 'config'}},
+          {kind: 'Field', name: {kind: 'Name', value: 'target'}},
           {
             kind: 'Field',
             name: {kind: 'Name', value: 'specification'},
@@ -145,6 +148,7 @@ export const AppVersionById = {
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
           {kind: 'Field', name: {kind: 'Name', value: 'config'}},
+          {kind: 'Field', name: {kind: 'Name', value: 'target'}},
           {
             kind: 'Field',
             name: {kind: 'Name', value: 'specification'},

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
@@ -17,6 +17,7 @@ export type AppVersionByTagQuery = {
       userIdentifier: string
       handle: string
       config: JsonMapType
+      target?: string | null
       specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
     }[]
   }
@@ -71,6 +72,7 @@ export const AppVersionByTag = {
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
           {kind: 'Field', name: {kind: 'Name', value: 'config'}},
+          {kind: 'Field', name: {kind: 'Name', value: 'target'}},
           {
             kind: 'Field',
             name: {kind: 'Name', value: 'specification'},

--- a/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
@@ -19,6 +19,7 @@ export type CreateAppVersionMutation = {
         userIdentifier: string
         handle: string
         config: JsonMapType
+        target?: string | null
         specification: {identifier: string; externalIdentifier: string; name: string; managementExperience: string}
       }[]
       metadata: {versionTag?: string | null; message?: string | null}
@@ -150,6 +151,7 @@ export const CreateAppVersion = {
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
           {kind: 'Field', name: {kind: 'Name', value: 'config'}},
+          {kind: 'Field', name: {kind: 'Name', value: 'target'}},
           {
             kind: 'Field',
             name: {kind: 'Name', value: 'specification'},

--- a/packages/app/src/cli/api/graphql/app-management/queries/active-app-release.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/active-app-release.graphql
@@ -31,6 +31,7 @@ fragment ReleasedAppModule on AppModule {
   userIdentifier
   handle
   config
+  target
   specification {
     identifier
     externalIdentifier

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -165,6 +165,7 @@ export interface AppModuleVersion {
   registrationUuid?: string
   registrationTitle: string
   config?: object
+  target?: string
   type: string
   specification?: AppModuleVersionSpecification
 }

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -1611,4 +1611,136 @@ describe('appExtensionRegistrations', () => {
     expect(result.app.extensionRegistrations).toHaveLength(2)
     expect(result.app.dashboardManagedExtensionRegistrations).toHaveLength(2)
   })
+
+  test('includes activeVersion with config when config is present', async () => {
+    const configData = {name: 'Test Extension', enabled: true}
+    const extensionModule = createMockAppModuleVersion({
+      registrationId: 'extension-with-config',
+      registrationTitle: 'Extension With Config',
+      config: configData,
+    })
+
+    const activeAppVersion = {
+      appModuleVersions: [extensionModule],
+    }
+
+    const result = await client.appExtensionRegistrations(appIdentifiers, activeAppVersion)
+
+    expect(result.app.extensionRegistrations).toHaveLength(1)
+    expect(result.app.extensionRegistrations[0]).toEqual({
+      id: 'extension-with-config',
+      uuid: 'mock-uuid',
+      title: 'Extension With Config',
+      type: 'ui_extension',
+      activeVersion: {
+        config: JSON.stringify(configData),
+      },
+    })
+  })
+
+  test('includes activeVersion with config and context when both are present', async () => {
+    const configData = {name: 'Test Extension', enabled: true}
+    const contextData = 'some-context-value'
+    const extensionModule = createMockAppModuleVersion({
+      registrationId: 'extension-with-config-and-context',
+      registrationTitle: 'Extension With Config And Context',
+      config: configData,
+      target: contextData,
+    })
+
+    const activeAppVersion = {
+      appModuleVersions: [extensionModule],
+    }
+
+    const result = await client.appExtensionRegistrations(appIdentifiers, activeAppVersion)
+
+    expect(result.app.extensionRegistrations).toHaveLength(1)
+    expect(result.app.extensionRegistrations[0]).toEqual({
+      id: 'extension-with-config-and-context',
+      uuid: 'mock-uuid',
+      title: 'Extension With Config And Context',
+      type: 'ui_extension',
+      activeVersion: {
+        config: JSON.stringify(configData),
+        context: contextData,
+      },
+    })
+  })
+
+  test('excludes activeVersion when config is not present', async () => {
+    const extensionModule = createMockAppModuleVersion({
+      registrationId: 'extension-without-config',
+      registrationTitle: 'Extension Without Config',
+      config: undefined,
+      target: 'some-context',
+    })
+
+    const activeAppVersion = {
+      appModuleVersions: [extensionModule],
+    }
+
+    const result = await client.appExtensionRegistrations(appIdentifiers, activeAppVersion)
+
+    expect(result.app.extensionRegistrations).toHaveLength(1)
+    expect(result.app.extensionRegistrations[0]).toEqual({
+      id: 'extension-without-config',
+      uuid: 'mock-uuid',
+      title: 'Extension Without Config',
+      type: 'ui_extension',
+      activeVersion: undefined,
+    })
+  })
+
+  test('includes only config when context is not present', async () => {
+    const configData = {name: 'Test Extension', enabled: false}
+    const extensionModule = createMockAppModuleVersion({
+      registrationId: 'extension-with-config-only',
+      registrationTitle: 'Extension With Config Only',
+      config: configData,
+      target: undefined,
+    })
+
+    const activeAppVersion = {
+      appModuleVersions: [extensionModule],
+    }
+
+    const result = await client.appExtensionRegistrations(appIdentifiers, activeAppVersion)
+
+    expect(result.app.extensionRegistrations).toHaveLength(1)
+    expect(result.app.extensionRegistrations[0]).toEqual({
+      id: 'extension-with-config-only',
+      uuid: 'mock-uuid',
+      title: 'Extension With Config Only',
+      type: 'ui_extension',
+      activeVersion: {
+        config: JSON.stringify(configData),
+      },
+    })
+  })
+
+  test('handles empty config object correctly', async () => {
+    const configData = {}
+    const extensionModule = createMockAppModuleVersion({
+      registrationId: 'extension-with-empty-config',
+      registrationTitle: 'Extension With Empty Config',
+      config: configData,
+    })
+
+    const activeAppVersion = {
+      appModuleVersions: [extensionModule],
+    }
+
+    const result = await client.appExtensionRegistrations(appIdentifiers, activeAppVersion)
+
+    expect(result.app.extensionRegistrations).toHaveLength(1)
+    expect(result.app.extensionRegistrations[0]).toEqual({
+      id: 'extension-with-empty-config',
+      uuid: 'mock-uuid',
+      title: 'Extension With Empty Config',
+      type: 'ui_extension',
+      activeVersion: {
+        config: JSON.stringify(configData),
+      },
+    })
+  })
 })

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -573,7 +573,12 @@ export class AppManagementClient implements DeveloperPlatformClient {
         uuid: mod.registrationUuid!,
         title: mod.registrationTitle,
         type: mod.type,
-        activeVersion: mod.config ? {config: JSON.stringify(mod.config)} : undefined,
+        activeVersion: mod.config
+          ? {
+              config: JSON.stringify(mod.config),
+              ...(mod.target && {context: mod.target}),
+            }
+          : undefined,
       }
       if (CONFIG_EXTENSION_IDS.includes(registration.id)) {
         configurationRegistrations.push(registration)
@@ -1334,6 +1339,7 @@ function appModuleVersion(mod: ReleasedAppModuleFragment): Required<AppModuleVer
     registrationTitle: mod.handle,
     type: mod.specification.externalIdentifier,
     config: mod.config,
+    target: mod.target ?? '',
     specification: {
       ...mod.specification,
       identifier: mod.specification.identifier,


### PR DESCRIPTION
# Add support for extension context in app module versions

## TL;DR

Fixes https://github.com/shop/issues-develop/issues/17833

Added support for the `target` field in app module versions to enhance extension configuration capabilities.

## What changed?

- Added the `target` field to the GraphQL query for released app modules
- Updated the `AppModuleVersion` interface to include the optional `target` property
- Modified the `appExtensionRegistrations` method to include the context field in the `activeVersion` object when both config and target are present
- Added comprehensive tests to verify the behavior with various combinations of config and context values

## How to test?

1. Run the test suite to verify the new functionality:
   ```
   npm test packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
   ```
2. Test the CLI with an app that uses extensions with context values:
   - Create an app with extensions that include target data
   - Verify that the target data is properly included as context in the extension registrations
   - Check that the context is correctly passed to the UI when viewing extensions

## Why make this change?

This change enables extensions to store and retrieve contextual information alongside their configuration. The target field (mapped to context in the client) provides a way for extensions to maintain state or metadata that isn't part of the user-configurable settings but is necessary for proper extension functionality. This enhancement improves the flexibility of the extension system and allows for more sophisticated extension behaviors.