### PR TITLE
Block dev when there are pending extensions to migrate

### DIFF
--- a/packages/app/src/cli/services/dev.test.ts
+++ b/packages/app/src/cli/services/dev.test.ts
@@ -132,4 +132,29 @@ describe('blockIfMigrationIncomplete', () => {
 
     await expect(blockIfMigrationIncomplete(devConfig)).rejects.toThrow(/need to be assigned uid identifiers/)
   })
+
+  test('does nothing for Partners with missing ids (not migrated)', async () => {
+    const developerPlatformClient = testDeveloperPlatformClient({
+      supportsDevSessions: false,
+      async appExtensionRegistrations() {
+        return {
+          app: {
+            extensionRegistrations: [
+              {id: '', uuid: 'u1', title: 'Legacy Ext 1', type: 'theme'},
+              {uuid: 'u2', title: 'Legacy Ext 2', type: 'web_pixel_extension'},
+            ],
+            configurationRegistrations: [],
+            dashboardManagedExtensionRegistrations: [],
+          },
+        } as any
+      },
+    })
+
+    const devConfig = {
+      ...baseConfig(),
+      developerPlatformClient,
+    } as any
+
+    await expect(blockIfMigrationIncomplete(devConfig)).resolves.toBeUndefined()
+  })
 })

--- a/packages/app/src/cli/services/dev.test.ts
+++ b/packages/app/src/cli/services/dev.test.ts
@@ -130,6 +130,6 @@ describe('blockIfMigrationIncomplete', () => {
       developerPlatformClient,
     } as any
 
-    await expect(blockIfMigrationIncomplete(devConfig)).rejects.toThrow(/need to be migrated/)
+    await expect(blockIfMigrationIncomplete(devConfig)).rejects.toThrow(/need to be assigned uid identifiers/)
   })
 })

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -242,8 +242,14 @@ export async function blockIfMigrationIncomplete(devConfig: DevConfig) {
   const remoteExtensions = (await developerPlatformClient.appExtensionRegistrations(remoteApp)).app
     .extensionRegistrations
   if (developerPlatformClient.supportsDevSessions && !remoteExtensions.every((extension) => extension.id)) {
-    const message = [`Your app includes extensions that need to be migrated to the Next-Gen Dev Platform.`]
-    const nextSteps = ['Run', {command: 'shopify app deploy'}, 'to finish the migration.']
+    const message = ['Your app has extensions which need to be assigned', {command: 'uid'}, 'identifiers.']
+    const nextSteps = [
+      'You must first map IDs to your existing extensions by running',
+      {command: 'shopify app deploy'},
+      'interactively, without',
+      {command: '--force'},
+      'to finish the migration.',
+    ]
     throw new AbortError(message, nextSteps)
   }
 }

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -239,9 +239,10 @@ export async function warnIfScopesDifferBeforeDev({
 
 export async function blockIfMigrationIncomplete(devConfig: DevConfig) {
   const {developerPlatformClient, remoteApp} = devConfig
-  const remoteExtensions = (await developerPlatformClient.appExtensionRegistrations(remoteApp)).app
-    .extensionRegistrations
-  if (developerPlatformClient.supportsDevSessions && !remoteExtensions.every((extension) => extension.id)) {
+  if (!developerPlatformClient.supportsDevSessions) return
+
+  const extensions = (await developerPlatformClient.appExtensionRegistrations(remoteApp)).app.extensionRegistrations
+  if (!extensions.every((extension) => extension.id)) {
     const message = ['Your app has extensions which need to be assigned', {command: 'uid'}, 'identifiers.']
     const nextSteps = [
       'You must first map IDs to your existing extensions by running',


### PR DESCRIPTION
### WHY are these changes introduced?

The new dev command may behave incorrectly if the app has extensions pending to migrate to the new dev platform (missing UIDs).

### WHAT is this pull request doing?

Raise an error when running dev before finishing the migration with deploy

<img width="1056" height="114" alt="Monosnap Hyper 2025-08-08 17-17-19" src="https://github.com/user-attachments/assets/05f8ecfd-7dc8-426c-a6b3-ad4a85eda01f" />

### How to test your changes?

- Migrate an org
- Run `p shopify app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
