### PR TITLE
hydrogen/Bump cli-hydrogen to 11.1.3

### DIFF
--- a/.changeset/stable-update-hydrogen-cli-11.1.3.md
+++ b/.changeset/stable-update-hydrogen-cli-11.1.3.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Update cli-hydrogen 11.1.3

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -115,7 +115,7 @@
     "@shopify/plugin-did-you-mean": "3.83.2",
     "@shopify/theme": "3.83.2",
     "@shopify/store": "3.83.2",
-    "@shopify/cli-hydrogen": "11.1.2",
+    "@shopify/cli-hydrogen": "11.1.3",
     "@types/global-agent": "3.0.0",
     "@typescript-eslint/eslint-plugin": "7.13.1",
     "@vitest/coverage-istanbul": "^3.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,8 +286,8 @@ importers:
         specifier: 3.83.2
         version: link:../app
       '@shopify/cli-hydrogen':
-        specifier: 11.1.2
-        version: 11.1.2(@graphql-codegen/cli@5.0.4(@parcel/watcher@2.5.1)(@types/node@22.15.29)(crossws@0.3.5)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.8.3))(graphql-config@5.1.5(@types/node@22.15.29)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.8.3))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0))
+        specifier: 11.1.3
+        version: 11.1.3(@graphql-codegen/cli@5.0.4(@parcel/watcher@2.5.1)(@types/node@22.15.29)(crossws@0.3.5)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.8.3))(graphql-config@5.1.5(@types/node@22.15.29)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.8.3))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0))
       '@shopify/cli-kit':
         specifier: 3.83.2
         version: link:../cli-kit
@@ -3254,8 +3254,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@shopify/cli-hydrogen@11.1.2':
-    resolution: {integrity: sha512-D1LdA1Hhhgmg96yjHC5YUjZbT1ukGVkT/bnIH/E29KGfrTWVIkjHD2x9OW4CkvDZfPtYTGawO3mhxi5xa3mTUg==}
+  '@shopify/cli-hydrogen@11.1.3':
+    resolution: {integrity: sha512-3x3ooh1Rhml0UnTCFwlTJdWmeKqiQS8/3Hb3cB6CJgoUwiZuNprumeeiQZgtSSGVgYJHbD5kot/QhzaRnENX+Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -12640,7 +12640,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@shopify/cli-hydrogen@11.1.2(@graphql-codegen/cli@5.0.4(@parcel/watcher@2.5.1)(@types/node@22.15.29)(crossws@0.3.5)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.8.3))(graphql-config@5.1.5(@types/node@22.15.29)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.8.3))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0))':
+  '@shopify/cli-hydrogen@11.1.3(@graphql-codegen/cli@5.0.4(@parcel/watcher@2.5.1)(@types/node@22.15.29)(crossws@0.3.5)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.8.3))(graphql-config@5.1.5(@types/node@22.15.29)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.8.3))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(sass@1.89.1)(yaml@2.7.0))':
     dependencies:
       '@ast-grep/napi': 0.11.0
       '@oclif/core': 4.4.0


### PR DESCRIPTION
## What this PR does

Updates @shopify/cli-hydrogen from 11.1.2 to 11.1.3

## Release Notes

### Patch Changes

- Fix issue so that Hydrogen build command will work with Remix ([#3056](https://github.com/Shopify/hydrogen/pull/3056)) by [@juanpprieto](https://github.com/juanpprieto)

## Notes

This is the stable branch PR with changeset for an urgent release. The corresponding main branch PR (without changeset): https://github.com/Shopify/cli/pull/6213