### PR TITLE
Update docs URL for themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To work with themes, the CLI needs to be installed globally with:
 
 You can also use do it through Homebrew on macOS: `brew tap shopify/shopify && brew install shopify-cli`
 
-Learn more in the docs: [Shopify CLI for themes](https://shopify.dev/docs/themes/tools/cli)
+Learn more in the docs: [Shopify CLI for themes](https://shopify.dev/docs/storefronts/themes/tools/cli)
 
 <p>&nbsp;</p>
 


### PR DESCRIPTION
This was linking to a page that no longer exists and redirects to the old 2.x docs.

| Before URL | After URL |
|--------|--------|
| <img width="2048" height="1536" alt="shopify dev_docs_storefronts_themes_tools_cli_cli-2_commands(iPad Mini)" src="https://github.com/user-attachments/assets/b1f470bc-8807-4428-91a8-1f0ab015dd96" /> | <img width="2048" height="1536" alt="shopify dev_docs_storefronts_themes_tools_cli(iPad Mini)" src="https://github.com/user-attachments/assets/3018e7aa-f548-4fca-ae5d-f4553e77642d" /> | 


