### PR TITLE
Remove mention of dev platform from `dev clean` command

### DIFF
--- a/docs-shopify.dev/commands/app-dev-clean.doc.ts
+++ b/docs-shopify.dev/commands/app-dev-clean.doc.ts
@@ -6,8 +6,6 @@ const data: ReferenceEntityTemplateSchema = {
   description: `Stop the app preview that was started with \`shopify app dev\`.
 
   It restores the app's active version to the selected development store.
-
-  It's valid only for apps created on the Next-Gen Dev Platform.
   `,
   overviewPreviewDescription: `Cleans up the app preview from the selected store.`,
   type: 'command',

--- a/docs-shopify.dev/generated/generated_docs_data.json
+++ b/docs-shopify.dev/generated/generated_docs_data.json
@@ -423,7 +423,7 @@
   },
   {
     "name": "app dev clean",
-    "description": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n\n  It's valid only for apps created on the Next-Gen Dev Platform.\n  ",
+    "description": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
     "overviewPreviewDescription": "Cleans up the app preview from the selected store.",
     "type": "command",
     "isVisualComponent": false,

--- a/packages/app/src/cli/commands/app/dev/clean.ts
+++ b/packages/app/src/cli/commands/app/dev/clean.ts
@@ -13,8 +13,6 @@ export default class DevClean extends AppLinkedCommand {
   static descriptionWithMarkdown = `Stop the app preview that was started with \`shopify app dev\`.
 
   It restores the app's active version to the selected development store.
-
-  It's valid only for apps created on the Next-Gen Dev Platform.
   `
 
   static description = this.descriptionWithoutMarkdown()

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -307,8 +307,6 @@ DESCRIPTION
   Stop the app preview that was started with `shopify app dev`.
 
   It restores the app's active version to the selected development store.
-
-  It's valid only for apps created on the Next-Gen Dev Platform.
 ```
 
 ## `shopify app env pull`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -597,8 +597,8 @@
       "args": {
       },
       "customPluginName": "@shopify/app",
-      "description": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n\n  It's valid only for apps created on the Next-Gen Dev Platform.\n  ",
-      "descriptionWithMarkdown": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n\n  It's valid only for apps created on the Next-Gen Dev Platform.\n  ",
+      "description": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
+      "descriptionWithMarkdown": "Stop the app preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
       "flags": {
         "client-id": {
           "description": "The Client ID of your app.",


### PR DESCRIPTION
### WHY are these changes introduced?

This command is becoming universal to all apps.
