### PR TITLE
fix spelling for network socket retry error

### DIFF
--- a/.changeset/modern-sloths-act.md
+++ b/.changeset/modern-sloths-act.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fixed typo in isARetryableNetworkError to catch network socket disconnected

--- a/packages/cli-kit/src/private/node/api.ts
+++ b/packages/cli-kit/src/private/node/api.ts
@@ -76,7 +76,7 @@ function isARetryableNetworkError(error: unknown): boolean {
       'ECONNABORTED',
       'ENOTFOUND',
       'ENETUNREACH',
-      'network socket disonnected',
+      'network socket disconnected',
       'ETIMEDOUT',
       'ECONNREFUSED',
       'EAI_FAIL',


### PR DESCRIPTION
### WHY are these changes introduced?

There was a small typo in the list of `isARetryableNetworkError` and it may have caused any `network socket disconnected` errors to be skipped over and not retried.

### WHAT is this pull request doing?

Fixed the typo

### How to test your changes?


### Post-release steps


### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
