### PR TITLE
Add in dev platform flow a --force check to block deploy before migrating partner-managed extensions

### DIFF
--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -794,7 +794,7 @@ describe('ImportExtensionsIfNeeded', () => {
         force: true,
       }),
     ).rejects.toThrow(
-      "App can't be deployed until legacy extensions are added to your version or removed from your app:",
+      "App can't be deployed until Partner Dashboard managed extensions are added to your version or removed from your app:",
     )
   })
 
@@ -819,7 +819,7 @@ describe('ImportExtensionsIfNeeded', () => {
         force: false,
       }),
     ).rejects.toThrow(
-      "App can't be deployed until legacy extensions are added to your version or removed from your app:",
+      "App can't be deployed until Partner Dashboard managed extensions are added to your version or removed from your app:",
     )
   })
 
@@ -884,7 +884,7 @@ describe('ImportExtensionsIfNeeded', () => {
         force: true,
       }),
     ).rejects.toThrow(
-      "App can't be deployed until legacy extensions are added to your version or removed from your app:",
+      "App can't be deployed until Partner Dashboard managed extensions are added to your version or removed from your app:",
     )
   })
 
@@ -909,7 +909,7 @@ describe('ImportExtensionsIfNeeded', () => {
         force: false,
       }),
     ).rejects.toThrow(
-      "App can't be deployed until legacy extensions are added to your version or removed from your app:",
+      "App can't be deployed until Partner Dashboard managed extensions are added to your version or removed from your app:",
     )
   })
 
@@ -983,5 +983,39 @@ describe('ImportExtensionsIfNeeded', () => {
     expect(renderConfirmationPrompt).not.toHaveBeenCalled()
     expect(importAllExtensions).not.toHaveBeenCalled()
     expect(result).toBe(app)
+  })
+
+  test('ensureDeploymentIdsPresence throws when forcing deploy and unassigned dashboard extensions exist on unsupported platform', async () => {
+    // Given
+    const app = testAppLinked()
+    const remoteApp = testOrganizationApp()
+    const developerPlatformClient = testDeveloperPlatformClient({
+      supportsDashboardManagedExtensions: false,
+      appExtensionRegistrations: async () =>
+        Promise.resolve({
+          app: {
+            extensionRegistrations: [{id: '', title: 'Legacy extension'}],
+            configurationRegistrations: [],
+          },
+        } as any),
+    })
+
+    const identifiersModule = await vi.importActual<typeof import('./context/identifiers.js')>(
+      './context/identifiers.js',
+    )
+
+    // When/Then
+    await expect(
+      identifiersModule.ensureDeploymentIdsPresence({
+        app,
+        developerPlatformClient,
+        appId: remoteApp.apiKey,
+        appName: remoteApp.title,
+        envIdentifiers: {},
+        force: true,
+        release: true,
+        remoteApp,
+      } as any),
+    ).rejects.toThrow('need to be assigned')
   })
 })

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -114,7 +114,7 @@ async function handleUnsupportedDashboardExtensions(
     `App can't be deployed until Partner Dashboard managed extensions are added to your version or removed from your app:\n`,
     extensions.map((ext) => `  - ${ext.title}`).join('\n'),
   ]
-  const nextSteps = ['\n\nRun ', {command: 'shopify app deploy'}, 'to add legacy extensions.']
+  const nextSteps = ['\n\nRun ', {command: 'shopify app import-extensions'}, 'to add legacy extensions.']
 
   if (force || !isTTY()) {
     throw new AbortError(message, nextSteps)

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -111,10 +111,10 @@ async function handleUnsupportedDashboardExtensions(
   const {app, remoteApp, developerPlatformClient, force, extensions} = options
 
   const message = [
-    `App can't be deployed until legacy extensions are added to your version or removed from your app:\n`,
+    `App can't be deployed until Partner Dashboard managed extensions are added to your version or removed from your app:\n`,
     extensions.map((ext) => `  - ${ext.title}`).join('\n'),
   ]
-  const nextSteps = ['\n\nRun ', {command: 'shopify app import-extensions'}, 'to add legacy extensions.']
+  const nextSteps = ['\n\nRun ', {command: 'shopify app deploy'}, 'to add legacy extensions.']
 
   if (force || !isTTY()) {
     throw new AbortError(message, nextSteps)

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -1326,7 +1326,7 @@ function mapBusinessPlatformStoresToOrganizationStores(
 
 function appModuleVersion(mod: ReleasedAppModuleFragment): Required<AppModuleVersion> {
   return {
-    registrationId: mod.userIdentifier,
+    registrationId: mod.userIdentifier === mod.uuid ? '' : mod.userIdentifier,
     registrationUuid: mod.uuid,
     registrationTitle: mod.handle,
     type: mod.specification.externalIdentifier,


### PR DESCRIPTION
### WHY are these changes introduced?

Prevents forced deployments when Partner Dashboard managed extensions need migration, ensuring a smoother migration process.

### WHAT is this pull request doing?

Adds a validation check that prevents users from running a forced deploy when using the App Management client with extensions that need migration. Instead, it shows a helpful error message instructing users to run a manual deploy first to import and migrate the extensions locally.

### How to test your changes?

1. Create an app with Partner Dashboard managed extensions
2. Try to run a forced deploy using the App Management client
3. Verify that the error message appears with the list of extensions that need migration
4. Run a manual deploy to import the extensions
5. Verify that the forced deploy now works after migration

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes